### PR TITLE
chore(integrations): fix listActivePlugins pagination and add missing test coverage

### DIFF
--- a/packages/integration-bing/test/bing-client.test.ts
+++ b/packages/integration-bing/test/bing-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { getSites, getUrlInfo, submitUrl, submitUrlBatch, getKeywordStats, getCrawlStats, getCrawlIssues } from '../src/bing-client.js'
+import { getSites, addSite, getUrlInfo, submitUrl, submitUrlBatch, getKeywordStats, getCrawlStats, getCrawlIssues } from '../src/bing-client.js'
 import { BING_WMT_API_BASE } from '../src/constants.js'
 
 describe('getSites', () => {
@@ -51,6 +51,40 @@ describe('getSites', () => {
     globalThis.fetch = async () => new Response('Rate limited', { status: 429 })
 
     await expect(() => getSites('key')).rejects.toThrow(/rate limit/)
+  })
+})
+
+describe('addSite', () => {
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('sends POST with siteUrl in body', async () => {
+    let capturedMethod = ''
+    let capturedBody: unknown
+
+    globalThis.fetch = async (_url: string | URL | Request, init?: RequestInit) => {
+      capturedMethod = init?.method ?? 'GET'
+      capturedBody = JSON.parse(String(init?.body ?? '{}'))
+      return new Response(JSON.stringify({ d: null }), { status: 200 })
+    }
+
+    await addSite('test-key', 'https://example.com/')
+
+    expect(capturedMethod).toBe('POST')
+    const body = capturedBody as { siteUrl: string }
+    expect(body.siteUrl).toBe('https://example.com/')
+  })
+
+  it('throws BingApiError on 401', async () => {
+    globalThis.fetch = async () => new Response('Unauthorized', { status: 401 })
+    await expect(() => addSite('bad-key', 'https://example.com/')).rejects.toMatchObject({ name: 'BingApiError' })
   })
 })
 

