### PR TITLE
fix: base-path-aware API route prefix and SPA fallback

### DIFF
--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -39,7 +39,8 @@ export interface ApiRoutesOptions {
   /** Skip auth for testing */
   skipAuth?: boolean
   /** API route prefix (default: /api/v1). Override for sub-path deployments e.g. /canonry/api/v1.
-   *  Named routePrefix (not prefix) to avoid collision with Fastify's reserved prefix option. */
+   *  Named routePrefix (not prefix) to avoid collision with Fastify's reserved prefix option.
+   *  Must start with '/' — values without a leading slash will be rejected at startup. */
   routePrefix?: string
   /** Callback when a run is created (wire up job runner) */
   onRunCreated?: (runId: string, projectId: string, providers?: string[], location?: import('@ainyc/canonry-contracts').LocationContext | null) => void
@@ -75,6 +76,14 @@ export interface ApiRoutesOptions {
 }
 
 export async function apiRoutes(app: FastifyInstance, opts: ApiRoutesOptions) {
+  // Validate routePrefix format eagerly to surface misconfiguration at startup
+  // rather than silently mis-routing all API requests.
+  if (opts.routePrefix !== undefined && !opts.routePrefix.startsWith('/')) {
+    throw new Error(
+      `apiRoutes: routePrefix must start with '/' — got ${JSON.stringify(opts.routePrefix)}`,
+    )
+  }
+
   // Decorate with db
   app.decorate('db', opts.db)
 

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -220,10 +220,14 @@ export async function createServer(opts: {
 
   // Resolve base path early so API route prefix and SPA handler both use it.
   // Normalize: ensure it starts and ends with '/' (e.g. '/canonry/').
+  // A value that normalises to bare '/' is treated as no base path to avoid
+  // a duplicate-route error with fastify-static (which also registers '/').
   const rawBasePath = process.env.CANONRY_BASE_PATH ?? opts.config.basePath
-  const basePath: string | undefined = rawBasePath
+  const normalizedBasePath = rawBasePath
     ? ('/' + rawBasePath.replace(/^\//, '').replace(/\/?$/, '/'))
     : undefined
+  const basePath: string | undefined =
+    normalizedBasePath === '/' ? undefined : normalizedBasePath
 
   // API routes are registered under <basePath>api/v1 (or /api/v1 when no base path).
   const apiPrefix = basePath ? `${basePath}api/v1` : '/api/v1'
@@ -494,25 +498,43 @@ export async function createServer(opts: {
       index: false,
     })
 
-    // Serve index.html with injected config for the root/base-path route
-    const rootRoute = basePath ?? '/'
-    app.get(rootRoute, (_request, reply) => {
+    // Serve index.html with injected config for the root/base-path route.
+    // Register both the trailing-slash form ('/canonry/') and the bare form
+    // ('/canonry') so either URL shape hits the handler without a 404.
+    const serveIndex = (_request: unknown, reply: { type: (t: string) => { send: (b: string) => unknown }; status: (s: number) => { send: (b: unknown) => unknown } }) => {
       if (fs.existsSync(indexPath)) {
         const html = fs.readFileSync(indexPath, 'utf-8')
         return reply.type('text/html').send(injectConfig(html))
       }
       return reply.status(404).send({ error: 'Dashboard not built' })
-    })
+    }
+    const rootRouteTrailing = basePath ?? '/'
+    app.get(rootRouteTrailing, serveIndex)
+    // Also register the no-trailing-slash variant when base path is set
+    // (e.g. '/canonry' in addition to '/canonry/') to avoid a 404 on bare navigation.
+    if (basePath) {
+      const rootRouteBare = basePath.replace(/\/$/, '')
+      if (rootRouteBare) app.get(rootRouteBare, serveIndex)
+    }
 
-    // SPA fallback: serve index.html for unmatched non-API routes
+    // SPA fallback: serve index.html for unmatched routes that belong to this app.
+    // - With no base path: serve for any non-API path (existing behaviour).
+    // - With base path: only serve for paths under basePath to avoid hijacking
+    //   other apps co-hosted on the same origin outside the base path.
     app.setNotFoundHandler((request, reply) => {
+      const url = request.url.split('?')[0]!
+
       // Never serve HTML for API routes — return proper JSON 404.
-      // Check both the prefixed path (/canonry/api/...) and the bare path (/api/...)
-      // so this guard works with and without --base-path.
+      // Guard against both the prefixed (/canonry/api/...) and bare (/api/...) forms.
       const isApiRoute =
-        request.url.startsWith('/api/') ||
-        (basePath !== undefined && request.url.startsWith(`${basePath}api/`))
+        url.startsWith('/api/') ||
+        (basePath !== undefined && url.startsWith(`${basePath}api/`))
       if (isApiRoute) {
+        return reply.status(404).send({ error: 'Not found', path: request.url })
+      }
+
+      // When a base path is configured, only serve the SPA for paths under it.
+      if (basePath && !url.startsWith(basePath)) {
         return reply.status(404).send({ error: 'Not found', path: request.url })
       }
 
@@ -524,18 +546,12 @@ export async function createServer(opts: {
     })
   }
 
-  // Health endpoint — registered at both /health and <basePath>health when base path is set
-  app.get('/health', async () => ({
-    status: 'ok',
-    service: 'canonry',
-    version: PKG_VERSION,
-  }))
+  // Health endpoint — registered at both /health and <basePath>health when base path is set,
+  // so load-balancer probes work regardless of whether the proxy strips the prefix.
+  const healthHandler = async () => ({ status: 'ok', service: 'canonry', version: PKG_VERSION })
+  app.get('/health', healthHandler)
   if (basePath) {
-    app.get(`${basePath}health`, async () => ({
-      status: 'ok',
-      service: 'canonry',
-      version: PKG_VERSION,
-    }))
+    app.get(`${basePath}health`, healthHandler)
   }
 
   // Start scheduler after setup


### PR DESCRIPTION
Fixes #113.

## Problem

When `canonry serve --base-path /canonry/` is used, the server is completely non-functional:
- All API calls to `/canonry/api/v1/*` return `200 OK` with the SPA's `index.html` instead of JSON
- The root `/` and static assets aren't served under the base path
- The `setNotFoundHandler` API guard only checked `/api/` prefix, missing base-path-prefixed routes

The Caddy reverse proxy masked this in production (Caddy strips `/canonry/` before forwarding), so it was only caught when running canonry directly with `--base-path`.

## Root Causes

Three issues in `server.ts`:

1. **API routes** registered at hardcoded `/api/v1` regardless of base path
2. **`setNotFoundHandler`** guard: `request.url.startsWith('/api/')` — missed `/canonry/api/v1/*`
3. **Static plugin + root handler** registered at `/` regardless of base path

## Changes

**`packages/api-routes/src/index.ts`**
- Added `routePrefix?: string` to `ApiRoutesOptions` (named `routePrefix` not `prefix` to avoid collision with Fastify's reserved `prefix` register option — using `prefix` would double-prefix all routes)
- Use `opts.routePrefix ?? '/api/v1'` in the inner register call

**`packages/canonry/src/server.ts`**
- Compute `basePath` once before `apiRoutes` registration (moved out of the static block)
- Pass `routePrefix: apiPrefix` to `apiRoutes` where `apiPrefix = basePath ? `${basePath}api/v1` : '/api/v1'`
- Register `@fastify/static` and root handler at `basePath ?? '/'`
- Update `setNotFoundHandler` guard to check both `/api/` and `${basePath}api/`
- Register `/health` at both `/health` and `${basePath}health` when base path is set

## Test Results

- `pnpm typecheck` ✅
- `pnpm test` ✅ (497 tests, 0 failures)

Manual verification with `--base-path /canonry/`:
```
GET /canonry/api/v1/health     → 200 JSON  ✅  (was: 200 HTML)
GET /canonry/api/v1/projects   → 200 JSON  ✅  (was: 200 HTML)
GET /canonry/health            → 200 JSON  ✅
GET /canonry/api/v1/missing    → 404 JSON  ✅  (was: 200 HTML)
GET /canonry/                  → 200 HTML  ✅
```