### PR TITLE
chore(integrations): overnight audit fixes

### DIFF
--- a/packages/integration-bing/src/bing-client.ts
+++ b/packages/integration-bing/src/bing-client.ts
@@ -1,4 +1,4 @@
-import { BING_WMT_API_BASE, BING_SUBMIT_URL_BATCH_LIMIT } from './constants.js'
+import { BING_WMT_API_BASE, BING_SUBMIT_URL_BATCH_LIMIT, BING_REQUEST_TIMEOUT_MS } from './constants.js'
 import type {
   BingSite,
   BingUrlInfo,
@@ -27,6 +27,7 @@ async function bingFetch<T>(apiKey: string, endpoint: string, opts?: { method?: 
     method,
     headers,
     body: opts?.body != null ? JSON.stringify(opts.body) : undefined,
+    signal: AbortSignal.timeout(BING_REQUEST_TIMEOUT_MS),
   })
 
   if (res.status === 401 || res.status === 403) {

--- a/packages/integration-bing/src/constants.ts
+++ b/packages/integration-bing/src/constants.ts
@@ -3,3 +3,7 @@ export const BING_WMT_API_BASE = 'https://ssl.bing.com/webmaster/api.svc/json'
 // URL submission limits
 export const BING_SUBMIT_URL_BATCH_LIMIT = 500
 export const BING_SUBMIT_URL_DAILY_LIMIT = 10000
+
+// HTTP request timeout (30 s) — prevents the process from hanging indefinitely
+// on a slow or unresponsive Bing Webmaster Tools endpoint.
+export const BING_REQUEST_TIMEOUT_MS = 30_000

--- a/packages/integration-google-analytics/src/constants.ts
+++ b/packages/integration-google-analytics/src/constants.ts
@@ -4,3 +4,7 @@ export const GA4_SCOPE = 'https://www.googleapis.com/auth/analytics.readonly'
 export const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token'
 export const GA4_DEFAULT_SYNC_DAYS = 30
 export const GA4_MAX_SYNC_DAYS = 90
+
+// HTTP request timeout (30 s) — prevents the process from hanging indefinitely
+// on a slow or unresponsive GA4 Data API endpoint.
+export const GA4_REQUEST_TIMEOUT_MS = 30_000

--- a/packages/integration-google-analytics/src/ga4-client.ts
+++ b/packages/integration-google-analytics/src/ga4-client.ts
@@ -5,6 +5,7 @@ import {
   GOOGLE_TOKEN_URL,
   GA4_DEFAULT_SYNC_DAYS,
   GA4_MAX_SYNC_DAYS,
+  GA4_REQUEST_TIMEOUT_MS,
 } from './constants.js'
 import type {
   GA4AiReferralRow,
@@ -62,6 +63,7 @@ export async function getAccessToken(clientEmail: string, privateKey: string): P
       grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
       assertion: jwt,
     }),
+    signal: AbortSignal.timeout(GA4_REQUEST_TIMEOUT_MS),
   })
 
   if (!res.ok) {
@@ -91,6 +93,7 @@ async function runReport(
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(request),
+    signal: AbortSignal.timeout(GA4_REQUEST_TIMEOUT_MS),
   })
 
   if (res.status === 401 || res.status === 403) {
@@ -148,6 +151,7 @@ async function batchRunReports(
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({ requests }),
+    signal: AbortSignal.timeout(GA4_REQUEST_TIMEOUT_MS),
   })
 
   if (res.status === 401 || res.status === 403) {

--- a/packages/integration-google/src/constants.ts
+++ b/packages/integration-google/src/constants.ts
@@ -9,3 +9,7 @@ export const GSC_DATA_LAG_DAYS = 3
 export const URL_INSPECTION_DAILY_LIMIT = 2000
 export const INDEXING_API_BASE = 'https://indexing.googleapis.com/v3'
 export const INDEXING_API_DAILY_LIMIT = 200
+
+// HTTP request timeout (30 s) — prevents the process from hanging indefinitely
+// on a slow or unresponsive Google API endpoint.
+export const GOOGLE_REQUEST_TIMEOUT_MS = 30_000

--- a/packages/integration-google/src/gsc-client.ts
+++ b/packages/integration-google/src/gsc-client.ts
@@ -1,4 +1,4 @@
-import { GSC_API_BASE, URL_INSPECTION_API, GSC_MAX_ROWS_PER_REQUEST, INDEXING_API_BASE } from './constants.js'
+import { GSC_API_BASE, URL_INSPECTION_API, GSC_MAX_ROWS_PER_REQUEST, INDEXING_API_BASE, GOOGLE_REQUEST_TIMEOUT_MS } from './constants.js'
 import type {
   GscSite,
   GscSitemap,
@@ -27,6 +27,7 @@ async function gscFetch<T>(accessToken: string, url: string, opts?: { method?: s
     method,
     headers,
     body: opts?.body != null ? JSON.stringify(opts.body) : undefined,
+    signal: AbortSignal.timeout(GOOGLE_REQUEST_TIMEOUT_MS),
   })
 
   if (res.status === 401) {

--- a/packages/integration-google/src/oauth.ts
+++ b/packages/integration-google/src/oauth.ts
@@ -1,4 +1,4 @@
-import { GOOGLE_AUTH_URL, GOOGLE_TOKEN_URL } from './constants.js'
+import { GOOGLE_AUTH_URL, GOOGLE_TOKEN_URL, GOOGLE_REQUEST_TIMEOUT_MS } from './constants.js'
 import type { GoogleTokenResponse } from './types.js'
 import { GoogleAuthError } from './types.js'
 
@@ -36,6 +36,7 @@ export async function exchangeCode(
       redirect_uri: redirectUri,
       grant_type: 'authorization_code',
     }),
+    signal: AbortSignal.timeout(GOOGLE_REQUEST_TIMEOUT_MS),
   })
 
   if (!res.ok) {
@@ -60,6 +61,7 @@ export async function refreshAccessToken(
       refresh_token: currentRefreshToken,
       grant_type: 'refresh_token',
     }),
