### PR TITLE
refactor: codebase health pass — error handling, JSON parsing, type safety (v1.31.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,114 @@ THIS IS AN **AGENT-FIRST** PLATFORM. The CLI and API are the primary interfaces.
 - Keep the monitoring app independent from the audit package repo except for the published npm dependency.
 - Raw observation snapshots only (`cited`/`not-cited`); transitions computed at query time.
 
+## Error Handling in API Routes (Critical)
+
+The global error handler in `packages/api-routes/src/index.ts` catches `AppError` instances and serializes them with the correct status code and JSON envelope. Route handlers must leverage this — never duplicate the serialization logic.
+
+### Rules
+
+1. **Throw `AppError` — never catch and manually reply.** Call `resolveProject(app.db, name)` directly. If the project doesn't exist it throws `notFound()`, which the global handler catches. Do not wrap in try-catch or use a `resolveProjectSafe` helper.
+2. **Always use factory functions from `@ainyc/canonry-contracts`.** Never hand-construct `{ error: { code: '...', message: '...' } }`. Use `validationError()`, `notFound()`, `authRequired()`, `providerError()`, etc. This guarantees typed error codes and a consistent envelope.
+3. **New error codes** must be added to the `ErrorCode` union in `packages/contracts/src/errors.ts` with a corresponding factory function.
+
+### Pattern
+
+```typescript
+// ✅ Correct — let the global handler serialize
+import { validationError, notFound } from '@ainyc/canonry-contracts'
+import { resolveProject } from './helpers.js'
+
+const project = resolveProject(app.db, request.params.name) // throws notFound on miss
+if (!body.keywords?.length) throw validationError('"keywords" must be non-empty')
+
+// ❌ Wrong — duplicates global handler logic
+try {
+  const project = resolveProject(app.db, name)
+} catch (e) {
+  reply.status(e.statusCode).send(e.toJSON()) // never do this
+}
+return reply.status(400).send({ error: { code: 'VALIDATION_ERROR', message: '...' } }) // never do this
+```
+
+## JSON Column Parsing (Critical)
+
+Many SQLite text columns store JSON (`projects.locations`, `providers`, `tags`, `labels`, `citedDomains`, etc.). Always use the typed helper from `@ainyc/canonry-db` — never call `JSON.parse` directly on DB column values.
+
+### Rules
+
+1. **Use `parseJsonColumn(value, fallback)` from `@ainyc/canonry-db`.** It handles null, empty strings, and invalid JSON safely.
+2. **Never write `JSON.parse(row.field || '[]') as SomeType[]`** — this pattern is fragile (missing fallback = crash, wrong cast = silent corruption).
+3. `JSON.parse` is fine for HTTP request bodies, config files, and other non-DB sources.
+
+### Pattern
+
+```typescript
+import { parseJsonColumn } from '@ainyc/canonry-db'
+
+// ✅ Correct
+const locations = parseJsonColumn<LocationContext[]>(project.locations, [])
+const labels = parseJsonColumn<Record<string, string>>(project.labels, {})
+
+// ❌ Wrong
+const locations = JSON.parse(project.locations || '[]') as LocationContext[]
+```
+
+## ApiClient Type Safety
+
+All `ApiClient` methods in `packages/canonry/src/client.ts` must return typed DTOs from `@ainyc/canonry-contracts`. CLI commands must not cast API responses with `as Record<string, unknown>` or `as { ... }`.
+
+- Define response interfaces in `packages/contracts/` when they don't already exist.
+- The `request<T>()` method is already generic — specify the correct type parameter.
+- When adding a new API endpoint, add the corresponding client method with a typed return value.
+
+## Transaction Boundaries
+
+Multi-table writes must be wrapped in a single `db.transaction()` call to ensure atomicity.
+
+### Rules
+
+1. **Do all async I/O (HTTP calls, DNS lookups, validation) before entering the transaction.** SQLite transactions must be synchronous (better-sqlite3 requirement).
+2. **Include audit log writes inside the transaction** — `writeAuditLog()` accepts transaction context via its `Pick<DatabaseClient, 'insert'>` parameter.
+3. **Fire callbacks (e.g., `onScheduleUpdated`) after the transaction commits**, not inside it.
+
+### Pattern
+
+```typescript
+// Validate async work first
+const urlCheck = await resolveWebhookTarget(url)
+if (!urlCheck.ok) throw validationError(urlCheck.message)
+
+// Then do all writes atomically
+app.db.transaction((tx) => {
+  tx.update(projects).set({ ... }).where(...).run()
+  tx.delete(keywords).where(...).run()
+  for (const kw of newKeywords) {
+    tx.insert(keywords).values({ ... }).run()
+  }
+  writeAuditLog(tx, { ... })
+})
+
+// Fire callbacks after commit
+opts.onScheduleUpdated?.('upsert', projectId)
+```
+
+## Atomic Counters
+
+Use `INSERT ... ON CONFLICT DO UPDATE` for counter increments. Never use read-then-write patterns, which lose counts under concurrent requests.
+
+### Pattern
+
+```typescript
+import { sql } from 'drizzle-orm'
+
+db.insert(usageCounters).values({
+  id: crypto.randomUUID(), scope, period, metric, count: 1, updatedAt: now,
+}).onConflictDoUpdate({
+  target: [usageCounters.scope, usageCounters.period, usageCounters.metric],
+  set: { count: sql`${usageCounters.count} + 1`, updatedAt: now },
+}).run()
+```
+
 ## Database Schema Changes (Critical)
 
 **Every new `sqliteTable(...)` in `packages/db/src/schema.ts` MUST have a corresponding migration in `packages/db/src/migrate.ts`.**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "1.30.0",
+  "version": "1.31.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/analytics.ts
+++ b/packages/api-routes/src/analytics.ts
@@ -1,6 +1,6 @@
 import { eq, desc, inArray } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
-import { querySnapshots, runs, keywords } from '@ainyc/canonry-db'
+import { querySnapshots, runs, keywords, parseJsonColumn } from '@ainyc/canonry-db'
 import { categorizeSource, categoryLabel } from '@ainyc/canonry-contracts'
 import type {
   BrandMetricsDto, GapAnalysisDto, SourceBreakdownDto,
@@ -15,8 +15,7 @@ export async function analyticsRoutes(app: FastifyInstance) {
     Params: { name: string }
     Querystring: { window?: string }
   }>('/projects/:name/analytics/metrics', async (request, reply) => {
-    const project = resolveProjectSafe(app, request.params.name, reply)
-    if (!project) return
+    const project = resolveProject(app.db, request.params.name)
 
     const window = parseWindow(request.query.window)
     const cutoff = windowCutoff(window)
@@ -93,8 +92,7 @@ export async function analyticsRoutes(app: FastifyInstance) {
     Params: { name: string }
     Querystring: { window?: string }
   }>('/projects/:name/analytics/gaps', async (request, reply) => {
-    const project = resolveProjectSafe(app, request.params.name, reply)
-    if (!project) return
+    const project = resolveProject(app.db, request.params.name)
 
     const window = parseWindow(request.query.window)
     const cutoff = windowCutoff(window)
@@ -182,7 +180,7 @@ export async function analyticsRoutes(app: FastifyInstance) {
         .map(s => s.provider)
       const competitorsCiting = new Set<string>()
       for (const s of kwSnapshots) {
-        const overlap = tryParseJson(s.competitorOverlap, [] as string[])
+        const overlap = parseJsonColumn<string[]>(s.competitorOverlap, [])
         for (const c of overlap) competitorsCiting.add(c)
       }
 
@@ -226,8 +224,7 @@ export async function analyticsRoutes(app: FastifyInstance) {
     Params: { name: string }
     Querystring: { window?: string }
   }>('/projects/:name/analytics/sources', async (request, reply) => {
-    const project = resolveProjectSafe(app, request.params.name, reply)
-    if (!project) return
+    const project = resolveProject(app.db, request.params.name)
 
     const window = parseWindow(request.query.window)
     const cutoff = windowCutoff(window)
@@ -295,27 +292,6 @@ export async function analyticsRoutes(app: FastifyInstance) {
 
 // --- Helpers ---
 
-function resolveProjectSafe(app: FastifyInstance, name: string, reply: { status: (code: number) => { send: (body: unknown) => unknown } }) {
-  try {
-    return resolveProject(app.db, name)
-  } catch (e: unknown) {
-    if (e && typeof e === 'object' && 'statusCode' in e && 'toJSON' in e) {
-      const err = e as { statusCode: number; toJSON(): unknown }
-      reply.status(err.statusCode).send(err.toJSON())
-      return null
-    }
-    throw e
-  }
-}
-
-function tryParseJson<T>(value: string | null, fallback: T): T {
-  if (!value) return fallback
-  try {
-    return JSON.parse(value) as T
-  } catch {
-    return fallback
-  }
-}
 
 // Domains that are provider infrastructure, not real grounding sources
 const PROVIDER_INFRA_DOMAINS = new Set([
@@ -338,7 +314,7 @@ function isProviderInfraDomain(uri: string): boolean {
 }
 
 function parseGroundingSources(rawResponse: string | null): Array<{ uri: string; title: string }> {
-  const parsed = tryParseJson(rawResponse, {} as Record<string, unknown>)
+  const parsed = parseJsonColumn<Record<string, unknown>>(rawResponse, {})
   const sources = parsed.groundingSources as Array<{ uri?: string; title?: string }> | undefined
   if (!Array.isArray(sources)) return []
   return sources.filter(

--- a/packages/api-routes/src/apply.ts
+++ b/packages/api-routes/src/apply.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto'
 import { eq } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
-import { projects, keywords, competitors, schedules, notifications } from '@ainyc/canonry-db'
+import { projects, keywords, competitors, schedules, notifications, parseJsonColumn } from '@ainyc/canonry-db'
 import { projectConfigSchema, validationError } from '@ainyc/canonry-contracts'
 import { writeAuditLog } from './helpers.js'
 import { resolvePreset, validateCron, isValidTimezone } from './schedule-utils.js'
@@ -19,10 +19,9 @@ export async function applyRoutes(app: FastifyInstance, opts?: ApplyRoutesOption
   app.post('/apply', async (request, reply) => {
     const parsed = projectConfigSchema.safeParse(request.body)
     if (!parsed.success) {
-      const err = validationError('Invalid project config', {
+      throw validationError('Invalid project config', {
         issues: parsed.error.issues.map(i => ({ path: i.path.join('.'), message: i.message })),
       })
-      return reply.status(err.statusCode).send(err.toJSON())
     }
 
     const config = parsed.data
@@ -37,78 +36,121 @@ export async function applyRoutes(app: FastifyInstance, opts?: ApplyRoutesOption
       if (allProviders.length) {
         const invalid = allProviders.filter(p => !validNames.includes(p))
         if (invalid.length) {
-          const err = validationError(`Invalid provider(s): ${[...new Set(invalid)].join(', ')}. Must be one of: ${validNames.join(', ')}`, {
+          throw validationError(`Invalid provider(s): ${[...new Set(invalid)].join(', ')}. Must be one of: ${validNames.join(', ')}`, {
             invalidProviders: [...new Set(invalid)],
             validProviders: validNames,
           })
-          return reply.status(err.statusCode).send(err.toJSON())
         }
+      }
+    }
+
+    // Validate schedule before entering transaction
+    let resolvedSchedule: { cronExpr: string; preset: string | null; timezone: string } | null = null
+    let deleteSchedule = false
+    if (config.spec.schedule) {
+      const schedSpec = config.spec.schedule
+      let cronExpr: string
+      let preset: string | null = null
+
+      if (schedSpec.preset) {
+        preset = schedSpec.preset
+        try {
+          cronExpr = resolvePreset(schedSpec.preset)
+        } catch (err: unknown) {
+          const msg = err instanceof Error ? err.message : String(err)
+          throw validationError(msg)
+        }
+      } else if (schedSpec.cron) {
+        cronExpr = schedSpec.cron
+        if (!validateCron(cronExpr)) throw validationError(`Invalid cron expression in schedule: ${cronExpr}`)
+      } else {
+        throw validationError('Schedule requires either "preset" or "cron"')
+      }
+
+      const timezone = schedSpec.timezone ?? 'UTC'
+      if (!isValidTimezone(timezone)) throw validationError(`Invalid timezone: ${timezone}`)
+
+      resolvedSchedule = { cronExpr, preset, timezone }
+    } else {
+      deleteSchedule = true
+    }
+
+    // Validate webhook URLs before entering transaction (async I/O)
+    const rawSpec = (request.body as { spec?: Record<string, unknown> })?.spec ?? {}
+    const hasNotifications = 'notifications' in rawSpec
+    if (hasNotifications) {
+      for (const notif of config.spec.notifications) {
+        const urlCheck = await resolveWebhookTarget(notif.url ?? '')
+        if (!urlCheck.ok) throw validationError(`Notification URL invalid: ${urlCheck.message}`)
       }
     }
 
     const now = new Date().toISOString()
     const name = config.metadata.name
 
-    // Upsert project
-    const existing = app.db.select().from(projects).where(eq(projects.name, name)).get()
-
+    // All validation done — wrap all writes in a single transaction
     let projectId: string
-    if (existing) {
-      projectId = existing.id
-      app.db.update(projects).set({
-        displayName: config.spec.displayName,
-        canonicalDomain: config.spec.canonicalDomain,
-        ownedDomains: JSON.stringify(config.spec.ownedDomains ?? []),
-        country: config.spec.country,
-        language: config.spec.language,
-        labels: JSON.stringify(config.metadata.labels),
-        providers: JSON.stringify(config.spec.providers ?? []),
-        locations: JSON.stringify(config.spec.locations ?? []),
-        defaultLocation: config.spec.defaultLocation ?? null,
-        configSource: 'config-file',
-        configRevision: existing.configRevision + 1,
-        updatedAt: now,
-      }).where(eq(projects.id, existing.id)).run()
+    let scheduleAction: 'upsert' | 'delete' | null = null
 
-      writeAuditLog(app.db, {
-        projectId,
-        actor: 'api',
-        action: 'project.applied',
-        entityType: 'project',
-        entityId: projectId,
-      })
-    } else {
-      projectId = crypto.randomUUID()
-      app.db.insert(projects).values({
-        id: projectId,
-        name,
-        displayName: config.spec.displayName,
-        canonicalDomain: config.spec.canonicalDomain,
-        ownedDomains: JSON.stringify(config.spec.ownedDomains ?? []),
-        country: config.spec.country,
-        language: config.spec.language,
-        tags: '[]',
-        labels: JSON.stringify(config.metadata.labels),
-        providers: JSON.stringify(config.spec.providers ?? []),
-        locations: JSON.stringify(config.spec.locations ?? []),
-        defaultLocation: config.spec.defaultLocation ?? null,
-        configSource: 'config-file',
-        configRevision: 1,
-        createdAt: now,
-        updatedAt: now,
-      }).run()
-
-      writeAuditLog(app.db, {
-        projectId,
-        actor: 'api',
-        action: 'project.created',
-        entityType: 'project',
-        entityId: projectId,
-      })
-    }
-
-    // Atomic replace: keywords + competitors in a single transaction
     app.db.transaction((tx) => {
+      // Upsert project
+      const existing = tx.select().from(projects).where(eq(projects.name, name)).get()
+
+      if (existing) {
+        projectId = existing.id
+        tx.update(projects).set({
+          displayName: config.spec.displayName,
+          canonicalDomain: config.spec.canonicalDomain,
+          ownedDomains: JSON.stringify(config.spec.ownedDomains ?? []),
+          country: config.spec.country,
+          language: config.spec.language,
+          labels: JSON.stringify(config.metadata.labels),
+          providers: JSON.stringify(config.spec.providers ?? []),
+          locations: JSON.stringify(config.spec.locations ?? []),
+          defaultLocation: config.spec.defaultLocation ?? null,
+          configSource: 'config-file',
+          configRevision: existing.configRevision + 1,
+          updatedAt: now,
+        }).where(eq(projects.id, existing.id)).run()
+
+        writeAuditLog(tx, {
+          projectId,
+          actor: 'api',
+          action: 'project.applied',
+          entityType: 'project',
+          entityId: projectId,
+        })
+      } else {
+        projectId = crypto.randomUUID()
+        tx.insert(projects).values({
+          id: projectId,
+          name,
+          displayName: config.spec.displayName,
+          canonicalDomain: config.spec.canonicalDomain,
+          ownedDomains: JSON.stringify(config.spec.ownedDomains ?? []),
+          country: config.spec.country,
+          language: config.spec.language,
+          tags: '[]',
+          labels: JSON.stringify(config.metadata.labels),
+          providers: JSON.stringify(config.spec.providers ?? []),
+          locations: JSON.stringify(config.spec.locations ?? []),
+          defaultLocation: config.spec.defaultLocation ?? null,
+          configSource: 'config-file',
+          configRevision: 1,
+          createdAt: now,
+          updatedAt: now,
+        }).run()
+
+        writeAuditLog(tx, {
+          projectId,
+          actor: 'api',
+          action: 'project.created',
+          entityType: 'project',
+          entityId: projectId,
+        })
+      }
+
+      // Replace keywords + competitors
       tx.delete(keywords).where(eq(keywords.projectId, projectId)).run()
       for (const kw of config.spec.keywords) {
         tx.insert(keywords).values({
@@ -144,132 +186,88 @@ export async function applyRoutes(app: FastifyInstance, opts?: ApplyRoutesOption
         entityType: 'competitor',
         diff: { competitors: config.spec.competitors },
       })
+
+      // Handle schedule
+      if (resolvedSchedule) {
+        const existingSched = tx.select().from(schedules).where(eq(schedules.projectId, projectId)).get()
+        if (existingSched) {
+          tx.update(schedules).set({
+            cronExpr: resolvedSchedule.cronExpr,
+            preset: resolvedSchedule.preset,
+            timezone: resolvedSchedule.timezone,
+            providers: JSON.stringify(config.spec.schedule?.providers ?? []),
+            enabled: 1,
+            updatedAt: now,
+          }).where(eq(schedules.id, existingSched.id)).run()
+        } else {
+          tx.insert(schedules).values({
+            id: crypto.randomUUID(),
+            projectId,
+            cronExpr: resolvedSchedule.cronExpr,
+            preset: resolvedSchedule.preset,
+            timezone: resolvedSchedule.timezone,
+            enabled: 1,
+            providers: JSON.stringify(config.spec.schedule?.providers ?? []),
+            createdAt: now,
+            updatedAt: now,
+          }).run()
+        }
+        scheduleAction = 'upsert'
+      } else if (deleteSchedule) {
+        const existingSched = tx.select().from(schedules).where(eq(schedules.projectId, projectId)).get()
+        if (existingSched) {
+          tx.delete(schedules).where(eq(schedules.projectId, projectId)).run()
+          scheduleAction = 'delete'
+        }
+      }
+
+      // Handle notifications
+      if (hasNotifications) {
+        tx.delete(notifications).where(eq(notifications.projectId, projectId)).run()
+        for (const notif of config.spec.notifications) {
+          tx.insert(notifications).values({
+            id: crypto.randomUUID(),
+            projectId,
+            channel: notif.channel,
+            config: JSON.stringify({ url: notif.url, events: notif.events }),
+            webhookSecret: crypto.randomBytes(32).toString('hex'),
+            enabled: 1,
+            createdAt: now,
+            updatedAt: now,
+          }).run()
+        }
+
+        writeAuditLog(tx, {
+          projectId,
+          actor: 'api',
+          action: 'notifications.replaced',
+          entityType: 'notification',
+          diff: { notifications: config.spec.notifications },
+        })
+      }
     })
 
-    // Handle schedule from config — declarative: absent means delete
-    if (config.spec.schedule) {
-      const schedSpec = config.spec.schedule
-      let cronExpr: string
-      let preset: string | null = null
-
-      if (schedSpec.preset) {
-        preset = schedSpec.preset
-        try {
-          cronExpr = resolvePreset(schedSpec.preset)
-        } catch (err: unknown) {
-          const msg = err instanceof Error ? err.message : String(err)
-          return reply.status(400).send({ error: { code: 'VALIDATION_ERROR', message: msg } })
-        }
-      } else if (schedSpec.cron) {
-        cronExpr = schedSpec.cron
-        if (!validateCron(cronExpr)) {
-          return reply.status(400).send({
-            error: { code: 'VALIDATION_ERROR', message: `Invalid cron expression in schedule: ${cronExpr}` },
-          })
-        }
-      } else {
-        return reply.status(400).send({
-          error: { code: 'VALIDATION_ERROR', message: 'Schedule requires either "preset" or "cron"' },
-        })
-      }
-
-      const timezone = schedSpec.timezone ?? 'UTC'
-      if (!isValidTimezone(timezone)) {
-        return reply.status(400).send({
-          error: { code: 'VALIDATION_ERROR', message: `Invalid timezone: ${timezone}` },
-        })
-      }
-
-      const existingSched = app.db.select().from(schedules).where(eq(schedules.projectId, projectId)).get()
-      if (existingSched) {
-        app.db.update(schedules).set({
-          cronExpr,
-          preset,
-          timezone,
-          providers: JSON.stringify(schedSpec.providers ?? []),
-          enabled: 1,
-          updatedAt: now,
-        }).where(eq(schedules.id, existingSched.id)).run()
-      } else {
-        app.db.insert(schedules).values({
-          id: crypto.randomUUID(),
-          projectId,
-          cronExpr,
-          preset,
-          timezone,
-          enabled: 1,
-          providers: JSON.stringify(schedSpec.providers ?? []),
-          createdAt: now,
-          updatedAt: now,
-        }).run()
-      }
-
-      opts?.onScheduleUpdated?.('upsert', projectId)
-    } else {
-      // Declaratively remove schedule if omitted from config
-      const existingSched = app.db.select().from(schedules).where(eq(schedules.projectId, projectId)).get()
-      if (existingSched) {
-        app.db.delete(schedules).where(eq(schedules.projectId, projectId)).run()
-        opts?.onScheduleUpdated?.('delete', projectId)
-      }
+    // Fire callbacks after transaction commits
+    if (scheduleAction) {
+      opts?.onScheduleUpdated?.(scheduleAction, projectId!)
     }
-
-    // Handle notifications from config — declarative replace only when key is
-    // explicitly present (absent key leaves existing notifications untouched).
-    const rawSpec = (request.body as { spec?: Record<string, unknown> })?.spec ?? {}
-    if ('notifications' in rawSpec) {
-      // Validate all URLs before any writes so the replace is atomic.
-      for (const notif of config.spec.notifications) {
-        const urlCheck = await resolveWebhookTarget(notif.url ?? '')
-        if (!urlCheck.ok) {
-          return reply.status(400).send({
-            error: { code: 'VALIDATION_ERROR', message: `Notification URL invalid: ${urlCheck.message}` },
-          })
-        }
-      }
-
-      app.db.delete(notifications).where(eq(notifications.projectId, projectId)).run()
-      for (const notif of config.spec.notifications) {
-        app.db.insert(notifications).values({
-          id: crypto.randomUUID(),
-          projectId,
-          channel: notif.channel,
-          config: JSON.stringify({ url: notif.url, events: notif.events }),
-          webhookSecret: crypto.randomBytes(32).toString('hex'),
-          enabled: 1,
-          createdAt: now,
-          updatedAt: now,
-        }).run()
-      }
-
-      writeAuditLog(app.db, {
-        projectId,
-        actor: 'api',
-        action: 'notifications.replaced',
-        entityType: 'notification',
-        diff: { notifications: config.spec.notifications },
-      })
-    }
-
-    // Handle google config — if spec.google.gsc.propertyUrl is set and a GSC connection
-    // exists for this project's domain, update the property.
     if ('google' in rawSpec && config.spec.google?.gsc?.propertyUrl) {
       opts?.onGoogleConnectionPropertyUpdated?.(config.spec.canonicalDomain, 'gsc', config.spec.google.gsc.propertyUrl)
     }
 
-    const project = app.db.select().from(projects).where(eq(projects.id, projectId)).get()!
+    const project = app.db.select().from(projects).where(eq(projects.id, projectId!)).get()!
     return reply.status(200).send({
       id: project.id,
       name: project.name,
       displayName: project.displayName,
       canonicalDomain: project.canonicalDomain,
-      ownedDomains: JSON.parse(project.ownedDomains || '[]') as string[],
+      ownedDomains: parseJsonColumn<string[]>(project.ownedDomains, []),
       country: project.country,
       language: project.language,
-      tags: JSON.parse(project.tags) as string[],
-      labels: JSON.parse(project.labels) as Record<string, string>,
-      providers: JSON.parse(project.providers || '[]') as string[],
-      locations: JSON.parse(project.locations || '[]') as unknown[],
+      tags: parseJsonColumn<string[]>(project.tags, []),
+      labels: parseJsonColumn<Record<string, string>>(project.labels, {}),
+      providers: parseJsonColumn<string[]>(project.providers, []),
+      locations: parseJsonColumn<unknown[]>(project.locations, []),
       defaultLocation: project.defaultLocation,
       configSource: project.configSource,
       configRevision: project.configRevision,

--- a/packages/api-routes/src/competitors.ts
+++ b/packages/api-routes/src/competitors.ts
@@ -8,8 +8,7 @@ import { resolveProject, writeAuditLog } from './helpers.js'
 export async function competitorRoutes(app: FastifyInstance) {
   // GET /projects/:name/competitors
   app.get<{ Params: { name: string } }>('/projects/:name/competitors', async (request, reply) => {
-    const project = resolveProjectSafe(app, request.params.name, reply)
-    if (!project) return
+    const project = resolveProject(app.db, request.params.name)
     const rows = app.db.select().from(competitors).where(eq(competitors.projectId, project.id)).all()
     return reply.send(rows.map(r => ({ id: r.id, domain: r.domain, createdAt: r.createdAt })))
   })
@@ -19,13 +18,11 @@ export async function competitorRoutes(app: FastifyInstance) {
     Params: { name: string }
     Body: { competitors: string[] }
   }>('/projects/:name/competitors', async (request, reply) => {
-    const project = resolveProjectSafe(app, request.params.name, reply)
-    if (!project) return
+    const project = resolveProject(app.db, request.params.name)
 
     const body = request.body
     if (!body || !Array.isArray(body.competitors)) {
-      const err = validationError('Body must contain a "competitors" array')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('Body must contain a "competitors" array')
     }
 
     const now = new Date().toISOString()
@@ -55,17 +52,4 @@ export async function competitorRoutes(app: FastifyInstance) {
     const rows = app.db.select().from(competitors).where(eq(competitors.projectId, project.id)).all()
     return reply.send(rows.map(r => ({ id: r.id, domain: r.domain, createdAt: r.createdAt })))
   })
-}
-
-function resolveProjectSafe(app: FastifyInstance, name: string, reply: { status: (code: number) => { send: (body: unknown) => unknown } }) {
-  try {
-    return resolveProject(app.db, name)
-  } catch (e: unknown) {
-    if (e && typeof e === 'object' && 'statusCode' in e && 'toJSON' in e) {
-      const err = e as { statusCode: number; toJSON(): unknown }
-      reply.status(err.statusCode).send(err.toJSON())
-      return null
-    }
-    throw e
-  }
 }

--- a/packages/api-routes/src/helpers.ts
+++ b/packages/api-routes/src/helpers.ts
@@ -1,5 +1,5 @@
 import crypto from 'node:crypto'
-import { eq, and } from 'drizzle-orm'
+import { eq, sql } from 'drizzle-orm'
 import type { DatabaseClient } from '@ainyc/canonry-db'
 import { projects, auditLog, usageCounters } from '@ainyc/canonry-db'
 import { notFound } from '@ainyc/canonry-contracts'
@@ -39,31 +39,19 @@ export function writeAuditLog(db: Pick<DatabaseClient, 'insert'>, entry: AuditEn
 export function incrementUsage(db: DatabaseClient, scope: string, metric: string) {
   const now = new Date()
   const period = now.toISOString().slice(0, 10)
-  const existing = db
-    .select()
-    .from(usageCounters)
-    .where(
-      and(
-        eq(usageCounters.scope, scope),
-        eq(usageCounters.period, period),
-        eq(usageCounters.metric, metric),
-      ),
-    )
-    .get()
 
-  if (existing) {
-    db.update(usageCounters)
-      .set({ count: existing.count + 1, updatedAt: now.toISOString() })
-      .where(eq(usageCounters.id, existing.id))
-      .run()
-  } else {
-    db.insert(usageCounters).values({
-      id: crypto.randomUUID(),
-      scope,
-      period,
-      metric,
-      count: 1,
+  db.insert(usageCounters).values({
+    id: crypto.randomUUID(),
+    scope,
+    period,
+    metric,
+    count: 1,
+    updatedAt: now.toISOString(),
+  }).onConflictDoUpdate({
+    target: [usageCounters.scope, usageCounters.period, usageCounters.metric],
+    set: {
+      count: sql`${usageCounters.count} + 1`,
       updatedAt: now.toISOString(),
-    }).run()
-  }
+    },
+  }).run()
 }

--- a/packages/api-routes/src/history.ts
+++ b/packages/api-routes/src/history.ts
@@ -1,14 +1,14 @@
 import { eq, desc, inArray } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
-import { auditLog, querySnapshots, runs, keywords } from '@ainyc/canonry-db'
+import { auditLog, querySnapshots, runs, keywords, parseJsonColumn } from '@ainyc/canonry-db'
+import { validationError } from '@ainyc/canonry-contracts'
 import { resolveProject } from './helpers.js'
 import { redactNotificationDiff } from './notification-redaction.js'
 
 export async function historyRoutes(app: FastifyInstance) {
   // GET /projects/:name/history — audit log for project
   app.get<{ Params: { name: string } }>('/projects/:name/history', async (request, reply) => {
-    const project = resolveProjectSafe(app, request.params.name, reply)
-    if (!project) return
+    const project = resolveProject(app.db, request.params.name)
 
     const rows = app.db
       .select()
@@ -36,8 +36,7 @@ export async function historyRoutes(app: FastifyInstance) {
     Params: { name: string }
     Querystring: { limit?: string; offset?: string; location?: string }
   }>('/projects/:name/snapshots', async (request, reply) => {
-    const project = resolveProjectSafe(app, request.params.name, reply)
-    if (!project) return
+    const project = resolveProject(app.db, request.params.name)
 
     const limit = parseInt(request.query.limit ?? '50', 10)
     const offset = parseInt(request.query.offset ?? '0', 10)
@@ -95,9 +94,9 @@ export async function historyRoutes(app: FastifyInstance) {
         model: s.model,
         citationState: s.citationState,
         answerText: s.answerText,
-        citedDomains: tryParseJson(s.citedDomains, [] as string[]),
-        competitorOverlap: tryParseJson(s.competitorOverlap, [] as string[]),
-        recommendedCompetitors: tryParseJson(s.recommendedCompetitors, [] as string[]),
+        citedDomains: parseJsonColumn<string[]>(s.citedDomains, []),
+        competitorOverlap: parseJsonColumn<string[]>(s.competitorOverlap, []),
+        recommendedCompetitors: parseJsonColumn<string[]>(s.recommendedCompetitors, []),
         location: s.location,
         createdAt: s.createdAt,
       })),
@@ -107,8 +106,7 @@ export async function historyRoutes(app: FastifyInstance) {
 
   // GET /projects/:name/timeline — per-keyword citation state over time
   app.get<{ Params: { name: string }; Querystring: { location?: string } }>('/projects/:name/timeline', async (request, reply) => {
-    const project = resolveProjectSafe(app, request.params.name, reply)
-    if (!project) return
+    const project = resolveProject(app.db, request.params.name)
 
     // Get project keywords
     const projectKeywords = app.db
@@ -244,12 +242,11 @@ export async function historyRoutes(app: FastifyInstance) {
     Params: { name: string }
     Querystring: { run1: string; run2: string }
   }>('/projects/:name/snapshots/diff', async (request, reply) => {
-    const project = resolveProjectSafe(app, request.params.name, reply)
-    if (!project) return
+    resolveProject(app.db, request.params.name) // validate project exists
 
     const { run1, run2 } = request.query
     if (!run1 || !run2) {
-      return reply.status(400).send({ error: { code: 'VALIDATION_ERROR', message: 'Both run1 and run2 query params are required' } })
+      throw validationError('Both run1 and run2 query params are required')
     }
 
     // Get snapshots for both runs
@@ -325,30 +322,9 @@ function formatAuditEntry(row: {
     entityId: row.entityId,
     diff: row.diff
       ? row.entityType === 'notification'
-        ? redactNotificationDiff(tryParseJson(row.diff, null))
-        : tryParseJson(row.diff, null)
+        ? redactNotificationDiff(parseJsonColumn<unknown>(row.diff, null))
+        : parseJsonColumn<unknown>(row.diff, null)
       : null,
     createdAt: row.createdAt,
-  }
-}
-
-function tryParseJson<T>(value: string, fallback: T): T {
-  try {
-    return JSON.parse(value) as T
-  } catch {
-    return fallback
-  }
-}
-
-function resolveProjectSafe(app: FastifyInstance, name: string, reply: { status: (code: number) => { send: (body: unknown) => unknown } }) {
-  try {
-    return resolveProject(app.db, name)
-  } catch (e: unknown) {
-    if (e && typeof e === 'object' && 'statusCode' in e && 'toJSON' in e) {
-      const err = e as { statusCode: number; toJSON(): unknown }
-      reply.status(err.statusCode).send(err.toJSON())
-      return null
-    }
-    throw e
   }
 }

--- a/packages/api-routes/src/keywords.ts
+++ b/packages/api-routes/src/keywords.ts
@@ -16,8 +16,7 @@ export interface KeywordRoutesOptions {
 export async function keywordRoutes(app: FastifyInstance, opts: KeywordRoutesOptions) {
   // GET /projects/:name/keywords
   app.get<{ Params: { name: string } }>('/projects/:name/keywords', async (request, reply) => {
-    const project = resolveProjectSafe(app, request.params.name, reply)
-    if (!project) return
+    const project = resolveProject(app.db, request.params.name)
     const rows = app.db.select().from(keywords).where(eq(keywords.projectId, project.id)).all()
     return reply.send(rows.map(r => ({ id: r.id, keyword: r.keyword, createdAt: r.createdAt })))
   })
@@ -27,13 +26,11 @@ export async function keywordRoutes(app: FastifyInstance, opts: KeywordRoutesOpt
     Params: { name: string }
     Body: { keywords: string[] }
   }>('/projects/:name/keywords', async (request, reply) => {
-    const project = resolveProjectSafe(app, request.params.name, reply)
-    if (!project) return
+    const project = resolveProject(app.db, request.params.name)
 
     const body = request.body
     if (!body || !Array.isArray(body.keywords)) {
-      const err = validationError('Body must contain a "keywords" array')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('Body must contain a "keywords" array')
     }
 
     const now = new Date().toISOString()
@@ -69,13 +66,11 @@ export async function keywordRoutes(app: FastifyInstance, opts: KeywordRoutesOpt
     Params: { name: string }
     Body: { keywords: string[] }
   }>('/projects/:name/keywords', async (request, reply) => {
-    const project = resolveProjectSafe(app, request.params.name, reply)
-    if (!project) return
+    const project = resolveProject(app.db, request.params.name)
 
     const body = request.body
     if (!body || !Array.isArray(body.keywords) || body.keywords.length === 0) {
-      const err = validationError('Body must contain a non-empty "keywords" array')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('Body must contain a non-empty "keywords" array')
     }
 
     const existing = app.db
@@ -112,13 +107,11 @@ export async function keywordRoutes(app: FastifyInstance, opts: KeywordRoutesOpt
     Params: { name: string }
     Body: { keywords: string[] }
   }>('/projects/:name/keywords', async (request, reply) => {
-    const project = resolveProjectSafe(app, request.params.name, reply)
-    if (!project) return
+    const project = resolveProject(app.db, request.params.name)
 
     const body = request.body
     if (!body || !Array.isArray(body.keywords)) {
-      const err = validationError('Body must contain a "keywords" array')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('Body must contain a "keywords" array')
     }
 
     const now = new Date().toISOString()
@@ -161,33 +154,28 @@ export async function keywordRoutes(app: FastifyInstance, opts: KeywordRoutesOpt
     Params: { name: string }
     Body: { provider: string; count?: number }
   }>('/projects/:name/keywords/generate', async (request, reply) => {
-    const project = resolveProjectSafe(app, request.params.name, reply)
-    if (!project) return
+    const project = resolveProject(app.db, request.params.name)
 
     const body = request.body
     if (!body?.provider || typeof body.provider !== 'string') {
-      const err = validationError('Body must contain a "provider" string')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('Body must contain a "provider" string')
     }
 
     const provider = body.provider.trim().toLowerCase()
     const validNames = opts.validProviderNames ?? []
     if (validNames.length && !validNames.includes(provider)) {
-      const err = validationError(`Unknown provider "${body.provider}". Valid providers: ${validNames.join(', ')}`, {
+      throw validationError(`Unknown provider "${body.provider}". Valid providers: ${validNames.join(', ')}`, {
         provider: body.provider,
         validProviders: validNames,
       })
-      return reply.status(err.statusCode).send(err.toJSON())
     }
     if (body.count !== undefined && (typeof body.count !== 'number' || !Number.isFinite(body.count) || !Number.isInteger(body.count))) {
-      const err = validationError('"count" must be an integer')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('"count" must be an integer')
     }
     const count = Math.min(Math.max(body.count ?? 5, 1), 20)
 
     if (!opts.onGenerateKeywords) {
-      const err = notImplemented('Key phrase generation is not supported in this deployment')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw notImplemented('Key phrase generation is not supported in this deployment')
     }
 
     const existingRows = app.db.select().from(keywords).where(eq(keywords.projectId, project.id)).all()
@@ -212,17 +200,4 @@ export async function keywordRoutes(app: FastifyInstance, opts: KeywordRoutesOpt
       })
     }
   })
-}
-
-function resolveProjectSafe(app: FastifyInstance, name: string, reply: { status: (code: number) => { send: (body: unknown) => unknown } }) {
-  try {
-    return resolveProject(app.db, name)
-  } catch (e: unknown) {
-    if (e && typeof e === 'object' && 'statusCode' in e && 'toJSON' in e) {
-      const err = e as { statusCode: number; toJSON(): unknown }
-      reply.status(err.statusCode).send(err.toJSON())
-      return null
-    }
-    throw e
-  }
 }

--- a/packages/api-routes/src/notifications.ts
+++ b/packages/api-routes/src/notifications.ts
@@ -1,8 +1,9 @@
 import crypto from 'node:crypto'
 import { eq } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
-import { notifications } from '@ainyc/canonry-db'
+import { notifications, parseJsonColumn } from '@ainyc/canonry-db'
 import type { NotificationEvent, NotificationDto } from '@ainyc/canonry-contracts'
+import { validationError, notFound, deliveryFailed } from '@ainyc/canonry-contracts'
 import { resolveProject, writeAuditLog } from './helpers.js'
 import { redactNotificationUrl } from './notification-redaction.js'
 import { deliverWebhook, resolveWebhookTarget } from './webhooks.js'
@@ -20,35 +21,20 @@ export async function notificationRoutes(app: FastifyInstance) {
     Params: { name: string }
     Body: { channel: string; url: string; events: string[] }
   }>('/projects/:name/notifications', async (request, reply) => {
-    const project = resolveProjectSafe(app, request.params.name, reply)
-    if (!project) return
+    const project = resolveProject(app.db, request.params.name)
 
     const { channel, url, events } = request.body ?? {}
 
-    if (channel !== 'webhook') {
-      return reply.status(400).send({
-        error: { code: 'VALIDATION_ERROR', message: 'Only "webhook" channel is supported' },
-      })
-    }
+    if (channel !== 'webhook') throw validationError('Only "webhook" channel is supported')
 
     const urlCheck = await resolveWebhookTarget(url ?? '')
-    if (!urlCheck.ok) {
-      return reply.status(400).send({
-        error: { code: 'VALIDATION_ERROR', message: urlCheck.message },
-      })
-    }
+    if (!urlCheck.ok) throw validationError(urlCheck.message)
 
-    if (!events?.length) {
-      return reply.status(400).send({
-        error: { code: 'VALIDATION_ERROR', message: '"events" must be a non-empty array' },
-      })
-    }
+    if (!events?.length) throw validationError('"events" must be a non-empty array')
 
     const invalid = events.filter(e => !VALID_EVENTS.includes(e as NotificationEvent))
     if (invalid.length) {
-      return reply.status(400).send({
-        error: { code: 'VALIDATION_ERROR', message: `Invalid event(s): ${invalid.join(', ')}. Must be one of: ${VALID_EVENTS.join(', ')}` },
-      })
+      throw validationError(`Invalid event(s): ${invalid.join(', ')}. Must be one of: ${VALID_EVENTS.join(', ')}`)
     }
 
     const now = new Date().toISOString()
@@ -84,8 +70,7 @@ export async function notificationRoutes(app: FastifyInstance) {
 
   // GET /projects/:name/notifications — list notifications
   app.get<{ Params: { name: string } }>('/projects/:name/notifications', async (request, reply) => {
-    const project = resolveProjectSafe(app, request.params.name, reply)
-    if (!project) return
+    const project = resolveProject(app.db, request.params.name)
 
     const rows = app.db.select().from(notifications).where(eq(notifications.projectId, project.id)).all()
     return reply.send(rows.map(formatNotification))
@@ -93,14 +78,11 @@ export async function notificationRoutes(app: FastifyInstance) {
 
   // DELETE /projects/:name/notifications/:id — remove notification
   app.delete<{ Params: { name: string; id: string } }>('/projects/:name/notifications/:id', async (request, reply) => {
-    const project = resolveProjectSafe(app, request.params.name, reply)
-    if (!project) return
+    const project = resolveProject(app.db, request.params.name)
 
     const notification = app.db.select().from(notifications).where(eq(notifications.id, request.params.id)).get()
     if (!notification || notification.projectId !== project.id) {
-      return reply.status(404).send({
-        error: { code: 'NOT_FOUND', message: `Notification '${request.params.id}' not found` },
-      })
+      throw notFound('Notification', request.params.id)
     }
 
     app.db.delete(notifications).where(eq(notifications.id, notification.id)).run()
@@ -118,25 +100,18 @@ export async function notificationRoutes(app: FastifyInstance) {
 
   // POST /projects/:name/notifications/:id/test — send a test webhook from the server
   app.post<{ Params: { name: string; id: string } }>('/projects/:name/notifications/:id/test', async (request, reply) => {
-    const project = resolveProjectSafe(app, request.params.name, reply)
-    if (!project) return
+    const project = resolveProject(app.db, request.params.name)
 
     const notification = app.db.select().from(notifications).where(eq(notifications.id, request.params.id)).get()
     if (!notification || notification.projectId !== project.id) {
-      return reply.status(404).send({
-        error: { code: 'NOT_FOUND', message: `Notification '${request.params.id}' not found` },
-      })
+      throw notFound('Notification', request.params.id)
     }
 
-    const config = JSON.parse(notification.config) as { url: string; events: string[] }
+    const config = parseJsonColumn<{ url: string; events: string[] }>(notification.config, { url: '', events: [] })
 
     // Re-validate URL at delivery time (stored URLs may predate validation logic)
     const urlCheck = await resolveWebhookTarget(config.url)
-    if (!urlCheck.ok) {
-      return reply.status(400).send({
-        error: { code: 'VALIDATION_ERROR', message: `Stored webhook URL is invalid: ${urlCheck.message}` },
-      })
-    }
+    if (!urlCheck.ok) throw validationError(`Stored webhook URL is invalid: ${urlCheck.message}`)
 
     const payload = {
       source: 'canonry',
@@ -163,15 +138,13 @@ export async function notificationRoutes(app: FastifyInstance) {
       diff: { status, error },
     })
 
-    if (error) {
-      return reply.status(502).send({ error: { code: 'DELIVERY_FAILED', message: error } })
-    }
+    if (error) throw deliveryFailed(error)
     return reply.send({ status, ok: status >= 200 && status < 300 })
   })
 }
 
 function formatNotification(row: typeof notifications.$inferSelect): Omit<NotificationDto, 'webhookSecret'> {
-  const config = JSON.parse(row.config) as { url: string; events: NotificationEvent[] }
+  const config = parseJsonColumn<{ url: string; events: NotificationEvent[] }>(row.config, { url: '', events: [] })
   const redacted = redactNotificationUrl(config.url)
   return {
     id: row.id,
@@ -184,18 +157,5 @@ function formatNotification(row: typeof notifications.$inferSelect): Omit<Notifi
     enabled: row.enabled === 1,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
-  }
-}
-
-function resolveProjectSafe(app: FastifyInstance, name: string, reply: { status: (code: number) => { send: (body: unknown) => unknown } }) {
-  try {
-    return resolveProject(app.db, name)
-  } catch (e: unknown) {
-    if (e && typeof e === 'object' && 'statusCode' in e && 'toJSON' in e) {
-      const err = e as { statusCode: number; toJSON(): unknown }
-      reply.status(err.statusCode).send(err.toJSON())
-      return null
-    }
-    throw e
   }
 }

--- a/packages/api-routes/src/projects.ts
+++ b/packages/api-routes/src/projects.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto'
 import { eq } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
-import { projects, keywords, competitors, schedules, notifications } from '@ainyc/canonry-db'
+import { projects, keywords, competitors, schedules, notifications, parseJsonColumn } from '@ainyc/canonry-db'
 import {
   validationError,
   locationContextSchema,
@@ -39,13 +39,12 @@ export async function projectRoutes(app: FastifyInstance, opts: ProjectRoutesOpt
     const { name } = request.params
     const parsedBody = projectUpsertRequestSchema.safeParse(request.body)
     if (!parsedBody.success) {
-      const err = validationError('Invalid project payload', {
+      throw validationError('Invalid project payload', {
         issues: parsedBody.error.issues.map(issue => ({
           path: issue.path.join('.'),
           message: issue.message,
         })),
       })
-      return reply.status(err.statusCode).send(err.toJSON())
     }
     const body = parsedBody.data
 
@@ -54,36 +53,33 @@ export async function projectRoutes(app: FastifyInstance, opts: ProjectRoutesOpt
     if (validNames.length && body.providers?.length) {
       const invalid = body.providers.filter(p => !validNames.includes(p))
       if (invalid.length) {
-        const err = validationError(`Invalid provider(s): ${invalid.join(', ')}. Must be one of: ${validNames.join(', ')}`, {
+        throw validationError(`Invalid provider(s): ${invalid.join(', ')}. Must be one of: ${validNames.join(', ')}`, {
           invalidProviders: invalid,
           validProviders: validNames,
         })
-        return reply.status(err.statusCode).send(err.toJSON())
       }
     }
 
     const now = new Date().toISOString()
     const existing = app.db.select().from(projects).where(eq(projects.name, name)).get()
     const existingLocations = existing
-      ? (JSON.parse(existing.locations || '[]') as LocationContext[])
+      ? (parseJsonColumn<LocationContext[]>(existing.locations, []))
       : []
     const nextLocations = body.locations ?? existingLocations
     const duplicateLabels = findDuplicateLocationLabels(nextLocations)
     if (duplicateLabels.length > 0) {
-      const err = validationError(`Duplicate location labels are not allowed: ${duplicateLabels.join(', ')}`, {
+      throw validationError(`Duplicate location labels are not allowed: ${duplicateLabels.join(', ')}`, {
         duplicateLabels,
       })
-      return reply.status(err.statusCode).send(err.toJSON())
     }
 
     const nextDefaultLocation = body.defaultLocation !== undefined
       ? (body.defaultLocation ?? null)
       : existing?.defaultLocation ?? null
     if (!hasLocationLabel(nextLocations, nextDefaultLocation)) {
-      const err = validationError(`defaultLocation "${nextDefaultLocation}" must match a configured location label`, {
+      throw validationError(`defaultLocation "${nextDefaultLocation}" must match a configured location label`, {
         defaultLocation: nextDefaultLocation,
       })
-      return reply.status(err.statusCode).send(err.toJSON())
     }
 
     if (existing) {
@@ -155,30 +151,13 @@ export async function projectRoutes(app: FastifyInstance, opts: ProjectRoutesOpt
 
   // GET /projects/:name — get single
   app.get<{ Params: { name: string } }>('/projects/:name', async (request, reply) => {
-    try {
-      const project = resolveProject(app.db, request.params.name)
-      return reply.send(formatProject(project))
-    } catch (e: unknown) {
-      if (e && typeof e === 'object' && 'statusCode' in e && 'toJSON' in e) {
-        const err = e as { statusCode: number; toJSON(): unknown }
-        return reply.status(err.statusCode).send(err.toJSON())
-      }
-      throw e
-    }
+    const project = resolveProject(app.db, request.params.name)
+    return reply.send(formatProject(project))
   })
 
   // DELETE /projects/:name
   app.delete<{ Params: { name: string } }>('/projects/:name', async (request, reply) => {
-    let project: ReturnType<typeof resolveProject>
-    try {
-      project = resolveProject(app.db, request.params.name)
-    } catch (e: unknown) {
-      if (e && typeof e === 'object' && 'statusCode' in e && 'toJSON' in e) {
-        const err = e as { statusCode: number; toJSON(): unknown }
-        return reply.status(err.statusCode).send(err.toJSON())
-      }
-      throw e
-    }
+    const project = resolveProject(app.db, request.params.name)
 
     writeAuditLog(app.db, {
       projectId: project.id,
@@ -198,28 +177,17 @@ export async function projectRoutes(app: FastifyInstance, opts: ProjectRoutesOpt
     Params: { name: string }
     Body: LocationContext
   }>('/projects/:name/locations', async (request, reply) => {
-    let project: ReturnType<typeof resolveProject>
-    try {
-      project = resolveProject(app.db, request.params.name)
-    } catch (e: unknown) {
-      if (e && typeof e === 'object' && 'statusCode' in e && 'toJSON' in e) {
-        const err = e as { statusCode: number; toJSON(): unknown }
-        return reply.status(err.statusCode).send(err.toJSON())
-      }
-      throw e
-    }
+    const project = resolveProject(app.db, request.params.name)
 
     const parsed = locationContextSchema.safeParse(request.body)
     if (!parsed.success) {
-      const err = validationError(parsed.error.issues.map(i => i.message).join(', '))
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError(parsed.error.issues.map(i => i.message).join(', '))
     }
 
     const location = parsed.data
-    const existing = JSON.parse(project.locations || '[]') as LocationContext[]
+    const existing = parseJsonColumn<LocationContext[]>(project.locations, [])
     if (existing.some(l => l.label === location.label)) {
-      const err = validationError(`Location "${location.label}" already exists`)
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError(`Location "${location.label}" already exists`)
     }
 
     existing.push(location)
@@ -242,18 +210,9 @@ export async function projectRoutes(app: FastifyInstance, opts: ProjectRoutesOpt
 
   // GET /projects/:name/locations — list locations
   app.get<{ Params: { name: string } }>('/projects/:name/locations', async (request, reply) => {
-    let project: ReturnType<typeof resolveProject>
-    try {
-      project = resolveProject(app.db, request.params.name)
-    } catch (e: unknown) {
-      if (e && typeof e === 'object' && 'statusCode' in e && 'toJSON' in e) {
-        const err = e as { statusCode: number; toJSON(): unknown }
-        return reply.status(err.statusCode).send(err.toJSON())
-      }
-      throw e
-    }
+    const project = resolveProject(app.db, request.params.name)
 
-    const locations = JSON.parse(project.locations || '[]') as LocationContext[]
+    const locations = parseJsonColumn<LocationContext[]>(project.locations, [])
     return reply.send({
       locations,
       defaultLocation: project.defaultLocation,
@@ -264,23 +223,13 @@ export async function projectRoutes(app: FastifyInstance, opts: ProjectRoutesOpt
   app.delete<{
     Params: { name: string; label: string }
   }>('/projects/:name/locations/:label', async (request, reply) => {
-    let project: ReturnType<typeof resolveProject>
-    try {
-      project = resolveProject(app.db, request.params.name)
-    } catch (e: unknown) {
-      if (e && typeof e === 'object' && 'statusCode' in e && 'toJSON' in e) {
-        const err = e as { statusCode: number; toJSON(): unknown }
-        return reply.status(err.statusCode).send(err.toJSON())
-      }
-      throw e
-    }
+    const project = resolveProject(app.db, request.params.name)
 
     const label = decodeURIComponent(request.params.label)
-    const existing = JSON.parse(project.locations || '[]') as LocationContext[]
+    const existing = parseJsonColumn<LocationContext[]>(project.locations, [])
     const filtered = existing.filter(l => l.label !== label)
     if (filtered.length === existing.length) {
-      const err = validationError(`Location "${label}" not found`)
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError(`Location "${label}" not found`)
     }
 
     const now = new Date().toISOString()
@@ -310,27 +259,16 @@ export async function projectRoutes(app: FastifyInstance, opts: ProjectRoutesOpt
     Params: { name: string }
     Body: { label: string }
   }>('/projects/:name/locations/default', async (request, reply) => {
-    let project: ReturnType<typeof resolveProject>
-    try {
-      project = resolveProject(app.db, request.params.name)
-    } catch (e: unknown) {
-      if (e && typeof e === 'object' && 'statusCode' in e && 'toJSON' in e) {
-        const err = e as { statusCode: number; toJSON(): unknown }
-        return reply.status(err.statusCode).send(err.toJSON())
-      }
-      throw e
-    }
+    const project = resolveProject(app.db, request.params.name)
 
     const label = request.body?.label
     if (!label) {
-      const err = validationError('label is required')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('label is required')
     }
 
-    const existing = JSON.parse(project.locations || '[]') as LocationContext[]
+    const existing = parseJsonColumn<LocationContext[]>(project.locations, [])
     if (!existing.some(l => l.label === label)) {
-      const err = validationError(`Location "${label}" not found. Add it first.`)
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError(`Location "${label}" not found. Add it first.`)
     }
 
     const now = new Date().toISOString()
@@ -352,16 +290,7 @@ export async function projectRoutes(app: FastifyInstance, opts: ProjectRoutesOpt
 
   // GET /projects/:name/export — export as canonry.yaml format
   app.get<{ Params: { name: string } }>('/projects/:name/export', async (request, reply) => {
-    let project: ReturnType<typeof resolveProject>
-    try {
-      project = resolveProject(app.db, request.params.name)
-    } catch (e: unknown) {
-      if (e && typeof e === 'object' && 'statusCode' in e && 'toJSON' in e) {
-        const err = e as { statusCode: number; toJSON(): unknown }
-        return reply.status(err.statusCode).send(err.toJSON())
-      }
-      throw e
-    }
+    const project = resolveProject(app.db, request.params.name)
 
     const kws = app.db.select().from(keywords).where(eq(keywords.projectId, project.id)).all()
     const comps = app.db.select().from(competitors).where(eq(competitors.projectId, project.id)).all()
@@ -373,21 +302,21 @@ export async function projectRoutes(app: FastifyInstance, opts: ProjectRoutesOpt
       kind: 'Project',
       metadata: {
         name: project.name,
-        labels: JSON.parse(project.labels) as Record<string, string>,
+        labels: parseJsonColumn<Record<string, string>>(project.labels, {}),
       },
       spec: {
         displayName: project.displayName,
         canonicalDomain: project.canonicalDomain,
-        ownedDomains: JSON.parse(project.ownedDomains || '[]') as string[],
+        ownedDomains: parseJsonColumn<string[]>(project.ownedDomains, []),
         country: project.country,
         language: project.language,
         keywords: kws.map(k => k.keyword),
         competitors: comps.map(c => c.domain),
-        providers: JSON.parse(project.providers || '[]') as string[],
-        locations: JSON.parse(project.locations || '[]') as LocationContext[],
+        providers: parseJsonColumn<string[]>(project.providers, []),
+        locations: parseJsonColumn<LocationContext[]>(project.locations, []),
         ...(project.defaultLocation ? { defaultLocation: project.defaultLocation } : {}),
         notifications: notificationRows.map((row) => {
-          const cfg = JSON.parse(row.config) as { url: string; events: string[] }
+          const cfg = parseJsonColumn<{ url: string; events: string[] }>(row.config, { url: '', events: [] })
           return {
             channel: row.channel,
             url: cfg.url,
@@ -398,7 +327,7 @@ export async function projectRoutes(app: FastifyInstance, opts: ProjectRoutesOpt
           schedule: {
             ...(schedule.preset ? { preset: schedule.preset } : { cron: schedule.cronExpr }),
             timezone: schedule.timezone,
-            providers: JSON.parse(schedule.providers || '[]') as string[],
+            providers: parseJsonColumn<string[]>(schedule.providers, []),
           },
         } : {}),
       },
@@ -431,13 +360,13 @@ function formatProject(row: {
     name: row.name,
     displayName: row.displayName,
     canonicalDomain: row.canonicalDomain,
-    ownedDomains: JSON.parse(row.ownedDomains || '[]') as string[],
+    ownedDomains: parseJsonColumn<string[]>(row.ownedDomains, []),
     country: row.country,
     language: row.language,
-    tags: JSON.parse(row.tags) as string[],
-    labels: JSON.parse(row.labels) as Record<string, string>,
-    providers: JSON.parse(row.providers || '[]') as string[],
-    locations: JSON.parse(row.locations || '[]') as LocationContext[],
+    tags: parseJsonColumn<string[]>(row.tags, []),
+    labels: parseJsonColumn<Record<string, string>>(row.labels, {}),
+    providers: parseJsonColumn<string[]>(row.providers, []),
+    locations: parseJsonColumn<LocationContext[]>(row.locations, []),
     defaultLocation: row.defaultLocation,
     configSource: row.configSource,
     configRevision: row.configRevision,

--- a/packages/api-routes/src/runs.ts
+++ b/packages/api-routes/src/runs.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto'
 import { eq, asc, desc } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
-import { runs, querySnapshots, keywords, projects } from '@ainyc/canonry-db'
+import { runs, querySnapshots, keywords, projects, parseJsonColumn } from '@ainyc/canonry-db'
 import type { LocationContext } from '@ainyc/canonry-contracts'
 import { unsupportedKind, runInProgress, runNotCancellable, notFound, validationError } from '@ainyc/canonry-contracts'
 import { resolveProject, writeAuditLog } from './helpers.js'
@@ -19,14 +19,10 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
     Params: { name: string }
     Body: { kind?: string; trigger?: string; providers?: string[]; location?: string; allLocations?: boolean; noLocation?: boolean }
   }>('/projects/:name/runs', async (request, reply) => {
-    const project = resolveProjectSafe(app, request.params.name, reply)
-    if (!project) return
+    const project = resolveProject(app.db, request.params.name)
 
     const kind = request.body?.kind ?? 'answer-visibility'
-    if (kind !== 'answer-visibility') {
-      const err = unsupportedKind(kind)
-      return reply.status(err.statusCode).send(err.toJSON())
-    }
+    if (kind !== 'answer-visibility') throw unsupportedKind(kind)
 
     const now = new Date().toISOString()
     const trigger = request.body?.trigger ?? 'manual'
@@ -37,11 +33,10 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
       if (validNames.length) {
         const invalid = normalized.filter(p => !validNames.includes(p))
         if (invalid.length) {
-          const err = validationError(`Invalid provider(s): ${invalid.join(', ')}. Must be one of: ${validNames.join(', ')}`, {
+          throw validationError(`Invalid provider(s): ${invalid.join(', ')}. Must be one of: ${validNames.join(', ')}`, {
             invalidProviders: invalid,
             validProviders: validNames,
           })
-          return reply.status(err.statusCode).send(err.toJSON())
         }
       }
       rawProviders.splice(0, rawProviders.length, ...normalized)
@@ -50,7 +45,7 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
 
     // Resolve location for this run
     let resolvedLocation: LocationContext | null | undefined
-    const projectLocations = JSON.parse(project.locations || '[]') as LocationContext[]
+    const projectLocations = parseJsonColumn<LocationContext[]>(project.locations, [])
 
     if (request.body?.noLocation) {
       resolvedLocation = null // explicitly no location
@@ -59,7 +54,7 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
     } else if (request.body?.location) {
       const loc = projectLocations.find(l => l.label === request.body.location)
       if (!loc) {
-        return reply.status(400).send({ error: { code: 'VALIDATION_ERROR', message: `Location "${request.body.location}" not found. Configure it first.` } })
+        throw validationError(`Location "${request.body.location}" not found. Configure it first.`)
       }
       resolvedLocation = loc
     }
@@ -69,7 +64,7 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
     // Skip the idle-check here — each location gets its own run regardless of other active runs.
     if (request.body?.allLocations) {
       if (projectLocations.length === 0) {
-        return reply.status(400).send({ error: { code: 'VALIDATION_ERROR', message: 'No locations configured for this project' } })
+        throw validationError('No locations configured for this project')
       }
 
       // Insert all run records first, then dispatch — bypassing queueRunIfProjectIdle
@@ -116,10 +111,7 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
       location: locationLabel,
     })
 
-    if (queueResult.conflict) {
-      const err = runInProgress(project.name)
-      return reply.status(err.statusCode).send(err.toJSON())
-    }
+    if (queueResult.conflict) throw runInProgress(project.name)
 
     const runId = queueResult.runId
 
@@ -145,8 +137,7 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
     Params: { name: string }
     Querystring: { limit?: string }
   }>('/projects/:name/runs', async (request, reply) => {
-    const project = resolveProjectSafe(app, request.params.name, reply)
-    if (!project) return
+    const project = resolveProject(app.db, request.params.name)
 
     const parsedLimit = parseInt(request.query.limit ?? '', 10)
     const limit = Number.isNaN(parsedLimit) || parsedLimit <= 0 ? undefined : parsedLimit
@@ -186,10 +177,7 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
     }
 
     const kind = request.body?.kind ?? 'answer-visibility'
-    if (kind !== 'answer-visibility') {
-      const err = unsupportedKind(kind)
-      return reply.status(err.statusCode).send(err.toJSON())
-    }
+    if (kind !== 'answer-visibility') throw unsupportedKind(kind)
 
     const rawProviders = request.body?.providers
     if (rawProviders?.length) {
@@ -198,11 +186,10 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
       if (validNames.length) {
         const invalid = normalized.filter(p => !validNames.includes(p))
         if (invalid.length) {
-          const err = validationError(`Invalid provider(s): ${invalid.join(', ')}. Must be one of: ${validNames.join(', ')}`, {
+          throw validationError(`Invalid provider(s): ${invalid.join(', ')}. Must be one of: ${validNames.join(', ')}`, {
             invalidProviders: invalid,
             validProviders: validNames,
           })
-          return reply.status(err.statusCode).send(err.toJSON())
         }
       }
       rawProviders.splice(0, rawProviders.length, ...normalized)
@@ -249,16 +236,10 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
   // POST /runs/:id/cancel — cancel a queued or running run
   app.post<{ Params: { id: string } }>('/runs/:id/cancel', async (request, reply) => {
     const run = app.db.select().from(runs).where(eq(runs.id, request.params.id)).get()
-    if (!run) {
-      const err = notFound('Run', request.params.id)
-      return reply.status(err.statusCode).send(err.toJSON())
-    }
+    if (!run) throw notFound('Run', request.params.id)
 
     const terminalStatuses = new Set(['completed', 'partial', 'failed', 'cancelled'])
-    if (terminalStatuses.has(run.status)) {
-      const err = runNotCancellable(run.id, run.status)
-      return reply.status(err.statusCode).send(err.toJSON())
-    }
+    if (terminalStatuses.has(run.status)) throw runNotCancellable(run.id, run.status)
 
     const now = new Date().toISOString()
     app.db
@@ -282,9 +263,7 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
   // GET /runs/:id — get single run with snapshots
   app.get<{ Params: { id: string } }>('/runs/:id', async (request, reply) => {
     const run = app.db.select().from(runs).where(eq(runs.id, request.params.id)).get()
-    if (!run) {
-      return reply.status(404).send({ error: { code: 'NOT_FOUND', message: `Run '${request.params.id}' not found` } })
-    }
+    if (!run) throw notFound('Run', request.params.id)
 
     const snapshots = app.db
       .select({
@@ -320,9 +299,9 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
           provider: s.provider,
           citationState: s.citationState,
           answerText: s.answerText,
-          citedDomains: tryParseJson(s.citedDomains, []),
-          competitorOverlap: tryParseJson(s.competitorOverlap, []),
-          recommendedCompetitors: tryParseJson(s.recommendedCompetitors, []),
+          citedDomains: parseJsonColumn<string[]>(s.citedDomains, []),
+          competitorOverlap: parseJsonColumn<string[]>(s.competitorOverlap, []),
+          recommendedCompetitors: parseJsonColumn<string[]>(s.recommendedCompetitors, []),
           model: s.model ?? rawParsed.model,
           location: s.location,
           groundingSources: rawParsed.groundingSources,
@@ -365,7 +344,7 @@ function parseSnapshotRawResponse(raw: string | null): {
   searchQueries: string[]
   model: string | null
 } {
-  const parsed = tryParseJson(raw ?? '{}', {} as Record<string, unknown>)
+  const parsed = parseJsonColumn<Record<string, unknown>>(raw, {})
   return {
     groundingSources: (parsed.groundingSources as unknown[] | undefined) ?? [],
     searchQueries: (parsed.searchQueries as string[] | undefined) ?? [],
@@ -373,23 +352,3 @@ function parseSnapshotRawResponse(raw: string | null): {
   }
 }
 
-function tryParseJson<T>(value: string, fallback: T): T {
-  try {
-    return JSON.parse(value) as T
-  } catch {
-    return fallback
-  }
-}
-
-function resolveProjectSafe(app: FastifyInstance, name: string, reply: { status: (code: number) => { send: (body: unknown) => unknown } }) {
-  try {
-    return resolveProject(app.db, name)
-  } catch (e: unknown) {
-    if (e && typeof e === 'object' && 'statusCode' in e && 'toJSON' in e) {
-      const err = e as { statusCode: number; toJSON(): unknown }
-      reply.status(err.statusCode).send(err.toJSON())
-      return null
-    }
-    throw e
-  }
-}

--- a/packages/api-routes/src/schedules.ts
+++ b/packages/api-routes/src/schedules.ts
@@ -1,12 +1,13 @@
 import crypto from 'node:crypto'
 import { eq } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
-import { schedules } from '@ainyc/canonry-db'
+import { schedules, parseJsonColumn } from '@ainyc/canonry-db'
 import {
   type ScheduleDto,
   type ProviderName,
   scheduleUpsertRequestSchema,
   validationError,
+  notFound,
 } from '@ainyc/canonry-contracts'
 import { resolveProject, writeAuditLog } from './helpers.js'
 import { resolvePreset, validateCron, isValidTimezone } from './schedule-utils.js'
@@ -23,18 +24,16 @@ export async function scheduleRoutes(app: FastifyInstance, opts: ScheduleRoutesO
     Params: { name: string }
     Body: { preset?: string; cron?: string; timezone?: string; providers?: string[]; enabled?: boolean }
   }>('/projects/:name/schedule', async (request, reply) => {
-    const project = resolveProjectSafe(app, request.params.name, reply)
-    if (!project) return
+    const project = resolveProject(app.db, request.params.name)
 
     const parsedBody = scheduleUpsertRequestSchema.safeParse(request.body)
     if (!parsedBody.success) {
-      const err = validationError('Invalid schedule payload', {
+      throw validationError('Invalid schedule payload', {
         issues: parsedBody.error.issues.map(issue => ({
           path: issue.path.join('.'),
           message: issue.message,
         })),
       })
-      return reply.status(err.statusCode).send(err.toJSON())
     }
     const { preset, cron, timezone, providers, enabled } = parsedBody.data
 
@@ -43,18 +42,15 @@ export async function scheduleRoutes(app: FastifyInstance, opts: ScheduleRoutesO
     if (validNames.length && providers?.length) {
       const invalid = providers.filter(p => !validNames.includes(p))
       if (invalid.length) {
-        const err = validationError(`Invalid provider(s): ${invalid.join(', ')}. Must be one of: ${validNames.join(', ')}`, {
+        throw validationError(`Invalid provider(s): ${invalid.join(', ')}. Must be one of: ${validNames.join(', ')}`, {
           invalidProviders: invalid,
           validProviders: validNames,
         })
-        return reply.status(err.statusCode).send(err.toJSON())
       }
     }
 
     if (!isValidTimezone(timezone)) {
-      return reply.status(400).send({
-        error: { code: 'VALIDATION_ERROR', message: `Invalid timezone: ${timezone}` },
-      })
+      throw validationError(`Invalid timezone: ${timezone}`)
     }
 
     let cronExpr: string
@@ -63,14 +59,12 @@ export async function scheduleRoutes(app: FastifyInstance, opts: ScheduleRoutesO
         cronExpr = resolvePreset(preset)
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err)
-        return reply.status(400).send({ error: { code: 'VALIDATION_ERROR', message: msg } })
+        throw validationError(msg)
       }
     } else {
       cronExpr = cron!
       if (!validateCron(cronExpr)) {
-        return reply.status(400).send({
-          error: { code: 'VALIDATION_ERROR', message: `Invalid cron expression: ${cronExpr}` },
-        })
+        throw validationError(`Invalid cron expression: ${cronExpr}`)
       }
     }
 
@@ -117,12 +111,11 @@ export async function scheduleRoutes(app: FastifyInstance, opts: ScheduleRoutesO
 
   // GET /projects/:name/schedule — get schedule
   app.get<{ Params: { name: string } }>('/projects/:name/schedule', async (request, reply) => {
-    const project = resolveProjectSafe(app, request.params.name, reply)
-    if (!project) return
+    const project = resolveProject(app.db, request.params.name)
 
     const schedule = app.db.select().from(schedules).where(eq(schedules.projectId, project.id)).get()
     if (!schedule) {
-      return reply.status(404).send({ error: { code: 'NOT_FOUND', message: `No schedule for project '${request.params.name}'` } })
+      throw notFound('Schedule', request.params.name)
     }
 
     return reply.send(formatSchedule(schedule))
@@ -130,12 +123,11 @@ export async function scheduleRoutes(app: FastifyInstance, opts: ScheduleRoutesO
 
   // DELETE /projects/:name/schedule — remove schedule
   app.delete<{ Params: { name: string } }>('/projects/:name/schedule', async (request, reply) => {
-    const project = resolveProjectSafe(app, request.params.name, reply)
-    if (!project) return
+    const project = resolveProject(app.db, request.params.name)
 
     const schedule = app.db.select().from(schedules).where(eq(schedules.projectId, project.id)).get()
     if (!schedule) {
-      return reply.status(404).send({ error: { code: 'NOT_FOUND', message: `No schedule for project '${request.params.name}'` } })
+      throw notFound('Schedule', request.params.name)
     }
 
     app.db.delete(schedules).where(eq(schedules.id, schedule.id)).run()
@@ -162,23 +154,10 @@ function formatSchedule(row: typeof schedules.$inferSelect): ScheduleDto {
     preset: row.preset,
     timezone: row.timezone,
     enabled: row.enabled === 1,
-    providers: JSON.parse(row.providers) as ProviderName[],
+    providers: parseJsonColumn<ProviderName[]>(row.providers, []),
     lastRunAt: row.lastRunAt,
     nextRunAt: row.nextRunAt,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
-  }
-}
-
-function resolveProjectSafe(app: FastifyInstance, name: string, reply: { status: (code: number) => { send: (body: unknown) => unknown } }) {
-  try {
-    return resolveProject(app.db, name)
-  } catch (e: unknown) {
-    if (e && typeof e === 'object' && 'statusCode' in e && 'toJSON' in e) {
-      const err = e as { statusCode: number; toJSON(): unknown }
-      reply.status(err.statusCode).send(err.toJSON())
-      return null
-    }
-    throw e
   }
 }

--- a/packages/api-routes/test/helpers.test.ts
+++ b/packages/api-routes/test/helpers.test.ts
@@ -1,0 +1,70 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { describe, it, expect, onTestFinished } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { createClient, migrate, usageCounters } from '@ainyc/canonry-db'
+import { incrementUsage } from '../src/helpers.js'
+
+function createTempDb() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-helpers-test-'))
+  const dbPath = path.join(tmpDir, 'test.db')
+  const db = createClient(dbPath)
+  migrate(db)
+  onTestFinished(() => fs.rmSync(tmpDir, { recursive: true, force: true }))
+  return db
+}
+
+describe('incrementUsage', () => {
+  it('inserts a new counter row on first call', () => {
+    const db = createTempDb()
+    incrementUsage(db, 'project:test', 'runs')
+
+    const rows = db.select().from(usageCounters)
+      .where(eq(usageCounters.scope, 'project:test'))
+      .all()
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0].count).toBe(1)
+    expect(rows[0].metric).toBe('runs')
+  })
+
+  it('increments an existing counter on subsequent calls', () => {
+    const db = createTempDb()
+    incrementUsage(db, 'project:test', 'runs')
+    incrementUsage(db, 'project:test', 'runs')
+    incrementUsage(db, 'project:test', 'runs')
+
+    const rows = db.select().from(usageCounters)
+      .where(eq(usageCounters.scope, 'project:test'))
+      .all()
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0].count).toBe(3)
+  })
+
+  it('keeps separate counters for different metrics', () => {
+    const db = createTempDb()
+    incrementUsage(db, 'project:test', 'runs')
+    incrementUsage(db, 'project:test', 'keywords')
+
+    const rows = db.select().from(usageCounters)
+      .where(eq(usageCounters.scope, 'project:test'))
+      .all()
+
+    expect(rows).toHaveLength(2)
+    const byMetric = Object.fromEntries(rows.map(r => [r.metric, r.count]))
+    expect(byMetric['runs']).toBe(1)
+    expect(byMetric['keywords']).toBe(1)
+  })
+
+  it('keeps separate counters for different scopes', () => {
+    const db = createTempDb()
+    incrementUsage(db, 'project:a', 'runs')
+    incrementUsage(db, 'project:b', 'runs')
+
+    const all = db.select().from(usageCounters).all()
+    expect(all).toHaveLength(2)
+    expect(all.every(r => r.count === 1)).toBe(true)
+  })
+})

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/client.ts
+++ b/packages/canonry/src/client.ts
@@ -1,6 +1,15 @@
 import { loadConfig } from './config.js'
 import type {
+  ProjectDto,
+  RunDto,
+  QuerySnapshotDto,
+  ScheduleDto,
+  NotificationDto,
   SnapshotReportDto,
+  BrandMetricsDto,
+  GapAnalysisDto,
+  SourceBreakdownDto,
+  LocationContext,
   WordpressAuditIssueDto,
   WordpressAuditPageDto,
   WordpressBulkMetaResultDto,
@@ -15,6 +24,27 @@ import type {
   WordpressSchemaStatusResultDto,
   WordpressStatusDto,
 } from '@ainyc/canonry-contracts'
+
+/** Run detail response includes snapshots */
+export interface RunDetailDto extends RunDto {
+  snapshots?: QuerySnapshotDto[]
+}
+
+/** Settings response from GET /settings */
+export interface SettingsDto {
+  providers: Array<{ name: string; displayName: string; configured: boolean; healthy?: boolean; model?: string; quota?: object }>
+  google?: object
+  bing?: object
+}
+
+/** Apply response */
+export type ApplyResultDto = ProjectDto
+
+/** Telemetry status */
+export interface TelemetryDto {
+  enabled: boolean
+  anonymousId?: string
+}
 
 /**
  * Create an ApiClient using the loaded config.
@@ -136,16 +166,16 @@ export class ApiClient {
     return (await res.json()) as T
   }
 
-  async putProject(name: string, body: object): Promise<object> {
-    return this.request<object>('PUT', `/projects/${encodeURIComponent(name)}`, body)
+  async putProject(name: string, body: object): Promise<ProjectDto> {
+    return this.request<ProjectDto>('PUT', `/projects/${encodeURIComponent(name)}`, body)
   }
 
-  async listProjects(): Promise<object[]> {
-    return this.request<object[]>('GET', '/projects')
+  async listProjects(): Promise<ProjectDto[]> {
+    return this.request<ProjectDto[]>('GET', '/projects')
   }
 
-  async getProject(name: string): Promise<object> {
-    return this.request<object>('GET', `/projects/${encodeURIComponent(name)}`)
+  async getProject(name: string): Promise<ProjectDto> {
+    return this.request<ProjectDto>('GET', `/projects/${encodeURIComponent(name)}`)
   }
 
   async deleteProject(name: string): Promise<void> {
@@ -176,21 +206,21 @@ export class ApiClient {
     return this.request<object[]>('GET', `/projects/${encodeURIComponent(project)}/competitors`)
   }
 
-  async triggerRun(project: string, body?: Record<string, unknown>): Promise<object> {
-    return this.request<object>('POST', `/projects/${encodeURIComponent(project)}/runs`, body ?? {})
+  async triggerRun(project: string, body?: Record<string, unknown>): Promise<RunDto | RunDto[]> {
+    return this.request<RunDto | RunDto[]>('POST', `/projects/${encodeURIComponent(project)}/runs`, body ?? {})
   }
 
-  async listRuns(project: string, limit?: number): Promise<object[]> {
+  async listRuns(project: string, limit?: number): Promise<RunDto[]> {
     const query = limit != null ? `?limit=${encodeURIComponent(String(limit))}` : ''
-    return this.request<object[]>('GET', `/projects/${encodeURIComponent(project)}/runs${query}`)
+    return this.request<RunDto[]>('GET', `/projects/${encodeURIComponent(project)}/runs${query}`)
   }
 
-  async getRun(id: string): Promise<object> {
-    return this.request<object>('GET', `/runs/${encodeURIComponent(id)}`)
+  async getRun(id: string): Promise<RunDetailDto> {
+    return this.request<RunDetailDto>('GET', `/runs/${encodeURIComponent(id)}`)
   }
 
-  async cancelRun(id: string): Promise<object> {
-    return this.request<object>('POST', `/runs/${encodeURIComponent(id)}/cancel`)
+  async cancelRun(id: string): Promise<RunDto> {
+    return this.request<RunDto>('POST', `/runs/${encodeURIComponent(id)}/cancel`)
   }
 
   async getTimeline(project: string): Promise<object[]> {
@@ -205,16 +235,16 @@ export class ApiClient {
     return this.request<object>('GET', `/projects/${encodeURIComponent(project)}/export`)
   }
 
-  async apply(config: object): Promise<object> {
-    return this.request<object>('POST', '/apply', config)
+  async apply(config: object): Promise<ApplyResultDto> {
+    return this.request<ApplyResultDto>('POST', '/apply', config)
   }
 
-  async getStatus(project: string): Promise<object> {
-    return this.request<object>('GET', `/projects/${encodeURIComponent(project)}`)
+  async getStatus(project: string): Promise<ProjectDto> {
+    return this.request<ProjectDto>('GET', `/projects/${encodeURIComponent(project)}`)
   }
 
-  async getSettings(): Promise<object> {
-    return this.request<object>('GET', '/settings')
+  async getSettings(): Promise<SettingsDto> {
+    return this.request<SettingsDto>('GET', '/settings')
   }
 
   async createSnapshot(body: {
@@ -230,56 +260,56 @@ export class ApiClient {
     return this.request<object>('PUT', `/settings/providers/${encodeURIComponent(name)}`, body)
   }
 
-  async putSchedule(project: string, body: object): Promise<object> {
-    return this.request<object>('PUT', `/projects/${encodeURIComponent(project)}/schedule`, body)
+  async putSchedule(project: string, body: object): Promise<ScheduleDto> {
+    return this.request<ScheduleDto>('PUT', `/projects/${encodeURIComponent(project)}/schedule`, body)
   }
 
-  async getSchedule(project: string): Promise<object> {
-    return this.request<object>('GET', `/projects/${encodeURIComponent(project)}/schedule`)
+  async getSchedule(project: string): Promise<ScheduleDto> {
+    return this.request<ScheduleDto>('GET', `/projects/${encodeURIComponent(project)}/schedule`)
   }
 
   async deleteSchedule(project: string): Promise<void> {
     await this.request<void>('DELETE', `/projects/${encodeURIComponent(project)}/schedule`)
   }
 
-  async createNotification(project: string, body: object): Promise<object> {
-    return this.request<object>('POST', `/projects/${encodeURIComponent(project)}/notifications`, body)
+  async createNotification(project: string, body: object): Promise<NotificationDto> {
+    return this.request<NotificationDto>('POST', `/projects/${encodeURIComponent(project)}/notifications`, body)
   }
 
-  async listNotifications(project: string): Promise<object[]> {
-    return this.request<object[]>('GET', `/projects/${encodeURIComponent(project)}/notifications`)
+  async listNotifications(project: string): Promise<NotificationDto[]> {
+    return this.request<NotificationDto[]>('GET', `/projects/${encodeURIComponent(project)}/notifications`)
   }
 
   async deleteNotification(project: string, id: string): Promise<void> {
     await this.request<void>('DELETE', `/projects/${encodeURIComponent(project)}/notifications/${encodeURIComponent(id)}`)
   }
 
-  async testNotification(project: string, id: string): Promise<object> {
-    return this.request<object>('POST', `/projects/${encodeURIComponent(project)}/notifications/${encodeURIComponent(id)}/test`)
+  async testNotification(project: string, id: string): Promise<{ status: number; ok: boolean }> {
+    return this.request<{ status: number; ok: boolean }>('POST', `/projects/${encodeURIComponent(project)}/notifications/${encodeURIComponent(id)}/test`)
   }
 
-  async addLocation(project: string, body: { label: string; city: string; region: string; country: string; timezone?: string }): Promise<object> {
-    return this.request<object>('POST', `/projects/${encodeURIComponent(project)}/locations`, body)
+  async addLocation(project: string, body: LocationContext): Promise<LocationContext> {
+    return this.request<LocationContext>('POST', `/projects/${encodeURIComponent(project)}/locations`, body)
   }
 
-  async listLocations(project: string): Promise<{ locations: Array<{ label: string; city: string; region: string; country: string; timezone?: string }>; defaultLocation: string | null }> {
-    return this.request<{ locations: Array<{ label: string; city: string; region: string; country: string; timezone?: string }>; defaultLocation: string | null }>('GET', `/projects/${encodeURIComponent(project)}/locations`)
+  async listLocations(project: string): Promise<{ locations: LocationContext[]; defaultLocation: string | null }> {
+    return this.request<{ locations: LocationContext[]; defaultLocation: string | null }>('GET', `/projects/${encodeURIComponent(project)}/locations`)
   }
 
   async removeLocation(project: string, label: string): Promise<void> {
     await this.request<void>('DELETE', `/projects/${encodeURIComponent(project)}/locations/${encodeURIComponent(label)}`)
   }
 
-  async setDefaultLocation(project: string, label: string): Promise<object> {
-    return this.request<object>('PUT', `/projects/${encodeURIComponent(project)}/locations/default`, { label })
+  async setDefaultLocation(project: string, label: string): Promise<{ defaultLocation: string }> {
+    return this.request<{ defaultLocation: string }>('PUT', `/projects/${encodeURIComponent(project)}/locations/default`, { label })
   }
 
-  async getTelemetry(): Promise<{ enabled: boolean; anonymousId?: string }> {
-    return this.request<{ enabled: boolean; anonymousId?: string }>('GET', '/telemetry')
+  async getTelemetry(): Promise<TelemetryDto> {
+    return this.request<TelemetryDto>('GET', '/telemetry')
   }
 
-  async updateTelemetry(enabled: boolean): Promise<{ enabled: boolean; anonymousId?: string }> {
-    return this.request<{ enabled: boolean; anonymousId?: string }>('PUT', '/telemetry', { enabled })
+  async updateTelemetry(enabled: boolean): Promise<TelemetryDto> {
+    return this.request<TelemetryDto>('PUT', '/telemetry', { enabled })
   }
 
   async generateKeywords(project: string, provider: string, count?: number): Promise<{ keywords: string[]; provider: string }> {
@@ -360,19 +390,19 @@ export class ApiClient {
   }
 
   // Analytics
-  async getAnalyticsMetrics(project: string, window?: string): Promise<object> {
+  async getAnalyticsMetrics(project: string, window?: string): Promise<BrandMetricsDto> {
     const qs = window ? `?window=${encodeURIComponent(window)}` : ''
-    return this.request<object>('GET', `/projects/${encodeURIComponent(project)}/analytics/metrics${qs}`)
+    return this.request<BrandMetricsDto>('GET', `/projects/${encodeURIComponent(project)}/analytics/metrics${qs}`)
   }
 
-  async getAnalyticsGaps(project: string, window?: string): Promise<object> {
+  async getAnalyticsGaps(project: string, window?: string): Promise<GapAnalysisDto> {
     const qs = window ? `?window=${encodeURIComponent(window)}` : ''
-    return this.request<object>('GET', `/projects/${encodeURIComponent(project)}/analytics/gaps${qs}`)
+    return this.request<GapAnalysisDto>('GET', `/projects/${encodeURIComponent(project)}/analytics/gaps${qs}`)
   }
 
-  async getAnalyticsSources(project: string, window?: string): Promise<object> {
+  async getAnalyticsSources(project: string, window?: string): Promise<SourceBreakdownDto> {
     const qs = window ? `?window=${encodeURIComponent(window)}` : ''
-    return this.request<object>('GET', `/projects/${encodeURIComponent(project)}/analytics/sources${qs}`)
+    return this.request<SourceBreakdownDto>('GET', `/projects/${encodeURIComponent(project)}/analytics/sources${qs}`)
   }
 
   // Google Indexing API

--- a/packages/canonry/src/commands/run.ts
+++ b/packages/canonry/src/commands/run.ts
@@ -1,4 +1,4 @@
-import { ApiClient, createApiClient } from '../client.js'
+import { ApiClient, createApiClient, type RunDetailDto } from '../client.js'
 import { resolveProviderInput } from '@ainyc/canonry-contracts'
 import { CliError } from '../cli-error.js'
 
@@ -86,7 +86,7 @@ export async function triggerRun(project: string, opts?: { provider?: string; wa
       console.log(JSON.stringify(result, null, 2))
     } else {
       process.stderr.write('\n')
-      printRunDetail(result as Record<string, unknown>)
+      printRunDetail(result)
     }
     return
   }
@@ -204,7 +204,7 @@ export async function cancelRun(project: string, runId?: string, format?: string
 
 export async function showRun(id: string, format?: string): Promise<void> {
   const client = getClient()
-  const run = await client.getRun(id) as Record<string, unknown>
+  const run = await client.getRun(id)
 
   if (format === 'json') {
     console.log(JSON.stringify(run, null, 2))
@@ -249,22 +249,22 @@ export async function listRuns(project: string, opts?: { format?: string; limit?
 
 const POLL_TIMEOUT_MS = 10 * 60 * 1000 // 10 minutes
 
-async function pollRun(client: ApiClient, runId: string): Promise<object> {
+async function pollRun(client: ApiClient, runId: string): Promise<RunDetailDto> {
   const deadline = Date.now() + POLL_TIMEOUT_MS
   for (;;) {
     await new Promise(r => setTimeout(r, 2000))
     if (Date.now() > deadline) {
       throw new Error(`Timed out waiting for run ${runId} after ${POLL_TIMEOUT_MS / 1000}s`)
     }
-    const run = await client.getRun(runId) as { status: string }
+    const run = await client.getRun(runId)
     process.stderr.write('.')
     if (TERMINAL_STATUSES.has(run.status)) {
-      return run as object
+      return run
     }
   }
 }
 
-function printRunDetail(run: Record<string, unknown>): void {
+function printRunDetail(run: RunDetailDto): void {
   console.log(`Run: ${run.id}`)
   console.log(`  Status:   ${run.status}`)
   console.log(`  Kind:     ${run.kind}`)
@@ -273,10 +273,9 @@ function printRunDetail(run: Record<string, unknown>): void {
   if (run.finishedAt) console.log(`  Finished: ${run.finishedAt}`)
   if (run.createdAt) console.log(`  Created:  ${run.createdAt}`)
   if (run.error) console.log(`  Error:    ${run.error}`)
-  const snapshots = run.snapshots as Array<Record<string, unknown>> | undefined
-  if (snapshots && snapshots.length > 0) {
-    console.log(`\n  Snapshots: ${snapshots.length}`)
-    for (const s of snapshots) {
+  if (run.snapshots && run.snapshots.length > 0) {
+    console.log(`\n  Snapshots: ${run.snapshots.length}`)
+    for (const s of run.snapshots) {
       const state = s.citationState === 'cited' ? '  cited    ' : '  not-cited'
       const modelLabel = s.model ? ` (${s.model})` : ''
       console.log(`    ${state}  ${s.provider}${modelLabel}  ${s.keyword}`)

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -12,6 +12,7 @@ export type ErrorCode =
   | 'RUN_NOT_CANCELLABLE'
   | 'NOT_IMPLEMENTED'
   | 'INTERNAL_ERROR'
+  | 'DELIVERY_FAILED'
 
 export class AppError extends Error {
   readonly code: ErrorCode
@@ -88,4 +89,8 @@ export function unsupportedKind(kind: string): AppError {
 
 export function notImplemented(message: string): AppError {
   return new AppError('NOT_IMPLEMENTED', message, 501)
+}
+
+export function deliveryFailed(message: string): AppError {
+  return new AppError('DELIVERY_FAILED', message, 502)
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,3 +1,4 @@
 export * from './client.js'
+export * from './json.js'
 export * from './migrate.js'
 export * from './schema.js'

--- a/packages/db/src/json.ts
+++ b/packages/db/src/json.ts
@@ -1,0 +1,12 @@
+/**
+ * Safely parse a JSON text column from SQLite.
+ * Returns `fallback` when the value is null, undefined, empty, or invalid JSON.
+ */
+export function parseJsonColumn<T>(value: string | null | undefined, fallback: T): T {
+  if (value == null || value === '') return fallback
+  try {
+    return JSON.parse(value) as T
+  } catch {
+    return fallback
+  }
+}

--- a/packages/db/test/json.test.ts
+++ b/packages/db/test/json.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { parseJsonColumn } from '../src/json.js'
+
+describe('parseJsonColumn', () => {
+  it('returns fallback for null', () => {
+    expect(parseJsonColumn(null, [])).toEqual([])
+  })
+
+  it('returns fallback for undefined', () => {
+    expect(parseJsonColumn(undefined, {})).toEqual({})
+  })
+
+  it('returns fallback for empty string', () => {
+    expect(parseJsonColumn('', [])).toEqual([])
+  })
+
+  it('returns fallback for invalid JSON', () => {
+    expect(parseJsonColumn('not-json', [])).toEqual([])
+  })
+
+  it('parses valid JSON array', () => {
+    expect(parseJsonColumn('["a","b"]', [])).toEqual(['a', 'b'])
+  })
+
+  it('parses valid JSON object', () => {
+    expect(parseJsonColumn('{"key":"value"}', {})).toEqual({ key: 'value' })
+  })
+
+  it('uses typed fallback', () => {
+    const fallback = { url: '', events: [] as string[] }
+    const result = parseJsonColumn<typeof fallback>(null, fallback)
+    expect(result).toBe(fallback)
+  })
+})


### PR DESCRIPTION
## Summary

- Replaces all manual `reply.status().send()` error patterns with `throw AppError` across all API route handlers, letting the global error handler serialize consistently
- Introduces `parseJsonColumn<T>()` in `@ainyc/canonry-db` and replaces every raw `JSON.parse()` on SQLite column values throughout the codebase
- Types all `ApiClient` methods in `packages/canonry` with DTOs from `@ainyc/canonry-contracts`; removes all `as Record<string, unknown>` casts from CLI commands
- Wraps the `apply` endpoint's multi-table write in a single `db.transaction()` and fixes `incrementUsage` to use an atomic `INSERT ... ON CONFLICT DO UPDATE`
- Adds `DELIVERY_FAILED` error code and factory to contracts, tests for `parseJsonColumn` and `incrementUsage`, and bumps version to 1.31.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)