### PR TITLE
fix: persist discovered sitemap URL across runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "1.19.3",
+  "version": "1.19.4",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "1.19.3",
+  "version": "1.19.4",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/gsc-inspect-sitemap.ts
+++ b/packages/canonry/src/gsc-inspect-sitemap.ts
@@ -61,8 +61,8 @@ export async function executeInspectSitemap(
       saveConfig(opts.config)
     }
 
-    // Determine sitemap URL
-    const sitemapUrl = opts.sitemapUrl || `https://${project.canonicalDomain}/sitemap.xml`
+    // Determine sitemap URL: explicit > stored on connection > default
+    const sitemapUrl = opts.sitemapUrl || conn.sitemapUrl || `https://${project.canonicalDomain}/sitemap.xml`
     console.log(`[Inspect Sitemap] Fetching sitemap from ${sitemapUrl}`)
 
     const urls = await fetchAndParseSitemap(sitemapUrl)


### PR DESCRIPTION
## Summary

Fixed sitemap URL persistence: `discover-sitemaps` stores the discovered URL on the connection, but `inspect-sitemap` wasn't reading it back. Now inspect-sitemap uses the stored value, eliminating the need to manually pass `--sitemap-url` on every run.

**Fallback priority:** explicit flag > stored on connection > default `/sitemap.xml`

## Changes

- `gsc-inspect-sitemap.ts`: Updated URL resolution logic to check `conn.sitemapUrl` before falling back to default
- Version bump: 1.19.3 → 1.19.4 (patch)

## Test Status

- All 497 tests pass
- Typechecking passes
- Linting passes