### PR TITLE
feat: add non-interactive mode to canonry init

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,9 @@ docs/                     Architecture, roadmap, testing, ADRs
 ## Commands
 
 ```bash
+# One-command dev setup: install deps, build all packages, install canonry globally
+./canonry-install.sh
+
 pnpm install
 pnpm run typecheck
 pnpm run test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,19 +12,21 @@ pnpm install
 
 ## Development
 
+To build everything and install the `canonry` CLI globally in one step:
+
+```bash
+./canonry-install.sh
+```
+
+This runs `pnpm install`, builds all packages, and installs `canonry` globally via npm. After that, `canonry --version` should work from any directory.
+
+Individual commands:
+
 ```bash
 pnpm run typecheck          # Type-check all packages
 pnpm run test               # Run test suite
 pnpm run lint               # Lint all packages
 pnpm run dev:web            # Run web dashboard in dev mode
-```
-
-To test the full stack locally:
-
-```bash
-pnpm --filter @ainyc/canonry run build
-node packages/canonry/bin/canonry.mjs init
-node packages/canonry/bin/canonry.mjs serve
 ```
 
 ## Project Structure

--- a/canonry-install.sh
+++ b/canonry-install.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Installing dependencies..."
+pnpm install
+
+echo "Building all packages..."
+pnpm -r run build
+
+echo "Installing canonry globally..."
+npm install -g ./packages/canonry
+
+echo ""
+echo "Done. Run 'canonry --version' to verify."

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.7.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/cli.ts
+++ b/packages/canonry/src/cli.ts
@@ -22,7 +22,8 @@ const USAGE = `
 canonry — AEO monitoring CLI
 
 Usage:
-  canonry init [--force]               Initialize config and database
+  canonry init [--force]               Initialize config and database (interactive)
+  canonry init --gemini-key <key>     Initialize non-interactively (also reads env vars)
   canonry bootstrap [--force]          Bootstrap config/database from env vars
   canonry serve                       Start the local server
   canonry project create <name>       Create a project
@@ -61,6 +62,12 @@ Usage:
   canonry --version                   Show version
 
 Options:
+  --gemini-key <key>   Gemini API key (or GEMINI_API_KEY env var)
+  --openai-key <key>   OpenAI API key (or OPENAI_API_KEY env var)
+  --claude-key <key>   Anthropic API key (or ANTHROPIC_API_KEY env var)
+  --local-url <url>    Local LLM base URL (or LOCAL_BASE_URL env var)
+  --local-model <name> Local LLM model name (default: llama3)
+  --local-key <key>    Local LLM API key (or LOCAL_API_KEY env var)
   --port <port>        Server port (default: 4100)
   --host <host>        Server bind address (default: 127.0.0.1)
   --domain <domain>    Canonical domain for project create
