### PR TITLE
Add Docker Hub publish and OpenAPI spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths:
       - '.github/workflows/ci.yml'
+      - '.dockerignore'
+      - 'Dockerfile'
+      - 'docker/**'
       - 'apps/**'
       - 'packages/**'
       - 'package.json'
@@ -16,6 +19,9 @@ on:
     branches: [main]
     paths:
       - '.github/workflows/ci.yml'
+      - '.dockerignore'
+      - 'Dockerfile'
+      - 'docker/**'
       - 'apps/**'
       - 'packages/**'
       - 'package.json'
@@ -42,3 +48,38 @@ jobs:
       - run: pnpm run typecheck
       - run: pnpm run test
       - run: pnpm run lint
+
+  docker-build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          load: true
+          tags: canonry:ci
+
+      - name: Smoke test container
+        shell: bash
+        run: |
+          docker run -d --rm --name canonry-ci -p 4100:4100 -e CANONRY_API_KEY=test canonry:ci
+
+          for attempt in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:4100/health >/dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+
+          docker logs canonry-ci
+          exit 1
+
+      - name: Cleanup smoke container
+        if: always()
+        run: docker rm -f canonry-ci || true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,62 +1,171 @@
-name: Publish to npm
+name: Publish
 
 on:
   push:
     branches: [main]
     paths:
-      - 'packages/canonry/package.json'
+      - '.github/workflows/publish.yml'
+      - '.dockerignore'
+      - 'Dockerfile'
+      - 'docker/**'
+      - 'apps/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'tsconfig.base.json'
+      - 'eslint.config.js'
+  workflow_dispatch:
 
 jobs:
