### PR TITLE
fix(ui): use 'key phrases' consistently in all user-facing strings

### DIFF
--- a/apps/web/src/build-dashboard.ts
+++ b/apps/web/src/build-dashboard.ts
@@ -442,7 +442,7 @@ export function buildInsights(input: InsightInput): ProjectInsightVm[] {
     insights.push({
       id: 'insight_lost',
       tone: 'negative',
-      title: `Lost citation on ${lostPhrases.length} keyword${lostPhrases.length > 1 ? 's' : ''}`,
+      title: `Lost citation on ${lostPhrases.length} key phrase${lostPhrases.length > 1 ? 's' : ''}`,
       detail: 'Citations dropped since the last run.',
       actionLabel: 'Lost',
       affectedPhrases: lostPhrases,
@@ -461,7 +461,7 @@ export function buildInsights(input: InsightInput): ProjectInsightVm[] {
       insights.push({
         id: `insight_comp_gained_${comp}`,
         tone: 'negative',
-        title: `${comp} appeared on ${gained.length} keyword${gained.length > 1 ? 's' : ''}`,
+        title: `${comp} appeared on ${gained.length} key phrase${gained.length > 1 ? 's' : ''}`,
         detail: 'A tracked competitor gained new citations.',
         actionLabel: 'Competitor',
         affectedPhrases: gained.map(kw => {
@@ -512,7 +512,7 @@ export function buildInsights(input: InsightInput): ProjectInsightVm[] {
     insights.push({
       id: 'insight_provider_pickup',
       tone: 'positive',
-      title: `Picked up by new provider on ${kwCount} keyword${kwCount > 1 ? 's' : ''}`,
+      title: `Picked up by new provider on ${kwCount} key phrase${kwCount > 1 ? 's' : ''}`,
       detail: 'Your domain started appearing on additional providers.',
       actionLabel: 'Pickup',
       affectedPhrases: newProviderPhrases,
@@ -523,7 +523,7 @@ export function buildInsights(input: InsightInput): ProjectInsightVm[] {
     insights.push({
       id: 'insight_first_citation',
       tone: 'positive',
-      title: `First citation on ${firstCitationKeywords.size} keyword${firstCitationKeywords.size > 1 ? 's' : ''}`,
+      title: `First citation on ${firstCitationKeywords.size} key phrase${firstCitationKeywords.size > 1 ? 's' : ''}`,
       detail: 'Your domain appeared in AI answers for the first time.',
       actionLabel: 'New',
       affectedPhrases: firstCitationPhrases,
@@ -550,8 +550,8 @@ export function buildInsights(input: InsightInput): ProjectInsightVm[] {
     insights.push({
       id: 'insight_persistent_gap',
       tone: 'caution',
-      title: `${gapPhrases.length} keyword${gapPhrases.length > 1 ? 's' : ''} uncited for ${GAP_THRESHOLD}+ runs`,
-      detail: 'These keywords have not been cited by any provider across multiple consecutive runs.',
+      title: `${gapPhrases.length} key phrase${gapPhrases.length > 1 ? 's' : ''} uncited for ${GAP_THRESHOLD}+ runs`,
+      detail: 'These key phrases have not been cited by any provider across multiple consecutive runs.',
       actionLabel: 'Gap',
       affectedPhrases: gapPhrases,
     })
@@ -566,7 +566,7 @@ export function buildInsights(input: InsightInput): ProjectInsightVm[] {
       insights.push({
         id: `insight_comp_lost_${comp}`,
         tone: 'neutral',
-        title: `${comp} dropped from ${lost.length} keyword${lost.length > 1 ? 's' : ''}`,
+        title: `${comp} dropped from ${lost.length} key phrase${lost.length > 1 ? 's' : ''}`,
         detail: 'A tracked competitor lost citations.',
         actionLabel: 'Competitor',
         affectedPhrases: lost.map(kw => {

--- a/apps/web/src/components/project/AnalyticsSection.tsx
+++ b/apps/web/src/components/project/AnalyticsSection.tsx
@@ -139,7 +139,7 @@ export function AnalyticsSection({ projectName }: { projectName: string }) {
         <div className="flex items-center justify-between mb-4">
           <div>
             <p className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 mb-1">Opportunity Analysis</p>
-            <h2 className="text-base font-semibold text-zinc-50 flex items-center gap-1.5">Brand Gap Analysis <InfoTooltip text="Classification based on the most recent completed run. Cited: your brand appeared in the AI answer. Gap: a competitor was cited but you were not. Not Cited: neither mentioned. Consistency shows how often each keyword was cited across all runs in the selected window." /></h2>
+            <h2 className="text-base font-semibold text-zinc-50 flex items-center gap-1.5">Brand Gap Analysis <InfoTooltip text="Classification based on the most recent completed run. Cited: your brand appeared in the AI answer. Gap: a competitor was cited but you were not. Not Cited: neither mentioned. Consistency shows how often each key phrase was cited across all runs in the selected window." /></h2>
           </div>
         </div>
 
@@ -394,7 +394,7 @@ function GapAnalysisTable({ gaps, filter }: { gaps: GapAnalysisDto; filter: GapC
   }, [gaps, filter])
 
   if (rows.length === 0) {
-    return <p className="text-sm text-zinc-500 py-4">No keywords found{filter ? ` with status "${filter}"` : ''}.</p>
+    return <p className="text-sm text-zinc-500 py-4">No key phrases found{filter ? ` with status "${filter}"` : ''}.</p>
   }
 
   return (

--- a/apps/web/src/mock-data.ts
+++ b/apps/web/src/mock-data.ts
@@ -867,7 +867,7 @@ export function createDashboardFixture(options: DashboardFixtureOptions = {}): D
     dashboard.portfolioOverview.recentRuns = []
     dashboard.portfolioOverview.emptyState = {
       title: 'No projects yet',
-      detail: 'Canonry becomes useful after one project, a small keyword set, and one competitor list are in place.',
+      detail: 'Canonry becomes useful after one project, a small key phrase set, and one competitor list are in place.',
       ctaLabel: 'Launch setup',
       ctaHref: '/setup',
     }

--- a/apps/web/test/build-insights.test.ts
+++ b/apps/web/test/build-insights.test.ts
@@ -98,7 +98,7 @@ test('lost citation: per-provider lost surfaces with correct keyword count', () 
   expect(lost!.tone).toBe('negative')
   // 2 affected phrases (kw1/gemini, kw2/gemini) across 2 keywords
   expect(lost!.affectedPhrases.length).toBe(2)
-  expect(lost!.title).toMatch(/2 keyword/)
+  expect(lost!.title).toMatch(/2 key phrase/)
   // Each affected phrase has a single provider
   expect(lost!.affectedPhrases[0]!.provider).toBe('gemini')
 })
@@ -227,7 +227,7 @@ test('competitor gained: competitor appears on keywords it was not cited on befo
   expect(gained).toBeTruthy()
   expect(gained!.tone).toBe('negative')
   expect(gained!.affectedPhrases.length).toBe(2)
-  expect(gained!.title).toMatch(/rival\.com appeared on 2 keyword/)
+  expect(gained!.title).toMatch(/rival\.com appeared on 2 key phrase/)
 })
 
 test('competitor gained: only tracked competitors are flagged', () => {
@@ -255,7 +255,7 @@ test('competitor lost: competitor drops out of citations', () => {
   const lost = insights.find(i => i.id === 'insight_comp_lost_rival.com')
   expect(lost).toBeTruthy()
   expect(lost!.tone).toBe('neutral')
-  expect(lost!.title).toMatch(/rival\.com dropped from 1 keyword/)
+  expect(lost!.title).toMatch(/rival\.com dropped from 1 key phrase/)
 })
 
 test('persistent gap: keyword uncited for 3+ runs', () => {
@@ -274,7 +274,7 @@ test('persistent gap: keyword uncited for 3+ runs', () => {
   const gap = insights.find(i => i.id === 'insight_persistent_gap')
   expect(gap).toBeTruthy()
   expect(gap!.tone).toBe('caution')
-  expect(gap!.title).toMatch(/1 keyword/)
+  expect(gap!.title).toMatch(/1 key phrase/)
 })
 
 test('persistent gap: not triggered below threshold', () => {


### PR DESCRIPTION
## Summary

Insight card titles and tooltip copy were using `keyword(s)` while metric cards, tooltips, setup UI, and most other copy already used `key phrase(s)`. This standardizes everything visible to users.

## Changes

**`build-dashboard.ts`** — 6 insight titles + 1 detail string:
- `Lost citation on N keyword(s)` → `key phrase(s)`
- `{comp} appeared on N keyword(s)` → `key phrase(s)`
- `Picked up by new provider on N keyword(s)` → `key phrase(s)`
- `First citation on N keyword(s)` → `key phrase(s)`
- `N keyword(s) uncited for X+ runs` → `key phrase(s)`
- `{comp} dropped from N keyword(s)` → `key phrase(s)`
- Detail copy for persistent gap insight

**`AnalyticsSection.tsx`** — 2 strings:
- Brand Gap Analysis tooltip
- Empty state: "No keywords found" → "No key phrases found"

**`mock-data.ts`** — 1 string (empty-state detail)

**`build-insights.test.ts`** — 4 regex matchers updated to match new copy

## Tests

typecheck ✅ lint ✅ tests 614/614 ✅