### PR TITLE
chore(providers): improve error logging in retry utilities

### DIFF
--- a/packages/provider-claude/src/utils.ts
+++ b/packages/provider-claude/src/utils.ts
@@ -15,7 +15,7 @@ export async function withRetry<T>(
       lastError = err
       if (attempt < maxRetries) {
         const delay = initialDelay * Math.pow(2, attempt)
-        console.warn(`[provider] Attempt ${attempt + 1} failed, retrying in ${delay}ms...`, err)
+        console.warn(`[provider] Attempt ${attempt + 1} failed, retrying in ${delay}ms...`, err instanceof Error ? err.message : String(err))
         await new Promise((resolve) => setTimeout(resolve, delay))
       }
     }

--- a/packages/provider-gemini/src/utils.ts
+++ b/packages/provider-gemini/src/utils.ts
@@ -15,7 +15,7 @@ export async function withRetry<T>(
       lastError = err
       if (attempt < maxRetries) {
         const delay = initialDelay * Math.pow(2, attempt)
-        console.warn(`[provider] Attempt ${attempt + 1} failed, retrying in ${delay}ms...`, err)
+        console.warn(`[provider] Attempt ${attempt + 1} failed, retrying in ${delay}ms...`, err instanceof Error ? err.message : String(err))
         await new Promise((resolve) => setTimeout(resolve, delay))
       }
     }

--- a/packages/provider-local/src/utils.ts
+++ b/packages/provider-local/src/utils.ts
@@ -15,7 +15,7 @@ export async function withRetry<T>(
       lastError = err
       if (attempt < maxRetries) {
         const delay = initialDelay * Math.pow(2, attempt)
-        console.warn(`[provider] Attempt ${attempt + 1} failed, retrying in ${delay}ms...`, err)
+        console.warn(`[provider] Attempt ${attempt + 1} failed, retrying in ${delay}ms...`, err instanceof Error ? err.message : String(err))
         await new Promise((resolve) => setTimeout(resolve, delay))
       }
     }

--- a/packages/provider-openai/src/utils.ts
+++ b/packages/provider-openai/src/utils.ts
@@ -15,7 +15,7 @@ export async function withRetry<T>(
       lastError = err
       if (attempt < maxRetries) {
         const delay = initialDelay * Math.pow(2, attempt)
-        console.warn(`[provider] Attempt ${attempt + 1} failed, retrying in ${delay}ms...`, err)
+        console.warn(`[provider] Attempt ${attempt + 1} failed, retrying in ${delay}ms...`, err instanceof Error ? err.message : String(err))
         await new Promise((resolve) => setTimeout(resolve, delay))
       }
     }

--- a/packages/provider-perplexity/src/utils.ts
+++ b/packages/provider-perplexity/src/utils.ts
@@ -15,7 +15,7 @@ export async function withRetry<T>(
       lastError = err
       if (attempt < maxRetries) {
         const delay = initialDelay * Math.pow(2, attempt)
-        console.warn(`[provider] Attempt ${attempt + 1} failed, retrying in ${delay}ms...`, err)
+        console.warn(`[provider] Attempt ${attempt + 1} failed, retrying in ${delay}ms...`, err instanceof Error ? err.message : String(err))
         await new Promise((resolve) => setTimeout(resolve, delay))
       }
     }


### PR DESCRIPTION
## Summary
Overnight audit of provider packages (`provider-cdp`, `provider-claude`, `provider-gemini`, `provider-local`, `provider-openai`, `provider-perplexity`) as per scheduled cron job.

## Scope
- Reviewed all `src/` and `test/` files in the listed packages.
- Checked for:
  - Insecure API key/credential handling (none found)
  - Missing error normalization (consistent across providers)
  - Unhandled API error responses (errors are caught and re‑thrown with provider prefix)
  - Incorrect type assumptions (no unsafe casts)
  - Missing retries or backoff (all API calls use `withRetry` with exponential backoff)
  - Adapter inconsistencies (interfaces are uniform)
  - CLAUDE.md violations (no imports from `apps/*`, credentials reside in `~/.canonry/config.yaml`, test coverage present)

## Findings
1. **Potential info leak in retry logs**: The `withRetry` utility in five providers (`claude`, `gemini`, `openai`, `local`, `perplexity`) logged the entire error object to `console.warn`. While the SDK errors are unlikely to contain secrets, we now log only the error message (`err.message` or `String(err)`) to eliminate any risk of exposing sensitive data in logs.

## Changes
- Updated `packages/provider-*/src/utils.ts` to log the error message instead of the full error object.

## Verification
- TypeScript compilation passes (`pnpm typecheck`)
- Linting passes (`pnpm lint`)
- All provider tests pass (`pnpm test`)

## Notes
No other actionable issues were identified. The provider adapters are well‑structured, secure, and consistent with the project’s design guidelines.
