### PR TITLE
Recover stale runs on server startup

### DIFF
--- a/packages/canonry/src/job-runner.ts
+++ b/packages/canonry/src/job-runner.ts
@@ -1,5 +1,5 @@
 import crypto from 'node:crypto'
-import { eq } from 'drizzle-orm'
+import { eq, inArray } from 'drizzle-orm'
 import type { DatabaseClient } from '@ainyc/canonry-db'
 import { runs, keywords, competitors, projects, querySnapshots, usageCounters } from '@ainyc/canonry-db'
 import type { ProviderName, NormalizedQueryResult } from '@ainyc/canonry-contracts'
@@ -13,6 +13,26 @@ export class JobRunner {
   constructor(db: DatabaseClient, registry: ProviderRegistry) {
     this.db = db
     this.registry = registry
+  }
+
+  recoverStaleRuns(): void {
+    const stale = this.db
+      .select({ id: runs.id, status: runs.status })
+      .from(runs)
+      .where(inArray(runs.status, ['running', 'queued']))
+      .all()
+
+    if (stale.length === 0) return
+
+    const now = new Date().toISOString()
+    for (const run of stale) {
+      this.db
+        .update(runs)
+        .set({ status: 'failed', finishedAt: now, error: 'Server restarted while run was in progress' })
+        .where(eq(runs.id, run.id))
+        .run()
+      console.log(`[JobRunner] Recovered stale run ${run.id} (was ${run.status})`)
+    }
   }
 
   async executeRun(runId: string, projectId: string, providerOverride?: ProviderName[]): Promise<void> {

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -102,6 +102,7 @@ export async function createServer(opts: {
   const serverUrl = `http://localhost:${port}`
 
   const jobRunner = new JobRunner(opts.db, registry)
+  jobRunner.recoverStaleRuns()
   const notifier = new Notifier(opts.db, serverUrl)
   jobRunner.onRunCompleted = (runId, projectId) => notifier.onRunCompleted(runId, projectId)
 


### PR DESCRIPTION
## Summary

- Adds `recoverStaleRuns()` to `JobRunner` — on startup, any run left in `running` or `queued` state is marked `failed` with the message *"Server restarted while run was in progress"*
- Called once during `createServer()` before the API routes are registered

## Motivation

If the server crashes or is restarted while a run is in progress, the run stays permanently stuck in `running` state. The in-process try/catch in `executeRun` can't help here — the process is gone. This adds a one-time recovery sweep so stale runs are cleaned up automatically on the next start.

## Test plan

- [x] Start server with a run already in `running` state in the DB — confirm it transitions to `failed` on startup
- [x] Normal startup with no stale runs — confirm no errors logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)