### PR TITLE
chore(apps): fix hardcoded API route prefix violations

### DIFF
--- a/packages/api-routes/src/cdp.ts
+++ b/packages/api-routes/src/cdp.ts
@@ -25,6 +25,8 @@ export interface CDPRoutesOptions {
   }[]>
   /** Callback to configure the CDP endpoint (host + port) */
   onCdpConfigure?: (host: string, port: number) => Promise<void> | void
+  /** API route prefix (default: '/api/v1') */
+  routePrefix?: string
 }
 
 function getScreenshotDir(): string {
@@ -234,7 +236,7 @@ export async function cdpRoutes(app: FastifyInstance, opts: CDPRoutesOptions) {
             citationState: browser.citationState,
             citedDomains: JSON.parse(browser.citedDomains || '[]'),
             groundingSources: parseGroundingSources(browser),
-            screenshotUrl: browser.screenshotPath ? `/api/v1/screenshots/${browser.id}` : undefined,
+            screenshotUrl: browser.screenshotPath ? `${opts.routePrefix ?? '/api/v1'}/screenshots/${browser.id}` : undefined,
           } : null,
           agreement,
         }

--- a/packages/api-routes/src/google.ts
+++ b/packages/api-routes/src/google.ts
@@ -50,6 +50,8 @@ export interface GoogleRoutesOptions {
   publicUrl?: string
   onGscSyncRequested?: (runId: string, projectId: string, opts?: { days?: number; full?: boolean }) => void
   onInspectSitemapRequested?: (runId: string, projectId: string, opts?: { sitemapUrl?: string }) => void
+  /** API route prefix (default: '/api/v1') */
+  routePrefix?: string
 }
 
 function signState(payload: string, secret: string): string {
@@ -166,15 +168,15 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
     let redirectUri: string
     if (publicUrl) {
       // CLI override — use the provided public URL as the base
-      redirectUri = publicUrl.replace(/\/$/, '') + '/api/v1/google/callback'
+      redirectUri = publicUrl.replace(/\/$/, '') + (opts.routePrefix ?? '/api/v1') + '/google/callback'
     } else if (opts.publicUrl) {
       // Config-level publicUrl — use for all OAuth redirects
-      redirectUri = opts.publicUrl.replace(/\/$/, '') + '/api/v1/google/callback'
+      redirectUri = opts.publicUrl.replace(/\/$/, '') + (opts.routePrefix ?? '/api/v1') + '/google/callback'
     } else {
       // Auto-detect from request headers — use legacy per-project URI for backward compat
       const proto = request.headers['x-forwarded-proto'] ?? 'http'
       const host = request.headers.host ?? 'localhost:4100'
-      redirectUri = `${proto}://${host}/api/v1/projects/${encodeURIComponent(request.params.name)}/google/callback`
+      redirectUri = `${proto}://${host}${opts.routePrefix ?? '/api/v1'}/projects/${encodeURIComponent(request.params.name)}/google/callback`
     }
 
     const scopes = type === 'gsc' ? [GSC_SCOPE, INDEXING_SCOPE] : [GA4_SCOPE]

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -155,7 +155,7 @@ export async function apiRoutes(app: FastifyInstance, opts: ApiRoutesOptions) {
       })
     }
 