--- a/packages/integration-google-analytics/test/ga4-client.test.ts
+++ b/packages/integration-google-analytics/test/ga4-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
-import { createServiceAccountJwt, fetchAiReferrals, fetchTrafficByLandingPage } from '../src/ga4-client.js'
+import { createServiceAccountJwt, fetchAiReferrals, fetchTrafficByLandingPage, getAccessToken, verifyConnectionWithToken, fetchAggregateSummary } from '../src/ga4-client.js'
 import crypto from 'node:crypto'
 
 describe('createServiceAccountJwt', () => {
@@ -191,5 +191,147 @@ describe('fetchAiReferrals', () => {
 
     expect(expressions).toContain('copilot')
     expect(expressions).not.toContain('bing')
+  })
+})
+
+describe('getAccessToken', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  it('exchanges a service account JWT for an access token', async () => {
+    const { privateKey } = crypto.generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+    })
+
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ access_token: 'sa-access-token', expires_in: 3600 }), { status: 200 }),
+    )
+
+    const token = await getAccessToken('sa@project.iam.gserviceaccount.com', privateKey)
+    expect(token).toBe('sa-access-token')
+
+    const [url, init] = fetchSpy.mock.calls[0]!
+    expect(String(url)).toContain('oauth2.googleapis.com/token')
+    expect(String(init?.body ?? '')).toContain('grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer')
+  })
+
+  it('throws GA4ApiError when token exchange fails', async () => {
+    const { privateKey } = crypto.generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+    })
+
+    fetchSpy.mockResolvedValueOnce(
+      new Response('{"error":"invalid_grant"}', { status: 400 }),
+    )
+
+    await expect(() => getAccessToken('sa@project.iam.gserviceaccount.com', privateKey))
+      .rejects.toMatchObject({ name: 'GA4ApiError' })
+  })
+})
+
+describe('verifyConnectionWithToken', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  it('returns true when a minimal runReport succeeds', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ rows: [], rowCount: 0 }), { status: 200 }),
+    )
+
+    const result = await verifyConnectionWithToken('valid-token', '123456789')
+    expect(result).toBe(true)
+
+    const [url, init] = fetchSpy.mock.calls[0]!
+    expect(String(url)).toContain('properties/123456789:runReport')
+    const body = JSON.parse(String(init?.body ?? '{}')) as { limit: number }
+    expect(body.limit).toBe(1)
+  })
+
+  it('throws GA4ApiError on 403 with service-disabled detail', async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(
+        JSON.stringify({ error: { status: 'SERVICE_DISABLED', message: 'API not enabled' } }),
+        { status: 403 },
+      ),
+    )
+
+    await expect(() => verifyConnectionWithToken('token', '123456789'))
+      .rejects.toMatchObject({ name: 'GA4ApiError' })
+  })
+})
+
+describe('fetchAggregateSummary', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  function mockFetchResponse(body: object, status = 200) {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  it('returns aggregate totals from a batchRunReports call', async () => {
+    fetchSpy.mockImplementation(async (_input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof _input === 'string' ? _input : _input instanceof URL ? _input.href : (_input as Request).url
+      expect(url).toContain(':batchRunReports')
+      const body = JSON.parse(String(init?.body ?? '{}')) as { requests: unknown[] }
+      expect(body.requests).toHaveLength(2)
+      return mockFetchResponse({
+        reports: [
+          {
+            rows: [{ dimensionValues: [], metricValues: [{ value: '5000' }, { value: '3200' }] }],
+            rowCount: 1,
+          },
+          {
+            rows: [{ dimensionValues: [], metricValues: [{ value: '1800' }] }],
+            rowCount: 1,
+          },
+        ],
+      })
+    })
+
+    const summary = await fetchAggregateSummary('fake-token', '123456', 30)
+    expect(summary.totalSessions).toBe(5000)
+    expect(summary.totalUsers).toBe(3200)
+    expect(summary.totalOrganicSessions).toBe(1800)
+    expect(summary.periodStart).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    expect(summary.periodEnd).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+
+  it('returns zeros when no rows are returned', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      mockFetchResponse({ reports: [{}, {}] }),
+    )
+
+    const summary = await fetchAggregateSummary('fake-token', '123456', 7)
+    expect(summary.totalSessions).toBe(0)
+    expect(summary.totalUsers).toBe(0)
+    expect(summary.totalOrganicSessions).toBe(0)
   })
 })

--- a/packages/integration-google/test/gsc-client.test.ts
+++ b/packages/integration-google/test/gsc-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { listSites, fetchSearchAnalytics, inspectUrl, publishUrlNotification, getUrlNotificationStatus } from '../src/gsc-client.js'
+import { listSites, listSitemaps, fetchSearchAnalytics, inspectUrl, publishUrlNotification, getUrlNotificationStatus } from '../src/gsc-client.js'
 import { GSC_API_BASE, URL_INSPECTION_API, INDEXING_API_BASE } from '../src/constants.js'
 
 describe('listSites', () => {
@@ -46,6 +46,63 @@ describe('listSites', () => {
       () => listSites('bad-token'),
     ).rejects.toThrow(/expired or revoked/)
     await expect(() => listSites('bad-token')).rejects.toMatchObject({ name: 'GoogleApiError' })
+  })
+})
+
+describe('listSitemaps', () => {
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('returns parsed sitemaps for a site', async () => {
+    const mockResponse = {
+      sitemap: [
+        { path: 'https://example.com/sitemap.xml', type: 'sitemap', lastDownloaded: '2026-03-15T10:00:00Z' },
+        { path: 'https://example.com/sitemap-news.xml', type: 'sitemap', isSitemapsIndex: false },
+      ],
+    }
+
+    let capturedUrl = ''
+    globalThis.fetch = async (url: string | URL | Request) => {
+      capturedUrl = String(url)
+      return new Response(JSON.stringify(mockResponse), { status: 200 })
+    }
+
+    const sitemaps = await listSitemaps('test-token', 'https://example.com/')
+    expect(capturedUrl).toContain(`${GSC_API_BASE}/sites/`)
+    expect(capturedUrl).toContain('sitemaps')
+    expect(sitemaps.length).toBe(2)
+    expect(sitemaps[0]!.path).toBe('https://example.com/sitemap.xml')
+    expect(sitemaps[1]!.path).toBe('https://example.com/sitemap-news.xml')
+  })
+
+  it('returns empty array when no sitemaps', async () => {
+    globalThis.fetch = async () => new Response(JSON.stringify({}), { status: 200 })
+
+    const sitemaps = await listSitemaps('test-token', 'https://example.com/')
+    expect(sitemaps).toEqual([])
+  })
+
+  it('URL-encodes the site URL in the request path', async () => {
+    let capturedUrl = ''
+    globalThis.fetch = async (url: string | URL | Request) => {
+      capturedUrl = String(url)
+      return new Response(JSON.stringify({ sitemap: [] }), { status: 200 })
+    }
+
+    await listSitemaps('test-token', 'sc-domain:example.com')
+    expect(capturedUrl).toContain(encodeURIComponent('sc-domain:example.com'))
+  })
+
+  it('throws GoogleApiError on 401', async () => {
+    globalThis.fetch = async () => new Response('Unauthorized', { status: 401 })
+    await expect(() => listSitemaps('bad-token', 'https://example.com/')).rejects.toMatchObject({ name: 'GoogleApiError' })
   })
 })
 

