### PR TITLE
fix(ui): invalidate project detail cache when latest run changes

### DIFF
--- a/apps/web/src/queries/query-keys.ts
+++ b/apps/web/src/queries/query-keys.ts
@@ -1,7 +1,7 @@
 export const queryKeys = {
   projects: {
     all: ['projects'] as const,
-    detail: (id: string) => ['projects', id] as const,
+    detail: (id: string, latestRunId?: string) => ['projects', id, latestRunId] as const,
     keywords: (name: string) => ['projects', name, 'keywords'] as const,
     competitors: (name: string) => ['projects', name, 'competitors'] as const,
     timeline: (name: string, location?: string) => ['projects', name, 'timeline', location] as const,

--- a/apps/web/src/queries/use-dashboard.ts
+++ b/apps/web/src/queries/use-dashboard.ts
@@ -54,7 +54,7 @@ export function useDashboard(initialDashboard?: DashboardVm | null) {
         .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
 
       return {
-        queryKey: queryKeys.projects.detail(project.id),
+        queryKey: queryKeys.projects.detail(project.id, completedRuns[0]?.id),
         queryFn: async (): Promise<ProjectData> => {
           const [kws, comps, timeline, latestRunDetail, previousRunDetail] = await Promise.all([
             fetchKeywords(project.name).catch(() => []),

--- a/apps/web/test/queries.test.ts
+++ b/apps/web/test/queries.test.ts
@@ -7,7 +7,8 @@ describe('queryKeys', () => {
   })
 
   it('projects.detail includes project id', () => {
-    expect(queryKeys.projects.detail('proj_123')).toEqual(['projects', 'proj_123'])
+    expect(queryKeys.projects.detail('proj_123')).toEqual(['projects', 'proj_123', undefined])
+    expect(queryKeys.projects.detail('proj_123', 'run_abc')).toEqual(['projects', 'proj_123', 'run_abc'])
   })
 
   it('projects.keywords includes project name', () => {


### PR DESCRIPTION
## Problem

After a sweep completed, the 'WHO WAS CITED IN ORDER' leaderboard showed stale domain lists from the *previous* run. The citation state badge ('cited / first citation') updated correctly, but `citedDomains` didn't — creating a confusing split where the badge said 'cited' but the owned domain was absent from the leaderboard.

**Root cause:** The project detail query key was `['projects', id]` — static, never changes. TanStack Query never invalidated it after a run completed. The badge derived from `runsQuery` (which polls during active runs) but `citedDomains` came from `latestRunDetail` inside the stale project detail cache.

## Fix

Include the latest completed run ID in the project detail query key:

```ts
// Before
queryKey: queryKeys.projects.detail(project.id)

// After  
queryKey: queryKeys.projects.detail(project.id, completedRuns[0]?.id)
```

When `runsQuery` updates and `completedRuns[0]` becomes the new run, the key changes and TanStack Query automatically refetches project detail with fresh `citedDomains`.

## Tests

- Updated `queries.test.ts` to cover both the no-runId and with-runId signatures
- 592/592 passing

Closes #142 (partial — citation position rank display is a separate follow-up)