### PR TITLE
fix: disable telemetry by default (opt-in)

### DIFF
--- a/packages/canonry/src/telemetry.ts
+++ b/packages/canonry/src/telemetry.ts
@@ -28,13 +28,13 @@ export function isTelemetryEnabled(): boolean {
   if (process.env.DO_NOT_TRACK === '1') return false
   if (process.env.CI) return false
 
-  if (!configExists()) return true
+  if (!configExists()) return false
 
   try {
     const config = loadConfig()
-    return config.telemetry !== false
+    return config.telemetry === true
   } catch {
-    return true
+    return false
   }
 }
 


### PR DESCRIPTION
## Summary

Changes telemetry from **opt-out** to **opt-in**.

Previously telemetry was enabled unless explicitly disabled. Now it is disabled unless explicitly enabled.

## Changes

`packages/canonry/src/telemetry.ts`:
- `isTelemetryEnabled()` returns `false` when no config exists (was `true`)
- Config check now looks for `telemetry === true` (was `telemetry !== false`)

## Behavior

| Scenario | Before | After |
|---|---|---|
| Fresh install, no config | ✅ enabled | ❌ disabled |
| Config with no telemetry field | ✅ enabled | ❌ disabled |
| Config with `telemetry: false` | ❌ disabled | ❌ disabled |
| Config with `telemetry: true` | ✅ enabled | ✅ enabled |
| `CANONRY_TELEMETRY_DISABLED=1` | ❌ disabled | ❌ disabled |
| `DO_NOT_TRACK=1` | ❌ disabled | ❌ disabled |
| CI environment | ❌ disabled | ❌ disabled |

Users who want to opt in can set `telemetry: true` in `~/.canonry/config.yaml` or run `canonry telemetry enable`.