### PR TITLE
fix(api-routes): allow loopback addresses in webhook URL validation

### DIFF
--- a/packages/api-routes/src/webhooks.ts
+++ b/packages/api-routes/src/webhooks.ts
@@ -170,7 +170,6 @@ function isBlockedIpv4(address: string): boolean {
   return (
     first === 0 ||
     first === 10 ||
-    first === 127 ||
     (first === 100 && second >= 64 && second <= 127) ||
     (first === 169 && second === 254) ||
     (first === 172 && second >= 16 && second <= 31) ||
@@ -181,7 +180,8 @@ function isBlockedIpv4(address: string): boolean {
 
 function isBlockedIpv6(address: string): boolean {
   const normalized = address.split('%')[0]!.toLowerCase()
-  if (normalized === '::' || normalized === '::1') {
+  // Block unspecified (::) but allow loopback (::1)
+  if (normalized === '::') {
     return true
   }
 


### PR DESCRIPTION
## Summary

Allow `127.x.x.x` (IPv4) and `::1` (IPv6) loopback addresses as valid webhook destinations. This enables same-machine webhook delivery where canonry sends notifications to a local agent endpoint without requiring a publicly reachable URL.

## Changes

- **IPv4:** Remove `first === 127` from `isBlockedIpv4()`
- **IPv6:** Remove `normalized === '::1'` from `isBlockedIpv6()`, keeping `::` (unspecified) blocked

## Why

Webhook destinations are currently blocked if they resolve to private/loopback IPs. This is appropriate for hosted deployments where canonry and the webhook target may be in different trust domains. However, for same-machine configurations (canonry running alongside a local agent), loopback webhooks are the natural choice and should not be rejected.

## Testing

Any of these URLs now validate successfully:

```bash
canonry notify add myproject --webhook http://127.0.0.1:18789/hooks/agent --events run.completed,run.failed
canonry notify add myproject --webhook http://[::1]:18789/hooks/agent --events run.completed
```
