### PR TITLE
fix(ui): rename 'Cited Keywords' card eyebrow to 'Cited Key Phrases'

### DIFF
--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -1336,7 +1336,7 @@ export function ProjectPage({
             />
             <div className="metric-card">
               <p className="metric-card-eyebrow">
-                Cited Keywords
+                Cited Key Phrases
                 <InfoTooltip text="How many of your tracked key phrases are being cited by at least one AI answer engine." />
               </p>
               <p className="metric-card-big-value">


### PR DESCRIPTION
Missed in #155 — the main visibility metric card eyebrow still read 'CITED KEYWORDS'. Changed to 'Cited Key Phrases' to match all other copy.\n\ntypecheck ✅ lint ✅ tests 614/614 ✅