### PR TITLE
chore(core-cli): fix unhandled exception in scheduler, structured logging in job-runner, add displayMessage to keyword CliError

### DIFF
--- a/packages/canonry/src/commands/keyword.ts
+++ b/packages/canonry/src/commands/keyword.ts
@@ -71,6 +71,7 @@ export async function importKeywords(project: string, filePath: string, format?:
     throw new CliError({
       code: 'KEYWORD_IMPORT_FILE_NOT_FOUND',
       message: `File not found: ${filePath}`,
+      displayMessage: `Error: file not found: ${filePath}`,
       details: {
         project,
         filePath,

--- a/packages/canonry/src/job-runner.ts
+++ b/packages/canonry/src/job-runner.ts
@@ -488,7 +488,7 @@ export class JobRunner {
       // Notify on failure too
       if (this.onRunCompleted) {
         this.onRunCompleted(runId, projectId).catch((notifErr: unknown) => {
-          console.error('[JobRunner] Notification callback failed:', notifErr)
+          log.error('notification.callback-failed', { runId, error: notifErr instanceof Error ? notifErr.message : String(notifErr) })
         })
       }
     }

--- a/packages/canonry/src/scheduler.ts
+++ b/packages/canonry/src/scheduler.ts
@@ -116,53 +116,57 @@ export class Scheduler {
   }
 
   private triggerRun(scheduleId: string, projectId: string): void {
-    const now = new Date().toISOString()
-    const currentSchedule = this.db.select().from(schedules).where(eq(schedules.id, scheduleId)).get()
-    if (!currentSchedule || currentSchedule.enabled !== 1) {
-      log.warn('schedule.stale', { scheduleId, projectId, msg: 'schedule no longer exists or is disabled' })
-      this.remove(projectId)
-      return
-    }
+    try {
+      const now = new Date().toISOString()
+      const currentSchedule = this.db.select().from(schedules).where(eq(schedules.id, scheduleId)).get()
+      if (!currentSchedule || currentSchedule.enabled !== 1) {
+        log.warn('schedule.stale', { scheduleId, projectId, msg: 'schedule no longer exists or is disabled' })
+        this.remove(projectId)
+        return
+      }
 
-    const task = this.tasks.get(projectId)
-    const nextRunAt = task?.getNextRun()?.toISOString() ?? null
+      const task = this.tasks.get(projectId)
+      const nextRunAt = task?.getNextRun()?.toISOString() ?? null
 
-    // Check if project still exists
-    const project = this.db.select().from(projects).where(eq(projects.id, projectId)).get()
-    if (!project) {
-      log.error('project.not-found', { projectId, msg: 'skipping scheduled run' })
-      this.remove(projectId)
-      return
-    }
+      // Check if project still exists
+      const project = this.db.select().from(projects).where(eq(projects.id, projectId)).get()
+      if (!project) {
+        log.error('project.not-found', { projectId, msg: 'skipping scheduled run' })
+        this.remove(projectId)
+        return
+      }
 
-    const queueResult = queueRunIfProjectIdle(this.db, {
-      createdAt: now,
-      kind: 'answer-visibility',
-      projectId,
-      trigger: 'scheduled',
-    })
+      const queueResult = queueRunIfProjectIdle(this.db, {
+        createdAt: now,
+        kind: 'answer-visibility',
+        projectId,
+        trigger: 'scheduled',
+      })
 
-    if (queueResult.conflict) {
-      log.info('run.skipped-active', { projectName: project.name, activeRunId: queueResult.activeRunId })
+      if (queueResult.conflict) {
+        log.info('run.skipped-active', { projectName: project.name, activeRunId: queueResult.activeRunId })
+        this.db.update(schedules).set({
+          nextRunAt,
+          updatedAt: now,
+        }).where(eq(schedules.id, currentSchedule.id)).run()
+        return
+      }
+
+      const runId = queueResult.runId
       this.db.update(schedules).set({
+        lastRunAt: now,
         nextRunAt,
         updatedAt: now,
       }).where(eq(schedules.id, currentSchedule.id)).run()
-      return
+
+      // Resolve providers
+      const scheduleProviders = JSON.parse(currentSchedule.providers) as string[]
+      const providers = scheduleProviders.length > 0 ? scheduleProviders as ProviderName[] : undefined
+
+      log.info('run.triggered', { runId, projectName: project.name, providers: providers ?? 'all' })
+      this.callbacks.onRunCreated(runId, projectId, providers)
+    } catch (err: unknown) {
+      log.error('trigger.error', { scheduleId, projectId, error: err instanceof Error ? err.message : String(err) })
     }
-
-    const runId = queueResult.runId
-    this.db.update(schedules).set({
-      lastRunAt: now,
-      nextRunAt,
-      updatedAt: now,
-    }).where(eq(schedules.id, currentSchedule.id)).run()
-
-    // Resolve providers
-    const scheduleProviders = JSON.parse(currentSchedule.providers) as string[]
-    const providers = scheduleProviders.length > 0 ? scheduleProviders as ProviderName[] : undefined
-
-    log.info('run.triggered', { runId, projectName: project.name, providers: providers ?? 'all' })
-    this.callbacks.onRunCreated(runId, projectId, providers)
   }
 }


### PR DESCRIPTION
## Summary

Overnight audit of `packages/canonry/src/` identified three substantive issues.

---

### 1. Unhandled exception risk in `Scheduler.triggerRun` (`scheduler.ts`)

**Issue:** `triggerRun` is invoked as a synchronous callback from a `node-cron` task. Any uncaught exception thrown inside it (e.g. from `queueRunIfProjectIdle`, DB writes, or `callbacks.onRunCreated`) would propagate out of the cron task handler and crash the scheduler silently — with no log entry and no recovery path.

**Fix:** Wrapped the entire body of `triggerRun` in a `try/catch` that logs the error via `log.error('trigger.error', ...)` and returns cleanly, preserving scheduler uptime.

---

### 2. `console.error` in notification failure callback (`job-runner.ts`)

**Issue:** The on-failure `onRunCompleted` callback used a bare `console.error()` call on rejection, inconsistent with every other error path in `job-runner.ts` which uses the `log` structured logger. This would produce an unstructured line on stderr and bypass any log-level filtering or aggregation.

**Fix:** Replaced with `log.error('notification.callback-failed', { runId, error: ... })` — consistent with the module's logging style and observable in structured log pipelines.

---

### 3. Missing `displayMessage` on `KEYWORD_IMPORT_FILE_NOT_FOUND` `CliError` (`commands/keyword.ts`)

**Issue:** Every other `CliError` throw in the CLI commands provides a `displayMessage` field (the user-facing string rendered by the error handler). The `importKeywords` command omitted it, meaning the CLI error handler would fall back to the internal `message` field or a generic fallback — potentially showing a raw error string instead of a clean user message.

**Fix:** Added `displayMessage: `Error: file not found: ${filePath}`` to the `CliError` constructor call.

---

### Verification

```
pnpm typecheck  ✓  (all 18 packages)
pnpm lint       ✓  (all 18 packages)
pnpm test       ✓  (79 test files, 756 tests)
```