### PR TITLE
fix(web): catch unhandled promise rejection in ProjectPage export handler

### DIFF
--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -1137,18 +1137,25 @@ export function ProjectPage({
   }
 
   async function handleExport() {
-    const data = await fetchExport(projectName)
-    const yaml = typeof data === 'string' ? data : JSON.stringify(data, null, 2)
-    const blob = new Blob([yaml], { type: 'text/yaml' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `${projectName}.yaml`
-    a.click()
-    // Blob URL is revoked asynchronously — a.click() returns void with no
-    // completion signal, so revoking synchronously can break the download.
-    // The blob is small and will be GC'd when the page unloads.
-
+    try {
+      const data = await fetchExport(projectName)
+      const yaml = typeof data === 'string' ? data : JSON.stringify(data, null, 2)
+      const blob = new Blob([yaml], { type: 'text/yaml' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `${projectName}.yaml`
+      a.click()
+      // Blob URL is revoked asynchronously — a.click() returns void with no
+      // completion signal, so revoking synchronously can break the download.
+      // The blob is small and will be GC'd when the page unloads.
+    } catch (err) {
+      addToast({
+        title: 'Export failed',
+        detail: err instanceof Error ? err.message : 'Could not export project YAML.',
+        tone: 'negative',
+      })
+    }
   }
 
   async function handleAddKeywords() {


### PR DESCRIPTION
## Summary

Overnight audit of `apps/api/` and `apps/web/` against the CLAUDE.md checklist and general security/reliability criteria.

---

## Issues Found & Fixed

### Web Frontend (`apps/web/`)

**Unhandled promise rejection in `handleExport` — `ProjectPage.tsx`**

`handleExport` is an `async` function used directly as a React `onClick` handler (`onClick={handleExport}`). If `fetchExport` rejects (e.g. network error or non-2xx API response), the resulting rejection was unhandled — no `try/catch`, no `.catch()`. This silently swallows the error and leaves the user with no feedback.

**Fix:** Wrapped the body of `handleExport` in a `try/catch` block that surfaces a toast notification on failure, consistent with how other mutation failures are reported across the page.

---

## Issues Reviewed But Not Changed

The following were checked and found to be already compliant or out of scope:

- **No hardcoded `/api/v1`** in web fetch calls — all API calls go through `apiFetch()` in `api.ts`, which correctly reads from `window.__CANONRY_CONFIG__.basePath`.
- **No hardcoded route prefixes** in `apps/api/` — `app.ts` correctly derives `routePrefix` from `env.basePath`.
- **No cross-app imports** — `apps/web` and `apps/api` do not import from each other.
- **No `dangerouslySetInnerHTML` / XSS vectors** — `highlight.ts` uses `React.createElement` to insert `<mark>` elements, not raw HTML.
- **No card grids for evidence/findings/competitors** — `EvidenceTable.tsx` and `CompetitorTable.tsx` use `<table>` elements.
- **No decorative background gradients or glow effects** added.
- **Error boundary present** — `ErrorBoundary.tsx` wraps the app root in `main.tsx`.
- **All other async handlers** (`handleDeleteProject`, `handleAddKeywords`, `handleAddCompetitor`, `handleAddOwnedDomain`, `handleRemoveOwnedDomain`, `handleTriggerRun`) have proper `try/catch` or delegate to mutation hooks that handle errors.
- **All web API calls go through `api.ts`** — no route methods or paths added or changed.
- **React Query stale data** — `useAddCompetitors` correctly calls `cancelQueries` before optimistic mutations; `refetchInterval` in `useRunDetail` and `useDashboard` is gated on active run status.

---

## Test Results

`pnpm typecheck && pnpm lint && pnpm test` — **80/80 test files, 772/772 tests passing**.