### PR TITLE
fix: detect Hostinger WordPress auth stripping

### DIFF
--- a/.claude/skills/canonry-setup/references/wordpress-integration.md
+++ b/.claude/skills/canonry-setup/references/wordpress-integration.md
@@ -54,3 +54,4 @@ canonry wordpress staging push mysite
 - Canonry does not use wp-admin automation or undocumented plugin APIs
 - If SEO meta is not writable through REST, canonry returns an actionable error instead of guessing
 - Duplicate slug matches are returned as explicit ambiguity errors with candidate page IDs/titles
+- Hostinger sites may need `SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1` in `.htaccess` because `hcdn` can strip the `Authorization` header

--- a/docs/wordpress-setup.md
+++ b/docs/wordpress-setup.md
@@ -135,6 +135,18 @@ Each command returns:
 
 The username or Application Password is wrong, or the account lacks page-edit permissions. Create a fresh Application Password in WordPress and reconnect.
 
+### `Detected hosting: Hostinger (hcdn)`
+
+Hostinger's CDN strips the `Authorization` header before it reaches WordPress, so REST auth fails even when the Application Password is valid.
+
+Add this line to `.htaccess` before `# BEGIN WordPress`:
+
+```apacheconf
+SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
+```
+
+Then re-run `canonry wordpress connect <project>`.
+
 ### `No staging URL configured`
 
 Reconnect the project with `--staging-url`, or use `--live` on the command.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "1.28.0",
+  "version": "1.28.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/test/wordpress.test.ts
+++ b/packages/api-routes/test/wordpress.test.ts
@@ -172,6 +172,57 @@ describe('WordPress routes', () => {
     expect(connections.has('test-project')).toBe(false)
   })
 
