### PR TITLE
chore(db): audit fixes for authentication material warnings

### DIFF
--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -138,6 +138,7 @@ export const googleConnections = sqliteTable('google_connections', {
   connectionType: text('connection_type').notNull(),
   propertyId: text('property_id'),
   sitemapUrl: text('sitemap_url'),
+  // WARNING: Authentication material should be stored in config.yaml per CLAUDE.md
   accessToken: text('access_token'),
   refreshToken: text('refresh_token'),
   tokenExpiresAt: text('token_expires_at'),
@@ -253,6 +254,7 @@ export const gaConnections = sqliteTable('ga_connections', {
   projectId: text('project_id').notNull().references(() => projects.id, { onDelete: 'cascade' }),
   propertyId: text('property_id').notNull(),
   clientEmail: text('client_email').notNull(),
+  // WARNING: Authentication material should be stored in config.yaml per CLAUDE.md
   privateKey: text('private_key').notNull(),
   createdAt: text('created_at').notNull(),
   updatedAt: text('updated_at').notNull(),


### PR DESCRIPTION
## Summary

Nightly audit of the  module found the following:

### ✅ Compliant
- No SQL injection vectors (all queries use Drizzle ORM or static raw SQL).
- All  definitions have corresponding  in migrations.
- All columns present in schema have corresponding migrations (either in  or  array).
- All indexes defined in schema are present in migration SQL.
- No edits to  (only appends to  array).
- TypeScript types are correctly inferred via Drizzle.
- Tests pass (
> canonry@1.39.0 typecheck /home/arberx/.openclaw/workspace/canonry
> pnpm -r --no-bail run typecheck

Scope: 19 of 20 workspace projects
packages/contracts typecheck$ tsc --noEmit -p tsconfig.json
packages/db typecheck$ tsc --noEmit -p tsconfig.json
packages/intelligence typecheck$ tsc --noEmit -p tsconfig.json
packages/intelligence typecheck: Done
packages/contracts typecheck: Done
packages/db typecheck: Done
apps/web typecheck$ tsc --noEmit -p tsconfig.json
packages/integration-bing typecheck$ tsc --noEmit -p tsconfig.json
packages/config typecheck$ tsc --noEmit -p tsconfig.json
packages/integration-google typecheck$ tsc --noEmit -p tsconfig.json
packages/integration-bing typecheck: Done
packages/integration-google-analytics typecheck$ tsc --noEmit -p tsconfig.json
packages/integration-google typecheck: Done
packages/integration-wordpress typecheck$ tsc --noEmit -p tsconfig.json
packages/config typecheck: Done
packages/provider-cdp typecheck$ tsc --noEmit -p tsconfig.json
packages/integration-google-analytics typecheck: Done
packages/provider-claude typecheck$ tsc --noEmit -p tsconfig.json
packages/integration-wordpress typecheck: Done
packages/provider-gemini typecheck$ tsc --noEmit -p tsconfig.json
packages/provider-cdp typecheck: Done
packages/provider-local typecheck$ tsc --noEmit -p tsconfig.json
packages/provider-claude typecheck: Done
packages/provider-openai typecheck$ tsc --noEmit -p tsconfig.json
packages/provider-gemini typecheck: Done
packages/provider-perplexity typecheck$ tsc --noEmit -p tsconfig.json
packages/provider-local typecheck: Done
packages/provider-openai typecheck: Done
packages/provider-perplexity typecheck: Done
apps/web typecheck: Done
packages/api-routes typecheck$ tsc --noEmit -p tsconfig.json
apps/worker typecheck$ tsc --noEmit -p tsconfig.json
apps/worker typecheck: Done
packages/api-routes typecheck: Done
apps/api typecheck$ tsc --noEmit -p tsconfig.json
packages/canonry typecheck$ tsc --noEmit -p tsconfig.json
apps/api typecheck: Done
packages/canonry typecheck: Done, 
> canonry@1.39.0 lint /home/arberx/.openclaw/workspace/canonry
> pnpm -r run lint

Scope: 19 of 20 workspace projects
packages/contracts lint$ eslint src/ test/
packages/db lint$ eslint src/ test/
packages/intelligence lint$ eslint src/ test/
packages/db lint: Done
packages/intelligence lint: Done
packages/contracts lint: Done
packages/config lint$ eslint src/ test/
packages/integration-bing lint$ eslint src/ test/
apps/web lint$ eslint src/ test/ vite.config.ts
packages/integration-google lint$ eslint src/ test/
packages/config lint: Done
packages/integration-google-analytics lint$ eslint src/ test/
packages/integration-bing lint: Done
packages/integration-wordpress lint$ eslint src/ test/
packages/integration-google lint: Done
packages/provider-cdp lint$ eslint src/ test/
packages/integration-google-analytics lint: Done
packages/provider-claude lint$ eslint src/ test/
packages/provider-cdp lint: Done
packages/provider-gemini lint$ eslint src/ test/
packages/integration-wordpress lint: Done
packages/provider-local lint$ eslint src/ test/
apps/web lint: Done
packages/provider-openai lint$ eslint src/ test/
packages/provider-claude lint: Done
packages/provider-perplexity lint$ eslint src/ test/
packages/provider-local lint: Done
packages/provider-gemini lint: Done
packages/provider-openai lint: Done
packages/provider-perplexity lint: Done
apps/worker lint$ eslint src/ test/
packages/api-routes lint$ eslint src/ test/
apps/worker lint: Done
packages/api-routes lint: Done
apps/api lint$ eslint src/ test/
packages/canonry lint$ eslint src/ test/
apps/api lint: Done
packages/canonry lint: Done, 
> canonry@1.39.0 test /home/arberx/.openclaw/workspace/canonry
> vitest run


[1m[46m RUN [49m[22m [36mv4.1.0 [39m[90m/home/arberx/.openclaw/workspace/canonry[39m

 [32m✓[39m packages/api-routes/test/cdp.test.ts [2m([22m[2m21 tests[22m[2m)[22m[33m 622[2mms[22m[39m
[90mstdout[2m | packages/canonry/test/index.test.ts[2m > [22m[2mcanonry[2m > [22m[2minitCommand embeds CANONRY_PORT into saved apiUrl
[22m[39mInitializing canonry...


Config saved to /tmp/canonry-init-port-9fb86e7b-0eb4-45dc-b9d5-25b433b53714/config.yaml
Database created at /tmp/canonry-init-port-9fb86e7b-0eb4-45dc-b9d5-25b433b53714/data.db
API key: cnry_b79da29dc5165ad89d52ec9c21e7082a
Providers: gemini
Run "canonry serve" to start the server.

{"ts":"2026-04-06T08:07:57.206Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.211Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.213Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
[90mstdout[2m | packages/canonry/test/index.test.ts[2m > [22m[2mcanonry[2m > [22m[2mbootstrapCommand creates config and replaces the default API key on force
[22m[39mBootstrap complete. Config saved to /tmp/canonry-bootstrap-a22288c5-55c1-457f-b8d0-954a3f7bfda0/config.yaml
SQLite database path: /tmp/canonry-bootstrap-a22288c5-55c1-457f-b8d0-954a3f7bfda0/data.db

[90mstdout[2m | packages/canonry/test/index.test.ts[2m > [22m[2mcanonry[2m > [22m[2mbootstrapCommand creates config and replaces the default API key on force
[22m[39mBootstrap complete. Config saved to /tmp/canonry-bootstrap-a22288c5-55c1-457f-b8d0-954a3f7bfda0/config.yaml
SQLite database path: /tmp/canonry-bootstrap-a22288c5-55c1-457f-b8d0-954a3f7bfda0/data.db

[90mstdout[2m | packages/canonry/test/index.test.ts[2m > [22m[2mcanonry[2m > [22m[2mbootstrapCommand creates config and replaces the default API key on force
[22m[39mBootstrap complete. Config saved to /tmp/canonry-bootstrap-a22288c5-55c1-457f-b8d0-954a3f7bfda0/config.yaml
SQLite database path: /tmp/canonry-bootstrap-a22288c5-55c1-457f-b8d0-954a3f7bfda0/data.db

{"ts":"2026-04-06T08:07:57.317Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.326Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.331Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.339Z","level":"info","module":"Server","action":"providers.configured","providers":["gemini"]}
{"ts":"2026-04-06T08:07:57.437Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.449Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.461Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.474Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.482Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.491Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.503Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.513Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.527Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.562Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.575Z","level":"info","module":"Server","action":"providers.configured","providers":["gemini"]}
{"ts":"2026-04-06T08:07:57.578Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.586Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.592Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.602Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.609Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.622Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.640Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.644Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.645Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.658Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.662Z","level":"info","module":"InspectSitemap","action":"sitemap.fetch","runId":"e730e6d0-6eb3-47c3-8efd-ba74375d85e1","projectId":"00bd7a44-fd11-4ebb-b214-582c2ed712c4","sitemapUrl":"https://example.com/sitemap.xml"}
{"ts":"2026-04-06T08:07:57.663Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.681Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.682Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.688Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.695Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.703Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.708Z","level":"info","module":"Server","action":"providers.configured","providers":["gemini"]}
{"ts":"2026-04-06T08:07:57.725Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.731Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.735Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.740Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.744Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.745Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.760Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.768Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.773Z","level":"info","module":"Server","action":"providers.configured","providers":["gemini"]}
{"ts":"2026-04-06T08:07:57.775Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.789Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.791Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.792Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.804Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.823Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.834Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.838Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.841Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.842Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.851Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.862Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.870Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.879Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.891Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
[90mstdout[2m | packages/canonry/test/index.test.ts[2m > [22m[2mcanonry[2m > [22m[2minitCommand non-interactive mode creates config from flags
[22m[39mInitializing canonry...


Config saved to /tmp/canonry-init-ac5ec8ad-4758-4992-84a4-ed7c6bfa0efc/config.yaml
Database created at /tmp/canonry-init-ac5ec8ad-4758-4992-84a4-ed7c6bfa0efc/data.db
API key: cnry_8237ebfd6125939e1f8446c0ce872196
Providers: gemini, openai
Run "canonry serve" to start the server.

{"ts":"2026-04-06T08:07:57.904Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.907Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.912Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.914Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.929Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.932Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.933Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.937Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
[90mstdout[2m | packages/canonry/test/index.test.ts[2m > [22m[2mcanonry[2m > [22m[2minitCommand non-interactive mode reads env vars as fallback
[22m[39mInitializing canonry...


Config saved to /tmp/canonry-init-env-b03b77de-4e94-4cd4-a4a0-698bae2bafc8/config.yaml
Database created at /tmp/canonry-init-env-b03b77de-4e94-4cd4-a4a0-698bae2bafc8/data.db
API key: cnry_e2548bf96544764adfc91c53072f6791
Providers: claude
Run "canonry serve" to start the server.

 [32m✓[39m packages/canonry/test/analytics.test.ts [2m([22m[2m7 tests[22m[2m)[22m[33m 805[2mms[22m[39m
{"ts":"2026-04-06T08:07:57.961Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.970Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.974Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.975Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.977Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.979Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:57.993Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:57.998Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.003Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.005Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.006Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.014Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.040Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.042Z","level":"info","module":"Server","action":"providers.configured","providers":["openai"]}
{"ts":"2026-04-06T08:07:58.043Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.043Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.049Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.060Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.062Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.072Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.080Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.088Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.093Z","level":"info","module":"IntelligenceService","action":"intelligence.skip","runId":"818eab8c-9650-4355-9fdb-c22e1ba85276","reason":"no completed runs"}
{"ts":"2026-04-06T08:07:58.093Z","level":"info","module":"Notifier","action":"run.completed","runId":"818eab8c-9650-4355-9fdb-c22e1ba85276","projectId":"e346307b-4ca2-4039-a42a-67141ef9446f"}
{"ts":"2026-04-06T08:07:58.093Z","level":"info","module":"Notifier","action":"notifications.none-enabled","projectId":"e346307b-4ca2-4039-a42a-67141ef9446f"}
{"ts":"2026-04-06T08:07:58.099Z","level":"info","module":"IntelligenceService","action":"intelligence.skip","runId":"de202440-ca8e-4e3b-9777-5cb2def0c9a0","reason":"no completed runs"}
{"ts":"2026-04-06T08:07:58.100Z","level":"info","module":"Notifier","action":"run.completed","runId":"de202440-ca8e-4e3b-9777-5cb2def0c9a0","projectId":"e346307b-4ca2-4039-a42a-67141ef9446f"}
{"ts":"2026-04-06T08:07:58.100Z","level":"info","module":"Notifier","action":"notifications.none-enabled","projectId":"e346307b-4ca2-4039-a42a-67141ef9446f"}
{"ts":"2026-04-06T08:07:58.103Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.104Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.113Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.114Z","level":"info","module":"Server","action":"providers.configured","providers":["gemini"]}
{"ts":"2026-04-06T08:07:58.130Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.130Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.137Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.138Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.139Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.152Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.157Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.157Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.159Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.160Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.161Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.178Z","level":"info","module":"GscSync","action":"fetch.start","runId":"86e02205-3dcf-4ea9-ad65-1bb714e6a330","projectId":"2ad83a9f-0000-4d99-880d-926bab3a3c5f","propertyId":"sc-domain:example.com","startDate":"2026-03-04","endDate":"2026-04-03"}
{"ts":"2026-04-06T08:07:58.179Z","level":"info","module":"GscSync","action":"fetch.complete","runId":"86e02205-3dcf-4ea9-ad65-1bb714e6a330","projectId":"2ad83a9f-0000-4d99-880d-926bab3a3c5f","rowCount":0}
{"ts":"2026-04-06T08:07:58.179Z","level":"info","module":"GscSync","action":"inspect.start","runId":"86e02205-3dcf-4ea9-ad65-1bb714e6a330","projectId":"2ad83a9f-0000-4d99-880d-926bab3a3c5f","urlCount":0}
{"ts":"2026-04-06T08:07:58.181Z","level":"info","module":"GscSync","action":"sync.completed","runId":"86e02205-3dcf-4ea9-ad65-1bb714e6a330","projectId":"2ad83a9f-0000-4d99-880d-926bab3a3c5f","searchDataRows":0,"urlInspections":0,"indexed":0,"notIndexed":0}
{"ts":"2026-04-06T08:07:58.183Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.183Z","level":"info","module":"IntelligenceService","action":"intelligence.skip","runId":"a3226f83-d137-40c1-95c8-c6273d96a549","reason":"no completed runs"}
{"ts":"2026-04-06T08:07:58.183Z","level":"info","module":"Notifier","action":"run.completed","runId":"a3226f83-d137-40c1-95c8-c6273d96a549","projectId":"8211a8ae-f888-4450-a451-b03ac85c994c"}
{"ts":"2026-04-06T08:07:58.184Z","level":"info","module":"Notifier","action":"notifications.none-enabled","projectId":"8211a8ae-f888-4450-a451-b03ac85c994c"}
{"ts":"2026-04-06T08:07:58.187Z","level":"info","module":"IntelligenceService","action":"intelligence.skip","runId":"a03a4cf8-1dee-4b78-a23b-03dfad6d8d1f","reason":"no completed runs"}
{"ts":"2026-04-06T08:07:58.187Z","level":"info","module":"Notifier","action":"run.completed","runId":"a03a4cf8-1dee-4b78-a23b-03dfad6d8d1f","projectId":"8211a8ae-f888-4450-a451-b03ac85c994c"}
{"ts":"2026-04-06T08:07:58.187Z","level":"info","module":"Notifier","action":"notifications.none-enabled","projectId":"8211a8ae-f888-4450-a451-b03ac85c994c"}
{"ts":"2026-04-06T08:07:58.191Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.192Z","level":"info","module":"IntelligenceService","action":"intelligence.skip","runId":"d2222b3b-49d9-442a-a3f5-7b4b9a027140","reason":"no completed runs"}
{"ts":"2026-04-06T08:07:58.192Z","level":"info","module":"Notifier","action":"run.completed","runId":"d2222b3b-49d9-442a-a3f5-7b4b9a027140","projectId":"8211a8ae-f888-4450-a451-b03ac85c994c"}
{"ts":"2026-04-06T08:07:58.193Z","level":"info","module":"Notifier","action":"notifications.none-enabled","projectId":"8211a8ae-f888-4450-a451-b03ac85c994c"}
{"ts":"2026-04-06T08:07:58.196Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.200Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
 [32m✓[39m packages/canonry/test/cli-run-contract.test.ts [2m([22m[2m6 tests[22m[2m)[22m[33m 830[2mms[22m[39m
     [33m[2m✓[22m[39m prints a JSON usage error for run cancel with missing project [33m 372[2mms[22m[39m
 [32m✓[39m packages/canonry/test/snapshot-command.test.ts [2m([22m[2m4 tests[22m[2m)[22m[33m 604[2mms[22m[39m
     [33m[2m✓[22m[39m prints snapshot JSON via the CLI [33m 309[2mms[22m[39m
{"ts":"2026-04-06T08:07:58.220Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.222Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.223Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.230Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.247Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.257Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.259Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.259Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.276Z","level":"info","module":"Server","action":"providers.configured","providers":["gemini"]}
{"ts":"2026-04-06T08:07:58.290Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.294Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.302Z","level":"info","module":"IntelligenceService","action":"intelligence.skip","runId":"748660b6-0b70-48cf-a6af-3dc8cd29bd5d","reason":"no completed runs"}
{"ts":"2026-04-06T08:07:58.303Z","level":"info","module":"Notifier","action":"run.completed","runId":"748660b6-0b70-48cf-a6af-3dc8cd29bd5d","projectId":"e9545c08-eb86-408b-8633-8a91ccd3115d"}
{"ts":"2026-04-06T08:07:58.303Z","level":"info","module":"Notifier","action":"notifications.none-enabled","projectId":"e9545c08-eb86-408b-8633-8a91ccd3115d"}
{"ts":"2026-04-06T08:07:58.303Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.306Z","level":"info","module":"IntelligenceService","action":"intelligence.skip","runId":"418a0d90-f915-437e-8fa0-dca0cea4ea28","reason":"no completed runs"}
{"ts":"2026-04-06T08:07:58.306Z","level":"info","module":"Notifier","action":"run.completed","runId":"418a0d90-f915-437e-8fa0-dca0cea4ea28","projectId":"e9545c08-eb86-408b-8633-8a91ccd3115d"}
{"ts":"2026-04-06T08:07:58.306Z","level":"info","module":"Notifier","action":"notifications.none-enabled","projectId":"e9545c08-eb86-408b-8633-8a91ccd3115d"}
 [32m✓[39m packages/canonry/test/index.test.ts [2m([22m[2m24 tests[22m[2m)[22m[33m 1165[2mms[22m[39m
{"ts":"2026-04-06T08:07:58.331Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.332Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.335Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.358Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.359Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.361Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
 [32m✓[39m packages/canonry/test/location-commands.test.ts [2m([22m[2m12 tests[22m[2m)[22m[33m 1225[2mms[22m[39m
{"ts":"2026-04-06T08:07:58.388Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
 [32m✓[39m apps/web/test/router.test.tsx [2m([22m[2m14 tests[22m[2m)[22m[33m 1058[2mms[22m[39m
{"ts":"2026-04-06T08:07:58.397Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.424Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.446Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.460Z","level":"info","module":"Scheduler","action":"cron.registered","projectId":"b2850a31-d943-424c-a5f0-cd6ce4e521a7","schedule":"daily","timezone":"UTC"}
 [32m✓[39m apps/web/test/run-notifications.test.tsx [2m([22m[2m7 tests[22m[2m)[22m[33m 1092[2mms[22m[39m
   [33m[2m✓[22m[39m toast CTA opens the existing run drawer via router state [33m 795[2mms[22m[39m
{"ts":"2026-04-06T08:07:58.474Z","level":"info","module":"Scheduler","action":"task.stopped","projectId":"b2850a31-d943-424c-a5f0-cd6ce4e521a7"}
{"ts":"2026-04-06T08:07:58.488Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.489Z","level":"info","module":"Scheduler","action":"cron.registered","projectId":"b2850a31-d943-424c-a5f0-cd6ce4e521a7","schedule":"daily","timezone":"UTC"}
{"ts":"2026-04-06T08:07:58.495Z","level":"info","module":"Scheduler","action":"task.removed","projectId":"b2850a31-d943-424c-a5f0-cd6ce4e521a7"}
{"ts":"2026-04-06T08:07:58.507Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.518Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
 [32m✓[39m packages/canonry/test/wordpress-commands.test.ts [2m([22m[2m11 tests[22m[2m)[22m[33m 1151[2mms[22m[39m
     [33m[2m✓[22m[39m errors when wordpress connect omits --app-password [33m 325[2mms[22m[39m
{"ts":"2026-04-06T08:07:58.537Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.570Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.582Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.620Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.639Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.684Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.691Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.700Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.726Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.749Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.804Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.804Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.823Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.868Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.889Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.925Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:58.954Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:58.966Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:59.004Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:59.005Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:59.020Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:59.043Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:59.045Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:59.064Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:59.069Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
 [32m✓[39m packages/canonry/test/keyword.test.ts [2m([22m[2m3 tests[22m[2m)[22m[33m 472[2mms[22m[39m
     [33m[2m✓[22m[39m removeKeywords prints the count of actually deleted phrases [33m 324[2mms[22m[39m
{"ts":"2026-04-06T08:07:59.094Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:59.144Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:59.208Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:59.230Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:59.253Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:59.265Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:59.306Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:59.325Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:59.361Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:59.378Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:59.406Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:59.423Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:59.453Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
[90mstdout[2m | packages/canonry/test/telemetry.test.ts[2m > [22m[2mtelemetry[2m > [22m[2mtelemetryCommand[2m > [22m[2mdisable sets telemetry: false in config file
[22m[39mTelemetry disabled. No data will be sent.

[90mstdout[2m | packages/canonry/test/telemetry.test.ts[2m > [22m[2mtelemetry[2m > [22m[2mtelemetryCommand[2m > [22m[2menable sets telemetry: true in config file
[22m[39mTelemetry enabled.

[90mstdout[2m | packages/canonry/test/telemetry.test.ts[2m > [22m[2mtelemetry[2m > [22m[2mtelemetryCommand[2m > [22m[2mdisable then enable round-trips correctly
[22m[39mTelemetry disabled. No data will be sent.
Telemetry enabled.

[90mstdout[2m | packages/canonry/test/telemetry.test.ts[2m > [22m[2mtelemetry[2m > [22m[2mtelemetryCommand[2m > [22m[2mdisable preserves other config fields
[22m[39mTelemetry disabled. No data will be sent.

{"ts":"2026-04-06T08:07:59.495Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:59.496Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:59.518Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:59.538Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:59.585Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:59.594Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:59.602Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:59.627Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
 [32m✓[39m packages/db/test/index.test.ts [2m([22m[2m14 tests[22m[2m)[22m[33m 328[2mms[22m[39m
{"ts":"2026-04-06T08:07:59.631Z","level":"info","module":"Server","action":"providers.configured","providers":["gemini"]}
 [32m✓[39m packages/canonry/test/telemetry.test.ts [2m([22m[2m45 tests[22m[2m)[22m[33m 322[2mms[22m[39m
{"ts":"2026-04-06T08:07:59.649Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
 [32m✓[39m packages/canonry/test/cli-operator-contract.test.ts [2m([22m[2m31 tests[22m[2m)[22m[33m 2276[2mms[22m[39m
 [32m✓[39m packages/api-routes/test/google.test.ts [2m([22m[2m29 tests[22m[2m)[22m[33m 351[2mms[22m[39m
 [32m✓[39m packages/api-routes/test/index.test.ts [2m([22m[2m39 tests[22m[2m)[22m[33m 337[2mms[22m[39m
{"ts":"2026-04-06T08:07:59.693Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:59.724Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:59.747Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:59.755Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:59.800Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:59.835Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:59.836Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
 [32m✓[39m packages/canonry/test/bing-commands.test.ts [2m([22m[2m3 tests[22m[2m)[22m[33m 446[2mms[22m[39m
{"ts":"2026-04-06T08:07:59.884Z","level":"info","module":"Server","action":"providers.configured","providers":["gemini"]}
{"ts":"2026-04-06T08:07:59.930Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:07:59.964Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:07:59.971Z","level":"info","module":"Server","action":"providers.configured","providers":["gemini"]}
{"ts":"2026-04-06T08:07:59.985Z","level":"info","module":"JobRunner","action":"run.dispatch","runId":"cae24b69-cf03-4eb9-b3cc-1a4e2a9c4dc6","providerCount":1,"providers":["gemini"]}
{"ts":"2026-04-06T08:07:59.988Z","level":"info","module":"JobRunner","action":"query.result","runId":"cae24b69-cf03-4eb9-b3cc-1a4e2a9c4dc6","provider":"gemini","keyword":"keyword-1","citedDomains":[],"groundingSources":[],"matchDomains":["example.com"]}
{"ts":"2026-04-06T08:07:59.990Z","level":"info","module":"JobRunner","action":"query.citation","runId":"cae24b69-cf03-4eb9-b3cc-1a4e2a9c4dc6","provider":"gemini","keyword":"keyword-1","citationState":"not-cited","answerMentioned":false}
{"ts":"2026-04-06T08:08:00.000Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:08:00.001Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:08:00.043Z","level":"info","module":"Server","action":"providers.configured","providers":["gemini"]}
{"ts":"2026-04-06T08:08:00.059Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:08:00.071Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:08:00.077Z","level":"info","module":"JobRunner","action":"run.dispatch","runId":"8fecdcb6-3cf8-424e-b1d3-d29fbe26ec35","providerCount":1,"providers":["gemini"]}
{"ts":"2026-04-06T08:08:00.082Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
 [32m✓[39m packages/canonry/test/cli-format.test.ts [2m([22m[2m4 tests[22m[2m)[22m[33m 529[2mms[22m[39m
{"ts":"2026-04-06T08:08:00.103Z","level":"info","module":"JobRunner","action":"query.result","runId":"8fecdcb6-3cf8-424e-b1d3-d29fbe26ec35","provider":"gemini","keyword":"keyword-1","citedDomains":[],"groundingSources":[],"matchDomains":["example.com"]}
{"ts":"2026-04-06T08:08:00.104Z","level":"info","module":"JobRunner","action":"query.citation","runId":"8fecdcb6-3cf8-424e-b1d3-d29fbe26ec35","provider":"gemini","keyword":"keyword-1","citationState":"not-cited","answerMentioned":false}
{"ts":"2026-04-06T08:08:00.104Z","level":"info","module":"JobRunner","action":"query.result","runId":"8fecdcb6-3cf8-424e-b1d3-d29fbe26ec35","provider":"gemini","keyword":"keyword-2","citedDomains":[],"groundingSources":[],"matchDomains":["example.com"]}
{"ts":"2026-04-06T08:08:00.105Z","level":"info","module":"JobRunner","action":"query.citation","runId":"8fecdcb6-3cf8-424e-b1d3-d29fbe26ec35","provider":"gemini","keyword":"keyword-2","citationState":"not-cited","answerMentioned":false}
{"ts":"2026-04-06T08:08:00.114Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:08:00.138Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:08:00.139Z","level":"info","module":"JobRunner","action":"query.result","runId":"8fecdcb6-3cf8-424e-b1d3-d29fbe26ec35","provider":"gemini","keyword":"keyword-3","citedDomains":[],"groundingSources":[],"matchDomains":["example.com"]}
{"ts":"2026-04-06T08:08:00.140Z","level":"info","module":"JobRunner","action":"query.citation","runId":"8fecdcb6-3cf8-424e-b1d3-d29fbe26ec35","provider":"gemini","keyword":"keyword-3","citationState":"not-cited","answerMentioned":false}
 [32m✓[39m packages/canonry/test/run-cancel-command.test.ts [2m([22m[2m4 tests[22m[2m)[22m[33m 515[2mms[22m[39m
     [33m[2m✓[22m[39m cancels a run by explicit run ID and outputs confirmation [33m 301[2mms[22m[39m
{"ts":"2026-04-06T08:08:00.182Z","level":"info","module":"JobRunner","action":"run.dispatch","runId":"600d3d8c-43d5-410c-abd0-cc0ee7831399","providerCount":1,"providers":["gemini"]}
 [32m✓[39m packages/canonry/test/job-runner-runtime-controls.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 250[2mms[22m[39m
{"ts":"2026-04-06T08:08:00.219Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:08:00.238Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:08:00.251Z","level":"info","module":"GscSync","action":"fetch.start","runId":"b9dce5e8-07c1-4723-abdb-e0c07b4b0a6b","projectId":"d4ef8a18-c312-4a8e-a5bc-df6c08e8bde1","propertyId":"sc-domain:example.com","startDate":"2026-03-04","endDate":"2026-04-03"}
{"ts":"2026-04-06T08:08:00.251Z","level":"info","module":"GscSync","action":"fetch.complete","runId":"b9dce5e8-07c1-4723-abdb-e0c07b4b0a6b","projectId":"d4ef8a18-c312-4a8e-a5bc-df6c08e8bde1","rowCount":0}
{"ts":"2026-04-06T08:08:00.252Z","level":"info","module":"GscSync","action":"inspect.start","runId":"b9dce5e8-07c1-4723-abdb-e0c07b4b0a6b","projectId":"d4ef8a18-c312-4a8e-a5bc-df6c08e8bde1","urlCount":0}
{"ts":"2026-04-06T08:08:00.252Z","level":"info","module":"GscSync","action":"sync.completed","runId":"b9dce5e8-07c1-4723-abdb-e0c07b4b0a6b","projectId":"d4ef8a18-c312-4a8e-a5bc-df6c08e8bde1","searchDataRows":0,"urlInspections":0,"indexed":0,"notIndexed":0}
{"ts":"2026-04-06T08:08:00.333Z","level":"info","module":"GA4Client","action":"fetch-traffic.start","propertyId":"123456","days":1}
{"ts":"2026-04-06T08:08:00.420Z","level":"info","module":"GA4Client","action":"fetch-traffic.done","propertyId":"123456","rowCount":10002}
{"ts":"2026-04-06T08:08:00.422Z","level":"info","module":"GA4Client","action":"fetch-traffic.start","propertyId":"123456","days":1}
{"ts":"2026-04-06T08:08:00.423Z","level":"info","module":"GA4Client","action":"fetch-traffic.done","propertyId":"123456","rowCount":1}
{"ts":"2026-04-06T08:08:00.426Z","level":"info","module":"GA4Client","action":"fetch-ai-referrals.start","propertyId":"123456","days":7}
{"ts":"2026-04-06T08:08:00.427Z","level":"info","module":"GA4Client","action":"fetch-ai-referrals.done","propertyId":"123456","rowCount":3}
{"ts":"2026-04-06T08:08:00.495Z","level":"info","module":"GA4Client","action":"fetch-aggregate.start","propertyId":"123456","days":30}
{"ts":"2026-04-06T08:08:00.496Z","level":"info","module":"GA4Client","action":"fetch-aggregate.done","propertyId":"123456","periodStart":"2026-03-07","periodEnd":"2026-04-06","totalSessions":5000,"totalUsers":3200,"totalOrganicSessions":1800}
{"ts":"2026-04-06T08:08:00.498Z","level":"info","module":"GA4Client","action":"fetch-aggregate.start","propertyId":"123456","days":7}
{"ts":"2026-04-06T08:08:00.498Z","level":"info","module":"GA4Client","action":"fetch-aggregate.done","propertyId":"123456","periodStart":"2026-03-30","periodEnd":"2026-04-06","totalSessions":0,"totalUsers":0,"totalOrganicSessions":0}
 [32m✓[39m packages/integration-google-analytics/test/ga4-client.test.ts [2m([22m[2m11 tests[22m[2m)[22m[33m 383[2mms[22m[39m
 [32m✓[39m apps/web/test/app.test.tsx [2m([22m[2m15 tests[22m[2m)[22m[33m 319[2mms[22m[39m
 [32m✓[39m packages/api-routes/test/export-roundtrip.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 228[2mms[22m[39m
{"ts":"2026-04-06T08:08:00.887Z","level":"info","module":"GA4Routes","action":"sync.complete","projectId":"fd1c0465-6bf9-412e-bf21-7175443f8e2b","rowCount":2,"aiReferralCount":1,"days":30,"totalUsers":55}
{"ts":"2026-04-06T08:08:00.902Z","level":"info","module":"GA4Routes","action":"sync.complete","projectId":"fd1c0465-6bf9-412e-bf21-7175443f8e2b","rowCount":0,"aiReferralCount":0,"days":30,"totalUsers":0}
 [32m✓[39m packages/api-routes/test/wordpress.test.ts [2m([22m[2m18 tests[22m[2m)[22m[32m 190[2mms[22m[39m
 [32m✓[39m packages/api-routes/test/security.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 290[2mms[22m[39m
 [32m✓[39m packages/api-routes/test/ga.test.ts [2m([22m[2m19 tests[22m[2m)[22m[32m 231[2mms[22m[39m
 [32m✓[39m packages/api-routes/test/error-envelopes.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 272[2mms[22m[39m
 [32m✓[39m packages/provider-cdp/test/connection.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 168[2mms[22m[39m
 [32m✓[39m packages/integration-google/test/gsc-client.test.ts [2m([22m[2m15 tests[22m[2m)[22m[32m 133[2mms[22m[39m
{"ts":"2026-04-06T08:08:01.310Z","level":"info","module":"IntelligenceService","action":"intelligence.analyzed","runId":"0f270902-554b-4958-8ccd-66e5744c49ff","regressions":0,"gains":1,"citedRate":1,"insights":1}
{"ts":"2026-04-06T08:08:01.313Z","level":"info","module":"IntelligenceService","action":"intelligence.persisted","runId":"0f270902-554b-4958-8ccd-66e5744c49ff","insights":1}
 [32m✓[39m packages/api-routes/test/analytics.test.ts [2m([22m[2m16 tests[22m[2m)[22m[32m 213[2mms[22m[39m
{"ts":"2026-04-06T08:08:01.334Z","level":"info","module":"IntelligenceService","action":"intelligence.skip","runId":"5911da15-05de-41b9-8794-6bce4722fa41","reason":"no snapshots"}
 [32m✓[39m packages/api-routes/test/openapi-contract.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 222[2mms[22m[39m
{"ts":"2026-04-06T08:08:01.353Z","level":"info","module":"IntelligenceService","action":"intelligence.skip","runId":"8f887679-1ea1-441d-bac0-b61707be6414","reason":"no snapshots"}
{"ts":"2026-04-06T08:08:01.377Z","level":"info","module":"IntelligenceService","action":"intelligence.analyzed","runId":"51b21a8c-3f32-4743-8f37-48173104d0ea","regressions":1,"gains":0,"citedRate":0,"insights":1}
{"ts":"2026-04-06T08:08:01.377Z","level":"info","module":"IntelligenceService","action":"intelligence.persisted","runId":"51b21a8c-3f32-4743-8f37-48173104d0ea","insights":1}
{"ts":"2026-04-06T08:08:01.380Z","level":"info","module":"IntelligenceService","action":"intelligence.analyzed","runId":"51b21a8c-3f32-4743-8f37-48173104d0ea","regressions":1,"gains":0,"citedRate":0,"insights":1}
{"ts":"2026-04-06T08:08:01.381Z","level":"info","module":"IntelligenceService","action":"intelligence.persisted","runId":"51b21a8c-3f32-4743-8f37-48173104d0ea","insights":1}
{"ts":"2026-04-06T08:08:01.401Z","level":"info","module":"IntelligenceService","action":"intelligence.analyzed","runId":"fe21fffd-775c-478d-a88e-c5cbfb1e5b7f","regressions":1,"gains":0,"citedRate":0,"insights":1}
{"ts":"2026-04-06T08:08:01.402Z","level":"info","module":"IntelligenceService","action":"intelligence.persisted","runId":"fe21fffd-775c-478d-a88e-c5cbfb1e5b7f","insights":1}
{"ts":"2026-04-06T08:08:01.422Z","level":"info","module":"IntelligenceService","action":"intelligence.persisted","runId":"a1d8df02-d21f-40ba-9ba5-887b21d369f0","insights":1}
{"ts":"2026-04-06T08:08:01.424Z","level":"info","module":"IntelligenceService","action":"intelligence.persisted","runId":"e6e9df37-8ffd-4405-a2fb-1f0c1d7d4838","insights":1}
{"ts":"2026-04-06T08:08:01.425Z","level":"info","module":"IntelligenceService","action":"intelligence.persisted","runId":"7c9a96c8-b12e-4ec9-a6f4-2d6cf02706fb","insights":1}
 [32m✓[39m packages/api-routes/test/snapshot.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 213[2mms[22m[39m
{"ts":"2026-04-06T08:08:01.463Z","level":"info","module":"IntelligenceService","action":"intelligence.persisted","runId":"1a1c71aa-5444-4597-a055-891c970b0865","insights":1}
 [32m✓[39m packages/canonry/test/intelligence-service.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 246[2mms[22m[39m
 [32m✓[39m packages/canonry/test/sitemap-parser.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 74[2mms[22m[39m
 [32m✓[39m packages/integration-wordpress/test/wordpress-client.test.ts [2m([22m[2m22 tests[22m[2m)[22m[32m 59[2mms[22m[39m
{"ts":"2026-04-06T08:08:01.837Z","level":"info","module":"JobRunner","action":"run.dispatch","runId":"e519d68c-3795-43f7-8318-79b178364ddb","providerCount":1,"providers":["gemini"]}
{"ts":"2026-04-06T08:08:01.839Z","level":"info","module":"JobRunner","action":"query.result","runId":"e519d68c-3795-43f7-8318-79b178364ddb","provider":"gemini","keyword":"test keyword","citedDomains":["docs.example.com"],"groundingSources":[],"matchDomains":["example.com","https://www.docs.example.com/path"]}
{"ts":"2026-04-06T08:08:01.842Z","level":"info","module":"JobRunner","action":"query.citation","runId":"e519d68c-3795-43f7-8318-79b178364ddb","provider":"gemini","keyword":"test keyword","citationState":"cited","answerMentioned":false}
{"level":30,"time":1775462881885,"pid":678885,"hostname":"agent-node","reqId":"req-1","req":{"method":"GET","url":"/health","host":"localhost:80","remoteAddress":"127.0.0.1"},"msg":"incoming request"}
 [32m✓[39m apps/api/test/app.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 178[2mms[22m[39m
{"level":30,"time":1775462881889,"pid":678885,"hostname":"agent-node","reqId":"req-1","res":{"statusCode":200},"responseTime":2.6944680213928223,"msg":"request completed"}
{"level":30,"time":1775462881890,"pid":678885,"hostname":"agent-node","reqId":"req-2","req":{"method":"GET","url":"/api/v1/projects","host":"localhost:80","remoteAddress":"127.0.0.1"},"msg":"incoming request"}
{"level":30,"time":1775462881891,"pid":678885,"hostname":"agent-node","reqId":"req-2","res":{"statusCode":401},"responseTime":0.4647548198699951,"msg":"request completed"}
{"level":30,"time":1775462881891,"pid":678885,"hostname":"agent-node","reqId":"req-3","req":{"method":"GET","url":"/api/v1/openapi.json","host":"localhost:80","remoteAddress":"127.0.0.1"},"msg":"incoming request"}
{"level":30,"time":1775462881893,"pid":678885,"hostname":"agent-node","reqId":"req-3","res":{"statusCode":200},"responseTime":1.9562199115753174,"msg":"request completed"}
{"ts":"2026-04-06T08:08:01.923Z","level":"info","module":"JobRunner","action":"run.dispatch","runId":"1e668ada-618e-45dc-8491-3c99075586b7","providerCount":1,"providers":["gemini"]}
{"ts":"2026-04-06T08:08:01.923Z","level":"info","module":"JobRunner","action":"query.result","runId":"1e668ada-618e-45dc-8491-3c99075586b7","provider":"gemini","keyword":"best digital health platforms","citedDomains":[],"groundingSources":[],"matchDomains":["acmehealth.com"]}
{"ts":"2026-04-06T08:08:01.924Z","level":"info","module":"JobRunner","action":"query.citation","runId":"1e668ada-618e-45dc-8491-3c99075586b7","provider":"gemini","keyword":"best digital health platforms","citationState":"not-cited","answerMentioned":true}
 [32m✓[39m packages/canonry/test/job-runner-owned-domains.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 151[2mms[22m[39m
 [32m✓[39m packages/api-routes/test/error-handler.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 167[2mms[22m[39m
 [32m✓[39m packages/canonry/test/daemon.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 39[2mms[22m[39m
 [32m✓[39m packages/api-routes/test/run-cancel.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 190[2mms[22m[39m
 [32m✓[39m packages/integration-bing/test/bing-client.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 49[2mms[22m[39m
 [32m✓[39m packages/integration-google/test/oauth.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 44[2mms[22m[39m
{"ts":"2026-04-06T08:08:02.284Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T08:08:02.299Z","level":"info","module":"BingRoutes","action":"inspect-url.result","domain":"example.com","url":"https://example.com/page","httpStatus":200,"inIndex":null,"documentSize":0,"lastCrawledDate":"2026-03-15T10:00:00Z"}
{"ts":"2026-04-06T08:08:02.303Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T08:08:02.306Z","level":"info","module":"BingRoutes","action":"inspect-url.result","domain":"example.com","url":"https://example.com/indexed","httpStatus":200,"inIndex":null,"documentSize":4096,"lastCrawledDate":"2026-03-15T10:00:00Z"}
{"ts":"2026-04-06T08:08:02.314Z","level":"info","module":"BingRoutes","action":"index-submit.start","domain":"example.com","siteUrl":"https://example.com/","urlCount":1,"allUnindexed":true}
{"ts":"2026-04-06T08:08:02.314Z","level":"info","module":"BingRoutes","action":"index-submit.ok","domain":"example.com","url":"https://example.com/not-indexed"}
{"ts":"2026-04-06T08:08:02.314Z","level":"info","module":"BingRoutes","action":"index-submit.complete","domain":"example.com","total":1,"succeeded":1,"failed":0}
 [32m✓[39m packages/canonry/test/google-commands.test.ts [2m([22m[2m11 tests[22m[2m)[22m[33m 5167[2mms[22m[39m
     [33m[2m✓[22m[39m googleCoverage prints "No URL inspections found" when project has no inspections [33m 305[2mms[22m[39m
     [33m[2m✓[22m[39m googleRefresh triggers GSC sync, waits, and prints coverage output [33m 2076[2mms[22m[39m
     [33m[2m✓[22m[39m googleRefresh outputs valid JSON when format is json [33m 2066[2mms[22m[39m
 [32m✓[39m packages/api-routes/test/helpers.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 93[2mms[22m[39m
 [32m✓[39m packages/api-routes/test/bing.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 142[2mms[22m[39m
{"ts":"2026-04-06T08:08:02.378Z","level":"info","module":"IntelligenceService","action":"intelligence.analyzed","runId":"def798ae-6c52-43fa-afcb-f6e5d23ba713","regressions":0,"gains":1,"citedRate":1,"insights":1}
{"ts":"2026-04-06T08:08:02.381Z","level":"info","module":"IntelligenceService","action":"intelligence.persisted","runId":"def798ae-6c52-43fa-afcb-f6e5d23ba713","insights":1}
{"ts":"2026-04-06T08:08:02.425Z","level":"info","module":"IntelligenceService","action":"intelligence.analyzed","runId":"308b6791-921f-49a9-93ed-c7aec064eca5","regressions":0,"gains":1,"citedRate":1,"insights":1}
{"ts":"2026-04-06T08:08:02.426Z","level":"info","module":"IntelligenceService","action":"intelligence.persisted","runId":"308b6791-921f-49a9-93ed-c7aec064eca5","insights":1}
 [32m✓[39m apps/web/test/ga-connect.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 40[2mms[22m[39m
[90mstdout[2m | apps/worker/test/worker.test.ts[2m > [22m[2mstartHealthServer exposes worker health payload
[22m[39m[worker] health server listening on 44139

{"ts":"2026-04-06T08:08:02.446Z","level":"info","module":"IntelligenceService","action":"intelligence.analyzed","runId":"5e624d0c-3a32-405f-a3d7-abc228a861f6","regressions":0,"gains":1,"citedRate":1,"insights":1}
{"ts":"2026-04-06T08:08:02.447Z","level":"info","module":"IntelligenceService","action":"intelligence.persisted","runId":"5e624d0c-3a32-405f-a3d7-abc228a861f6","insights":1}
 [32m✓[39m packages/canonry/test/run-coordinator.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 107[2mms[22m[39m
 [32m✓[39m apps/worker/test/worker.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 51[2mms[22m[39m
 [32m✓[39m packages/contracts/test/index.test.ts [2m([22m[2m54 tests[22m[2m)[22m[32m 37[2mms[22m[39m
 [32m✓[39m apps/web/test/search-console-refresh.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 33[2mms[22m[39m
 [32m✓[39m apps/web/test/build-dashboard.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 32[2mms[22m[39m
 [32m✓[39m packages/canonry/test/save-config.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 48[2mms[22m[39m
 [32m✓[39m apps/web/test/traffic-section.test.tsx [2m([22m[2m1 test[22m[2m)[22m[32m 134[2mms[22m[39m
 [32m✓[39m packages/api-routes/test/schedule-utils.test.ts [2m([22m[2m13 tests[22m[2m)[22m[32m 30[2mms[22m[39m
 [32m✓[39m apps/web/test/toast-store.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 17[2mms[22m[39m
 [32m✓[39m packages/api-routes/test/run-queue.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 37[2mms[22m[39m
 [32m✓[39m apps/web/test/health-helpers.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m packages/config/test/index.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 15[2mms[22m[39m
 [32m✓[39m apps/web/test/format-helpers.test.ts [2m([22m[2m19 tests[22m[2m)[22m[32m 11[2mms[22m[39m
{"ts":"2026-04-06T08:08:02.828Z","level":"info","module":"Scheduler","action":"cron.registered","projectId":"proj_1","schedule":"* * * * *","timezone":"UTC"}
{"ts":"2026-04-06T08:08:02.829Z","level":"info","module":"Scheduler","action":"started","scheduleCount":1}
{"ts":"2026-04-06T08:08:02.830Z","level":"warn","module":"Scheduler","action":"schedule.stale","scheduleId":"sched_1","projectId":"proj_1","msg":"schedule no longer exists or is disabled"}
{"ts":"2026-04-06T08:08:02.831Z","level":"info","module":"Scheduler","action":"task.removed","projectId":"proj_1"}
 [32m✓[39m apps/worker/test/audit-client.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 45[2mms[22m[39m
 [32m✓[39m packages/canonry/test/scheduler.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 53[2mms[22m[39m
 [32m✓[39m packages/canonry/test/snapshot-service.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 11[2mms[22m[39m
 [32m✓[39m packages/provider-cdp/test/chatgpt.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m packages/api-routes/test/webhooks.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m packages/provider-perplexity/test/normalize.test.ts [2m([22m[2m15 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m apps/web/test/build-insights.test.ts [2m([22m[2m15 tests[22m[2m)[22m[32m 12[2mms[22m[39m
 [32m✓[39m packages/contracts/test/source-categories.test.ts [2m([22m[2m16 tests[22m[2m)[22m[32m 14[2mms[22m[39m
 [32m✓[39m packages/provider-claude/test/index.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m packages/provider-openai/test/index.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m apps/web/test/queries.test.ts [2m([22m[2m13 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m packages/provider-cdp/test/adapter.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m packages/provider-cdp/test/normalize.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m packages/intelligence/test/analyzer.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 12[2mms[22m[39m
 [32m✓[39m packages/db/test/json.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m packages/intelligence/test/insights.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m packages/provider-gemini/test/index.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m packages/intelligence/test/regressions.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m packages/intelligence/test/gains.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m packages/intelligence/test/health.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m packages/provider-local/test/normalize.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m packages/canonry/test/google-config.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m packages/intelligence/test/causes.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m apps/web/test/api-error.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m packages/canonry/test/notify-events.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m packages/canonry/test/gsc-sync.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m packages/provider-local/test/index.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m apps/web/test/vite-config.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m packages/canonry/test/gsc-inspect-sitemap.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m packages/canonry/test/cli-error.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 38[2mms[22m[39m
 [32m✓[39m packages/canonry/test/job-runner-competitors.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 4[2mms[22m[39m

[2m Test Files [22m [1m[32m89 passed[39m[22m[90m (89)[39m
[2m      Tests [22m [1m[32m812 passed[39m[22m[90m (812)[39m
[2m   Start at [22m 08:07:54
[2m   Duration [22m 8.90s[2m (transform 9.97s, setup 0ms, import 52.65s, tests 24.77s, environment 2.28s)[22m).

### ⚠️ Violation (addressed)
- **Authentication material stored in DB**: The  and  tables contain , , and  columns, which should be stored in  per CLAUDE.md guidelines.

**Fix applied**: Added inline warnings in  referencing CLAUDE.md. (Migrations already contain similar warnings.)

### 📝 Notes
- The existing migration warnings already caution against storing secrets in the database.
- Moving authentication material out of the SQLite database is a larger architectural change that may be addressed in a future migration.

### 🔍 Scope
Only  was audited (schema, migrations, client, tests).