--- a/packages/integration-wordpress/src/wordpress-client.ts
+++ b/packages/integration-wordpress/src/wordpress-client.ts
@@ -400,12 +400,22 @@ export async function listActivePlugins(
 ): Promise<string[] | null> {
   const site = resolveEnvironment(connection, env)
   try {
-    const { body } = await fetchJson<Array<{ plugin: string; status: string }>>(
-      connection,
-      site.siteUrl,
-      '/wp-json/wp/v2/plugins?per_page=100&_fields=plugin,status',
-    )
-    return body
+    const allPlugins: Array<{ plugin: string; status: string }> = []
+    let page = 1
+    let totalPages = 1
+
+    while (page <= totalPages) {
+      const { body, response } = await fetchJson<Array<{ plugin: string; status: string }>>(
+        connection,
+        site.siteUrl,
+        `/wp-json/wp/v2/plugins?per_page=100&page=${page}&_fields=plugin,status`,
+      )
+      totalPages = Number.parseInt(response.headers.get('x-wp-totalpages') ?? '1', 10) || 1
+      allPlugins.push(...body)
+      page += 1
+    }
+
+    return allPlugins
       .filter((plugin) => plugin.status === 'active')
       .map((plugin) => plugin.plugin)
       .sort()

--- a/packages/integration-wordpress/test/wordpress-client.test.ts
+++ b/packages/integration-wordpress/test/wordpress-client.test.ts
@@ -446,6 +446,44 @@ describe('wordpress client', () => {
     })
   })
 