+    signal: AbortSignal.timeout(GOOGLE_REQUEST_TIMEOUT_MS),
   })
 
   if (!res.ok) {

--- a/packages/integration-wordpress/src/wordpress-client.ts
+++ b/packages/integration-wordpress/src/wordpress-client.ts
@@ -24,6 +24,11 @@ import { WordpressApiError } from './types.js'
 import type { BusinessProfile, SchemaPageEntry, SchemaProfileFile } from './schema-templates.js'
 import { generateSchema, isSupportedSchemaType, parseSchemaPageEntry } from './schema-templates.js'
 
+// HTTP request timeout (30 s for authenticated REST calls, 15 s for public HTML fetches).
+// Prevents the process from hanging indefinitely on a slow or unresponsive WordPress site.
+const WP_REQUEST_TIMEOUT_MS = 30_000
+const WP_FETCH_TEXT_TIMEOUT_MS = 15_000
+
 const PAGE_FIELDS = 'id,slug,status,link,modified,modified_gmt,title,content,meta'
 const PAGE_LIST_FIELDS = 'id,slug,status,link,modified,modified_gmt,title'
 const VERIFY_PAGE_FIELDS = 'id,status'
@@ -94,6 +99,7 @@ async function fetchJson<T>(
       ...(init?.body != null ? { 'Content-Type': 'application/json' } : {}),
       ...(init?.headers ?? {}),
     },
+    signal: AbortSignal.timeout(WP_REQUEST_TIMEOUT_MS),
   })
 
   if (res.status === 401 || res.status === 403) {
@@ -151,7 +157,7 @@ async function fetchPageCollectionSummary(
 
 async function fetchText(url: string): Promise<string | null> {
   try {
-    const res = await fetch(url)
+    const res = await fetch(url, { signal: AbortSignal.timeout(WP_FETCH_TEXT_TIMEOUT_MS) })
     if (!res.ok) return null
     return await res.text()
   } catch {


### PR DESCRIPTION
Automated overnight audit. Fixes in integration client packages.

## Changes

Added `AbortSignal.timeout()` to all outgoing `fetch()` calls across the four audited integration packages to prevent the CLI process from hanging indefinitely when an API endpoint is slow or unresponsive.

### Packages affected
- `packages/integration-bing` — `bingFetch()`: added 30 s timeout via `BING_REQUEST_TIMEOUT_MS`
- `packages/integration-google` — `gscFetch()`, `exchangeCode()`, `refreshAccessToken()`: added 30 s timeout via `GOOGLE_REQUEST_TIMEOUT_MS`
- `packages/integration-google-analytics` — `getAccessToken()`, `runReport()`, `batchRunReports()`: added 30 s timeout via `GA4_REQUEST_TIMEOUT_MS`
- `packages/integration-wordpress` — `fetchJson()`: 30 s timeout; `fetchText()` (public HTML fetch): 15 s timeout

## Audit findings — no action required
- **No OAuth credentials or tokens stored in SQLite DB** — all auth material flows through `config.yaml` as required
- **No `apps/*` imports** in any integration package src/
- **No sensitive data leaked in logs** — API keys are passed in request headers/bodies, not in logged URLs or `endpoint` strings
- **Test coverage** — all non-trivial integration logic (rate-limit handling, batch chunking, token refresh, error propagation) has adequate test coverage

All checks pass: `pnpm typecheck && pnpm lint && pnpm test` (78 files, 746 tests).