### PR TITLE
fix: correct tooltip positioning and chart date parsing

### DIFF
--- a/apps/web/src/components/project/TrafficSection.tsx
+++ b/apps/web/src/components/project/TrafficSection.tsx
@@ -492,7 +492,7 @@ export function TrafficSection({ projectName }: { projectName: string }) {
                 ) : (
                   <div className="space-y-3">
                     <div className="grid gap-3 sm:grid-cols-3">
-                      <AttributionStat label="AI Sessions" value="0" hint="no AI referrals detected" tone="neutral" tooltip="Total sessions attributed to AI referral sources detected via GA4 sessionSource and firstUserSource dimensions." />
+                      <AttributionStat label="AI Sessions" value="0" hint="0 sessions" tone="neutral" tooltip="Total sessions attributed to AI referral sources detected via GA4 sessionSource and firstUserSource dimensions." />
                       <AttributionStat label="Share of Traffic" value="0%" hint="of total sessions" tone="neutral" tooltip="Percentage of your total site sessions that originated from AI answer engines." />
                       <AttributionStat label="Tracked Sources" value="0" hint="sources monitored: 7" tone="neutral" tooltip="Number of distinct AI referral sources detected. Monitoring: ChatGPT, Claude, Gemini, Perplexity, OpenAI, Anthropic, and Copilot." />
                     </div>
@@ -803,7 +803,7 @@ function AttributionStat({
   tooltip?: string
 }) {
   return (
-    <div className="rounded-lg border border-zinc-800/60 bg-zinc-950/40 px-4 py-3">
+    <div className="rounded-lg border border-zinc-800/60 bg-zinc-950/40 px-4 py-3 flex flex-col">
       <p className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 mb-1 flex items-center gap-1">
         {label}
         {tooltip && <InfoTooltip text={tooltip} />}

--- a/apps/web/src/components/shared/ChartPrimitives.tsx
+++ b/apps/web/src/components/shared/ChartPrimitives.tsx
@@ -70,15 +70,23 @@ export const CHART_SERIES_COLORS = [
   '#f87171', // red-400
 ] as const
 
+/** Parse a date string that may be a date-only ("2026-03-15") or full ISO timestamp. */
+function parseChartDate(value: string): Date {
+  const s = String(value)
+  // Date-only strings (no "T") need a time suffix to avoid UTC-midnight timezone shifts
+  if (!s.includes('T')) return new Date(s + 'T00:00:00')
+  return new Date(s)
+}
+
 /** Format a date label for chart tooltips (e.g. "Mar 15, 2026"). */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function formatChartDateLabel(value: any): string {
-  const d = new Date(String(value) + 'T00:00:00')
+  const d = parseChartDate(String(value))
   return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
 }
 
 /** Format a date tick for chart axes (e.g. "3/15"). */
 export function formatChartDateTick(value: string): string {
-  const d = new Date(value + 'T00:00:00')
+  const d = parseChartDate(value)
   return `${d.getMonth() + 1}/${d.getDate()}`
 }

--- a/apps/web/src/components/shared/InfoTooltip.tsx
+++ b/apps/web/src/components/shared/InfoTooltip.tsx
@@ -14,8 +14,8 @@ export function InfoTooltip({ text }: { text: string }) {
     if (!iconRef.current) return
     const rect = iconRef.current.getBoundingClientRect()
     setPos({
-      top: rect.top + window.scrollY,
-      left: rect.left + rect.width / 2 + window.scrollX,
+      top: rect.top,
+      left: rect.left + rect.width / 2,
     })
   }, [])
 
@@ -30,8 +30,26 @@ export function InfoTooltip({ text }: { text: string }) {
       {pos !== null && createPortal(
         <span
           role="tooltip"
-          className="info-tooltip-bubble info-tooltip-bubble--fixed"
-          style={{ top: pos.top, left: pos.left }}
+          style={{
+            position: 'fixed',
+            top: pos.top,
+            left: pos.left,
+            transform: 'translateX(-50%) translateY(calc(-100% - 8px))',
+            zIndex: 9999,
+            pointerEvents: 'none',
+            width: '14rem',
+            padding: '0.5rem 0.75rem',
+            fontSize: '11px',
+            fontWeight: 400,
+            textTransform: 'none',
+            letterSpacing: 'normal',
+            lineHeight: '1rem',
+            color: '#d4d4d8',
+            backgroundColor: '#18181b',
+            border: '1px solid rgba(63, 63, 70, 0.6)',
+            borderRadius: '0.5rem',
+            boxShadow: '0 10px 15px -3px rgba(0,0,0,.1), 0 4px 6px -4px rgba(0,0,0,.1)',
+          }}
         >
           {text}
         </span>,

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1088,17 +1088,7 @@
     @apply pointer-events-auto opacity-100;
   }
 
-  /* Portal-rendered tooltip — escapes overflow:hidden/auto containers */
-  .info-tooltip-bubble--fixed {
-    position: fixed;
-    transform: translateX(-50%) translateY(calc(-100% - 8px));
-    opacity: 1;
-    pointer-events: none;
-    z-index: 9999;
-    /* override absolute positioning from base class */
-    bottom: auto;
-    left: auto;
-  }
+  /* Portal-rendered tooltip uses inline styles — see InfoTooltip.tsx */
 
   /* ── Data table (generic) ── */
 


### PR DESCRIPTION
## Summary

- Fix `InfoTooltip` scroll-offset bug: use viewport-relative `getBoundingClientRect()` coords with `position: fixed` instead of adding `window.scrollY`/`window.scrollX`; move all bubble styles inline, removing the now-redundant `.info-tooltip-bubble--fixed` CSS class.
- Fix chart date double-append bug in `ChartPrimitives.tsx` by introducing a `parseChartDate()` helper that correctly handles both date-only strings (`"2026-03-15"`) and full ISO timestamps without producing malformed dates.
- Minor `TrafficSection` tweaks: normalize "AI Sessions" empty-state hint text to `"0 sessions"` and add `flex flex-col` to `AttributionStat` container for correct vertical layout.

## Test plan

- [ ] Verify tooltips appear correctly positioned when page is scrolled
- [ ] Verify tooltips render correctly inside `overflow: hidden` containers
- [ ] Verify chart axes and tooltips display correct dates for both date-only and ISO timestamp data

🤖 Generated with [Claude Code](https://claude.com/claude-code)