### PR TITLE
feat: social monitoring UI overview page and project integration

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,6 +5,7 @@ import {
   Globe,
   LayoutDashboard,
   Menu,
+  MessageSquare,
   Play,
   Rocket,
   Settings,
@@ -119,6 +120,7 @@ export function RootLayout() {
     const path = location.pathname
     if (path === '/') return 'Portfolio'
     if (path === '/projects') return 'Projects'
+    if (path === '/social') return 'Social'
     if (path === '/runs') return 'Runs'
     if (path === '/settings') return 'Settings'
     if (path === '/setup') return 'Setup'
@@ -165,6 +167,15 @@ export function RootLayout() {
           >
             <Globe className="sidebar-icon" />
             <span>Projects</span>
+          </Link>
+          <Link
+            to="/social"
+            className="sidebar-link"
+            activeProps={{ className: 'sidebar-link sidebar-link-active' }}
+            activeOptions={{ exact: true }}
+          >
+            <MessageSquare className="sidebar-icon" />
+            <span>Social</span>
           </Link>
           <Link
             to="/runs"
@@ -289,6 +300,9 @@ export function RootLayout() {
           </Link>
           <Link to="/projects" className="mobile-nav-link" activeProps={{ className: 'mobile-nav-link mobile-nav-link-active' }} activeOptions={{ exact: false }}>
             Projects
+          </Link>
+          <Link to="/social" className="mobile-nav-link" activeProps={{ className: 'mobile-nav-link mobile-nav-link-active' }} activeOptions={{ exact: true }}>
+            Social
           </Link>
           <Link to="/runs" className="mobile-nav-link" activeProps={{ className: 'mobile-nav-link mobile-nav-link-active' }} activeOptions={{ exact: true }}>
             Runs

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -868,6 +868,71 @@ export function fetchAnalyticsSources(project: string, window?: MetricsWindow): 
   return apiFetch(`/projects/${encodeURIComponent(project)}/analytics/sources${qs}`)
 }
 
+// ── Social monitoring ────────────────────────────────────────────────────────
+
+export interface ApiSocialPlatform {
+  id: string
+  name: string
+  configured: boolean
+  mentions7d: number
+  engagement: number
+  sentiment: number
+  domainLinks: number
+}
+
+export interface ApiSocialMention {
+  id: string
+  platform: string
+  author: string
+  content: string
+  sentiment: 'positive' | 'negative' | 'neutral'
+  likes: number
+  shares: number
+  comments: number
+  postedAt: string
+  url: string
+  projectKeywords?: string[]
+}
+
+export interface ApiSocialSummary {
+  totalMentions7d: number
+  sentimentScore: number
+  domainLinks: number
+  platforms: ApiSocialPlatform[]
+  recentMentions: ApiSocialMention[]
+  trendByDay?: number[]
+}
+
+export function fetchSocialSummary(): Promise<ApiSocialSummary> {
+  return apiFetch('/social/summary')
+}
+
+export function fetchProjectSocialMentions(
+  project: string,
+  params?: { platform?: string; limit?: number; offset?: number },
+): Promise<ApiSocialMention[]> {
+  const qs = new URLSearchParams()
+  if (params?.platform) qs.set('platform', params.platform)
+  if (params?.limit !== undefined) qs.set('limit', String(params.limit))
+  if (params?.offset !== undefined) qs.set('offset', String(params.offset))
+  const query = qs.toString() ? `?${qs.toString()}` : ''
+  return apiFetch(`/projects/${encodeURIComponent(project)}/social/mentions${query}`)
+}
+
+export function connectSocialPlatform(platform: string, apiKey: string): Promise<ApiSocialPlatform> {
+  return apiFetch(`/social/platforms/${encodeURIComponent(platform)}/connect`, {
+    method: 'POST',
+    body: JSON.stringify({ apiKey }),
+  })
+}
+
+export function disconnectSocialPlatform(platform: string): Promise<void> {
+  return apiFetch(`/social/platforms/${encodeURIComponent(platform)}/disconnect`, {
+    method: 'POST',
+    body: '{}',
+  })
+}
+
 // ── Health ──────────────────────────────────────────────────────────────────
 
 import type { ServiceStatus } from './view-models.js'

--- a/apps/web/src/components/project/SocialSignalsSection.tsx
+++ b/apps/web/src/components/project/SocialSignalsSection.tsx
@@ -1,0 +1,232 @@
+import { useEffect, useState } from 'react'
+import { ExternalLink } from 'lucide-react'
+
+import { ToneBadge } from '../shared/ToneBadge.js'
+import { Sparkline } from '../shared/Sparkline.js'
+import { fetchProjectSocialMentions, type ApiSocialMention } from '../../api.js'
+import type { MetricTone } from '../../view-models.js'
+
+const PLATFORM_FILTERS = ['All', 'Twitter', 'Reddit', 'LinkedIn']
+
+function sentimentTone(sentiment: 'positive' | 'negative' | 'neutral'): MetricTone {
+  if (sentiment === 'positive') return 'positive'
+  if (sentiment === 'negative') return 'negative'
+  return 'neutral'
+}
+
+function summarizeMentions(mentions: ApiSocialMention[]) {
+  const positive = mentions.filter((m) => m.sentiment === 'positive').length
+  const negative = mentions.filter((m) => m.sentiment === 'negative').length
+  const total = mentions.length
+
+  // Find top hashtag or subreddit pattern
+  const tags: Record<string, number> = {}
+  for (const m of mentions) {
+    const matches = m.content.match(/[#/][\w]+/g) ?? []
+    for (const tag of matches) {
+      tags[tag] = (tags[tag] ?? 0) + 1
+    }
+  }
+  const topTag = Object.entries(tags).sort((a, b) => b[1] - a[1])[0]?.[0] ?? '—'
+
+  return {
+    total,
+    positivePercent: total > 0 ? Math.round((positive / total) * 100) : 0,
+    negativePercent: total > 0 ? Math.round((negative / total) * 100) : 0,
+    topTag,
+  }
+}
+
+function formatPostedAt(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+    })
+  } catch {
+    return iso
+  }
+}
+
+export function SocialSignalsSection({ projectName }: { projectName: string }) {
+  const [mentions, setMentions] = useState<ApiSocialMention[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [platformFilter, setPlatformFilter] = useState<string>('All')
+
+  useEffect(() => {
+    setLoading(true)
+    setError(null)
+    fetchProjectSocialMentions(projectName, { limit: 50 })
+      .then(setMentions)
+      .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load social signals'))
+      .finally(() => setLoading(false))
+  }, [projectName])
+
+  const filteredMentions = mentions.filter(
+    (m) => platformFilter === 'All' || m.platform === platformFilter,
+  )
+
+  const summary = summarizeMentions(filteredMentions)
+
+  // Build a simple 7-day sparkline from postedAt timestamps
+  const trendByDay = (() => {
+    const counts: Record<string, number> = {}
+    for (const m of mentions) {
+      const day = m.postedAt.slice(0, 10)
+      counts[day] = (counts[day] ?? 0) + 1
+    }
+    const days = Object.keys(counts).sort()
+    return days.map((d) => counts[d] ?? 0)
+  })()
+
+  if (loading) {
+    return (
+      <section className="page-section-divider" aria-label="Social Signals">
+        <div className="section-head section-head-inline">
+          <div>
+            <p className="eyebrow eyebrow-soft">Social</p>
+            <h2>Social Signals</h2>
+          </div>
+        </div>
+        <p className="supporting-copy" aria-live="polite">Loading social signals…</p>
+      </section>
+    )
+  }
+
+  if (error) {
+    return (
+      <section className="page-section-divider" aria-label="Social Signals">
+        <div className="section-head section-head-inline">
+          <div>
+            <p className="eyebrow eyebrow-soft">Social</p>
+            <h2>Social Signals</h2>
+          </div>
+        </div>
+        <p className="text-sm text-zinc-500">
+          Social monitoring not available. Connect platforms in{' '}
+          <a href="/settings" className="underline underline-offset-2 hover:text-zinc-200">
+            Settings → Social Platforms
+          </a>
+          .
+        </p>
+      </section>
+    )
+  }
+
+  return (
+    <section className="page-section-divider" aria-label="Social Signals">
+      <div className="section-head section-head-inline">
+        <div>
+          <p className="eyebrow eyebrow-soft">Social</p>
+          <h2>Social Signals</h2>
+        </div>
+      </div>
+
+      {/* Summary row */}
+      <div className="flex flex-wrap items-center gap-4 mb-4 rounded-lg border border-zinc-800 bg-zinc-900/40 p-3">
+        <div>
+          <p className="text-xs text-zinc-500">Mentions</p>
+          <p className="text-lg font-semibold text-zinc-100">{summary.total}</p>
+        </div>
+        <div>
+          <p className="text-xs text-zinc-500">Positive</p>
+          <p className="text-lg font-semibold text-emerald-400">{summary.positivePercent}%</p>
+        </div>
+        <div>
+          <p className="text-xs text-zinc-500">Negative</p>
+          <p className="text-lg font-semibold text-rose-400">{summary.negativePercent}%</p>
+        </div>
+        <div>
+          <p className="text-xs text-zinc-500">Top tag</p>
+          <p className="text-sm font-medium text-zinc-300 font-mono">{summary.topTag}</p>
+        </div>
+        {trendByDay.length > 1 && (
+          <div className="ml-auto flex items-center gap-2">
+            <span className="text-xs text-zinc-500">Trend</span>
+            <Sparkline points={trendByDay} tone="neutral" />
+          </div>
+        )}
+      </div>
+
+      {/* Platform filter chips */}
+      <div className="filter-row mb-3" role="toolbar" aria-label="Platform filters">
+        {PLATFORM_FILTERS.map((p) => (
+          <button
+            key={p}
+            className={`filter-chip ${platformFilter === p ? 'filter-chip-active' : ''}`}
+            type="button"
+            aria-pressed={platformFilter === p}
+            onClick={() => setPlatformFilter(p)}
+          >
+            {p}
+          </button>
+        ))}
+      </div>
+
+      {filteredMentions.length > 0 ? (
+        <div className="data-table-wrapper">
+          <table className="data-table" aria-label="Social mentions for this project">
+            <thead>
+              <tr>
+                <th>Platform</th>
+                <th>Author</th>
+                <th>Content</th>
+                <th>Sentiment</th>
+                <th>Engagement</th>
+                <th>Posted</th>
+                <th aria-label="Link"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredMentions.slice(0, 20).map((mention) => (
+                <tr key={mention.id}>
+                  <td className="text-zinc-400 text-xs">{mention.platform}</td>
+                  <td className="font-medium">{mention.author}</td>
+                  <td
+                    className="max-w-xs truncate text-zinc-300 text-sm"
+                    title={mention.content}
+                  >
+                    {mention.content.length > 60
+                      ? `${mention.content.slice(0, 60)}…`
+                      : mention.content}
+                  </td>
+                  <td>
+                    <ToneBadge tone={sentimentTone(mention.sentiment)}>
+                      {mention.sentiment}
+                    </ToneBadge>
+                  </td>
+                  <td className="text-zinc-400 text-xs">
+                    {mention.likes + mention.shares + mention.comments}
+                  </td>
+                  <td className="text-zinc-500 text-xs whitespace-nowrap">
+                    {formatPostedAt(mention.postedAt)}
+                  </td>
+                  <td>
+                    {mention.url && (
+                      <a
+                        href={mention.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-zinc-500 hover:text-zinc-200 transition-colors"
+                        aria-label={`Open mention by ${mention.author} on ${mention.platform}`}
+                      >
+                        <ExternalLink className="size-3.5" />
+                      </a>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p className="supporting-copy">
+          {platformFilter === 'All'
+            ? 'No social mentions found for this project. Connect platforms in Settings → Social Platforms.'
+            : `No ${platformFilter} mentions found for this project.`}
+        </p>
+      )}
+    </section>
+  )
+}

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -15,6 +15,7 @@ import { EvidenceTable } from '../components/project/EvidenceTable.js'
 import { CompetitorTable } from '../components/project/CompetitorTable.js'
 import { AnalyticsSection } from '../components/project/AnalyticsSection.js'
 import { GscSection } from '../components/project/GscSection.js'
+import { SocialSignalsSection } from '../components/project/SocialSignalsSection.js'
 import { formatTimestamp } from '../lib/format-helpers.js'
 import { ProjectSettingsSection } from '../components/project/ProjectSettingsSection.js'
 import { ScheduleSection } from '../components/project/ScheduleSection.js'
@@ -1028,6 +1029,9 @@ export function ProjectPage({
               evidence={filteredEvidence}
             />
           </section>
+
+          {/* Social Signals */}
+          <SocialSignalsSection projectName={model.project.name} />
 
           {/* Competitor table */}
           <section className="page-section-divider">

--- a/apps/web/src/pages/ProjectsPage.tsx
+++ b/apps/web/src/pages/ProjectsPage.tsx
@@ -6,6 +6,7 @@ import { Button } from '../components/ui/button.js'
 import { Card } from '../components/ui/card.js'
 import { StatusBadge } from '../components/shared/StatusBadge.js'
 import { ToneBadge } from '../components/shared/ToneBadge.js'
+import { Sparkline } from '../components/shared/Sparkline.js'
 import { YamlApplyPanel } from '../components/project/YamlApplyPanel.js'
 import { createProject } from '../api.js'
 import { useDashboard } from '../queries/use-dashboard.js'
@@ -162,6 +163,7 @@ export function ProjectsPage() {
                 <th>Name</th>
                 <th>Domain</th>
                 <th>Visibility</th>
+                <th>Social (7d)</th>
                 <th>Last run</th>
                 <th className="text-right">Country</th>
               </tr>
@@ -169,6 +171,7 @@ export function ProjectsPage() {
             <tbody>
               {projects.map((p) => {
                 const latestRun = p.recentRuns[0]
+                const socialTrend = p.socialTrend ?? []
                 return (
                   <tr key={p.project.id} className="cursor-pointer" onClick={() => navigate({ to: '/projects/$projectId', params: { projectId: p.project.id } })}>
                     <td>
@@ -185,6 +188,13 @@ export function ProjectsPage() {
                     <td className="text-zinc-400">{p.project.canonicalDomain}</td>
                     <td>
                       <ToneBadge tone={p.visibilitySummary.tone}>{p.visibilitySummary.value}</ToneBadge>
+                    </td>
+                    <td>
+                      {socialTrend.length > 1 ? (
+                        <Sparkline points={socialTrend} tone="neutral" />
+                      ) : (
+                        <span className="text-zinc-600 text-xs">—</span>
+                      )}
                     </td>
                     <td className="text-zinc-500 text-sm">
                       {latestRun ? (

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -5,13 +5,121 @@ import { Card } from '../components/ui/card.js'
 import { ToneBadge } from '../components/shared/ToneBadge.js'
 import { ProviderConfigForm } from '../components/settings/ProviderConfigForm.js'
 import { GoogleOAuthConfigForm } from '../components/settings/GoogleOAuthConfigForm.js'
-import { updateBingApiKey } from '../api.js'
+import { updateBingApiKey, connectSocialPlatform, disconnectSocialPlatform } from '../api.js'
 import { CdpConfigCard } from '../components/settings/CdpConfigCard.js'
 import { toneFromService } from '../lib/tone-helpers.js'
 import { useDashboard } from '../queries/use-dashboard.js'
 import { useHealth } from '../queries/use-health.js'
 import { useInitialDashboard } from '../contexts/dashboard-context.js'
 import type { HealthSnapshot } from '../view-models.js'
+
+const SOCIAL_PLATFORMS = [
+  { id: 'twitter', name: 'Twitter / X', description: 'Monitor brand mentions, hashtags, and engagement.' },
+  { id: 'reddit', name: 'Reddit', description: 'Track subreddit mentions and comment sentiment.' },
+  { id: 'linkedin', name: 'LinkedIn', description: 'Follow professional mentions and company references.' },
+]
+
+function SocialPlatformCard({
+  platform,
+}: {
+  platform: (typeof SOCIAL_PLATFORMS)[number]
+}) {
+  const [apiKey, setApiKey] = useState('')
+  const [connected, setConnected] = useState(false)
+  const [configuring, setConfiguring] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleConnect = async () => {
+    if (!apiKey.trim()) return
+    setSaving(true)
+    setError(null)
+    try {
+      await connectSocialPlatform(platform.id, apiKey.trim())
+      setConnected(true)
+      setConfiguring(false)
+      setApiKey('')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to connect')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDisconnect = async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      await disconnectSocialPlatform(platform.id)
+      setConnected(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to disconnect')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Card className="surface-card">
+      <div className="section-head">
+        <div>
+          <p className="eyebrow eyebrow-soft">Social Platform</p>
+          <h2>{platform.name}</h2>
+        </div>
+        <ToneBadge tone={connected ? 'positive' : 'neutral'}>
+          {connected ? 'Connected' : 'Disconnected'}
+        </ToneBadge>
+      </div>
+      <p className="mt-2 text-sm text-zinc-500">{platform.description}</p>
+      {error && <p className="mt-1 text-xs text-rose-400">{error}</p>}
+      <div className="mt-2 flex gap-2">
+        {connected ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={saving}
+            onClick={handleDisconnect}
+          >
+            {saving ? 'Disconnecting…' : 'Disconnect'}
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setConfiguring((v) => !v)}
+          >
+            {configuring ? 'Cancel' : 'Connect'}
+          </Button>
+        )}
+      </div>
+      {configuring && !connected && (
+        <div className="mt-3 space-y-2 rounded-lg border border-zinc-800 bg-zinc-900/40 p-3">
+          <label className="text-xs text-zinc-500" htmlFor={`api-key-${platform.id}`}>
+            API Key
+          </label>
+          <input
+            id={`api-key-${platform.id}`}
+            type="password"
+            className="mt-0.5 w-full rounded border border-zinc-700 bg-transparent px-2 py-1.5 text-sm text-zinc-200 placeholder-zinc-600 focus:border-zinc-500 focus:outline-none"
+            placeholder={`${platform.name} API key`}
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+          />
+          <Button
+            type="button"
+            size="sm"
+            disabled={!apiKey.trim() || saving}
+            onClick={handleConnect}
+          >
+            {saving ? 'Connecting…' : 'Save & Connect'}
+          </Button>
+        </div>
+      )}
+    </Card>
+  )
+}
 
 const defaultHealthSnapshot: HealthSnapshot = {
   apiStatus: { label: 'API', state: 'checking', detail: 'Checking service health' },
@@ -219,6 +327,10 @@ export function SettingsPage() {
         </Card>
 
         <CdpConfigCard />
+
+        {SOCIAL_PLATFORMS.map((platform) => (
+          <SocialPlatformCard key={platform.id} platform={platform} />
+        ))}
 
         <Card className="surface-card">
           <div className="section-head">

--- a/apps/web/src/pages/SocialPage.tsx
+++ b/apps/web/src/pages/SocialPage.tsx
@@ -1,0 +1,317 @@
+import { useEffect, useState } from 'react'
+import { ExternalLink } from 'lucide-react'
+
+import { Card } from '../components/ui/card.js'
+import { Button } from '../components/ui/button.js'
+import { ScoreGauge } from '../components/shared/ScoreGauge.js'
+import { ToneBadge } from '../components/shared/ToneBadge.js'
+import { Sparkline } from '../components/shared/Sparkline.js'
+import { fetchSocialSummary, type ApiSocialSummary } from '../api.js'
+import type { MetricTone } from '../view-models.js'
+
+const PLATFORMS = ['Twitter', 'Reddit', 'LinkedIn']
+
+function sentimentTone(sentiment: number): MetricTone {
+  if (sentiment >= 65) return 'positive'
+  if (sentiment >= 40) return 'neutral'
+  return 'negative'
+}
+
+function mentionSentimentTone(sentiment: 'positive' | 'negative' | 'neutral'): MetricTone {
+  if (sentiment === 'positive') return 'positive'
+  if (sentiment === 'negative') return 'negative'
+  return 'neutral'
+}
+
+function formatEngagement(likes: number, shares: number, comments: number): string {
+  const total = likes + shares + comments
+  if (total >= 1000) return `${(total / 1000).toFixed(1)}k`
+  return String(total)
+}
+
+function formatPostedAt(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  } catch {
+    return iso
+  }
+}
+
+export function SocialPage() {
+  const [data, setData] = useState<ApiSocialSummary | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [platformFilter, setPlatformFilter] = useState<string>('All')
+  const [mentionPage, setMentionPage] = useState(0)
+
+  const PAGE_SIZE = 10
+
+  useEffect(() => {
+    setLoading(true)
+    setError(null)
+    fetchSocialSummary()
+      .then(setData)
+      .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load social data'))
+      .finally(() => setLoading(false))
+  }, [])
+
+  const filteredMentions = (data?.recentMentions ?? []).filter(
+    (m) => platformFilter === 'All' || m.platform === platformFilter,
+  )
+  const paginatedMentions = filteredMentions.slice(mentionPage * PAGE_SIZE, (mentionPage + 1) * PAGE_SIZE)
+  const totalPages = Math.ceil(filteredMentions.length / PAGE_SIZE)
+
+  const totalMentions = data?.totalMentions7d ?? 0
+  const sentimentScore = data?.sentimentScore ?? 0
+  const domainLinks = data?.domainLinks ?? 0
+  const trendPoints = data?.trendByDay ?? []
+
+  return (
+    <div className="page-container">
+      <div className="page-header">
+        <div className="page-header-left">
+          <h1 className="page-title">Social</h1>
+          <p className="page-subtitle">Mentions, sentiment, and domain links across social platforms.</p>
+        </div>
+      </div>
+
+      {loading && (
+        <p className="supporting-copy" aria-live="polite">
+          Loading social data…
+        </p>
+      )}
+
+      {error && (
+        <Card className="surface-card">
+          <p className="text-sm text-rose-400" role="alert">
+            {error}
+          </p>
+          <p className="supporting-copy mt-1">
+            Social monitoring requires the social API endpoints to be configured. Check Settings → Social Platforms.
+          </p>
+        </Card>
+      )}
+
+      {!loading && !error && (
+        <>
+          {/* Hero metrics row */}
+          <section className="page-section" aria-label="Social metrics overview">
+            <div className="gauge-row">
+              <ScoreGauge
+                value={String(totalMentions)}
+                label="Total Mentions (7d)"
+                delta={trendPoints.length > 1 ? `${trendPoints.at(-1)! - trendPoints[0]!} since start of period` : '—'}
+                tone={totalMentions > 0 ? 'positive' : 'neutral'}
+                description="Posts and comments mentioning your brand across all connected platforms."
+                isNumeric={false}
+              />
+              <ScoreGauge
+                value={`${sentimentScore}%`}
+                label="Sentiment Score"
+                delta={sentimentScore >= 65 ? 'Mostly positive' : sentimentScore >= 40 ? 'Mixed' : 'Mostly negative'}
+                tone={sentimentTone(sentimentScore)}
+                description="Percentage of mentions with a positive sentiment signal."
+                isNumeric={false}
+              />
+              <ScoreGauge
+                value={String(domainLinks)}
+                label="Domain Links"
+                delta="Posts linking to your canonical domain"
+                tone={domainLinks > 0 ? 'positive' : 'neutral'}
+                description="Mentions that include a direct link to your canonical domain."
+                isNumeric={false}
+              />
+            </div>
+
+            {trendPoints.length > 1 && (
+              <div className="mt-4 flex items-center gap-2">
+                <span className="text-xs text-zinc-500">7d trend</span>
+                <Sparkline points={trendPoints} tone={sentimentTone(sentimentScore)} />
+              </div>
+            )}
+          </section>
+
+          {/* Platform breakdown table */}
+          <section className="page-section-divider" aria-label="Platform breakdown">
+            <div className="section-head section-head-inline">
+              <div>
+                <p className="eyebrow eyebrow-soft">Social platforms</p>
+                <h2>Platform breakdown</h2>
+              </div>
+            </div>
+
+            {data?.platforms && data.platforms.length > 0 ? (
+              <div className="data-table-wrapper">
+                <table className="data-table" aria-label="Platform breakdown">
+                  <thead>
+                    <tr>
+                      <th>Platform</th>
+                      <th>Mentions (7d)</th>
+                      <th>Engagement</th>
+                      <th>Sentiment</th>
+                      <th>Domain Links</th>
+                      <th>Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.platforms.map((platform) => (
+                      <tr key={platform.id}>
+                        <td className="font-medium">{platform.name}</td>
+                        <td>{platform.mentions7d.toLocaleString()}</td>
+                        <td>{platform.engagement.toLocaleString()}</td>
+                        <td>
+                          <ToneBadge tone={sentimentTone(platform.sentiment)}>
+                            {platform.sentiment}%
+                          </ToneBadge>
+                        </td>
+                        <td>{platform.domainLinks.toLocaleString()}</td>
+                        <td>
+                          <ToneBadge tone={platform.configured ? 'positive' : 'neutral'}>
+                            {platform.configured ? 'Connected' : 'Disconnected'}
+                          </ToneBadge>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <p className="supporting-copy">
+                No platforms connected yet. Go to Settings → Social Platforms to connect your first platform.
+              </p>
+            )}
+          </section>
+
+          {/* Recent mentions table */}
+          <section className="page-section-divider" aria-label="Recent mentions">
+            <div className="section-head section-head-inline">
+              <div>
+                <p className="eyebrow eyebrow-soft">Recent activity</p>
+                <h2>Recent mentions</h2>
+              </div>
+              <p className="supporting-copy">{filteredMentions.length} mention{filteredMentions.length !== 1 ? 's' : ''}</p>
+            </div>
+
+            {/* Platform filter chips */}
+            <div className="filter-row mb-3" role="toolbar" aria-label="Platform filters">
+              {['All', ...PLATFORMS].map((p) => (
+                <button
+                  key={p}
+                  className={`filter-chip ${platformFilter === p ? 'filter-chip-active' : ''}`}
+                  type="button"
+                  aria-pressed={platformFilter === p}
+                  onClick={() => {
+                    setPlatformFilter(p)
+                    setMentionPage(0)
+                  }}
+                >
+                  {p}
+                </button>
+              ))}
+            </div>
+
+            {paginatedMentions.length > 0 ? (
+              <>
+                <div className="data-table-wrapper">
+                  <table className="data-table" aria-label="Recent social mentions">
+                    <thead>
+                      <tr>
+                        <th>Platform</th>
+                        <th>Author</th>
+                        <th>Content</th>
+                        <th>Sentiment</th>
+                        <th>Engagement</th>
+                        <th>Posted At</th>
+                        <th aria-label="Link"></th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {paginatedMentions.map((mention) => (
+                        <tr key={mention.id}>
+                          <td className="text-zinc-400 text-xs">{mention.platform}</td>
+                          <td className="font-medium">{mention.author}</td>
+                          <td
+                            className="max-w-xs truncate text-zinc-300 text-sm"
+                            title={mention.content}
+                          >
+                            {mention.content.length > 80
+                              ? `${mention.content.slice(0, 80)}…`
+                              : mention.content}
+                          </td>
+                          <td>
+                            <ToneBadge tone={mentionSentimentTone(mention.sentiment)}>
+                              {mention.sentiment}
+                            </ToneBadge>
+                          </td>
+                          <td className="text-zinc-400 text-xs">
+                            {formatEngagement(mention.likes, mention.shares, mention.comments)}
+                          </td>
+                          <td className="text-zinc-500 text-xs whitespace-nowrap">
+                            {formatPostedAt(mention.postedAt)}
+                          </td>
+                          <td>
+                            {mention.url && (
+                              <a
+                                href={mention.url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-zinc-500 hover:text-zinc-200 transition-colors"
+                                aria-label={`Open mention by ${mention.author} on ${mention.platform}`}
+                              >
+                                <ExternalLink className="size-3.5" />
+                              </a>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+
+                {/* Pagination */}
+                {totalPages > 1 && (
+                  <div className="flex items-center justify-between mt-3">
+                    <p className="text-xs text-zinc-500">
+                      Page {mentionPage + 1} of {totalPages}
+                    </p>
+                    <div className="flex gap-2">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={mentionPage === 0}
+                        onClick={() => setMentionPage((p) => p - 1)}
+                      >
+                        Previous
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={mentionPage >= totalPages - 1}
+                        onClick={() => setMentionPage((p) => p + 1)}
+                      >
+                        Next
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </>
+            ) : (
+              <p className="supporting-copy">
+                {platformFilter === 'All'
+                  ? 'No mentions found. Connect a platform in Settings → Social Platforms.'
+                  : `No ${platformFilter} mentions found.`}
+              </p>
+            )}
+          </section>
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/router/routes.tsx
+++ b/apps/web/src/router/routes.tsx
@@ -9,6 +9,7 @@ import { ProjectPage } from '../pages/ProjectPage.js'
 import { RunsPage } from '../pages/RunsPage.js'
 import { SettingsPage } from '../pages/SettingsPage.js'
 import { SetupPage } from '../pages/SetupPage.js'
+import { SocialPage } from '../pages/SocialPage.js'
 import { NotFoundPage } from '../pages/NotFoundPage.js'
 import { queryKeys } from '../queries/query-keys.js'
 
@@ -80,6 +81,12 @@ export const projectAnalyticsRoute = createRoute({
   component: () => <ProjectPage tab="analytics" />,
 })
 
+export const socialRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/social',
+  component: SocialPage,
+})
+
 export const runsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/runs',
@@ -121,6 +128,7 @@ export const routeTree = rootRoute.addChildren([
     projectSearchConsoleRoute,
     projectAnalyticsRoute,
   ]),
+  socialRoute,
   runsRoute,
   settingsRoute,
   setupRoute,

--- a/apps/web/src/view-models.ts
+++ b/apps/web/src/view-models.ts
@@ -156,6 +156,8 @@ export interface ProjectCommandCenterVm {
   visibilityEvidence: CitationInsightVm[]
   competitors: CompetitorVm[]
   recentRuns: RunListItemVm[]
+  /** 7-day social mention trend (mention counts per day, oldest first). Optional until social API is connected. */
+  socialTrend?: number[]
 }
 
 export interface SetupHealthCheckVm {
@@ -230,3 +232,54 @@ export interface DashboardVm {
 }
 
 export type RunFilter = 'all' | RunStatus
+
+// ── Social monitoring ─────────────────────────────────────────────────────────
+
+export interface SocialPlatformVm {
+  id: string
+  name: string
+  mentions7d: number
+  engagement: number
+  sentiment: number
+  domainLinks: number
+  connected: boolean
+}
+
+export interface SocialMentionVm {
+  id: string
+  platform: string
+  author: string
+  content: string
+  sentiment: 'positive' | 'negative' | 'neutral'
+  sentimentTone: MetricTone
+  likes: number
+  shares: number
+  comments: number
+  postedAt: string
+  url: string
+}
+
+export interface SocialSummaryVm {
+  totalMentions: number
+  sentimentScore: number
+  domainLinks: number
+  trendByDay: number[]
+}
+
+export interface SocialOverviewVm {
+  summary: SocialSummaryVm
+  platforms: SocialPlatformVm[]
+  recentMentions: SocialMentionVm[]
+  mentionPage: number
+  mentionPageSize: number
+  platformFilter: string
+}
+
+export interface ProjectSocialSignalsVm {
+  mentionCount: number
+  positivePercent: number
+  negativePercent: number
+  topTag: string
+  mentions: SocialMentionVm[]
+  trendByDay: number[]
+}


### PR DESCRIPTION
## Summary

Adds social monitoring pages and components to the web dashboard, including a dedicated Social overview page (/social), a Social Signals section in the Project Command Center, a Social sparkline column in the portfolio projects table, and a Social Platforms section in Settings.

## Changes

- **api.ts**: Added social API types (`ApiSocialPlatform`, `ApiSocialMention`, `ApiSocialSummary`) and stub fetch functions (`fetchSocialSummary`, `fetchProjectSocialMentions`, `connectSocialPlatform`, `disconnectSocialPlatform`)
- **view-models.ts**: Added social view model types (`SocialPlatformVm`, `SocialMentionVm`, `SocialOverviewVm`, `ProjectSocialSignalsVm`); added optional `socialTrend?: number[]` to `ProjectCommandCenterVm`
- **src/pages/SocialPage.tsx** (new): Social overview page with hero ScoreGauge metrics row (Total Mentions, Sentiment Score, Domain Links), platform breakdown table, and paginated/filterable recent mentions table with ToneBadge sentiment
- **src/components/project/SocialSignalsSection.tsx** (new): Self-contained Social Signals section for the Project Command Center — shows mention count, sentiment split, top hashtag/subreddit, 7d sparkline trend, platform filter chips, and a social mentions table
- **src/pages/ProjectPage.tsx**: Import and render SocialSignalsSection below visibility evidence, before competitor table
- **src/pages/ProjectsPage.tsx**: Added Sparkline import and Social (7d) column to portfolio projects table
- **src/pages/SettingsPage.tsx**: Added SocialPlatformCard component and Social Platforms section (Twitter/X, Reddit, LinkedIn) with API key input, connect/disconnect buttons
- **src/router/routes.tsx**: Added `/social` route pointing to SocialPage
- **src/App.tsx**: Added MessageSquare icon import, Social nav link in sidebar and mobile nav, Social breadcrumb label

## Testing

All 507 tests pass (`pnpm typecheck && pnpm lint && pnpm test`). TypeScript compiles cleanly with no errors. Social pages gracefully handle missing backend (shows informative empty states since Social API endpoints are not yet implemented — tracked in the dependent issue).

Fixes AINYC/canonry#101