### PR TITLE
feat(cli): enforce agent-first contract — remove interactive prompts, add typed exit codes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,11 +69,26 @@ THIS IS AN **AGENT-FIRST** PLATFORM. The CLI and API are the primary interfaces.
 3. **Ideal:** Add the UI interaction in `apps/web/` — aim to include it, but never block a release waiting for UI work.
 
 ### Agent & automation design principles
-- Every operation must be scriptable via CLI or API without human interaction.
-- CLI output must be machine-parseable (support `--format json` on all commands that produce output).
-- API responses must be self-describing and stable — external agents and scripts depend on them.
-- Prefer config-as-code (`canonry apply`) over interactive wizards.
-- Error messages must be actionable from a terminal — include the failed command, the reason, and a suggested fix.
+
+The CLI and API **are** the agent interface. No MCP layer, no virtual filesystem, no special agent SDK. If an AI agent can't do something with `canonry <command> --format json` or an HTTP call, it's a bug.
+
+#### Rules
+
+1. **No interactive prompts.** Every CLI command must be fully operable via flags and environment variables. Never import `node:readline` in command files — ESLint enforces this. If a value is sensitive (API keys, passwords), accept it via `--flag`, env var, or `config.yaml`. Prompts are allowed only in `canonry init` as a convenience; all init values must also be passable via flags.
+2. **JSON everywhere.** Every command that produces output must support `--format json`. JSON output goes to stdout. Errors go to stderr as `{ "error": { "code": "...", "message": "..." } }`. Human-readable text is the default; JSON is the machine contract.
+3. **Idempotent writes.** `canonry apply` is the model — running it twice with the same input produces the same state. New write commands must follow this pattern. `POST` endpoints that create resources (like runs) are exempt, but must return a stable identifier and handle conflicts gracefully (e.g., `runInProgress` error with the existing run ID).
+4. **Single-call reads.** If an agent needs two API calls to answer a common question, add a composite endpoint. Examples: `/projects/:name/runs/latest` (don't make agents list-then-filter), `/projects/:name/search?q=term` (don't make agents fetch all snapshots to grep). The test: can an agent get what it needs in one `curl` call?
+5. **Meaningful exit codes.** `0` = success, `1` = user error (bad input, not found, validation), `2` = system error (network, provider failure, internal). Agents use exit codes to decide whether to retry.
+6. **Stable output contracts.** JSON field names, endpoint paths, and error codes are public API. Renaming a JSON field is a breaking change. Add fields freely; never remove or rename without a version bump.
+
+#### Checklist for any new command or endpoint
+
+- [ ] Fully operable without interactive input (no readline, no prompts)
+- [ ] `--format json` supported, outputs to stdout
+- [ ] Errors output structured JSON to stderr with a code from `CliError`
+- [ ] Write operations are idempotent (or return conflict details)
+- [ ] Common read patterns achievable in a single API call
+- [ ] Exit code follows 0/1/2 convention
 
 ## Maintenance Guidance
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,6 +25,20 @@ export default tseslint.config(
     ignores: ['dist/', 'node_modules/', 'apps/**/dist/', 'packages/**/dist/'],
   },
   {
+    // CLI commands must be fully non-interactive. readline is only allowed in
+    // init.ts as a human convenience — all init values are also passable via flags.
+    files: ['packages/canonry/src/commands/**/*.ts', 'packages/canonry/src/cli-commands/**/*.ts'],
+    ignores: ['packages/canonry/src/commands/init.ts'],
+    rules: {
+      'no-restricted-imports': ['error', {
+        paths: [
+          { name: 'node:readline', message: 'CLI commands must be non-interactive. Accept values via flags, env vars, or config.yaml.' },
+          { name: 'readline', message: 'CLI commands must be non-interactive. Accept values via flags, env vars, or config.yaml.' },
+        ],
+      }],
+    },
+  },
+  {
     files: ['**/*.js'],
     extends: [js.configs.recommended],
     languageOptions: {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "1.37.1",
+  "version": "1.38.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "1.37.1",
+  "version": "1.38.0",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/cli-error.ts
+++ b/packages/canonry/src/cli-error.ts
@@ -1,16 +1,27 @@
 export type CliFormat = 'text' | 'json'
 
+/**
+ * Exit codes follow a convention agents can branch on:
+ *   0 = success
+ *   1 = user error (bad input, not found, validation — do not retry)
+ *   2 = system error (network, provider failure, internal — may retry)
+ */
+export const EXIT_USER_ERROR = 1
+export const EXIT_SYSTEM_ERROR = 2
+
 type CliErrorOptions = {
   code: string
   message: string
   displayMessage?: string
   details?: Record<string, unknown>
+  exitCode?: typeof EXIT_USER_ERROR | typeof EXIT_SYSTEM_ERROR
 }
 
 export class CliError extends Error {
   readonly code: string
   readonly displayMessage?: string
   readonly details?: Record<string, unknown>
+  readonly exitCode: number
 
   constructor(options: CliErrorOptions) {
     super(options.message)
@@ -18,6 +29,7 @@ export class CliError extends Error {
     this.code = options.code
     this.displayMessage = options.displayMessage
     this.details = options.details
+    this.exitCode = options.exitCode ?? EXIT_USER_ERROR
   }
 }
 
@@ -34,6 +46,22 @@ export function usageError(
     message: options?.message ?? firstLine.replace(/^Error:\s*/, ''),
     displayMessage,
     details: options?.details,
+  })
+}
+
+export function systemError(
+  message: string,
+  options?: {
+    displayMessage?: string
+    details?: Record<string, unknown>
+  },
+): CliError {
+  return new CliError({
+    code: 'CLI_SYSTEM_ERROR',
+    message,
+    displayMessage: options?.displayMessage,
+    details: options?.details,
+    exitCode: EXIT_SYSTEM_ERROR,
   })
 }
 

--- a/packages/canonry/src/cli.ts
+++ b/packages/canonry/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node --import tsx
 import { pathToFileURL } from 'node:url'
 import { trackEvent, isTelemetryEnabled, isFirstRun, getOrCreateAnonymousId, showFirstRunNotice } from './telemetry.js'
-import { printCliError, usageError } from './cli-error.js'
+import { CliError, EXIT_SYSTEM_ERROR, EXIT_USER_ERROR, printCliError, usageError } from './cli-error.js'
 import { dispatchRegisteredCommand } from './cli-dispatch.js'
 import { REGISTERED_CLI_COMMANDS } from './cli-commands.js'
 
@@ -222,7 +222,7 @@ export async function runCli(args = process.argv.slice(2)): Promise<number> {
     })
   } catch (err: unknown) {
     printCliError(err, format)
-    return 1
+    return err instanceof CliError ? err.exitCode : EXIT_SYSTEM_ERROR
   }
 }
 

