### PR TITLE
fix: align OpenAI prompt with other providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "1.7.0",
+  "version": "1.7.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/provider-openai/src/normalize.ts
+++ b/packages/provider-openai/src/normalize.ts
@@ -87,8 +87,8 @@ export function normalizeResult(raw: OpenAIRawResult): OpenAINormalizedResult {
 
 // --- Internal helpers ---
 
-function buildPrompt(keyword: string): string {
-  return `Search the web for "${keyword}" and provide a comprehensive, factual answer. Include relevant sources.`
+export function buildPrompt(keyword: string): string {
+  return keyword
 }
 
 function extractResponseText(response: OpenAI.Responses.Response): string {

--- a/packages/provider-openai/test/index.test.ts
+++ b/packages/provider-openai/test/index.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { validateConfig, normalizeResult } from '../src/index.js'
+import { validateConfig, normalizeResult, buildPrompt } from '../src/index.js'
 import type { OpenAIRawResult } from '../src/index.js'
 
 const validConfig = {
@@ -127,4 +127,9 @@ test('normalizeResult handles invalid grounding URIs', () => {
 
   const result = normalizeResult(raw)
   assert.deepEqual(result.citedDomains, ['valid.com'])
+})
+
+test('buildPrompt returns the keyword verbatim', () => {
+  assert.equal(buildPrompt('best crm software'), 'best crm software')
+  assert.equal(buildPrompt(''), '')
 })


### PR DESCRIPTION
OpenAI's `buildPrompt` was wrapping keywords in instruction text ("Search the web for... and provide a comprehensive answer"), unlike Gemini which passes keywords verbatim. This inconsistency biases OpenAI results compared to how real users query answer engines.

**Changes:**
- OpenAI prompt now returns keyword as-is, matching Gemini behavior
- Export `buildPrompt` for testability
- Add test verifying prompt behavior
- Patch version bump to 1.7.1

This ensures more consistent cross-provider result comparison.

🤖 Generated with Claude Code