### PR TITLE
feat: unified dashboard with AI visibility + social signals (#105)

### DIFF
--- a/apps/web/src/build-dashboard.ts
+++ b/apps/web/src/build-dashboard.ts
@@ -663,7 +663,10 @@ export interface ProjectData {
 // ── Social signal helpers ────────────────────────────────────────────────────
 
 function buildSocialSparkline(social: SocialData): SocialSparklineVm {
-  const counts = social.dailyMentionCounts.slice(-7)
+  if (social.dailyMentionCounts.length !== 7) {
+    throw new Error(`dailyMentionCounts must have exactly 7 elements, got ${social.dailyMentionCounts.length}`)
+  }
+  const counts = social.dailyMentionCounts
   const first = counts[0] ?? 0
   const last = counts[counts.length - 1] ?? 0
   return {
@@ -681,7 +684,8 @@ function computeSentimentScore(sentiment: SocialData['sentiment']): number {
 
 function computeDomainLinkRate(social: SocialData): number {
   if (social.totalMentions === 0) return 0
-  return Math.round((social.mentionsWithCanonicalLink / social.totalMentions) * 100)
+  const rate = (social.mentionsWithCanonicalLink / social.totalMentions) * 100
+  return Math.min(100, Math.round(rate))
 }
 
 function computeCompositeScore(aiScore: number, sentimentScore: number, domainLinkRate: number): number {
@@ -707,6 +711,11 @@ function buildBrandHealth(aiVisibilityScore: number, social: SocialData): BrandH
   }
 }
 
+/** Minimum mentions considered "active social discussion" for cross-signal insights. */
+const LOW_SOCIAL_THRESHOLD = 10
+/** Minimum mentions to qualify as meaningful social traction vs AI citation gap. */
+const SOCIAL_TRACTION_THRESHOLD = 20
+
 /**
  * Build cross-signal insights by comparing AI citation data against social
  * discussion trends. Generates observations such as high-AI / low-social gaps
@@ -720,10 +729,13 @@ export function buildCrossSignalInsights(
 
   if (!social) return insights
 
+  // Derive totalMentions from the daily array to ensure consistency with spike detection.
+  // Note: social.totalMentions is kept for display purposes but thresholds use the derived value.
+  const totalMentions = social.dailyMentionCounts.reduce((s, n) => s + n, 0)
+
   // Insight: high AI visibility but low social discussion
   const citedKeywords = evidence.filter(e => e.citationState === 'cited').map(e => e.keyword)
-  const totalMentions = social.totalMentions
-  if (citedKeywords.length > 0 && totalMentions < 10) {
+  if (citedKeywords.length > 0 && totalMentions < LOW_SOCIAL_THRESHOLD) {
     insights.push({
       id: 'cross_high_ai_low_social',
       tone: 'caution',
@@ -762,7 +774,7 @@ export function buildCrossSignalInsights(
 
   // Insight: good social but no AI citations
   const notCitedCount = evidence.filter(e => e.citationState === 'not-cited' || e.citationState === 'pending').length
-  if (notCitedCount > 0 && totalMentions >= 20) {
+  if (notCitedCount > 0 && totalMentions >= SOCIAL_TRACTION_THRESHOLD) {
     insights.push({
       id: 'cross_social_no_ai',
       tone: 'caution',

--- a/apps/web/src/build-dashboard.ts
+++ b/apps/web/src/build-dashboard.ts
@@ -10,8 +10,10 @@ import type {
 } from './api.js'
 import type {
   AffectedPhrase,
+  BrandHealthVm,
   CitationInsightVm,
   CitationState,
+  CrossSignalInsightVm,
   EvidenceHistoryScope,
   ModelTransitionVm,
   CompetitorVm,
@@ -23,6 +25,7 @@ import type {
   RunHistoryPoint,
   RunListItemVm,
   ScoreSummaryVm,
+  SocialSparklineVm,
 } from './view-models.js'
 
 function toProjectDto(p: ApiProject): ProjectDto {
@@ -627,6 +630,24 @@ function runStatusSummary(projectRuns: ApiRun[]): ScoreSummaryVm {
   }
 }
 
+/**
+ * Optional social signals for a project. When present, enables brand health
+ * and cross-signal insight generation. All fields are read-only inputs derived
+ * from a social monitoring service; this package only consumes them.
+ */
+export interface SocialData {
+  /** 7-day daily mention counts (oldest → newest, length must be 7). */
+  dailyMentionCounts: number[]
+  /** Total engagement (likes + shares + comments) over the same window. */
+  totalEngagement: number
+  /** Number of mentions that link to the project's canonical domain. */
+  mentionsWithCanonicalLink: number
+  /** Total mention count over the 7-day window. */
+  totalMentions: number
+  /** Sentiment breakdown across all mentions. */
+  sentiment: { positive: number; neutral: number; negative: number }
+}
+
 export interface ProjectData {
   project: ApiProject
   runs: ApiRun[]
@@ -635,6 +656,122 @@ export interface ProjectData {
   timeline: ApiTimelineEntry[]
   latestRunDetail: ApiRunDetail | null
   previousRunDetail: ApiRunDetail | null
+  /** Optional social monitoring data. Omit when not yet connected. */
+  socialData?: SocialData | null
+}
+
+// ── Social signal helpers ────────────────────────────────────────────────────
+
+function buildSocialSparkline(social: SocialData): SocialSparklineVm {
+  const counts = social.dailyMentionCounts.slice(-7)
+  const first = counts[0] ?? 0
+  const last = counts[counts.length - 1] ?? 0
+  return {
+    counts,
+    delta: last - first,
+    sentimentSummary: social.sentiment,
+  }
+}
+
+function computeSentimentScore(sentiment: SocialData['sentiment']): number {
+  const total = sentiment.positive + sentiment.neutral + sentiment.negative
+  if (total === 0) return 0
+  return Math.round((sentiment.positive / total) * 100)
+}
+
+function computeDomainLinkRate(social: SocialData): number {
+  if (social.totalMentions === 0) return 0
+  return Math.round((social.mentionsWithCanonicalLink / social.totalMentions) * 100)
+}
+
+function computeCompositeScore(aiScore: number, sentimentScore: number, domainLinkRate: number): number {
+  // Weighted blend: AI visibility 50%, sentiment 30%, domain link rate 20%
+  return Math.round(aiScore * 0.5 + sentimentScore * 0.3 + domainLinkRate * 0.2)
+}
+
+function buildBrandHealth(aiVisibilityScore: number, social: SocialData): BrandHealthVm {
+  const sentimentScore = computeSentimentScore(social.sentiment)
+  const domainLinkRate = computeDomainLinkRate(social)
+  const compositeScore = computeCompositeScore(aiVisibilityScore, sentimentScore, domainLinkRate)
+
+  return {
+    aiVisibilityScore,
+    aiVisibilityTone: scoreTone(aiVisibilityScore),
+    socialReach: social.totalEngagement,
+    sentimentScore,
+    sentimentTone: scoreTone(sentimentScore),
+    domainLinkRate,
+    domainLinkTone: scoreTone(domainLinkRate),
+    compositeScore,
+    compositeTone: scoreTone(compositeScore),
+  }
+}
+
+/**
+ * Build cross-signal insights by comparing AI citation data against social
+ * discussion trends. Generates observations such as high-AI / low-social gaps
+ * or keywords with social traction but no AI visibility.
+ */
+export function buildCrossSignalInsights(
+  evidence: CitationInsightVm[],
+  social: SocialData | null | undefined,
+): CrossSignalInsightVm[] {
+  const insights: CrossSignalInsightVm[] = []
+
+  if (!social) return insights
+
+  // Insight: high AI visibility but low social discussion
+  const citedKeywords = evidence.filter(e => e.citationState === 'cited').map(e => e.keyword)
+  const totalMentions = social.totalMentions
+  if (citedKeywords.length > 0 && totalMentions < 10) {
+    insights.push({
+      id: 'cross_high_ai_low_social',
+      tone: 'caution',
+      title: 'Strong AI visibility but low social discussion',
+      detail: `${citedKeywords.length} keyword${citedKeywords.length > 1 ? 's are' : ' is'} cited in AI answers but social mention volume is low (${totalMentions} mention${totalMentions !== 1 ? 's' : ''} in 7d). Consider seeding social content to amplify reach.`,
+    })
+  }
+
+  // Insight: negative sentiment spike
+  const { positive, negative, neutral } = social.sentiment
+  const totalSentiment = positive + negative + neutral
+  if (totalSentiment > 0 && negative / totalSentiment >= 0.4) {
+    insights.push({
+      id: 'cross_negative_sentiment',
+      tone: 'negative',
+      title: 'Elevated negative sentiment in social mentions',
+      detail: `${Math.round((negative / totalSentiment) * 100)}% of recent mentions carry negative sentiment. Review brand messaging and monitor for escalation.`,
+    })
+  }
+
+  // Insight: social mentions spiking (last day >> daily average)
+  const counts = social.dailyMentionCounts
+  if (counts.length >= 2) {
+    const latestDay = counts[counts.length - 1] ?? 0
+    const prior = counts.slice(0, -1)
+    const avg = prior.reduce((s, n) => s + n, 0) / prior.length
+    if (avg > 0 && latestDay >= avg * 2) {
+      insights.push({
+        id: 'cross_social_spike',
+        tone: 'positive',
+        title: 'Social mention spike detected',
+        detail: `Mentions jumped to ${latestDay} today vs a ${Math.round(avg)}/day average — a ${Math.round((latestDay / avg - 1) * 100)}% increase. Engage while the conversation is active.`,
+      })
+    }
+  }
+
+  // Insight: good social but no AI citations
+  const notCitedCount = evidence.filter(e => e.citationState === 'not-cited' || e.citationState === 'pending').length
+  if (notCitedCount > 0 && totalMentions >= 20) {
+    insights.push({
+      id: 'cross_social_no_ai',
+      tone: 'caution',
+      title: 'Social traction without AI citation',
+      detail: `${notCitedCount} keyword${notCitedCount > 1 ? 's have' : ' has'} no AI citation despite active social discussion (${totalMentions} mention${totalMentions !== 1 ? 's' : ''}). Optimise content for AI answer engines to convert social reach into AI visibility.`,
+    })
+  }
+
+  return insights
 }
 
 export function buildProjectCommandCenter(data: ProjectData): ProjectCommandCenterVm {
@@ -675,6 +812,11 @@ export function buildProjectCommandCenter(data: ProjectData): ProjectCommandCent
       total,
     }))
 
+  const brandHealth = data.socialData
+    ? buildBrandHealth(kwVis.score, data.socialData)
+    : null
+  const crossSignalInsights = buildCrossSignalInsights(evidence, data.socialData)
+
   return {
     project: dto,
     dateRangeLabel: 'All time',
@@ -705,6 +847,8 @@ export function buildProjectCommandCenter(data: ProjectData): ProjectCommandCent
     runStatus: runStatusSummary(sortedRuns),
     insights,
     visibilityEvidence: evidence,
+    brandHealth,
+    crossSignalInsights,
     competitors: data.competitors.map((c, i) => {
       const citedKeywordSet = new Set<string>()
       for (const snap of snapshots) {
@@ -760,6 +904,15 @@ export function buildPortfolioProject(data: ProjectData): PortfolioProjectVm {
         triggerLabel: '',
       }
 
+  const socialSparkline = data.socialData ? buildSocialSparkline(data.socialData) : null
+  const brandVisibilityScore = data.socialData
+    ? computeCompositeScore(
+        kwVis.score,
+        computeSentimentScore(data.socialData.sentiment),
+        computeDomainLinkRate(data.socialData),
+      )
+    : null
+
   return {
     project: dto,
     visibilityScore: kwVis.score,
@@ -770,6 +923,8 @@ export function buildPortfolioProject(data: ProjectData): PortfolioProjectVm {
       : 'No runs completed yet.',
     trend: [],
     competitorPressureLabel: pressure.label,
+    socialSparkline,
+    brandVisibilityScore,
   }
 }
 

--- a/apps/web/src/mock-data.ts
+++ b/apps/web/src/mock-data.ts
@@ -474,6 +474,8 @@ const baseProjectCommandCenters: ProjectCommandCenterVm[] = [
       },
     ],
     recentRuns: [runCitypointQueued, runCitypointVisibility],
+    brandHealth: null,
+    crossSignalInsights: [],
   },
   {
     project: projects[1],
@@ -563,6 +565,8 @@ const baseProjectCommandCenters: ProjectCommandCenterVm[] = [
       },
     ],
     recentRuns: [runHarborVisibility],
+    brandHealth: null,
+    crossSignalInsights: [],
   },
   {
     project: projects[2],
@@ -645,6 +649,8 @@ const baseProjectCommandCenters: ProjectCommandCenterVm[] = [
       },
     ],
     recentRuns: [runNorthstarVisibility],
+    brandHealth: null,
+    crossSignalInsights: [],
   },
 ]
 
@@ -659,6 +665,8 @@ const baseDashboard: DashboardVm = {
         insight: 'Lost emergency-intent citations after competitors refreshed availability pages.',
         trend: [73, 71, 69, 66, 61],
         competitorPressureLabel: 'High',
+        socialSparkline: null,
+        brandVisibilityScore: null,
       },
       {
         project: projects[1],
@@ -668,6 +676,8 @@ const baseDashboard: DashboardVm = {
         insight: 'Practice-area consolidation is stabilizing branded and informational prompts.',
         trend: [68, 70, 71, 73, 74],
         competitorPressureLabel: 'Moderate',
+        socialSparkline: null,
+        brandVisibilityScore: null,
       },
       {
         project: projects[2],
@@ -677,6 +687,8 @@ const baseDashboard: DashboardVm = {
         insight: 'Location pages are improving, but local treatment proof still trails competitors.',
         trend: [52, 54, 55, 57, 58],
         competitorPressureLabel: 'Moderate',
+        socialSparkline: null,
+        brandVisibilityScore: null,
       },
     ],
     attentionItems: [

--- a/apps/web/src/view-models.ts
+++ b/apps/web/src/view-models.ts
@@ -86,7 +86,9 @@ export interface CrossSignalInsightVm {
   tone: MetricTone
   title: string
   detail: string
+  // TODO: populate when per-keyword cross-signal insights are implemented.
   keyword?: string
+  // TODO: populate when per-platform cross-signal insights are implemented.
   platform?: string
 }
 

--- a/apps/web/src/view-models.ts
+++ b/apps/web/src/view-models.ts
@@ -55,6 +55,41 @@ export interface RunListItemVm extends RunDto {
   triggerLabel: string
 }
 
+export interface SocialSparklineVm {
+  /** 7-day daily mention counts (oldest to newest). */
+  counts: number[]
+  /** Net change from first to last day in the window. */
+  delta: number
+  /** Overall sentiment distribution across the 7d window. */
+  sentimentSummary: { positive: number; neutral: number; negative: number }
+}
+
+export interface BrandHealthVm {
+  /** AI citation rate — existing keyword visibility score (0-100). */
+  aiVisibilityScore: number
+  aiVisibilityTone: MetricTone
+  /** Total engagement (likes + shares + comments) across monitored platforms. */
+  socialReach: number
+  /** Percentage of mentions with positive sentiment (0-100). */
+  sentimentScore: number
+  sentimentTone: MetricTone
+  /** Percentage of social mentions that link to the canonical domain (0-100). */
+  domainLinkRate: number
+  domainLinkTone: MetricTone
+  /** Composite brand visibility combining AI + social signals (0-100). */
+  compositeScore: number
+  compositeTone: MetricTone
+}
+
+export interface CrossSignalInsightVm {
+  id: string
+  tone: MetricTone
+  title: string
+  detail: string
+  keyword?: string
+  platform?: string
+}
+
 export interface PortfolioProjectVm {
   project: ProjectDto
   visibilityScore: number
@@ -63,6 +98,10 @@ export interface PortfolioProjectVm {
   insight: string
   trend: number[]
   competitorPressureLabel: string
+  /** 7-day social mention sparkline. Null when no social data is available. */
+  socialSparkline: SocialSparklineVm | null
+  /** Composite brand visibility score combining AI + social (null if no data). */
+  brandVisibilityScore: number | null
 }
 
 export interface PortfolioOverviewVm {
@@ -156,6 +195,10 @@ export interface ProjectCommandCenterVm {
   visibilityEvidence: CitationInsightVm[]
   competitors: CompetitorVm[]
   recentRuns: RunListItemVm[]
+  /** Combined brand health section (AI + social). Null when no social data available. */
+  brandHealth: BrandHealthVm | null
+  /** Cross-signal insights comparing AI visibility against social discussion trends. */
+  crossSignalInsights: CrossSignalInsightVm[]
 }
 
 export interface SetupHealthCheckVm {

--- a/apps/web/test/build-social.test.ts
+++ b/apps/web/test/build-social.test.ts
@@ -1,0 +1,105 @@
+import { test, expect } from 'vitest'
+
+import { buildCrossSignalInsights, type SocialData } from '../src/build-dashboard.js'
+import type { CitationInsightVm } from '../src/view-models.js'
+
+function makeEvidence(
+  overrides: Partial<CitationInsightVm> & {
+    keyword: string
+    provider: string
+    citationState: CitationInsightVm['citationState']
+  },
+): CitationInsightVm {
+  return {
+    id: `ev_${overrides.keyword}_${overrides.provider}`,
+    answerSnippet: '',
+    citedDomains: [],
+    evidenceUrls: [],
+    competitorDomains: [],
+    relatedTechnicalSignals: [],
+    groundingSources: [],
+    summary: '',
+    changeLabel: '',
+    runHistory: [],
+    location: null,
+    model: null,
+    ...overrides,
+  }
+}
+
+function makeSocialData(overrides: Partial<SocialData> = {}): SocialData {
+  return {
+    dailyMentionCounts: [2, 3, 2, 4, 3, 3, 4],
+    totalEngagement: 120,
+    mentionsWithCanonicalLink: 10,
+    totalMentions: 21,
+    sentiment: { positive: 14, neutral: 5, negative: 2 },
+    ...overrides,
+  }
+}
+
+test('buildCrossSignalInsights returns empty array when no social data', () => {
+  const evidence = [makeEvidence({ keyword: 'kw1', provider: 'gemini', citationState: 'cited' })]
+  expect(buildCrossSignalInsights(evidence, null)).toEqual([])
+  expect(buildCrossSignalInsights(evidence, undefined)).toEqual([])
+})
+
+test('buildCrossSignalInsights: high AI visibility but low social discussion', () => {
+  const evidence = [
+    makeEvidence({ keyword: 'kw1', provider: 'gemini', citationState: 'cited' }),
+    makeEvidence({ keyword: 'kw2', provider: 'openai', citationState: 'cited' }),
+  ]
+  const social = makeSocialData({ totalMentions: 5, dailyMentionCounts: [1, 1, 1, 1, 1, 0, 0] })
+  const insights = buildCrossSignalInsights(evidence, social)
+  const hi = insights.find(i => i.id === 'cross_high_ai_low_social')
+  expect(hi).toBeTruthy()
+  expect(hi!.tone).toBe('caution')
+  expect(hi!.title).toMatch(/low social discussion/i)
+})
+
+test('buildCrossSignalInsights: elevated negative sentiment', () => {
+  const social = makeSocialData({ sentiment: { positive: 5, neutral: 5, negative: 10 } })
+  const insights = buildCrossSignalInsights([], social)
+  const neg = insights.find(i => i.id === 'cross_negative_sentiment')
+  expect(neg).toBeTruthy()
+  expect(neg!.tone).toBe('negative')
+  expect(neg!.detail).toMatch(/50%/)
+})
+
+test('buildCrossSignalInsights: social spike detected', () => {
+  const social = makeSocialData({
+    dailyMentionCounts: [2, 2, 2, 2, 2, 2, 20], // last day spikes 10x
+  })
+  const insights = buildCrossSignalInsights([], social)
+  const spike = insights.find(i => i.id === 'cross_social_spike')
+  expect(spike).toBeTruthy()
+  expect(spike!.tone).toBe('positive')
+  expect(spike!.title).toMatch(/spike/i)
+})
+
+test('buildCrossSignalInsights: social traction without AI citation', () => {
+  const evidence = [
+    makeEvidence({ keyword: 'kw1', provider: 'gemini', citationState: 'not-cited' }),
+    makeEvidence({ keyword: 'kw2', provider: 'openai', citationState: 'pending' }),
+  ]
+  const social = makeSocialData({ totalMentions: 50 })
+  const insights = buildCrossSignalInsights(evidence, social)
+  const noAi = insights.find(i => i.id === 'cross_social_no_ai')
+  expect(noAi).toBeTruthy()
+  expect(noAi!.tone).toBe('caution')
+  expect(noAi!.detail).toMatch(/2 keyword/)
+})
+
+test('buildCrossSignalInsights: healthy state produces no insights', () => {
+  const evidence = [makeEvidence({ keyword: 'kw1', provider: 'gemini', citationState: 'cited' })]
+  // Lots of mentions, positive sentiment, no spike
+  const social = makeSocialData({
+    totalMentions: 50,
+    sentiment: { positive: 40, neutral: 8, negative: 2 },
+    dailyMentionCounts: [7, 7, 7, 7, 7, 7, 8],
+  })
+  const insights = buildCrossSignalInsights(evidence, social)
+  expect(insights.find(i => i.id === 'cross_high_ai_low_social')).toBeUndefined()
+  expect(insights.find(i => i.id === 'cross_negative_sentiment')).toBeUndefined()
+  expect(insights.find(i => i.id === 'cross_social_no_ai')).toBeUndefined()
+})

--- a/apps/web/test/build-social.test.ts
+++ b/apps/web/test/build-social.test.ts
@@ -102,4 +102,5 @@ test('buildCrossSignalInsights: healthy state produces no insights', () => {
   expect(insights.find(i => i.id === 'cross_high_ai_low_social')).toBeUndefined()
   expect(insights.find(i => i.id === 'cross_negative_sentiment')).toBeUndefined()
   expect(insights.find(i => i.id === 'cross_social_no_ai')).toBeUndefined()
+  expect(insights.find(i => i.id === 'cross_social_spike')).toBeUndefined()
 })

--- a/packages/api-routes/src/notifications.ts
+++ b/packages/api-routes/src/notifications.ts
@@ -3,18 +3,12 @@ import { eq } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import { notifications } from '@ainyc/canonry-db'
 import type { NotificationEvent, NotificationDto } from '@ainyc/canonry-contracts'
+import { notificationEventSchema } from '@ainyc/canonry-contracts'
 import { resolveProject, writeAuditLog } from './helpers.js'
 import { deliverWebhook, resolveWebhookTarget } from './webhooks.js'
 
-const VALID_EVENTS: NotificationEvent[] = [
-  'citation.lost',
-  'citation.gained',
-  'run.completed',
-  'run.failed',
-  'social.mention.new',
-  'social.sentiment.negative',
-  'social.spike',
-]
+// Derived from the schema so it stays in sync automatically when events are added/removed.
+const VALID_EVENTS: NotificationEvent[] = notificationEventSchema.options
 
 export async function notificationRoutes(app: FastifyInstance) {
   // GET /notifications/events — list valid notification event types

--- a/packages/api-routes/src/notifications.ts
+++ b/packages/api-routes/src/notifications.ts
@@ -6,7 +6,15 @@ import type { NotificationEvent, NotificationDto } from '@ainyc/canonry-contract
 import { resolveProject, writeAuditLog } from './helpers.js'
 import { deliverWebhook, resolveWebhookTarget } from './webhooks.js'
 
-const VALID_EVENTS: NotificationEvent[] = ['citation.lost', 'citation.gained', 'run.completed', 'run.failed']
+const VALID_EVENTS: NotificationEvent[] = [
+  'citation.lost',
+  'citation.gained',
+  'run.completed',
+  'run.failed',
+  'social.mention.new',
+  'social.sentiment.negative',
+  'social.spike',
+]
 
 export async function notificationRoutes(app: FastifyInstance) {
   // GET /notifications/events — list valid notification event types

--- a/packages/canonry/src/commands/notify.ts
+++ b/packages/canonry/src/commands/notify.ts
@@ -73,6 +73,9 @@ const EVENT_DESCRIPTIONS: Record<string, string> = {
   'citation.gained': 'A keyword gained citation status',
   'run.completed': 'A visibility run completed successfully',
   'run.failed': 'A visibility run failed',
+  'social.mention.new': 'A new social mention of the project was detected',
+  'social.sentiment.negative': 'A social mention with negative sentiment was detected',
+  'social.spike': 'An unusual increase in social mention volume was detected',
 }
 
 export function listEvents(format?: string): void {

--- a/packages/canonry/test/notify-events.test.ts
+++ b/packages/canonry/test/notify-events.test.ts
@@ -1,7 +1,7 @@
 import { it, expect } from 'vitest'
 import { listEvents } from '../src/commands/notify.js'
 
-it('listEvents prints all 4 notification event types', () => {
+it('listEvents prints all 7 notification event types', () => {
   const logs: string[] = []
   const origLog = console.log
   console.log = (...args: unknown[]) => logs.push(args.join(' '))
@@ -16,6 +16,9 @@ it('listEvents prints all 4 notification event types', () => {
   expect(output.includes('citation.gained')).toBeTruthy()
   expect(output.includes('run.completed')).toBeTruthy()
   expect(output.includes('run.failed')).toBeTruthy()
+  expect(output.includes('social.mention.new')).toBeTruthy()
+  expect(output.includes('social.sentiment.negative')).toBeTruthy()
+  expect(output.includes('social.spike')).toBeTruthy()
 })
 
 it('listEvents outputs valid JSON with --format json', () => {
@@ -30,6 +33,6 @@ it('listEvents outputs valid JSON with --format json', () => {
 
   const parsed = JSON.parse(logs.join('\n'))
   expect(Array.isArray(parsed)).toBeTruthy()
-  expect(parsed.length).toBe(4)
+  expect(parsed.length).toBe(7)
   expect(parsed.every((e: { event: string; description: string }) => e.event && e.description)).toBeTruthy()
 })

--- a/packages/contracts/src/notification.ts
+++ b/packages/contracts/src/notification.ts
@@ -5,6 +5,9 @@ export const notificationEventSchema = z.enum([
   'citation.gained',
   'run.completed',
   'run.failed',
+  'social.mention.new',
+  'social.sentiment.negative',
+  'social.spike',
 ])
 export type NotificationEvent = z.infer<typeof notificationEventSchema>
 
@@ -33,5 +36,26 @@ export interface WebhookPayload {
     to: string
     provider: string
   }>
+  dashboardUrl: string
+}
+
+export interface SocialWebhookPayload {
+  source: 'canonry'
+  event: 'social.mention.new' | 'social.sentiment.negative' | 'social.spike'
+  project: { name: string; canonicalDomain: string }
+  mention?: {
+    platform: string
+    url: string
+    snippet: string
+    sentiment: 'positive' | 'negative' | 'neutral'
+    mentionedAt: string
+    linksToCanonicalDomain: boolean
+  }
+  spike?: {
+    platform: string
+    mentionCount: number
+    windowHours: number
+    baselineMentionCount: number
+  }
   dashboardUrl: string
 }

--- a/packages/contracts/src/notification.ts
+++ b/packages/contracts/src/notification.ts
@@ -41,7 +41,8 @@ export interface WebhookPayload {
 
 export interface SocialWebhookPayload {
   source: 'canonry'
-  event: 'social.mention.new' | 'social.sentiment.negative' | 'social.spike'
+  // Narrow to just the social events via Extract to avoid diverging from NotificationEvent.
+  event: Extract<NotificationEvent, `social.${string}`>
   project: { name: string; canonicalDomain: string }
   mention?: {
     platform: string
@@ -59,3 +60,6 @@ export interface SocialWebhookPayload {
   }
   dashboardUrl: string
 }
+
+// Discriminated union for webhook consumers covering all payload types.
+export type AnyWebhookPayload = WebhookPayload | SocialWebhookPayload


### PR DESCRIPTION
## Summary

Implements the foundational data layer for the unified brand health dashboard combining AI answer engine visibility scores with social platform signals.

## Changes

### View Models (`apps/web/src/view-models.ts`)
- Added `SocialSparklineVm` — 7-day mention trend with delta and sentiment summary
- Added `BrandHealthVm` — combined AI visibility + social reach + sentiment + domain link rate + composite score
- Added `CrossSignalInsightVm` — cross-signal observation with tone, title, and detail
- Extended `PortfolioProjectVm` with `socialSparkline` and `brandVisibilityScore` fields
- Extended `ProjectCommandCenterVm` with `brandHealth` and `crossSignalInsights` fields

### Dashboard Builder (`apps/web/src/build-dashboard.ts`)
- Added `SocialData` input type for consuming social monitoring data
- Added `buildBrandHealth()` — computes AI visibility score, social reach, sentiment score (% positive), domain link rate, and weighted composite score
- Added `buildCrossSignalInsights()` — generates cross-signal observations:
  - High AI visibility but low social discussion
  - Elevated negative sentiment (≥40%)
  - Social mention spike (last day ≥2× daily average)
  - Social traction without AI citations
- Updated `buildPortfolioProject()` to populate `socialSparkline` and `brandVisibilityScore`
- Updated `buildProjectCommandCenter()` to populate `brandHealth` and `crossSignalInsights`

### Webhook Events
- **`packages/contracts/src/notification.ts`** — Added `social.mention.new`, `social.sentiment.negative`, `social.spike` to `notificationEventSchema`; added `SocialWebhookPayload` interface
- **`packages/api-routes/src/notifications.ts`** — Added new events to `VALID_EVENTS`
- **`packages/canonry/src/commands/notify.ts`** — Added descriptions for new events

### Tests
- Updated `notify-events.test.ts` — checks for all 7 events (up from 4)
- Added `apps/web/test/build-social.test.ts` — 6 tests covering all cross-signal insight scenarios and the healthy/no-data edge cases

## Testing

All new and modified tests pass (40 tests in apps/web, 66 tests in packages/canonry). Pre-existing failures in `packages/canonry` (6 tests) are caused by a missing `@ainyc/canonry-provider-cdp` node_modules install and are unrelated to this PR.

## Caveats

This PR implements the data layer (view-models + builders + webhook contracts). UI rendering components (`ScoreGauge`, `ToneBadge` usage for brand health section, sparkline chart component) are expected to be implemented separately as the design system evolves.

Fixes AINYC/canonry#105