### PR TITLE
Refine empty state card typography on setup page

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1039,8 +1039,8 @@ function OverviewPage({
       ) : (
         <Card className="surface-card empty-card">
           <h3>{model.emptyState?.title ?? 'No projects yet'}</h3>
-          <p>{model.emptyState?.detail}</p>
-          <Button asChild>
+          <p className="supporting-copy">{model.emptyState?.detail}</p>
+          <Button size="sm" asChild>
             <a
               href={model.emptyState?.ctaHref ?? '/setup'}
               onClick={createNavigationHandler(onNavigate, model.emptyState?.ctaHref ?? '/setup')}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "1.4.2",
+  "version": "1.4.3",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Summary
Add `supporting-copy` class to description paragraph and shrink button to `size="sm"` for better proportions. Reduces default 16px text down to `text-sm` for visual hierarchy, making the initial setup screen feel less imposing.

## Changes
- Added `supporting-copy` class to empty state description paragraph (14px/zinc-500)
- Shrunk CTA button to `size="sm"` (h-8 px-3 text-xs)
- Bumped version to 1.4.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)