-  publish:
+  version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.package.outputs.version }}
+      version_changed: ${{ steps.package.outputs.version_changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Read Canonry package version
+        id: package
+        shell: bash
+        run: |
+          VERSION=$(node -p "require('./packages/canonry/package.json').version")
+          PREVIOUS=""
+
+          if git rev-parse HEAD~1 >/dev/null 2>&1; then
+            PREVIOUS=$(git show HEAD~1:packages/canonry/package.json 2>/dev/null | node -e "let json=''; process.stdin.on('data', (chunk) => json += chunk); process.stdin.on('end', () => { try { console.log(JSON.parse(json).version ?? '') } catch { process.exit(1) } });" 2>/dev/null || true)
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+          if [ -n "$PREVIOUS" ] && [ "$VERSION" != "$PREVIOUS" ]; then
+            echo "version_changed=true" >> "$GITHUB_OUTPUT"
+            echo "Version changed: $PREVIOUS -> $VERSION"
+          else
+            echo "version_changed=false" >> "$GITHUB_OUTPUT"
+            if [ -n "$PREVIOUS" ]; then
+              echo "Version unchanged ($VERSION), skipping npm publish"
+            else
+              echo "No previous package version available, skipping npm publish"
+            fi
+          fi
+
+  publish-npm:
+    needs: version
+    if: github.ref_name == github.event.repository.default_branch && github.event_name == 'push' && needs.version.outputs.version_changed == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-
-      - name: Check if version changed
-        id: version-check
-        run: |
-          CURRENT=$(node -p "require('./packages/canonry/package.json').version")
-          PREVIOUS=$(git show HEAD~1:packages/canonry/package.json 2>/dev/null | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).version" 2>/dev/null || echo "")
-          if [ "$CURRENT" = "$PREVIOUS" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "Version unchanged ($CURRENT), skipping publish"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-            echo "Version changed: $PREVIOUS -> $CURRENT"
-          fi
 
       - uses: pnpm/action-setup@v4
-        if: steps.version-check.outputs.skip != 'true'
         with:
           version: 10.28.2
 
       - uses: actions/setup-node@v4
-        if: steps.version-check.outputs.skip != 'true'
         with:
           node-version: 22
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
       - run: pnpm install --frozen-lockfile
-        if: steps.version-check.outputs.skip != 'true'
 
       - run: pnpm run typecheck
-        if: steps.version-check.outputs.skip != 'true'
 
       - run: pnpm run test
-        if: steps.version-check.outputs.skip != 'true'
 
       - name: Copy root README into package
-        if: steps.version-check.outputs.skip != 'true'
         run: cp README.md packages/canonry/README.md
 
       - name: Build and publish
-        if: steps.version-check.outputs.skip != 'true'
         run: pnpm --filter @ainyc/canonry publish --no-git-checks --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-docker:
+    needs: version
+    if: github.ref_name == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Resolve Docker Hub image
+        id: image
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_REPOSITORY: ${{ vars.DOCKERHUB_REPOSITORY }}
+        shell: bash
+        run: |
+          if [ -z "$DOCKERHUB_USERNAME" ]; then
+            echo "DOCKERHUB_USERNAME secret is required" >&2
+            exit 1
+          fi
+
+          IMAGE="${DOCKERHUB_REPOSITORY:-$DOCKERHUB_USERNAME/canonry}"
+          IMAGE=$(printf '%s' "$IMAGE" | tr '[:upper:]' '[:lower:]')
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve Docker tags
+        id: tags
+        env:
+          IMAGE: ${{ steps.image.outputs.image }}
+          VERSION: ${{ needs.version.outputs.version }}
+          VERSION_CHANGED: ${{ needs.version.outputs.version_changed }}
+          EVENT_NAME: ${{ github.event_name }}
+        shell: bash
+        run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+
+          {
+            echo "tags<<EOF"
+            echo "$IMAGE:latest"
+            echo "$IMAGE:sha-$SHORT_SHA"
+            if [ "$EVENT_NAME" = "push" ] && [ "$VERSION_CHANGED" = "true" ]; then
+              echo "$IMAGE:$VERSION"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Resolve OCI labels
+        id: labels
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+        shell: bash
+        run: |
+          {
+            echo "labels<<EOF"
+            echo "org.opencontainers.image.title=canonry"
+            echo "org.opencontainers.image.description=Open-source AEO monitoring for your domain."
+            echo "org.opencontainers.image.source=https://github.com/AINYC/canonry"
+            echo "org.opencontainers.image.url=https://github.com/AINYC/canonry"
+            echo "org.opencontainers.image.revision=$GITHUB_SHA"
+            echo "org.opencontainers.image.version=$VERSION"
+            echo "org.opencontainers.image.licenses=FSL-1.1-ALv2"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          labels: ${{ steps.labels.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -303,6 +303,14 @@ docker run --rm \
   canonry
 ```
 
+GitHub Actions can publish the same root image to Docker Hub. Configure these repository settings first:
+
+- Secret `DOCKERHUB_USERNAME`
+- Secret `DOCKERHUB_TOKEN`
+- Optional repository variable `DOCKERHUB_REPOSITORY` if you want something other than `<DOCKERHUB_USERNAME>/canonry`
+
+`.github/workflows/ci.yml` now builds and boots the container on pushes and PRs, and `.github/workflows/publish.yml` pushes `latest` plus `sha-<commit>` tags on `main`. When `packages/canonry/package.json` changes version, the publish workflow also pushes that semver tag and publishes the npm package.
+
 Keep the container to a single replica and mount persistent storage at `/data` so SQLite and `config.yaml` survive restarts.
 
 No CORS configuration is required for this Docker setup. The dashboard and API are served by the same Canonry process on the same origin. CORS only becomes relevant if you split the frontend and API onto different domains.

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -24,6 +24,10 @@ export function buildApp(env: PlatformEnv) {
   app.register(apiRoutes, {
     db,
     skipAuth: false,
+    openApiInfo: {
+      title: 'Canonry API',
+      version: '0.1.0',
+    },
     providerSummary,
   })
 

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -56,6 +56,13 @@ test('buildApp registers health and API routes', async (t) => {
     [200, 401].includes(projectsResponse.statusCode),
     `Expected 200 or 401 but got ${projectsResponse.statusCode}`,
   )
+
+  const openApiResponse = await app.inject({
+    method: 'GET',
+    url: '/api/v1/openapi.json',
+  })
+  assert.equal(openApiResponse.statusCode, 200)
+  assert.equal(openApiResponse.json().info.version, '0.1.0')
 })
 
 test('loadApiEnv delegates to shared platform config', () => {

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -10,6 +10,8 @@ import { runRoutes } from './runs.js'
 import type { RunRoutesOptions } from './runs.js'
 import { applyRoutes } from './apply.js'
 import { historyRoutes } from './history.js'
+import { openApiRoutes } from './openapi.js'
+import type { OpenApiInfo } from './openapi.js'
 import { settingsRoutes } from './settings.js'
 import type { SettingsRoutesOptions, ProviderSummaryEntry } from './settings.js'
 import { telemetryRoutes } from './telemetry.js'
@@ -26,6 +28,7 @@ declare module 'fastify' {
 
 export interface ApiRoutesOptions {
   db: DatabaseClient
+  openApiInfo?: OpenApiInfo
   /** Skip auth for testing */
   skipAuth?: boolean
   /** Callback when a run is created (wire up job runner) */
@@ -56,6 +59,7 @@ export async function apiRoutes(app: FastifyInstance, opts: ApiRoutesOptions) {
 
   // Register route plugins under /api/v1
   await app.register(async (api) => {
+    await api.register(openApiRoutes, opts.openApiInfo ?? {})
     await api.register(projectRoutes, {
       onProjectDeleted: opts.onProjectDeleted,
     } satisfies ProjectRoutesOptions)

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -1,0 +1,713 @@
+import type { FastifyInstance } from 'fastify'
+
+export interface OpenApiInfo {
+  title?: string
+  version?: string
+  description?: string
+}
+
+type HttpMethod = 'get' | 'post' | 'put' | 'delete'
+
+interface OpenApiParameter {
+  name: string
+  in: 'path' | 'query'
+  required?: boolean
+  description: string
+  schema: Record<string, unknown>
+}
+
+interface OpenApiOperation {
+  method: HttpMethod
+  path: string
+  summary: string
+  tags: string[]
+  auth?: boolean
+  description?: string
+  parameters?: OpenApiParameter[]
+  requestBody?: {
+    required?: boolean
+    description?: string
+    content: Record<string, { schema: Record<string, unknown> }>
+  }
+  responses: Record<string, { description: string }>
+}
+
+const stringSchema = { type: 'string' }
+const booleanSchema = { type: 'boolean' }
+const integerSchema = { type: 'integer' }
+const objectSchema = { type: 'object', additionalProperties: true }
+const stringArraySchema = { type: 'array', items: stringSchema }
+
+const nameParameter: OpenApiParameter = {
+  name: 'name',
+  in: 'path',
+  required: true,
+  description: 'Project name.',
+  schema: stringSchema,
+}
+
+const runIdParameter: OpenApiParameter = {
+  name: 'id',
+  in: 'path',
+  required: true,
+  description: 'Run ID.',
+  schema: stringSchema,
+}
+
+const notificationIdParameter: OpenApiParameter = {
+  name: 'id',
+  in: 'path',
+  required: true,
+  description: 'Notification ID.',
+  schema: stringSchema,
+}
+
+const providerNameParameter: OpenApiParameter = {
+  name: 'name',
+  in: 'path',
+  required: true,
+  description: 'Provider name.',
+  schema: { type: 'string', enum: ['gemini', 'openai', 'claude', 'local'] },
+}
+
+const routeCatalog: OpenApiOperation[] = [
+  {
+    method: 'get',
+    path: '/api/v1/openapi.json',
+    summary: 'Get the OpenAPI document',
+    description: 'Machine-readable description of the Canonry API surface.',
+    tags: ['meta'],
+    auth: false,
+    responses: {
+      200: { description: 'OpenAPI document.' },
+    },
+  },
+  {
+    method: 'put',
+    path: '/api/v1/projects/{name}',
+    summary: 'Create or update a project',
+    tags: ['projects'],
+    parameters: [nameParameter],
+    requestBody: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            required: ['displayName', 'canonicalDomain', 'country', 'language'],
+            properties: {
+              displayName: stringSchema,
+              canonicalDomain: stringSchema,
+              country: stringSchema,
+              language: stringSchema,
+              tags: stringArraySchema,
+              labels: objectSchema,
+              providers: stringArraySchema,
+              configSource: stringSchema,
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: { description: 'Project updated.' },
+      201: { description: 'Project created.' },
+    },
+  },
+  {
+    method: 'get',
+    path: '/api/v1/projects',
+    summary: 'List projects',
+    tags: ['projects'],
+    responses: {
+      200: { description: 'Projects returned.' },
+    },
+  },
+  {
+    method: 'get',
+    path: '/api/v1/projects/{name}',
+    summary: 'Get a project',
+    tags: ['projects'],
+    parameters: [nameParameter],
+    responses: {
+      200: { description: 'Project returned.' },
+      404: { description: 'Project not found.' },
+    },
+  },
+  {
+    method: 'delete',
+    path: '/api/v1/projects/{name}',
+    summary: 'Delete a project',
+    tags: ['projects'],
+    parameters: [nameParameter],
+    responses: {
+      204: { description: 'Project deleted.' },
+      404: { description: 'Project not found.' },
+    },
+  },
+  {
+    method: 'get',
+    path: '/api/v1/projects/{name}/export',
+    summary: 'Export a project as config',
+    tags: ['projects'],
+    parameters: [nameParameter],
+    responses: {
+      200: { description: 'Project configuration returned.' },
+      404: { description: 'Project not found.' },
+    },
+  },
+  {
+    method: 'get',
+    path: '/api/v1/projects/{name}/keywords',
+    summary: 'List keywords',
+    tags: ['keywords'],
+    parameters: [nameParameter],
+    responses: {
+      200: { description: 'Keywords returned.' },
+    },
+  },
+  {
+    method: 'put',
+    path: '/api/v1/projects/{name}/keywords',
+    summary: 'Replace keywords',
+    tags: ['keywords'],
+    parameters: [nameParameter],
+    requestBody: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            required: ['keywords'],
+            properties: {
+              keywords: stringArraySchema,
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: { description: 'Keywords replaced.' },
+    },
+  },
+  {
+    method: 'post',
+    path: '/api/v1/projects/{name}/keywords',
+    summary: 'Append keywords',
+    tags: ['keywords'],
+    parameters: [nameParameter],
+    requestBody: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            required: ['keywords'],
+            properties: {
+              keywords: stringArraySchema,
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: { description: 'Keywords appended.' },
+    },
+  },
+  {
+    method: 'post',
+    path: '/api/v1/projects/{name}/keywords/generate',
+    summary: 'Generate keyword suggestions',
+    tags: ['keywords'],
+    parameters: [nameParameter],
+    requestBody: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            required: ['provider'],
+            properties: {
+              provider: { type: 'string', enum: ['gemini', 'openai', 'claude', 'local'] },
+              count: integerSchema,
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: { description: 'Keyword suggestions returned.' },
+      501: { description: 'Keyword generation is not available.' },
+    },
+  },
+  {
+    method: 'get',
+    path: '/api/v1/projects/{name}/competitors',
+    summary: 'List competitors',
+    tags: ['competitors'],
+    parameters: [nameParameter],
+    responses: {
+      200: { description: 'Competitors returned.' },
+    },
+  },
+  {
+    method: 'put',
+    path: '/api/v1/projects/{name}/competitors',
+    summary: 'Replace competitors',
+    tags: ['competitors'],
+    parameters: [nameParameter],
+    requestBody: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            required: ['competitors'],
+            properties: {
+              competitors: stringArraySchema,
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: { description: 'Competitors replaced.' },
+    },
+  },
+  {
+    method: 'post',
+    path: '/api/v1/projects/{name}/runs',
+    summary: 'Trigger a project run',
+    tags: ['runs'],
+    parameters: [nameParameter],
+    requestBody: {
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              kind: stringSchema,
+              trigger: stringSchema,
+              providers: stringArraySchema,
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      201: { description: 'Run queued.' },
+      409: { description: 'Run already in progress.' },
+    },
+  },
+  {
+    method: 'get',
+    path: '/api/v1/projects/{name}/runs',
+    summary: 'List project runs',
+    tags: ['runs'],
+    parameters: [nameParameter],
+    responses: {
+      200: { description: 'Runs returned.' },
+    },
+  },
+  {
+    method: 'get',
+    path: '/api/v1/runs',
+    summary: 'List all runs',
+    tags: ['runs'],
+    responses: {
+      200: { description: 'Runs returned.' },
+    },
+  },
+  {
+    method: 'post',
+    path: '/api/v1/runs',
+    summary: 'Trigger runs for all projects',
+    tags: ['runs'],
+    requestBody: {
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              kind: stringSchema,
+              providers: stringArraySchema,
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      207: { description: 'Run results returned.' },
+    },
+  },
+  {
+    method: 'get',
+    path: '/api/v1/runs/{id}',
+    summary: 'Get a run and its snapshots',
+    tags: ['runs'],
+    parameters: [runIdParameter],
+    responses: {
+      200: { description: 'Run returned.' },
+      404: { description: 'Run not found.' },
+    },
+  },
+  {
+    method: 'post',
+    path: '/api/v1/apply',
+    summary: 'Apply a Canonry config document',
+    tags: ['config'],
+    requestBody: {
+      required: true,
+      description: 'Canonry project configuration as JSON.',
+      content: {
+        'application/json': {
+          schema: objectSchema,
+        },
+      },
+    },
+    responses: {
+      200: { description: 'Config applied.' },
+      400: { description: 'Invalid config.' },
+    },
+  },
+  {
+    method: 'get',
+    path: '/api/v1/projects/{name}/history',
+    summary: 'Get project audit history',
+    tags: ['history'],
+    parameters: [nameParameter],
+    responses: {
+      200: { description: 'Audit history returned.' },
+    },
+  },
+  {
+    method: 'get',
+    path: '/api/v1/history',
+    summary: 'Get global audit history',
+    tags: ['history'],
+    responses: {
+      200: { description: 'Audit history returned.' },
+    },
+  },
+  {
+    method: 'get',
+    path: '/api/v1/projects/{name}/snapshots',
+    summary: 'List query snapshots',
+    tags: ['history'],
+    parameters: [
+      nameParameter,
+      {
+        name: 'limit',
+        in: 'query',
+        description: 'Maximum number of snapshots to return.',
+        schema: integerSchema,
+      },
+      {
+        name: 'offset',
+        in: 'query',
+        description: 'Number of snapshots to skip.',
+        schema: integerSchema,
+      },
+    ],
+    responses: {
+      200: { description: 'Snapshots returned.' },
+    },
+  },
+  {
+    method: 'get',
+    path: '/api/v1/projects/{name}/timeline',
+    summary: 'Get keyword timeline',
+    tags: ['history'],
+    parameters: [nameParameter],
+    responses: {
+      200: { description: 'Timeline returned.' },
+    },
+  },
+  {
+    method: 'get',
+    path: '/api/v1/projects/{name}/snapshots/diff',
+    summary: 'Compare two runs',
+    tags: ['history'],
+    parameters: [
+      nameParameter,
+      {
+        name: 'run1',
+        in: 'query',
+        required: true,
+        description: 'First run ID.',
+        schema: stringSchema,
+      },
+      {
+        name: 'run2',
+        in: 'query',
+        required: true,
+        description: 'Second run ID.',
+        schema: stringSchema,
+      },
+    ],
+    responses: {
+      200: { description: 'Diff returned.' },
+      400: { description: 'Missing run IDs.' },
+    },
+  },
+  {
+    method: 'get',
+    path: '/api/v1/settings',
+    summary: 'Get provider settings summary',
+    tags: ['settings'],
+    responses: {
+      200: { description: 'Settings returned.' },
+    },
+  },
+  {
+    method: 'put',
+    path: '/api/v1/settings/providers/{name}',
+    summary: 'Update provider settings',
+    tags: ['settings'],
+    parameters: [providerNameParameter],
+    requestBody: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              apiKey: stringSchema,
+              baseUrl: stringSchema,
+              model: stringSchema,
+              quota: objectSchema,
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: { description: 'Provider updated.' },
+      400: { description: 'Invalid provider settings.' },
+      501: { description: 'Provider updates are not supported.' },
+    },
+  },
+  {
+    method: 'put',
+    path: '/api/v1/projects/{name}/schedule',
+    summary: 'Create or update a schedule',
+    tags: ['schedules'],
+    parameters: [nameParameter],
+    requestBody: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              preset: stringSchema,
+              cron: stringSchema,
+              timezone: stringSchema,
+              providers: stringArraySchema,
+              enabled: booleanSchema,
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: { description: 'Schedule updated.' },
+      201: { description: 'Schedule created.' },
+    },
+  },
+  {
+    method: 'get',
+    path: '/api/v1/projects/{name}/schedule',
+    summary: 'Get a schedule',
+    tags: ['schedules'],
+    parameters: [nameParameter],
+    responses: {
+      200: { description: 'Schedule returned.' },
+      404: { description: 'Schedule not found.' },
+    },
+  },
+  {
+    method: 'delete',
+    path: '/api/v1/projects/{name}/schedule',
+    summary: 'Delete a schedule',
+    tags: ['schedules'],
+    parameters: [nameParameter],
+    responses: {
+      204: { description: 'Schedule deleted.' },
+      404: { description: 'Schedule not found.' },
+    },
+  },
+  {
+    method: 'get',
+    path: '/api/v1/notifications/events',
+    summary: 'List notification event types',
+    tags: ['notifications'],
+    responses: {
+      200: { description: 'Events returned.' },
+    },
+  },
+  {
+    method: 'post',
+    path: '/api/v1/projects/{name}/notifications',
+    summary: 'Create a notification',
+    tags: ['notifications'],
+    parameters: [nameParameter],
+    requestBody: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            required: ['channel', 'url', 'events'],
+            properties: {
+              channel: stringSchema,
+              url: stringSchema,
+              events: stringArraySchema,
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      201: { description: 'Notification created.' },
+    },
+  },
+  {
+    method: 'get',
+    path: '/api/v1/projects/{name}/notifications',
+    summary: 'List notifications',
+    tags: ['notifications'],
+    parameters: [nameParameter],
+    responses: {
+      200: { description: 'Notifications returned.' },
+    },
+  },
+  {
+    method: 'delete',
+    path: '/api/v1/projects/{name}/notifications/{id}',
+    summary: 'Delete a notification',
+    tags: ['notifications'],
+    parameters: [nameParameter, notificationIdParameter],
+    responses: {
+      204: { description: 'Notification deleted.' },
+      404: { description: 'Notification not found.' },
+    },
+  },
+  {
+    method: 'post',
+    path: '/api/v1/projects/{name}/notifications/{id}/test',
+    summary: 'Send a test notification',
+    tags: ['notifications'],
+    parameters: [nameParameter, notificationIdParameter],
+    responses: {
+      200: { description: 'Test notification sent.' },
+      400: { description: 'Stored notification config is invalid.' },
+      404: { description: 'Notification not found.' },
+      502: { description: 'Notification delivery failed.' },
+    },
+  },
+  {
+    method: 'get',
+    path: '/api/v1/telemetry',
+    summary: 'Get telemetry status',
+    tags: ['telemetry'],
+    responses: {
+      200: { description: 'Telemetry status returned.' },
+      501: { description: 'Telemetry status is not available.' },
+    },
+  },
+  {
+    method: 'put',
+    path: '/api/v1/telemetry',
+    summary: 'Update telemetry status',
+    tags: ['telemetry'],
+    requestBody: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            required: ['enabled'],
+            properties: {
+              enabled: booleanSchema,
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: { description: 'Telemetry updated.' },
+      400: { description: 'Invalid telemetry request.' },
+      501: { description: 'Telemetry configuration is not available.' },
+    },
+  },
+]
+
+export function buildOpenApiDocument(info: OpenApiInfo = {}) {
+  const paths = routeCatalog.reduce<Record<string, Record<string, unknown>>>((acc, route) => {
+    const operation: Record<string, unknown> = {
+      summary: route.summary,
+      tags: route.tags,
+      responses: route.responses,
+      operationId: buildOperationId(route.method, route.path),
+    }
+
+    if (route.description) operation.description = route.description
+    if (route.parameters) operation.parameters = route.parameters
+    if (route.requestBody) operation.requestBody = route.requestBody
+    if (route.auth === false) operation.security = []
+
+    const pathItem = acc[route.path] ?? {}
+    pathItem[route.method] = operation
+    acc[route.path] = pathItem
+    return acc
+  }, {})
+
+  return {
+    openapi: '3.1.0',
+    info: {
+      title: info.title ?? 'Canonry API',
+      version: info.version ?? '0.0.0',
+      description: info.description ?? 'REST API for Canonry projects, runs, schedules, and notifications.',
+    },
+    servers: [
+      {
+        url: '/',
+      },
+    ],
+    security: [{ bearerAuth: [] }],
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'API key',
+        },
+      },
+    },
+    paths,
+  }
+}
+
+export async function openApiRoutes(app: FastifyInstance, opts: OpenApiInfo = {}) {
+  app.get('/openapi.json', async (_request, reply) => {
+    return reply.type('application/json').send(buildOpenApiDocument(opts))
+  })
+}
+
+function buildOperationId(method: HttpMethod, path: string): string {
+  const parts = path
+    .split('/')
+    .filter(Boolean)
+    .map((part) => {
+      if (part.startsWith('{') && part.endsWith('}')) {
+        return `by-${part.slice(1, -1)}`
+      }
+      return part
+    })
+
+  return [method, ...parts]
+    .join('-')
+    .replace(/[^a-zA-Z0-9]+(.)/g, (_match, char: string) => char.toUpperCase())
+    .replace(/^[^a-zA-Z]+/, '')
+}

--- a/packages/api-routes/test/index.test.ts
+++ b/packages/api-routes/test/index.test.ts
@@ -62,6 +62,22 @@ describe('api-routes', () => {
     assert.equal(body[0].name, 'my-site')
   })
 
+  it('GET /api/v1/openapi.json returns the API spec', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/v1/openapi.json' })
+    assert.equal(res.statusCode, 200)
+    assert.match(res.headers['content-type'] ?? '', /application\/json/)
+
+    const body = JSON.parse(res.payload) as {
+      openapi: string
+      paths: Record<string, Record<string, { security?: unknown[] }>>
+    }
+
+    assert.equal(body.openapi, '3.1.0')
+    assert.ok(body.paths['/api/v1/openapi.json'])
+    assert.ok(body.paths['/api/v1/projects'])
+    assert.deepEqual(body.paths['/api/v1/openapi.json']?.get?.security, [])
+  })
+
   it('GET /api/v1/projects/:name gets a single project', async () => {
     const res = await app.inject({ method: 'GET', url: '/api/v1/projects/my-site' })
     assert.equal(res.statusCode, 200)

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -130,6 +130,10 @@ export async function createServer(opts: {
   await app.register(apiRoutes, {
     db: opts.db,
     skipAuth: false,
+    openApiInfo: {
+      title: 'Canonry API',
+      version: PKG_VERSION,
+    },
     providerSummary,
     onRunCreated: (runId: string, projectId: string, providers?: string[]) => {
       // Fire and forget — run executes in background

--- a/packages/canonry/test/index.test.ts
+++ b/packages/canonry/test/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
 import os from 'node:os'
 import fs from 'node:fs'
 import path from 'node:path'
@@ -10,6 +11,9 @@ import { initCommand } from '../src/commands/init.js'
 import { getConfigDir, loadConfig } from '../src/config.js'
 import { createServer } from '../src/server.js'
 import { ApiClient } from '../src/client.js'
+
+const _require = createRequire(import.meta.url)
+const { version: PKG_VERSION } = _require('../package.json') as { version: string }
 
 function restoreEnvVar(name: string, originalValue: string | undefined) {
   if (originalValue === undefined) {
@@ -303,6 +307,56 @@ describe('canonry', () => {
       assert.equal(res.statusCode, 200)
       const body = JSON.parse(res.body) as { status: string }
       assert.equal(body.status, 'ok')
+    } finally {
+      await app.close()
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it('openapi endpoint is public and reports the Canonry version', async () => {
+    const tmpDir = path.join(os.tmpdir(), `canonry-test-${crypto.randomUUID()}`)
+    fs.mkdirSync(tmpDir, { recursive: true })
+    const dbPath = path.join(tmpDir, 'test.db')
+
+    const db = createClient(dbPath)
+    migrate(db)
+
+    const rawKey = `cnry_${crypto.randomBytes(16).toString('hex')}`
+    const keyHash = crypto.createHash('sha256').update(rawKey).digest('hex')
+    db.insert(apiKeys).values({
+      id: crypto.randomUUID(),
+      name: 'test',
+      keyHash,
+      keyPrefix: rawKey.slice(0, 9),
+      scopes: '["*"]',
+      createdAt: new Date().toISOString(),
+    }).run()
+
+    const app = await createServer({
+      config: {
+        apiUrl: 'http://localhost:4100',
+        database: dbPath,
+        apiKey: rawKey,
+        geminiApiKey: 'test-key',
+      },
+      db,
+    })
+
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/v1/openapi.json',
+      })
+
+      assert.equal(res.statusCode, 200)
+      const body = JSON.parse(res.body) as {
+        info: { version: string }
+        paths: Record<string, Record<string, { security?: unknown[] }>>
+      }
+
+      assert.equal(body.info.version, PKG_VERSION)
+      assert.ok(body.paths['/api/v1/projects/{name}'])
+      assert.deepEqual(body.paths['/api/v1/openapi.json']?.get?.security, [])
     } finally {
       await app.close()
       fs.rmSync(tmpDir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- add CI coverage for the root Docker image and publish the Canonry container to Docker Hub from GitHub Actions
- expose `/api/v1/openapi.json` from the shared API routes and wire version metadata into both app entrypoints
- document the Docker Hub setup and add regression tests for the new OpenAPI endpoint

## Testing
- pnpm run typecheck
- pnpm --filter @ainyc/canonry-api-routes test
- pnpm --filter @ainyc/canonry-api test
- pnpm --filter @ainyc/canonry test