### PR TITLE
feat: tabbed sidebar — Competitors + Sources

### DIFF
--- a/apps/web/src/components/layout/EvidenceDetailModal.tsx
+++ b/apps/web/src/components/layout/EvidenceDetailModal.tsx
@@ -33,6 +33,7 @@ export function EvidenceDetailModal({
   onClose: () => void
 }) {
   const [showFullAnswer, setShowFullAnswer] = useState(false)
+  const [sidebarTab, setSidebarTab] = useState<'competitors' | 'sources'>('competitors')
   const [selectedRunIdx, setSelectedRunIdx] = useState(-1) // -1 = latest (current)
   const [historicalSnapshot, setHistoricalSnapshot] = useState<EvidenceDisplayData | null>(null)
   const [loadingHistory, setLoadingHistory] = useState(false)
@@ -470,68 +471,103 @@ export function EvidenceDetailModal({
 
                 {/* Right: leaderboard + sources */}
                 <div className="evidence-modal-sidebar">
-                  {/* Citation leaderboard */}
-                  {display.citedDomains.length > 0 && (
-                    <div>
-                      <p className="drawer-section-label">Who was cited \u2014 in order</p>
-                      <div className="citation-leaderboard">
-                        {display.citedDomains.map((domain, i) => {
-                          const norm = domain.toLowerCase().replace(/^www\./, '')
-                          const isYou = myDomains.has(norm)
-                          const isCompetitor = !isYou && display.competitorDomains.some(
-                            c => c.toLowerCase().replace(/^www\./, '') === norm,
-                          )
-                          const variant = isYou ? 'you' : isCompetitor ? 'competitor' : 'other'
-                          return (
-                            <div key={domain} className={`citation-leaderboard-item citation-leaderboard-item--${variant}`}>
-                              <span className="citation-leaderboard-rank">#{i + 1}</span>
-                              <span className="citation-leaderboard-domain">{domain}</span>
-                              {isYou && <span className="citation-leaderboard-tag">You</span>}
-                              {isCompetitor && <span className="citation-leaderboard-tag">Competitor</span>}
-                            </div>
-                          )
-                        })}
-                        {!isCited && (
-                          <div className="citation-leaderboard-item citation-leaderboard-item--not-cited border-dashed">
-                            <span className="citation-leaderboard-rank text-zinc-600">{'\u2014'}</span>
-                            <span className="citation-leaderboard-domain text-zinc-600">{project.project.canonicalDomain}</span>
-                            <span className="citation-leaderboard-tag text-zinc-600">Not cited</span>
+                  {/* Tabbed sidebar navigation */}
+                  {(display.citedDomains.length > 0 || display.groundingSources.length > 0 || display.evidenceUrls.length > 0) && (
+                    <div className="sidebar-tabs">
+                      <button
+                        className={`sidebar-tab ${sidebarTab === 'competitors' ? 'sidebar-tab--active' : ''}`}
+                        onClick={() => setSidebarTab('competitors')}
+                      >
+                        Competitors
+                      </button>
+                      <button
+                        className={`sidebar-tab ${sidebarTab === 'sources' ? 'sidebar-tab--active' : ''}`}
+                        onClick={() => setSidebarTab('sources')}
+                      >
+                        Sources
+                      </button>
+                    </div>
+                  )}
+
+                  {/* Competitors tab — domains cited instead */}
+                  {sidebarTab === 'competitors' && (
+                    <>
+                      {display.citedDomains.length > 0 ? (
+                        <div>
+                          <p className="drawer-section-label">Domains cited instead</p>
+                          <div className="citation-leaderboard">
+                            {display.citedDomains.map((domain, i) => {
+                              const norm = domain.toLowerCase().replace(/^www\./, '')
+                              const isYou = myDomains.has(norm)
+                              const isCompetitor = !isYou && display.competitorDomains.some(
+                                c => c.toLowerCase().replace(/^www\./, '') === norm,
+                              )
+                              const variant = isYou ? 'you' : isCompetitor ? 'competitor' : 'other'
+                              return (
+                                <div key={domain} className={`citation-leaderboard-item citation-leaderboard-item--${variant}`}>
+                                  <span className="citation-leaderboard-rank">#{i + 1}</span>
+                                  <span className="citation-leaderboard-domain">{domain}</span>
+                                  {isYou && <span className="citation-leaderboard-tag">You</span>}
+                                  {isCompetitor && <span className="citation-leaderboard-tag">Competitor</span>}
+                                </div>
+                              )
+                            })}
+                            {!isCited && (
+                              <div className="citation-leaderboard-item citation-leaderboard-item--not-cited border-dashed">
+                                <span className="citation-leaderboard-rank text-zinc-600">{'\u2014'}</span>
+                                <span className="citation-leaderboard-domain text-zinc-600">{project.project.canonicalDomain}</span>
+                                <span className="citation-leaderboard-tag text-zinc-600">Not cited</span>
+                              </div>
+                            )}
                           </div>
-                        )}
-                      </div>
-                    </div>
+                        </div>
+                      ) : (
+                        <div className="flex items-center justify-center h-24 text-zinc-600 text-sm">
+                          No competitor data {isViewingHistory ? 'for this run' : 'yet'}
+                        </div>
+                      )}
+                    </>
                   )}
 
-                  {/* Grounding sources */}
-                  {display.groundingSources.length > 0 && (
-                    <div>
-                      <p className="drawer-section-label">Grounding sources ({display.groundingSources.length})</p>
-                      <ul className="grid gap-0.5">
-                        {display.groundingSources.map((src, i) => (
-                          <li key={i} className="truncate text-sm">
-                            <a href={src.uri} target="_blank" rel="noreferrer" className="text-zinc-400 hover:text-zinc-200 transition-colors">
-                              {src.title || src.uri}
-                            </a>
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
+                  {/* Sources tab — grounding sources + evidence URLs */}
+                  {sidebarTab === 'sources' && (
+                    <>
+                      {display.groundingSources.length > 0 && (
+                        <div>
+                          <p className="drawer-section-label">Grounding sources ({display.groundingSources.length})</p>
+                          <ul className="grid gap-0.5">
+                            {display.groundingSources.map((src, i) => (
+                              <li key={i} className="truncate text-sm">
+                                <a href={src.uri} target="_blank" rel="noreferrer" className="text-zinc-400 hover:text-zinc-200 transition-colors">
+                                  {src.title || src.uri}
+                                </a>
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
 
-                  {/* Evidence URLs */}
-                  {display.evidenceUrls.length > 0 && (
-                    <div>
-                      <p className="drawer-section-label">Evidence URLs</p>
-                      <ul className="grid gap-1">
-                        {display.evidenceUrls.map((url) => (
-                          <li key={url} className="truncate text-sm">
-                            <a href={url} target="_blank" rel="noreferrer" className="text-zinc-400 hover:text-zinc-200 transition-colors">
-                              {url}
-                            </a>
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
+                      {display.evidenceUrls.length > 0 && (
+                        <div>
+                          <p className="drawer-section-label">Evidence URLs</p>
+                          <ul className="grid gap-1">
+                            {display.evidenceUrls.map((url) => (
+                              <li key={url} className="truncate text-sm">
+                                <a href={url} target="_blank" rel="noreferrer" className="text-zinc-400 hover:text-zinc-200 transition-colors">
+                                  {url}
+                                </a>
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+
+                      {display.groundingSources.length === 0 && display.evidenceUrls.length === 0 && (
+                        <div className="flex items-center justify-center h-24 text-zinc-600 text-sm">
+                          No source data {isViewingHistory ? 'for this run' : 'yet'}
+                        </div>
+                      )}
+                    </>
                   )}
 
                   {/* No data state */}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1397,6 +1397,19 @@
     @apply md:border-l md:border-zinc-800/40 md:pl-6;
   }
 
+  .sidebar-tabs {
+    @apply flex gap-1 p-0.5 rounded-lg bg-zinc-900/60 border border-zinc-800/40;
+  }
+
+  .sidebar-tab {
+    @apply flex-1 px-3 py-1.5 text-xs font-medium rounded-md transition-colors;
+    @apply text-zinc-500 hover:text-zinc-300;
+  }
+
+  .sidebar-tab--active {
+    @apply bg-zinc-800 text-zinc-200 shadow-sm;
+  }
+
   .evidence-answer-collapsed {
     max-height: 200px;
     overflow: hidden;


### PR DESCRIPTION
Fixes #196

## Changes

Restructures the evidence detail modal sidebar into a tabbed view:

### Competitors tab (default)
- Shows "Domains cited instead" — the ranked leaderboard of domains AI cited in its response
- Tags your domain and known competitors
- Shows your "Not cited" position when absent

### Sources tab
- Grounding sources (URLs the AI referenced to build its answer)
- Evidence URLs

### Why
The previous single-list layout labeled "Who was cited — in order" mixed domain leaderboard data with grounding sources. Users expected to see competitor company names but saw article source domains instead. The tabbed view separates these concerns and defaults to the competitive view.

### Note
This is the UI-only fix. The leaderboard still shows domains (from grounding sources), not extracted company names. Company-name extraction from answer text is a separate backend change (storing `recommendedCompetitors` per run result). That can be a follow-up.

## Testing
- 724 tests pass
- Typecheck clean
- Lint clean