### PR TITLE
chore(core-cli): fix JSON.parse violations, atomic usage counter upsert, and competitor add-count bug

### DIFF
--- a/packages/canonry/src/commands/competitor.ts
+++ b/packages/canonry/src/commands/competitor.ts
@@ -23,7 +23,11 @@ export async function addCompetitors(project: string, domains: string[], format?
     return
   }
 
-  console.log(`Added ${domains.length} competitor(s) to "${project}".`)
+  if (addedDomains.length === 0) {
+    console.log(`No new competitors added to "${project}" (all already tracked).`)
+  } else {
+    console.log(`Added ${addedDomains.length} competitor(s) to "${project}".`)
+  }
 }
 
 export async function listCompetitors(project: string, format?: string): Promise<void> {

--- a/packages/canonry/src/job-runner.ts
+++ b/packages/canonry/src/job-runner.ts
@@ -2,9 +2,9 @@ import crypto from 'node:crypto'
 import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
-import { and, eq, inArray } from 'drizzle-orm'
+import { and, eq, inArray, sql } from 'drizzle-orm'
 import type { DatabaseClient } from '@ainyc/canonry-db'
-import { runs, keywords, competitors, projects, querySnapshots, usageCounters } from '@ainyc/canonry-db'
+import { runs, keywords, competitors, projects, querySnapshots, usageCounters, parseJsonColumn } from '@ainyc/canonry-db'
 import type { ProviderName, NormalizedQueryResult, LocationContext } from '@ainyc/canonry-contracts'
 import { brandKeyFromText, determineAnswerMentioned, effectiveDomains, normalizeProjectDomain, isBrowserProvider } from '@ainyc/canonry-contracts'
 import type { ProviderRegistry, RegisteredProvider } from './provider-registry.js'
@@ -182,14 +182,14 @@ export class JobRunner {
       } else if (locationOverride) {
         runLocation = locationOverride
       } else {
-        const projectLocations = JSON.parse(project.locations || '[]') as LocationContext[]
+        const projectLocations = parseJsonColumn<LocationContext[]>(project.locations, [])
         if (project.defaultLocation && projectLocations.length > 0) {
           runLocation = projectLocations.find(l => l.label === project.defaultLocation)
         }
       }
 
       // Resolve which providers to use — honour per-run override, then project config
-      const projectProviders = providerOverride ?? (JSON.parse(project.providers || '[]') as ProviderName[])
+      const projectProviders = providerOverride ?? parseJsonColumn<ProviderName[]>(project.providers, [])
       activeProviders = this.registry.getForProject(projectProviders)
 
       if (activeProviders.length === 0) {
@@ -215,7 +215,7 @@ export class JobRunner {
       const competitorDomains = projectCompetitors.map(c => c.domain)
       const allDomains = effectiveDomains({
         canonicalDomain: project.canonicalDomain,
-        ownedDomains: JSON.parse(project.ownedDomains || '[]') as string[],
+        ownedDomains: parseJsonColumn<string[]>(project.ownedDomains, []),
       })
       const executionContext: RunExecutionContext = {
         providerCount: activeProviders.length,
@@ -495,33 +495,20 @@ export class JobRunner {
   }
 
   private incrementUsage(scope: string, metric: string, count: number): void {
-    const now = new Date()
-    const period = now.toISOString().slice(0, 10)
-    const id = crypto.randomUUID()
+    const now = new Date().toISOString()
+    const period = now.slice(0, 10)
 
-    const existing = this.db
-      .select()
-      .from(usageCounters)
-      .where(eq(usageCounters.scope, scope))
-      .all()
-      .find(r => r.period === period && r.metric === metric)
-
-    if (existing) {
-      this.db
-        .update(usageCounters)
-        .set({ count: existing.count + count, updatedAt: now.toISOString() })
-        .where(eq(usageCounters.id, existing.id))
-        .run()
-    } else {
-      this.db.insert(usageCounters).values({
-        id,
-        scope,
-        period,
-        metric,
-        count,
-        updatedAt: now.toISOString(),
-      }).run()
-    }
+    this.db.insert(usageCounters).values({
+      id: crypto.randomUUID(),
+      scope,
+      period,
+      metric,
+      count,
+      updatedAt: now,
+    }).onConflictDoUpdate({
+      target: [usageCounters.scope, usageCounters.period, usageCounters.metric],
+      set: { count: sql`${usageCounters.count} + ${count}`, updatedAt: now },
+    }).run()
   }
 
   private flushProviderUsage(projectId: string, providerDispatchCounts: ReadonlyMap<ProviderName, number>): void {

--- a/packages/canonry/src/scheduler.ts
+++ b/packages/canonry/src/scheduler.ts
@@ -2,7 +2,7 @@ import cron from 'node-cron'
 import { eq } from 'drizzle-orm'
 import { queueRunIfProjectIdle } from '@ainyc/canonry-api-routes'
 import type { DatabaseClient } from '@ainyc/canonry-db'
-import { schedules, projects } from '@ainyc/canonry-db'
+import { schedules, projects, parseJsonColumn } from '@ainyc/canonry-db'
 import type { ProviderName } from '@ainyc/canonry-contracts'
 import { createLogger } from './logger.js'
 
@@ -160,7 +160,7 @@ export class Scheduler {
       }).where(eq(schedules.id, currentSchedule.id)).run()
 
       // Resolve providers
-      const scheduleProviders = JSON.parse(currentSchedule.providers) as string[]
+      const scheduleProviders = parseJsonColumn<string[]>(currentSchedule.providers, [])
       const providers = scheduleProviders.length > 0 ? scheduleProviders as ProviderName[] : undefined
 
       log.info('run.triggered', { runId, projectName: project.name, providers: providers ?? 'all' })


### PR DESCRIPTION
## Summary

Audit of `packages/canonry/src/` found three substantive issues. All fixed; typecheck, lint, and all 772 tests pass.

---

### 1. Raw `JSON.parse` on DB columns — `job-runner.ts` & `scheduler.ts`

**Files:** `src/job-runner.ts`, `src/scheduler.ts`

**Issue (CLAUDE.md violation):** Three `JSON.parse(col || '[]')` calls in `job-runner.ts` and one in `scheduler.ts` were reading SQLite JSON columns directly, bypassing the shared `parseJsonColumn` helper exported by `@ainyc/canonry-db`. This is explicitly called out in CLAUDE.md: _"Always use parseJsonColumn from @ainyc/canonry-db when reading JSON columns"_.

**Fix:** Replaced all four raw `JSON.parse` calls with `parseJsonColumn<T>(value, fallback)`. Added `parseJsonColumn` to the import lists in both files.

---

### 2. Non-atomic read-then-write in `incrementUsage` — `job-runner.ts`

**File:** `src/job-runner.ts`

**Issue:** `incrementUsage` performed a `SELECT` followed by either an `UPDATE` or `INSERT` in two separate statements. Under concurrent run execution this creates a TOCTOU race: two concurrent job completions for the same scope/metric/period could both see `existing = undefined`, both attempt an INSERT, and one would fail with a unique-constraint error (or silently lose a count).

**Fix:** Replaced the read-then-write with a single `INSERT ... onConflictDoUpdate` using a SQL expression to atomically increment the counter. Added the missing `sql` helper to the drizzle-orm import.

---

### 3. Wrong count in `addCompetitors` success message — `competitor.ts`

**File:** `src/commands/competitor.ts`

**Issue (logic bug):** `addCompetitors` computed `addedDomains` (the domains not already tracked) but then printed `Added ${domains.length} competitor(s)` — always the length of the _input_ array, not the number actually added. If all supplied domains were already tracked, the output would say "Added 3 competitor(s)" even though nothing changed. The JSON output path was already correct (`addedCount: addedDomains.length`); only the human-readable path was wrong.

**Fix:** Changed the text output to use `addedDomains.length`, and added an explicit "no new competitors added" message when all inputs were already present.

---

### Checks

`pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm test` ✅ (772 tests, 80 suites)
