### PR TITLE
fix(ui): fetch health from basePath-prefixed URL, not hardcoded /health

### DIFF
--- a/apps/web/src/queries/use-health.ts
+++ b/apps/web/src/queries/use-health.ts
@@ -1,10 +1,15 @@
 import { useQuery } from '@tanstack/react-query'
 import { fetchServiceStatus } from '../api.js'
+import { _BASE_PREFIX } from '../lib/base-path.js'
 import type { HealthSnapshot, ServiceStatus } from '../view-models.js'
 import { queryKeys } from './query-keys.js'
 
 async function fetchHealth(): Promise<HealthSnapshot> {
-  const apiStatus = await fetchServiceStatus('/health', 'API')
+  // Use the basePath-prefixed health URL so the request hits the canonry server
+  // even when served under a sub-path (e.g. /canonry/). A hardcoded '/health'
+  // would miss the Caddy proxy rule and land on the wrong backend.
+  const healthUrl = _BASE_PREFIX ? `${_BASE_PREFIX}/health` : '/health'
+  const apiStatus = await fetchServiceStatus(healthUrl, 'API')
   const workerStatus: ServiceStatus = apiStatus.state === 'ok'
     ? { label: 'Runner', state: 'ok', detail: 'In-process job runner' }
     : { label: 'Runner', state: apiStatus.state, detail: 'Depends on API' }


### PR DESCRIPTION
## Problem

Service health card shows `unknown · database configured` instead of the actual version.

**Root cause:** `use-health.ts` fetches `/health` as a hardcoded absolute path. When canonry is served at `/canonry/` behind Caddy, the browser resolves `/health` as a root-level path that doesn't match the `/canonry/*` proxy rule — so the request hits the wrong backend (OpenClaw gateway on port 18789). That backend returns a 200 with no `version` field, so `fetchServiceStatus` falls back to `'unknown'`.

**Caddy config (relevant):**
```
handle /canonry* {
    reverse_proxy localhost:4100   # ← canonry
}
handle {
    reverse_proxy localhost:18789  # ← everything else goes here, including /health
}
```

## Fix

Use `_BASE_PREFIX` (already injected at runtime via `window.__CANONRY_CONFIG__.basePath`) to build the health URL:
- Sub-path deployment: `/canonry/health` ✅ hits canonry server
- Root deployment: `/health` ✅ unchanged behaviour

## Result

Service health card will show `1.21.0 · database configured` instead of `unknown · database configured`.