### PR TITLE
fix: normalize non-finite Bing CTR values to prevent NaN rendering

### DIFF
--- a/apps/web/src/components/project/GscSection.tsx
+++ b/apps/web/src/components/project/GscSection.tsx
@@ -1037,7 +1037,7 @@ export function GscSection({
                             <td className="max-w-xs truncate text-zinc-400">{row.page}</td>
                             <td className="text-right tabular-nums text-zinc-300">{row.clicks.toLocaleString()}</td>
                             <td className="text-right tabular-nums text-zinc-400">{row.impressions.toLocaleString()}</td>
-                            <td className="text-right tabular-nums text-zinc-400">{(row.ctr * 100).toFixed(1)}%</td>
+                            <td className="text-right tabular-nums text-zinc-400">{(Number.isFinite(row.ctr) ? row.ctr * 100 : 0).toFixed(1)}%</td>
                             <td className="text-right tabular-nums text-zinc-400">{row.position.toFixed(1)}</td>
                           </tr>
                         ))}

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -697,7 +697,7 @@ function BingSection({ projectName }: { projectName: string }) {
                         <td className="py-1.5 px-3 text-zinc-300 truncate max-w-[480px]">{row.query}</td>
                         <td className="py-1.5 px-3 text-right text-zinc-200">{row.clicks}</td>
                         <td className="py-1.5 px-3 text-right text-zinc-400">{row.impressions}</td>
-                        <td className="py-1.5 px-3 text-right text-zinc-400">{(row.ctr * 100).toFixed(1)}%</td>
+                        <td className="py-1.5 px-3 text-right text-zinc-400">{(Number.isFinite(row.ctr) ? row.ctr * 100 : 0).toFixed(1)}%</td>
                         <td className="py-1.5 px-3 text-right text-zinc-400">{row.averagePosition.toFixed(1)}</td>
                       </tr>
                     ))}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "1.28.1",
+  "version": "1.28.2",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/bing.ts
+++ b/packages/api-routes/src/bing.ts
@@ -563,7 +563,7 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
       query: s.Query,
       impressions: s.Impressions,
       clicks: s.Clicks,
-      ctr: s.Ctr,
+      ctr: Number.isFinite(s.Ctr) ? s.Ctr : 0,
       averagePosition: s.AverageClickPosition ?? s.AverageImpressionPosition ?? 0,
     }))
   })

--- a/packages/api-routes/test/bing.test.ts
+++ b/packages/api-routes/test/bing.test.ts
@@ -226,6 +226,27 @@ describe('Bing routes', () => {
     expect(body.unknown.map((row) => row.url)).toEqual(['https://example.com/unknown'])
   })
 
+  it('performance normalizes non-finite CTR values to 0', async () => {
+    const bingModule = await import('@ainyc/canonry-integration-bing')
+    vi.spyOn(bingModule, 'getKeywordStats').mockResolvedValue([
+      { Query: 'normal query', Impressions: 100, Clicks: 5, Ctr: 0.05, AverageClickPosition: 3, AverageImpressionPosition: 3 },
+      { Query: 'nan ctr', Impressions: 0, Clicks: 0, Ctr: NaN, AverageClickPosition: 0, AverageImpressionPosition: 0 },
+      { Query: 'infinity ctr', Impressions: 0, Clicks: 0, Ctr: Infinity, AverageClickPosition: 0, AverageImpressionPosition: 0 },
+    ])
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/projects/test-project/bing/performance',
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as Array<{ query: string; ctr: number }>
+    expect(body).toHaveLength(3)
+    expect(body[0]!.ctr).toBe(0.05)
+    expect(body[1]!.ctr).toBe(0)
+    expect(body[2]!.ctr).toBe(0)
+  })
+
   it('allUnindexed only submits URLs with an explicit not-indexed status', async () => {
     const now = new Date().toISOString()
     db.insert(bingUrlInspections).values([

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "1.28.1",
+  "version": "1.28.2",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Summary

- Bing Webmaster API returns `NaN`/`Infinity` for CTR when impressions are zero (division by zero), causing the UI to render `NaN%`
- Added `Number.isFinite()` guard in the API response mapper (`packages/api-routes/src/bing.ts`) to normalize non-finite values to `0` at the source
- Added the same guard defensively in the Bing and GSC UI table renderers
- Added a test covering the `NaN` and `Infinity` CTR cases in `packages/api-routes/test/bing.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)