### PR TITLE
chore(db): fix missing migrations and improve SQLite concurrency

### DIFF
--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -11,5 +11,6 @@ export function createClient(databasePath: string) {
   const sqlite = new Database(databasePath)
   sqlite.pragma('journal_mode = WAL')
   sqlite.pragma('foreign_keys = ON')
+  sqlite.pragma('busy_timeout = 5000')
   return drizzle(sqlite, { schema })
 }

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -315,6 +315,13 @@ const MIGRATIONS = [
   `CREATE UNIQUE INDEX IF NOT EXISTS idx_ga_ai_ref_unique ON ga_ai_referrals(project_id, date, source, medium)`,
   // v18: Answer-level visibility derived from answer text
   `ALTER TABLE query_snapshots ADD COLUMN answer_mentioned INTEGER`,
+  // v19: Add named unique indexes and missing columns from early tables
+  `CREATE UNIQUE INDEX IF NOT EXISTS idx_keywords_project_keyword ON keywords(project_id, keyword)`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS idx_competitors_project_domain ON competitors(project_id, domain)`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS idx_schedules_project ON schedules(project_id)`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS idx_usage_scope_period_metric ON usage_counters(scope, period, metric)`,
+  `ALTER TABLE projects ADD COLUMN config_source TEXT NOT NULL DEFAULT 'cli'`,
+  `ALTER TABLE projects ADD COLUMN config_revision INTEGER NOT NULL DEFAULT 1`,
 ]
 
 export function migrate(db: DatabaseClient) {


### PR DESCRIPTION
Database layer audit (overnight) for packages/db.

### Fixes:
1.  **Concurrency Improvement**: Added `busy_timeout = 5000` to `Database` initialization in `client.ts`. This allows concurrent writers/readers in WAL mode to wait instead of throwing immediate `SQLITE_BUSY` errors.
2.  **Missing Named Unique Indexes**: Added v19 migration to create `idx_keywords_project_keyword`, `idx_competitors_project_domain`, `idx_schedules_project`, and `idx_usage_scope_period_metric`. These were defined in `schema.ts` but implemented as anonymous inline constraints in migrations, violating the consistency rule.
3.  **Missing Column Backfills**: Added v19 migrations to backfill `config_source` and `config_revision` columns in the `projects` table. These were previously added to `MIGRATION_SQL` (fresh installs) but skipped for existing databases.

### Observations:
-   **Auth Credentials in DB**: Found `google_connections` (access/refresh tokens) and `ga_connections` (private keys) storing sensitive material in SQLite. This violates `CLAUDE.md`'s preference for local config storage. Fixing this is out of scope for a `packages/db`-only audit as it requires refactoring providers/API.
-   **Schema Consistency**: Verified all other tables (`query_snapshots`, `ga_*`, `bing_*`) match between `schema.ts` and `migrate.ts`.

All tests passed (`pnpm --filter @ainyc/canonry-db test`).