### PR TITLE
feat: add canonry google request-indexing command

### DIFF
--- a/packages/api-routes/src/google.ts
+++ b/packages/api-routes/src/google.ts
@@ -11,7 +11,9 @@ import {
   listSites,
   listSitemaps,
   inspectUrl as gscInspectUrl,
+  requestIndexing,
   GSC_SCOPE,
+  INDEXING_DAILY_LIMIT,
 } from '@ainyc/canonry-integration-google'
 
 export interface GoogleConnectionRecord {
@@ -892,5 +894,93 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
     }
 
     return { propertyId }
+  })
+
+  // POST /projects/:name/google/gsc/request-indexing
+  app.post<{
+    Params: { name: string }
+    Body: { url: string; wait?: boolean }
+  }>('/projects/:name/google/gsc/request-indexing', async (request, reply) => {
+    const { clientId: googleClientId, clientSecret: googleClientSecret } = getAuthConfig()
+    if (!googleClientId || !googleClientSecret) {
+      const err = validationError('Google OAuth is not configured')
+      return reply.status(err.statusCode).send(err.toJSON())
+    }
+
+    const store = requireConnectionStore(reply)
+    if (!store) return
+
+    const project = resolveProject(app.db, request.params.name)
+    const { url } = request.body ?? {}
+    if (!url) {
+      const err = validationError('url is required')
+      return reply.status(err.statusCode).send(err.toJSON())
+    }
+
+    const { accessToken } = await getValidToken(store, project.canonicalDomain, 'gsc', googleClientId, googleClientSecret)
+    const result = await requestIndexing(accessToken, url, 'URL_UPDATED')
+    const notifyTime = result.urlNotificationMetadata?.latestUpdate?.notifyTime ?? new Date().toISOString()
+
+    return {
+      url,
+      notifiedAt: notifyTime,
+      type: 'URL_UPDATED',
+    }
+  })
+
+  // POST /projects/:name/google/gsc/request-indexing/all
+  app.post<{ Params: { name: string } }>('/projects/:name/google/gsc/request-indexing/all', async (request, reply) => {
+    const { clientId: googleClientId, clientSecret: googleClientSecret } = getAuthConfig()
+    if (!googleClientId || !googleClientSecret) {
+      const err = validationError('Google OAuth is not configured')
+      return reply.status(err.statusCode).send(err.toJSON())
+    }
+
+    const store = requireConnectionStore(reply)
+    if (!store) return
+
+    const project = resolveProject(app.db, request.params.name)
+
+    // Fetch URLs with non-indexed state from latest inspection data
+    const unindexed = app.db
+      .select({ url: gscUrlInspections.url })
+      .from(gscUrlInspections)
+      .where(
+        and(
+          eq(gscUrlInspections.projectId, project.id),
+          sql`${gscUrlInspections.indexingState} IN ('URL_IS_UNKNOWN_TO_GOOGLE', 'EXCLUDED', 'ERROR')`,
+        ),
+      )
+      .orderBy(desc(gscUrlInspections.inspectedAt))
+      .all()
+
+    // Deduplicate — latest inspection per URL
+    const seen = new Set<string>()
+    const urls: string[] = []
+    for (const row of unindexed) {
+      if (!seen.has(row.url)) {
+        seen.add(row.url)
+        urls.push(row.url)
+      }
+    }
+
+    if (urls.length > INDEXING_DAILY_LIMIT) {
+      const err = validationError(`${urls.length} unindexed URLs exceeds the daily Indexing API limit of ${INDEXING_DAILY_LIMIT}. Run with a specific URL or reduce the scope.`)
+      return reply.status(err.statusCode).send(err.toJSON())
+    }
+
+    const { accessToken } = await getValidToken(store, project.canonicalDomain, 'gsc', googleClientId, googleClientSecret)
+
+    const results = []
+    for (const url of urls) {
+      const result = await requestIndexing(accessToken, url, 'URL_UPDATED')
+      results.push({
+        url,
+        notifiedAt: result.urlNotificationMetadata?.latestUpdate?.notifyTime ?? new Date().toISOString(),
+        type: 'URL_UPDATED',
+      })
+    }
+
+    return results
   })
 }

--- a/packages/canonry/src/cli.ts
+++ b/packages/canonry/src/cli.ts
@@ -23,6 +23,7 @@ import {
   googleInspections, googleDeindexed, googleCoverage, googleCoverageHistory, googleInspectSitemap,
   googleDiscoverSitemaps,
 } from './commands/google.js'
