### PR TITLE
fix(perplexity): extractCitations handles both direct API and stored DB format

### DIFF
--- a/packages/provider-perplexity/src/normalize.ts
+++ b/packages/provider-perplexity/src/normalize.ts
@@ -95,14 +95,29 @@ export function normalizeResult(raw: PerplexityRawResult): PerplexityNormalizedR
 // --- Internal helpers ---
 
 /**
- * Extract the citations array from the Perplexity response.
- * Perplexity adds a `citations` field to the response object
- * containing an array of source URLs.
+ * Extract the citations array from a Perplexity response.
+ *
+ * Handles two shapes:
+ * 1. Direct API response — `rawResponse.citations` (array of URL strings at top level)
+ * 2. Stored DB format — `rawResponse.apiResponse.citations` (job-runner wraps the raw API
+ *    response under an `apiResponse` key before persisting to query_snapshots.raw_response)
+ *
+ * Perplexity's Sonar models return citations by default; no extra flag required.
  */
 export function extractCitations(rawResponse: Record<string, unknown>): string[] {
-  const citations = rawResponse.citations
-  if (!Array.isArray(citations)) return []
-  return citations.filter((c): c is string => typeof c === 'string')
+  // Shape 1: direct API response (used at execution time)
+  if (Array.isArray(rawResponse.citations)) {
+    return rawResponse.citations.filter((c): c is string => typeof c === 'string')
+  }
+  // Shape 2: stored DB format — citations nested under apiResponse
+  const apiResponse = rawResponse.apiResponse
+  if (apiResponse !== null && typeof apiResponse === 'object' && !Array.isArray(apiResponse)) {
+    const nested = (apiResponse as Record<string, unknown>).citations
+    if (Array.isArray(nested)) {
+      return nested.filter((c): c is string => typeof c === 'string')
+    }
+  }
+  return []
 }
 
 function extractAnswerText(rawResponse: Record<string, unknown>): string {

--- a/packages/provider-perplexity/test/normalize.test.ts
+++ b/packages/provider-perplexity/test/normalize.test.ts
@@ -29,6 +29,49 @@ describe('extractCitations', () => {
     }
     expect(extractCitations(raw)).toEqual(['https://example.com', 'https://other.com'])
   })
+
+  it('extracts citations from stored DB format (nested under apiResponse)', () => {
+    // job-runner stores raw_response as { model, groundingSources, searchQueries, apiResponse }
+    // where apiResponse is the actual Perplexity API response containing citations
+    const dbStoredFormat = {
+      model: 'sonar',
+      groundingSources: [{ uri: 'https://example.com', title: '' }],
+      searchQueries: ['AEO agency NYC'],
+      apiResponse: {
+        id: 'abc123',
+        model: 'sonar',
+        choices: [{ message: { content: 'answer text' } }],
+        citations: [
+          'https://example.com/page1',
+          'https://ainyc.ai/services',
+        ],
+      },
+    }
+    expect(extractCitations(dbStoredFormat)).toEqual([
+      'https://example.com/page1',
+      'https://ainyc.ai/services',
+    ])
+  })
+
+  it('prefers top-level citations over nested apiResponse citations', () => {
+    // If both exist, direct API response format takes precedence
+    const raw = {
+      citations: ['https://direct.com'],
+      apiResponse: {
+        citations: ['https://nested.com'],
+      },
+    }
+    expect(extractCitations(raw)).toEqual(['https://direct.com'])
+  })
+
+  it('returns empty array when apiResponse has no citations', () => {
+    const raw = {
+      model: 'sonar',
+      groundingSources: [],
+      apiResponse: { id: 'abc', choices: [] },
+    }
+    expect(extractCitations(raw)).toEqual([])
+  })
 })
 
 describe('extractCitedDomains', () => {


### PR DESCRIPTION
## Problem

`extractCitations()` in `provider-perplexity/src/normalize.ts` only checked `rawResponse.citations` at the top level. This works correctly at execution time (when `rawResponse` is the raw Perplexity API response), but fails when called on the stored DB format.

The job-runner stores `raw_response` in `query_snapshots` as a wrapper:
```json
{ "model": "sonar", "groundingSources": [...], "searchQueries": [...], "apiResponse": <raw API response> }
```

So citations are at `apiResponse.citations` in the stored format, not at the top level.

## Impact

- **No historical data loss** — citations were captured correctly at execution time via `groundingSources`, which are stored separately
- **Future re-processing** (re-analysis, debugging, analytics) of stored `raw_response` values would silently return no citations

## Fix

Update `extractCitations` to handle both shapes:
1. **Direct API response** (execution time): `rawResponse.citations` — takes precedence
2. **Stored DB format** (re-processing): `rawResponse.apiResponse.citations`

## Tests

Added 3 new test cases:
- Stored DB format extraction
- Precedence (direct API wins over nested)
- Empty apiResponse with no citations