--- a/packages/canonry/src/client.ts
+++ b/packages/canonry/src/client.ts
@@ -1,3 +1,4 @@
+import { CliError, EXIT_SYSTEM_ERROR, EXIT_USER_ERROR } from './cli-error.js'
 import { loadConfig } from './config.js'
 import type {
   ProjectDto,
@@ -137,14 +138,18 @@ export class ApiClient {
         body: serializedBody,
       })
     } catch (err) {
+      if (err instanceof CliError) throw err
       const msg = err instanceof Error ? err.message : String(err)
       if (msg.includes('fetch failed') || msg.includes('ECONNREFUSED') || msg.includes('connect ECONNREFUSED')) {
-        throw new Error(
-          `Could not connect to canonry server at ${this.baseUrl.replace('/api/v1', '')}. ` +
-          'Start it with "canonry serve" (or "canonry serve &" to run in background).',
-        )
+        throw new CliError({
+          code: 'CONNECTION_ERROR',
+          message:
+            `Could not connect to canonry server at ${this.baseUrl.replace('/api/v1', '')}. ` +
+            'Start it with "canonry serve" (or "canonry serve &" to run in background).',
+          exitCode: EXIT_SYSTEM_ERROR,
+        })
       }
-      throw err
+      throw new CliError({ code: 'CONNECTION_ERROR', message: msg, exitCode: EXIT_SYSTEM_ERROR })
     }
 
     if (!res.ok) {
@@ -154,16 +159,18 @@ export class ApiClient {
       } catch {
         errorBody = { error: { code: 'UNKNOWN', message: res.statusText } }
       }
-      const msg =
+      const errorObj =
         errorBody &&
         typeof errorBody === 'object' &&
         'error' in errorBody &&
         errorBody.error &&
-        typeof errorBody.error === 'object' &&
-        'message' in errorBody.error
-          ? String((errorBody.error as { message: string }).message)
-          : `HTTP ${res.status}: ${res.statusText}`
-      throw new Error(msg)
+        typeof errorBody.error === 'object'
+          ? (errorBody.error as { code?: string; message?: string })
+          : null
+      const msg = errorObj?.message ? String(errorObj.message) : `HTTP ${res.status}: ${res.statusText}`
+      const code = errorObj?.code ? String(errorObj.code) : 'API_ERROR'
+      const exitCode = res.status >= 500 ? EXIT_SYSTEM_ERROR : EXIT_USER_ERROR
+      throw new CliError({ code, message: msg, exitCode })
     }
 
     if (res.status === 204) {

--- a/packages/canonry/src/commands/bing.ts
+++ b/packages/canonry/src/commands/bing.ts
@@ -6,25 +6,13 @@ function getClient() {
 }
 
 export async function bingConnect(project: string, opts?: { apiKey?: string; format?: string }): Promise<void> {
-  let apiKey = opts?.apiKey
-
-  if (!apiKey) {
-    const readline = await import('node:readline')
-    const rl = readline.createInterface({ input: process.stdin, output: process.stderr })
-
-    apiKey = await new Promise<string>((resolve) => {
-      rl.question('Bing Webmaster Tools API key: ', (answer) => {
-        rl.close()
-        resolve(answer.trim())
-      })
-    })
-  }
+  const apiKey = opts?.apiKey
 
   if (!apiKey) {
     throw new CliError({
       code: 'BING_API_KEY_REQUIRED',
-      message: 'API key is required (pass --api-key or enter interactively)',
-      displayMessage: 'Error: API key is required (pass --api-key or enter interactively)',
+      message: 'API key is required. Pass --api-key <key>.',
+      displayMessage: 'Error: API key is required. Pass --api-key <key>.',
       details: {
         project,
       },

--- a/packages/canonry/src/commands/wordpress.ts
+++ b/packages/canonry/src/commands/wordpress.ts
@@ -16,17 +16,6 @@ function getClient() {
   return createApiClient()
 }
 
-async function promptForAppPassword(): Promise<string> {
-  const readline = await import('node:readline')
-  const rl = readline.createInterface({ input: process.stdin, output: process.stderr })
-
-  return new Promise<string>((resolve) => {
-    rl.question('WordPress Application Password: ', (answer) => {
-      rl.close()
-      resolve(answer.trim())
-    })
-  })
-}
 
 function printJson(value: unknown): void {
   console.log(JSON.stringify(value, null, 2))
@@ -180,12 +169,12 @@ export async function wordpressConnect(
     format?: string
   },
 ): Promise<void> {
-  const appPassword = opts.appPassword ?? await promptForAppPassword()
+  const appPassword = opts.appPassword
   if (!appPassword) {
     throw new CliError({
       code: 'WORDPRESS_APP_PASSWORD_REQUIRED',
       message: 'WordPress Application Password is required',
-      displayMessage: 'Error: WordPress Application Password is required (pass --app-password or enter interactively).',
+      displayMessage: 'Error: WordPress Application Password is required. Pass --app-password <password>.',
       details: { project },
     })
   }
@@ -555,12 +544,12 @@ export async function wordpressOnboard(
     format?: string
   },
 ): Promise<void> {
-  const appPassword = opts.appPassword ?? await promptForAppPassword()
+  const appPassword = opts.appPassword
   if (!appPassword) {
     throw new CliError({
       code: 'WORDPRESS_APP_PASSWORD_REQUIRED',
       message: 'WordPress Application Password is required',
-      displayMessage: 'Error: WordPress Application Password is required (pass --app-password or enter interactively).',
+      displayMessage: 'Error: WordPress Application Password is required. Pass --app-password <password>.',
       details: { project },
     })
   }

--- a/packages/canonry/test/cli-error.test.ts
+++ b/packages/canonry/test/cli-error.test.ts
@@ -1,0 +1,60 @@
+import { vi, describe, it, expect, afterEach } from 'vitest'
+import { systemError, CliError, EXIT_SYSTEM_ERROR } from '../src/cli-error.js'
+import { runCli } from '../src/cli.js'
+import { dispatchRegisteredCommand } from '../src/cli-dispatch.js'
+
+vi.mock('../src/cli-dispatch.js', () => ({
+  dispatchRegisteredCommand: vi.fn(),
+}))
+
+describe('systemError()', () => {
+  it('creates a CliError with code CLI_SYSTEM_ERROR and exitCode 2', () => {
+    const err = systemError('provider call failed')
+    expect(err).toBeInstanceOf(CliError)
+    expect(err.code).toBe('CLI_SYSTEM_ERROR')
+    expect(err.exitCode).toBe(EXIT_SYSTEM_ERROR)
+    expect(err.exitCode).toBe(2)
+    expect(err.message).toBe('provider call failed')
+  })
+
+  it('accepts optional displayMessage and details', () => {
+    const err = systemError('network timeout', {
+      displayMessage: 'Connection timed out. Please try again.',
+      details: { url: 'https://api.example.com' },
+    })
+    expect(err.displayMessage).toBe('Connection timed out. Please try again.')
+    expect(err.details).toEqual({ url: 'https://api.example.com' })
+  })
+})
+
+describe('runCli() exit code propagation', () => {
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('returns 2 when a systemError is thrown by a command', async () => {
+    vi.mocked(dispatchRegisteredCommand).mockRejectedValueOnce(
+      systemError('provider unavailable'),
+    )
+    const origError = console.error
+    console.error = () => {}
+    try {
+      expect(await runCli(['run', 'my-project'])).toBe(2)
+    } finally {
+      console.error = origError
+    }
+  })
+
+  it('returns 2 when an unexpected non-CliError exception is thrown', async () => {
+    vi.mocked(dispatchRegisteredCommand).mockRejectedValueOnce(
+      new Error('unexpected crash'),
+    )
+    const origError = console.error
+    console.error = () => {}
+    try {
+      expect(await runCli(['run', 'my-project'])).toBe(2)
+    } finally {
+      console.error = origError
+    }
+  })
+})

--- a/packages/canonry/test/wordpress-commands.test.ts
+++ b/packages/canonry/test/wordpress-commands.test.ts
@@ -115,7 +115,7 @@ describe('wordpress CLI commands', () => {
     }
   })
 
-  it('prompts for an app password when wordpress connect omits --app-password', async () => {
+  it('errors when wordpress connect omits --app-password', async () => {
     originalConfigDir = process.env.CANONRY_CONFIG_DIR
     originalFetch = globalThis.fetch
 
@@ -123,81 +123,22 @@ describe('wordpress CLI commands', () => {
     closeHarness = harness.close
     process.env.CANONRY_CONFIG_DIR = harness.tmpDir
 
-    vi.resetModules()
-    vi.doMock('node:readline', () => ({
-      createInterface: () => ({
-        question: (_prompt: string, callback: (value: string) => void) => callback('interactive-app-pass'),
-        close: () => undefined,
-      }),
-    }))
+    const result = await invokeCli([
+      'wordpress',
+      'connect',
+      'test-proj',
+      '--url',
+      'https://example.com',
+      '--user',
+      'admin',
+      '--format',
+      'json',
+    ])
 
-    globalThis.fetch = async (input: string | URL | Request, init?: RequestInit) => {
-      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
-      if (url.startsWith(harness.serverUrl)) {
-        return originalFetch(input, init)
-      }
-      if (url.includes('/wp-json/wp/v2/users/me?')) {
-        return jsonResponse({ id: 1, slug: 'admin' })
-      }
-      if (url.includes('/wp-json/wp/v2/plugins')) {
-        return new Response('Not found', { status: 404 })
-      }
-      if (url.includes('/wp-json/wp/v2/pages?per_page=1')) {
-        return jsonResponse([], {
-          headers: {
-            'x-wp-total': '0',
-            'x-wp-totalpages': '1',
-          },
-        })
-      }
-      if (url === 'https://example.com' || url === 'https://example.com/') {
-        return new Response('<meta name="generator" content="WordPress 6.8.1" />', { status: 200 })
-      }
-      throw new Error(`Unhandled URL: ${url}`)
-    }
-
-    const logs: string[] = []
-    const origLog = console.log
-    const origError = console.error
-    const origStderrWrite = process.stderr.write
-
-    let stdout = ''
-    try {
-      console.log = (...parts: unknown[]) => logs.push(parts.join(' '))
-      console.error = () => undefined
-      process.stderr.write = (() => true) as typeof process.stderr.write
-
-      const { runCli } = await import('../src/cli.js')
-      await runCli([
-        'wordpress',
-        'connect',
-        'test-proj',
-        '--url',
-        'https://example.com',
-        '--user',
-        'admin',
-        '--format',
-        'json',
-      ])
-      stdout = logs.join('\n')
-    } finally {
-      console.log = origLog
-      console.error = origError
-      process.stderr.write = origStderrWrite
-      vi.doUnmock('node:readline')
-    }
-
-    const body = parseJsonOutput(stdout) as { connected: boolean; defaultEnv: string }
-    expect(body.connected).toBe(true)
-    expect(body.defaultEnv).toBe('live')
-
-    const stored = parse(fs.readFileSync(harness.configPath, 'utf-8')) as {
-      wordpress?: { connections?: Array<{ username: string; appPassword: string }> }
-    }
-    expect(stored.wordpress?.connections?.[0]).toMatchObject({
-      username: 'admin',
-      appPassword: 'interactive-app-pass',
-    })
+    expect(result.exitCode).toBe(1)
+    const error = parseJsonOutput(result.stderr) as { error: { code: string; message: string } }
+    expect(error.error.code).toBe('WORDPRESS_APP_PASSWORD_REQUIRED')
+    expect(error.error.message).toContain('Application Password is required')
   })
 
   it('shows an actionable error when wordpress connect fails with invalid credentials', async () => {


### PR DESCRIPTION
## Summary

- Removes `readline` prompt fallbacks from `bing` and `wordpress` commands so all CLI commands are fully operable via flags without human interaction
- Adds `EXIT_USER_ERROR`/`EXIT_SYSTEM_ERROR` constants and a `systemError()` factory to `cli-error.ts`; `runCli()` now returns the correct exit code (1 for user errors, 2 for system/network errors)
- `ApiClient` now throws typed `CliError` with exit codes mapped by HTTP status (4xx→1, 5xx→2, network→2), so agents can branch on exit codes from any CLI command
- Adds an ESLint rule banning `readline` imports in command files (with `init.ts` exempted), and updates CLAUDE.md with explicit numbered agent-design rules and a per-command checklist

## Test plan

- [ ] `pnpm test` passes (207 tests, including new `cli-error.test.ts` covering `systemError()` and exit code 2 propagation)
- [ ] `canonry bing connect <proj>` without `--api-key` exits 1 with structured JSON error
- [ ] `canonry wordpress connect <proj>` without `--app-password` exits 1 with structured JSON error
- [ ] Network failure (server not running) exits 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)