### PR TITLE
feat(cli): add --tunnel flag to canonry notify add

### DIFF
--- a/packages/api-routes/src/webhooks.ts
+++ b/packages/api-routes/src/webhooks.ts
@@ -118,15 +118,23 @@ async function resolveHostAddresses(hostname: string): Promise<Array<{ address: 
   }
 
   try {
-    const records = await dns.lookup(hostname, { all: true, verbatim: true })
+    // Use dns.resolve4/dns.resolve6 instead of dns.lookup to bypass
+    // stub resolvers (e.g. systemd-resolved) that may time out for
+    // external CDN domains like cloudflared.
+    const [ipv4, ipv6] = await Promise.allSettled([dns.resolve4(hostname), dns.resolve6(hostname)])
     const unique = new Map<string, { address: string; family: 4 | 6 }>()
-    for (const record of records) {
-      if (record.family !== 4 && record.family !== 6) continue
-      unique.set(`${record.family}:${record.address}`, {
-        address: record.address,
-        family: record.family,
-      })
+
+    if (ipv4.status === 'fulfilled') {
+      for (const address of ipv4.value) {
+        unique.set(`4:${address}`, { address, family: 4 })
+      }
     }
+    if (ipv6.status === 'fulfilled') {
+      for (const address of ipv6.value) {
+        unique.set(`6:${address}`, { address, family: 6 })
+      }
+    }
+
     return [...unique.values()]
   } catch {
     return []

--- a/packages/canonry/src/cli-commands/notify.ts
+++ b/packages/canonry/src/cli-commands/notify.ts
@@ -1,6 +1,8 @@
 import { addNotification, listEvents, listNotifications, removeNotification, testNotification } from '../commands/notify.js'
 import type { CliCommandSpec } from '../cli-dispatch.js'
 import { requirePositional, requireProject, requireStringOption, stringOption, unknownSubcommand } from '../cli-command-helpers.js'
+import { openCloudflaredTunnel } from '../commands/tunnel.js'
+import { loadConfig } from '../config.js'
 
 export const NOTIFY_CLI_COMMANDS: readonly CliCommandSpec[] = [
   {
@@ -12,25 +14,55 @@ export const NOTIFY_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['notify', 'add'],
-    usage: 'canonry notify add <project> --webhook <url> --events <list> [--format json]',
+    usage: 'canonry notify add <project> --webhook <url> --events <list> [--format json]'
+      + '\n       canonry notify add <project> --tunnel --events <list>',
     options: {
       webhook: stringOption(),
       events: stringOption(),
+      tunnel: { type: 'boolean', default: false },
     },
     run: async (input) => {
-      const project = requireProject(input, 'notify.add', 'canonry notify add <project> --webhook <url> --events <list> [--format json]')
-      const webhook = requireStringOption(input, 'webhook', {
-        command: 'notify.add',
-        usage: 'canonry notify add <project> --webhook <url> --events <list> [--format json]',
-        message: '--webhook is required',
-      })
+      const project = requireProject(
+        input,
+        'notify.add',
+        'canonry notify add <project> --webhook <url> --events <list> | --tunnel',
+      )
+
+      const useTunnel = input.values.tunnel === true
+      const webhookRaw = input.values.webhook
+
+      if (!useTunnel && !webhookRaw) {
+        throw new Error('Error: --webhook or --tunnel is required. See --help for usage.')
+      }
+
+      if (useTunnel && webhookRaw) {
+        throw new Error('Error: --webhook and --tunnel cannot be used together.')
+      }
+
       const events = requireStringOption(input, 'events', {
         command: 'notify.add',
-        usage: 'canonry notify add <project> --webhook <url> --events <list> [--format json]',
+        usage: 'canonry notify add <project> --webhook <url> --events <list> | --tunnel',
         message: '--events is required (comma-separated). Use "canonry notify events" to see valid events.',
       })
+
+      let webhookUrl: string
+      if (useTunnel) {
+        process.stderr.write('Spawning cloudflared quicktunnel to local canonry server...\n')
+        const config = loadConfig()
+        const targetUrl = `http://localhost:${config.port ?? 4100}`
+        webhookUrl = await openCloudflaredTunnel(targetUrl)
+        process.stderr.write(`  Tunnel ready: ${webhookUrl}\n`)
+        process.stderr.write('  The tunnel URL is temporary — it only works while cloudflared is running.\n\n')
+      } else {
+        webhookUrl = requireStringOption(input, 'webhook', {
+          command: 'notify.add',
+          usage: 'canonry notify add <project> --webhook <url> --events <list>',
+          message: '--webhook is required',
+        })
+      }
+
       await addNotification(project, {
-        webhook,
+        webhook: webhookUrl,
         events: events.split(',').map(entry => entry.trim()).filter(Boolean),
         format: input.format,
       })

--- a/packages/canonry/src/commands/tunnel.ts
+++ b/packages/canonry/src/commands/tunnel.ts
@@ -1,0 +1,83 @@
+import { spawn } from 'node:child_process'
+import { createWriteStream } from 'node:fs'
+
+/**
+ * Spawns a cloudflared quicktunnel to the given target URL and returns
+ * the assigned public URL. Cleans up the tunnel process on exit.
+ */
+export async function openCloudflaredTunnel(targetUrl: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const tunnelLog = createWriteStream('/tmp/canonry-tunnel.log')
+
+    const proc = spawn('cloudflared', ['tunnel', '--url', targetUrl], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    let resolved = false
+
+    let cleaned = false
+    const cleanup = () => {
+      if (cleaned) return
+      cleaned = true
+      if (!proc.killed) {
+        proc.kill('SIGTERM')
+      }
+      try {
+        tunnelLog.end()
+      } catch {
+        // already closed
+      }
+    }
+
+    process.on('exit', cleanup)
+
+    // cloudflared writes the tunnel URL to stderr
+    proc.stderr?.on('data', (chunk: Buffer) => {
+      if (resolved) return
+      const line = chunk.toString()
+      try {
+        tunnelLog.write(line)
+      } catch {
+        // stream closed
+      }
+      const match = line.match(/https:\/\/[a-z0-9-]+\.trycloudflare\.com/)
+      if (match) {
+        resolved = true
+        // Don't kill cloudflared — keep the tunnel alive for the webhook
+        resolve(match[0])
+      }
+    })
+
+    proc.stdout?.on('data', (chunk: Buffer) => {
+      try {
+        tunnelLog.write(chunk.toString())
+      } catch {
+        // stream closed
+      }
+    })
+
+    proc.on('error', (err) => {
+      tunnelLog.end()
+      if (!resolved) {
+        resolved = true
+        reject(new Error(`Failed to spawn cloudflared: ${err.message}`))
+      }
+    })
+
+    proc.on('exit', (code) => {
+      tunnelLog.end()
+      if (!resolved && code !== null && code !== 0) {
+        resolved = true
+        reject(new Error(`cloudflared exited with code ${code}`))
+      }
+    })
+
+    // Timeout after 30 seconds
+    setTimeout(() => {
+      if (!resolved) {
+        cleanup()
+        reject(new Error('cloudflared tunnel timed out after 30s'))
+      }
+    }, 30_000)
+  })
+}

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,48 @@
+## Summary
+
+Two changes:
+
+### 1. `canonry notify add --tunnel` — Spin up a cloudflared quicktunnel automatically
+
+Adds `--tunnel` as an alternative to `--webhook`. When used, canonry spawns a cloudflared quicktunnel to the local server and uses the resulting public URL as the webhook target. The tunnel is kept alive for the duration of the process so the webhook remains reachable.
+
+```bash
+# Before: manually find a publicly reachable URL
+canonry notify add myproject --webhook https://public.example.com/hooks/canonry --events run.completed,run.failed
+
+# After: canonry handles the tunnel automatically
+canonry notify add myproject --tunnel --events run.completed,run.failed
+# Spawning cloudflared quicktunnel to local canonry server...
+#   Tunnel ready: https://xxxx.trycloudflare.com
+```
+
+**Implementation:**
+- `packages/canonry/src/commands/tunnel.ts` — new file, wraps cloudflared spawn + URL extraction
+- `packages/canonry/src/cli-commands/notify.ts` — new `--tunnel` flag, mutually exclusive with `--webhook`
+
+### 2. `resolveHostAddresses` DNS resolution fix
+
+The webhook URL validator was using `dns.lookup`, which routes through the system stub resolver (e.g. systemd-resolved). On networks where the stub resolver fails to reach authoritative DNS for CDN domains (cloudflared, Fastly, etc.), this caused valid webhook URLs to be rejected as "hostname could not be resolved."
+
+Switched to `dns.resolve4` / `dns.resolve6` which perform recursive queries directly to the configured nameservers.
+
+```diff
+- const records = await dns.lookup(hostname, { all: true, verbatim: true })
++ const [ipv4, ipv6] = await Promise.allSettled([dns.resolve4(hostname), dns.resolve6(hostname)])
+```
+
+**Files changed:**
+- `packages/api-routes/src/webhooks.ts` — replace `dns.lookup` with `dns.resolve4`/`dns.resolve6`
+
+## Testing
+
+```bash
+canonry notify add myproject --tunnel --events run.completed,run.failed
+# Verify the notification was created with a public trycloudflare.com URL
+canonry notify list myproject
+```
+
+## Requirements
+
+- `cloudflared` binary must be installed and in PATH
+- DNS resolution for `*.trycloudflare.com` must work via the configured nameserver


### PR DESCRIPTION
## Summary

Two changes:

### 1. `canonry notify add --tunnel` — Spin up a cloudflared quicktunnel automatically

Adds `--tunnel` as an alternative to `--webhook`. When used, canonry spawns a cloudflared quicktunnel to the local server and uses the resulting public URL as the webhook target. The tunnel is kept alive for the duration of the process so the webhook remains reachable.

```bash
# Before: manually find a publicly reachable URL
canonry notify add myproject --webhook https://public.example.com/hooks/canonry --events run.completed,run.failed

# After: canonry handles the tunnel automatically
canonry notify add myproject --tunnel --events run.completed,run.failed
# Spawning cloudflared quicktunnel to local canonry server...
#   Tunnel ready: https://xxxx.trycloudflare.com
```

**Implementation:**
- `packages/canonry/src/commands/tunnel.ts` — new file, wraps cloudflared spawn + URL extraction
- `packages/canonry/src/cli-commands/notify.ts` — new `--tunnel` flag, mutually exclusive with `--webhook`

### 2. `resolveHostAddresses` DNS resolution fix

The webhook URL validator was using `dns.lookup`, which routes through the system stub resolver (e.g. systemd-resolved). On networks where the stub resolver fails to reach authoritative DNS for CDN domains (cloudflared, Fastly, etc.), this caused valid webhook URLs to be rejected as "hostname could not be resolved."

Switched to `dns.resolve4` / `dns.resolve6` which perform recursive queries directly to the configured nameservers.

```diff
- const records = await dns.lookup(hostname, { all: true, verbatim: true })
+ const [ipv4, ipv6] = await Promise.allSettled([dns.resolve4(hostname), dns.resolve6(hostname)])
```

**Files changed:**
- `packages/api-routes/src/webhooks.ts` — replace `dns.lookup` with `dns.resolve4`/`dns.resolve6`

## Testing

```bash
canonry notify add myproject --tunnel --events run.completed,run.failed
# Verify the notification was created with a public trycloudflare.com URL
canonry notify list myproject
```

## Requirements

- `cloudflared` binary must be installed and in PATH
- DNS resolution for `*.trycloudflare.com` must work via the configured nameserver
