### PR TITLE
docs: Distributed node architecture with persona-framed queries

### DIFF
--- a/docs/adr/0005-distributed-node-hub-architecture.md
+++ b/docs/adr/0005-distributed-node-hub-architecture.md
@@ -1,0 +1,29 @@
+# ADR 0005: Distributed Node + Hub Architecture with Persona-Framed Queries
+
+## Decision
+
+Canonry adopts a hub-and-spoke architecture where local installations act as sensing nodes that sync observation snapshots to a central hub for cross-location, cross-audience analytics. Persona-framed queries are a first-class concept, allowing the same keywords to be tracked across multiple simulated audience segments.
+
+The observation matrix becomes: `keyword × provider × node × persona`.
+
+## Why
+
+- every existing AEO monitoring tool queries LLMs from cloud data centers, producing a single decontextualized perspective that diverges from what real users see as LLM search becomes hyper-localized and personalized
+- Canonry's local-first architecture is uniquely positioned: each installation is already on a real user's machine with real location, real browser profile, and real personalization signals
+- even if LLM providers eventually ship brand visibility APIs, they will report aggregate statistics — not per-location, per-audience breakdowns; the dimensions captured by distributed nodes + personas are structurally inaccessible to cloud-only tools
+- persona-framed queries work with all existing API providers today (system instructions in Gemini, OpenAI, Claude) and require no new infrastructure — immediate differentiation at low cost
+- cross-provider, cross-location, cross-audience analytics is a moat that compounds with each additional node in the network
+
+## Consequences
+
+- snapshots gain node identity metadata (`nodeId`, `nodeLocation`, `nodeContext`) and a `personaId` column; existing data stays valid with defaults (`nodeId = 'local'`, `personaId = null`)
+- a new `personas` table stores per-project persona definitions with `systemInstruction` (preferred) and `queryPrefix` (fallback) fields
+- the job runner fans out across personas: `keyword × provider × persona` per run; `null` persona preserves existing behavior
+- each provider adapter applies persona context as a system instruction where the API supports it, falling back to query text modification for providers that don't
+- hub mode is a flag on the same binary (`canonry serve --mode hub`), not a separate artifact
+- sync protocol is append-only and cursor-based: nodes push snapshots, hub pushes config; nodes are authoritative for their snapshots, hub is authoritative for config
+- sync triggers automatically on run completion when a hub is configured, with `canonry sync` as a manual fallback
+- sync scope is configurable: normalized summary by default, opt-in to full raw responses
+- a browser provider (Chrome MCP first, CDP fallback) will capture the highest-signal localized data from real ChatGPT/Perplexity sessions
+- the architecture is additive and backward compatible: single-node installs are unaffected, sync is opt-in, no existing API endpoints change
+- the architecture supports open-core monetization (free nodes, paid hub) but no licensing decision is made yet

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -114,25 +114,61 @@ These build on existing infrastructure with minimal schema/architecture changes.
 
 ---
 
+## Phase 2.7: Distributed Node Architecture
+
+See [ADR 0005](adr/0005-distributed-node-hub-architecture.md) for full rationale.
+
+Cloud SaaS AEO tools query from data centers, producing a single decontextualized perspective. As LLM search becomes hyper-localized and personalized, this gap becomes a structural blind spot. Canonry's local-first architecture enables a distributed sensing network where each installation captures the real, localized, audience-specific perspective — something no cloud-only tool can replicate.
+
+### Node Identity & Context Metadata
+**Gap**: Snapshots have no origin context. When multiple Canonry instances exist, there's no way to distinguish or aggregate their data.
+**Implementation**: Add `nodeId`, `nodeLocation`, `nodeContext` columns to `querySnapshots`. Node identity configured via env vars or `canonry.yaml`. Defaults to `'local'` for backward compatibility.
+**Impact**: Foundation for all multi-node features. Zero UX change for single-node users.
+
+### Persona-Framed Queries
+**Gap**: Analysts capture their own personalized perspective, not their target audience's. A 28-year-old SEO professional gets different LLM answers than a 35-year-old homeowner.
+**Implementation**: New `personas` table per project. Each persona defines a `systemInstruction` (passed as system message to Gemini/OpenAI/Claude APIs) with query text modification as fallback. Job runner fans out across personas: `keyword × provider × persona`. Add `personaId` to snapshots. Config-as-code support in `canonry.yaml`. Surface parity: CLI (`canonry persona add`), API (`POST /api/v1/projects/:name/personas`), and UI (persona management + filter).
+**Impact**: Enables audience-segmented AEO monitoring using existing API providers — no new infrastructure. "Homeowners see us cited, property managers don't" becomes a trackable metric.
+
+### Browser Provider (ChatGPT UI)
+**Gap**: API-based queries (`web_search_preview`) return different results than the real ChatGPT UI. The UI reflects logged-in user context, conversation history, and real personalization.
+**Implementation**: New `packages/provider-chatgpt-browser/` adapter. Chrome MCP integration first (leverages existing MCP ecosystem), CDP (Chrome DevTools Protocol) as fallback. Implements standard `ProviderAdapter` interface. Navigates to ChatGPT, submits query, extracts answer text + cited sources from DOM.
+**Impact**: Highest-signal provider. Captures what real users actually see. Combined with personas and node identity, creates a multi-dimensional observation matrix.
+
+### Hub Sync Protocol
+**Gap**: Multiple Canonry nodes have no way to share data or aggregate insights across locations.
+**Implementation**: Hub mode via `canonry serve --mode hub` (same binary). Nodes push snapshots to hub on run completion (auto-sync) or manually (`canonry sync`). Hub pushes config to nodes. Append-only, cursor-based sync. Nodes are authoritative for their snapshots; hub is authoritative for config. Configurable sync scope: normalized summary by default, opt-in to full raw responses.
+**Impact**: Enables cross-location analytics. Agency with nodes in Portland and Seattle can compare citation variance. Hub also runs API-based baseline queries as a non-personalized control group.
+
+### Cross-Node & Cross-Persona Analytics
+**Gap**: No tool offers geographic citation heatmaps or audience-segmented SOV.
+**Implementation**: New hub-side API endpoints: citation consistency, localization delta, geographic heatmap, audience SOV. Dashboard additions: heatmap view, consistency gauge, persona variance charts, per-node run breakdowns.
+**Impact**: Metrics that are structurally impossible for cloud SaaS tools: "Cited in 80% of local queries but 30% of generic queries" and "Strong with homeowners, invisible to property managers."
+
+---
+
 ## Phase 4: Long-Term Initiatives
 
 ### Google AI Overviews Provider
 Requires SerpAPI or similar to scrape Google search results with AI Overview snippets. "Bring your own SerpAPI key" approach.
 
