### PR TITLE
fix: filter dashboard to answer-visibility runs only

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5052,7 +5052,7 @@ async function loadDashboardData(): Promise<DashboardVm | null> {
       projects.map(async (project) => {
         const projectRuns = allRuns.filter(r => r.projectId === project.id)
         const completedRuns = projectRuns
-          .filter(r => r.status === 'completed' || r.status === 'partial')
+          .filter(r => (r.status === 'completed' || r.status === 'partial') && r.kind === 'answer-visibility')
           .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
 
         const [kws, comps, timeline, latestRunDetail, previousRunDetail] = await Promise.all([


### PR DESCRIPTION
## Problem

When a `gsc-sync` run is the most recent completed run, the dashboard shows **"No data"** for Answer Visibility. GSC sync runs have zero snapshots, so `computeKeywordVisibility()` returns an empty score.

## Root Cause

`completedRuns` in `App.tsx` filtered only by `status` (`completed` or `partial`), not by `kind`. The latest `gsc-sync` run sorted first and was selected as `latestRunDetail` — which has no snapshots.

## Fix

Filter `completedRuns` to `kind === 'answer-visibility'` so the dashboard always picks the latest visibility sweep.

## Test

1. Run a GSC sync (`canonry google sync <project>`)
2. Confirm the dashboard still shows Answer Visibility data from the latest sweep
3. Confirm `canonry evidence <project>` matches the UI