### PR TITLE
fix(ui): portal-render InfoTooltip to escape overflow:auto containers

### DIFF
--- a/apps/web/src/components/shared/InfoTooltip.tsx
+++ b/apps/web/src/components/shared/InfoTooltip.tsx
@@ -1,11 +1,42 @@
+import { useState, useRef, useCallback } from 'react'
+import { createPortal } from 'react-dom'
+
+interface TooltipPos {
+  top: number
+  left: number
+}
+
 export function InfoTooltip({ text }: { text: string }) {
+  const [pos, setPos] = useState<TooltipPos | null>(null)
+  const iconRef = useRef<SVGSVGElement>(null)
+
+  const show = useCallback(() => {
+    if (!iconRef.current) return
+    const rect = iconRef.current.getBoundingClientRect()
+    setPos({
+      top: rect.top + window.scrollY,
+      left: rect.left + rect.width / 2 + window.scrollX,
+    })
+  }, [])
+
+  const hide = useCallback(() => setPos(null), [])
+
   return (
-    <span className="info-tooltip-wrapper">
-      <svg className="info-tooltip-icon" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <span className="info-tooltip-wrapper" onMouseEnter={show} onMouseLeave={hide} onFocus={show} onBlur={hide}>
+      <svg ref={iconRef} className="info-tooltip-icon" viewBox="0 0 16 16" fill="none" aria-hidden="true">
         <circle cx="8" cy="8" r="7" stroke="currentColor" strokeWidth="1.5" />
         <path d="M8 7v4M8 5.5v0" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
       </svg>
-      <span className="info-tooltip-bubble" role="tooltip">{text}</span>
+      {pos !== null && createPortal(
+        <span
+          role="tooltip"
+          className="info-tooltip-bubble info-tooltip-bubble--fixed"
+          style={{ top: pos.top, left: pos.left }}
+        >
+          {text}
+        </span>,
+        document.body,
+      )}
     </span>
   )
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1088,6 +1088,18 @@
     @apply pointer-events-auto opacity-100;
   }
 
+  /* Portal-rendered tooltip — escapes overflow:hidden/auto containers */
+  .info-tooltip-bubble--fixed {
+    position: fixed;
+    transform: translateX(-50%) translateY(calc(-100% - 8px));
+    opacity: 1;
+    pointer-events: none;
+    z-index: 9999;
+    /* override absolute positioning from base class */
+    bottom: auto;
+    left: auto;
+  }
+
   /* ── Data table (generic) ── */
 
   .data-table-wrapper {


### PR DESCRIPTION
## Problem

Tooltips inside the evidence drawer sidebar (Sources tab) were being clipped by the `overflow-y: auto` scroll container. Because the bubble uses `position: absolute`, it was constrained within the scrolling ancestor, causing it to overlap content below the icon rather than appearing above it.

Closes #214

## Fix

Switch `InfoTooltip` to portal-render the bubble into `document.body` via React's `createPortal`. Position is computed from `getBoundingClientRect` on hover/focus, then applied as `position: fixed` — completely unaffected by any ancestor overflow constraints.

- `InfoTooltip.tsx`: adds `useRef` + `useState` for position, `createPortal` for rendering
- `styles.css`: adds `.info-tooltip-bubble--fixed` class with `position: fixed` and `transform: translateX(-50%) translateY(calc(-100% - 8px))` to render above the icon
- Existing `.info-tooltip-bubble` styles unchanged — non-portal usage still works

## Testing

Open the evidence drawer → Sources tab → hover any ⓘ icon. Tooltip should appear above the icon, not over the list below.