### PR TITLE
chore(db): overnight audit fixes

### DIFF
--- a/packages/db/test/index.test.ts
+++ b/packages/db/test/index.test.ts
@@ -7,7 +7,31 @@ import Database from 'better-sqlite3'
 import { eq } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/better-sqlite3'
 import * as schema from '../src/schema.js'
-import { createClient, migrate, projects, keywords, runs, querySnapshots, auditLog, apiKeys, usageCounters, schedules, notifications } from '../src/index.js'
+import {
+  createClient,
+  migrate,
+  projects,
+  keywords,
+  competitors,
+  runs,
+  querySnapshots,
+  auditLog,
+  apiKeys,
+  usageCounters,
+  schedules,
+  notifications,
+  googleConnections,
+  gscSearchData,
+  gscUrlInspections,
+  gscCoverageSnapshots,
+  bingConnections,
+  bingUrlInspections,
+  bingKeywordStats,
+  gaConnections,
+  gaTrafficSnapshots,
+  gaAiReferrals,
+  gaTrafficSummaries,
+} from '../src/index.js'
 
 function createTempDb() {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-test-'))
@@ -58,6 +82,42 @@ test('migrate creates all tables', () => {
 
   const notifRows = db.select().from(notifications).all()
   expect(notifRows).toEqual([])
+
+  const competitorRows = db.select().from(competitors).all()
+  expect(competitorRows).toEqual([])
+
+  const googleConnRows = db.select().from(googleConnections).all()
+  expect(googleConnRows).toEqual([])
+
+  const gscSearchRows = db.select().from(gscSearchData).all()
+  expect(gscSearchRows).toEqual([])
+
+  const gscInspectRows = db.select().from(gscUrlInspections).all()
+  expect(gscInspectRows).toEqual([])
+
+  const gscCoverageRows = db.select().from(gscCoverageSnapshots).all()
+  expect(gscCoverageRows).toEqual([])
+
+  const bingConnRows = db.select().from(bingConnections).all()
+  expect(bingConnRows).toEqual([])
+
+  const bingInspectRows = db.select().from(bingUrlInspections).all()
+  expect(bingInspectRows).toEqual([])
+
+  const bingKwRows = db.select().from(bingKeywordStats).all()
+  expect(bingKwRows).toEqual([])
+
+  const gaConnRows = db.select().from(gaConnections).all()
+  expect(gaConnRows).toEqual([])
+
+  const gaTrafficRows = db.select().from(gaTrafficSnapshots).all()
+  expect(gaTrafficRows).toEqual([])
+
+  const gaAiRefRows = db.select().from(gaAiReferrals).all()
+  expect(gaAiRefRows).toEqual([])
+
+  const gaSummaryRows = db.select().from(gaTrafficSummaries).all()
+  expect(gaSummaryRows).toEqual([])
 })
 
 test('migrate is idempotent', () => {


### PR DESCRIPTION
Automated overnight audit. Fixes in packages/db/.

## What changed

`packages/db/test/index.test.ts` — the `migrate creates all tables` test previously only verified 9 of the 21 tables defined in `schema.ts`. The following 12 tables were never queried in the test, meaning a broken migration for any of them would pass CI undetected:

- `competitors`
- `googleConnections`
- `gscSearchData`
- `gscUrlInspections`
- `gscCoverageSnapshots`
- `bingConnections`
- `bingUrlInspections`
- `bingKeywordStats`
- `gaConnections`
- `gaTrafficSnapshots`
- `gaAiReferrals`
- `gaTrafficSummaries`

All 12 are now verified with `.select().from(table).all()` immediately after `migrate()` runs, which will throw if the table does not exist.

## What was reviewed and found clean

- All 21 `sqliteTable(...)` entries in `schema.ts` have corresponding `CREATE TABLE IF NOT EXISTS` in either `MIGRATION_SQL` or the `MIGRATIONS` array ✓
- No new columns in `schema.ts` lack an `ALTER TABLE ... ADD COLUMN` migration ✓
- `MIGRATION_SQL` (bootstrap block) has not been modified; all incremental changes append to `MIGRATIONS` ✓
- All `index()`/`uniqueIndex()` calls in `schema.ts` have corresponding `CREATE INDEX` statements in migrations ✓
- No SQL injection vectors — all queries use Drizzle ORM parameterized methods ✓
- No connection leaks — `createClient` returns the Drizzle wrapper; no raw handles left open ✓
- `migrate()` is idempotent: `MIGRATION_SQL` uses `IF NOT EXISTS`, incremental migrations catch errors silently ✓

## Note (not fixed — architectural)

`google_connections` stores OAuth `access_token`/`refresh_token` and `ga_connections` stores a GA4 service-account `private_key` in SQLite. CLAUDE.md flags auth credentials as belonging in `~/.canonry/config.yaml`. These are pre-existing design choices requiring significant API changes; flagged here for awareness but out of scope for an overnight patch.