### PR TITLE
fix(web): clarify AI attribution chart shows baseline sessions

### DIFF
--- a/apps/web/src/components/project/TrafficSection.tsx
+++ b/apps/web/src/components/project/TrafficSection.tsx
@@ -378,8 +378,11 @@ export function TrafficSection({ projectName }: { projectName: string }) {
                   <div>
                     <p className="eyebrow eyebrow-soft">Trend</p>
                     <h3 className="text-sm font-semibold text-zinc-100">
-                      {chartSources.length > 0 ? 'AI vs. total sessions' : 'Total sessions over time'}
+                      {chartSources.length > 0 ? 'AI vs. total sessions' : 'All sessions (baseline)'}
                     </h3>
+                    {chartSources.length === 0 && (
+                      <p className="text-xs text-zinc-500 mt-0.5">AI referral sessions will be overlaid here once detected</p>
+                    )}
                   </div>
                   {chartSources.length === 0 && (
                     <p className="text-xs text-zinc-500">No AI referrals detected yet</p>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "1.37.0",
+  "version": "1.37.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Summary
- Renamed chart title from "Total sessions over time" to "All sessions (baseline)" when no AI referrals are detected
- Added subtitle: "AI referral sessions will be overlaid here once detected" to set expectations
- Fixes confusion where users assumed the total sessions chart represented AI sessions since it sits under the "AI Attribution" header

## Test plan
- [ ] Open a project with GA4 connected but no AI referrals — verify chart says "All sessions (baseline)" with the explanatory subtitle
- [ ] Open a project with AI referrals detected — verify chart still says "AI vs. total sessions" with no subtitle

🤖 Generated with [Claude Code](https://claude.com/claude-code)