### PR TITLE
chore(core-cli): fix latest-run index bug, remove redundant casts, add graceful shutdown, expose --format json on status/evidence/history

### DIFF
--- a/packages/canonry/src/cli-commands/operator.ts
+++ b/packages/canonry/src/cli-commands/operator.ts
@@ -11,25 +11,25 @@ import { usageError } from '../cli-error.js'
 export const OPERATOR_CLI_COMMANDS: readonly CliCommandSpec[] = [
   {
     path: ['status'],
-    usage: 'canonry status <project>',
+    usage: 'canonry status <project> [--format json]',
     run: async (input) => {
-      const project = requireProject(input, 'status', 'canonry status <project>')
+      const project = requireProject(input, 'status', 'canonry status <project> [--format json]')
       await showStatus(project, input.format)
     },
   },
   {
     path: ['evidence'],
-    usage: 'canonry evidence <project>',
+    usage: 'canonry evidence <project> [--format json]',
     run: async (input) => {
-      const project = requireProject(input, 'evidence', 'canonry evidence <project>')
+      const project = requireProject(input, 'evidence', 'canonry evidence <project> [--format json]')
       await showEvidence(project, input.format)
     },
   },
   {
     path: ['history'],
-    usage: 'canonry history <project>',
+    usage: 'canonry history <project> [--format json]',
     run: async (input) => {
-      const project = requireProject(input, 'history', 'canonry history <project>')
+      const project = requireProject(input, 'history', 'canonry history <project> [--format json]')
       await showHistory(project, input.format)
     },
   },

--- a/packages/canonry/src/cli.ts
+++ b/packages/canonry/src/cli.ts
@@ -42,10 +42,10 @@ Usage:
   canonry run --all                   Trigger runs for all projects
   canonry run show <id>               Show run details and snapshots
   canonry runs <project>              List runs for a project (--limit <n>)
-  canonry status <project>            Show project summary
-  canonry evidence <project>          Show per-phrase results
+  canonry status <project>            Show project summary [--format json]
+  canonry evidence <project>          Show per-phrase results [--format json]
   canonry analytics <project>         Show analytics (--feature metrics|gaps|sources, --window 7d|30d|90d|all)
-  canonry history <project>           Show audit trail
+  canonry history <project>           Show audit trail [--format json]
   canonry export <project>            Export project as YAML
   canonry apply <file...>              Apply declarative config (multi-doc YAML supported)
   canonry schedule set <project>      Set schedule (--preset or --cron)

--- a/packages/canonry/src/commands/project.ts
+++ b/packages/canonry/src/commands/project.ts
@@ -1,3 +1,4 @@
+import type { ProjectDto } from '@ainyc/canonry-contracts'
 import { effectiveDomains } from '@ainyc/canonry-contracts'
 import { createApiClient } from '../client.js'
 
@@ -10,13 +11,13 @@ export async function createProject(
   opts: { domain: string; ownedDomains?: string[]; country: string; language: string; displayName: string; format?: string },
 ): Promise<void> {
   const client = getClient()
-  const result = await client.putProject(name, {
+  const result: ProjectDto = await client.putProject(name, {
     displayName: opts.displayName,
     canonicalDomain: opts.domain,
     ownedDomains: opts.ownedDomains ?? [],
     country: opts.country,
     language: opts.language,
-  }) as { id: string; name: string; canonicalDomain: string; country: string; language: string }
+  })
 
   if (opts.format === 'json') {
     console.log(JSON.stringify(result, null, 2))
@@ -28,13 +29,7 @@ export async function createProject(
 
 export async function listProjects(format?: string): Promise<void> {
   const client = getClient()
-  const projects = await client.listProjects() as Array<{
-    name: string
-    canonicalDomain: string
-    ownedDomains?: string[]
-    country: string
-    language: string
-  }>
+  const projects: ProjectDto[] = await client.listProjects()
 
   if (format === 'json') {
     console.log(JSON.stringify(projects, null, 2))
@@ -68,28 +63,14 @@ export async function listProjects(format?: string): Promise<void> {
 
 export async function showProject(name: string, format?: string): Promise<void> {
   const client = getClient()
-  const project = await client.getProject(name) as {
-    id: string
-    name: string
-    displayName: string
-    canonicalDomain: string
-    ownedDomains?: string[]
-    country: string
-    language: string
-    tags: string[]
-    labels: Record<string, string>
-    configSource: string
-    configRevision: number
-    createdAt: string
-    updatedAt: string
-  }
+  const project: ProjectDto = await client.getProject(name)
 
   if (format === 'json') {
     console.log(JSON.stringify(project, null, 2))
     return
   }
 
-  console.log(`Project: ${project.displayName}\n`)
+  console.log(`Project: ${project.displayName ?? project.name}\n`)
   console.log(`  Name:             ${project.name}`)
   console.log(`  ID:               ${project.id}`)
   console.log(`  Domain:           ${project.canonicalDomain}`)
@@ -104,8 +85,8 @@ export async function showProject(name: string, format?: string): Promise<void> 
   console.log(`  Tags:             ${project.tags.length > 0 ? project.tags.join(', ') : '(none)'}`)
   const labelEntries = Object.entries(project.labels)
   console.log(`  Labels:           ${labelEntries.length > 0 ? labelEntries.map(([k, v]) => `${k}=${v}`).join(', ') : '(none)'}`)
-  console.log(`  Created:          ${project.createdAt}`)
-  console.log(`  Updated:          ${project.updatedAt}`)
+  if (project.createdAt) console.log(`  Created:          ${project.createdAt}`)
+  if (project.updatedAt) console.log(`  Updated:          ${project.updatedAt}`)
 }
 
 export async function updateProjectSettings(
@@ -122,13 +103,7 @@ export async function updateProjectSettings(
   },
 ): Promise<void> {
   const client = getClient()
-  const project = await client.getProject(name) as {
-    displayName: string
-    canonicalDomain: string
-    ownedDomains?: string[]
-    country: string
-    language: string
-  }
+  const project: ProjectDto = await client.getProject(name)
 
   let ownedDomains = opts.ownedDomains ?? project.ownedDomains ?? []
   if (opts.addOwnedDomain) {
@@ -140,21 +115,13 @@ export async function updateProjectSettings(
     ownedDomains = ownedDomains.filter(d => !toRemove.has(d))
   }
 
-  const result = await client.putProject(name, {
-    displayName: opts.displayName ?? project.displayName,
+  const result: ProjectDto = await client.putProject(name, {
+    displayName: opts.displayName ?? project.displayName ?? project.name,
     canonicalDomain: opts.domain ?? project.canonicalDomain,
     ownedDomains,
     country: opts.country ?? project.country,
     language: opts.language ?? project.language,
-  }) as {
-    id: string
-    name: string
-    displayName: string
-    canonicalDomain: string
-    ownedDomains?: string[]
-    country: string
-    language: string
-  }
+  })
 
   if (opts.format === 'json') {
     console.log(JSON.stringify(result, null, 2))
@@ -244,7 +211,7 @@ export async function setDefaultLocation(project: string, label: string, format?
   const result = await client.setDefaultLocation(project, label)
 
   if (format === 'json') {
-    console.log(JSON.stringify({ project, ...(result as object) }, null, 2))
+    console.log(JSON.stringify({ project, ...result }, null, 2))
     return
   }
 

--- a/packages/canonry/src/commands/schedule.ts
+++ b/packages/canonry/src/commands/schedule.ts
@@ -1,19 +1,8 @@
+import type { ScheduleDto } from '@ainyc/canonry-contracts'
 import { createApiClient } from '../client.js'
 
 function getClient() {
   return createApiClient()
-}
-
-interface ScheduleResponse {
-  id: string
-  projectId: string
-  cronExpr: string
-  preset: string | null
-  timezone: string
-  enabled: boolean
-  providers: string[]
-  lastRunAt: string | null
-  nextRunAt: string | null
 }
 
 export async function setSchedule(project: string, opts: {
@@ -30,7 +19,7 @@ export async function setSchedule(project: string, opts: {
   if (opts.timezone) body.timezone = opts.timezone
   if (opts.providers?.length) body.providers = opts.providers
 
-  const result = await client.putSchedule(project, body) as ScheduleResponse
+  const result: ScheduleDto = await client.putSchedule(project, body)
   if (opts.format === 'json') {
     console.log(JSON.stringify(result, null, 2))
     return
@@ -41,7 +30,7 @@ export async function setSchedule(project: string, opts: {
 
 export async function showSchedule(project: string, format?: string): Promise<void> {
   const client = getClient()
-  const result = await client.getSchedule(project) as ScheduleResponse
+  const result: ScheduleDto = await client.getSchedule(project)
 
   if (format === 'json') {
     console.log(JSON.stringify(result, null, 2))
@@ -53,13 +42,13 @@ export async function showSchedule(project: string, format?: string): Promise<vo
 
 export async function enableSchedule(project: string, format?: string): Promise<void> {
   const client = getClient()
-  const current = await client.getSchedule(project) as ScheduleResponse
+  const current: ScheduleDto = await client.getSchedule(project)
   const body: Record<string, unknown> = { timezone: current.timezone, enabled: true }
   if (current.preset) body.preset = current.preset
   else body.cron = current.cronExpr
   if (current.providers.length) body.providers = current.providers
 
-  const result = await client.putSchedule(project, body) as ScheduleResponse
+  const result: ScheduleDto = await client.putSchedule(project, body)
   if (format === 'json') {
     console.log(JSON.stringify(result, null, 2))
     return
@@ -69,13 +58,13 @@ export async function enableSchedule(project: string, format?: string): Promise<
 
 export async function disableSchedule(project: string, format?: string): Promise<void> {
   const client = getClient()
-  const current = await client.getSchedule(project) as ScheduleResponse
+  const current: ScheduleDto = await client.getSchedule(project)
   const body: Record<string, unknown> = { timezone: current.timezone, enabled: false }
   if (current.preset) body.preset = current.preset
   else body.cron = current.cronExpr
   if (current.providers.length) body.providers = current.providers
 
-  const result = await client.putSchedule(project, body) as ScheduleResponse
+  const result: ScheduleDto = await client.putSchedule(project, body)
   if (format === 'json') {
     console.log(JSON.stringify(result, null, 2))
     return
@@ -93,7 +82,7 @@ export async function removeSchedule(project: string, format?: string): Promise<
   console.log(`Schedule removed for "${project}"`)
 }
 
-function printSchedule(s: ScheduleResponse): void {
+function printSchedule(s: ScheduleDto): void {
   const label = s.preset ?? s.cronExpr
   console.log(`  Schedule:  ${label}`)
   console.log(`  Cron:      ${s.cronExpr}`)

--- a/packages/canonry/src/commands/serve.ts
+++ b/packages/canonry/src/commands/serve.ts
@@ -17,6 +17,17 @@ export async function serveCommand(format: CliFormat = 'text'): Promise<void> {
   // Create and start server
   const app = await createServer({ config, db })
 
+  // Graceful shutdown on SIGTERM (sent by `canonry stop`) and SIGINT (Ctrl+C)
+  const shutdown = (): void => {
+    app.close().then(() => {
+      process.exit(0)
+    }).catch(() => {
+      process.exit(1)
+    })
+  }
+  process.on('SIGTERM', shutdown)
+  process.on('SIGINT', shutdown)
+
   try {
     await app.listen({ host, port })
     const url = `http://${host === '0.0.0.0' ? 'localhost' : host}:${port}`

--- a/packages/canonry/src/commands/status.ts
+++ b/packages/canonry/src/commands/status.ts
@@ -1,3 +1,4 @@
+import type { ProjectDto, RunDto } from '@ainyc/canonry-contracts'
 import { createApiClient } from '../client.js'
 
 function getClient() {
@@ -6,20 +7,13 @@ function getClient() {
 
 export async function showStatus(project: string, format?: string): Promise<void> {
   const client = getClient()
-  const projectData = await client.getProject(project) as {
-    id: string
-    name: string
-    displayName: string
-    canonicalDomain: string
-    country: string
-    language: string
-  }
+  const projectData: ProjectDto = await client.getProject(project)
 
-  let runs: Array<{ id: string; status: string; kind: string; createdAt: string; finishedAt: string | null }> = []
+  let runs: RunDto[] = []
   try {
-    runs = await client.listRuns(project) as typeof runs
+    runs = await client.listRuns(project)
   } catch {
-    // Runs endpoint may not be available
+    // Runs endpoint may not be available (e.g. older server)
   }
 
   if (format === 'json') {
@@ -27,13 +21,14 @@ export async function showStatus(project: string, format?: string): Promise<void
     return
   }
 
-  console.log(`Status: ${projectData.displayName} (${projectData.name})\n`)
+  console.log(`Status: ${projectData.displayName ?? projectData.name} (${projectData.name})\n`)
   console.log(`  Domain:   ${projectData.canonicalDomain}`)
   console.log(`  Country:  ${projectData.country}`)
   console.log(`  Language: ${projectData.language}`)
 
   if (runs.length > 0) {
-    const latest = runs[runs.length - 1]!
+    // listRuns returns runs in descending createdAt order (newest first)
+    const latest = runs[0]!
     console.log(`\n  Latest run:`)
     console.log(`    ID:       ${latest.id}`)
     console.log(`    Status:   ${latest.status}`)

--- a/packages/canonry/test/cli-operator-contract.test.ts
+++ b/packages/canonry/test/cli-operator-contract.test.ts
@@ -109,7 +109,7 @@ describe('operator CLI contract', () => {
     expect(parsed.error.code).toBe('CLI_USAGE_ERROR')
     expect(parsed.error.message).toBe('project name is required')
     expect(parsed.error.details.command).toBe('status')
-    expect(parsed.error.details.usage).toBe('canonry status <project>')
+    expect(parsed.error.details.usage).toBe('canonry status <project> [--format json]')
   })
 
   it('prints project status to stdout in JSON mode', async () => {


### PR DESCRIPTION
## Issues Found and Fixed

### 1. Bug: `status` command showed oldest run instead of latest (status.ts)
`listRuns` returns runs in descending `createdAt` order (newest first). The code used `runs[runs.length - 1]` which is the **oldest** run. Fixed to `runs[0]` so the displayed "Latest run" is actually the most recent one.

### 2. Redundant `as {...}` type casts (status.ts, schedule.ts, project.ts)
Multiple commands were casting already-typed `ApiClient` return values to inline object shapes:
- `status.ts`: `getProject()` result cast to `{ id, name, ... }` and `listRuns()` result cast to `typeof runs`
- `schedule.ts`: `putSchedule()` and `getSchedule()` results cast to a local `ScheduleResponse` interface that duplicated `ScheduleDto`
- `project.ts`: `listProjects()`, `getProject()`, `putProject()` results cast to inline shapes

All casts removed in favour of explicit type annotations using the canonical DTOs from `@ainyc/canonry-contracts`. The local `ScheduleResponse` interface in `schedule.ts` was dead code and is removed.

### 3. No graceful shutdown handler in `serve` command (serve.ts)
`stopDaemon` sends `SIGTERM` to the server process, but `serveCommand` had no `SIGTERM`/`SIGINT` handlers. Node.js exits immediately on `SIGTERM` without draining in-flight HTTP requests or closing the Fastify server cleanly. Added `process.on('SIGTERM', shutdown)` and `process.on('SIGINT', shutdown)` that call `app.close()` before exiting.

### 4. Missing `[--format json]` in `status`, `evidence`, `history` usage strings (operator.ts, cli.ts)
These three commands already supported `--format json` (via `dispatchRegisteredCommand`'s `withFormatOption`), but their `usage` strings did not advertise it. Updated usage strings in both `operator.ts` and `cli.ts` help text to match the other output commands. Updated the corresponding contract test snapshot to match the new string.

---

All checks pass: `pnpm typecheck && pnpm lint && pnpm test` (774 tests, 80 files).