### PR TITLE
fix(test): mock GSC fetch in flaky google-commands tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "1.21.0",
+  "version": "1.21.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/test/google-commands.test.ts
+++ b/packages/canonry/test/google-commands.test.ts
@@ -186,10 +186,21 @@ describe('google CLI commands', () => {
       language: 'en',
     })
 
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('googleapis.com/webmasters')) {
+        return new Response('Unauthorized', { status: 401 })
+      }
+      return originalFetch(input, init)
+    }
+
     const { googleListSitemaps } = await import('../src/commands/google.js')
-    // The fake access token causes Google to return 401, which gscFetch propagates as
-    // a GoogleApiError(401) → Fastify returns HTTP 401 → ApiClient throws
-    await expect(() => googleListSitemaps('test-proj', {})).rejects.toThrow('Access token expired or revoked')
+    try {
+      await expect(() => googleListSitemaps('test-proj', {})).rejects.toThrow('Access token expired or revoked')
+    } finally {
+      globalThis.fetch = originalFetch
+    }
   })
 
   it('googleDiscoverSitemaps rejects when the GSC access token is rejected by Google', async () => {
@@ -200,10 +211,21 @@ describe('google CLI commands', () => {
       language: 'en',
     })
 
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('googleapis.com/webmasters')) {
+        return new Response('Unauthorized', { status: 401 })
+      }
+      return originalFetch(input, init)
+    }
+
     const { googleDiscoverSitemaps } = await import('../src/commands/google.js')
-    // The fake access token causes Google to return 401, which gscFetch propagates as
-    // a GoogleApiError(401) → Fastify returns HTTP 401 → ApiClient throws
-    await expect(() => googleDiscoverSitemaps('test-proj', { wait: false })).rejects.toThrow('Access token expired or revoked')
+    try {
+      await expect(() => googleDiscoverSitemaps('test-proj', { wait: false })).rejects.toThrow('Access token expired or revoked')
+    } finally {
+      globalThis.fetch = originalFetch
+    }
   })
 
   it('googleRequestIndexing prints success output for a single URL', async () => {


### PR DESCRIPTION
## Summary
- `googleListSitemaps` and `googleDiscoverSitemaps` tests were making real HTTP calls to Google's Search Console API with a fake access token, causing flaky timeouts when the network was slow
- Added `globalThis.fetch` mocks that intercept `googleapis.com/webmasters` calls and return 401 directly, matching the pattern already used by `googleRequestIndexing` tests in the same file
- Patch version bump to 1.21.1

## Test plan
- [x] All 9 tests in `google-commands.test.ts` pass
- [x] Full test suite passes (586 tests across 60 files)
- [x] Verify the previously-flaky tests no longer timeout on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)