+  it('returns actionable Hostinger auth guidance when wordpress connect fails behind hcdn', async () => {
+    const wordpressModule = await import('@ainyc/canonry-integration-wordpress')
+    vi.spyOn(wordpressModule, 'verifyWordpressConnection').mockRejectedValue(
+      new WordpressApiError(
+        'AUTH_INVALID',
+        [
+          'WordPress REST API authentication failed.',
+          '',
+          'Detected hosting: Hostinger (hcdn)',
+          "Hostinger's CDN strips the Authorization header before it reaches WordPress.",
+          '',
+          'Fix: add the following line to your .htaccess file before "# BEGIN WordPress":',
+          '',
+          '  SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1',
+          '',
+          'Then re-run: canonry wordpress connect <project>',
+        ].join('\n'),
+        401,
+      ),
+    )
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/test-project/wordpress/connect',
+      payload: {
+        url: 'https://example.com/',
+        username: 'admin',
+        appPassword: 'app-pass',
+      },
+    })
+
+    expect(res.statusCode).toBe(401)
+    expect(res.json()).toEqual({
+      error: {
+        code: 'AUTH_INVALID',
+        message: [
+          'WordPress REST API authentication failed.',
+          '',
+          'Detected hosting: Hostinger (hcdn)',
+          "Hostinger's CDN strips the Authorization header before it reaches WordPress.",
+          '',
+          'Fix: add the following line to your .htaccess file before "# BEGIN WordPress":',
+          '',
+          '  SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1',
+          '',
+          'Then re-run: canonry wordpress connect <project>',
+        ].join('\n'),
+      },
+    })
+  })
+
   it('passes the requested environment through page listing routes', async () => {
     const now = new Date().toISOString()
     connections.set('test-project', {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/test/wordpress-commands.test.ts
+++ b/packages/canonry/test/wordpress-commands.test.ts
@@ -136,6 +136,9 @@ describe('wordpress CLI commands', () => {
       if (url.startsWith(harness.serverUrl)) {
         return originalFetch(input, init)
       }
+      if (url.includes('/wp-json/wp/v2/users/me?')) {
+        return jsonResponse({ id: 1, slug: 'admin' })
+      }
       if (url.includes('/wp-json/wp/v2/plugins')) {
         return new Response('Not found', { status: 404 })
       }
@@ -195,6 +198,63 @@ describe('wordpress CLI commands', () => {
       username: 'admin',
       appPassword: 'interactive-app-pass',
     })
+  })
+
+  it('prints the Hostinger .htaccess workaround when wordpress connect hits stripped auth headers', async () => {
+    originalConfigDir = process.env.CANONRY_CONFIG_DIR
+    originalFetch = globalThis.fetch
+
+    const harness = await startHarness()
+    closeHarness = harness.close
+    process.env.CANONRY_CONFIG_DIR = harness.tmpDir
+
+    globalThis.fetch = async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.startsWith(harness.serverUrl)) {
+        return originalFetch(input, init)
+      }
+      if (url.includes('/wp-json/wp/v2/users/me?')) {
+        return new Response(
+          JSON.stringify({
+            code: 'rest_not_logged_in',
+            message: 'You are not currently logged in.',
+            data: { status: 401 },
+          }),
+          {
+            status: 401,
+            headers: {
+              'content-type': 'application/json',
+              'platform': 'hostinger',
+              'panel': 'hpanel',
+              'server': 'hcdn',
+            },
+          },
+        )
+      }
+      throw new Error(`Unhandled URL: ${url}`)
+    }
+
+    const result = await invokeCli([
+      'wordpress',
+      'connect',
+      'test-proj',
+      '--url',
+      'https://example.com',
+      '--user',
+      'admin',
+      '--app-password',
+      'app-pass',
+    ])
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toContain('Detected hosting: Hostinger (hcdn)')
+    expect(result.stderr).toContain('SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1')
+    expect(result.stderr).toContain('canonry wordpress connect <project>')
+
+    const stored = parse(fs.readFileSync(harness.configPath, 'utf-8')) as {
+      wordpress?: { connections?: Array<{ projectName: string }> }
+    }
+    expect(stored.wordpress?.connections ?? []).toHaveLength(0)
   })
 
   it('routes wordpress pages to the staging environment when --staging is provided', async () => {

--- a/packages/integration-wordpress/src/wordpress-client.ts
+++ b/packages/integration-wordpress/src/wordpress-client.ts
@@ -19,6 +19,7 @@ import { WordpressApiError } from './types.js'
 const PAGE_FIELDS = 'id,slug,status,link,modified,modified_gmt,title,content,meta'
 const PAGE_LIST_FIELDS = 'id,slug,status,link,modified,modified_gmt,title'
 const VERIFY_PAGE_FIELDS = 'id,status'
+const VERIFY_USER_FIELDS = 'id,slug'
 const SEO_TARGETS = [
   {
     pluginHints: ['wordpress-seo', 'yoast'],
@@ -49,6 +50,55 @@ function encodeBasicAuth(username: string, appPassword: string): string {
   return Buffer.from(`${username}:${appPassword}`).toString('base64')
 }
 
+function parseJsonObject(text: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(text) as unknown
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null
+  } catch {
+    return null
+  }
+}
+
+function detectHostingerHeaders(headers: Headers): string | null {
+  const platform = headers.get('platform')?.trim().toLowerCase()
+  const server = headers.get('server')?.trim().toLowerCase()
+  const panel = headers.get('panel')?.trim().toLowerCase()
+
+  if (platform === 'hostinger') return server === 'hcdn' ? 'Hostinger (hcdn)' : 'Hostinger'
+  if (server === 'hcdn') return 'Hostinger (hcdn)'
+  if (panel === 'hpanel') return 'Hostinger (hpanel)'
+  return null
+}
+
+function buildHostingerAuthMessage(hostingLabel: string): string {
+  return [
+    'WordPress REST API authentication failed.',
+    '',
+    `Detected hosting: ${hostingLabel}`,
+    "Hostinger's CDN strips the Authorization header before it reaches WordPress.",
+    '',
+    'Fix: add the following line to your .htaccess file before "# BEGIN WordPress":',
+    '',
+    '  SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1',
+    '',
+    'Then re-run: canonry wordpress connect <project>',
+  ].join('\n')
+}
+
+function buildAuthErrorMessage(res: Response, responseText: string): string {
+  const payload = parseJsonObject(responseText)
+  const wordpressCode = typeof payload?.code === 'string' ? payload.code : null
+  const hostingLabel = detectHostingerHeaders(res.headers)
+
+  if (hostingLabel && wordpressCode === 'rest_not_logged_in') {
+    return buildHostingerAuthMessage(hostingLabel)
+  }
+
+  return 'WordPress credentials are invalid or lack permission for this action'
+}
+
 async function fetchJson<T>(
   connection: WordpressConnectionRecord,
   siteUrl: string,
@@ -65,7 +115,8 @@ async function fetchJson<T>(
   })
 
   if (res.status === 401 || res.status === 403) {
-    throw new WordpressApiError('AUTH_INVALID', 'WordPress credentials are invalid or lack permission for this action', res.status)
+    const text = await res.text().catch(() => '')
+    throw new WordpressApiError('AUTH_INVALID', buildAuthErrorMessage(res, text), res.status)
   }
 
   if (res.status === 404) {
@@ -81,6 +132,17 @@ async function fetchJson<T>(
     body: (await res.json()) as T,
     response: res,
   }
+}
+
+async function verifyAuthenticatedRestAccess(
+  connection: WordpressConnectionRecord,
+  siteUrl: string,
+): Promise<void> {
+  await fetchJson<Record<string, unknown>>(
+    connection,
+    siteUrl,
+    `/wp-json/wp/v2/users/me?_fields=${VERIFY_USER_FIELDS}`,
+  )
 }
 
 async function fetchPageCollectionSummary(
@@ -299,6 +361,7 @@ export async function verifyWordpressConnection(
   connection: WordpressConnectionRecord,
 ): Promise<WordpressSiteStatusDto> {
   const site = resolveEnvironment({ ...connection, defaultEnv: 'live' }, 'live')
+  await verifyAuthenticatedRestAccess(connection, site.siteUrl)
   const response = await fetchPageCollectionSummary(connection, site.siteUrl, { context: 'view' })
   const homeHtml = await fetchText(site.siteUrl)
   return {
@@ -316,6 +379,7 @@ export async function getSiteStatus(
 ): Promise<WordpressSiteStatusDto> {
   const site = resolveEnvironment(connection, env)
   try {
+    await verifyAuthenticatedRestAccess(connection, site.siteUrl)
     const response = await fetchPageCollectionSummary(connection, site.siteUrl, { context: 'view' })
     const homeHtml = await fetchText(site.siteUrl)
     const plugins = await listActivePlugins(connection, env)

--- a/packages/integration-wordpress/test/wordpress-client.test.ts
+++ b/packages/integration-wordpress/test/wordpress-client.test.ts
@@ -258,6 +258,9 @@ describe('wordpress client', () => {
     globalThis.fetch = async (input: string | URL | Request) => {
       const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
       requestedUrls.push(url)
+      if (url.includes('/wp-json/wp/v2/users/me?')) {
+        return jsonResponse({ id: 1, slug: 'admin' })
+      }
       if (url.includes('/wp-json/wp/v2/pages?')) {
         return jsonResponse([], {
           headers: {
@@ -274,9 +277,47 @@ describe('wordpress client', () => {
 
     await verifyWordpressConnection(createConnection())
 
-    const verifyRequest = requestedUrls.find((url) => url.includes('/wp-json/wp/v2/pages?'))
-    expect(verifyRequest).toBeTruthy()
-    expect(verifyRequest).toContain('context=view')
-    expect(verifyRequest).not.toContain('context=edit')
+    const authRequest = requestedUrls.find((url) => url.includes('/wp-json/wp/v2/users/me?'))
+    const pageSummaryRequest = requestedUrls.find((url) => url.includes('/wp-json/wp/v2/pages?'))
+    expect(authRequest).toBeTruthy()
+    expect(authRequest).not.toContain('context=edit')
+    expect(pageSummaryRequest).toBeTruthy()
+    expect(pageSummaryRequest).toContain('context=view')
+    expect(pageSummaryRequest).not.toContain('context=edit')
+  })
+
+  it('surfaces the Hostinger Authorization-header workaround on auth failures', async () => {
+    globalThis.fetch = async (input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('/wp-json/wp/v2/users/me?')) {
+        return new Response(
+          JSON.stringify({
+            code: 'rest_not_logged_in',
+            message: 'You are not currently logged in.',
+            data: { status: 401 },
+          }),
+          {
+            status: 401,
+            headers: {
+              'content-type': 'application/json',
+              'platform': 'hostinger',
+              'panel': 'hpanel',
+              'server': 'hcdn',
+            },
+          },
+        )
+      }
+      throw new Error(`Unhandled URL: ${url}`)
+    }
+
+    await expect(() => verifyWordpressConnection(createConnection())).rejects.toMatchObject({
+      name: 'WordpressApiError',
+      code: 'AUTH_INVALID',
+      message: expect.stringContaining('Detected hosting: Hostinger (hcdn)'),
+    } satisfies Partial<WordpressApiError>)
+
+    await expect(() => verifyWordpressConnection(createConnection())).rejects.toThrow(
+      'SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1',
+    )
   })
 })


### PR DESCRIPTION
## Summary
- detect Hostinger/hcdn WordPress auth failures in the shared WordPress client
- verify WordPress connections through an authenticated REST endpoint so stripped Authorization headers fail fast
- add regression coverage and troubleshooting docs for the .htaccess workaround

Closes #186