### PR TITLE
fix(config): use saveConfigPatch for runtime updates to prevent test-session clobbering

### DIFF
--- a/packages/canonry/src/commands/cdp.ts
+++ b/packages/canonry/src/commands/cdp.ts
@@ -1,4 +1,4 @@
-import { loadConfig, saveConfig } from '../config.js'
+import { loadConfig, saveConfigPatch } from '../config.js'
 import { createApiClient } from '../client.js'
 import { CliError } from '../cli-error.js'
 
@@ -20,7 +20,7 @@ export async function cdpConnect(opts: { host?: string; port?: string; format?: 
     host,
     port,
   }
-  saveConfig(config)
+  saveConfigPatch(config)
 
   if (opts.format === 'json') {
     console.log(JSON.stringify({

--- a/packages/canonry/src/commands/settings.ts
+++ b/packages/canonry/src/commands/settings.ts
@@ -1,4 +1,4 @@
-import { loadConfig, saveConfig, getConfigPath } from '../config.js'
+import { loadConfig, saveConfigPatch, getConfigPath } from '../config.js'
 import { createApiClient } from '../client.js'
 import { setGoogleAuthConfig } from '../google-config.js'
 
@@ -81,7 +81,7 @@ export function setGoogleAuth(opts: { clientId: string; clientSecret: string; fo
     clientId: opts.clientId,
     clientSecret: opts.clientSecret,
   })
-  saveConfig(config)
+  saveConfigPatch(config)
 
   if (opts.format === 'json') {
     console.log(JSON.stringify({

--- a/packages/canonry/src/commands/telemetry.ts
+++ b/packages/canonry/src/commands/telemetry.ts
@@ -1,4 +1,4 @@
-import { configExists, getConfigPath, loadConfig, saveConfig } from '../config.js'
+import { configExists, getConfigPath, loadConfig, saveConfigPatch } from '../config.js'
 import { CliError, type CliFormat, usageError } from '../cli-error.js'
 
 export function telemetryCommand(subcommand?: string, format: CliFormat = 'text'): void {
@@ -87,7 +87,7 @@ export function telemetryCommand(subcommand?: string, format: CliFormat = 'text'
       }
       const config = loadConfig()
       config.telemetry = true
-      saveConfig(config)
+      saveConfigPatch(config)
 
       if (format === 'json') {
         console.log(JSON.stringify({
@@ -114,7 +114,7 @@ export function telemetryCommand(subcommand?: string, format: CliFormat = 'text'
       }
       const config = loadConfig()
       config.telemetry = false
-      saveConfig(config)
+      saveConfigPatch(config)
 
       if (format === 'json') {
         console.log(JSON.stringify({

--- a/packages/canonry/src/config.ts
+++ b/packages/canonry/src/config.ts
@@ -274,6 +274,55 @@ export function saveConfig(config: CanonryConfig): void {
   fs.writeFileSync(configPath, yaml, { encoding: 'utf-8', mode: 0o600 })
 }
 
+/**
+ * Perform a targeted (partial) save: read the on-disk config, apply only the
+ * specified keys from `patch`, and write back.  Use this for runtime updates
+ * (provider settings, connection tokens, etc.) to prevent a server started
+ * with a temporary CANONRY_CONFIG_DIR from clobbering production values like
+ * `database`, `apiKey`, and `anonymousId`.
+ */
+export function saveConfigPatch(patch: Partial<CanonryConfig>): void {
+  const configDir = getConfigDir()
+  if (!fs.existsSync(configDir)) {
+    fs.mkdirSync(configDir, { recursive: true })
+  }
+  const configPath = getConfigPath()
+
+  let base: Partial<CanonryConfig> = {}
+  if (fs.existsSync(configPath)) {
+    try {
+      const raw = fs.readFileSync(configPath, 'utf-8')
+      base = (parse(raw) as Partial<CanonryConfig>) ?? {}
+    } catch {
+      base = {}
+    }
+  }
+
+  const merged = { ...base, ...patch }
+
+  // Always preserve these critical production settings if they exist on disk.
+  // This prevents a server started with a temporary CANONRY_CONFIG_DIR from
+  // overwriting the production config file with its session-specific defaults.
+  if (base.database) merged.database = base.database
+  if (base.apiKey) merged.apiKey = base.apiKey
+  if (base.anonymousId) merged.anonymousId = base.anonymousId
+  if (base.dashboardPasswordHash) merged.dashboardPasswordHash = base.dashboardPasswordHash
+
+  // Deep-merge providers: for each provider, preserve keys that exist on disk
+  // but are absent or null in the patch (e.g. vertexProject, vertexRegion,
+  // vertexCredentials set manually on prod but unknown to a test session).
+  if (base.providers && patch.providers) {
+    merged.providers = { ...base.providers }
+    for (const [key, patchEntry] of Object.entries(patch.providers)) {
+      const baseEntry = base.providers[key] ?? {}
+      merged.providers[key] = { ...baseEntry, ...patchEntry }
+    }
+  }
+
+  const yaml = stringify(merged)
+  fs.writeFileSync(configPath, yaml, { encoding: 'utf-8', mode: 0o600 })
+}
+
 export function configExists(): boolean {
   return fs.existsSync(getConfigPath())
 }

--- a/packages/canonry/src/gsc-inspect-sitemap.ts
+++ b/packages/canonry/src/gsc-inspect-sitemap.ts
@@ -7,7 +7,7 @@ import {
   refreshAccessToken,
 } from '@ainyc/canonry-integration-google'
 import type { CanonryConfig } from './config.js'
-import { saveConfig } from './config.js'
+import { saveConfigPatch } from './config.js'
 import { getGoogleAuthConfig, getGoogleConnection, patchGoogleConnection } from './google-config.js'
 import { fetchAndParseSitemap } from './sitemap-parser.js'
 import { createLogger } from './logger.js'
@@ -61,7 +61,7 @@ export async function executeInspectSitemap(
         tokenExpiresAt: new Date(Date.now() + tokens.expires_in * 1000).toISOString(),
         updatedAt: new Date().toISOString(),
       })
-      saveConfig(opts.config)
+      saveConfigPatch(opts.config)
     }
 
     // Determine sitemap URL: explicit > stored on connection > default

--- a/packages/canonry/src/gsc-sync.ts
+++ b/packages/canonry/src/gsc-sync.ts
@@ -9,7 +9,7 @@ import {
   GSC_DATA_LAG_DAYS,
 } from '@ainyc/canonry-integration-google'
 import type { CanonryConfig } from './config.js'
-import { saveConfig } from './config.js'
+import { saveConfigPatch } from './config.js'
 import { getGoogleAuthConfig, getGoogleConnection, patchGoogleConnection } from './google-config.js'
 import { createLogger } from './logger.js'
 
@@ -74,7 +74,7 @@ export async function executeGscSync(
         tokenExpiresAt: new Date(Date.now() + tokens.expires_in * 1000).toISOString(),
         updatedAt: new Date().toISOString(),
       })
-      saveConfig(opts.config)
+      saveConfigPatch(opts.config)
     }
 
     // Determine date range

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -19,7 +19,7 @@ import { cdpChatgptAdapter } from '@ainyc/canonry-provider-cdp'
 import { perplexityAdapter } from '@ainyc/canonry-provider-perplexity'
 import { authInvalid, validationError, type ProviderAdapter } from '@ainyc/canonry-contracts'
 import type { CanonryConfig, ProviderConfigEntry } from './config.js'
-import { saveConfig, loadConfig } from './config.js'
+import { saveConfigPatch, loadConfig } from './config.js'
 import {
   getGoogleAuthConfig,
   getGoogleConnection,
@@ -281,7 +281,7 @@ export async function createServer(opts: {
       } else {
         opts.config.bing.connections.push(connection)
       }
-      saveConfig(opts.config)
+      saveConfigPatch(opts.config)
       return connection
     },
     updateConnection: (
@@ -291,7 +291,7 @@ export async function createServer(opts: {
       const conn = opts.config.bing?.connections?.find((c) => c.domain === domain)
       if (!conn) return undefined
       Object.assign(conn, patch)
-      saveConfig(opts.config)
+      saveConfigPatch(opts.config)
       return conn
     },
     deleteConnection: (domain: string) => {
@@ -299,7 +299,7 @@ export async function createServer(opts: {
       const idx = opts.config.bing.connections.findIndex((c) => c.domain === domain)
       if (idx < 0) return false
       opts.config.bing.connections.splice(idx, 1)
-      saveConfig(opts.config)
+      saveConfigPatch(opts.config)
       return true
     },
   } as const
@@ -318,12 +318,12 @@ export async function createServer(opts: {
       updatedAt: string
     }) => {
       const updated = upsertGa4Connection(opts.config, connection)
-      saveConfig(opts.config)
+      saveConfigPatch(opts.config)
       return updated
     },
     deleteConnection: (projectName: string) => {
       const removed = removeGa4Connection(opts.config, projectName)
-      if (removed) saveConfig(opts.config)
+      if (removed) saveConfigPatch(opts.config)
       return removed
     },
   } as const
@@ -346,7 +346,7 @@ export async function createServer(opts: {
       updatedAt: string
     }) => {
       const updated = upsertGoogleConnection(opts.config, connection)
-      saveConfig(opts.config)
+      saveConfigPatch(opts.config)
       return updated
     },
     updateConnection: (
@@ -363,12 +363,12 @@ export async function createServer(opts: {
       }>,
     ) => {
       const updated = patchGoogleConnection(opts.config, domain, connectionType, patch)
-      if (updated) saveConfig(opts.config)
+      if (updated) saveConfigPatch(opts.config)
       return updated
     },
     deleteConnection: (domain: string, connectionType: 'gsc' | 'ga4') => {
       const removed = removeGoogleConnection(opts.config, domain, connectionType)
-      if (removed) saveConfig(opts.config)
+      if (removed) saveConfigPatch(opts.config)
       return removed
     },
   } as const
@@ -503,7 +503,7 @@ export async function createServer(opts: {
     }
 
     opts.config.dashboardPasswordHash = hashApiKey(password)
-    saveConfig(opts.config)
+    saveConfigPatch(opts.config)
 
     if (!createPasswordSession(reply)) {
       const err = authInvalid()
@@ -661,7 +661,7 @@ export async function createServer(opts: {
       }
 
       try {
-        saveConfig(opts.config)
+        saveConfigPatch(opts.config)
       } catch (err) {
         app.log.error({ err }, 'Failed to save config')
         return null
@@ -735,7 +735,7 @@ export async function createServer(opts: {
     onGoogleSettingsUpdate: (clientId: string, clientSecret: string) => {
       try {
         setGoogleAuthConfig(opts.config, { clientId, clientSecret })
-        saveConfig(opts.config)
+        saveConfigPatch(opts.config)
         googleSettingsSummary.configured = true
         return { ...googleSettingsSummary }
       } catch (err) {
@@ -747,7 +747,7 @@ export async function createServer(opts: {
       try {
         if (!opts.config.bing) opts.config.bing = {}
         opts.config.bing.apiKey = apiKey
-        saveConfig(opts.config)
+        saveConfigPatch(opts.config)
         bingSettingsSummary.configured = true
         return { ...bingSettingsSummary }
       } catch (err) {
@@ -774,7 +774,7 @@ export async function createServer(opts: {
     setTelemetryEnabled: (enabled: boolean) => {
       const config = loadConfig()
       config.telemetry = enabled
-      saveConfig(config)
+      saveConfigPatch(config)
       // Keep in-memory config in sync
       opts.config.telemetry = enabled
     },
@@ -783,7 +783,7 @@ export async function createServer(opts: {
       opts.config.cdp.host = host
       opts.config.cdp.port = port
       try {
-        saveConfig(opts.config)
+        saveConfigPatch(opts.config)
       } catch (err) {
         app.log.error({ err }, 'Failed to save CDP config')
         throw err

--- a/packages/canonry/src/telemetry.ts
+++ b/packages/canonry/src/telemetry.ts
@@ -1,5 +1,5 @@
 import crypto from 'node:crypto'
-import { loadConfig, saveConfig, configExists } from './config.js'
+import { loadConfig, saveConfigPatch, configExists } from './config.js'
 
 import { createRequire } from 'node:module'
 const _require = createRequire(import.meta.url)
@@ -51,7 +51,7 @@ export function getOrCreateAnonymousId(): string | undefined {
 
     const id = crypto.randomUUID()
     config.anonymousId = id
-    saveConfig(config)
+    saveConfigPatch(config)
     return id
   } catch {
     return undefined

--- a/packages/provider-gemini/src/normalize.ts
+++ b/packages/provider-gemini/src/normalize.ts
@@ -160,8 +160,9 @@ export async function executeTrackedQuery(input: GeminiTrackedQueryInput): Promi
   const prompt = buildPrompt(input.keyword, input.location)
 
   if (isVertexConfig(input.config)) {
-    // Vertex AI SDK uses googleSearchRetrieval, not googleSearch
-    const vertexSearchTool = { googleSearchRetrieval: {} }
+    // Vertex AI SDK: newer models (gemini-2.5+) require googleSearch; older models used googleSearchRetrieval.
+    // Use googleSearch which works across all current stable Vertex models.
+    const vertexSearchTool = { googleSearch: {} }
     const generativeModel = createVertexModel(input.config, model, [vertexSearchTool] as unknown[])
     const result = await generativeModel.generateContent(prompt)
     const response = result.response


### PR DESCRIPTION
## Problem

When canonry's test suite runs, it starts server instances with temporary `CANONRY_CONFIG_DIR` paths. Those servers call `saveConfig(opts.config)` for any runtime update (provider settings, connection tokens, telemetry, etc.), which writes the full in-memory config — including the test session's `database` path and random `apiKey` — back to `~/.canonry/config.yaml`.

This caused repeated production config corruption: Vertex AI settings (`vertexProject`, `vertexRegion`, `vertexCredentials`) and the production `database` path would be overwritten with test-session values after every `pnpm test` run.

Closes #176

## Fix

Introduce `saveConfigPatch()` — a read-modify-write alternative that:
1. Re-reads the on-disk config before writing
2. Merges the incoming patch on top of the on-disk state
3. Hard-preserves `database`, `apiKey`, `anonymousId`, and `dashboardPasswordHash` from disk
4. Deep-merges `providers` so per-provider keys set manually on prod (e.g. `vertexProject`) survive a patch that only knows about `apiKey`

All runtime update paths in `server.ts`, `commands/settings.ts`, `commands/cdp.ts`, `commands/telemetry.ts`, `telemetry.ts`, `gsc-sync.ts`, and `gsc-inspect-sitemap.ts` are switched to `saveConfigPatch`.

`saveConfig` (full overwrite) is preserved for `commands/init.ts` and `commands/bootstrap.ts` where a full write is the correct behavior.

## Also included

- **`googleSearchRetrieval` → `googleSearch`** for the Vertex AI provider path in `provider-gemini/src/normalize.ts`. Gemini 2.5+ models on Vertex no longer accept the legacy `google_search_retrieval` grounding tool and return a 400 error. The newer `google_search` field is used instead.