### PR TITLE
chore(providers): normalize error handling and add retries

### DIFF
--- a/packages/provider-cdp/src/adapter.ts
+++ b/packages/provider-cdp/src/adapter.ts
@@ -103,47 +103,52 @@ export const cdpChatgptAdapter: ProviderAdapter = {
     const conn = getConnection(config)
     const target = chatgptTarget
 
-    // Navigate to a fresh conversation
-    const client = await conn.prepareForQuery(target)
-
-    // Submit the query
-    await target.submitQuery(client, input.keyword)
-
-    // Wait for the response to complete
-    await target.waitForResponse(client)
-
-    // Extract answer text
-    const answerText = await target.extractAnswer(client)
-
-    // Extract citations
-    const groundingSources = await target.extractCitations(client)
-
-    // Capture cropped screenshot of the response area
-    const screenshotId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
-    const screenshotPath = path.join(getScreenshotDir(), `${screenshotId}.png`)
-    let capturedScreenshotPath: string | undefined
     try {
-      capturedScreenshotPath = await captureElementScreenshot(
-        client,
-        target.responseSelector,
-        screenshotPath,
-      )
-    } catch {
-      // Screenshot failure is non-fatal — we still have the text data
-    }
+      // Navigate to a fresh conversation
+      const client = await conn.prepareForQuery(target)
 
-    return {
-      provider: 'cdp:chatgpt',
-      rawResponse: {
-        answerText,
+      // Submit the query
+      await target.submitQuery(client, input.keyword)
+
+      // Wait for the response to complete
+      await target.waitForResponse(client)
+
+      // Extract answer text
+      const answerText = await target.extractAnswer(client)
+
+      // Extract citations
+      const groundingSources = await target.extractCitations(client)
+
+      // Capture cropped screenshot of the response area
+      const screenshotId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+      const screenshotPath = path.join(getScreenshotDir(), `${screenshotId}.png`)
+      let capturedScreenshotPath: string | undefined
+      try {
+        capturedScreenshotPath = await captureElementScreenshot(
+          client,
+          target.responseSelector,
+          screenshotPath,
+        )
+      } catch {
+        // Screenshot failure is non-fatal — we still have the text data
+      }
+
+      return {
+        provider: 'cdp:chatgpt',
+        rawResponse: {
+          answerText,
+          groundingSources,
+          extractedAt: new Date().toISOString(),
+          targetUrl: target.newConversationUrl,
+        },
+        model: 'chatgpt-web',
         groundingSources,
-        extractedAt: new Date().toISOString(),
-        targetUrl: target.newConversationUrl,
-      },
-      model: 'chatgpt-web',
-      groundingSources,
-      searchQueries: [input.keyword],
-      screenshotPath: capturedScreenshotPath,
+        searchQueries: [input.keyword],
+        screenshotPath: capturedScreenshotPath,
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err)
+      throw new Error(`[provider-cdp] ${msg}`)
     }
   },
 

--- a/packages/provider-claude/src/normalize.ts
+++ b/packages/provider-claude/src/normalize.ts
@@ -1,5 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk'
 import type { WebSearchTool20250305 } from '@anthropic-ai/sdk/resources/messages/messages.js'
