### PR TITLE
chore(providers): overnight audit fixes

### DIFF
--- a/packages/provider-cdp/src/connection.ts
+++ b/packages/provider-cdp/src/connection.ts
@@ -130,7 +130,7 @@ export class CDPConnectionManager {
       await sleep(1500)
     } catch (err) {
       throw new CDPProviderError(
-        'CDP_CONNECTION_REFUSED',
+        'CDP_TARGET_SELECTOR_FAILED',
         `Failed to navigate to ${target.newConversationUrl}: ${err instanceof Error ? err.message : String(err)}`,
       )
     }

--- a/packages/provider-local/src/normalize.ts
+++ b/packages/provider-local/src/normalize.ts
@@ -131,7 +131,7 @@ export async function generateText(prompt: string, config: LocalConfig): Promise
  * Scan answer text for domain mentions — used as a citation heuristic
  * since local LLMs don't have structured grounding/search data.
  */
-function extractDomainMentions(text: string): string[] {
+export function extractDomainMentions(text: string): string[] {
   const domains = new Set<string>()
 
   // Match URLs like https://example.com/path or http://example.com

--- a/packages/provider-local/test/normalize.test.ts
+++ b/packages/provider-local/test/normalize.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { extractDomainMentions, normalizeResult } from '../src/normalize.js'
+import type { LocalRawResult } from '../src/types.js'
+
+describe('normalizeResult', () => {
+  it('extracts domain mentions from answer text', () => {
+    const text = 'Check out example.com and https://another-site.org/path. Also sub.domain.co.uk.'
+    const domains = extractDomainMentions(text)
+    expect(domains).toContain('example.com')
+    expect(domains).toContain('another-site.org')
+    expect(domains).toContain('sub.domain.co.uk')
+    expect(domains).not.toContain('www.example.com')
+  })
+
+  it('normalizes a full local result', () => {
+    const raw: LocalRawResult = {
+      provider: 'local',
+      model: 'llama3',
+      rawResponse: {
+        choices: [
+          {
+            message: {
+              content: 'The domain is canonry.io'
+            }
+          }
+        ]
+      },
+      groundingSources: [],
+      searchQueries: []
+    }
+    const normalized = normalizeResult(raw)
+    expect(normalized.answerText).toBe('The domain is canonry.io')
+    expect(normalized.citedDomains).toContain('canonry.io')
+  })
+})

--- a/packages/provider-perplexity/src/normalize.ts
+++ b/packages/provider-perplexity/src/normalize.ts
@@ -54,10 +54,12 @@ export async function executeTrackedQuery(input: PerplexityTrackedQueryInput): P
   const model = input.config.model ?? DEFAULT_MODEL
   const client = new OpenAI({ apiKey: input.config.apiKey, baseURL: BASE_URL })
 
+  const prompt = buildPrompt(input.keyword, input.location)
+
   const response = await client.chat.completions.create({
     model,
     messages: [
-      { role: 'user', content: input.keyword },
+      { role: 'user', content: prompt },
     ],
   })
 
@@ -93,6 +95,13 @@ export function normalizeResult(raw: PerplexityRawResult): PerplexityNormalizedR
 }
 
 // --- Internal helpers ---
+
+function buildPrompt(keyword: string, location?: PerplexityTrackedQueryInput['location']): string {
+  if (location) {
+    return `${keyword} (searching from ${location.city}, ${location.region}, ${location.country})`
+  }
+  return keyword
+}
 
 /**
  * Extract the citations array from a Perplexity response.


### PR DESCRIPTION
Automated overnight audit. Fixes in provider adapter packages.

- provider-perplexity: Fix executeTrackedQuery to include location context in the prompt.
- provider-cdp: Fix error code when navigation fails in connection manager.
- provider-local: Export extractDomainMentions for testing and add missing normalizeResult test coverage.