-    await api.register(openApiRoutes, opts.openApiInfo ?? {})
+    await api.register(openApiRoutes, { ...opts.openApiInfo, routePrefix: opts.routePrefix })
     await api.register(projectRoutes, {
       onProjectDeleted: opts.onProjectDeleted,
       validProviderNames: opts.providerAdapters?.map(a => a.name),
@@ -211,6 +211,7 @@ export async function apiRoutes(app: FastifyInstance, opts: ApiRoutesOptions) {
       googleConnectionStore: opts.googleConnectionStore,
       googleStateSecret: opts.googleStateSecret,
       publicUrl: opts.publicUrl,
+      routePrefix: opts.routePrefix,
       onGscSyncRequested: opts.onGscSyncRequested,
       onInspectSitemapRequested: opts.onInspectSitemapRequested,
     } satisfies GoogleRoutesOptions)
@@ -222,6 +223,7 @@ export async function apiRoutes(app: FastifyInstance, opts: ApiRoutesOptions) {
       getCdpStatus: opts.getCdpStatus,
       onCdpScreenshot: opts.onCdpScreenshot,
       onCdpConfigure: opts.onCdpConfigure,
+      routePrefix: opts.routePrefix,
     } satisfies CDPRoutesOptions)
     await api.register(ga4Routes, {
       ga4CredentialStore: opts.ga4CredentialStore,

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -4,6 +4,8 @@ export interface OpenApiInfo {
   title?: string
   version?: string
   description?: string
+  /** API route prefix (default: '/api/v1') */
+  routePrefix?: string
 }
 
 type HttpMethod = 'get' | 'post' | 'put' | 'delete'
@@ -2141,7 +2143,12 @@ const routeCatalog: OpenApiOperation[] = [
 ]
 
 export function buildOpenApiDocument(info: OpenApiInfo = {}) {
+  const BASE_PREFIX = '/api/v1'
+  const prefix = info.routePrefix ?? BASE_PREFIX
   const paths = routeCatalog.reduce<Record<string, Record<string, unknown>>>((acc, route) => {
+    // Strip the hardcoded prefix from the route path, then prepend the configured prefix
+    const subpath = route.path.startsWith(BASE_PREFIX) ? route.path.slice(BASE_PREFIX.length) : route.path
+    const fullPath = prefix + subpath
     const operation: Record<string, unknown> = {
       summary: route.summary,
       tags: route.tags,
@@ -2154,9 +2161,9 @@ export function buildOpenApiDocument(info: OpenApiInfo = {}) {
     if (route.requestBody) operation.requestBody = route.requestBody
     if (route.auth === false) operation.security = []
 
-    const pathItem = acc[route.path] ?? {}
+    const pathItem = acc[fullPath] ?? {}
     pathItem[route.method] = operation
-    acc[route.path] = pathItem
+    acc[fullPath] = pathItem
     return acc
   }, {})
 


### PR DESCRIPTION
## Summary

This audit fix addresses violations of CLAUDE.md rules regarding hardcoded  prefixes in API routes.

### Changes

1. **OpenAPI spec generation** ():
   - Added  option to  interface.
   - Updated  to respect  when constructing API paths.
   - The OpenAPI spec now correctly reflects the configured route prefix (e.g., ).

2. **CDP screenshot URLs** ():
   - Added  to .
   - Updated the browser‑diff endpoint to construct screenshot URLs using the configured prefix.
   - The frontend can now fetch screenshots when the API is mounted under a custom path.

3. **Google OAuth redirect URIs** ():
   - Added  to .
   - Updated all three redirect‑URI construction sites (public‑URL override, config‑level public‑URL, and auto‑detected per‑project legacy URIs) to include the configured prefix.
   - Ensures OAuth callbacks reach the correct endpoint when the API is behind a reverse proxy that does not strip the base path.

4. **Route registration updates** ():
   - Pass  to , , and  (where missing).
   - Keeps the existing default fallback () for backward compatibility.

### Why this matters

- **Consistency:** All API routes now honor the  parameter, aligning with the existing pattern used by WordPress routes.
- **Deployment flexibility:** When Canonry is deployed behind a reverse proxy that does **not** strip the base path (e.g.,  proxied directly), the frontend and OAuth providers can still reach the correct endpoints.
- **CLAUDE.md compliance:** Eliminates hardcoded  strings in favor of the configurable prefix.

### Testing

- All existing unit tests pass (
> canonry@1.39.0 test /home/arberx/.openclaw/workspace/canonry
> vitest run


[1m[46m RUN [49m[22m [36mv4.1.0 [39m[90m/home/arberx/.openclaw/workspace/canonry[39m

 [32m✓[39m packages/api-routes/test/cdp.test.ts [2m([22m[2m21 tests[22m[2m)[22m[33m 644[2mms[22m[39m
{"ts":"2026-04-06T09:14:09.004Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.007Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.008Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
[90mstdout[2m | packages/canonry/test/index.test.ts[2m > [22m[2mcanonry[2m > [22m[2minitCommand embeds CANONRY_PORT into saved apiUrl
[22m[39mInitializing canonry...


Config saved to /tmp/canonry-init-port-c24c8a6f-37fe-49ea-b26b-f22fd203f22c/config.yaml
Database created at /tmp/canonry-init-port-c24c8a6f-37fe-49ea-b26b-f22fd203f22c/data.db
API key: cnry_a3ac55ccc428f9dfb4f5233b8a5a0353
Providers: gemini
Run "canonry serve" to start the server.

[90mstdout[2m | packages/canonry/test/index.test.ts[2m > [22m[2mcanonry[2m > [22m[2mbootstrapCommand creates config and replaces the default API key on force
[22m[39mBootstrap complete. Config saved to /tmp/canonry-bootstrap-fead01ed-c8c1-4455-9fb7-c04286b836dc/config.yaml
SQLite database path: /tmp/canonry-bootstrap-fead01ed-c8c1-4455-9fb7-c04286b836dc/data.db

[90mstdout[2m | packages/canonry/test/index.test.ts[2m > [22m[2mcanonry[2m > [22m[2mbootstrapCommand creates config and replaces the default API key on force
[22m[39mBootstrap complete. Config saved to /tmp/canonry-bootstrap-fead01ed-c8c1-4455-9fb7-c04286b836dc/config.yaml
SQLite database path: /tmp/canonry-bootstrap-fead01ed-c8c1-4455-9fb7-c04286b836dc/data.db

[90mstdout[2m | packages/canonry/test/index.test.ts[2m > [22m[2mcanonry[2m > [22m[2mbootstrapCommand creates config and replaces the default API key on force
[22m[39mBootstrap complete. Config saved to /tmp/canonry-bootstrap-fead01ed-c8c1-4455-9fb7-c04286b836dc/config.yaml
SQLite database path: /tmp/canonry-bootstrap-fead01ed-c8c1-4455-9fb7-c04286b836dc/data.db

{"ts":"2026-04-06T09:14:09.114Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.123Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.123Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.139Z","level":"info","module":"Server","action":"providers.configured","providers":["gemini"]}
{"ts":"2026-04-06T09:14:09.251Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.258Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.272Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.296Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.313Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.328Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.329Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.337Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.338Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.343Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.359Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.363Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.401Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.403Z","level":"info","module":"Server","action":"providers.configured","providers":["gemini"]}
{"ts":"2026-04-06T09:14:09.404Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.416Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.425Z","level":"info","module":"InspectSitemap","action":"sitemap.fetch","runId":"4194ab4e-b810-4977-837d-657e71f09107","projectId":"a4c3bfe9-4e79-4025-a1d2-ca189a968307","sitemapUrl":"https://example.com/sitemap.xml"}
{"ts":"2026-04-06T09:14:09.447Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.452Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.461Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.463Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.470Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.482Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.487Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.492Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.494Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.500Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.517Z","level":"info","module":"Server","action":"providers.configured","providers":["gemini"]}
{"ts":"2026-04-06T09:14:09.525Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.533Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.535Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.545Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.550Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.564Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.567Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.570Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.573Z","level":"info","module":"Server","action":"providers.configured","providers":["gemini"]}
{"ts":"2026-04-06T09:14:09.573Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.574Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.591Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.597Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.598Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.618Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.619Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.624Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
[90mstdout[2m | packages/canonry/test/index.test.ts[2m > [22m[2mcanonry[2m > [22m[2minitCommand non-interactive mode creates config from flags
[22m[39mInitializing canonry...


Config saved to /tmp/canonry-init-dd225fe4-2fc7-4b8f-a3d0-671d91287de7/config.yaml
Database created at /tmp/canonry-init-dd225fe4-2fc7-4b8f-a3d0-671d91287de7/data.db
API key: cnry_7f40f505dcaacc4266088ca0a56b498a
Providers: gemini, openai
Run "canonry serve" to start the server.

{"ts":"2026-04-06T09:14:09.632Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.647Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.648Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.657Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
[90mstdout[2m | packages/canonry/test/index.test.ts[2m > [22m[2mcanonry[2m > [22m[2minitCommand non-interactive mode reads env vars as fallback
[22m[39mInitializing canonry...


Config saved to /tmp/canonry-init-env-97417358-444a-4ced-9222-da8ab04ec348/config.yaml
Database created at /tmp/canonry-init-env-97417358-444a-4ced-9222-da8ab04ec348/data.db
API key: cnry_3babe5e647887ef498f52b4340e7ea20
Providers: claude
Run "canonry serve" to start the server.

{"ts":"2026-04-06T09:14:09.661Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.686Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.706Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.706Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.707Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.708Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.712Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.725Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.725Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.726Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.732Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.754Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.754Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.757Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.760Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
 [32m✓[39m packages/canonry/test/analytics.test.ts [2m([22m[2m7 tests[22m[2m)[22m[33m 822[2mms[22m[39m
{"ts":"2026-04-06T09:14:09.769Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.772Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.781Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.790Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.792Z","level":"info","module":"Server","action":"providers.configured","providers":["openai"]}
{"ts":"2026-04-06T09:14:09.802Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.805Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.808Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.813Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.831Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.833Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.843Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.844Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.851Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.855Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.865Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.869Z","level":"info","module":"GscSync","action":"fetch.start","runId":"f31a189a-2942-41da-95e4-783e215653dc","projectId":"8c3f1357-5e17-4072-9df5-d2ff8e6242b1","propertyId":"sc-domain:example.com","startDate":"2026-03-04","endDate":"2026-04-03"}
{"ts":"2026-04-06T09:14:09.870Z","level":"info","module":"Server","action":"providers.configured","providers":["gemini"]}
{"ts":"2026-04-06T09:14:09.871Z","level":"info","module":"GscSync","action":"fetch.complete","runId":"f31a189a-2942-41da-95e4-783e215653dc","projectId":"8c3f1357-5e17-4072-9df5-d2ff8e6242b1","rowCount":0}
{"ts":"2026-04-06T09:14:09.871Z","level":"info","module":"GscSync","action":"inspect.start","runId":"f31a189a-2942-41da-95e4-783e215653dc","projectId":"8c3f1357-5e17-4072-9df5-d2ff8e6242b1","urlCount":0}
{"ts":"2026-04-06T09:14:09.872Z","level":"info","module":"GscSync","action":"sync.completed","runId":"f31a189a-2942-41da-95e4-783e215653dc","projectId":"8c3f1357-5e17-4072-9df5-d2ff8e6242b1","searchDataRows":0,"urlInspections":0,"indexed":0,"notIndexed":0}
{"ts":"2026-04-06T09:14:09.881Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.889Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.889Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.892Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.907Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.909Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.914Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.915Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.922Z","level":"info","module":"IntelligenceService","action":"intelligence.skip","runId":"7ee2e715-9cd6-4ed2-b0e1-bf3ce3b6bfb0","reason":"no completed runs"}
{"ts":"2026-04-06T09:14:09.922Z","level":"info","module":"Notifier","action":"run.completed","runId":"7ee2e715-9cd6-4ed2-b0e1-bf3ce3b6bfb0","projectId":"e3acd680-c6b8-4652-937e-fb83cb6dad93"}
{"ts":"2026-04-06T09:14:09.922Z","level":"info","module":"Notifier","action":"notifications.none-enabled","projectId":"e3acd680-c6b8-4652-937e-fb83cb6dad93"}
{"ts":"2026-04-06T09:14:09.929Z","level":"info","module":"IntelligenceService","action":"intelligence.skip","runId":"1660d282-d678-4e22-99d0-fb9c94af7342","reason":"no completed runs"}
{"ts":"2026-04-06T09:14:09.929Z","level":"info","module":"Notifier","action":"run.completed","runId":"1660d282-d678-4e22-99d0-fb9c94af7342","projectId":"e3acd680-c6b8-4652-937e-fb83cb6dad93"}
{"ts":"2026-04-06T09:14:09.929Z","level":"info","module":"Notifier","action":"notifications.none-enabled","projectId":"e3acd680-c6b8-4652-937e-fb83cb6dad93"}
{"ts":"2026-04-06T09:14:09.942Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.943Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.950Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.951Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.952Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.963Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:09.968Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.977Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.978Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:09.984Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:10.002Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:10.003Z","level":"info","module":"IntelligenceService","action":"intelligence.skip","runId":"1565d880-aee7-463f-98d5-0463d83fa978","reason":"no completed runs"}
{"ts":"2026-04-06T09:14:10.003Z","level":"info","module":"Notifier","action":"run.completed","runId":"1565d880-aee7-463f-98d5-0463d83fa978","projectId":"509045b8-d102-4b84-9deb-c9f7b510f2df"}
{"ts":"2026-04-06T09:14:10.003Z","level":"info","module":"Notifier","action":"notifications.none-enabled","projectId":"509045b8-d102-4b84-9deb-c9f7b510f2df"}
{"ts":"2026-04-06T09:14:10.004Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:10.006Z","level":"info","module":"IntelligenceService","action":"intelligence.skip","runId":"40305952-cbf3-49e2-9b03-89ad8fecbd8c","reason":"no completed runs"}
{"ts":"2026-04-06T09:14:10.007Z","level":"info","module":"Notifier","action":"run.completed","runId":"40305952-cbf3-49e2-9b03-89ad8fecbd8c","projectId":"509045b8-d102-4b84-9deb-c9f7b510f2df"}
{"ts":"2026-04-06T09:14:10.007Z","level":"info","module":"Notifier","action":"notifications.none-enabled","projectId":"509045b8-d102-4b84-9deb-c9f7b510f2df"}
{"ts":"2026-04-06T09:14:10.008Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:10.010Z","level":"info","module":"IntelligenceService","action":"intelligence.skip","runId":"00a8dac2-3c56-4ef5-b1cf-6a653ef0cd70","reason":"no completed runs"}
{"ts":"2026-04-06T09:14:10.010Z","level":"info","module":"Notifier","action":"run.completed","runId":"00a8dac2-3c56-4ef5-b1cf-6a653ef0cd70","projectId":"509045b8-d102-4b84-9deb-c9f7b510f2df"}
{"ts":"2026-04-06T09:14:10.010Z","level":"info","module":"Notifier","action":"notifications.none-enabled","projectId":"509045b8-d102-4b84-9deb-c9f7b510f2df"}
{"ts":"2026-04-06T09:14:10.016Z","level":"info","module":"Server","action":"providers.configured","providers":["gemini"]}
 [32m✓[39m packages/canonry/test/cli-run-contract.test.ts [2m([22m[2m6 tests[22m[2m)[22m[33m 773[2mms[22m[39m
 [32m✓[39m apps/web/test/run-notifications.test.tsx [2m([22m[2m7 tests[22m[2m)[22m[33m 915[2mms[22m[39m
   [33m[2m✓[22m[39m toast CTA opens the existing run drawer via router state [33m 707[2mms[22m[39m
{"ts":"2026-04-06T09:14:10.031Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:10.033Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:10.036Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
 [32m✓[39m packages/canonry/test/snapshot-command.test.ts [2m([22m[2m4 tests[22m[2m)[22m[33m 596[2mms[22m[39m
{"ts":"2026-04-06T09:14:10.038Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
 [32m✓[39m packages/canonry/test/index.test.ts [2m([22m[2m24 tests[22m[2m)[22m[33m 1100[2mms[22m[39m
{"ts":"2026-04-06T09:14:10.052Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:10.069Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:10.069Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:10.088Z","level":"info","module":"IntelligenceService","action":"intelligence.skip","runId":"9b2bdbc4-f7a5-4335-a18c-d6a622859fbb","reason":"no completed runs"}
{"ts":"2026-04-06T09:14:10.089Z","level":"info","module":"Notifier","action":"run.completed","runId":"9b2bdbc4-f7a5-4335-a18c-d6a622859fbb","projectId":"4186ca08-30cd-4fb8-8c4a-1a0e189a550f"}
{"ts":"2026-04-06T09:14:10.089Z","level":"info","module":"Notifier","action":"notifications.none-enabled","projectId":"4186ca08-30cd-4fb8-8c4a-1a0e189a550f"}
{"ts":"2026-04-06T09:14:10.092Z","level":"info","module":"IntelligenceService","action":"intelligence.skip","runId":"69f93bd4-4306-4478-8752-7150d92cb9e0","reason":"no completed runs"}
{"ts":"2026-04-06T09:14:10.092Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:10.092Z","level":"info","module":"Notifier","action":"run.completed","runId":"69f93bd4-4306-4478-8752-7150d92cb9e0","projectId":"4186ca08-30cd-4fb8-8c4a-1a0e189a550f"}
{"ts":"2026-04-06T09:14:10.092Z","level":"info","module":"Notifier","action":"notifications.none-enabled","projectId":"4186ca08-30cd-4fb8-8c4a-1a0e189a550f"}
{"ts":"2026-04-06T09:14:10.099Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:10.128Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:10.145Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:10.146Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:10.148Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:10.166Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
 [32m✓[39m packages/canonry/test/location-commands.test.ts [2m([22m[2m12 tests[22m[2m)[22m[33m 1225[2mms[22m[39m
{"ts":"2026-04-06T09:14:10.176Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
 [32m✓[39m apps/web/test/router.test.tsx [2m([22m[2m14 tests[22m[2m)[22m[33m 1109[2mms[22m[39m
{"ts":"2026-04-06T09:14:10.205Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:10.209Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:10.223Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:10.247Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:10.250Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:10.267Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:10.278Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:10.294Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:10.305Z","level":"info","module":"Scheduler","action":"cron.registered","projectId":"3a9f947e-b011-4a13-9fcd-a5a38716d3eb","schedule":"daily","timezone":"UTC"}
 [32m✓[39m packages/canonry/test/wordpress-commands.test.ts [2m([22m[2m11 tests[22m[2m)[22m[33m 1074[2mms[22m[39m
{"ts":"2026-04-06T09:14:10.318Z","level":"info","module":"Scheduler","action":"task.stopped","projectId":"3a9f947e-b011-4a13-9fcd-a5a38716d3eb"}
{"ts":"2026-04-06T09:14:10.332Z","level":"info","module":"Scheduler","action":"cron.registered","projectId":"3a9f947e-b011-4a13-9fcd-a5a38716d3eb","schedule":"daily","timezone":"UTC"}
{"ts":"2026-04-06T09:14:10.337Z","level":"info","module":"Scheduler","action":"task.removed","projectId":"3a9f947e-b011-4a13-9fcd-a5a38716d3eb"}
{"ts":"2026-04-06T09:14:10.367Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:10.372Z","level":"info","module":"GA4Client","action":"fetch-traffic.start","propertyId":"123456","days":1}
{"ts":"2026-04-06T09:14:10.387Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:10.438Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:10.448Z","level":"info","module":"GA4Client","action":"fetch-traffic.done","propertyId":"123456","rowCount":10002}
{"ts":"2026-04-06T09:14:10.449Z","level":"info","module":"GA4Client","action":"fetch-traffic.start","propertyId":"123456","days":1}
{"ts":"2026-04-06T09:14:10.450Z","level":"info","module":"GA4Client","action":"fetch-traffic.done","propertyId":"123456","rowCount":1}
{"ts":"2026-04-06T09:14:10.452Z","level":"info","module":"GA4Client","action":"fetch-ai-referrals.start","propertyId":"123456","days":7}
{"ts":"2026-04-06T09:14:10.453Z","level":"info","module":"GA4Client","action":"fetch-ai-referrals.done","propertyId":"123456","rowCount":3}
{"ts":"2026-04-06T09:14:10.457Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:10.504Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:10.519Z","level":"info","module":"Server","action":"providers.configured","providers":["gemini"]}
{"ts":"2026-04-06T09:14:10.532Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:10.533Z","level":"info","module":"GA4Client","action":"fetch-aggregate.start","propertyId":"123456","days":30}
{"ts":"2026-04-06T09:14:10.534Z","level":"info","module":"GA4Client","action":"fetch-aggregate.done","propertyId":"123456","periodStart":"2026-03-07","periodEnd":"2026-04-06","totalSessions":5000,"totalUsers":3200,"totalOrganicSessions":1800}
{"ts":"2026-04-06T09:14:10.535Z","level":"info","module":"GA4Client","action":"fetch-aggregate.start","propertyId":"123456","days":7}
{"ts":"2026-04-06T09:14:10.536Z","level":"info","module":"GA4Client","action":"fetch-aggregate.done","propertyId":"123456","periodStart":"2026-03-30","periodEnd":"2026-04-06","totalSessions":0,"totalUsers":0,"totalOrganicSessions":0}
 [32m✓[39m packages/integration-google-analytics/test/ga4-client.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 292[2mms[22m[39m
{"ts":"2026-04-06T09:14:10.580Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:10.597Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:10.618Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:10.635Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:10.642Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:10.676Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:10.694Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:10.757Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:10.782Z","level":"info","module":"Server","action":"providers.configured","providers":["gemini"]}
{"ts":"2026-04-06T09:14:10.793Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:10.822Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:10.843Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:10.857Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:10.890Z","level":"info","module":"Server","action":"providers.configured","providers":["gemini"]}
{"ts":"2026-04-06T09:14:10.915Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:10.925Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:10.937Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:10.956Z","level":"info","module":"Server","action":"providers.configured","providers":["gemini"]}
{"ts":"2026-04-06T09:14:10.964Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:10.976Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:10.979Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
 [32m✓[39m packages/canonry/test/cli-format.test.ts [2m([22m[2m4 tests[22m[2m)[22m[33m 541[2mms[22m[39m
     [33m[2m✓[22m[39m showStatus with format json outputs valid JSON [33m 305[2mms[22m[39m
{"ts":"2026-04-06T09:14:11.007Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:11.021Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:11.082Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:11.101Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:11.129Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:11.154Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:11.189Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:11.205Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:11.241Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:11.256Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
 [32m✓[39m packages/db/test/index.test.ts [2m([22m[2m14 tests[22m[2m)[22m[32m 293[2mms[22m[39m
{"ts":"2026-04-06T09:14:11.258Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:11.285Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:11.297Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:11.324Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:11.341Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
[90mstdout[2m | packages/canonry/test/telemetry.test.ts[2m > [22m[2mtelemetry[2m > [22m[2mtelemetryCommand[2m > [22m[2mdisable sets telemetry: false in config file
[22m[39mTelemetry disabled. No data will be sent.

[90mstdout[2m | packages/canonry/test/telemetry.test.ts[2m > [22m[2mtelemetry[2m > [22m[2mtelemetryCommand[2m > [22m[2menable sets telemetry: true in config file
[22m[39mTelemetry enabled.

[90mstdout[2m | packages/canonry/test/telemetry.test.ts[2m > [22m[2mtelemetry[2m > [22m[2mtelemetryCommand[2m > [22m[2mdisable then enable round-trips correctly
[22m[39mTelemetry disabled. No data will be sent.
Telemetry enabled.

{"ts":"2026-04-06T09:14:11.367Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
[90mstdout[2m | packages/canonry/test/telemetry.test.ts[2m > [22m[2mtelemetry[2m > [22m[2mtelemetryCommand[2m > [22m[2mdisable preserves other config fields
[22m[39mTelemetry disabled. No data will be sent.

{"ts":"2026-04-06T09:14:11.374Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
 [32m✓[39m packages/api-routes/test/google.test.ts [2m([22m[2m29 tests[22m[2m)[22m[33m 352[2mms[22m[39m
{"ts":"2026-04-06T09:14:11.393Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:11.434Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:11.463Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:11.481Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:11.497Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
 [32m✓[39m packages/api-routes/test/index.test.ts [2m([22m[2m39 tests[22m[2m)[22m[33m 355[2mms[22m[39m
{"ts":"2026-04-06T09:14:11.503Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:11.512Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:11.514Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
 [32m✓[39m packages/canonry/test/cli-operator-contract.test.ts [2m([22m[2m31 tests[22m[2m)[22m[33m 2259[2mms[22m[39m
 [32m✓[39m packages/canonry/test/telemetry.test.ts [2m([22m[2m45 tests[22m[2m)[22m[33m 348[2mms[22m[39m
{"ts":"2026-04-06T09:14:11.558Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:11.562Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:11.586Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:11.609Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:11.625Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:11.645Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
 [32m✓[39m packages/canonry/test/run-cancel-command.test.ts [2m([22m[2m4 tests[22m[2m)[22m[33m 490[2mms[22m[39m
{"ts":"2026-04-06T09:14:11.670Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:11.721Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:11.750Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:11.805Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:11.815Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:11.853Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:11.868Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:11.891Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
 [32m✓[39m packages/canonry/test/keyword.test.ts [2m([22m[2m3 tests[22m[2m)[22m[33m 474[2mms[22m[39m
{"ts":"2026-04-06T09:14:11.901Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:11.918Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:11.919Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
{"ts":"2026-04-06T09:14:11.934Z","level":"info","module":"GscSync","action":"fetch.start","runId":"c6c1f9e1-3fe1-48a3-b272-6ab943037ea6","projectId":"d6076511-ee66-4197-b394-25edfce9af43","propertyId":"sc-domain:example.com","startDate":"2026-03-04","endDate":"2026-04-03"}
{"ts":"2026-04-06T09:14:11.935Z","level":"info","module":"GscSync","action":"fetch.complete","runId":"c6c1f9e1-3fe1-48a3-b272-6ab943037ea6","projectId":"d6076511-ee66-4197-b394-25edfce9af43","rowCount":0}
{"ts":"2026-04-06T09:14:11.935Z","level":"info","module":"GscSync","action":"inspect.start","runId":"c6c1f9e1-3fe1-48a3-b272-6ab943037ea6","projectId":"d6076511-ee66-4197-b394-25edfce9af43","urlCount":0}
{"ts":"2026-04-06T09:14:11.936Z","level":"info","module":"GscSync","action":"sync.completed","runId":"c6c1f9e1-3fe1-48a3-b272-6ab943037ea6","projectId":"d6076511-ee66-4197-b394-25edfce9af43","searchDataRows":0,"urlInspections":0,"indexed":0,"notIndexed":0}
 [32m✓[39m packages/canonry/test/bing-commands.test.ts [2m([22m[2m3 tests[22m[2m)[22m[33m 445[2mms[22m[39m
 [32m✓[39m packages/api-routes/test/security.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 290[2mms[22m[39m
{"ts":"2026-04-06T09:14:12.335Z","level":"info","module":"IntelligenceService","action":"intelligence.analyzed","runId":"d48074c5-1d36-4c6a-b547-f4f0357de3fe","regressions":0,"gains":1,"citedRate":1,"insights":1}
{"ts":"2026-04-06T09:14:12.337Z","level":"info","module":"IntelligenceService","action":"intelligence.persisted","runId":"d48074c5-1d36-4c6a-b547-f4f0357de3fe","insights":1}
{"ts":"2026-04-06T09:14:12.341Z","level":"info","module":"JobRunner","action":"run.dispatch","runId":"95e8ed35-8b84-4a61-b567-c59a37cece6f","providerCount":1,"providers":["gemini"]}
{"ts":"2026-04-06T09:14:12.344Z","level":"info","module":"JobRunner","action":"query.result","runId":"95e8ed35-8b84-4a61-b567-c59a37cece6f","provider":"gemini","keyword":"keyword-1","citedDomains":[],"groundingSources":[],"matchDomains":["example.com"]}
{"ts":"2026-04-06T09:14:12.345Z","level":"info","module":"JobRunner","action":"query.citation","runId":"95e8ed35-8b84-4a61-b567-c59a37cece6f","provider":"gemini","keyword":"keyword-1","citationState":"not-cited","answerMentioned":false}
{"ts":"2026-04-06T09:14:12.364Z","level":"info","module":"IntelligenceService","action":"intelligence.skip","runId":"ae408ceb-164c-4bdf-b03c-84bcfc9008be","reason":"no snapshots"}
{"ts":"2026-04-06T09:14:12.386Z","level":"info","module":"IntelligenceService","action":"intelligence.skip","runId":"488d7ce3-5203-4f81-ac5a-7fb732e79317","reason":"no snapshots"}
{"ts":"2026-04-06T09:14:12.409Z","level":"info","module":"IntelligenceService","action":"intelligence.analyzed","runId":"c72e933e-3619-40fb-a1b6-9156cf901c13","regressions":1,"gains":0,"citedRate":0,"insights":1}
{"ts":"2026-04-06T09:14:12.410Z","level":"info","module":"IntelligenceService","action":"intelligence.persisted","runId":"c72e933e-3619-40fb-a1b6-9156cf901c13","insights":1}
{"ts":"2026-04-06T09:14:12.413Z","level":"info","module":"IntelligenceService","action":"intelligence.analyzed","runId":"c72e933e-3619-40fb-a1b6-9156cf901c13","regressions":1,"gains":0,"citedRate":0,"insights":1}
{"ts":"2026-04-06T09:14:12.414Z","level":"info","module":"IntelligenceService","action":"intelligence.persisted","runId":"c72e933e-3619-40fb-a1b6-9156cf901c13","insights":1}
{"ts":"2026-04-06T09:14:12.429Z","level":"info","module":"JobRunner","action":"run.dispatch","runId":"edd39190-aca8-44b2-a168-5d67ff5a824d","providerCount":1,"providers":["gemini"]}
{"ts":"2026-04-06T09:14:12.437Z","level":"info","module":"IntelligenceService","action":"intelligence.analyzed","runId":"f04ff02e-ac80-421d-bb25-a2c8e932e404","regressions":1,"gains":0,"citedRate":0,"insights":1}
{"ts":"2026-04-06T09:14:12.438Z","level":"info","module":"IntelligenceService","action":"intelligence.persisted","runId":"f04ff02e-ac80-421d-bb25-a2c8e932e404","insights":1}
{"ts":"2026-04-06T09:14:12.457Z","level":"info","module":"JobRunner","action":"query.result","runId":"edd39190-aca8-44b2-a168-5d67ff5a824d","provider":"gemini","keyword":"keyword-1","citedDomains":[],"groundingSources":[],"matchDomains":["example.com"]}
{"ts":"2026-04-06T09:14:12.457Z","level":"info","module":"JobRunner","action":"query.citation","runId":"edd39190-aca8-44b2-a168-5d67ff5a824d","provider":"gemini","keyword":"keyword-1","citationState":"not-cited","answerMentioned":false}
{"ts":"2026-04-06T09:14:12.458Z","level":"info","module":"JobRunner","action":"query.result","runId":"edd39190-aca8-44b2-a168-5d67ff5a824d","provider":"gemini","keyword":"keyword-2","citedDomains":[],"groundingSources":[],"matchDomains":["example.com"]}
{"ts":"2026-04-06T09:14:12.458Z","level":"info","module":"JobRunner","action":"query.citation","runId":"edd39190-aca8-44b2-a168-5d67ff5a824d","provider":"gemini","keyword":"keyword-2","citationState":"not-cited","answerMentioned":false}
{"ts":"2026-04-06T09:14:12.469Z","level":"info","module":"IntelligenceService","action":"intelligence.persisted","runId":"97962e85-7c10-4330-919e-2e712f2f0268","insights":1}
{"ts":"2026-04-06T09:14:12.470Z","level":"info","module":"IntelligenceService","action":"intelligence.persisted","runId":"48ae7829-3c57-4d49-9129-40b0406166e9","insights":1}
{"ts":"2026-04-06T09:14:12.472Z","level":"info","module":"IntelligenceService","action":"intelligence.persisted","runId":"b8789b24-a21e-48a6-b3b2-0568447a760c","insights":1}
{"ts":"2026-04-06T09:14:12.483Z","level":"info","module":"JobRunner","action":"query.result","runId":"edd39190-aca8-44b2-a168-5d67ff5a824d","provider":"gemini","keyword":"keyword-3","citedDomains":[],"groundingSources":[],"matchDomains":["example.com"]}
{"ts":"2026-04-06T09:14:12.483Z","level":"info","module":"JobRunner","action":"query.citation","runId":"edd39190-aca8-44b2-a168-5d67ff5a824d","provider":"gemini","keyword":"keyword-3","citationState":"not-cited","answerMentioned":false}
{"ts":"2026-04-06T09:14:12.491Z","level":"info","module":"IntelligenceService","action":"intelligence.persisted","runId":"b24af088-d35d-48d7-9dd1-53dbf1cff859","insights":1}
{"ts":"2026-04-06T09:14:12.526Z","level":"info","module":"JobRunner","action":"run.dispatch","runId":"cbe3c91e-ab38-4b4f-acb1-957e37055a9c","providerCount":1,"providers":["gemini"]}
 [32m✓[39m packages/canonry/test/job-runner-runtime-controls.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 233[2mms[22m[39m
 [32m✓[39m packages/canonry/test/intelligence-service.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 260[2mms[22m[39m
 [32m✓[39m packages/api-routes/test/error-envelopes.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 242[2mms[22m[39m
{"ts":"2026-04-06T09:14:12.784Z","level":"info","module":"GA4Routes","action":"sync.complete","projectId":"427a5b9e-4913-4619-b189-c3eac156cefc","rowCount":2,"aiReferralCount":1,"days":30,"totalUsers":55}
{"ts":"2026-04-06T09:14:12.791Z","level":"info","module":"GA4Routes","action":"sync.complete","projectId":"427a5b9e-4913-4619-b189-c3eac156cefc","rowCount":0,"aiReferralCount":0,"days":30,"totalUsers":0}
 [32m✓[39m packages/api-routes/test/ga.test.ts [2m([22m[2m19 tests[22m[2m)[22m[32m 205[2mms[22m[39m
 [32m✓[39m apps/web/test/app.test.tsx [2m([22m[2m15 tests[22m[2m)[22m[33m 324[2mms[22m[39m
 [32m✓[39m packages/api-routes/test/export-roundtrip.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 254[2mms[22m[39m
 [32m✓[39m packages/api-routes/test/openapi-contract.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 208[2mms[22m[39m
 [32m✓[39m packages/provider-cdp/test/connection.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 178[2mms[22m[39m
 [32m✓[39m packages/api-routes/test/analytics.test.ts [2m([22m[2m16 tests[22m[2m)[22m[32m 218[2mms[22m[39m
 [32m✓[39m packages/api-routes/test/snapshot.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 215[2mms[22m[39m
 [32m✓[39m packages/integration-google/test/gsc-client.test.ts [2m([22m[2m15 tests[22m[2m)[22m[32m 184[2mms[22m[39m
 [32m✓[39m packages/api-routes/test/wordpress.test.ts [2m([22m[2m18 tests[22m[2m)[22m[32m 221[2mms[22m[39m
 [32m✓[39m packages/canonry/test/sitemap-parser.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 81[2mms[22m[39m
{"level":30,"time":1775466853741,"pid":682507,"hostname":"agent-node","reqId":"req-1","req":{"method":"GET","url":"/health","host":"localhost:80","remoteAddress":"127.0.0.1"},"msg":"incoming request"}
 [32m✓[39m packages/api-routes/test/run-cancel.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 213[2mms[22m[39m
{"level":30,"time":1775466853749,"pid":682507,"hostname":"agent-node","reqId":"req-1","res":{"statusCode":200},"responseTime":3.592755079269409,"msg":"request completed"}
{"level":30,"time":1775466853751,"pid":682507,"hostname":"agent-node","reqId":"req-2","req":{"method":"GET","url":"/api/v1/projects","host":"localhost:80","remoteAddress":"127.0.0.1"},"msg":"incoming request"}
{"level":30,"time":1775466853752,"pid":682507,"hostname":"agent-node","reqId":"req-2","res":{"statusCode":401},"responseTime":0.681053876876831,"msg":"request completed"}
{"level":30,"time":1775466853753,"pid":682507,"hostname":"agent-node","reqId":"req-3","req":{"method":"GET","url":"/api/v1/openapi.json","host":"localhost:80","remoteAddress":"127.0.0.1"},"msg":"incoming request"}
{"level":30,"time":1775466853755,"pid":682507,"hostname":"agent-node","reqId":"req-3","res":{"statusCode":200},"responseTime":1.9485270977020264,"msg":"request completed"}
 [32m✓[39m apps/api/test/app.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 190[2mms[22m[39m
{"ts":"2026-04-06T09:14:13.785Z","level":"info","module":"JobRunner","action":"run.dispatch","runId":"62afcd12-fd48-4391-a6d0-07c40f6635bb","providerCount":1,"providers":["gemini"]}
{"ts":"2026-04-06T09:14:13.788Z","level":"info","module":"JobRunner","action":"query.result","runId":"62afcd12-fd48-4391-a6d0-07c40f6635bb","provider":"gemini","keyword":"test keyword","citedDomains":["docs.example.com"],"groundingSources":[],"matchDomains":["example.com","https://www.docs.example.com/path"]}
{"ts":"2026-04-06T09:14:13.790Z","level":"info","module":"JobRunner","action":"query.citation","runId":"62afcd12-fd48-4391-a6d0-07c40f6635bb","provider":"gemini","keyword":"test keyword","citationState":"cited","answerMentioned":false}
{"ts":"2026-04-06T09:14:13.861Z","level":"info","module":"BingRoutes","action":"inspect-url.result","domain":"example.com","url":"https://example.com/page","httpStatus":200,"inIndex":null,"documentSize":0,"lastCrawledDate":"2026-03-15T10:00:00Z"}
{"ts":"2026-04-06T09:14:13.869Z","level":"info","module":"BingRoutes","action":"inspect-url.result","domain":"example.com","url":"https://example.com/indexed","httpStatus":200,"inIndex":null,"documentSize":4096,"lastCrawledDate":"2026-03-15T10:00:00Z"}
{"ts":"2026-04-06T09:14:13.880Z","level":"info","module":"BingRoutes","action":"index-submit.start","domain":"example.com","siteUrl":"https://example.com/","urlCount":1,"allUnindexed":true}
{"ts":"2026-04-06T09:14:13.880Z","level":"info","module":"BingRoutes","action":"index-submit.ok","domain":"example.com","url":"https://example.com/not-indexed"}
{"ts":"2026-04-06T09:14:13.880Z","level":"info","module":"BingRoutes","action":"index-submit.complete","domain":"example.com","total":1,"succeeded":1,"failed":0}
{"ts":"2026-04-06T09:14:13.882Z","level":"info","module":"JobRunner","action":"run.dispatch","runId":"0a068c6d-0832-4d54-a20e-3f6bddcb9f94","providerCount":1,"providers":["gemini"]}
{"ts":"2026-04-06T09:14:13.883Z","level":"info","module":"JobRunner","action":"query.result","runId":"0a068c6d-0832-4d54-a20e-3f6bddcb9f94","provider":"gemini","keyword":"best digital health platforms","citedDomains":[],"groundingSources":[],"matchDomains":["acmehealth.com"]}
{"ts":"2026-04-06T09:14:13.883Z","level":"info","module":"JobRunner","action":"query.citation","runId":"0a068c6d-0832-4d54-a20e-3f6bddcb9f94","provider":"gemini","keyword":"best digital health platforms","citationState":"not-cited","answerMentioned":true}
 [32m✓[39m packages/api-routes/test/bing.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 118[2mms[22m[39m
 [32m✓[39m packages/canonry/test/job-runner-owned-domains.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 161[2mms[22m[39m
 [32m✓[39m packages/integration-wordpress/test/wordpress-client.test.ts [2m([22m[2m22 tests[22m[2m)[22m[32m 62[2mms[22m[39m
 [32m✓[39m packages/api-routes/test/error-handler.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 145[2mms[22m[39m
{"ts":"2026-04-06T09:14:13.966Z","level":"info","module":"Server","action":"providers.configured","providers":[]}
{"ts":"2026-04-06T09:14:13.989Z","level":"info","module":"Scheduler","action":"started","scheduleCount":0}
 [32m✓[39m packages/canonry/test/google-commands.test.ts [2m([22m[2m11 tests[22m[2m)[22m[33m 5066[2mms[22m[39m
     [33m[2m✓[22m[39m googleRefresh triggers GSC sync, waits, and prints coverage output [33m 2070[2mms[22m[39m
     [33m[2m✓[22m[39m googleRefresh outputs valid JSON when format is json [33m 2064[2mms[22m[39m
 [32m✓[39m packages/integration-bing/test/bing-client.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 72[2mms[22m[39m
{"ts":"2026-04-06T09:14:14.088Z","level":"info","module":"IntelligenceService","action":"intelligence.analyzed","runId":"cf7b8963-c442-4620-aa43-a354a01864e2","regressions":0,"gains":1,"citedRate":1,"insights":1}
{"ts":"2026-04-06T09:14:14.090Z","level":"info","module":"IntelligenceService","action":"intelligence.persisted","runId":"cf7b8963-c442-4620-aa43-a354a01864e2","insights":1}
{"ts":"2026-04-06T09:14:14.147Z","level":"info","module":"IntelligenceService","action":"intelligence.analyzed","runId":"6ecd00e6-4681-45b7-9615-e61fa024f8f7","regressions":0,"gains":1,"citedRate":1,"insights":1}
 [32m✓[39m packages/api-routes/test/helpers.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 102[2mms[22m[39m
{"ts":"2026-04-06T09:14:14.148Z","level":"info","module":"IntelligenceService","action":"intelligence.persisted","runId":"6ecd00e6-4681-45b7-9615-e61fa024f8f7","insights":1}
[90mstdout[2m | apps/worker/test/worker.test.ts[2m > [22m[2mstartHealthServer exposes worker health payload
[22m[39m[worker] health server listening on 41241

 [32m✓[39m packages/integration-google/test/oauth.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 38[2mms[22m[39m
 [32m✓[39m packages/canonry/test/save-config.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 39[2mms[22m[39m
{"ts":"2026-04-06T09:14:14.170Z","level":"info","module":"IntelligenceService","action":"intelligence.analyzed","runId":"5a326c77-5b29-4336-85d1-41e0edb330e0","regressions":0,"gains":1,"citedRate":1,"insights":1}
{"ts":"2026-04-06T09:14:14.171Z","level":"info","module":"IntelligenceService","action":"intelligence.persisted","runId":"5a326c77-5b29-4336-85d1-41e0edb330e0","insights":1}
 [32m✓[39m packages/canonry/test/run-coordinator.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 124[2mms[22m[39m
 [32m✓[39m apps/web/test/ga-connect.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 36[2mms[22m[39m
 [32m✓[39m apps/worker/test/worker.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 46[2mms[22m[39m
 [32m✓[39m packages/canonry/test/daemon.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 43[2mms[22m[39m
 [32m✓[39m apps/web/test/traffic-section.test.tsx [2m([22m[2m1 test[22m[2m)[22m[32m 116[2mms[22m[39m
 [32m✓[39m apps/worker/test/audit-client.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 37[2mms[22m[39m
 [32m✓[39m packages/api-routes/test/schedule-utils.test.ts [2m([22m[2m13 tests[22m[2m)[22m[32m 26[2mms[22m[39m
 [32m✓[39m apps/web/test/toast-store.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 16[2mms[22m[39m
 [32m✓[39m apps/web/test/build-dashboard.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 30[2mms[22m[39m
 [32m✓[39m apps/web/test/search-console-refresh.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 49[2mms[22m[39m
 [32m✓[39m packages/contracts/test/source-categories.test.ts [2m([22m[2m16 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m packages/intelligence/test/analyzer.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m packages/contracts/test/index.test.ts [2m([22m[2m54 tests[22m[2m)[22m[32m 35[2mms[22m[39m
 [32m✓[39m apps/web/test/format-helpers.test.ts [2m([22m[2m19 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m packages/config/test/index.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 16[2mms[22m[39m
 [32m✓[39m apps/web/test/build-insights.test.ts [2m([22m[2m15 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m packages/provider-perplexity/test/normalize.test.ts [2m([22m[2m15 tests[22m[2m)[22m[32m 11[2mms[22m[39m
 [32m✓[39m apps/web/test/queries.test.ts [2m([22m[2m13 tests[22m[2m)[22m[32m 9[2mms[22m[39m
{"ts":"2026-04-06T09:14:14.699Z","level":"info","module":"Scheduler","action":"cron.registered","projectId":"proj_1","schedule":"* * * * *","timezone":"UTC"}
{"ts":"2026-04-06T09:14:14.699Z","level":"info","module":"Scheduler","action":"started","scheduleCount":1}
{"ts":"2026-04-06T09:14:14.701Z","level":"warn","module":"Scheduler","action":"schedule.stale","scheduleId":"sched_1","projectId":"proj_1","msg":"schedule no longer exists or is disabled"}
{"ts":"2026-04-06T09:14:14.702Z","level":"info","module":"Scheduler","action":"task.removed","projectId":"proj_1"}
 [32m✓[39m packages/canonry/test/scheduler.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 96[2mms[22m[39m
 [32m✓[39m packages/canonry/test/snapshot-service.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 11[2mms[22m[39m
 [32m✓[39m packages/provider-gemini/test/index.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m packages/provider-cdp/test/chatgpt.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m packages/api-routes/test/webhooks.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m packages/provider-cdp/test/adapter.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m apps/web/test/health-helpers.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m packages/intelligence/test/gains.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m packages/provider-openai/test/index.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m packages/provider-claude/test/index.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m packages/api-routes/test/run-queue.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 54[2mms[22m[39m
 [32m✓[39m packages/provider-cdp/test/normalize.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m packages/db/test/json.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m packages/intelligence/test/regressions.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m packages/provider-local/test/normalize.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m packages/intelligence/test/health.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m packages/intelligence/test/insights.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m apps/web/test/api-error.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m packages/canonry/test/google-config.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m packages/intelligence/test/causes.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m packages/provider-local/test/index.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m packages/canonry/test/notify-events.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m packages/canonry/test/gsc-sync.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m apps/web/test/vite-config.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m packages/canonry/test/gsc-inspect-sitemap.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m packages/canonry/test/cli-error.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 37[2mms[22m[39m
 [32m✓[39m packages/canonry/test/job-runner-competitors.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 3[2mms[22m[39m

[2m Test Files [22m [1m[32m89 passed[39m[22m[90m (89)[39m
[2m      Tests [22m [1m[32m812 passed[39m[22m[90m (812)[39m
[2m   Start at [22m 09:14:06
[2m   Duration [22m 8.76s[2m (transform 10.10s, setup 0ms, import 52.64s, tests 24.39s, environment 2.24s)[22m).
- Type‑check passes (
> canonry@1.39.0 typecheck /home/arberx/.openclaw/workspace/canonry
> pnpm -r --no-bail run typecheck

Scope: 19 of 20 workspace projects
packages/contracts typecheck$ tsc --noEmit -p tsconfig.json
packages/db typecheck$ tsc --noEmit -p tsconfig.json
packages/intelligence typecheck$ tsc --noEmit -p tsconfig.json
packages/intelligence typecheck: Done
packages/contracts typecheck: Done
packages/db typecheck: Done
apps/web typecheck$ tsc --noEmit -p tsconfig.json
packages/config typecheck$ tsc --noEmit -p tsconfig.json
packages/integration-bing typecheck$ tsc --noEmit -p tsconfig.json
packages/integration-google typecheck$ tsc --noEmit -p tsconfig.json
packages/integration-bing typecheck: Done
packages/integration-google-analytics typecheck$ tsc --noEmit -p tsconfig.json
packages/integration-google typecheck: Done
packages/integration-wordpress typecheck$ tsc --noEmit -p tsconfig.json
packages/config typecheck: Done
packages/provider-cdp typecheck$ tsc --noEmit -p tsconfig.json
packages/integration-google-analytics typecheck: Done
packages/provider-claude typecheck$ tsc --noEmit -p tsconfig.json
packages/integration-wordpress typecheck: Done
packages/provider-gemini typecheck$ tsc --noEmit -p tsconfig.json
packages/provider-cdp typecheck: Done
packages/provider-local typecheck$ tsc --noEmit -p tsconfig.json
packages/provider-claude typecheck: Done
packages/provider-openai typecheck$ tsc --noEmit -p tsconfig.json
packages/provider-gemini typecheck: Done
packages/provider-perplexity typecheck$ tsc --noEmit -p tsconfig.json
packages/provider-local typecheck: Done
packages/provider-openai typecheck: Done
packages/provider-perplexity typecheck: Done
apps/web typecheck: Done
apps/worker typecheck$ tsc --noEmit -p tsconfig.json
packages/api-routes typecheck$ tsc --noEmit -p tsconfig.json
apps/worker typecheck: Done
packages/api-routes typecheck: Done
apps/api typecheck$ tsc --noEmit -p tsconfig.json
packages/canonry typecheck$ tsc --noEmit -p tsconfig.json
apps/api typecheck: Done
packages/canonry typecheck: Done).
- Lint passes (
> canonry@1.39.0 lint /home/arberx/.openclaw/workspace/canonry
> pnpm -r run lint

Scope: 19 of 20 workspace projects
packages/contracts lint$ eslint src/ test/
packages/db lint$ eslint src/ test/
packages/intelligence lint$ eslint src/ test/
packages/db lint: Done
packages/intelligence lint: Done
packages/contracts lint: Done
packages/config lint$ eslint src/ test/
apps/web lint$ eslint src/ test/ vite.config.ts
packages/integration-bing lint$ eslint src/ test/
packages/integration-google lint$ eslint src/ test/
packages/config lint: Done
packages/integration-google-analytics lint$ eslint src/ test/
packages/integration-bing lint: Done
packages/integration-wordpress lint$ eslint src/ test/
packages/integration-google lint: Done
packages/provider-cdp lint$ eslint src/ test/
packages/integration-google-analytics lint: Done
packages/provider-claude lint$ eslint src/ test/
packages/provider-cdp lint: Done
packages/provider-gemini lint$ eslint src/ test/
packages/integration-wordpress lint: Done
packages/provider-local lint$ eslint src/ test/
apps/web lint: Done
packages/provider-openai lint$ eslint src/ test/
packages/provider-claude lint: Done
packages/provider-perplexity lint$ eslint src/ test/
packages/provider-gemini lint: Done
packages/provider-local lint: Done
packages/provider-openai lint: Done
packages/provider-perplexity lint: Done
apps/worker lint$ eslint src/ test/
packages/api-routes lint$ eslint src/ test/
apps/worker lint: Done
packages/api-routes lint: Done
apps/api lint$ eslint src/ test/
packages/canonry lint$ eslint src/ test/
apps/api lint: Done
packages/canonry lint: Done).
- No functional changes to the API contract; only path prefix adjustments.