+import { withRetry } from './utils.js'
 import type {
   ClaudeConfig,
   ClaudeHealthcheckResult,
@@ -52,11 +53,13 @@ export async function healthcheck(config: ClaudeConfig): Promise<ClaudeHealthche
   try {
     const model = resolveModel(config)
     const client = new Anthropic({ apiKey: config.apiKey })
-    const response = await client.messages.create({
-      model,
-      max_tokens: 32,
-      messages: [{ role: 'user', content: 'Say "ok"' }],
-    })
+    const response = await withRetry(() =>
+      client.messages.create({
+        model,
+        max_tokens: 32,
+        messages: [{ role: 'user', content: 'Say "ok"' }],
+      }),
+    )
     const text = extractTextFromResponse(response)
     return {
       ok: text.length > 0,
@@ -93,22 +96,29 @@ export async function executeTrackedQuery(input: ClaudeTrackedQueryInput): Promi
     }
   }
 
-  const response = await client.messages.create({
-    model,
-    max_tokens: 4096,
-    tools: [webSearchTool as unknown as WebSearchTool20250305],
-    messages: [{ role: 'user', content: input.keyword }],
-  })
+  try {
+    const response = await withRetry(() =>
+      client.messages.create({
+        model,
+        max_tokens: 4096,
+        tools: [webSearchTool as unknown as WebSearchTool20250305],
+        messages: [{ role: 'user', content: input.keyword }],
+      }),
+    )
 
-  const groundingSources = extractGroundingSources(response)
-  const searchQueries = extractSearchQueries(response)
+    const groundingSources = extractGroundingSources(response)
+    const searchQueries = extractSearchQueries(response)
 
-  return {
-    provider: 'claude',
-    rawResponse: responseToRecord(response),
-    model,
-    groundingSources,
-    searchQueries,
+    return {
+      provider: 'claude',
+      rawResponse: responseToRecord(response),
+      model,
+      groundingSources,
+      searchQueries,
+    }
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    throw new Error(`[provider-claude] ${msg}`)
   }
 }
 
@@ -224,11 +234,13 @@ function extractDomainFromUri(uri: string): string | null {
 export async function generateText(prompt: string, config: ClaudeConfig): Promise<string> {
   const model = resolveModel(config)
   const client = new Anthropic({ apiKey: config.apiKey })
-  const response = await client.messages.create({
-    model,
-    max_tokens: 2048,
-    messages: [{ role: 'user', content: prompt }],
-  })
+  const response = await withRetry(() =>
+    client.messages.create({
+      model,
+      max_tokens: 2048,
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  )
   return extractTextFromResponse(response)
 }
 

--- a/packages/provider-claude/src/utils.ts
+++ b/packages/provider-claude/src/utils.ts
@@ -1,0 +1,25 @@
+/**
+ * Simple exponential backoff retry wrapper.
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: { maxRetries?: number; initialDelay?: number } = {},
+): Promise<T> {
+  const { maxRetries = 3, initialDelay = 1000 } = options
+  let lastError: unknown
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn()
+    } catch (err: unknown) {
+      lastError = err
+      if (attempt < maxRetries) {
+        const delay = initialDelay * Math.pow(2, attempt)
+        console.warn(`[provider] Attempt ${attempt + 1} failed, retrying in ${delay}ms...`, err)
+        await new Promise((resolve) => setTimeout(resolve, delay))
+      }
+    }
+  }
+
+  throw lastError
+}

--- a/packages/provider-gemini/src/normalize.ts
+++ b/packages/provider-gemini/src/normalize.ts
@@ -1,4 +1,5 @@
 import { GoogleGenAI, type GenerateContentResponse } from '@google/genai'
+import { withRetry } from './utils.js'
 import type {
   GeminiConfig,
   GeminiHealthcheckResult,
@@ -82,10 +83,12 @@ export async function healthcheck(config: GeminiConfig): Promise<GeminiHealthche
   try {
     const model = resolveModel(config)
     const client = createClient(config)
-    const result = await client.models.generateContent({
-      model,
-      contents: 'Say "ok"',
-    })
+    const result = await withRetry(() =>
+      client.models.generateContent({
+        model,
+        contents: 'Say "ok"',
+      }),
+    )
     const text = result.text ?? ''
     const backend = isVertexConfig(config) ? 'vertex ai' : 'api key'
     return {
@@ -109,23 +112,30 @@ export async function executeTrackedQuery(input: GeminiTrackedQueryInput): Promi
   const prompt = buildPrompt(input.keyword, input.location)
   const client = createClient(input.config)
 
-  const result = await client.models.generateContent({
-    model,
-    contents: prompt,
-    config: {
-      tools: [{ googleSearch: {} }],
-    },
-  })
+  try {
+    const result = await withRetry(() =>
+      client.models.generateContent({
+        model,
+        contents: prompt,
+        config: {
+          tools: [{ googleSearch: {} }],
+        },
+      }),
+    )
 
-  const groundingSources = extractGroundingMetadata(result)
-  const searchQueries = extractSearchQueries(result)
+    const groundingSources = extractGroundingMetadata(result)
+    const searchQueries = extractSearchQueries(result)
 
-  return {
-    provider: 'gemini',
-    rawResponse: responseToRecord(result),
-    model,
-    groundingSources,
-    searchQueries,
+    return {
+      provider: 'gemini',
+      rawResponse: responseToRecord(result),
+      model,
+      groundingSources,
+      searchQueries,
+    }
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    throw new Error(`[provider-gemini] ${msg}`)
   }
 }
 
@@ -260,10 +270,12 @@ function extractDomainFromUri(uri: string): string | null {
 export async function generateText(prompt: string, config: GeminiConfig): Promise<string> {
   const model = resolveModel(config)
   const client = createClient(config)
-  const result = await client.models.generateContent({
-    model,
-    contents: prompt,
-  })
+  const result = await withRetry(() =>
+    client.models.generateContent({
+      model,
+      contents: prompt,
+    }),
+  )
   return result.text ?? ''
 }
 

--- a/packages/provider-gemini/src/utils.ts
+++ b/packages/provider-gemini/src/utils.ts
@@ -1,0 +1,25 @@
+/**
+ * Simple exponential backoff retry wrapper.
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: { maxRetries?: number; initialDelay?: number } = {},
+): Promise<T> {
+  const { maxRetries = 3, initialDelay = 1000 } = options
+  let lastError: unknown
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn()
+    } catch (err: unknown) {
+      lastError = err
+      if (attempt < maxRetries) {
+        const delay = initialDelay * Math.pow(2, attempt)
+        console.warn(`[provider] Attempt ${attempt + 1} failed, retrying in ${delay}ms...`, err)
+        await new Promise((resolve) => setTimeout(resolve, delay))
+      }
+    }
+  }
+
+  throw lastError
+}

--- a/packages/provider-local/src/normalize.ts
+++ b/packages/provider-local/src/normalize.ts
@@ -1,4 +1,5 @@
 import OpenAI from 'openai'
+import { withRetry } from './utils.js'
 import type {
   LocalConfig,
   LocalHealthcheckResult,
@@ -30,16 +31,19 @@ export async function healthcheck(config: LocalConfig): Promise<LocalHealthcheck
       baseURL: config.baseUrl,
       apiKey: config.apiKey || 'not-needed',
     })
-    const models = await client.models.list()
-    const modelList = []
-    for await (const m of models) {
-      modelList.push(m.id)
-      if (modelList.length >= 5) break
-    }
+    const models = await withRetry(async () => {
+      const list = await client.models.list()
+      const items = []
+      for await (const m of list) {
+        items.push(m.id)
+        if (items.length >= 5) break
+      }
+      return items
+    })
     return {
       ok: true,
       provider: 'local',
-      message: `connected, ${modelList.length} model(s) available`,
+      message: `connected, ${models.length} model(s) available`,
       model: config.model ?? DEFAULT_MODEL,
     }
   } catch (err: unknown) {
@@ -59,26 +63,33 @@ export async function executeTrackedQuery(input: LocalTrackedQueryInput): Promis
     apiKey: input.config.apiKey || 'not-needed',
   })
 
-  const response = await client.chat.completions.create({
-    model,
-    messages: [
-      {
-        role: 'system',
-        content: 'You are a helpful assistant. Provide comprehensive, factual answers. When mentioning websites or services, include their domain names.',
-      },
-      {
-        role: 'user',
-        content: buildPrompt(input.keyword, input.location),
-      },
-    ],
-  })
+  try {
+    const response = await withRetry(() =>
+      client.chat.completions.create({
+        model,
+        messages: [
+          {
+            role: 'system',
+            content: 'You are a helpful assistant. Provide comprehensive, factual answers. When mentioning websites or services, include their domain names.',
+          },
+          {
+            role: 'user',
+            content: buildPrompt(input.keyword, input.location),
+          },
+        ],
+      }),
+    )
 
-  return {
-    provider: 'local',
-    rawResponse: responseToRecord(response),
-    model,
-    groundingSources: [],
-    searchQueries: [],
+    return {
+      provider: 'local',
+      rawResponse: responseToRecord(response),
+      model,
+      groundingSources: [],
+      searchQueries: [],
+    }
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    throw new Error(`[provider-local] ${msg}`)
   }
 }
 
@@ -120,10 +131,12 @@ export async function generateText(prompt: string, config: LocalConfig): Promise
     baseURL: config.baseUrl,
     apiKey: config.apiKey || 'not-needed',
   })
-  const response = await client.chat.completions.create({
-    model,
-    messages: [{ role: 'user', content: prompt }],
-  })
+  const response = await withRetry(() =>
+    client.chat.completions.create({
+      model,
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  )
   return response.choices[0]?.message?.content ?? ''
 }
 

--- a/packages/provider-local/src/utils.ts
+++ b/packages/provider-local/src/utils.ts
@@ -1,0 +1,25 @@
+/**
+ * Simple exponential backoff retry wrapper.
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: { maxRetries?: number; initialDelay?: number } = {},
+): Promise<T> {
+  const { maxRetries = 3, initialDelay = 1000 } = options
+  let lastError: unknown
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn()
+    } catch (err: unknown) {
+      lastError = err
+      if (attempt < maxRetries) {
+        const delay = initialDelay * Math.pow(2, attempt)
+        console.warn(`[provider] Attempt ${attempt + 1} failed, retrying in ${delay}ms...`, err)
+        await new Promise((resolve) => setTimeout(resolve, delay))
+      }
+    }
+  }
+
+  throw lastError
+}

--- a/packages/provider-openai/src/normalize.ts
+++ b/packages/provider-openai/src/normalize.ts
@@ -1,4 +1,5 @@
 import OpenAI from 'openai'
+import { withRetry } from './utils.js'
 import type {
   OpenAIConfig,
   OpenAIHealthcheckResult,
@@ -28,10 +29,12 @@ export async function healthcheck(config: OpenAIConfig): Promise<OpenAIHealthche
 
   try {
     const client = new OpenAI({ apiKey: config.apiKey })
-    const response = await client.responses.create({
-      model: config.model ?? DEFAULT_MODEL,
-      input: 'Say "ok"',
-    })
+    const response = await withRetry(() =>
+      client.responses.create({
+        model: config.model ?? DEFAULT_MODEL,
+        input: 'Say "ok"',
+      }),
+    )
     const text = extractResponseText(response)
     return {
       ok: text.length > 0,
@@ -64,22 +67,29 @@ export async function executeTrackedQuery(input: OpenAITrackedQueryInput): Promi
     }
   }
 
-  const response = await client.responses.create({
-    model,
-    tools: [webSearchTool as { type: 'web_search_preview' }],
-    tool_choice: 'required' as never,
-    input: buildPrompt(input.keyword),
-  })
+  try {
+    const response = await withRetry(() =>
+      client.responses.create({
+        model,
+        tools: [webSearchTool as { type: 'web_search_preview' }],
+        tool_choice: 'required' as never,
+        input: buildPrompt(input.keyword),
+      }),
+    )
 
-  const groundingSources = extractGroundingSources(response)
-  const searchQueries = extractSearchQueries(response)
+    const groundingSources = extractGroundingSources(response)
+    const searchQueries = extractSearchQueries(response)
 
-  return {
-    provider: 'openai',
-    rawResponse: responseToRecord(response),
-    model,
-    groundingSources,
-    searchQueries,
+    return {
+      provider: 'openai',
+      rawResponse: responseToRecord(response),
+      model,
+      groundingSources,
+      searchQueries,
+    }
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    throw new Error(`[provider-openai] ${msg}`)
   }
 }
 
@@ -214,10 +224,12 @@ function extractDomainFromUri(uri: string): string | null {
 export async function generateText(prompt: string, config: OpenAIConfig): Promise<string> {
   const model = config.model ?? DEFAULT_MODEL
   const client = new OpenAI({ apiKey: config.apiKey })
-  const response = await client.responses.create({
-    model,
-    input: prompt,
-  })
+  const response = await withRetry(() =>
+    client.responses.create({
+      model,
+      input: prompt,
+    }),
+  )
   return extractResponseText(response)
 }
 

--- a/packages/provider-openai/src/utils.ts
+++ b/packages/provider-openai/src/utils.ts
@@ -1,0 +1,25 @@
+/**
+ * Simple exponential backoff retry wrapper.
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: { maxRetries?: number; initialDelay?: number } = {},
+): Promise<T> {
+  const { maxRetries = 3, initialDelay = 1000 } = options
+  let lastError: unknown
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn()
+    } catch (err: unknown) {
+      lastError = err
+      if (attempt < maxRetries) {
+        const delay = initialDelay * Math.pow(2, attempt)
+        console.warn(`[provider] Attempt ${attempt + 1} failed, retrying in ${delay}ms...`, err)
+        await new Promise((resolve) => setTimeout(resolve, delay))
+      }
+    }
+  }
+
+  throw lastError
+}

--- a/packages/provider-perplexity/src/normalize.ts
+++ b/packages/provider-perplexity/src/normalize.ts
@@ -1,4 +1,5 @@
 import OpenAI from 'openai'
+import { withRetry } from './utils.js'
 import type {
   PerplexityConfig,
   PerplexityHealthcheckResult,
@@ -29,10 +30,12 @@ export async function healthcheck(config: PerplexityConfig): Promise<PerplexityH
 
   try {
     const client = new OpenAI({ apiKey: config.apiKey, baseURL: BASE_URL })
-    const response = await client.chat.completions.create({
-      model: config.model ?? DEFAULT_MODEL,
-      messages: [{ role: 'user', content: 'Say "ok"' }],
-    })
+    const response = await withRetry(() =>
+      client.chat.completions.create({
+        model: config.model ?? DEFAULT_MODEL,
+        messages: [{ role: 'user', content: 'Say "ok"' }],
+      }),
+    )
     const text = response.choices[0]?.message?.content ?? ''
     return {
       ok: text.length > 0,
@@ -56,28 +59,33 @@ export async function executeTrackedQuery(input: PerplexityTrackedQueryInput): P
 
   const prompt = buildPrompt(input.keyword, input.location)
 
-  const response = await client.chat.completions.create({
-    model,
-    messages: [
-      { role: 'user', content: prompt },
-    ],
-  })
+  try {
+    const response = await withRetry(() =>
+      client.chat.completions.create({
+        model,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    )
 
-  const rawResponse = responseToRecord(response)
+    const rawResponse = responseToRecord(response)
 
-  // Perplexity returns citations as a top-level array on the response
-  const citations = extractCitations(rawResponse)
-  const groundingSources = citations.map(url => ({
-    uri: url,
-    title: '',
-  }))
+    // Perplexity returns citations as a top-level array on the response
+    const citations = extractCitations(rawResponse)
+    const groundingSources = citations.map((url) => ({
+      uri: url,
+      title: '',
+    }))
 
-  return {
-    provider: 'perplexity',
-    rawResponse,
-    model,
-    groundingSources,
-    searchQueries: [input.keyword],
+    return {
+      provider: 'perplexity',
+      rawResponse,
+      model,
+      groundingSources,
+      searchQueries: [input.keyword],
+    }
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    throw new Error(`[provider-perplexity] ${msg}`)
   }
 }
 
@@ -162,10 +170,12 @@ function extractDomainFromUri(uri: string): string | null {
 export async function generateText(prompt: string, config: PerplexityConfig): Promise<string> {
   const model = config.model ?? DEFAULT_MODEL
   const client = new OpenAI({ apiKey: config.apiKey, baseURL: BASE_URL })
-  const response = await client.chat.completions.create({
-    model,
-    messages: [{ role: 'user', content: prompt }],
-  })
+  const response = await withRetry(() =>
+    client.chat.completions.create({
+      model,
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  )
   return response.choices[0]?.message?.content ?? ''
 }
 

--- a/packages/provider-perplexity/src/utils.ts
+++ b/packages/provider-perplexity/src/utils.ts
@@ -1,0 +1,25 @@
+/**
+ * Simple exponential backoff retry wrapper.
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: { maxRetries?: number; initialDelay?: number } = {},
+): Promise<T> {
+  const { maxRetries = 3, initialDelay = 1000 } = options
+  let lastError: unknown
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn()
+    } catch (err: unknown) {
+      lastError = err
+      if (attempt < maxRetries) {
+        const delay = initialDelay * Math.pow(2, attempt)
+        console.warn(`[provider] Attempt ${attempt + 1} failed, retrying in ${delay}ms...`, err)
+        await new Promise((resolve) => setTimeout(resolve, delay))
+      }
+    }
+  }
+
+  throw lastError
+}


### PR DESCRIPTION
Audit of provider packages completed.

Key fixes:
- **Exponential Backoff Retries**: Added `withRetry` utility to `gemini`, `claude`, `openai`, `perplexity`, and `local` providers. This improves robustness against transient network failures and 429 rate limit responses.
- **Error Normalization**: Wrapped `executeTrackedQuery` in all provider adapters (including `cdp`) with try-catch blocks that prefix error messages with the provider name (e.g., `[provider-gemini] ...`). This ensures that the `JobRunner` can more easily identify failing providers.
- **Enhanced Healthchecks**: Applied retries to `healthcheck` calls to reduce false negatives during provider configuration.
- **Improved Type Consistency**: Ensured that all providers follow the same pattern for error reporting in their adapters.

Packages audited:
- packages/provider-cdp/
- packages/provider-claude/
- packages/provider-gemini/
- packages/provider-local/
- packages/provider-openai/
- packages/provider-perplexity/

All checks passed: `pnpm typecheck`, `pnpm lint`, `pnpm test`.