-### ChatGPT UI Scraping Provider ("Bring Your Own Browser")
-Browser automation where the user logs into ChatGPT and Canonry reads the page via Playwright/Puppeteer. Most accurate ChatGPT visibility data possible.
+### Real User Panel
+Lightweight browser extension that real users opt into. Passively observes AI search interactions, anonymizes data, and reports citations back to the hub. The "Nielsen ratings for AI search" model — captures actual personalized results without simulation.
+
+### Synthetic Browser Profiles
+Multiple Chrome profiles with different ChatGPT custom instructions, browsing history, and cookies. Canonry rotates through them for deeper persona simulation beyond query framing.
 
 ### Historical Trend Analytics & Forecasting
 Time-series analytics over SOV, sentiment, and citation position. 7/30/90-day trends. Moving averages and linear regression for SOV projections.
 
 ### Multi-Tenant Cloud Mode
-Postgres mode, team workspaces, API key scoping per team, Stripe billing integration.
+Postgres mode, team workspaces, API key scoping per team, Stripe billing integration. Hub mode provides the foundation.
 
 ### Integrations Ecosystem
 Slack (alerts), Google Sheets (export), Looker Studio (data source), Zapier/n8n (webhook docs), Google Search Console (correlate organic vs. AI visibility).
 
 ### Agency/Multi-Brand Management
-Project grouping ("workspaces" or "organizations"), cross-project dashboards, templated configs for agency workflows.
+Project grouping ("workspaces" or "organizations"), cross-project dashboards, templated configs for agency workflows. Builds on hub + multi-node architecture.
 
 ---
 
@@ -147,6 +183,8 @@ Project grouping ("workspaces" or "organizations"), cross-project dashboards, te
 | Results CSV/JSON export | Low | Medium | **P1** |
 | Perplexity provider | Low | High | **P1** |
 | Answer diff viewer | Medium | High | **P1** |
+| Node identity & context metadata | Low | High | **P1** |
+| Persona-framed queries | Medium | Very High | **P1** |
 | Site audit / tech readiness | Low-Medium (uses `@ainyc/aeo-audit`) | High | **P2** |
 | Prompt-to-topic clustering | Medium | High | **P2** |
 | Content optimization recs | Medium | Very High | **P2** |
@@ -154,7 +192,11 @@ Project grouping ("workspaces" or "organizations"), cross-project dashboards, te
 | Claude Code skill | Low-Medium | High | **P2** |
 | Crawl health monitoring | Low (uses `@ainyc/aeo-audit`) | Medium | **P2** |
 | Google AI Overviews provider | Medium | High | **P2** |
-| ChatGPT UI scraping | High | High | **P3** |
+| Browser provider (Chrome MCP/CDP) | Medium | Very High | **P2** |
+| Hub sync protocol | Medium | High | **P2** |
+| Cross-node/persona analytics | Medium | High | **P2** |
+| Real user panel | High | Very High | **P3** |
+| Synthetic browser profiles | Medium | High | **P3** |
 | Trend analytics & forecasting | High | Medium | **P3** |
 | Cloud multi-tenant mode | High | High | **P3** |
 | Integrations ecosystem | High | Medium | **P3** |


### PR DESCRIPTION
## Summary

Introduces Canonry's hub-and-spoke architecture strategy for capturing hyper-localized and audience-segmented LLM visibility data.

**ADR 0005** defines the architectural decision: local installations act as sensing nodes that sync snapshots to a central hub, with persona-framed queries enabling cross-audience analytics. **Phase 2.7 roadmap** outlines five features: node identity metadata, persona-framed queries, browser provider (Chrome MCP/CDP), hub sync protocol, and cross-node analytics.

## Key Design Decisions

- **Personas as first-class concept**: System instructions (preferred) + query text modification (fallback) enable audience segmentation across existing API providers with zero new infrastructure
- **Hub as a mode flag**: `canonry serve --mode hub` keeps single-artifact philosophy
- **Observation matrix**: `keyword × provider × node × persona` captures dimensions structurally inaccessible to cloud-only tools
- **Defensible differentiation**: Even if providers ship visibility APIs, they'll report aggregate data — not per-location, per-audience breakdowns

## Test Plan

- ✅ Lint: all rules pass
- ✅ Typecheck: no errors
- ✅ ADR follows existing format (Decision → Why → Consequences)
- ✅ Roadmap entries consistent with ADR decisions
- Documentation-only changes; no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)