### PR TITLE
fix(bing): show configured=true when connections exist, not just global apiKey

### DIFF
--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -174,7 +174,13 @@ export async function createServer(opts: {
     configured: Boolean(opts.config.google?.clientId && opts.config.google?.clientSecret),
   }
   const bingSettingsSummary = {
-    configured: Boolean(opts.config.bing?.apiKey),
+    // Treat Bing as configured if there is at least one connection with an API key,
+    // OR if a global bing.apiKey is set. The CLI stores keys per-connection
+    // (bing.connections[].apiKey), so checking only bing.apiKey missed existing connections.
+    configured: Boolean(
+      opts.config.bing?.apiKey ||
+      opts.config.bing?.connections?.some((c) => c.apiKey)
+    ),
   }
 
   // Bing connection store — stores connections in ~/.canonry/config.yaml


### PR DESCRIPTION
## Problem

The Bing settings card in the UI showed **"Needs config"** even after running `canonry bing connect` and adding an API key.

**Root cause:** `bingSettingsSummary.configured` checked `opts.config.bing?.apiKey` (a global key), but `canonry bing connect` stores the key per-connection under `bing.connections[].apiKey`. No global key is ever written, so `configured` was always `false`.

**Config shape written by CLI:**
```yaml
bing:
  connections:
    - domain: ainyc.ai
      apiKey: <key>   # ← here, not at bing.apiKey
      siteUrl: https://ainyc.ai/
```

## Fix

Check both paths:
- `bing.connections[].apiKey` — any connection has a key (covers CLI-configured installs)
- `bing.apiKey` — global key (supports both storage patterns, backwards compat)