@@ -117,8 +124,28 @@ async function main() {
   try {
     switch (command) {
       case 'init': {
-        const initForce = args.includes('--force') || args.includes('-f')
-        await initCommand({ force: initForce })
+        const { values: initValues } = parseArgs({
+          args: args.slice(1),
+          options: {
+            force: { type: 'boolean', short: 'f', default: false },
+            'gemini-key': { type: 'string' },
+            'openai-key': { type: 'string' },
+            'claude-key': { type: 'string' },
+            'local-url': { type: 'string' },
+            'local-model': { type: 'string' },
+            'local-key': { type: 'string' },
+          },
+          allowPositionals: false,
+        })
+        await initCommand({
+          force: initValues.force,
+          geminiKey: initValues['gemini-key'],
+          openaiKey: initValues['openai-key'],
+          claudeKey: initValues['claude-key'],
+          localUrl: initValues['local-url'],
+          localModel: initValues['local-model'],
+          localKey: initValues['local-key'],
+        })
         break
       }
 

--- a/packages/canonry/src/client.ts
+++ b/packages/canonry/src/client.ts
@@ -14,11 +14,23 @@ export class ApiClient {
       'Content-Type': 'application/json',
     }
 
-    const res = await fetch(url, {
-      method,
-      headers,
-      body: body != null ? JSON.stringify(body) : undefined,
-    })
+    let res: Response
+    try {
+      res = await fetch(url, {
+        method,
+        headers,
+        body: body != null ? JSON.stringify(body) : undefined,
+      })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      if (msg.includes('fetch failed') || msg.includes('ECONNREFUSED') || msg.includes('connect ECONNREFUSED')) {
+        throw new Error(
+          `Could not connect to canonry server at ${this.baseUrl.replace('/api/v1', '')}. ` +
+          'Start it with "canonry serve" (or "canonry serve &" to run in background).',
+        )
+      }
+      throw err
+    }
 
     if (!res.ok) {
       let errorBody: unknown

--- a/packages/canonry/src/commands/init.ts
+++ b/packages/canonry/src/commands/init.ts
@@ -1,12 +1,13 @@
 import crypto from 'node:crypto'
 import fs from 'node:fs'
 import readline from 'node:readline'
+import path from 'node:path'
+import { getBootstrapEnv } from '@ainyc/canonry-config'
 import { getConfigDir, getConfigPath, configExists, saveConfig } from '../config.js'
 import type { CanonryConfig, ProviderConfigEntry } from '../config.js'
 import { trackEvent, showFirstRunNotice } from '../telemetry.js'
 import { createClient, migrate } from '@ainyc/canonry-db'
 import { apiKeys } from '@ainyc/canonry-db'
-import path from 'node:path'
 
 function prompt(question: string): Promise<string> {
   const rl = readline.createInterface({
@@ -27,7 +28,17 @@ const DEFAULT_QUOTA = {
   maxRequestsPerDay: 500,
 }
 
-export async function initCommand(opts?: { force?: boolean }): Promise<void> {
+export interface InitOptions {
+  force?: boolean
+  geminiKey?: string
+  openaiKey?: string
+  claudeKey?: string
+  localUrl?: string
+  localModel?: string
+  localKey?: string
+}
+
+export async function initCommand(opts?: InitOptions): Promise<void> {
   console.log('Initializing canonry...\n')
 
   if (configExists() && !opts?.force) {
@@ -42,39 +53,58 @@ export async function initCommand(opts?: { force?: boolean }): Promise<void> {
     fs.mkdirSync(configDir, { recursive: true })
   }
 
-  // Prompt for provider API keys
+  // Check for non-interactive mode: CLI flags take priority, env vars are fallback
+  const envProviders = getBootstrapEnv(process.env, {
+    GEMINI_API_KEY: opts?.geminiKey,
+    OPENAI_API_KEY: opts?.openaiKey,
+    ANTHROPIC_API_KEY: opts?.claudeKey,
+    LOCAL_BASE_URL: opts?.localUrl,
+    LOCAL_MODEL: opts?.localModel,
+    LOCAL_API_KEY: opts?.localKey,
+  }).providers
+  const nonInteractive = !!(envProviders.gemini || envProviders.openai || envProviders.claude || envProviders.local)
+
   const providers: CanonryConfig['providers'] = {}
 
-  console.log('Configure AI providers (at least one required):\n')
+  if (nonInteractive) {
+    // Non-interactive mode — providers fully resolved by getBootstrapEnv
+    Object.assign(providers, envProviders)
+  } else {
+    // Interactive mode — prompt for each provider
+    console.log('Configure AI providers (at least one required):\n')
+    console.log('Tip: For non-interactive setup, pass --gemini-key, --openai-key,')
+    console.log('--claude-key flags or set GEMINI_API_KEY, OPENAI_API_KEY,')
+    console.log('ANTHROPIC_API_KEY env vars. Or use "canonry bootstrap".\n')
 
-  // Gemini
-  const geminiApiKey = await prompt('Gemini API key (press Enter to skip): ')
-  if (geminiApiKey) {
-    const geminiModel = await prompt('  Gemini model [gemini-2.5-flash]: ') || 'gemini-2.5-flash'
-    providers.gemini = { apiKey: geminiApiKey, model: geminiModel, quota: DEFAULT_QUOTA }
-  }
+    // Gemini
+    const geminiApiKey = await prompt('Gemini API key (press Enter to skip): ')
+    if (geminiApiKey) {
+      const geminiModel = await prompt('  Gemini model [gemini-2.5-flash]: ') || 'gemini-2.5-flash'
+      providers.gemini = { apiKey: geminiApiKey, model: geminiModel, quota: DEFAULT_QUOTA }
+    }
 
-  // OpenAI
-  const openaiApiKey = await prompt('OpenAI API key (press Enter to skip): ')
-  if (openaiApiKey) {
-    const openaiModel = await prompt('  OpenAI model [gpt-4o]: ') || 'gpt-4o'
-    providers.openai = { apiKey: openaiApiKey, model: openaiModel, quota: DEFAULT_QUOTA }
-  }
+    // OpenAI
+    const openaiApiKey = await prompt('OpenAI API key (press Enter to skip): ')
+    if (openaiApiKey) {
+      const openaiModel = await prompt('  OpenAI model [gpt-4o]: ') || 'gpt-4o'
+      providers.openai = { apiKey: openaiApiKey, model: openaiModel, quota: DEFAULT_QUOTA }
+    }
 
-  // Claude
-  const claudeApiKey = await prompt('Anthropic API key (press Enter to skip): ')
-  if (claudeApiKey) {
-    const claudeModel = await prompt('  Claude model [claude-sonnet-4-6]: ') || 'claude-sonnet-4-6'
-    providers.claude = { apiKey: claudeApiKey, model: claudeModel, quota: DEFAULT_QUOTA }
-  }
+    // Claude
+    const claudeApiKey = await prompt('Anthropic API key (press Enter to skip): ')
+    if (claudeApiKey) {
+      const claudeModel = await prompt('  Claude model [claude-sonnet-4-6]: ') || 'claude-sonnet-4-6'
+      providers.claude = { apiKey: claudeApiKey, model: claudeModel, quota: DEFAULT_QUOTA }
+    }
 
-  // Local LLM
-  console.log('\nLocal LLM (Ollama, LM Studio, llama.cpp, vLLM — any OpenAI-compatible API):')
-  const localBaseUrl = await prompt('Local LLM base URL (press Enter to skip, e.g. http://localhost:11434/v1): ')
-  if (localBaseUrl) {
-    const localModel = await prompt('  Model name [llama3]: ') || 'llama3'
-    const localApiKey = await prompt('  API key (press Enter if not needed): ') || undefined
-    providers.local = { baseUrl: localBaseUrl, apiKey: localApiKey, model: localModel, quota: DEFAULT_QUOTA }
+    // Local LLM
+    console.log('\nLocal LLM (Ollama, LM Studio, llama.cpp, vLLM — any OpenAI-compatible API):')
+    const localBaseUrl = await prompt('Local LLM base URL (press Enter to skip, e.g. http://localhost:11434/v1): ')
+    if (localBaseUrl) {
+      const localModel = await prompt('  Model name [llama3]: ') || 'llama3'
+      const localApiKey = await prompt('  API key (press Enter if not needed): ') || undefined
+      providers.local = { baseUrl: localBaseUrl, apiKey: localApiKey, model: localModel, quota: DEFAULT_QUOTA }
+    }
   }
 
   // Validate at least one provider

--- a/packages/canonry/src/config.ts
+++ b/packages/canonry/src/config.ts
@@ -49,14 +49,23 @@ export function loadConfig(): CanonryConfig {
   const configPath = getConfigPath()
   if (!fs.existsSync(configPath)) {
     throw new Error(
-      `Config not found at ${configPath}. Run "canonry init" to create one.`,
+      `Config not found at ${configPath}.\n` +
+      'Run "canonry init" to set up interactively, or "canonry init --gemini-key <key>" for non-interactive setup.\n' +
+      'For CI/Docker, use "canonry bootstrap" with env vars (GEMINI_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY).',
     )
   }
   const raw = fs.readFileSync(configPath, 'utf-8')
   const parsed = parse(raw) as CanonryConfig
   if (!parsed.apiUrl || !parsed.database || !parsed.apiKey) {
+    const missing = [
+      !parsed.apiUrl && 'apiUrl',
+      !parsed.database && 'database',
+      !parsed.apiKey && 'apiKey',
+    ].filter(Boolean).join(', ')
     throw new Error(
-      `Invalid config at ${configPath}. Required fields: apiUrl, database, apiKey`,
+      `Invalid config at ${configPath} — missing: ${missing}.\n` +
+      'These fields are auto-generated. Run "canonry init" (or "canonry init --gemini-key <key>" for non-interactive setup) to create a valid config.\n' +
+      'Do not write config.yaml by hand; use "canonry init" or "canonry bootstrap" instead.',
     )
   }
 

--- a/packages/canonry/test/index.test.ts
+++ b/packages/canonry/test/index.test.ts
@@ -6,8 +6,10 @@ import path from 'node:path'
 import crypto from 'node:crypto'
 import { createClient, migrate, apiKeys } from '@ainyc/canonry-db'
 import { bootstrapCommand } from '../src/commands/bootstrap.js'
+import { initCommand } from '../src/commands/init.js'
 import { getConfigDir, loadConfig } from '../src/config.js'
 import { createServer } from '../src/server.js'
+import { ApiClient } from '../src/client.js'
 
 function restoreEnvVar(name: string, originalValue: string | undefined) {
   if (originalValue === undefined) {
@@ -204,6 +206,64 @@ describe('canonry', () => {
       await app.close()
       fs.rmSync(tmpDir, { recursive: true, force: true })
     }
+  })
+
+  it('initCommand non-interactive mode creates config from flags', async () => {
+    const tmpDir = path.join(os.tmpdir(), `canonry-init-${crypto.randomUUID()}`)
+    const originalConfigDir = process.env.CANONRY_CONFIG_DIR
+    process.env.CANONRY_CONFIG_DIR = tmpDir
+
+    try {
+      await initCommand({
+        force: true,
+        geminiKey: 'test-gemini-key',
+        openaiKey: 'test-openai-key',
+      })
+
+      const config = loadConfig()
+      assert.equal(config.database, path.join(tmpDir, 'data.db'))
+      assert.equal(config.providers?.gemini?.apiKey, 'test-gemini-key')
+      assert.equal(config.providers?.gemini?.model, 'gemini-2.5-flash')
+      assert.equal(config.providers?.openai?.apiKey, 'test-openai-key')
+      assert.equal(config.providers?.openai?.model, 'gpt-4o')
+      assert.equal(config.providers?.claude, undefined)
+      assert.ok(config.apiKey.startsWith('cnry_'))
+    } finally {
+      restoreEnvVar('CANONRY_CONFIG_DIR', originalConfigDir)
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it('initCommand non-interactive mode reads env vars as fallback', async () => {
+    const tmpDir = path.join(os.tmpdir(), `canonry-init-env-${crypto.randomUUID()}`)
+    const originalConfigDir = process.env.CANONRY_CONFIG_DIR
+    const originalAnthropicKey = process.env.ANTHROPIC_API_KEY
+    process.env.CANONRY_CONFIG_DIR = tmpDir
+    process.env.ANTHROPIC_API_KEY = 'test-anthropic-env'
+
+    try {
+      await initCommand({ force: true })
+
+      const config = loadConfig()
+      assert.equal(config.providers?.claude?.apiKey, 'test-anthropic-env')
+      assert.equal(config.providers?.claude?.model, 'claude-sonnet-4-6')
+    } finally {
+      restoreEnvVar('CANONRY_CONFIG_DIR', originalConfigDir)
+      restoreEnvVar('ANTHROPIC_API_KEY', originalAnthropicKey)
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it('ApiClient gives clear error when server is not running', async () => {
+    const client = new ApiClient('http://localhost:19999', 'cnry_fake_key')
+    await assert.rejects(
+      () => client.listProjects(),
+      (err: Error) => {
+        assert.ok(err.message.includes('Could not connect to canonry server'))
+        assert.ok(err.message.includes('canonry serve'))
+        return true
+      },
+    )
   })
 
   it('health endpoint returns ok', async () => {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -131,8 +131,14 @@ export function getPlatformEnv(source: NodeJS.ProcessEnv): PlatformEnv {
   }
 }
 
-export function getBootstrapEnv(source: NodeJS.ProcessEnv): BootstrapEnv {
-  const parsed = bootstrapEnvSchema.parse(source)
+export function getBootstrapEnv(
+  source: NodeJS.ProcessEnv,
+  overrides?: Partial<Record<string, string | undefined>>,
+): BootstrapEnv {
+  const filtered = overrides
+    ? Object.fromEntries(Object.entries(overrides).filter(([, v]) => v != null))
+    : {}
+  const parsed = bootstrapEnvSchema.parse({ ...source, ...filtered })
   const providers: BootstrapEnv['providers'] = {}
 
   if (parsed.GEMINI_API_KEY) {


### PR DESCRIPTION
## Summary

Enables `canonry init` to accept API keys via CLI flags (`--gemini-key`, `--openai-key`, `--claude-key`, `--local-url`) or environment variables, skipping interactive prompts. This makes the tool agent/CI-friendly for non-TTY environments.

Also refactors env var parsing to comply with CLAUDE.md by moving it into `getBootstrapEnv()` in `packages/config`, improves error messages in `ApiClient` and `config.ts`, and adds comprehensive tests for the non-interactive paths.

Includes `canonry-install.sh` for one-command dev setup.

## Test plan

- All 55 existing tests pass
- New tests cover non-interactive init via CLI flags and env var fallback
- New test verifies `ApiClient` gives clear error when server is unreachable
- Linter passes (`pnpm run lint`)