### PR TITLE
fix(api-routes): use dns.resolve4/resolve6 in webhook URL validator

### DIFF
--- a/packages/api-routes/src/webhooks.ts
+++ b/packages/api-routes/src/webhooks.ts
@@ -118,15 +118,23 @@ async function resolveHostAddresses(hostname: string): Promise<Array<{ address: 
   }
 
   try {
-    const records = await dns.lookup(hostname, { all: true, verbatim: true })
+    // Use dns.resolve4/dns.resolve6 instead of dns.lookup to bypass
+    // stub resolvers (e.g. systemd-resolved) that may time out for
+    // external CDN domains.
+    const [ipv4, ipv6] = await Promise.allSettled([dns.resolve4(hostname), dns.resolve6(hostname)])
     const unique = new Map<string, { address: string; family: 4 | 6 }>()
-    for (const record of records) {
-      if (record.family !== 4 && record.family !== 6) continue
-      unique.set(`${record.family}:${record.address}`, {
-        address: record.address,
-        family: record.family,
-      })
+
+    if (ipv4.status === 'fulfilled') {
+      for (const address of ipv4.value) {
+        unique.set(`4:${address}`, { address, family: 4 })
+      }
     }
+    if (ipv6.status === 'fulfilled') {
+      for (const address of ipv6.value) {
+        unique.set(`6:${address}`, { address, family: 6 })
+      }
+    }
+
     return [...unique.values()]
   } catch {
     return []


### PR DESCRIPTION
## Summary

The webhook URL validator uses  to resolve webhook hostnames.  routes through the system stub resolver (e.g. systemd-resolved at ). On networks where the stub resolver fails to reach authoritative DNS for public domains (e.g. cloudflared CDN), valid webhook URLs are incorrectly rejected with "hostname could not be resolved".

## Fix

Replace  with / which perform recursive queries directly to the configured nameservers.

```diff
- const records = await dns.lookup(hostname, { all: true, verbatim: true })
+ const [ipv4, ipv6] = await Promise.allSettled([dns.resolve4(hostname), dns.resolve6(hostname)])
```

## Testing

Verify webhook URL validation works for public CDN domains when the system uses a stub resolver.