+import { googleRequestIndexing } from './commands/google-request-indexing.js'
 import { trackEvent, isTelemetryEnabled, isFirstRun, getOrCreateAnonymousId, showFirstRunNotice } from './telemetry.js'
 
 const USAGE = `
@@ -90,6 +91,7 @@ Usage:
   canonry google coverage <project>  Show index coverage summary
   canonry google inspections <project>  Show URL inspection history (--url <url>)
   canonry google deindexed <project>  Show pages that lost indexing
+  canonry google request-indexing <project> <url> [--all-unindexed] [--wait]  Request indexing for a URL or all unindexed URLs
   canonry settings                    Show active provider and quota settings
   canonry settings provider <name>    Update a provider config
   canonry settings google             Update Google OAuth credentials
@@ -1066,6 +1068,36 @@ async function main() {
             await googleDeindexed(project, format)
             break
           }
+          case 'request-indexing': {
+            const project = args[2]
+            const url = args[3]
+            const { values: requestIndexingValues } = parseArgs({
+              args: args.slice(4),
+              options: {
+                'all-unindexed': { type: 'boolean', default: false },
+                wait: { type: 'boolean', default: false },
+                format: { type: 'string' },
+              },
+              allowPositionals: false,
+            })
+
+            if (!project) {
+              console.error('Error: project name is required')
+              process.exit(1)
+            }
+
+            if (!url && !requestIndexingValues['all-unindexed']) {
+              console.error('Error: URL or --all-unindexed is required')
+              process.exit(1)
+            }
+
+            await googleRequestIndexing(project, url, {
+              allUnindexed: requestIndexingValues['all-unindexed'],
+              wait: requestIndexingValues.wait,
+              format: requestIndexingValues.format === 'json' ? 'json' : format,
+            })
+            break
+          }
           case 'discover-sitemaps': {
             const project = args[2]
             if (!project) {
@@ -1088,7 +1120,7 @@ async function main() {
           }
           default:
             console.error(`Unknown google subcommand: ${subcommand ?? '(none)'}`)
-            console.log('Available: connect, disconnect, status, properties, set-property, set-sitemap, list-sitemaps, discover-sitemaps, sync, performance, inspect, inspect-sitemap, coverage, coverage-history, inspections, deindexed')
+            console.log('Available: connect, disconnect, status, properties, set-property, set-sitemap, list-sitemaps, discover-sitemaps, sync, performance, inspect, inspect-sitemap, coverage, coverage-history, inspections, deindexed, request-indexing')
             process.exit(1)
         }
         break

--- a/packages/canonry/src/client.ts
+++ b/packages/canonry/src/client.ts
@@ -267,4 +267,12 @@ export class ApiClient {
   async gscDiscoverSitemaps(project: string): Promise<object> {
     return this.request<object>('POST', `/projects/${encodeURIComponent(project)}/google/gsc/discover-sitemaps`, {})
   }
+
+  async gscRequestIndexing(project: string, url: string, opts?: { wait?: boolean }): Promise<object> {
+    return this.request<object>('POST', `/projects/${encodeURIComponent(project)}/google/gsc/request-indexing`, { url, wait: opts?.wait })
+  }
+
+  async gscRequestIndexingAll(project: string): Promise<object[]> {
+    return this.request<object[]>('POST', `/projects/${encodeURIComponent(project)}/google/gsc/request-indexing/all`, {})
+  }
 }

--- a/packages/canonry/src/commands/google-request-indexing.ts
+++ b/packages/canonry/src/commands/google-request-indexing.ts
@@ -1,0 +1,57 @@
+import { loadConfig } from '../config.js'
+import { ApiClient } from '../client.js'
+
+function getClient(): ApiClient {
+  const config = loadConfig()
+  return new ApiClient(config.apiUrl, config.apiKey)
+}
+
+interface RequestIndexingOptions {
+  allUnindexed?: boolean
+  wait?: boolean
+  format?: string
+}
+
+interface RequestIndexingResult {
+  url: string
+  notifiedAt: string
+  type: string
+}
+
+export async function googleRequestIndexing(
+  project: string,
+  url: string | undefined,
+  options: RequestIndexingOptions,
+): Promise<void> {
+  const client = getClient()
+
+  if (options.allUnindexed) {
+    const results = await client.gscRequestIndexingAll(project) as RequestIndexingResult[]
+    if (options.format === 'json') {
+      console.log(JSON.stringify(results, null, 2))
+      return
+    }
+    for (const r of results) {
+      console.log(`Indexing requested: ${r.url}`)
+      console.log(`  Notified at: ${r.notifiedAt}`)
+      console.log(`  Type: ${r.type}`)
+    }
+    return
+  }
+
+  if (!url) {
+    console.error('Error: URL or --all-unindexed is required')
+    process.exit(1)
+  }
+
+  const result = await client.gscRequestIndexing(project, url, { wait: options.wait }) as RequestIndexingResult
+
+  if (options.format === 'json') {
+    console.log(JSON.stringify(result, null, 2))
+    return
+  }
+
+  console.log(`Indexing requested: ${result.url}`)
+  console.log(`  Notified at: ${result.notifiedAt}`)
+  console.log(`  Type: ${result.type}`)
+}

--- a/packages/integration-google/src/constants.ts
+++ b/packages/integration-google/src/constants.ts
@@ -6,3 +6,6 @@ export const URL_INSPECTION_API = 'https://searchconsole.googleapis.com/v1/urlIn
 export const GSC_MAX_ROWS_PER_REQUEST = 25000
 export const GSC_DATA_LAG_DAYS = 3
 export const URL_INSPECTION_DAILY_LIMIT = 2000
+export const INDEXING_API_BASE = 'https://indexing.googleapis.com/v3'
+export const INDEXING_SCOPE = 'https://www.googleapis.com/auth/indexing'
+export const INDEXING_DAILY_LIMIT = 200

--- a/packages/integration-google/src/index.ts
+++ b/packages/integration-google/src/index.ts
@@ -1,5 +1,7 @@
 export { getAuthUrl, exchangeCode, refreshAccessToken } from './oauth.js'
 export { listSites, listSitemaps, fetchSearchAnalytics, inspectUrl } from './gsc-client.js'
 export type { FetchSearchAnalyticsOptions } from './gsc-client.js'
+export { requestIndexing } from './indexing-client.js'
+export type { UrlNotificationResult } from './indexing-client.js'
 export * from './constants.js'
 export * from './types.js'

--- a/packages/integration-google/src/indexing-client.ts
+++ b/packages/integration-google/src/indexing-client.ts
@@ -1,0 +1,49 @@
+import { INDEXING_API_BASE } from './constants.js'
+import { GoogleApiError } from './types.js'
+
+export interface UrlNotificationResult {
+  urlNotificationMetadata: {
+    url: string
+    latestUpdate: {
+      url: string
+      type: string
+      notifyTime: string
+    }
+  }
+}
+
+async function indexingFetch<T>(accessToken: string, url: string, body: unknown): Promise<T> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+
+  if (res.status === 401) {
+    throw new GoogleApiError('Access token expired or revoked', 401)
+  }
+  if (res.status === 429) {
+    throw new GoogleApiError('Google Indexing API rate limit exceeded (200/day)', 429)
+  }
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new GoogleApiError(`Google Indexing API error: ${res.status} ${text}`, res.status)
+  }
+
+  return res.json() as Promise<T>
+}
+
+export async function requestIndexing(
+  accessToken: string,
+  url: string,
+  type: 'URL_UPDATED' | 'URL_DELETED' = 'URL_UPDATED',
+): Promise<UrlNotificationResult> {
+  return indexingFetch<UrlNotificationResult>(
+    accessToken,
+    `${INDEXING_API_BASE}/urlNotifications:publish`,
+    { url, type },
+  )
+}


### PR DESCRIPTION
## Summary

Adds `canonry google request-indexing <project> <url>` to programmatically request URL indexing via the Google Indexing API.

## Changes

- **`packages/integration-google`**: New `requestIndexing()` function calling `https://indexing.googleapis.com/v3/urlNotifications:publish`; added `INDEXING_API_BASE`, `INDEXING_SCOPE`, `INDEXING_DAILY_LIMIT` constants
- **`packages/api-routes`**: Two new routes:
  - `POST /projects/:name/google/gsc/request-indexing` — single URL
  - `POST /projects/:name/google/gsc/request-indexing/all` — batch all unindexed URLs from coverage data
- **`packages/canonry`**: New `googleRequestIndexing()` command + client methods + CLI wiring

## CLI Usage

```
# Single URL
canonry google request-indexing <project> <url>

# Batch all unindexed/unknown URLs from last coverage run
canonry google request-indexing <project> --all-unindexed
```

## Output

```
Indexing requested: https://ainyc.ai/aeo-agency-new-york-city
  Notified at: 2026-03-17T17:40:00Z
  Type: URL_UPDATED
```

## Notes

- Uses existing GSC OAuth credentials — no new auth setup required
- Rate limit guard on `--all-unindexed`: errors if count exceeds 200/day limit

Closes #91