### PR TITLE
Fix latest run selection in status

### DIFF
--- a/packages/canonry/src/commands/status.ts
+++ b/packages/canonry/src/commands/status.ts
@@ -27,8 +27,10 @@ export async function showStatus(project: string, format?: string): Promise<void
   console.log(`  Language: ${projectData.language}`)
 
   if (runs.length > 0) {
-    // listRuns returns runs in descending createdAt order (newest first)
-    const latest = runs[0]!
+    // Derive the latest run from timestamps instead of relying on API ordering.
+    const latest = runs.reduce((current, candidate) =>
+      candidate.createdAt > current.createdAt ? candidate : current,
+    )
     console.log(`\n  Latest run:`)
     console.log(`    ID:       ${latest.id}`)
     console.log(`    Status:   ${latest.status}`)

--- a/packages/canonry/test/cli-operator-contract.test.ts
+++ b/packages/canonry/test/cli-operator-contract.test.ts
@@ -125,6 +125,36 @@ describe('operator CLI contract', () => {
     expect(parsed.runs).toBeInstanceOf(Array)
   })
 
+  it('prints the most recent run in text mode', async () => {
+    const project = await client.getProject('test-proj') as { id: string }
+    const olderRunId = crypto.randomUUID()
+    const latestRunId = crypto.randomUUID()
+
+    db.insert(runs).values({
+      id: olderRunId,
+      projectId: project.id,
+      status: 'completed',
+      createdAt: '2026-03-27T18:13:34.794Z',
+      finishedAt: '2026-03-27T18:14:11.600Z',
+    }).run()
+
+    db.insert(runs).values({
+      id: latestRunId,
+      projectId: project.id,
+      status: 'completed',
+      createdAt: '2026-04-06T23:42:40.348Z',
+      finishedAt: '2026-04-06T23:50:47.958Z',
+    }).run()
+
+    const result = await invokeCli(['status', 'test-proj'])
+
+    expect(result.exitCode).toBe(undefined)
+    expect(result.stderr).toBe('')
+    expect(result.stdout).toContain(`ID:       ${latestRunId}`)
+    expect(result.stdout).not.toContain(olderRunId)
+    expect(result.stdout).toContain('Total runs: 2')
+  })
+
   it('prints evidence to stdout in JSON mode', async () => {
     const project = await client.getProject('test-proj') as { id: string }
     const keywordId = crypto.randomUUID()


### PR DESCRIPTION
## Summary
- fix `canonry status` so it selects the newest run by `createdAt` instead of assuming the first run in the API response is latest
- add a CLI regression test covering two completed runs with different timestamps
- bump the root and publishable package versions from `1.39.1` to `1.39.2`

## Root Cause
`canonry status` called `listRuns(project)` and assumed the first element was the newest run. The project runs endpoint returns oldest-first when no `limit` is supplied, while `canonry runs <project> --limit 1` returns the actual newest run. That made the two commands disagree.

## Impact
Users checking project status now see the latest completed run instead of a stale older run.

## Validation
- `pnpm exec vitest run packages/canonry/test/cli-operator-contract.test.ts`
- `pnpm run typecheck`
- `pnpm run lint`

Closes #264