### PR TITLE
fix(ui): move Bing submit feedback inline with button

### DIFF
--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -403,7 +403,6 @@ function BingSection({ projectName }: { projectName: string }) {
           </div>
         </div>
         {error && <p className="mb-3 text-xs text-rose-400">{error}</p>}
-        {successMessage && <p className="mb-3 text-xs text-emerald-400">{successMessage}</p>}
         <div className="space-y-3">
           <div className="rounded-lg border border-zinc-800/60 bg-zinc-900/30 px-4 py-3">
             <div className="flex items-center gap-3">
@@ -467,9 +466,12 @@ function BingSection({ projectName }: { projectName: string }) {
               <div>
                 <div className="mb-2 flex items-center justify-between gap-3">
                   <h4 className="text-xs font-medium text-zinc-400">Not Indexed ({coverage.notIndexed.length})</h4>
-                  <Button size="sm" variant="ghost" onClick={handleSubmitAllUnindexed}>
-                    Submit all to Bing
-                  </Button>
+                  <div className="flex items-center gap-2">
+                    {successMessage && <span className="text-xs text-emerald-400">{successMessage}</span>}
+                    <Button size="sm" variant="ghost" onClick={handleSubmitAllUnindexed}>
+                      Submit all to Bing
+                    </Button>
+                  </div>
                 </div>
                 <div className="overflow-x-auto rounded-lg border border-zinc-800/60">
                   <table className="w-full text-xs">


### PR DESCRIPTION
## Problem

The success message ('Submitted 18/18 URLs to Bing') was rendering in the **Connection card** at the top of the Bing section, far above the 'Submit all to Bing' button which lives in the **Coverage card** below. Users saw no visible feedback even though the message was technically in the DOM.

## Fix

Moved `successMessage` inline — right next to the button, same row:

```
Not Indexed (18)    [Submitted 18/18 URLs to Bing]  [Submit all to Bing]
```

Removed the stray render from the connection card.

typecheck ✅ build ✅