### PR TITLE
fix: constrain provider badge width in model breakdown table

### DIFF
--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -497,7 +497,7 @@ export function ProjectPage({
                     {model.providerScores.map((ps) => (
                       <tr key={`${ps.provider}::${ps.model ?? 'unknown'}`}>
                         <td>
-                          <div className="flex flex-col gap-0.5">
+                          <div className="flex flex-col items-start gap-0.5">
                             <ProviderBadge provider={ps.provider} />
                             {ps.model && <span className="text-[11px] font-mono text-zinc-500">{ps.model}</span>}
                           </div>


### PR DESCRIPTION
The provider badge in the Visibility by model table was stretching to fill the entire table cell width. Added `items-start` to the flex container to align the badge to the start of the cell instead of stretching it.

This keeps the colored badge compact around the provider name and subtitle, matching the intended design.