### PR TITLE
fix(ui): dedupe matched terms chips + merge competitor signals in Mentions tab

### DIFF
--- a/apps/web/src/components/layout/EvidenceDetailModal.tsx
+++ b/apps/web/src/components/layout/EvidenceDetailModal.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import * as Dialog from '@radix-ui/react-dialog'
 import { X } from 'lucide-react'
-import { effectiveDomains, normalizeProjectDomain } from '@ainyc/canonry-contracts'
+import { brandKeyFromText, effectiveDomains, normalizeProjectDomain } from '@ainyc/canonry-contracts'
 
 import { InfoTooltip } from '../shared/InfoTooltip.js'
 import { highlightTermsInText, type HighlightTermGroup } from '../../lib/highlight.js'
@@ -600,11 +600,10 @@ export function EvidenceDetailModal({
                           </div>
                           <div className="flex flex-wrap gap-1.5">
                             {(() => {
-                              const brandKey = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, '')
                               const domainChips = display.competitorDomains.map(d => d.replace(/^www\./, ''))
-                              const domainKeys = new Set(domainChips.map(d => brandKey(d.replace(/\.[^.]+$/, ''))))
+                              const domainKeys = new Set(domainChips.map(d => brandKeyFromText(d.replace(/\.[^.]+$/, ''))))
                               const filteredNames = display.recommendedCompetitors.filter(
-                                name => !domainKeys.has(brandKey(name))
+                                name => !domainKeys.has(brandKeyFromText(name))
                               )
                               return [...filteredNames, ...domainChips].map(name => (
                                 <span key={name} className="mention-chip mention-chip--competitor">{name}</span>

--- a/packages/canonry/src/job-runner.ts
+++ b/packages/canonry/src/job-runner.ts
@@ -6,7 +6,7 @@ import { and, eq, inArray } from 'drizzle-orm'
 import type { DatabaseClient } from '@ainyc/canonry-db'
 import { runs, keywords, competitors, projects, querySnapshots, usageCounters } from '@ainyc/canonry-db'
 import type { ProviderName, NormalizedQueryResult, LocationContext } from '@ainyc/canonry-contracts'
-import { determineAnswerMentioned, effectiveDomains, normalizeProjectDomain, isBrowserProvider } from '@ainyc/canonry-contracts'
+import { brandKeyFromText, determineAnswerMentioned, effectiveDomains, normalizeProjectDomain, isBrowserProvider } from '@ainyc/canonry-contracts'
 import type { ProviderRegistry, RegisteredProvider } from './provider-registry.js'
 import { trackEvent } from './telemetry.js'
 import { createLogger } from './logger.js'
@@ -769,9 +769,6 @@ function cleanCandidateName(candidate: string): string {
     .trim()
 }
 
-function brandKeyFromText(value: string): string {
-  return value.toLowerCase().replace(/[^a-z0-9]/g, '')
-}
 
 function collectBrandKeysFromDomain(domain: string): string[] {
   const hostname = normalizeProjectDomain(domain).split('/')[0] ?? ''

--- a/packages/contracts/src/answer-visibility.ts
+++ b/packages/contracts/src/answer-visibility.ts
@@ -91,6 +91,14 @@ export function visibilityStateFromAnswerMentioned(answerMentioned: boolean | nu
   return answerMentioned ? 'visible' : 'not-visible'
 }
 
+/**
+ * Normalize a brand name or domain label to a lowercase alphanumeric key
+ * for fuzzy comparison (e.g. "Downtown Smiles" → "downtownsmiles").
+ */
+export function brandKeyFromText(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, '')
+}
+
 function domainMentioned(lowerAnswer: string, normalizedDomain: string): boolean {
   const escapedDomain = escapeRegExp(normalizedDomain.toLowerCase())
   const patterns = [


### PR DESCRIPTION
## Changes

### 1. Deduplicate matched terms chips (closes redundancy in #207)

`extractAnswerMentions` was returning both the domain (`ainyc.ai`) and its root token (`ainyc`) as separate chips since both matched. The token is redundant — if the domain already matched, the bare SLD adds no information.

Fix in `packages/contracts/src/answer-visibility.ts`: after deduplication, drop any bare token that is subsumed by a domain match (i.e. the token equals the SLD prefix of a matched domain).

Before: `ainyc.ai` · `ainyc`
After: `ainyc.ai`

### 2. Merge competitor signals in the Mentions tab

Previously:
- `recommendedCompetitors` (LLM-extracted names from answer text) → Mentions tab
- `competitorDomains` (domain-level matches from source links) → Sources tab only

This split meant the Mentions tab gave an incomplete picture of competitor presence. Both signals are now merged and deduplicated into a single chip row in the Mentions tab under **Competitors in answer**.

The Sources tab still shows the full domain-level breakdown with rank ordering — this is additive, not a removal.