### PR TITLE
Add npm publish workflow, include README

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,6 +51,10 @@ jobs:
       - run: pnpm run test
         if: steps.version-check.outputs.skip != 'true'
 
+      - name: Copy root README into package
+        if: steps.version-check.outputs.skip != 'true'
+        run: cp README.md packages/canonry/README.md
+
       - name: Build and publish
         if: steps.version-check.outputs.skip != 'true'
         run: pnpm --filter @ainyc/canonry publish --no-git-checks --access public

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "license": "AGPL-3.0-only",
   "bin": {
@@ -17,7 +17,8 @@
     "bin/",
     "dist/",
     "assets/",
-    "src/"
+    "src/",
+    "README.md"
   ],
   "engines": {
     "node": ">=20"
@@ -25,7 +26,7 @@
   "scripts": {
     "build": "tsup && tsx build-web.ts",
     "build:web": "tsx build-web.ts",
-    "prepublishOnly": "pnpm run build",
+    "prepublishOnly": "cp ../../README.md ./README.md && pnpm run build",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "tsx --test test/*.test.ts",
     "lint": "eslint src/ test/"


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that publishes `@ainyc/canonry` to npm when the version in `packages/canonry/package.json` changes on main
- Copy root README into package directory before publish so it appears on the npm page
- Bump version to 1.0.1 (1.0.0 was published without README)

## Test plan
- [ ] Verify `NPM_TOKEN` secret is set in repo settings
- [ ] Merge to main and confirm workflow triggers and publishes 1.0.1
- [ ] Check npm page shows the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)