### PR TITLE
chore(apps): overnight audit fixes for API and web frontend

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -24,6 +24,7 @@ export function buildApp(env: PlatformEnv) {
   app.register(apiRoutes, {
     db,
     skipAuth: false,
+    routePrefix: env.basePath === '/' ? '/api/v1' : `${env.basePath.replace(/\/$/, '')}/api/v1`,
     openApiInfo: {
       title: 'Canonry API',
       version: '0.1.0',

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -3,19 +3,24 @@ import type { FastifyInstance } from 'fastify'
 import type { PlatformEnv } from '@ainyc/canonry-config'
 
 interface HealthResponse {
-  service: 'aeo-platform-api'
+  service: 'canonry'
   status: 'ok'
   version: string
   port: number
+  basePath: string
   databaseUrlConfigured: boolean
+  lastHeartbeatAt: string
 }
 
 export function registerHealthRoutes(app: FastifyInstance, env: PlatformEnv): void {
-  app.get('/health', async (): Promise<HealthResponse> => ({
-    service: 'aeo-platform-api',
+  const path = env.basePath === '/' ? '/health' : `${env.basePath.replace(/\/$/, '')}/health`
+  app.get(path, async (): Promise<HealthResponse> => ({
+    service: 'canonry',
     status: 'ok',
     version: '0.1.0',
     port: env.apiPort,
+    basePath: env.basePath,
     databaseUrlConfigured: env.databaseUrl.length > 0,
+    lastHeartbeatAt: new Date().toISOString(),
   }))
 }

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -37,13 +37,15 @@ test('buildApp registers health and API routes', async () => {
     url: '/health',
   })
   expect(healthResponse.statusCode).toBe(200)
-  expect(healthResponse.json()).toEqual({
-    service: 'aeo-platform-api',
+  expect(healthResponse.json()).toMatchObject({
+    service: 'canonry',
     status: 'ok',
     version: '0.1.0',
     port: 3000,
+    basePath: '/',
     databaseUrlConfigured: true,
   })
+  expect(healthResponse.json().lastHeartbeatAt).toBeDefined()
 
   // API routes are registered — projects endpoint is available
   const projectsResponse = await app.inject({
@@ -69,6 +71,7 @@ test('loadApiEnv delegates to shared platform config', () => {
     API_PORT: '4100',
     WORKER_PORT: '4101',
     WEB_PORT: '4173',
+    CANONRY_BASE_PATH: '/canonry',
     BOOTSTRAP_SECRET: 'secret',
     GEMINI_API_KEY: 'gemini-key',
     GEMINI_MAX_CONCURRENCY: '4',
@@ -78,6 +81,7 @@ test('loadApiEnv delegates to shared platform config', () => {
 
   expect(env.apiPort).toBe(4100)
   expect(env.workerPort).toBe(4101)
+  expect(env.basePath).toBe('/canonry')
   expect(env.bootstrapSecret).toBe('secret')
   expect(env.providers.gemini).toBeTruthy()
   expect(env.providers.gemini!.quota).toEqual({

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -441,7 +441,9 @@ export function loginWithApiKey(apiKey: string): Promise<ApiSessionState> {
 }
 
 export async function fetchHealthCheck(): Promise<{ status: string }> {
-  const res = await fetch('/health')
+  const basePath = window.__CANONRY_CONFIG__?.basePath || ''
+  const url = `${basePath.replace(/\/$/, '')}/health`
+  const res = await fetch(url)
   if (!res.ok) throw new Error(`Health check failed: ${res.status}`)
   return res.json() as Promise<{ status: string }>
 }

--- a/apps/web/src/components/project/BingSummaryMetric.tsx
+++ b/apps/web/src/components/project/BingSummaryMetric.tsx
@@ -1,0 +1,22 @@
+export function BingSummaryMetric({
+  label,
+  value,
+  tone,
+}: {
+  label: string
+  value: string | number
+  tone: 'positive' | 'negative' | 'neutral'
+}) {
+  const valueClass = tone === 'positive'
+    ? 'text-emerald-400'
+    : tone === 'negative'
+      ? 'text-rose-400'
+      : 'text-zinc-200'
+
+  return (
+    <div className="rounded-lg border border-zinc-800/60 bg-zinc-900/20 p-3">
+      <p className="text-xs uppercase tracking-wide text-zinc-500">{label}</p>
+      <p className={`mt-2 text-2xl font-semibold ${valueClass}`}>{value}</p>
+    </div>
+  )
+}

--- a/apps/web/src/components/project/SearchConsoleSummaryCard.tsx
+++ b/apps/web/src/components/project/SearchConsoleSummaryCard.tsx
@@ -1,0 +1,62 @@
+import { ToneBadge } from '../shared/ToneBadge.js'
+import { formatTimestamp } from '../../lib/format-helpers.js'
+
+export function SearchConsoleSummaryCard({
+  eyebrow,
+  title,
+  status,
+  tone,
+  targetLabel,
+  targetValue,
+  coverageValue,
+  note,
+  updatedAt,
+  active,
+  onClick,
+}: {
+  eyebrow: string
+  title: string
+  status: string
+  tone: 'positive' | 'caution' | 'negative' | 'neutral'
+  targetLabel: string
+  targetValue: string
+  coverageValue: string
+  note: string
+  updatedAt: string | null
+  active: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`surface-card w-full text-left transition-colors ${
+        active
+          ? 'border-zinc-200 bg-zinc-900/50'
+          : 'hover:border-zinc-700 hover:bg-zinc-900/40'
+      }`}
+    >
+      <div className="section-head">
+        <div className="min-w-0">
+          <p className="eyebrow eyebrow-soft">{eyebrow}</p>
+          <h3>{title}</h3>
+        </div>
+        <ToneBadge tone={tone}>{status}</ToneBadge>
+      </div>
+      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+        <div className="rounded-lg border border-zinc-800/60 bg-zinc-900/20 p-3">
+          <p className="text-xs uppercase tracking-wide text-zinc-500">{targetLabel}</p>
+          <p className="mt-1 truncate text-sm text-zinc-200">{targetValue}</p>
+        </div>
+        <div className="rounded-lg border border-zinc-800/60 bg-zinc-900/20 p-3">
+          <p className="text-xs uppercase tracking-wide text-zinc-500">Coverage</p>
+          <p className="mt-1 text-sm text-zinc-200">{coverageValue}</p>
+        </div>
+      </div>
+      <div className="mt-3 flex flex-col gap-1 text-xs text-zinc-500 sm:flex-row sm:items-center sm:justify-between">
+        <span>{note}</span>
+        <span>{updatedAt ? `Updated ${formatTimestamp(updatedAt)}` : 'No recent sync yet'}</span>
+      </div>
+    </button>
+  )
+}

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -13,6 +13,8 @@ import { ScoreGauge } from '../components/shared/ScoreGauge.js'
 import { ToneBadge } from '../components/shared/ToneBadge.js'
 import { EvidenceTable } from '../components/project/EvidenceTable.js'
 import { CompetitorTable } from '../components/project/CompetitorTable.js'
+import { SearchConsoleSummaryCard } from '../components/project/SearchConsoleSummaryCard.js'
+import { BingSummaryMetric } from '../components/project/BingSummaryMetric.js'
 import { AnalyticsSection } from '../components/project/AnalyticsSection.js'
 import { TrafficSection } from '../components/project/TrafficSection.js'
 import { GscSection } from '../components/project/GscSection.js'
@@ -62,89 +64,6 @@ import type { ProjectCommandCenterVm, RunHistoryPoint } from '../view-models.js'
 export type ProjectPageTab = 'overview' | 'search-console' | 'analytics' | 'traffic'
 
 type SearchConsoleWorkspace = 'google' | 'bing'
-
-function SearchConsoleSummaryCard({
-  eyebrow,
-  title,
-  status,
-  tone,
-  targetLabel,
-  targetValue,
-  coverageValue,
-  note,
-  updatedAt,
-  active,
-  onClick,
-}: {
-  eyebrow: string
-  title: string
-  status: string
-  tone: 'positive' | 'caution' | 'negative' | 'neutral'
-  targetLabel: string
-  targetValue: string
-  coverageValue: string
-  note: string
-  updatedAt: string | null
-  active: boolean
-  onClick: () => void
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={`surface-card w-full text-left transition-colors ${
-        active
-          ? 'border-zinc-200 bg-zinc-900/50'
-          : 'hover:border-zinc-700 hover:bg-zinc-900/40'
-      }`}
-    >
-      <div className="section-head">
-        <div className="min-w-0">
-          <p className="eyebrow eyebrow-soft">{eyebrow}</p>
-          <h3>{title}</h3>
-        </div>
-        <ToneBadge tone={tone}>{status}</ToneBadge>
-      </div>
-      <div className="mt-4 grid gap-3 sm:grid-cols-2">
-        <div className="rounded-lg border border-zinc-800/60 bg-zinc-900/20 p-3">
-          <p className="text-xs uppercase tracking-wide text-zinc-500">{targetLabel}</p>
-          <p className="mt-1 truncate text-sm text-zinc-200">{targetValue}</p>
-        </div>
-        <div className="rounded-lg border border-zinc-800/60 bg-zinc-900/20 p-3">
-          <p className="text-xs uppercase tracking-wide text-zinc-500">Coverage</p>
-          <p className="mt-1 text-sm text-zinc-200">{coverageValue}</p>
-        </div>
-      </div>
-      <div className="mt-3 flex flex-col gap-1 text-xs text-zinc-500 sm:flex-row sm:items-center sm:justify-between">
-        <span>{note}</span>
-        <span>{updatedAt ? `Updated ${formatTimestamp(updatedAt)}` : 'No recent sync yet'}</span>
-      </div>
-    </button>
-  )
-}
-
-function BingSummaryMetric({
-  label,
-  value,
-  tone,
-}: {
-  label: string
-  value: string | number
-  tone: 'positive' | 'negative' | 'neutral'
-}) {
-  const valueClass = tone === 'positive'
-    ? 'text-emerald-400'
-    : tone === 'negative'
-      ? 'text-rose-400'
-      : 'text-zinc-200'
-
-  return (
-    <div className="rounded-lg border border-zinc-800/60 bg-zinc-900/20 p-3">
-      <p className="text-xs uppercase tracking-wide text-zinc-500">{label}</p>
-      <p className={`mt-2 text-2xl font-semibold ${valueClass}`}>{value}</p>
-    </div>
-  )
-}
 
 function BingSection({
   projectName,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -7,6 +7,7 @@ const envSchema = z.object({
   WORKER_PORT: z.coerce.number().int().positive().default(3001),
   WEB_PORT: z.coerce.number().int().positive().default(4173),
   BOOTSTRAP_SECRET: z.string().default('change-me'),
+  CANONRY_BASE_PATH: z.string().default('/'),
   // Gemini
   GEMINI_API_KEY: z.string().optional(),
   GEMINI_MODEL: z.string().optional(),
@@ -73,6 +74,7 @@ export interface PlatformEnv {
   apiPort: number
   workerPort: number
   webPort: number
+  basePath: string
   bootstrapSecret: string
   providers: {
     gemini?: ProviderEnvConfig
@@ -165,6 +167,7 @@ export function getPlatformEnv(source: NodeJS.ProcessEnv): PlatformEnv {
     apiPort: parsed.API_PORT,
     workerPort: parsed.WORKER_PORT,
     webPort: parsed.WEB_PORT,
+    basePath: parsed.CANONRY_BASE_PATH,
     bootstrapSecret: parsed.BOOTSTRAP_SECRET,
     providers,
   }


### PR DESCRIPTION
This PR addresses several issues found during the overnight audit of `apps/api/` and `apps/web/`:

### API Fixes
- **Health Discovery**: Added `basePath` and `lastHeartbeatAt` to the `/health` endpoint and updated the service name to `canonry` as per `CLAUDE.md`.
- **Config**: Added `CANONRY_BASE_PATH` to the environment schema and `PlatformEnv` to support configurable route prefixes.
- **Route Prefixing**: Updated `apps/api/src/app.ts` to correctly pass the `routePrefix` to `apiRoutes` based on the environment configuration.

### Web Fixes
- **Health Check**: Fixed `fetchHealthCheck` in `apps/web/src/api.ts` to use the configured `basePath` instead of hardcoding the root path.
- **Component Organization**: Moved `SearchConsoleSummaryCard` and `BingSummaryMetric` from `ProjectPage.tsx` to `components/project/` to resolve the "new components used in only one place" violation.

### General
- Updated tests in `apps/api/test/app.test.ts` to reflect the changes in the health response and environment loading.
- Verified all fixes with `pnpm typecheck`, `pnpm lint`, and `pnpm test`.