### PR TITLE
Add husky git hooks for lint and conventional commits

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,23 @@
+commit_msg=$(head -1 "$1")
+
+# Allow merge commits
+if echo "$commit_msg" | grep -qE "^Merge "; then
+  exit 0
+fi
+
+# Conventional Commits: type(optional-scope): description
+if ! echo "$commit_msg" | grep -qE "^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?: .+"; then
+  echo "ERROR: Commit message must follow Conventional Commits format:"
+  echo ""
+  echo "  <type>(<optional scope>): <description>"
+  echo ""
+  echo "  Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert"
+  echo ""
+  echo "  Examples:"
+  echo "    feat: add webhook retry logic"
+  echo "    fix(api): handle empty keyword list"
+  echo "    docs: update roadmap for phase 3"
+  echo ""
+  echo "  Got: $commit_msg"
+  exit 1
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm run lint

--- a/package.json
+++ b/package.json
@@ -10,19 +10,24 @@
     "lint": "pnpm -r run lint",
     "dev:api": "pnpm --filter @ainyc/canonry-api run dev",
     "dev:worker": "pnpm --filter @ainyc/canonry-worker run dev",
-    "dev:web": "pnpm --filter @ainyc/canonry-web run dev"
+    "dev:web": "pnpm --filter @ainyc/canonry-web run dev",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",
     "@types/node": "^24.5.1",
     "eslint": "^9.0.0",
     "globals": "^17.4.0",
+    "husky": "^9.1.7",
     "tsx": "^4.20.5",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.43.0"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["better-sqlite3", "esbuild"]
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "esbuild"
+    ]
   },
   "engines": {
     "node": ">=20"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       globals:
         specifier: ^17.4.0
         version: 17.4.0
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       tsx:
         specifier: ^4.20.5
         version: 4.21.0
@@ -2120,6 +2123,11 @@ packages:
 
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -4606,6 +4614,8 @@ snapshots:
   humanize-ms@1.2.1:
     dependencies:
       ms: 2.1.3
+
+  husky@9.1.7: {}
 
   iconv-lite@0.6.3:
     dependencies:


### PR DESCRIPTION
## Summary

Adds git hooks to enforce code quality and commit message standards:

- **Pre-commit hook** runs `pnpm run lint` to catch style issues before commits
- **Commit-msg hook** validates Conventional Commits format (feat, fix, docs, etc.)
- Merge commits are exempted from commit message validation
- TypeCheck and tests are left to CI for faster local development

## Test Plan

- ✅ Pre-commit hook runs lint on commit
- ✅ Valid conventional commits (e.g., `feat: description`) pass validation
- ✅ Invalid commits (e.g., `bad message`) are rejected with helpful error message
- ✅ Scoped commits (e.g., `fix(api): handle edge case`) are accepted