### PR TITLE
chore(providers): fix generateText API mismatch, domain lowercasing consistency, CDP connection leak, and local serialization safety

### DIFF
--- a/packages/provider-cdp/src/adapter.ts
+++ b/packages/provider-cdp/src/adapter.ts
@@ -30,8 +30,11 @@ function getConnection(config: ProviderConfig): CDPConnectionManager {
   if (parts.length >= 1 && parts[0]) host = parts[0]
   if (parts.length >= 2 && parts[1]) port = parseInt(parts[1], 10) || 9222
 
-  // Reuse or create connection
+  // Reuse or create connection; disconnect the old one if the endpoint changed
   if (!sharedConnection || sharedConnection.endpoint !== `${host}:${port}`) {
+    if (sharedConnection) {
+      sharedConnection.disconnect().catch(() => { /* ignore cleanup errors */ })
+    }
     sharedConnection = new CDPConnectionManager(host, port)
   }
   return sharedConnection

--- a/packages/provider-claude/src/normalize.ts
+++ b/packages/provider-claude/src/normalize.ts
@@ -192,7 +192,7 @@ function extractCitedDomains(raw: ClaudeRawResult): string[] {
 function extractDomainFromUri(uri: string): string | null {
   try {
     const url = new URL(uri)
-    return url.hostname.replace(/^www\./, '')
+    return url.hostname.replace(/^www\./, '').toLowerCase()
   } catch {
     return null
   }

--- a/packages/provider-local/src/normalize.ts
+++ b/packages/provider-local/src/normalize.ts
@@ -75,7 +75,7 @@ export async function executeTrackedQuery(input: LocalTrackedQueryInput): Promis
 
   return {
     provider: 'local',
-    rawResponse: JSON.parse(JSON.stringify(response)) as Record<string, unknown>,
+    rawResponse: responseToRecord(response),
     model,
     groundingSources: [],
     searchQueries: [],
@@ -148,4 +148,12 @@ export function extractDomainMentions(text: string): string[] {
   }
 
   return [...domains]
+}
+
+function responseToRecord(response: OpenAI.Chat.Completions.ChatCompletion): Record<string, unknown> {
+  try {
+    return JSON.parse(JSON.stringify(response)) as Record<string, unknown>
+  } catch {
+    return { error: 'failed to serialize response' }
+  }
 }

--- a/packages/provider-openai/src/normalize.ts
+++ b/packages/provider-openai/src/normalize.ts
@@ -200,7 +200,7 @@ function extractCitedDomains(raw: OpenAIRawResult): string[] {
 function extractDomainFromUri(uri: string): string | null {
   try {
     const url = new URL(uri)
-    return url.hostname.replace(/^www\./, '')
+    return url.hostname.replace(/^www\./, '').toLowerCase()
   } catch {
     return null
   }
@@ -209,11 +209,11 @@ function extractDomainFromUri(uri: string): string | null {
 export async function generateText(prompt: string, config: OpenAIConfig): Promise<string> {
   const model = config.model ?? DEFAULT_MODEL
   const client = new OpenAI({ apiKey: config.apiKey })
-  const response = await client.chat.completions.create({
+  const response = await client.responses.create({
     model,
-    messages: [{ role: 'user', content: prompt }],
+    input: prompt,
   })
-  return response.choices[0]?.message?.content ?? ''
+  return extractResponseText(response)
 }
 
 function responseToRecord(response: OpenAI.Responses.Response): Record<string, unknown> {

--- a/packages/provider-perplexity/src/normalize.ts
+++ b/packages/provider-perplexity/src/normalize.ts
@@ -153,7 +153,7 @@ export function extractCitedDomains(groundingSources: GroundingSource[]): string
 function extractDomainFromUri(uri: string): string | null {
   try {
     const url = new URL(uri)
-    return url.hostname.replace(/^www\./, '')
+    return url.hostname.replace(/^www\./, '').toLowerCase()
   } catch {
     return null
   }


### PR DESCRIPTION
## Summary

Overnight audit of `packages/provider-cdp/`, `packages/provider-claude/`, `packages/provider-gemini/`, `packages/provider-local/`, `packages/provider-openai/`, `packages/provider-perplexity/` — four substantive issues found and fixed.

---

## Issues Fixed

### 1. `provider-openai`: `generateText` used the wrong API (`chat.completions` → `responses`)

`generateText` in `normalize.ts` was calling `client.chat.completions.create` with a `messages` payload, while every other call in the same file (including `executeTrackedQuery` and `healthcheck`) correctly uses `client.responses.create` with an `input` field. The Chat Completions API shape differs from the Responses API and the models listed in the adapter (`gpt-5.4`, `gpt-5.4-pro`, etc.) are Responses-API-only. This would have caused a runtime error or wrong response shape for any caller of `generateText`.

**Fix:** Changed `generateText` to use `client.responses.create` and `extractResponseText` (already used elsewhere in the same file).

---

### 2. Domain extraction inconsistency across providers (claude, openai, perplexity)

`extractDomainFromUri` in `provider-gemini` and `provider-cdp` lowercases the extracted hostname via `.toLowerCase()`, but the same function in `provider-claude`, `provider-openai`, and `provider-perplexity` did not. This caused inconsistent `citedDomains` output depending on which provider was queried — a domain like `Example.com` would be stored differently across providers, breaking deduplication and match logic in the job runner.

**Fix:** Added `.toLowerCase()` to `extractDomainFromUri` in `provider-claude/normalize.ts`, `provider-openai/normalize.ts`, and `provider-perplexity/normalize.ts` to match `provider-gemini` and `provider-cdp`.

---

### 3. `provider-cdp`: leaked Chrome connection on endpoint change

In `adapter.ts`, the module-level `sharedConnection` singleton was silently replaced when `config.cdpEndpoint` changed (different host/port). The old `CDPConnectionManager` — which holds open CDP WebSocket connections and active browser tabs — was discarded without calling `disconnect()`. Over multiple endpoint changes this would leak WebSocket connections and Chrome tabs.

**Fix:** Added an explicit `sharedConnection.disconnect().catch(() => {})` call before replacing the singleton.

---

### 4. `provider-local`: inline `JSON.parse(JSON.stringify(...)))` without error handling

`executeTrackedQuery` in `normalize.ts` serialized the raw API response using `JSON.parse(JSON.stringify(response))` inline with no try/catch. Every other provider uses a dedicated `responseToRecord` helper that wraps serialization in a try/catch and returns `{ error: 'failed to serialize response' }` on failure. A circular reference or non-serializable value in the Ollama/OpenAI-compat response would throw an unhandled exception and crash the query.

**Fix:** Added a `responseToRecord` helper (matching the pattern in all other providers) and used it in `executeTrackedQuery`.

---

## Verification

```
pnpm typecheck  ✅
pnpm lint       ✅
pnpm test       ✅  (79 test files, 756 tests)
```