### PR TITLE
chore(providers): fix model validation, Vertex AI config guard, CDP connection pool, and OpenAI response safety

### DIFF
--- a/packages/provider-cdp/src/adapter.ts
+++ b/packages/provider-cdp/src/adapter.ts
@@ -14,8 +14,10 @@ import { captureElementScreenshot } from './screenshot.js'
 import { normalizeResult as cdpNormalizeResult } from './normalize.js'
 import { CDPProviderError } from './targets/types.js'
 
-// Shared connection manager singleton (one Chrome instance, multiple targets)
-let sharedConnection: CDPConnectionManager | null = null
+// Connection pool keyed by "host:port" — one manager per distinct CDP endpoint.
+// Using a map (instead of a single shared singleton) prevents concurrent calls
+// targeting different endpoints from silently destroying each other's connection.
+const connectionPool = new Map<string, CDPConnectionManager>()
 
 function getConnection(config: ProviderConfig): CDPConnectionManager {
   if (!config.cdpEndpoint) {
@@ -30,14 +32,13 @@ function getConnection(config: ProviderConfig): CDPConnectionManager {
   if (parts.length >= 1 && parts[0]) host = parts[0]
   if (parts.length >= 2 && parts[1]) port = parseInt(parts[1], 10) || 9222
 
-  // Reuse or create connection; disconnect the old one if the endpoint changed
-  if (!sharedConnection || sharedConnection.endpoint !== `${host}:${port}`) {
-    if (sharedConnection) {
-      sharedConnection.disconnect().catch(() => { /* ignore cleanup errors */ })
-    }
-    sharedConnection = new CDPConnectionManager(host, port)
+  const key = `${host}:${port}`
+  let conn = connectionPool.get(key)
+  if (!conn) {
+    conn = new CDPConnectionManager(host, port)
+    connectionPool.set(key, conn)
   }
-  return sharedConnection
+  return conn
 }
 
 function getScreenshotDir(): string {

--- a/packages/provider-claude/src/normalize.ts
+++ b/packages/provider-claude/src/normalize.ts
@@ -10,16 +10,38 @@ import type {
 } from './types.js'
 
 const DEFAULT_MODEL = 'claude-sonnet-4-6'
+const VALIDATION_PATTERN = /^claude-/
+
+/**
+ * Resolve the effective model name, validating that it is a recognised Claude
+ * model identifier (must start with "claude-"). If an invalid name is stored
+ * the default is used and a warning is logged.
+ */
+function resolveModel(config: ClaudeConfig): string {
+  const m = config.model
+  if (!m) return DEFAULT_MODEL
+  if (VALIDATION_PATTERN.test(m)) return m
+  console.warn(
+    `[provider-claude] Invalid model name "${m}" — this provider uses the Anthropic API ` +
+    `which only accepts "claude-*" model names. ` +
+    `Falling back to ${DEFAULT_MODEL}.`,
+  )
+  return DEFAULT_MODEL
+}
 
 export function validateConfig(config: ClaudeConfig): ClaudeHealthcheckResult {
   if (!config.apiKey || config.apiKey.length === 0) {
     return { ok: false, provider: 'claude', message: 'missing api key' }
   }
+  const model = resolveModel(config)
+  const warning = config.model && !VALIDATION_PATTERN.test(config.model)
+    ? ` (invalid model "${config.model}" replaced with default)`
+    : ''
   return {
     ok: true,
     provider: 'claude',
-    message: 'config valid',
-    model: config.model ?? DEFAULT_MODEL,
+    message: `config valid${warning}`,
+    model,
   }
 }
 
@@ -28,9 +50,10 @@ export async function healthcheck(config: ClaudeConfig): Promise<ClaudeHealthche
   if (!validation.ok) return validation
 
   try {
+    const model = resolveModel(config)
     const client = new Anthropic({ apiKey: config.apiKey })
     const response = await client.messages.create({
-      model: config.model ?? DEFAULT_MODEL,
+      model,
       max_tokens: 32,
       messages: [{ role: 'user', content: 'Say "ok"' }],
     })
@@ -39,20 +62,20 @@ export async function healthcheck(config: ClaudeConfig): Promise<ClaudeHealthche
       ok: text.length > 0,
       provider: 'claude',
       message: text.length > 0 ? 'claude api key verified' : 'empty response from claude',
-      model: config.model ?? DEFAULT_MODEL,
+      model,
     }
   } catch (err: unknown) {
     return {
       ok: false,
       provider: 'claude',
       message: err instanceof Error ? err.message : String(err),
-      model: config.model ?? DEFAULT_MODEL,
+      model: resolveModel(config),
     }
   }
 }
 
 export async function executeTrackedQuery(input: ClaudeTrackedQueryInput): Promise<ClaudeRawResult> {
-  const model = input.config.model ?? DEFAULT_MODEL
+  const model = resolveModel(input.config)
   const client = new Anthropic({ apiKey: input.config.apiKey })
 
   const webSearchTool: Record<string, unknown> = {
@@ -199,7 +222,7 @@ function extractDomainFromUri(uri: string): string | null {
 }
 
 export async function generateText(prompt: string, config: ClaudeConfig): Promise<string> {
-  const model = config.model ?? DEFAULT_MODEL
+  const model = resolveModel(config)
   const client = new Anthropic({ apiKey: config.apiKey })
   const response = await client.messages.create({
     model,

--- a/packages/provider-claude/test/index.test.ts
+++ b/packages/provider-claude/test/index.test.ts
@@ -31,6 +31,13 @@ test('validateConfig uses custom model when specified', () => {
   expect(result.model).toBe('claude-haiku-4-5-20251001')
 })
 
+test('validateConfig falls back to default model for non-claude model name', () => {
+  const result = validateConfig({ ...validConfig, model: 'gpt-5.4' })
+  expect(result.ok).toBe(true)
+  expect(result.model).toBe('claude-sonnet-4-6')
+  expect(result.message).toMatch(/invalid model/)
+})
+
 test('normalizeResult extracts answer text from content blocks', () => {
   const raw: ClaudeRawResult = {
     provider: 'claude',

--- a/packages/provider-gemini/src/adapter.ts
+++ b/packages/provider-gemini/src/adapter.ts
@@ -37,6 +37,7 @@ export const geminiAdapter: ProviderAdapter = {
     validationHint: 'model name must start with "gemini-" (e.g. gemini-3-flash)',
     knownModels: [
       { id: 'gemini-3.1-pro-preview', displayName: 'Gemini 3.1 Pro (Preview)', tier: 'flagship' },
+      { id: 'gemini-3-flash', displayName: 'Gemini 3 Flash', tier: 'standard' },
       { id: 'gemini-3-flash-preview', displayName: 'Gemini 3 Flash (Preview)', tier: 'standard' },
       { id: 'gemini-3.1-flash-lite-preview', displayName: 'Gemini 3.1 Flash-Lite (Preview)', tier: 'economy' },
       { id: 'gemini-2.5-flash', displayName: 'Gemini 2.5 Flash', tier: 'standard' },

--- a/packages/provider-gemini/src/normalize.ts
+++ b/packages/provider-gemini/src/normalize.ts
@@ -55,6 +55,13 @@ function createClient(config: GeminiConfig): GoogleGenAI {
 }
 
 export function validateConfig(config: GeminiConfig): GeminiHealthcheckResult {
+  // Check for explicitly provided (but empty) Vertex project — user intended Vertex AI
+  // but forgot to fill in the project ID. 'vertexProject' in config distinguishes
+  // "key present but empty" from "key absent" (fallback to API key auth).
+  if ('vertexProject' in config && config.vertexProject !== undefined && config.vertexProject.trim().length === 0) {
+    return { ok: false, provider: 'gemini', message: 'missing Vertex AI project ID' }
+  }
+
   if (isVertexConfig(config)) {
     const model = resolveModel(config)
     return {

--- a/packages/provider-gemini/test/index.test.ts
+++ b/packages/provider-gemini/test/index.test.ts
@@ -31,6 +31,16 @@ test('validateConfig uses custom model when specified', () => {
   expect(result.model).toBe('gemini-1.5-pro')
 })
 
+test('validateConfig rejects Vertex AI config with empty project ID', () => {
+  const result = validateConfig({
+    apiKey: '',
+    quotaPolicy: validConfig.quotaPolicy,
+    vertexProject: '',
+  })
+  expect(result.ok).toBe(false)
+  expect(result.message).toMatch(/missing Vertex AI project ID/i)
+})
+
 test('validateConfig accepts Vertex AI config without API key', () => {
   const result = validateConfig({
     apiKey: '',

--- a/packages/provider-openai/src/normalize.ts
+++ b/packages/provider-openai/src/normalize.ts
@@ -122,13 +122,15 @@ function extractResponseText(response: OpenAI.Responses.Response): string {
 
 function extractGroundingSources(response: OpenAI.Responses.Response): GroundingSource[] {
   const sources: GroundingSource[] = []
+  const seen = new Set<string>()
   try {
     for (const item of response.output) {
       if (item.type === 'message') {
         for (const content of item.content) {
           if (content.type === 'output_text' && content.annotations) {
             for (const annotation of content.annotations) {
-              if (annotation.type === 'url_citation') {
+              if (annotation.type === 'url_citation' && !seen.has(annotation.url)) {
+                seen.add(annotation.url)
                 sources.push({
                   uri: annotation.url,
                   title: annotation.title ?? '',
@@ -152,7 +154,10 @@ function extractSearchQueries(response: OpenAI.Responses.Response): string[] {
   try {
     for (const item of response.output) {
       if (item.type === 'web_search_call' && 'query' in item) {
-        queries.push((item as unknown as { query: string }).query)
+        const query = (item as unknown as { query?: unknown }).query
+        if (typeof query === 'string' && query.length > 0) {
+          queries.push(query)
+        }
       }
     }
   } catch {


### PR DESCRIPTION
## Summary

Overnight audit of all six provider packages (cdp, claude, gemini, local, openai, perplexity). Five substantive bugs fixed.

---

## Issues Found and Fixed

### 1. `provider-gemini` — Vertex AI empty project ID not rejected
**File:** `packages/provider-gemini/src/normalize.ts`

`isVertexConfig()` returns `false` when `vertexProject` is an empty string (because `!!''` is `false`), so passing `{ apiKey: '', vertexProject: '' }` would fall through to the API-key check and return a confusing `'missing api key'` error instead of the correct `'missing Vertex AI project ID'`. Added an explicit pre-check that catches `vertexProject` present but empty before the `isVertexConfig` branch.

**Test added:** `validateConfig rejects Vertex AI config with empty project ID`

---

### 2. `provider-gemini` — Default model `gemini-3-flash` missing from `knownModels`
**File:** `packages/provider-gemini/src/adapter.ts`

`DEFAULT_MODEL = 'gemini-3-flash'` was used as the fallback model, but the adapter's `knownModels` array did not include this model ID. This caused the default to be unreachable via the standard model registry (e.g. in the UI model picker). Added `gemini-3-flash` as a `standard` tier entry.

---

### 3. `provider-claude` — No model name validation (inconsistent with Gemini)
**File:** `packages/provider-claude/src/normalize.ts`

The Gemini adapter validates model names against a `/^gemini-/` pattern and falls back to the default with a console warning. Claude had no equivalent check — passing `model: 'gpt-5.4'` would validate as `ok: true`, then fail at the Anthropic API with an opaque SDK error. Added a `resolveModel()` helper (pattern `/^claude-/`) that mirrors the Gemini pattern. All internal uses of `config.model ?? DEFAULT_MODEL` replaced with `resolveModel(config)` to keep the effective model consistent across `validateConfig`, `healthcheck`, `executeTrackedQuery`, and `generateText`.

**Test added:** `validateConfig falls back to default model for non-claude model name`

---

### 4. `provider-openai` — `extractSearchQueries` unsafe cast could push `undefined`
**File:** `packages/provider-openai/src/normalize.ts`

The extraction cast `(item as unknown as { query: string }).query` assumed the field always exists and is a string. If a `web_search_call` output item lacks the `query` field (possible in future API versions or with mocked data), `undefined` would be pushed into the `searchQueries` array, corrupting downstream consumers that iterate and use string methods. Changed cast to `{ query?: unknown }` with a `typeof query === 'string'` guard.

---

### 5. `provider-openai` — `extractGroundingSources` no URL-level deduplication
**File:** `packages/provider-openai/src/normalize.ts`

When the OpenAI Responses API returns multiple `output_text` content blocks, the same URL citation can appear in the annotations of each block. This caused duplicate `GroundingSource` entries for the same URL, inflating citation counts. Added a `Set<string>` seen-URL guard so each URL is only emitted once.

---

### 6. `provider-cdp` — Module-level singleton connection broken by endpoint changes
**File:** `packages/provider-cdp/src/adapter.ts`

A single `let sharedConnection` module-level variable held the CDP connection. If two concurrent calls targeted different endpoints (different `config.cdpEndpoint` values, e.g. dev vs prod browser), the second call would disconnect the first's active connection via a fire-and-forget `void sharedConnection.disconnect()`, leaving the first call with a dead socket. Replaced the singleton with a `Map<string, CDPConnectionManager>` keyed by `host:port`, so each distinct endpoint maintains its own persistent connection independently.

---

## Test Results
`pnpm typecheck && pnpm lint && pnpm test` — **774/774 tests passing**, 0 lint errors, 0 type errors.