### PR TITLE
fix: drawer close navigates to current page instead of home

### DIFF
--- a/apps/web/src/hooks/use-drawer.ts
+++ b/apps/web/src/hooks/use-drawer.ts
@@ -1,20 +1,21 @@
-import { useNavigate, useSearch } from '@tanstack/react-router'
+import { useNavigate, useSearch, useRouterState } from '@tanstack/react-router'
 import { rootRoute } from '../router/routes.js'
 
 export function useDrawer() {
   const navigate = useNavigate()
   const search = useSearch({ strict: false }) as { runId?: string; evidenceId?: string }
+  const currentPath = useRouterState({ select: (s) => s.location.pathname })
   const runId = search.runId ?? null
   const evidenceId = search.evidenceId ?? null
 
   const openRun = (id: string) =>
-    navigate({ to: '.', from: rootRoute.to, search: (prev) => ({ ...prev, runId: id, evidenceId: undefined }) })
+    navigate({ to: currentPath, from: rootRoute.to, search: (prev) => ({ ...prev, runId: id, evidenceId: undefined }) })
 
   const openEvidence = (id: string) =>
-    navigate({ to: '.', from: rootRoute.to, search: (prev) => ({ ...prev, evidenceId: id, runId: undefined }) })
+    navigate({ to: currentPath, from: rootRoute.to, search: (prev) => ({ ...prev, evidenceId: id, runId: undefined }) })
 
   const closeDrawer = () =>
-    navigate({ to: '.', from: rootRoute.to, search: (prev) => ({ ...prev, runId: undefined, evidenceId: undefined }) })
+    navigate({ to: currentPath, from: rootRoute.to, search: (prev) => ({ ...prev, runId: undefined, evidenceId: undefined }) })
 
   return { runId, evidenceId, openRun, openEvidence, closeDrawer }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "1.19.2",
+  "version": "1.19.3",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "1.19.2",
+  "version": "1.19.3",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Problem
When closing the evidence detail drawer (or any drawer), navigation returned to the home page instead of staying on the current project page.

## Root Cause
The `useDrawer()` hook used `navigate({ to: '.', from: rootRoute.to, ... })`. Since `rootRoute.to` is `'/'`, the relative path always resolved to the home page.

## Solution
Use the actual current pathname from `useRouterState()` instead of the root route. Drawers now open and close without changing pages.

## Changes
- `apps/web/src/hooks/use-drawer.ts`: Replace `to: '.'` with `to: currentPath`
- Version bumps: 1.19.2 → 1.19.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)