### PR TITLE
chore(integrations): add missing test coverage for WordPress schema templates

### DIFF
--- a/packages/integration-wordpress/test/schema-templates.test.ts
+++ b/packages/integration-wordpress/test/schema-templates.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest'
+import {
+  generateSchema,
+  isSupportedSchemaType,
+  parseSchemaPageEntry,
+  supportedSchemaTypes,
+  type BusinessProfile,
+} from '../src/schema-templates.js'
+
+describe('schema-templates', () => {
+  const mockBusiness: BusinessProfile = {
+    name: 'Test Business',
+    url: 'https://example.com',
+    description: 'A test business',
+    phone: '+1234567890',
+    email: 'info@example.com',
+    address: {
+      street: '123 Main St',
+      city: 'Anytown',
+      state: 'CA',
+      zip: '90210',
+      country: 'USA',
+    },
+  }
+
+  describe('isSupportedSchemaType', () => {
+    it('returns true for supported types', () => {
+      expect(isSupportedSchemaType('LocalBusiness')).toBe(true)
+      expect(isSupportedSchemaType('Organization')).toBe(true)
+      expect(isSupportedSchemaType('FAQPage')).toBe(true)
+      expect(isSupportedSchemaType('Service')).toBe(true)
+      expect(isSupportedSchemaType('WebPage')).toBe(true)
+    })
+
+    it('returns false for unsupported types', () => {
+      expect(isSupportedSchemaType('Product')).toBe(false)
+      expect(isSupportedSchemaType('Person')).toBe(false)
+      expect(isSupportedSchemaType('')).toBe(false)
+    })
+  })
+
+  describe('supportedSchemaTypes', () => {
+    it('returns list of supported types', () => {
+      const types = supportedSchemaTypes()
+      expect(types).toEqual([
+        'LocalBusiness',
+        'Organization',
+        'FAQPage',
+        'Service',
+        'WebPage',
+      ])
+    })
+  })
+
+  describe('parseSchemaPageEntry', () => {
+    it('parses string entry', () => {
+      const result = parseSchemaPageEntry('LocalBusiness')
+      expect(result).toEqual({ type: 'LocalBusiness' })
+    })
+
+    it('parses object entry with type only', () => {
+      const result = parseSchemaPageEntry({ type: 'Organization' })
+      expect(result).toEqual({ type: 'Organization' })
+    })
+
+    it('parses object entry with type and faqs', () => {
+      const faqs = [
+        { q: 'Question 1', a: 'Answer 1' },
+        { q: 'Question 2', a: 'Answer 2' },
+      ]
+      const result = parseSchemaPageEntry({ type: 'FAQPage', faqs })
+      expect(result).toEqual({ type: 'FAQPage', faqs })
+    })
+  })
+
+  describe('generateSchema', () => {
+    it('generates LocalBusiness schema', () => {
+      const schema = generateSchema('LocalBusiness', mockBusiness)
+      expect(schema['@type']).toBe('LocalBusiness')
+      expect(schema.name).toBe(mockBusiness.name)
+      expect(schema.url).toBe(mockBusiness.url)
+      expect(schema.description).toBe(mockBusiness.description)
+      expect(schema.telephone).toBe(mockBusiness.phone)
+      expect(schema.email).toBe(mockBusiness.email)
+      expect(schema.address).toEqual({
+        '@type': 'PostalAddress',
+        streetAddress: mockBusiness.address!.street,
+        addressLocality: mockBusiness.address!.city,
+        addressRegion: mockBusiness.address!.state,
+        postalCode: mockBusiness.address!.zip,
+        addressCountry: mockBusiness.address!.country,
+      })
+    })
+
+    it('generates Organization schema', () => {
+      const schema = generateSchema('Organization', mockBusiness)
+      expect(schema['@type']).toBe('Organization')
+      expect(schema.name).toBe(mockBusiness.name)
+      expect(schema.url).toBe(mockBusiness.url)
+      expect(schema.description).toBe(mockBusiness.description)
+      expect(schema.telephone).toBe(mockBusiness.phone)
+      expect(schema.email).toBe(mockBusiness.email)
+      expect(schema.address).toEqual({
+        '@type': 'PostalAddress',
+        streetAddress: mockBusiness.address!.street,
+        addressLocality: mockBusiness.address!.city,
+        addressRegion: mockBusiness.address!.state,
+        postalCode: mockBusiness.address!.zip,
+        addressCountry: mockBusiness.address!.country,
+      })
+    })
+
+    it('generates FAQPage schema with faqs', () => {
+      const faqs = [
+        { q: 'Question 1', a: 'Answer 1' },
+        { q: 'Question 2', a: 'Answer 2' },
+      ]
+      const schema = generateSchema('FAQPage', mockBusiness, { faqs })
+      expect(schema['@type']).toBe('FAQPage')
+      expect(schema.name).toBe(mockBusiness.name)
+      expect(schema.mainEntity).toEqual([
+        {
+          '@type': 'Question',
+          name: 'Question 1',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'Answer 1',
+          },
+        },
+        {
+          '@type': 'Question',
+          name: 'Question 2',
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: 'Answer 2',
+          },
+        },
+      ])
+    })
+
+    it('generates FAQPage schema without faqs', () => {
+      const schema = generateSchema('FAQPage', mockBusiness)
+      expect(schema['@type']).toBe('FAQPage')
+      expect(schema.name).toBe(mockBusiness.name)
+      expect(schema.mainEntity).toBeUndefined()
+    })
+
+    it('generates Service schema', () => {
+      const schema = generateSchema('Service', mockBusiness)
+      expect(schema['@type']).toBe('Service')
+      expect(schema.name).toBe(mockBusiness.name)
+      expect(schema.url).toBe(mockBusiness.url)
+      expect(schema.description).toBe(mockBusiness.description)
+      expect(schema.areaServed).toEqual({
+        '@type': 'PostalAddress',
+        streetAddress: mockBusiness.address!.street,
+        addressLocality: mockBusiness.address!.city,
+        addressRegion: mockBusiness.address!.state,
+        postalCode: mockBusiness.address!.zip,
+        addressCountry: mockBusiness.address!.country,
+      })
+    })
+
+    it('generates WebPage schema', () => {
+      const schema = generateSchema('WebPage', mockBusiness)
+      expect(schema['@type']).toBe('WebPage')
+      expect(schema.name).toBe(mockBusiness.name)
+      expect(schema.url).toBe(mockBusiness.url)
+      expect(schema.description).toBe(mockBusiness.description)
+    })
+
+    it('throws error for unsupported type', () => {
+      expect(() => generateSchema('InvalidType', mockBusiness)).toThrow('Unsupported schema type')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

This PR adds missing test coverage for `packages/integration-wordpress/src/schema-templates.ts`, addressing a CLAUDE.md violation (missing test coverage). No other security or code quality issues were found in the integration packages (`integration-bing`, `integration-google`, `integration-google-analytics`, `integration-wordpress`).

## Issues Found and Fixed

### 1. Missing test coverage for WordPress schema templates
- **Location:** `packages/integration-wordpress/src/schema-templates.ts`
- **Issue:** The module had no dedicated test file, violating the CLAUDE.md requirement for test coverage.
- **Fix:** Added `packages/integration-wordpress/test/schema-templates.test.ts` with comprehensive unit tests for all exported functions (`isSupportedSchemaType`, `supportedSchemaTypes`, `parseSchemaPageEntry`, `generateSchema`).
- **Verification:** All new tests pass; existing test suite remains green.

### 2. No security issues detected
- **OAuth credential handling:** No OAuth credentials or tokens are stored in SQLite DB by the integration packages (storage occurs in `packages/db` which is outside the audit scope).
- **Unsanitized inputs:** All external API calls properly validate and encode inputs (URL validation, encodeURIComponent).
- **Missing request validation:** Each client function includes validation for required parameters.
- **Error handling gaps:** Appropriate error classes are used, and HTTP errors are logged without exposing sensitive data.
- **Sensitive data leaking in logs:** Logs only include HTTP status and truncated response bodies; no tokens or secrets are logged.
- **Rate limit handling:** Clients detect HTTP 429 and throw appropriate errors.
- **HTTP client security:** Uses `fetch` with timeouts and proper headers.
- **Import violations:** No integration packages import from `apps/*`.

## Testing

- `pnpm typecheck` passes across all packages.
- `pnpm lint` reports no new errors.
- `pnpm test` passes for all integration packages.

## Notes

- The audit focused solely on `packages/integration-*` as specified.
- The `packages/db` schema stores OAuth tokens (access_token, refresh_token) in the `google_connections` table, but this is outside the scope of integration packages and should be reviewed separately if required.