### PR TITLE
fix: add canonry-integration-bing to tsup noExternal bundle list

### DIFF
--- a/packages/canonry/tsup.config.ts
+++ b/packages/canonry/tsup.config.ts
@@ -38,5 +38,6 @@ export default defineConfig({
     '@ainyc/canonry-provider-local',
     '@ainyc/canonry-provider-cdp',
     '@ainyc/canonry-integration-google',
+    '@ainyc/canonry-integration-bing',
   ],
 })


### PR DESCRIPTION
## Problem

`@ainyc/canonry-integration-bing` was introduced in #116 but not added to the `noExternal` list in `tsup.config.ts`. Building from source fails with:

```
You can mark the path "@ainyc/canonry-integration-bing" as external to exclude it from the bundle
Error: Build failed with 1 error
```

## Fix

One-line addition — matches the existing pattern for all other workspace packages (`@ainyc/canonry-integration-google`, etc.).