### PR TITLE
chore(db): audit fixes for credential storage warnings

### DIFF
--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -143,6 +143,7 @@ const MIGRATIONS = [
   // v5b: Backfill model from rawResponse JSON for existing snapshots
   `UPDATE query_snapshots SET model = json_extract(raw_response, '$.model') WHERE model IS NULL AND raw_response IS NOT NULL AND json_extract(raw_response, '$.model') IS NOT NULL`,
   // v6: Google Search Console integration — google_connections table (domain-scoped)
+  // WARNING: access_token, refresh_token are authentication material; consider storing in config.yaml per CLAUDE.md
   `CREATE TABLE IF NOT EXISTS google_connections (
     id              TEXT PRIMARY KEY,
     domain          TEXT NOT NULL,
@@ -258,6 +259,7 @@ const MIGRATIONS = [
   `CREATE INDEX IF NOT EXISTS idx_bing_keyword_project ON bing_keyword_stats(project_id)`,
   `CREATE INDEX IF NOT EXISTS idx_bing_keyword_query ON bing_keyword_stats(query)`,
   // v13: Google Analytics 4 — ga_connections table (service account auth)
+  // WARNING: private_key is authentication material; consider storing in config.yaml per CLAUDE.md
   `CREATE TABLE IF NOT EXISTS ga_connections (
     id            TEXT PRIMARY KEY,
     project_id    TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,


### PR DESCRIPTION
## Database Audit Findings

Audited `packages/db/` per CLAUDE.md guidelines. Focus areas: SQL injection vectors, missing migrations, unsafe schema changes, missing indexes, credential storage.

### Findings

1. **Migration coverage**: All tables and columns defined in `schema.ts` have corresponding migrations in `migrate.ts` (either in `MIGRATION_SQL` or `MIGRATIONS` array). No missing `CREATE TABLE` or `ALTER TABLE` statements.
2. **SQL injection**: No raw SQL concatenation found. Drizzle ORM used throughout; `migrate.ts` uses static SQL strings with `sql.raw`.
3. **JSON column parsing**: Safe `parseJsonColumn` helper used as required.
4. **Indexes**: All indexes defined in schema exist in migrations. No missing indexes on foreign keys.
5. **Schema safety**: All migrations are additive (`ADD COLUMN`, `CREATE TABLE IF NOT EXISTS`). No `DROP COLUMN` or `DROP TABLE` operations that could cause data loss.
6. **Parameterization**: All queries via Drizzle are parameterized.
7. **Transaction handling**: Not applicable within db package (transaction boundaries are managed by callers).
8. **Connection leaks**: SQLite connection managed by Better-SQLite3, no pooling.

### Credential Storage Concern

- `google_connections` table stores `access_token` and `refresh_token` (OAuth tokens).
- `ga_connections` table stores `private_key` (service account key).

CLAUDE.md states: "Store provider API keys, Google OAuth client credentials, and Google OAuth access/refresh tokens in the local config file. Do not treat the SQLite database as the authoritative store for authentication material."

**Action taken**: Added warning comments in `migrate.ts` next to the relevant table definitions, reminding developers to consider storing authentication material in `config.yaml`.

### Tests

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test` ✅ (all packages, including db tests)

### Changes

- `packages/db/src/migrate.ts`: added warning comments for credential storage.

### Recommended Follow-up

Consider moving OAuth tokens and service account keys out of the database and into the local config file (`~/.canonry/config.yaml`) to align with CLAUDE.md guidance. This would be a breaking change requiring updates to integration packages.