+  it('paginates listActivePlugins across multiple pages', async () => {
+    const requestedUrls: string[] = []
+    globalThis.fetch = async (input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      requestedUrls.push(url)
+      if (url.includes('/wp-json/wp/v2/plugins?per_page=100&page=1')) {
+        return jsonResponse(
+          Array.from({ length: 100 }, (_, i) => ({ plugin: `plugin-${i}/plugin-${i}.php`, status: 'active' })),
+          { headers: { 'x-wp-totalpages': '2' } },
+        )
+      }
+      if (url.includes('/wp-json/wp/v2/plugins?per_page=100&page=2')) {
+        return jsonResponse(
+          [
+            { plugin: 'extra-plugin/extra.php', status: 'active' },
+            { plugin: 'inactive-plugin/inactive.php', status: 'inactive' },
+          ],
+          { headers: { 'x-wp-totalpages': '2' } },
+        )
+      }
+      throw new Error(`Unhandled URL: ${url}`)
+    }
+
+    const { listActivePlugins: _listActivePlugins } = await import('../src/wordpress-client.js')
+    const conn = createConnection()
+    // We can't import listActivePlugins directly in this test; instead verify
+    // through getSiteStatus which calls it internally.
+    // Re-import via the public index
+    const { listActivePlugins } = await import('../src/index.js')
+    const plugins = await listActivePlugins(conn, 'live')
+
+    expect(plugins).not.toBeNull()
+    expect(plugins!.length).toBe(101) // 100 page-1 active + 1 page-2 active (inactive excluded)
+    expect(plugins).toContain('extra-plugin/extra.php')
+    expect(plugins).not.toContain('inactive-plugin/inactive.php')
+    expect(requestedUrls.some((u) => u.includes('page=2'))).toBe(true)
+  })
+
   it('returns an actionable error message when auth fails on connect', async () => {
     globalThis.fetch = async (input: string | URL | Request) => {
       const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url


### PR DESCRIPTION
## Summary

Overnight audit of `packages/integration-bing/`, `packages/integration-google/`, `packages/integration-google-analytics/`, and `packages/integration-wordpress/`.

No OAuth credential storage in SQLite, no imports from `apps/*`, no unsanitized inputs, no sensitive data leaking in logs, and rate-limit/error handling was already solid. One functional bug found and two CLAUDE.md test-coverage violations corrected.

---

## Issues Found & Fixed

### 1. Bug: `listActivePlugins` silently truncated at 100 plugins (integration-wordpress)

**File:** `packages/integration-wordpress/src/wordpress-client.ts`

`listActivePlugins` issued a single `/wp-json/wp/v2/plugins?per_page=100` request and never followed `x-wp-totalpages`. Any WordPress site with more than 100 plugins (common on large multisite setups) would silently return an incomplete list. This caused downstream `detectSeoWriteStrategy` and `bulkSetSeoMeta` to potentially misclassify the SEO plugin availability, leading to failed or no-op SEO writes.

**Fix:** Replaced the single-page fetch with a paginated loop that reads `x-wp-totalpages` from the response header and continues until all pages are consumed.

### 2. Missing test coverage: `addSite` untested (integration-bing, CLAUDE.md violation)

**File:** `packages/integration-bing/test/bing-client.test.ts`

`addSite` was exported but had zero test coverage. CLAUDE.md requires all exported functions to have tests.

**Fix:** Added two tests — one verifying the POST body contains `siteUrl`, one verifying a 401 response throws `BingApiError`.

### 3. Missing test coverage: `listSitemaps` untested (integration-google, CLAUDE.md violation)

**File:** `packages/integration-google/test/gsc-client.test.ts`

`listSitemaps` was exported but had zero test coverage.

**Fix:** Added four tests covering: successful sitemap list parsing, empty-sitemap response returning `[]`, URL-encoding of the site URL path segment (critical for `sc-domain:` prefixed properties), and 401 throwing `GoogleApiError`.

### 4. Missing test coverage: `getAccessToken`, `verifyConnectionWithToken`, `fetchAggregateSummary` untested (integration-google-analytics, CLAUDE.md violation)

**File:** `packages/integration-google-analytics/test/ga4-client.test.ts`

Three exported functions had no tests.

**Fix:**
- `getAccessToken`: tests JWT-bearer token exchange success path and 400 failure path (`GA4ApiError`).
- `verifyConnectionWithToken`: tests successful minimal `runReport` ping (returns `true`, sends `limit: 1`) and 403 `SERVICE_DISABLED` failure path.
- `fetchAggregateSummary`: tests `batchRunReports` aggregate totals (sessions/users/organic sessions/date range) and zero-row empty response handling.

### 5. Missing test coverage: `listActivePlugins` pagination (integration-wordpress)

**File:** `packages/integration-wordpress/test/wordpress-client.test.ts`

No test exercised the multi-page path through `listActivePlugins` (which was also the buggy code path).

**Fix:** Added a test that mocks 100 plugins on page 1 and 2 plugins (1 active, 1 inactive) on page 2, verifying: all 101 active plugins are returned, inactive plugins are excluded, and page 2 was actually requested.

---

## Checklist

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 769/769 passed