### PR TITLE
fix(bing): include unknown URLs in coverage percentage denominator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "1.25.1",
+  "version": "1.25.2",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/bing.ts
+++ b/packages/api-routes/src/bing.ts
@@ -253,7 +253,7 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
     const indexed = indexedUrls.length
     const notIndexed = notIndexedUrls.length
     const unknown = unknownUrls.length
-    const total = indexed + notIndexed
+    const total = indexed + notIndexed + unknown
 
     const formatRow = (r: typeof allInspections[number]) => ({
       id: r.id,
@@ -370,12 +370,12 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
     // Use any explicit legacy InIndex flag if it is present. Otherwise, only a
     // positive DocumentSize is strong enough to treat the URL as indexed.
     // Zero-byte responses stay unknown instead of being forced to "not indexed".
-    const derivedInIndex: boolean | null =
-      result.InIndex != null
-        ? result.InIndex
-        : result.DocumentSize != null && result.DocumentSize > 0
-          ? true
-          : null
+    let derivedInIndex: boolean | null = null
+    if (result.InIndex != null) {
+      derivedInIndex = result.InIndex
+    } else if (result.DocumentSize != null && result.DocumentSize > 0) {
+      derivedInIndex = true
+    }
 
     const lastCrawledDate = parseBingDate(result.LastCrawledDate)
     const inIndexDate = parseBingDate(result.InIndexDate)

--- a/packages/api-routes/test/bing.test.ts
+++ b/packages/api-routes/test/bing.test.ts
@@ -155,7 +155,7 @@ describe('Bing routes', () => {
     expect(body.inIndex).toBe(true)
   })
 
-  it('coverage excludes unknown rows from the not-indexed bucket', async () => {
+  it('coverage includes unknown rows in total for percentage calculation', async () => {
     const now = new Date().toISOString()
     db.insert(bingUrlInspections).values([
       {
@@ -215,11 +215,11 @@ describe('Bing routes', () => {
       unknown: Array<{ url: string }>
     }
     expect(body.summary).toEqual({
-      total: 2,
+      total: 3,
       indexed: 1,
       notIndexed: 1,
       unknown: 1,
-      percentage: 50,
+      percentage: 33.3,
     })
     expect(body.indexed.map((row) => row.url)).toEqual(['https://example.com/indexed'])
     expect(body.notIndexed.map((row) => row.url)).toEqual(['https://example.com/not-indexed'])

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "1.25.1",
+  "version": "1.25.2",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/commands/bing.ts
+++ b/packages/canonry/src/commands/bing.ts
@@ -163,11 +163,16 @@ export async function bingCoverage(project: string, format?: string): Promise<vo
     return
   }
 
-  const pctColor = summary.percentage >= 80 ? '\x1b[32m' : summary.percentage >= 50 ? '\x1b[33m' : '\x1b[31m'
   const reset = '\x1b[0m'
+  let pctColor: string
+  if (summary.percentage >= 80) pctColor = '\x1b[32m'
+  else if (summary.percentage >= 50) pctColor = '\x1b[33m'
+  else pctColor = '\x1b[31m'
+
+  const unknownNote = (summary.unknown ?? 0) > 0 ? `, ${summary.unknown} unknown` : ''
 
   console.log(`\nBing Index Coverage for "${project}"\n`)
-  console.log(`  SUMMARY: ${pctColor}${summary.indexed} / ${summary.total} pages indexed (${summary.percentage}%)${reset}\n`)
+  console.log(`  SUMMARY: ${pctColor}${summary.indexed} / ${summary.total} pages indexed (${summary.percentage}%)${reset}${unknownNote}\n`)
 
   if (result.indexed.length > 0) {
     console.log(`  INDEXED (${result.indexed.length}):`)
@@ -189,10 +194,6 @@ export async function bingCoverage(project: string, format?: string): Promise<vo
 
   if (result.lastInspectedAt) {
     console.log(`  Last inspected: ${result.lastInspectedAt}`)
-  }
-
-  if ((summary.unknown ?? 0) > 0) {
-    console.log(`  Unknown status: ${summary.unknown}`)
   }
 }
 


### PR DESCRIPTION
## Summary
- Coverage percentage now divides by all inspected URLs (indexed + notIndexed + unknown) instead of only confirmed entries, fixing misleading 100% when most URLs have unknown status
- Cleaned up nested ternary in `derivedInIndex` to an if/else block for readability
- CLI summary line now shows unknown count inline; removed redundant separate line

## Test plan
- [x] Updated existing coverage test to expect `total: 3` and `percentage: 33.3` (was `total: 2`, `percentage: 50`)
- [x] All 620 tests pass, typecheck and lint clean

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)