### PR TITLE
feat(ui): Refresh overview triggers live GSC sync and polls to completion

### DIFF
--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { ChevronRight, Download, Trash2 } from 'lucide-react'
 import { useParams, useNavigate } from '@tanstack/react-router'
 import { Link } from '@tanstack/react-router'
@@ -628,9 +628,9 @@ function SearchConsoleSection({
 }) {
   const [workspace, setWorkspace] = useState<SearchConsoleWorkspace>('google')
   const [loading, setLoading] = useState(true)
-  const [refreshing, setRefreshing] = useState(false)
-  const [refreshLabel, setRefreshLabel] = useState('Refresh overview')
+  const [refreshState, setRefreshState] = useState<'idle' | 'syncing' | 'reloading'>('idle')
   const [error, setError] = useState<string | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
   const [googleConfigured, setGoogleConfigured] = useState(false)
   const [googleConnection, setGoogleConnection] = useState<ApiGoogleConnection | null>(null)
   const [googleCoverage, setGoogleCoverage] = useState<ApiGscCoverageSummary | null>(null)
@@ -639,11 +639,7 @@ function SearchConsoleSection({
   const [bingCoverage, setBingCoverage] = useState<ApiBingCoverageSummary | null>(null)
 
   async function loadSummary(silent = false) {
-    if (silent) {
-      setRefreshing(true)
-    } else {
-      setLoading(true)
-    }
+    if (!silent) setLoading(true)
     setError(null)
 
     try {
@@ -670,7 +666,6 @@ function SearchConsoleSection({
       setError(err instanceof Error ? err.message : 'Failed to load search console overview')
     } finally {
       setLoading(false)
-      setRefreshing(false)
     }
   }
 
@@ -679,17 +674,22 @@ function SearchConsoleSection({
    * run them in parallel, wait for both to settle, then reload coverage data.
    */
   async function handleRefresh() {
-    if (refreshing) return
-    setRefreshing(true)
+    if (refreshState !== 'idle') return
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+    const signal = controller.signal
+
+    setRefreshState('syncing')
     setError(null)
 
-    try {
-      setRefreshLabel('Querying Google & Bing…')
+    const failures: string[] = []
 
+    try {
       // --- Google: trigger a background GSC sync job and poll to completion ---
       async function syncGoogle() {
         if (!googleConnection) return
-        const run = await triggerGscSync(projectName).catch(() => null)
+        const run = await triggerGscSync(projectName)
         if (!run?.id) return
 
         const POLL_INTERVAL_MS = 2000
@@ -697,37 +697,67 @@ function SearchConsoleSection({
         const deadline = Date.now() + TIMEOUT_MS
 
         while (Date.now() < deadline) {
+          if (signal.aborted) return
           await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS))
+          if (signal.aborted) return
           const detail = await fetchRunDetail(run.id).catch(() => null)
           if (!detail) break
-          if (['completed', 'failed', 'cancelled'].includes(detail.status)) break
+          if (['completed', 'failed', 'cancelled'].includes(detail.status)) {
+            if (detail.status !== 'completed') failures.push(`Google sync ${detail.status}`)
+            break
+          }
         }
       }
 
-      // --- Bing: re-inspect all previously known URLs in parallel ---
+      // --- Bing: re-inspect previously known URLs with concurrency limit ---
+      const BING_CONCURRENCY = 10
       async function syncBing() {
         if (!bingConnection?.connected) return
         const inspections = await fetchBingInspections(projectName).catch(() => [] as ApiBingInspection[])
         const uniqueUrls = [...new Set(inspections.map((i) => i.url))]
         if (uniqueUrls.length === 0) return
-        await Promise.allSettled(uniqueUrls.map((url) => inspectBingUrl(projectName, url)))
+
+        for (let i = 0; i < uniqueUrls.length; i += BING_CONCURRENCY) {
+          if (signal.aborted) return
+          const batch = uniqueUrls.slice(i, i + BING_CONCURRENCY)
+          const results = await Promise.allSettled(batch.map((url) => inspectBingUrl(projectName, url)))
+          const batchFailures = results.filter((r) => r.status === 'rejected').length
+          if (batchFailures > 0) failures.push(`${batchFailures} Bing inspection(s) failed`)
+        }
       }
 
-      await Promise.allSettled([syncGoogle(), syncBing()])
+      const results = await Promise.allSettled([syncGoogle(), syncBing()])
+      for (const r of results) {
+        if (r.status === 'rejected') {
+          failures.push(r.reason instanceof Error ? r.reason.message : 'Sync failed')
+        }
+      }
+
+      if (signal.aborted) return
 
       // Reload both coverage summaries from fresh DB values
-      setRefreshLabel('Reloading…')
+      setRefreshState('reloading')
       await loadSummary(true)
+
+      if (failures.length > 0) {
+        setError(`Partial refresh: ${failures.join('; ')}`)
+      }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Refresh failed')
+      if (!signal.aborted) {
+        setError(err instanceof Error ? err.message : 'Refresh failed')
+      }
     } finally {
-      setRefreshing(false)
-      setRefreshLabel('Refresh overview')
+      if (!signal.aborted) {
+        setRefreshState('idle')
+      }
     }
   }
 
   useEffect(() => {
     void loadSummary()
+    return () => {
+      abortRef.current?.abort()
+    }
   }, [projectName])
 
   const googleTone = googleConnection ? 'positive' : googleConfigured ? 'caution' : 'negative'
@@ -773,8 +803,8 @@ function SearchConsoleSection({
               Scan both engines at a glance, then open the Google or Bing workspace when you need to inspect coverage or take action.
             </p>
           </div>
-          <Button type="button" variant="outline" size="sm" disabled={loading || refreshing} onClick={() => void handleRefresh()}>
-            {loading || refreshing ? refreshLabel : 'Refresh overview'}
+          <Button type="button" variant="outline" size="sm" disabled={loading || refreshState !== 'idle'} onClick={() => void handleRefresh()}>
+            {loading ? 'Loading…' : refreshState === 'syncing' ? 'Querying Google & Bing…' : refreshState === 'reloading' ? 'Reloading…' : 'Refresh overview'}
           </Button>
         </div>
 

--- a/apps/web/test/search-console-refresh.test.ts
+++ b/apps/web/test/search-console-refresh.test.ts
@@ -1,0 +1,71 @@
+import { test, expect, onTestFinished, describe } from 'vitest'
+
+import { triggerGscSync, fetchRunDetail, inspectBingUrl } from '../src/api.js'
+
+function mockFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+  const realFetch = globalThis.fetch
+  globalThis.fetch = handler as typeof fetch
+  return () => {
+    globalThis.fetch = realFetch
+  }
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('triggerGscSync', () => {
+  test('returns run object on success', async () => {
+    const restore = mockFetch(() => jsonResponse({ id: 'run-1', status: 'pending' }))
+    onTestFinished(restore)
+
+    const result = await triggerGscSync('my-project')
+    expect(result).toEqual({ id: 'run-1', status: 'pending' })
+  })
+
+  test('throws on non-ok response', async () => {
+    const restore = mockFetch(() => jsonResponse({ error: 'not found' }, 404))
+    onTestFinished(restore)
+
+    await expect(triggerGscSync('missing')).rejects.toThrow()
+  })
+})
+
+describe('fetchRunDetail polling', () => {
+  test('returns terminal status', async () => {
+    const restore = mockFetch(() => jsonResponse({ id: 'run-1', status: 'completed' }))
+    onTestFinished(restore)
+
+    const detail = await fetchRunDetail('run-1')
+    expect(detail.status).toBe('completed')
+  })
+
+  test('handles failed status', async () => {
+    const restore = mockFetch(() => jsonResponse({ id: 'run-1', status: 'failed' }))
+    onTestFinished(restore)
+
+    const detail = await fetchRunDetail('run-1')
+    expect(detail.status).toBe('failed')
+  })
+})
+
+describe('Bing concurrency batching', () => {
+  test('inspectBingUrl calls are made per-url', async () => {
+    const calls: string[] = []
+    const restore = mockFetch((url) => {
+      calls.push(url as string)
+      return jsonResponse({ url: 'https://example.com', status: 'Submitted' })
+    })
+    onTestFinished(restore)
+
+    const urls = ['https://example.com/a', 'https://example.com/b']
+    await Promise.allSettled(urls.map((url) => inspectBingUrl('proj', url)))
+
+    expect(calls).toHaveLength(2)
+    expect(calls[0]).toContain('/bing/inspect')
+    expect(calls[1]).toContain('/bing/inspect')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "1.21.0",
+  "version": "1.21.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Problem

Clicking **Refresh overview** in the Search Console section re-read cached data from the DB. The **Updated** timestamps never changed, making the button feel broken.

## Solution

Wire the button to an actual sync flow:

1. **Trigger** a GSC sync job via `triggerGscSync(project)`
2. **Poll** `fetchRunDetail(id)` every 2 s until the run settles (completed / failed / cancelled), max 2 min timeout
3. **Show progress** with dynamic button labels: `Syncing GSC…` → `Reloading…`
4. **Reload** both Google and Bing coverage from the DB once the job finishes

If the project has no GSC connection yet, it falls back to a silent reload (original behaviour).

Bing doesn't have a bulk sync job endpoint so its coverage reloads from the DB after GSC completes — will reflect any Bing inspections stored since the last load.