### PR TITLE
fix(runtime): harden controls and API contracts

### DIFF
--- a/packages/api-routes/src/cdp.ts
+++ b/packages/api-routes/src/cdp.ts
@@ -4,7 +4,7 @@ import os from 'node:os'
 import type { FastifyInstance } from 'fastify'
 import { eq, and } from 'drizzle-orm'
 import { querySnapshots, runs, keywords } from '@ainyc/canonry-db'
-import type { GroundingSource } from '@ainyc/canonry-contracts'
+import { notFound, notImplemented, validationError, type GroundingSource } from '@ainyc/canonry-contracts'
 import { resolveProject } from './helpers.js'
 
 export interface CDPRoutesOptions {
@@ -44,17 +44,20 @@ export async function cdpRoutes(app: FastifyInstance, opts: CDPRoutesOptions) {
       .get()
 
     if (!snapshot?.screenshotPath) {
-      return reply.code(404).send({ error: 'Screenshot not found' })
+      const err = notFound('Screenshot', snapshotId)
+      return reply.code(err.statusCode).send(err.toJSON())
     }
 
     const base = path.resolve(getScreenshotDir())
     const fullPath = path.resolve(path.join(base, snapshot.screenshotPath))
     // Prevent path traversal: ensure resolved path stays within base dir
     if (!fullPath.startsWith(base + path.sep) && fullPath !== base) {
-      return reply.code(404).send({ error: 'Screenshot not found' })
+      const err = notFound('Screenshot', snapshotId)
+      return reply.code(err.statusCode).send(err.toJSON())
     }
     if (!fs.existsSync(fullPath)) {
-      return reply.code(404).send({ error: 'Screenshot file not found on disk' })
+      const err = notFound('Screenshot file', snapshotId)
+      return reply.code(err.statusCode).send(err.toJSON())
     }
 
     const stream = fs.createReadStream(fullPath)
@@ -64,19 +67,23 @@ export async function cdpRoutes(app: FastifyInstance, opts: CDPRoutesOptions) {
   // PUT /settings/cdp — configure the CDP endpoint (host + port)
   app.put<{ Body: { host: string; port?: number } }>('/settings/cdp', async (request, reply) => {
     if (!opts.onCdpConfigure) {
-      return reply.code(501).send({ error: 'CDP configuration not supported in this deployment' })
+      const err = notImplemented('CDP configuration not supported in this deployment')
+      return reply.code(err.statusCode).send(err.toJSON())
     }
     const { host, port = 9222 } = request.body
     if (!host || typeof host !== 'string') {
-      return reply.code(400).send({ error: 'host is required' })
+      const err = validationError('host is required')
+      return reply.code(err.statusCode).send(err.toJSON())
     }
     // Restrict to loopback addresses only — arbitrary hosts would allow SSRF
     const ALLOWED_HOSTS = ['localhost', '127.0.0.1', '::1']
     if (!ALLOWED_HOSTS.includes(host)) {
-      return reply.code(400).send({ error: 'host must be localhost, 127.0.0.1, or ::1' })
+      const err = validationError('host must be localhost, 127.0.0.1, or ::1')
+      return reply.code(err.statusCode).send(err.toJSON())
     }
     if (!Number.isInteger(port) || port < 1 || port > 65535) {
-      return reply.code(400).send({ error: 'port must be an integer between 1 and 65535' })
+      const err = validationError('port must be an integer between 1 and 65535')
+      return reply.code(err.statusCode).send(err.toJSON())
     }
     await opts.onCdpConfigure(host, port)
     return reply.code(200).send({ endpoint: `ws://${host}:${port}` })
@@ -85,7 +92,8 @@ export async function cdpRoutes(app: FastifyInstance, opts: CDPRoutesOptions) {
   // GET /cdp/status — CDP connection health + tab status
   app.get('/cdp/status', async (_request, reply) => {
     if (!opts.getCdpStatus) {
-      return reply.code(501).send({ error: 'CDP not configured' })
+      const err = notImplemented('CDP not configured')
+      return reply.code(err.statusCode).send(err.toJSON())
     }
     const status = await opts.getCdpStatus()
     return reply.send(status)
@@ -94,12 +102,14 @@ export async function cdpRoutes(app: FastifyInstance, opts: CDPRoutesOptions) {
   // POST /cdp/screenshot — one-off screenshot query (not tied to a project/run)
   app.post<{ Body: { query: string; targets?: string[] } }>('/cdp/screenshot', async (request, reply) => {
     if (!opts.onCdpScreenshot) {
-      return reply.code(501).send({ error: 'CDP not configured' })
+      const err = notImplemented('CDP not configured')
+      return reply.code(err.statusCode).send(err.toJSON())
     }
 
     const { query, targets } = request.body
     if (!query || typeof query !== 'string') {
-      return reply.code(400).send({ error: 'query is required' })
+      const err = validationError('query is required')
+      return reply.code(err.statusCode).send(err.toJSON())
     }
 
     const results = await opts.onCdpScreenshot(query, targets)
@@ -120,7 +130,10 @@ export async function cdpRoutes(app: FastifyInstance, opts: CDPRoutesOptions) {
         .from(runs)
         .where(and(eq(runs.id, runId), eq(runs.projectId, project.id)))
         .get()
-      if (!run) return reply.code(404).send({ error: 'Run not found' })
+      if (!run) {
+        const err = notFound('Run', runId)
+        return reply.code(err.statusCode).send(err.toJSON())
+      }
 
       // Get all snapshots for this run
       const snapshots = app.db

--- a/packages/api-routes/src/helpers.ts
+++ b/packages/api-routes/src/helpers.ts
@@ -38,7 +38,7 @@ export function writeAuditLog(db: Pick<DatabaseClient, 'insert'>, entry: AuditEn
 
 export function incrementUsage(db: DatabaseClient, scope: string, metric: string) {
   const now = new Date()
-  const period = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`
+  const period = now.toISOString().slice(0, 10)
   const existing = db
     .select()
     .from(usageCounters)

--- a/packages/api-routes/src/keywords.ts
+++ b/packages/api-routes/src/keywords.ts
@@ -2,7 +2,7 @@ import crypto from 'node:crypto'
 import { eq } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import { keywords } from '@ainyc/canonry-db'
-import { validationError, parseProviderName } from '@ainyc/canonry-contracts'
+import { validationError, parseProviderName, notImplemented } from '@ainyc/canonry-contracts'
 import { resolveProject, writeAuditLog } from './helpers.js'
 
 export interface KeywordRoutesOptions {
@@ -180,7 +180,8 @@ export async function keywordRoutes(app: FastifyInstance, opts: KeywordRoutesOpt
     const count = Math.min(Math.max(body.count ?? 5, 1), 20)
 
     if (!opts.onGenerateKeywords) {
-      return reply.status(501).send({ error: 'Key phrase generation is not supported in this deployment' })
+      const err = notImplemented('Key phrase generation is not supported in this deployment')
+      return reply.status(err.statusCode).send(err.toJSON())
     }
 
     const existingRows = app.db.select().from(keywords).where(eq(keywords.projectId, project.id)).all()
@@ -198,7 +199,10 @@ export async function keywordRoutes(app: FastifyInstance, opts: KeywordRoutesOpt
     } catch (err) {
       request.log.error({ err }, 'Key phrase generation failed')
       return reply.status(500).send({
-        error: err instanceof Error ? err.message : 'Failed to generate key phrases',
+        error: {
+          code: 'INTERNAL_ERROR',
+          message: err instanceof Error ? err.message : 'Failed to generate key phrases',
+        },
       })
     }
   })

--- a/packages/api-routes/src/projects.ts
+++ b/packages/api-routes/src/projects.ts
@@ -2,7 +2,13 @@ import crypto from 'node:crypto'
 import { eq } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import { projects, keywords, competitors, schedules, notifications } from '@ainyc/canonry-db'
-import { validationError, locationContextSchema } from '@ainyc/canonry-contracts'
+import {
+  validationError,
+  locationContextSchema,
+  projectUpsertRequestSchema,
+  findDuplicateLocationLabels,
+  hasLocationLabel,
+} from '@ainyc/canonry-contracts'
 import type { LocationContext } from '@ainyc/canonry-contracts'
 import { resolveProject, writeAuditLog } from './helpers.js'
 
@@ -29,21 +35,41 @@ export async function projectRoutes(app: FastifyInstance, opts: ProjectRoutesOpt
     }
   }>('/projects/:name', async (request, reply) => {
     const { name } = request.params
-    const body = request.body
-    if (!body || !body.displayName || !body.canonicalDomain || !body.country || !body.language) {
-      const err = validationError('Missing required fields: displayName, canonicalDomain, country, language')
+    const parsedBody = projectUpsertRequestSchema.safeParse(request.body)
+    if (!parsedBody.success) {
+      const err = validationError('Invalid project payload', {
+        issues: parsedBody.error.issues.map(issue => ({
+          path: issue.path.join('.'),
+          message: issue.message,
+        })),
+      })
       return reply.status(err.statusCode).send(err.toJSON())
     }
-    if (body.ownedDomains !== undefined && (
-      !Array.isArray(body.ownedDomains) ||
-      body.ownedDomains.some(d => typeof d !== 'string' || d.trim() === '')
-    )) {
-      const err = validationError('ownedDomains must be an array of non-empty strings')
-      return reply.status(err.statusCode).send(err.toJSON())
-    }
+    const body = parsedBody.data
 
     const now = new Date().toISOString()
     const existing = app.db.select().from(projects).where(eq(projects.name, name)).get()
+    const existingLocations = existing
+      ? (JSON.parse(existing.locations || '[]') as LocationContext[])
+      : []
+    const nextLocations = body.locations ?? existingLocations
+    const duplicateLabels = findDuplicateLocationLabels(nextLocations)
+    if (duplicateLabels.length > 0) {
+      const err = validationError(`Duplicate location labels are not allowed: ${duplicateLabels.join(', ')}`, {
+        duplicateLabels,
+      })
+      return reply.status(err.statusCode).send(err.toJSON())
+    }
+
+    const nextDefaultLocation = body.defaultLocation !== undefined
+      ? (body.defaultLocation ?? null)
+      : existing?.defaultLocation ?? null
+    if (!hasLocationLabel(nextLocations, nextDefaultLocation)) {
+      const err = validationError(`defaultLocation "${nextDefaultLocation}" must match a configured location label`, {
+        defaultLocation: nextDefaultLocation,
+      })
+      return reply.status(err.statusCode).send(err.toJSON())
+    }
 
     if (existing) {
       app.db.update(projects).set({
@@ -55,8 +81,8 @@ export async function projectRoutes(app: FastifyInstance, opts: ProjectRoutesOpt
         tags: JSON.stringify(body.tags ?? []),
         labels: JSON.stringify(body.labels ?? {}),
         providers: JSON.stringify(body.providers ?? []),
-        locations: JSON.stringify(body.locations ?? JSON.parse(existing.locations || '[]')),
-        defaultLocation: body.defaultLocation !== undefined ? (body.defaultLocation ?? null) : existing.defaultLocation,
+        locations: JSON.stringify(nextLocations),
+        defaultLocation: nextDefaultLocation,
         configSource: body.configSource ?? 'api',
         configRevision: existing.configRevision + 1,
         updatedAt: now,
@@ -86,8 +112,8 @@ export async function projectRoutes(app: FastifyInstance, opts: ProjectRoutesOpt
       tags: JSON.stringify(body.tags ?? []),
       labels: JSON.stringify(body.labels ?? {}),
       providers: JSON.stringify(body.providers ?? []),
-      locations: JSON.stringify(body.locations ?? []),
-      defaultLocation: body.defaultLocation ?? null,
+      locations: JSON.stringify(nextLocations),
+      defaultLocation: nextDefaultLocation,
       configSource: body.configSource ?? 'api',
       configRevision: 1,
       createdAt: now,

--- a/packages/api-routes/src/schedules.ts
+++ b/packages/api-routes/src/schedules.ts
@@ -2,7 +2,12 @@ import crypto from 'node:crypto'
 import { eq } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import { schedules } from '@ainyc/canonry-db'
-import type { ScheduleDto, ProviderName } from '@ainyc/canonry-contracts'
+import {
+  type ScheduleDto,
+  type ProviderName,
+  scheduleUpsertRequestSchema,
+  validationError,
+} from '@ainyc/canonry-contracts'
 import { resolveProject, writeAuditLog } from './helpers.js'
 import { resolvePreset, validateCron, isValidTimezone } from './schedule-utils.js'
 
@@ -19,13 +24,17 @@ export async function scheduleRoutes(app: FastifyInstance, opts: ScheduleRoutesO
     const project = resolveProjectSafe(app, request.params.name, reply)
     if (!project) return
 
-    const { preset, cron, timezone = 'UTC', providers = [], enabled = true } = request.body ?? {}
-
-    if ((!preset && !cron) || (preset && cron)) {
-      return reply.status(400).send({
-        error: { code: 'VALIDATION_ERROR', message: 'Exactly one of "preset" or "cron" must be provided' },
+    const parsedBody = scheduleUpsertRequestSchema.safeParse(request.body)
+    if (!parsedBody.success) {
+      const err = validationError('Invalid schedule payload', {
+        issues: parsedBody.error.issues.map(issue => ({
+          path: issue.path.join('.'),
+          message: issue.message,
+        })),
       })
+      return reply.status(err.statusCode).send(err.toJSON())
     }
+    const { preset, cron, timezone, providers, enabled } = parsedBody.data
 
     if (!isValidTimezone(timezone)) {
       return reply.status(400).send({

--- a/packages/api-routes/src/settings.ts
+++ b/packages/api-routes/src/settings.ts
@@ -1,6 +1,11 @@
 import type { FastifyInstance } from 'fastify'
 import type { ProviderQuotaPolicy } from '@ainyc/canonry-contracts'
-import { parseProviderName, MODEL_REGISTRY } from '@ainyc/canonry-contracts'
+import {
+  apiProviderNameSchema,
+  MODEL_REGISTRY,
+  validationError,
+  notImplemented,
+} from '@ainyc/canonry-contracts'
 
 export interface ProviderSummaryEntry {
   name: string
@@ -37,22 +42,28 @@ export async function settingsRoutes(app: FastifyInstance, opts: SettingsRoutesO
     Params: { name: string }
     Body: { apiKey?: string; baseUrl?: string; model?: string; quota?: Partial<ProviderQuotaPolicy> }
   }>('/settings/providers/:name', async (request, reply) => {
-    const providerName = parseProviderName(request.params.name)
+    const providerName = apiProviderNameSchema.safeParse(request.params.name)
     const { apiKey, baseUrl, model, quota } = request.body ?? {}
 
-    if (!providerName) {
-      return reply.status(400).send({ error: `Invalid provider: ${request.params.name}. Must be one of: gemini, openai, claude, local` })
+    if (!providerName.success) {
+      const err = validationError(`Invalid provider: ${request.params.name}. Must be one of: gemini, openai, claude, local`, {
+        provider: request.params.name,
+        validProviders: ['gemini', 'openai', 'claude', 'local'],
+      })
+      return reply.status(err.statusCode).send(err.toJSON())
     }
-    const name = providerName
+    const name = providerName.data
 
     // Local provider requires baseUrl; others require apiKey
     if (name === 'local') {
       if (!baseUrl || typeof baseUrl !== 'string') {
-        return reply.status(400).send({ error: 'baseUrl is required for local provider' })
+        const err = validationError('baseUrl is required for local provider')
+        return reply.status(err.statusCode).send(err.toJSON())
       }
     } else {
       if (!apiKey || typeof apiKey !== 'string') {
-        return reply.status(400).send({ error: 'apiKey is required' })
+        const err = validationError('apiKey is required')
+        return reply.status(err.statusCode).send(err.toJSON())
       }
     }
 
@@ -66,7 +77,8 @@ export async function settingsRoutes(app: FastifyInstance, opts: SettingsRoutesO
     }
 
     if (!opts.onProviderUpdate) {
-      return reply.status(501).send({ error: 'Provider configuration updates are not supported in this deployment' })
+      const err = notImplemented('Provider configuration updates are not supported in this deployment')
+      return reply.status(err.statusCode).send(err.toJSON())
     }
 
     // Validate quota fields if provided
@@ -86,7 +98,12 @@ export async function settingsRoutes(app: FastifyInstance, opts: SettingsRoutesO
 
     const result = opts.onProviderUpdate(name, apiKey ?? '', model, baseUrl, quota)
     if (!result) {
-      return reply.status(500).send({ error: 'Failed to update provider configuration' })
+      return reply.status(500).send({
+        error: {
+          code: 'INTERNAL_ERROR',
+          message: 'Failed to update provider configuration',
+        },
+      })
     }
 
     return result
@@ -104,12 +121,18 @@ export async function settingsRoutes(app: FastifyInstance, opts: SettingsRoutesO
     }
 
     if (!opts.onGoogleUpdate) {
-      return reply.status(501).send({ error: 'Google OAuth configuration updates are not supported in this deployment' })
+      const err = notImplemented('Google OAuth configuration updates are not supported in this deployment')
+      return reply.status(err.statusCode).send(err.toJSON())
     }
 
     const result = opts.onGoogleUpdate(clientId, clientSecret)
     if (!result) {
-      return reply.status(500).send({ error: 'Failed to update Google OAuth configuration' })
+      return reply.status(500).send({
+        error: {
+          code: 'INTERNAL_ERROR',
+          message: 'Failed to update Google OAuth configuration',
+        },
+      })
     }
 
     return result
@@ -127,12 +150,18 @@ export async function settingsRoutes(app: FastifyInstance, opts: SettingsRoutesO
     }
 
     if (!opts.onBingUpdate) {
-      return reply.status(501).send({ error: 'Bing configuration updates are not supported in this deployment' })
+      const err = notImplemented('Bing configuration updates are not supported in this deployment')
+      return reply.status(err.statusCode).send(err.toJSON())
     }
 
     const result = opts.onBingUpdate(apiKey)
     if (!result) {
-      return reply.status(500).send({ error: 'Failed to update Bing configuration' })
+      return reply.status(500).send({
+        error: {
+          code: 'INTERNAL_ERROR',
+          message: 'Failed to update Bing configuration',
+        },
+      })
     }
 
     return result

--- a/packages/api-routes/src/telemetry.ts
+++ b/packages/api-routes/src/telemetry.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance } from 'fastify'
+import { notImplemented, validationError } from '@ainyc/canonry-contracts'
 
 export interface TelemetryRoutesOptions {
   getTelemetryStatus?: () => { enabled: boolean; anonymousId?: string }
@@ -8,7 +9,8 @@ export interface TelemetryRoutesOptions {
 export async function telemetryRoutes(app: FastifyInstance, opts: TelemetryRoutesOptions) {
   app.get('/telemetry', async (_request, reply) => {
     if (!opts.getTelemetryStatus) {
-      return reply.status(501).send({ error: 'Telemetry status is not available in this deployment' })
+      const err = notImplemented('Telemetry status is not available in this deployment')
+      return reply.status(err.statusCode).send(err.toJSON())
     }
 
     const status = opts.getTelemetryStatus()
@@ -20,12 +22,14 @@ export async function telemetryRoutes(app: FastifyInstance, opts: TelemetryRoute
 
   app.put<{ Body: { enabled: boolean } }>('/telemetry', async (request, reply) => {
     if (!opts.setTelemetryEnabled) {
-      return reply.status(501).send({ error: 'Telemetry configuration is not available in this deployment' })
+      const err = notImplemented('Telemetry configuration is not available in this deployment')
+      return reply.status(err.statusCode).send(err.toJSON())
     }
 
     const { enabled } = request.body ?? {}
     if (typeof enabled !== 'boolean') {
-      return reply.status(400).send({ error: 'enabled (boolean) is required' })
+      const err = validationError('enabled (boolean) is required')
+      return reply.status(err.statusCode).send(err.toJSON())
     }
 
     opts.setTelemetryEnabled(enabled)

--- a/packages/api-routes/test/cdp.test.ts
+++ b/packages/api-routes/test/cdp.test.ts
@@ -25,6 +25,12 @@ describe('GET /api/v1/cdp/status', () => {
     await app.ready()
     const res = await app.inject({ method: 'GET', url: '/api/v1/cdp/status' })
     expect(res.statusCode).toBe(501)
+    expect(JSON.parse(res.payload)).toEqual({
+      error: {
+        code: 'NOT_IMPLEMENTED',
+        message: 'CDP not configured',
+      },
+    })
     await app.close()
     fs.rmSync(tmpDir, { recursive: true, force: true })
   })
@@ -84,6 +90,12 @@ describe('POST /api/v1/cdp/screenshot', () => {
       payload: { query: 'test query' },
     })
     expect(res.statusCode).toBe(501)
+    expect(JSON.parse(res.payload)).toEqual({
+      error: {
+        code: 'NOT_IMPLEMENTED',
+        message: 'CDP not configured',
+      },
+    })
     await app.close()
     fs.rmSync(tmpDir, { recursive: true, force: true })
   })
@@ -97,6 +109,12 @@ describe('POST /api/v1/cdp/screenshot', () => {
       payload: {},
     })
     expect(res.statusCode).toBe(400)
+    expect(JSON.parse(res.payload)).toEqual({
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'query is required',
+      },
+    })
     await app.close()
     fs.rmSync(tmpDir, { recursive: true, force: true })
   })

--- a/packages/api-routes/test/error-envelopes.test.ts
+++ b/packages/api-routes/test/error-envelopes.test.ts
@@ -1,0 +1,92 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import Fastify from 'fastify'
+import { expect, it, describe } from 'vitest'
+import { createClient, migrate } from '@ainyc/canonry-db'
+import { apiRoutes } from '../src/index.js'
+import type { ApiRoutesOptions } from '../src/index.js'
+
+function buildApp(opts: Partial<Omit<ApiRoutesOptions, 'db'>> = {}) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-error-envelope-test-'))
+  const dbPath = path.join(tmpDir, 'test.db')
+  const db = createClient(dbPath)
+  migrate(db)
+  const app = Fastify()
+  app.register(apiRoutes, { db, skipAuth: true, ...opts })
+  return { app, tmpDir }
+}
+
+describe('api error envelopes', () => {
+  it('returns a typed envelope for unsupported telemetry status', async () => {
+    const { app, tmpDir } = buildApp()
+    await app.ready()
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/telemetry',
+    })
+
+    expect(res.statusCode).toBe(501)
+    expect(JSON.parse(res.payload)).toEqual({
+      error: {
+        code: 'NOT_IMPLEMENTED',
+        message: 'Telemetry status is not available in this deployment',
+      },
+    })
+
+    await app.close()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns a typed envelope for invalid telemetry payloads', async () => {
+    const { app, tmpDir } = buildApp({
+      getTelemetryStatus: () => ({ enabled: true }),
+      setTelemetryEnabled: () => {},
+    })
+    await app.ready()
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/v1/telemetry',
+      payload: {},
+    })
+
+    expect(res.statusCode).toBe(400)
+    expect(JSON.parse(res.payload)).toEqual({
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'enabled (boolean) is required',
+      },
+    })
+
+    await app.close()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns a typed envelope for invalid provider settings names', async () => {
+    const { app, tmpDir } = buildApp()
+    await app.ready()
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/v1/settings/providers/not-a-provider',
+      payload: { apiKey: 'test' },
+    })
+
+    expect(res.statusCode).toBe(400)
+    const body = JSON.parse(res.payload) as {
+      error: {
+        code: string
+        message: string
+        details: { provider: string; validProviders: string[] }
+      }
+    }
+    expect(body.error.code).toBe('VALIDATION_ERROR')
+    expect(body.error.details.provider).toBe('not-a-provider')
+    expect(body.error.details.validProviders).toEqual(['gemini', 'openai', 'claude', 'local'])
+
+    await app.close()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+})

--- a/packages/api-routes/test/index.test.ts
+++ b/packages/api-routes/test/index.test.ts
@@ -58,6 +58,28 @@ describe('api-routes', () => {
     expect(body.ownedDomains).toEqual(['docs.example.com'])
   })
 
+  it('PUT /api/v1/projects/:name rejects an unknown defaultLocation', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/v1/projects/bad-default',
+      payload: {
+        displayName: 'Bad Default',
+        canonicalDomain: 'example.com',
+        country: 'US',
+        language: 'en',
+        locations: [
+          { label: 'nyc', city: 'New York', region: 'NY', country: 'US' },
+        ],
+        defaultLocation: 'sf',
+      },
+    })
+
+    expect(res.statusCode).toBe(400)
+    const body = JSON.parse(res.payload)
+    expect(body.error.code).toBe('VALIDATION_ERROR')
+    expect(body.error.message).toMatch(/defaultLocation/)
+  })
+
   it('GET /api/v1/projects lists projects', async () => {
     const res = await app.inject({ method: 'GET', url: '/api/v1/projects' })
     expect(res.statusCode).toBe(200)
@@ -203,6 +225,22 @@ describe('api-routes', () => {
     expect(res.statusCode).toBe(200)
     const body = JSON.parse(res.payload) as Array<{ id: string }>
     expect(body.map(run => run.id)).toEqual([olderRunId, latestRunId])
+  })
+
+  it('PUT /api/v1/projects/:name/schedule rejects unknown provider names', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/v1/projects/my-site/schedule',
+      payload: {
+        preset: 'daily',
+        providers: ['bogus-provider'],
+      },
+    })
+
+    expect(res.statusCode).toBe(400)
+    const body = JSON.parse(res.payload)
+    expect(body.error.code).toBe('VALIDATION_ERROR')
+    expect(body.error.details.issues[0].path).toBe('providers.0')
   })
 
   it('GET /api/v1/projects/:name/history returns audit log', async () => {

--- a/packages/canonry/src/job-runner.ts
+++ b/packages/canonry/src/job-runner.ts
@@ -2,13 +2,99 @@ import crypto from 'node:crypto'
 import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
-import { eq, inArray } from 'drizzle-orm'
+import { and, eq, inArray } from 'drizzle-orm'
 import type { DatabaseClient } from '@ainyc/canonry-db'
 import { runs, keywords, competitors, projects, querySnapshots, usageCounters } from '@ainyc/canonry-db'
 import type { ProviderName, NormalizedQueryResult, LocationContext } from '@ainyc/canonry-contracts'
 import { effectiveDomains, normalizeProjectDomain, isBrowserProvider } from '@ainyc/canonry-contracts'
 import type { ProviderRegistry, RegisteredProvider } from './provider-registry.js'
 import { trackEvent } from './telemetry.js'
+
+class RunCancelledError extends Error {
+  constructor(runId: string) {
+    super(`Run ${runId} was cancelled`)
+    this.name = 'RunCancelledError'
+  }
+}
+
+class ProviderExecutionGate {
+  private readonly window: number[] = []
+  private readonly waiters: Array<() => void> = []
+  private rateLimitChain = Promise.resolve()
+  private inFlight = 0
+
+  constructor(
+    private readonly maxConcurrency: number,
+    private readonly maxPerMinute: number,
+  ) {}
+
+  async run<T>(task: () => Promise<T>): Promise<T> {
+    await this.acquire()
+    try {
+      await this.waitForRateLimit()
+      return await task()
+    } finally {
+      this.release()
+    }
+  }
+
+  private async acquire(): Promise<void> {
+    if (this.inFlight < Math.max(1, this.maxConcurrency)) {
+      this.inFlight++
+      return
+    }
+
+    await new Promise<void>((resolve) => {
+      this.waiters.push(resolve)
+    })
+    this.inFlight++
+  }
+
+  private release(): void {
+    this.inFlight = Math.max(0, this.inFlight - 1)
+    const next = this.waiters.shift()
+    next?.()
+  }
+
+  private async waitForRateLimit(): Promise<void> {
+    let releaseChain: (() => void) | undefined
+    const previousChain = this.rateLimitChain
+    this.rateLimitChain = new Promise<void>((resolve) => {
+      releaseChain = resolve
+    })
+
+    await previousChain
+    try {
+      const now = Date.now()
+      const windowStart = now - 60_000
+      while (this.window.length > 0 && this.window[0]! < windowStart) {
+        this.window.shift()
+      }
+
+      if (this.window.length >= this.maxPerMinute) {
+        const oldestInWindow = this.window[0]!
+        const waitMs = oldestInWindow + 60_000 - now + 50
+        await new Promise(resolve => setTimeout(resolve, waitMs))
+        const nowAfterWait = Date.now()
+        const newWindowStart = nowAfterWait - 60_000
+        while (this.window.length > 0 && this.window[0]! < newWindowStart) {
+          this.window.shift()
+        }
+      }
+
+      this.window.push(Date.now())
+    } finally {
+      releaseChain?.()
+    }
+  }
+}
+
+type RunExecutionContext = {
+  providerCount: number
+  providers: ProviderName[]
+  keywordCount: number
+  location?: string
+}
 
 export class JobRunner {
   private db: DatabaseClient
@@ -43,14 +129,36 @@ export class JobRunner {
   async executeRun(runId: string, projectId: string, providerOverride?: ProviderName[], locationOverride?: LocationContext | null): Promise<void> {
     const now = new Date().toISOString()
     const startTime = Date.now()
+    let runLocation: LocationContext | undefined
+    let activeProviders: RegisteredProvider[] = []
+    let projectKeywords: typeof keywords.$inferSelect[] = []
+    const providerDispatchCounts = new Map<ProviderName, number>()
 
     try {
-      // Mark run as running
-      this.db
-        .update(runs)
-        .set({ status: 'running', startedAt: now })
-        .where(eq(runs.id, runId))
-        .run()
+      const existingRun = this.getRunState(runId)
+      if (!existingRun) {
+        throw new Error(`Run ${runId} not found`)
+      }
+      if (existingRun.status === 'cancelled') {
+        this.handleCancelledRun(runId, projectId, startTime, {
+          providerCount: 0,
+          providers: [],
+          keywordCount: 0,
+        })
+        return
+      }
+      if (existingRun.status !== 'queued' && existingRun.status !== 'running') {
+        throw new Error(`Run ${runId} is not executable from status '${existingRun.status}'`)
+      }
+
+      if (existingRun.status === 'queued') {
+        this.db
+          .update(runs)
+          .set({ status: 'running', startedAt: now })
+          .where(and(eq(runs.id, runId), eq(runs.status, 'queued')))
+          .run()
+      }
+      this.throwIfRunCancelled(runId)
 
       // Fetch project
       const project = this.db
@@ -66,7 +174,6 @@ export class JobRunner {
       // Resolve location: explicit override > project default > none
       // locationOverride === null means explicitly no location (--no-location)
       // locationOverride === undefined means use project default
-      let runLocation: LocationContext | undefined
       if (locationOverride === null) {
         runLocation = undefined
       } else if (locationOverride) {
@@ -80,7 +187,7 @@ export class JobRunner {
 
       // Resolve which providers to use — honour per-run override, then project config
       const projectProviders = providerOverride ?? (JSON.parse(project.providers || '[]') as ProviderName[])
-      const activeProviders = this.registry.getForProject(projectProviders)
+      activeProviders = this.registry.getForProject(projectProviders)
 
       if (activeProviders.length === 0) {
         throw new Error('No providers configured. Add at least one provider API key.')
@@ -89,7 +196,7 @@ export class JobRunner {
       console.log(`[JobRunner] Run ${runId}: dispatching to ${activeProviders.length} providers: ${activeProviders.map(p => p.adapter.name).join(', ')}`)
 
       // Fetch keywords for the project
-      const projectKeywords = this.db
+      projectKeywords = this.db
         .select()
         .from(keywords)
         .where(eq(keywords.projectId, projectId))
@@ -103,12 +210,22 @@ export class JobRunner {
         .all()
 
       const competitorDomains = projectCompetitors.map(c => c.domain)
+      const allDomains = effectiveDomains({
+        canonicalDomain: project.canonicalDomain,
+        ownedDomains: JSON.parse(project.ownedDomains || '[]') as string[],
+      })
+      const executionContext: RunExecutionContext = {
+        providerCount: activeProviders.length,
+        providers: activeProviders.map(provider => provider.adapter.name),
+        keywordCount: projectKeywords.length,
+        ...(runLocation ? { location: runLocation.label } : {}),
+      }
 
       // Enforce daily quota per provider — each provider receives one query per keyword.
       // Track and check usage per (projectId, providerName) so that a provider that has
       // never been used isn't blocked by another provider's past usage.
       const queriesPerProvider = projectKeywords.length
-      const todayPeriod = getCurrentPeriod()
+      const todayPeriod = getCurrentUsageDay()
 
       for (const p of activeProviders) {
         const providerScope = `${projectId}:${p.adapter.name}`
@@ -128,10 +245,15 @@ export class JobRunner {
         }
       }
 
-      // Per-provider rate limiting: separate sliding windows
-      const minuteWindows = new Map<ProviderName, number[]>()
-      for (const p of activeProviders) {
-        minuteWindows.set(p.adapter.name, [])
+      const executionGates = new Map<ProviderName, ProviderExecutionGate>()
+      for (const provider of activeProviders) {
+        executionGates.set(
+          provider.adapter.name,
+          new ProviderExecutionGate(
+            provider.config.quotaPolicy.maxConcurrency,
+            provider.config.quotaPolicy.maxRequestsPerMinute,
+          ),
+        )
       }
 
       // Track per-provider errors for partial completion
@@ -142,24 +264,21 @@ export class JobRunner {
       const apiProviders = activeProviders.filter(p => !isBrowserProvider(p.adapter.name))
       const browserProviders = activeProviders.filter(p => isBrowserProvider(p.adapter.name))
 
-      // Process each keyword across all providers
-      for (const kw of projectKeywords) {
-        // Fan out across API providers for this keyword
-        const providerPromises = apiProviders.map(async (registeredProvider) => {
-          const { adapter, config } = registeredProvider
-          const providerName = adapter.name
+      const processKeywordForProvider = async (
+        registeredProvider: RegisteredProvider,
+        kw: typeof keywords.$inferSelect,
+      ): Promise<void> => {
+        const { adapter, config } = registeredProvider
+        const providerName = adapter.name
+        const gate = executionGates.get(providerName)
+        if (!gate) {
+          throw new Error(`Missing execution gate for provider ${providerName}`)
+        }
 
-          try {
-            // Enforce per-minute rate limit
-            await this.waitForRateLimit(
-              minuteWindows.get(providerName)!,
-              config.quotaPolicy.maxRequestsPerMinute,
-            )
-
-            const allDomains = effectiveDomains({
-              canonicalDomain: project.canonicalDomain,
-              ownedDomains: JSON.parse(project.ownedDomains || '[]') as string[],
-            })
+        try {
+          await gate.run(async () => {
+            this.throwIfRunCancelled(runId)
+            providerDispatchCounts.set(providerName, (providerDispatchCounts.get(providerName) ?? 0) + 1)
 
             const raw = await adapter.executeTrackedQuery(
               {
@@ -170,6 +289,8 @@ export class JobRunner {
               },
               config,
             )
+
+            this.throwIfRunCancelled(runId)
 
             const normalized = adapter.normalizeResult(raw)
 
@@ -231,108 +352,34 @@ export class JobRunner {
 
             totalSnapshotsInserted++
             console.log(`[JobRunner] ${providerName}: keyword "${kw.keyword}" → ${citationState}`)
-          } catch (err: unknown) {
-            const msg = err instanceof Error ? err.message : String(err)
-            console.error(`[JobRunner] ${providerName}: keyword "${kw.keyword}" FAILED: ${msg}`)
-            providerErrors.set(providerName, msg)
+          })
+        } catch (err: unknown) {
+          if (err instanceof RunCancelledError) {
+            throw err
           }
-        })
 
-        await Promise.all(providerPromises)
-
-        // Browser providers run sequentially (shared browser, one tab at a time)
-        for (const registeredProvider of browserProviders) {
-          const { adapter, config } = registeredProvider
-          const providerName = adapter.name
-
-          try {
-            await this.waitForRateLimit(
-              minuteWindows.get(providerName)!,
-              config.quotaPolicy.maxRequestsPerMinute,
-            )
-
-            const allDomains = effectiveDomains({
-              canonicalDomain: project.canonicalDomain,
-              ownedDomains: JSON.parse(project.ownedDomains || '[]') as string[],
-            })
-
-            const raw = await adapter.executeTrackedQuery(
-              {
-                keyword: kw.keyword,
-                canonicalDomains: allDomains,
-                competitorDomains,
-                location: runLocation,
-              },
-              config,
-            )
-
-            const normalized = adapter.normalizeResult(raw)
-
-            console.log(`[JobRunner] ${providerName}: "${kw.keyword}" citedDomains=${JSON.stringify(normalized.citedDomains)}, groundingSources=${JSON.stringify(normalized.groundingSources.map(s => s.uri))}, domains=${JSON.stringify(allDomains)}`)
-            const citationState = determineCitationState(normalized, allDomains)
-            const overlap = computeCompetitorOverlap(normalized, competitorDomains)
-
-            // Move screenshot to canonical location if present
-            let screenshotRelPath: string | null = null
-            if (raw.screenshotPath && fs.existsSync(raw.screenshotPath)) {
-              const snapshotId = crypto.randomUUID()
-              const screenshotDir = path.join(os.homedir(), '.canonry', 'screenshots', runId)
-              if (!fs.existsSync(screenshotDir)) fs.mkdirSync(screenshotDir, { recursive: true })
-              const destPath = path.join(screenshotDir, `${snapshotId}.png`)
-              fs.renameSync(raw.screenshotPath, destPath)
-              screenshotRelPath = `${runId}/${snapshotId}.png`
-
-              this.db.insert(querySnapshots).values({
-                id: snapshotId,
-                runId,
-                keywordId: kw.id,
-                provider: providerName,
-                model: raw.model,
-                citationState,
-                answerText: normalized.answerText,
-                citedDomains: JSON.stringify(normalized.citedDomains),
-                competitorOverlap: JSON.stringify(overlap),
-                location: runLocation?.label ?? null,
-                screenshotPath: screenshotRelPath,
-                rawResponse: JSON.stringify({
-                  model: raw.model,
-                  groundingSources: normalized.groundingSources,
-                  searchQueries: normalized.searchQueries,
-                  apiResponse: raw.rawResponse,
-                }),
-                createdAt: new Date().toISOString(),
-              }).run()
-            } else {
-              this.db.insert(querySnapshots).values({
-                id: crypto.randomUUID(),
-                runId,
-                keywordId: kw.id,
-                provider: providerName,
-                model: raw.model,
-                citationState,
-                answerText: normalized.answerText,
-                citedDomains: JSON.stringify(normalized.citedDomains),
-                competitorOverlap: JSON.stringify(overlap),
-                location: runLocation?.label ?? null,
-                rawResponse: JSON.stringify({
-                  model: raw.model,
-                  groundingSources: normalized.groundingSources,
-                  searchQueries: normalized.searchQueries,
-                  apiResponse: raw.rawResponse,
-                }),
-                createdAt: new Date().toISOString(),
-              }).run()
-            }
-
-            totalSnapshotsInserted++
-            console.log(`[JobRunner] ${providerName}: keyword "${kw.keyword}" → ${citationState}`)
-          } catch (err: unknown) {
-            const msg = err instanceof Error ? err.message : String(err)
-            console.error(`[JobRunner] ${providerName}: keyword "${kw.keyword}" FAILED: ${msg}`)
+          const msg = err instanceof Error ? err.message : String(err)
+          console.error(`[JobRunner] ${providerName}: keyword "${kw.keyword}" FAILED: ${msg}`)
+          if (!providerErrors.has(providerName)) {
             providerErrors.set(providerName, msg)
           }
         }
       }
+
+      await Promise.all(apiProviders.map(async (registeredProvider) => {
+        await Promise.all(projectKeywords.map(async (kw) => {
+          await processKeywordForProvider(registeredProvider, kw)
+        }))
+      }))
+
+      // Browser providers still run keyword-by-keyword to preserve tab reuse semantics.
+      for (const registeredProvider of browserProviders) {
+        for (const kw of projectKeywords) {
+          await processKeywordForProvider(registeredProvider, kw)
+        }
+      }
+
+      this.throwIfRunCancelled(runId)
 
       // Determine final run status
       const allFailed = totalSnapshotsInserted === 0 && providerErrors.size > 0
@@ -360,21 +407,19 @@ export class JobRunner {
           .run()
       }
 
+      this.flushProviderUsage(projectId, providerDispatchCounts)
+
       // Track run completion telemetry
       const finalStatus = allFailed ? 'failed' : someFailed ? 'partial' : 'completed'
       trackEvent('run.completed', {
         status: finalStatus,
-        providerCount: activeProviders.length,
-        providers: activeProviders.map(p => p.adapter.name),
-        keywordCount: projectKeywords.length,
+        providerCount: executionContext.providerCount,
+        providers: executionContext.providers,
+        keywordCount: executionContext.keywordCount,
         durationMs: Date.now() - startTime,
-        ...(runLocation ? { location: runLocation.label } : {}),
+        ...(executionContext.location ? { location: executionContext.location } : {}),
       })
 
-      // Increment per-provider usage counters to keep quota checks accurate
-      for (const p of activeProviders) {
-        this.incrementUsage(`${projectId}:${p.adapter.name}`, 'queries', queriesPerProvider)
-      }
       this.incrementUsage(projectId, 'runs', 1)
 
       // Notify after run completion
@@ -384,6 +429,19 @@ export class JobRunner {
         })
       }
     } catch (err: unknown) {
+      const executionContext: RunExecutionContext = {
+        providerCount: activeProviders.length,
+        providers: activeProviders.map(provider => provider.adapter.name),
+        keywordCount: projectKeywords.length,
+        ...(runLocation ? { location: runLocation.label } : {}),
+      }
+
+      if (err instanceof RunCancelledError || this.isRunCancelled(runId)) {
+        this.flushProviderUsage(projectId, providerDispatchCounts)
+        this.handleCancelledRun(runId, projectId, startTime, executionContext)
+        return
+      }
+
       // Mark run as failed
       const errorMessage = err instanceof Error ? err.message : String(err)
       this.db
@@ -396,13 +454,16 @@ export class JobRunner {
         .where(eq(runs.id, runId))
         .run()
 
+      this.flushProviderUsage(projectId, providerDispatchCounts)
+
       // Track fatal run failures (missing project, quota exceeded, no providers, etc.)
       trackEvent('run.completed', {
         status: 'failed',
-        providerCount: 0,
-        providers: [],
-        keywordCount: 0,
+        providerCount: executionContext.providerCount,
+        providers: executionContext.providers,
+        keywordCount: executionContext.keywordCount,
         durationMs: Date.now() - startTime,
+        ...(executionContext.location ? { location: executionContext.location } : {}),
       })
 
       // Notify on failure too
@@ -414,28 +475,9 @@ export class JobRunner {
     }
   }
 
-  private async waitForRateLimit(window: number[], maxPerMinute: number): Promise<void> {
-    const now = Date.now()
-    const windowStart = now - 60_000
-    while (window.length > 0 && window[0]! < windowStart) {
-      window.shift()
-    }
-    if (window.length >= maxPerMinute) {
-      const oldestInWindow = window[0]!
-      const waitMs = oldestInWindow + 60_000 - now + 50
-      await new Promise(resolve => setTimeout(resolve, waitMs))
-      const nowAfterWait = Date.now()
-      const newWindowStart = nowAfterWait - 60_000
-      while (window.length > 0 && window[0]! < newWindowStart) {
-        window.shift()
-      }
-    }
-    window.push(Date.now())
-  }
-
   private incrementUsage(scope: string, metric: string, count: number): void {
     const now = new Date()
-    const period = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`
+    const period = now.toISOString().slice(0, 10)
     const id = crypto.randomUUID()
 
     const existing = this.db
@@ -462,11 +504,73 @@ export class JobRunner {
       }).run()
     }
   }
+
+  private flushProviderUsage(projectId: string, providerDispatchCounts: ReadonlyMap<ProviderName, number>): void {
+    for (const [providerName, count] of providerDispatchCounts.entries()) {
+      if (count <= 0) continue
+      this.incrementUsage(`${projectId}:${providerName}`, 'queries', count)
+    }
+  }
+
+  private getRunState(runId: string): { status: string; finishedAt: string | null; error: string | null } | undefined {
+    return this.db
+      .select({
+        status: runs.status,
+        finishedAt: runs.finishedAt,
+        error: runs.error,
+      })
+      .from(runs)
+      .where(eq(runs.id, runId))
+      .get()
+  }
+
+  private isRunCancelled(runId: string): boolean {
+    return this.getRunState(runId)?.status === 'cancelled'
+  }
+
+  private throwIfRunCancelled(runId: string): void {
+    if (this.isRunCancelled(runId)) {
+      throw new RunCancelledError(runId)
+    }
+  }
+
+  private handleCancelledRun(
+    runId: string,
+    projectId: string,
+    startTime: number,
+    context: RunExecutionContext,
+  ): void {
+    const currentRun = this.getRunState(runId)
+    if (currentRun && !currentRun.finishedAt) {
+      this.db
+        .update(runs)
+        .set({
+          finishedAt: new Date().toISOString(),
+          error: currentRun.error ?? 'Cancelled by user',
+        })
+        .where(eq(runs.id, runId))
+        .run()
+    }
+
+    trackEvent('run.completed', {
+      status: 'cancelled',
+      providerCount: context.providerCount,
+      providers: context.providers,
+      keywordCount: context.keywordCount,
+      durationMs: Date.now() - startTime,
+      ...(context.location ? { location: context.location } : {}),
+    })
+
+    if (this.onRunCompleted) {
+      this.onRunCompleted(runId, projectId).catch((err: unknown) => {
+        console.error('[JobRunner] Notification callback failed:', err)
+      })
+    }
+  }
 }
 
-function getCurrentPeriod(): string {
-  const d = new Date()
-  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`
+function getCurrentUsageDay(): string {
+  return new Date().toISOString().slice(0, 10)
 }
 
 function domainMatches(domain: string, canonicalDomain: string): boolean {

--- a/packages/canonry/test/job-runner-runtime-controls.test.ts
+++ b/packages/canonry/test/job-runner-runtime-controls.test.ts
@@ -1,0 +1,230 @@
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { eq } from 'drizzle-orm'
+import { expect, onTestFinished, test } from 'vitest'
+import type {
+  NormalizedQueryResult,
+  ProviderAdapter,
+  ProviderConfig,
+  ProviderHealthcheckResult,
+  RawQueryResult,
+  TrackedQueryInput,
+} from '@ainyc/canonry-contracts'
+import { createClient, keywords, migrate, projects, querySnapshots, runs, usageCounters } from '@ainyc/canonry-db'
+import { JobRunner } from '../src/job-runner.js'
+import { ProviderRegistry } from '../src/provider-registry.js'
+
+function createTempDb(prefix: string) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+  onTestFinished(() => fs.rmSync(tmpDir, { recursive: true, force: true }))
+  const dbPath = path.join(tmpDir, 'test.db')
+  const db = createClient(dbPath)
+  migrate(db)
+  return { db, tmpDir }
+}
+
+function buildAdapter(overrides?: Partial<ProviderAdapter>): ProviderAdapter {
+  return {
+    name: 'gemini',
+    validateConfig(_config: ProviderConfig): ProviderHealthcheckResult {
+      return { ok: true, provider: 'gemini', message: 'ok' }
+    },
+    async healthcheck(_config: ProviderConfig): Promise<ProviderHealthcheckResult> {
+      return { ok: true, provider: 'gemini', message: 'ok' }
+    },
+    async executeTrackedQuery(_input: TrackedQueryInput, _config: ProviderConfig): Promise<RawQueryResult> {
+      return {
+        provider: 'gemini',
+        rawResponse: {},
+        model: 'stub-model',
+        groundingSources: [],
+        searchQueries: [],
+      }
+    },
+    normalizeResult(_raw: RawQueryResult): NormalizedQueryResult {
+      return {
+        provider: 'gemini',
+        answerText: 'stub answer',
+        citedDomains: [],
+        groundingSources: [],
+        searchQueries: [],
+      }
+    },
+    async generateText(_prompt: string, _config: ProviderConfig): Promise<string> {
+      return 'stub'
+    },
+    ...overrides,
+  }
+}
+
+function seedRunFixture(db: ReturnType<typeof createClient>, keywordCount: number) {
+  const now = new Date().toISOString()
+  const projectId = crypto.randomUUID()
+  const runId = crypto.randomUUID()
+
+  db.insert(projects).values({
+    id: projectId,
+    name: 'test-project',
+    displayName: 'Test Project',
+    canonicalDomain: 'example.com',
+    country: 'US',
+    language: 'en',
+    providers: '[]',
+    createdAt: now,
+    updatedAt: now,
+  }).run()
+
+  for (let index = 0; index < keywordCount; index++) {
+    db.insert(keywords).values({
+      id: crypto.randomUUID(),
+      projectId,
+      keyword: `keyword-${index + 1}`,
+      createdAt: now,
+    }).run()
+  }
+
+  db.insert(runs).values({
+    id: runId,
+    projectId,
+    status: 'queued',
+    createdAt: now,
+  }).run()
+
+  return { now, projectId, runId }
+}
+
+test('JobRunner ignores previous-day usage when enforcing maxRequestsPerDay', async () => {
+  const { db } = createTempDb('canonry-job-runner-quota-')
+  const { projectId, runId, now } = seedRunFixture(db, 1)
+
+  const previousDay = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
+  db.insert(usageCounters).values({
+    id: crypto.randomUUID(),
+    scope: `${projectId}:gemini`,
+    period: previousDay,
+    metric: 'queries',
+    count: 1,
+    updatedAt: now,
+  }).run()
+
+  const registry = new ProviderRegistry()
+  registry.register(buildAdapter(), {
+    provider: 'gemini',
+    apiKey: 'test-key',
+    quotaPolicy: {
+      maxConcurrency: 1,
+      maxRequestsPerMinute: 60,
+      maxRequestsPerDay: 1,
+    },
+  })
+
+  const runner = new JobRunner(db, registry)
+  await runner.executeRun(runId, projectId)
+
+  const run = db.select().from(runs).where(eq(runs.id, runId)).get()
+  expect(run?.status).toBe('completed')
+  const snapshots = db.select().from(querySnapshots).where(eq(querySnapshots.runId, runId)).all()
+  expect(snapshots).toHaveLength(1)
+})
+
+test('JobRunner honors per-provider maxConcurrency for API providers', async () => {
+  const { db } = createTempDb('canonry-job-runner-concurrency-')
+  const { projectId, runId } = seedRunFixture(db, 3)
+
+  let inFlight = 0
+  let maxSeen = 0
+
+  const registry = new ProviderRegistry()
+  registry.register(buildAdapter({
+    async executeTrackedQuery(_input: TrackedQueryInput, _config: ProviderConfig): Promise<RawQueryResult> {
+      inFlight++
+      maxSeen = Math.max(maxSeen, inFlight)
+      await new Promise(resolve => setTimeout(resolve, 25))
+      inFlight--
+      return {
+        provider: 'gemini',
+        rawResponse: {},
+        model: 'stub-model',
+        groundingSources: [],
+        searchQueries: [],
+      }
+    },
+  }), {
+    provider: 'gemini',
+    apiKey: 'test-key',
+    quotaPolicy: {
+      maxConcurrency: 2,
+      maxRequestsPerMinute: 60,
+      maxRequestsPerDay: 100,
+    },
+  })
+
+  const runner = new JobRunner(db, registry)
+  await runner.executeRun(runId, projectId)
+
+  expect(maxSeen).toBe(2)
+  const run = db.select().from(runs).where(eq(runs.id, runId)).get()
+  expect(run?.status).toBe('completed')
+})
+
+test('JobRunner stops dispatching new work after a run is cancelled', async () => {
+  const { db } = createTempDb('canonry-job-runner-cancel-')
+  const { projectId, runId } = seedRunFixture(db, 2)
+
+  let callCount = 0
+  let releaseFirstCall: (() => void) | undefined
+  const firstCallStarted = new Promise<void>((resolve) => {
+    releaseFirstCall = resolve
+  })
+  let markFirstCallStarted: (() => void) | undefined
+  const waitForFirstCall = new Promise<void>((resolve) => {
+    markFirstCallStarted = resolve
+  })
+
+  const registry = new ProviderRegistry()
+  registry.register(buildAdapter({
+    async executeTrackedQuery(_input: TrackedQueryInput, _config: ProviderConfig): Promise<RawQueryResult> {
+      callCount++
+      if (callCount === 1) {
+        markFirstCallStarted?.()
+        await firstCallStarted
+      }
+
+      return {
+        provider: 'gemini',
+        rawResponse: {},
+        model: 'stub-model',
+        groundingSources: [],
+        searchQueries: [],
+      }
+    },
+  }), {
+    provider: 'gemini',
+    apiKey: 'test-key',
+    quotaPolicy: {
+      maxConcurrency: 1,
+      maxRequestsPerMinute: 60,
+      maxRequestsPerDay: 100,
+    },
+  })
+
+  const runner = new JobRunner(db, registry)
+  const execution = runner.executeRun(runId, projectId)
+
+  await waitForFirstCall
+  db.update(runs)
+    .set({ status: 'cancelled', finishedAt: new Date().toISOString(), error: 'Cancelled by user' })
+    .where(eq(runs.id, runId))
+    .run()
+  releaseFirstCall?.()
+
+  await execution
+
+  const run = db.select().from(runs).where(eq(runs.id, runId)).get()
+  expect(run?.status).toBe('cancelled')
+  expect(callCount).toBe(1)
+  const snapshots = db.select().from(querySnapshots).where(eq(querySnapshots.runId, runId)).all()
+  expect(snapshots).toHaveLength(0)
+})

--- a/packages/contracts/src/config-schema.ts
+++ b/packages/contracts/src/config-schema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import { providerNameSchema, locationContextSchema } from './provider.js'
 import { notificationEventSchema } from './notification.js'
+import { findDuplicateLocationLabels, hasLocationLabel } from './project.js'
 
 export const configMetadataSchema = z.object({
   name: z.string().min(1).max(63).regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/, {
@@ -49,6 +50,23 @@ export const configSpecSchema = z.object({
   schedule: configScheduleSchema,
   notifications: z.array(configNotificationSchema).optional().default([]),
   google: configGoogleSchema,
+}).superRefine((spec, ctx) => {
+  const duplicateLabels = findDuplicateLocationLabels(spec.locations)
+  if (duplicateLabels.length > 0) {
+    ctx.addIssue({
+      code: 'custom',
+      message: `Duplicate location labels are not allowed: ${duplicateLabels.join(', ')}`,
+      path: ['locations'],
+    })
+  }
+
+  if (!hasLocationLabel(spec.locations, spec.defaultLocation)) {
+    ctx.addIssue({
+      code: 'custom',
+      message: `defaultLocation "${spec.defaultLocation}" must match a configured location label`,
+      path: ['defaultLocation'],
+    })
+  }
 })
 
 export const projectConfigSchema = z.object({

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -10,6 +10,7 @@ export type ErrorCode =
   | 'RUN_IN_PROGRESS'
   | 'UNSUPPORTED_KIND'
   | 'RUN_NOT_CANCELLABLE'
+  | 'NOT_IMPLEMENTED'
   | 'INTERNAL_ERROR'
 
 export class AppError extends Error {
@@ -83,4 +84,8 @@ export function runNotCancellable(runId: string, status: string): AppError {
 
 export function unsupportedKind(kind: string): AppError {
   return new AppError('UNSUPPORTED_KIND', `Kind '${kind}' is not supported in this version`, 400)
+}
+
+export function notImplemented(message: string): AppError {
+  return new AppError('NOT_IMPLEMENTED', message, 501)
 }

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -1,8 +1,47 @@
 import { z } from 'zod'
-import { locationContextSchema } from './provider.js'
+import { locationContextSchema, providerNameSchema, type LocationContext } from './provider.js'
 
 export const configSourceSchema = z.enum(['cli', 'api', 'config-file'])
 export type ConfigSource = z.infer<typeof configSourceSchema>
+
+export function findDuplicateLocationLabels(locations: readonly Pick<LocationContext, 'label'>[]): string[] {
+  const seen = new Set<string>()
+  const duplicates = new Set<string>()
+
+  for (const location of locations) {
+    if (seen.has(location.label)) {
+      duplicates.add(location.label)
+      continue
+    }
+    seen.add(location.label)
+  }
+
+  return [...duplicates]
+}
+
+export function hasLocationLabel(
+  locations: readonly Pick<LocationContext, 'label'>[],
+  label: string | null | undefined,
+): boolean {
+  if (!label) return true
+  return locations.some(location => location.label === label)
+}
+
+export const projectUpsertRequestSchema = z.object({
+  displayName: z.string().min(1),
+  canonicalDomain: z.string().min(1),
+  ownedDomains: z.array(z.string().min(1)).optional(),
+  country: z.string().length(2),
+  language: z.string().min(2),
+  tags: z.array(z.string()).optional(),
+  labels: z.record(z.string(), z.string()).optional(),
+  providers: z.array(providerNameSchema).optional(),
+  locations: z.array(locationContextSchema).optional(),
+  defaultLocation: z.string().nullable().optional(),
+  configSource: configSourceSchema.optional(),
+})
+
+export type ProjectUpsertRequest = z.infer<typeof projectUpsertRequestSchema>
 
 export const projectDtoSchema = z.object({
   id: z.string(),

--- a/packages/contracts/src/provider.ts
+++ b/packages/contracts/src/provider.ts
@@ -13,6 +13,10 @@ export const PROVIDER_NAMES = ['gemini', 'openai', 'claude', 'local', 'cdp:chatg
 export const providerNameSchema = z.enum(PROVIDER_NAMES)
 export type ProviderName = z.infer<typeof providerNameSchema>
 
+export const API_PROVIDER_NAMES = ['gemini', 'openai', 'claude', 'local'] as const
+export const apiProviderNameSchema = z.enum(API_PROVIDER_NAMES)
+export type ApiProviderName = z.infer<typeof apiProviderNameSchema>
+
 /** Classify providers by surface: API-based or browser-based (CDP) */
 export const PROVIDER_MODE: Record<ProviderName, 'api' | 'browser'> = {
   gemini: 'api',

--- a/packages/contracts/src/schedule.ts
+++ b/packages/contracts/src/schedule.ts
@@ -18,3 +18,16 @@ export const scheduleDtoSchema = z.object({
 })
 
 export type ScheduleDto = z.infer<typeof scheduleDtoSchema>
+
+export const scheduleUpsertRequestSchema = z.object({
+  preset: z.string().optional(),
+  cron: z.string().optional(),
+  timezone: z.string().optional().default('UTC'),
+  enabled: z.boolean().optional().default(true),
+  providers: z.array(providerNameSchema).optional().default([]),
+}).refine(
+  (data) => (data.preset && !data.cron) || (!data.preset && data.cron),
+  { message: 'Exactly one of "preset" or "cron" must be provided' },
+)
+
+export type ScheduleUpsertRequest = z.infer<typeof scheduleUpsertRequestSchema>

--- a/packages/contracts/test/index.test.ts
+++ b/packages/contracts/test/index.test.ts
@@ -134,6 +134,42 @@ test('projectConfigSchema rejects invalid project names', () => {
   })).toThrow()
 })
 
+test('projectConfigSchema rejects a defaultLocation that is not configured', () => {
+  expect(() => projectConfigSchema.parse({
+    apiVersion: 'canonry/v1',
+    kind: 'Project',
+    metadata: { name: 'my-project' },
+    spec: {
+      displayName: 'My Project',
+      canonicalDomain: 'example.com',
+      country: 'US',
+      language: 'en',
+      locations: [
+        { label: 'nyc', city: 'New York', region: 'NY', country: 'US' },
+      ],
+      defaultLocation: 'sf',
+    },
+  })).toThrow(/defaultLocation/)
+})
+
+test('projectConfigSchema rejects duplicate location labels', () => {
+  expect(() => projectConfigSchema.parse({
+    apiVersion: 'canonry/v1',
+    kind: 'Project',
+    metadata: { name: 'my-project' },
+    spec: {
+      displayName: 'My Project',
+      canonicalDomain: 'example.com',
+      country: 'US',
+      language: 'en',
+      locations: [
+        { label: 'nyc', city: 'New York', region: 'NY', country: 'US' },
+        { label: 'nyc', city: 'Brooklyn', region: 'NY', country: 'US' },
+      ],
+    },
+  })).toThrow(/Duplicate location labels/)
+})
+
 test('citationStateSchema accepts only raw observation values', () => {
   expect(citationStateSchema.parse('cited')).toBe('cited')
   expect(citationStateSchema.parse('not-cited')).toBe('not-cited')


### PR DESCRIPTION
## Summary
- make run cancellation a real terminal state and stop dispatching new work after cancellation
- enforce actual daily quota buckets and provider `maxConcurrency` in the job runner
- align direct REST project and schedule validation with the config-as-code contracts
- normalize remaining API error responses onto typed error envelopes

## Testing
- pnpm run typecheck
- pnpm run lint
- pnpm run test