### PR TITLE
feat(ga4): add social media referral tracking to traffic section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,45 @@ THIS IS AN **AGENT-FIRST** PLATFORM. The CLI and API are the primary interfaces.
 2. **Required:** Add the CLI command in `packages/canonry/src/commands/`.
 3. **Ideal:** Add the UI interaction in `apps/web/` — aim to include it, but never block a release waiting for UI work.
 
+### UI/CLI parity (Critical)
+
+**Every dashboard view, widget, and computed metric visible in the web UI must have an equivalent API endpoint and CLI command that returns the same data.** The UI is a consumer of the API, not a privileged surface. If a user can see it in the browser, an agent must be able to read it from the CLI.
+
+#### Rules
+
+1. **No UI-only calculations.** If the UI computes a derived metric (percentages, trends, diffs, scores, roll-ups), that calculation must live in the API response — not in frontend component code. The API returns the computed value; both the UI and CLI consume it.
+2. **No UI-only state.** Every dashboard panel, section, or page that displays data must map to a CLI command. If the UI shows a "Social Referral Summary" card, there must be a `canonry ga social-referral-summary` command that returns the same information.
+3. **Mirror granularity.** If the UI shows both a summary and a detail view, the CLI must offer both. A single dump endpoint that requires agents to post-process is not equivalent.
+4. **Same data, same shape.** The JSON output of `--format json` for a CLI command should be structurally identical to the API response the UI consumes. An agent should be able to replace a UI `fetch()` call with a `canonry ... --format json` call and get the same fields.
+
+#### When adding a new UI component
+
+Before building any new dashboard section or widget:
+
+1. Confirm the backing API endpoint already exists (or add it first).
+2. Confirm the matching CLI command already exists (or add it first).
+3. Ensure all derived metrics and calculations are in the API response, not computed in the component.
+4. The UI component should only be responsible for layout and presentation — never for business logic or data aggregation.
+
+#### Anti-patterns
+
+```typescript
+// ❌ Wrong — UI computes a metric that agents can't access
+const aiShare = Math.round((traffic.aiSessions / traffic.totalSessions) * 100)
+
+// ✅ Correct — API returns the computed metric, UI just displays it
+// API response: { aiSharePct: 12 }
+<span>{traffic.aiSharePct}%</span>
+```
+
+```typescript
+// ❌ Wrong — UI aggregates raw data that the API doesn't expose as a summary
+const totalBySource = referrals.reduce((acc, r) => { ... }, {})
+
+// ✅ Correct — API has a summary endpoint, UI consumes it
+// GET /projects/:name/ga/attribution returns { channelBreakdown: [...] }
+```
+
 ### Agent & automation design principles
 
 The CLI and API **are** the agent interface. No MCP layer, no virtual filesystem, no special agent SDK. If an AI agent can't do something with `canonry <command> --format json` or an HTTP call, it's a bug.
@@ -133,6 +172,7 @@ The CLI and API **are** the agent interface. No MCP layer, no virtual filesystem
 4. **Single-call reads.** If an agent needs two API calls to answer a common question, add a composite endpoint. Examples: `/projects/:name/runs/latest` (don't make agents list-then-filter), `/projects/:name/search?q=term` (don't make agents fetch all snapshots to grep). The test: can an agent get what it needs in one `curl` call?
 5. **Meaningful exit codes.** `0` = success, `1` = user error (bad input, not found, validation), `2` = system error (network, provider failure, internal). Agents use exit codes to decide whether to retry.
 6. **Stable output contracts.** JSON field names, endpoint paths, and error codes are public API. Renaming a JSON field is a breaking change. Add fields freely; never remove or rename without a version bump.
+7. **UI/CLI parity.** Every piece of data or computed metric visible in the web UI must be retrievable via the API and CLI. If the UI shows it, an agent must be able to `curl` or `canonry ... --format json` it. Derived calculations (percentages, trends, roll-ups) belong in the API response, not in frontend code. See the "UI/CLI parity" section above for the full rules.
 
 #### Checklist for any new command or endpoint
 
@@ -142,6 +182,13 @@ The CLI and API **are** the agent interface. No MCP layer, no virtual filesystem
 - [ ] Write operations are idempotent (or return conflict details)
 - [ ] Common read patterns achievable in a single API call
 - [ ] Exit code follows 0/1/2 convention
+
+#### Checklist for any new UI component
+
+- [ ] Backing API endpoint exists and returns all data the component displays
+- [ ] Matching CLI command exists with `--format json` support
+- [ ] All derived metrics (percentages, trends, diffs) are computed in the API, not the component
+- [ ] JSON shape from CLI matches the API response the UI fetches
 
 ## Maintenance Guidance
 
@@ -435,6 +482,7 @@ This repo uses per-package `AGENTS.md` files for local context. **These must sta
 | Add a new table or column in `packages/db/src/schema.ts` | Update `docs/data-model.md` (ER diagram + table groups) |
 | Add a new API route file in `packages/api-routes/src/` | Update `packages/api-routes/AGENTS.md` key files table |
 | Add a new CLI command | Update `packages/canonry/AGENTS.md` |
+| Add a new UI dashboard section or widget | Verify backing API endpoint + CLI command exist first (UI/CLI parity rule) |
 | Add a new provider package | Update `docs/providers/README.md` and create `docs/providers/<name>.md` |
 | Add a new integration package | Create `packages/integration-<name>/AGENTS.md` |
 | Change a critical pattern (error handling, DB access, auth) | Update the relevant package's AGENTS.md patterns section |

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,4 +1,4 @@
-import type { ErrorCode, GroundingSource, ScheduleDto, NotificationDto, GscCoverageSummaryDto, GscCoverageSnapshotDto, IndexingRequestResultDto, BrandMetricsDto, GapAnalysisDto, SourceBreakdownDto, MetricsWindow, GA4AiReferralHistoryEntry, GA4SessionHistoryEntry, InsightDto, HealthSnapshotDto, RunKind, RunStatus, RunTrigger, CitationState, ComputedTransition } from '@ainyc/canonry-contracts'
+import type { ErrorCode, GroundingSource, ScheduleDto, NotificationDto, GscCoverageSummaryDto, GscCoverageSnapshotDto, IndexingRequestResultDto, BrandMetricsDto, GapAnalysisDto, SourceBreakdownDto, MetricsWindow, GA4AiReferralHistoryEntry, GA4SessionHistoryEntry, GA4SocialReferralHistoryEntry, InsightDto, HealthSnapshotDto, RunKind, RunStatus, RunTrigger, CitationState, ComputedTransition } from '@ainyc/canonry-contracts'
 
 export type { GroundingSource }
 
@@ -954,6 +954,14 @@ export interface ApiGaTrafficReferral {
   users: number
 }
 
+export interface ApiGaSocialReferral {
+  source: string
+  medium: string
+  sourceDimension: 'session' | 'first_user' | 'manual_utm'
+  sessions: number
+  users: number
+}
+
 export interface ApiGaTraffic {
   totalSessions: number
   totalOrganicSessions: number
@@ -964,6 +972,11 @@ export interface ApiGaTraffic {
   aiSessionsDeduped: number
   /** Deduped AI user total. */
   aiUsersDeduped: number
+  socialReferrals: ApiGaSocialReferral[]
+  /** Deduped social session total. */
+  socialSessionsDeduped: number
+  /** Deduped social user total. */
+  socialUsersDeduped: number
   lastSyncedAt: string | null
 }
 
@@ -971,6 +984,7 @@ export interface ApiGaSyncResult {
   synced: boolean
   rowCount: number
   aiReferralCount: number
+  socialReferralCount: number
   days: number
   syncedAt: string
 }
@@ -998,10 +1012,14 @@ export function connectGa(project: string, body: { propertyId: string; keyJson: 
   })
 }
 
-export type { GA4AiReferralHistoryEntry, GA4SessionHistoryEntry }
+export type { GA4AiReferralHistoryEntry, GA4SessionHistoryEntry, GA4SocialReferralHistoryEntry }
 
 export function fetchGaAiReferralHistory(project: string): Promise<GA4AiReferralHistoryEntry[]> {
   return apiFetch(`/projects/${encodeURIComponent(project)}/ga/ai-referral-history`)
+}
+
+export function fetchGaSocialReferralHistory(project: string): Promise<GA4SocialReferralHistoryEntry[]> {
+  return apiFetch(`/projects/${encodeURIComponent(project)}/ga/social-referral-history`)
 }
 
 export function fetchGaSessionHistory(project: string): Promise<GA4SessionHistoryEntry[]> {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -957,7 +957,7 @@ export interface ApiGaTrafficReferral {
 export interface ApiGaSocialReferral {
   source: string
   medium: string
-  sourceDimension: 'session' | 'first_user' | 'manual_utm'
+  channelGroup: string
   sessions: number
   users: number
 }
@@ -973,10 +973,10 @@ export interface ApiGaTraffic {
   /** Deduped AI user total. */
   aiUsersDeduped: number
   socialReferrals: ApiGaSocialReferral[]
-  /** Deduped social session total. */
-  socialSessionsDeduped: number
-  /** Deduped social user total. */
-  socialUsersDeduped: number
+  /** Total social sessions (session-scoped via sessionDefaultChannelGroup). */
+  socialSessions: number
+  /** Total social users (session-scoped via sessionDefaultChannelGroup). */
+  socialUsers: number
   lastSyncedAt: string | null
 }
 

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -977,6 +977,12 @@ export interface ApiGaTraffic {
   socialSessions: number
   /** Total social users (session-scoped via sessionDefaultChannelGroup). */
   socialUsers: number
+  /** Organic sessions as a percentage of total sessions (0–100, rounded). */
+  organicSharePct: number
+  /** Deduped AI sessions as a percentage of total sessions (0–100, rounded). */
+  aiSharePct: number
+  /** Social sessions as a percentage of total sessions (0–100, rounded). */
+  socialSharePct: number
   lastSyncedAt: string | null
 }
 

--- a/apps/web/src/components/project/TrafficSection.tsx
+++ b/apps/web/src/components/project/TrafficSection.tsx
@@ -274,20 +274,14 @@ export function TrafficSection({ projectName }: { projectName: string }) {
     )
   }
 
-  const organicPct = traffic && traffic.totalSessions > 0
-    ? Math.round((traffic.totalOrganicSessions / traffic.totalSessions) * 100)
-    : 0
+  const organicPct = traffic?.organicSharePct ?? 0
   const aiSessions = traffic?.aiSessionsDeduped ?? 0
-  const aiSharePct = traffic && traffic.totalSessions > 0
-    ? Math.round((aiSessions / traffic.totalSessions) * 100)
-    : 0
+  const aiSharePct = traffic?.aiSharePct ?? 0
   const aiSourceCount = traffic ? new Set(traffic.aiReferrals.map((referral) => referral.source.toLowerCase())).size : 0
   const topAiSource = sortedAiReferrals[0] ?? null
 
   const socialSessions = traffic?.socialSessions ?? 0
-  const socialSharePct = traffic && traffic.totalSessions > 0
-    ? Math.round((socialSessions / traffic.totalSessions) * 100)
-    : 0
+  const socialSharePct = traffic?.socialSharePct ?? 0
   const socialSourceCount = traffic ? new Set(traffic.socialReferrals.map((r) => r.source.toLowerCase())).size : 0
   const topSocialSource = sortedSocialReferrals[0] ?? null
 

--- a/apps/web/src/components/project/TrafficSection.tsx
+++ b/apps/web/src/components/project/TrafficSection.tsx
@@ -593,7 +593,7 @@ export function TrafficSection({ projectName }: { projectName: string }) {
               <p className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 mb-1">Social Attribution</p>
               <h2 className="text-base font-semibold text-zinc-50 flex items-center gap-1.5">
                 Social Media Traffic
-                <InfoTooltip text="Tracks sessions from social media platforms detected via GA4 sessionSource, firstUserSource, and sessionManualSource dimensions. Includes Facebook, Instagram, X/Twitter, LinkedIn, YouTube, TikTok, Reddit, Pinterest, and more." />
+                <InfoTooltip text="Tracks sessions classified as social traffic by GA4's default channel grouping (Organic Social and Paid Social). Google maintains the source-to-channel mapping." />
               </h2>
             </div>
 
@@ -612,7 +612,7 @@ export function TrafficSection({ projectName }: { projectName: string }) {
                         value={formatCompact(socialSessions)}
                         hint={`${socialSessions.toLocaleString()} sessions`}
                         tone="positive"
-                        tooltip="Total sessions attributed to social media platforms detected via GA4 sessionSource, firstUserSource, and sessionManualSource dimensions."
+                        tooltip="Total sessions classified as Organic Social or Paid Social by GA4's default channel grouping."
                       />
                       <AttributionStat
                         label="Share of Traffic"
@@ -644,8 +644,8 @@ export function TrafficSection({ projectName }: { projectName: string }) {
                       <AttributionStat label="Platforms" value="0" hint="known platforms" tone="neutral" tooltip="Number of distinct social media platforms detected." />
                     </div>
                     <div className="rounded-lg border border-zinc-800/60 bg-zinc-900/30 px-4 py-3 text-sm text-zinc-400">
-                      <p className="mb-1.5 text-zinc-300">Monitoring for social media traffic from:</p>
-                      <p className="text-xs text-zinc-500">Facebook, Instagram, X/Twitter, LinkedIn, YouTube, TikTok, Reddit, Pinterest, Threads, Mastodon, Bluesky, and Snapchat. Sessions will appear here once GA4 detects visits from these platforms.</p>
+                      <p className="mb-1.5 text-zinc-300">Monitoring social media traffic via GA4 channel grouping</p>
+                      <p className="text-xs text-zinc-500">Sessions classified as Organic Social or Paid Social by GA4 will appear here. Google maintains the source-to-channel mapping, which includes Facebook, Instagram, X/Twitter, LinkedIn, Reddit, Pinterest, Snapchat, and other platforms.</p>
                     </div>
                   </div>
                 )}

--- a/apps/web/src/components/project/TrafficSection.tsx
+++ b/apps/web/src/components/project/TrafficSection.tsx
@@ -284,7 +284,7 @@ export function TrafficSection({ projectName }: { projectName: string }) {
   const aiSourceCount = traffic ? new Set(traffic.aiReferrals.map((referral) => referral.source.toLowerCase())).size : 0
   const topAiSource = sortedAiReferrals[0] ?? null
 
-  const socialSessions = traffic?.socialSessionsDeduped ?? 0
+  const socialSessions = traffic?.socialSessions ?? 0
   const socialSharePct = traffic && traffic.totalSessions > 0
     ? Math.round((socialSessions / traffic.totalSessions) * 100)
     : 0
@@ -669,7 +669,7 @@ export function TrafficSection({ projectName }: { projectName: string }) {
                         <tr className="text-[10px] uppercase tracking-wider text-zinc-500">
                           <SortHeader label="Source" sortKey="source" current={socialSortKey} dir={socialSortDir} onSort={handleSocialSort} align="left" />
                           <SortHeader label="Medium" sortKey="medium" current={socialSortKey} dir={socialSortDir} onSort={handleSocialSort} align="left" />
-                          <th className="py-1 font-medium text-left">Attribution</th>
+                          <th className="py-1 font-medium text-left">Channel</th>
                           <SortHeader label="Sessions" sortKey="sessions" current={socialSortKey} dir={socialSortDir} onSort={handleSocialSort} align="right" />
                           <th className="py-1 font-medium text-right">Share</th>
                           <SortHeader label="Users" sortKey="users" current={socialSortKey} dir={socialSortDir} onSort={handleSocialSort} align="right" />
@@ -677,7 +677,7 @@ export function TrafficSection({ projectName }: { projectName: string }) {
                       </thead>
                       <tbody>
                         {sortedSocialReferrals.map((referral) => (
-                          <SocialReferralRow key={`${referral.source}:${referral.medium}:${referral.sourceDimension}`} referral={referral} totalSessions={socialSessions} />
+                          <SocialReferralRow key={`${referral.source}:${referral.medium}:${referral.channelGroup}`} referral={referral} totalSessions={socialSessions} />
                         ))}
                       </tbody>
                     </table>
@@ -1047,8 +1047,7 @@ function SocialReferralRow({
   totalSessions: number
 }) {
   const share = totalSessions > 0 ? ((referral.sessions / totalSessions) * 100).toFixed(1) : '0.0'
-  const dimLabel = DIMENSION_LABELS[referral.sourceDimension] ?? referral.sourceDimension
-  const dimTooltip = DIMENSION_TOOLTIPS[referral.sourceDimension] ?? ''
+  const channelLabel = referral.channelGroup === 'Paid Social' ? 'Paid' : 'Organic'
 
   return (
     <tr className="border-t border-zinc-800/40">
@@ -1061,9 +1060,9 @@ function SocialReferralRow({
       <td className="py-1.5">
         <span
           className="inline-block text-[10px] px-1.5 py-0.5 rounded-full border border-zinc-700 text-zinc-400"
-          title={dimTooltip}
+          title={`GA4 channel group: ${referral.channelGroup}`}
         >
-          {dimLabel}
+          {channelLabel}
         </span>
       </td>
       <td className="py-1.5 text-right text-sky-400 tabular-nums">

--- a/apps/web/src/components/project/TrafficSection.tsx
+++ b/apps/web/src/components/project/TrafficSection.tsx
@@ -29,12 +29,13 @@ import {
   triggerGaSync,
   disconnectGa,
 } from '../../api.js'
-import type { ApiGaStatus, ApiGaTraffic, ApiGaTrafficPage, ApiGaTrafficReferral, GA4AiReferralHistoryEntry, GA4SessionHistoryEntry } from '../../api.js'
+import type { ApiGaStatus, ApiGaTraffic, ApiGaTrafficPage, ApiGaTrafficReferral, ApiGaSocialReferral, GA4AiReferralHistoryEntry, GA4SessionHistoryEntry } from '../../api.js'
 
 const SOURCE_COLORS = CHART_SERIES_COLORS
 
 type PageSortKey = 'landingPage' | 'sessions' | 'organicSessions' | 'users'
 type ReferralSortKey = 'source' | 'medium' | 'sessions' | 'users'
+type SocialSortKey = 'source' | 'medium' | 'sessions' | 'users'
 type SortDir = 'asc' | 'desc'
 
 function formatCompact(n: number): string {
@@ -66,6 +67,8 @@ export function TrafficSection({ projectName }: { projectName: string }) {
   const [pageSortDir, setPageSortDir] = useState<SortDir>('desc')
   const [referralSortKey, setReferralSortKey] = useState<ReferralSortKey>('sessions')
   const [referralSortDir, setReferralSortDir] = useState<SortDir>('desc')
+  const [socialSortKey, setSocialSortKey] = useState<SocialSortKey>('sessions')
+  const [socialSortDir, setSocialSortDir] = useState<SortDir>('desc')
   const [aiHistory, setAiHistory] = useState<GA4AiReferralHistoryEntry[]>([])
   const [sessionHistory, setSessionHistory] = useState<GA4SessionHistoryEntry[]>([])
 
@@ -118,7 +121,7 @@ export function TrafficSection({ projectName }: { projectName: string }) {
     setNotice(null)
     try {
       const result = await triggerGaSync(projectName)
-      setNotice(`Synced ${result.rowCount.toLocaleString()} page rows and ${result.aiReferralCount.toLocaleString()} AI referral rows (${result.days} days)`)
+      setNotice(`Synced ${result.rowCount.toLocaleString()} page rows, ${result.aiReferralCount.toLocaleString()} AI and ${result.socialReferralCount.toLocaleString()} social referral rows (${result.days} days)`)
       const [t, h, sh] = await Promise.all([
         fetchGaTraffic(projectName),
         fetchGaAiReferralHistory(projectName).catch(() => [] as GA4AiReferralHistoryEntry[]),
@@ -170,6 +173,15 @@ export function TrafficSection({ projectName }: { projectName: string }) {
     }
   }
 
+  function handleSocialSort(key: SocialSortKey) {
+    if (socialSortKey === key) {
+      setSocialSortDir((d) => (d === 'desc' ? 'asc' : 'desc'))
+    } else {
+      setSocialSortKey(key)
+      setSocialSortDir('desc')
+    }
+  }
+
   const sortedPages = useMemo(() => {
     if (!traffic?.topPages) return []
     return [...traffic.topPages].sort((a, b) => {
@@ -193,6 +205,18 @@ export function TrafficSection({ projectName }: { projectName: string }) {
       return referralSortDir === 'asc' ? (av as number) - (bv as number) : (bv as number) - (av as number)
     })
   }, [traffic?.aiReferrals, referralSortKey, referralSortDir])
+
+  const sortedSocialReferrals = useMemo(() => {
+    if (!traffic?.socialReferrals) return []
+    return [...traffic.socialReferrals].sort((a, b) => {
+      const av = a[socialSortKey]
+      const bv = b[socialSortKey]
+      if (typeof av === 'string' && typeof bv === 'string') {
+        return socialSortDir === 'asc' ? av.localeCompare(bv) : bv.localeCompare(av)
+      }
+      return socialSortDir === 'asc' ? (av as number) - (bv as number) : (bv as number) - (av as number)
+    })
+  }, [traffic?.socialReferrals, socialSortKey, socialSortDir])
 
   // Keep this above the early returns so the hook order stays stable while the
   // component transitions from loading or disconnected to connected.
@@ -259,6 +283,13 @@ export function TrafficSection({ projectName }: { projectName: string }) {
     : 0
   const aiSourceCount = traffic ? new Set(traffic.aiReferrals.map((referral) => referral.source.toLowerCase())).size : 0
   const topAiSource = sortedAiReferrals[0] ?? null
+
+  const socialSessions = traffic?.socialSessionsDeduped ?? 0
+  const socialSharePct = traffic && traffic.totalSessions > 0
+    ? Math.round((socialSessions / traffic.totalSessions) * 100)
+    : 0
+  const socialSourceCount = traffic ? new Set(traffic.socialReferrals.map((r) => r.source.toLowerCase())).size : 0
+  const topSocialSource = sortedSocialReferrals[0] ?? null
 
   return (
     <>
@@ -552,6 +583,119 @@ export function TrafficSection({ projectName }: { projectName: string }) {
         </>
       )}
 
+      {/* Social Media Referrals */}
+      {traffic && (
+        <>
+          <div className="page-section-divider" />
+
+          <section>
+            <div className="mb-4">
+              <p className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 mb-1">Social Attribution</p>
+              <h2 className="text-base font-semibold text-zinc-50 flex items-center gap-1.5">
+                Social Media Traffic
+                <InfoTooltip text="Tracks sessions from social media platforms detected via GA4 sessionSource, firstUserSource, and sessionManualSource dimensions. Includes Facebook, Instagram, X/Twitter, LinkedIn, YouTube, TikTok, Reddit, Pinterest, and more." />
+              </h2>
+            </div>
+
+            <div className="grid gap-4 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.5fr)]">
+              <Card className="surface-card p-5">
+                <div className="mb-4">
+                  <p className="eyebrow eyebrow-soft">Summary</p>
+                  <h3 className="text-sm font-semibold text-zinc-100">Social media visits</h3>
+                </div>
+
+                {traffic.socialReferrals.length > 0 ? (
+                  <>
+                    <div className="grid gap-3 sm:grid-cols-3">
+                      <AttributionStat
+                        label="Social Sessions"
+                        value={formatCompact(socialSessions)}
+                        hint={`${socialSessions.toLocaleString()} sessions`}
+                        tone="positive"
+                        tooltip="Total sessions attributed to social media platforms detected via GA4 sessionSource, firstUserSource, and sessionManualSource dimensions."
+                      />
+                      <AttributionStat
+                        label="Share of Traffic"
+                        value={`${socialSharePct}%`}
+                        hint="of total sessions"
+                        tone="neutral"
+                        tooltip="Percentage of your total site sessions that originated from social media platforms."
+                      />
+                      <AttributionStat
+                        label="Platforms"
+                        value={String(socialSourceCount)}
+                        hint={`${traffic.socialReferrals.length} source rows`}
+                        tone="neutral"
+                        tooltip="Number of distinct social media platforms detected. Each unique source/medium combination counts as one source row."
+                      />
+                    </div>
+
+                    {topSocialSource && (
+                      <div className="mt-4 rounded-lg border border-sky-800/40 bg-sky-500/6 px-4 py-3 text-sm text-sky-100">
+                        Top social source: <span className="font-medium">{topSocialSource.source}</span> via {topSocialSource.medium}, accounting for {topSocialSource.sessions.toLocaleString()} sessions.
+                      </div>
+                    )}
+                  </>
+                ) : (
+                  <div className="space-y-3">
+                    <div className="grid gap-3 sm:grid-cols-3">
+                      <AttributionStat label="Social Sessions" value="0" hint="0 sessions" tone="neutral" tooltip="Total sessions attributed to social media platforms." />
+                      <AttributionStat label="Share of Traffic" value="0%" hint="of total sessions" tone="neutral" tooltip="Percentage of your total site sessions from social media." />
+                      <AttributionStat label="Platforms" value="0" hint="known platforms" tone="neutral" tooltip="Number of distinct social media platforms detected." />
+                    </div>
+                    <div className="rounded-lg border border-zinc-800/60 bg-zinc-900/30 px-4 py-3 text-sm text-zinc-400">
+                      <p className="mb-1.5 text-zinc-300">Monitoring for social media traffic from:</p>
+                      <p className="text-xs text-zinc-500">Facebook, Instagram, X/Twitter, LinkedIn, YouTube, TikTok, Reddit, Pinterest, Threads, Mastodon, Bluesky, and Snapchat. Sessions will appear here once GA4 detects visits from these platforms.</p>
+                    </div>
+                  </div>
+                )}
+              </Card>
+
+              <Card className="surface-card p-5">
+                <div className="mb-4 flex items-end justify-between gap-3">
+                  <div>
+                    <p className="eyebrow eyebrow-soft">Breakdown</p>
+                    <h3 className="text-sm font-semibold text-zinc-100">Source / medium</h3>
+                  </div>
+                  <p className="text-xs text-zinc-500">
+                    {traffic.socialReferrals.length > 0 ? `${traffic.socialReferrals.length} rows` : 'No source rows'}
+                  </p>
+                </div>
+
+                {traffic.socialReferrals.length > 0 ? (
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="text-[10px] uppercase tracking-wider text-zinc-500">
+                          <SortHeader label="Source" sortKey="source" current={socialSortKey} dir={socialSortDir} onSort={handleSocialSort} align="left" />
+                          <SortHeader label="Medium" sortKey="medium" current={socialSortKey} dir={socialSortDir} onSort={handleSocialSort} align="left" />
+                          <th className="py-1 font-medium text-left">Attribution</th>
+                          <SortHeader label="Sessions" sortKey="sessions" current={socialSortKey} dir={socialSortDir} onSort={handleSocialSort} align="right" />
+                          <th className="py-1 font-medium text-right">Share</th>
+                          <SortHeader label="Users" sortKey="users" current={socialSortKey} dir={socialSortDir} onSort={handleSocialSort} align="right" />
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {sortedSocialReferrals.map((referral) => (
+                          <SocialReferralRow key={`${referral.source}:${referral.medium}:${referral.sourceDimension}`} referral={referral} totalSessions={socialSessions} />
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                ) : (
+                  <div className="flex flex-col items-center justify-center py-8 text-center">
+                    <p className="text-sm text-zinc-400 mb-2">No social media sessions detected yet</p>
+                    <p className="text-xs text-zinc-500 max-w-sm">
+                      When visitors arrive from Facebook, X/Twitter, LinkedIn, or other social platforms, their sessions will be broken down here by source and medium.
+                    </p>
+                  </div>
+                )}
+              </Card>
+            </div>
+          </section>
+        </>
+      )}
+
       {/* Top Landing Pages */}
       {traffic && traffic.topPages.length > 0 && (
         <>
@@ -595,7 +739,7 @@ export function TrafficSection({ projectName }: { projectName: string }) {
             ? `Last synced ${relativeTime(traffic.lastSyncedAt)}`
             : 'Never synced'}
         </span>
-        <span>{traffic ? `${traffic.topPages.length} pages · ${traffic.aiReferrals.length} AI rows` : ''}</span>
+        <span>{traffic ? `${traffic.topPages.length} pages · ${traffic.aiReferrals.length} AI rows · ${traffic.socialReferrals.length} social rows` : ''}</span>
       </div>
     </>
   )
@@ -883,6 +1027,46 @@ function AiReferralRow({
         </span>
       </td>
       <td className="py-1.5 text-right text-emerald-400 tabular-nums">
+        {referral.sessions.toLocaleString()}
+      </td>
+      <td className="py-1.5 text-right text-zinc-400 tabular-nums">
+        {share}%
+      </td>
+      <td className="py-1.5 text-right text-zinc-200 tabular-nums">
+        {referral.users.toLocaleString()}
+      </td>
+    </tr>
+  )
+}
+
+function SocialReferralRow({
+  referral,
+  totalSessions,
+}: {
+  referral: ApiGaSocialReferral
+  totalSessions: number
+}) {
+  const share = totalSessions > 0 ? ((referral.sessions / totalSessions) * 100).toFixed(1) : '0.0'
+  const dimLabel = DIMENSION_LABELS[referral.sourceDimension] ?? referral.sourceDimension
+  const dimTooltip = DIMENSION_TOOLTIPS[referral.sourceDimension] ?? ''
+
+  return (
+    <tr className="border-t border-zinc-800/40">
+      <td className="py-1.5 text-zinc-200 max-w-[220px] truncate" title={referral.source}>
+        {referral.source}
+      </td>
+      <td className="py-1.5 text-zinc-500 max-w-[180px] truncate" title={referral.medium}>
+        {referral.medium}
+      </td>
+      <td className="py-1.5">
+        <span
+          className="inline-block text-[10px] px-1.5 py-0.5 rounded-full border border-zinc-700 text-zinc-400"
+          title={dimTooltip}
+        >
+          {dimLabel}
+        </span>
+      </td>
+      <td className="py-1.5 text-right text-sky-400 tabular-nums">
         {referral.sessions.toLocaleString()}
       </td>
       <td className="py-1.5 text-right text-zinc-400 tabular-nums">

--- a/apps/web/test/traffic-section.test.tsx
+++ b/apps/web/test/traffic-section.test.tsx
@@ -60,10 +60,10 @@ test('loads connected GA4 data without changing hook order', async () => {
         aiSessionsDeduped: 12,
         aiUsersDeduped: 9,
         socialReferrals: [
-          { source: 'facebook.com', medium: 'social', sourceDimension: 'session', sessions: 8, users: 6 },
+          { source: 'facebook.com', medium: 'social', channelGroup: 'Organic Social', sessions: 8, users: 6 },
         ],
-        socialSessionsDeduped: 8,
-        socialUsersDeduped: 6,
+        socialSessions: 8,
+        socialUsers: 6,
         lastSyncedAt: '2026-03-31T12:00:00.000Z',
       })
     }

--- a/apps/web/test/traffic-section.test.tsx
+++ b/apps/web/test/traffic-section.test.tsx
@@ -59,6 +59,11 @@ test('loads connected GA4 data without changing hook order', async () => {
         ],
         aiSessionsDeduped: 12,
         aiUsersDeduped: 9,
+        socialReferrals: [
+          { source: 'facebook.com', medium: 'social', sourceDimension: 'session', sessions: 8, users: 6 },
+        ],
+        socialSessionsDeduped: 8,
+        socialUsersDeduped: 6,
         lastSyncedAt: '2026-03-31T12:00:00.000Z',
       })
     }

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -24,6 +24,7 @@ erDiagram
   projects ||--o{ ga_traffic_snapshots : has
   projects ||--o{ ga_traffic_summaries : has
   projects ||--o{ ga_ai_referrals : has
+  projects ||--o{ ga_social_referrals : has
 
   projects ||--o{ gsc_search_data : has
   projects ||--o{ gsc_url_inspections : has
@@ -73,6 +74,7 @@ erDiagram
 | **ga_traffic_snapshots** | Traffic data snapshots |
 | **ga_traffic_summaries** | Aggregated traffic summaries |
 | **ga_ai_referrals** | AI engine referral tracking. Unique: `(projectId, date, source, medium, sourceDimension)` |
+| **ga_social_referrals** | Social media referral tracking. Unique: `(projectId, date, source, medium, sourceDimension)` |
 
 ### Intelligence
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -74,7 +74,7 @@ erDiagram
 | **ga_traffic_snapshots** | Traffic data snapshots |
 | **ga_traffic_summaries** | Aggregated traffic summaries |
 | **ga_ai_referrals** | AI engine referral tracking. Unique: `(projectId, date, source, medium, sourceDimension)` |
-| **ga_social_referrals** | Social media referral tracking. Unique: `(projectId, date, source, medium, sourceDimension)` |
+| **ga_social_referrals** | Social media referral tracking. Unique: `(projectId, date, source, medium, channelGroup)` |
 
 ### Intelligence
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "1.43.0",
+  "version": "1.44.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "1.41.0",
+  "version": "1.42.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "1.42.0",
+  "version": "1.43.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/ga.ts
+++ b/packages/api-routes/src/ga.ts
@@ -429,7 +429,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
             date: row.date,
             source: row.source,
             medium: row.medium,
-            sourceDimension: row.sourceDimension,
+            channelGroup: row.channelGroup,
             sessions: row.sessions,
             users: row.users,
             syncedAt: now,
@@ -545,31 +545,25 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       .select({
         source: gaSocialReferrals.source,
         medium: gaSocialReferrals.medium,
-        sourceDimension: gaSocialReferrals.sourceDimension,
+        channelGroup: gaSocialReferrals.channelGroup,
         sessions: sql<number>`SUM(${gaSocialReferrals.sessions})`,
         users: sql<number>`SUM(${gaSocialReferrals.users})`,
       })
       .from(gaSocialReferrals)
       .where(eq(gaSocialReferrals.projectId, project.id))
-      .groupBy(gaSocialReferrals.source, gaSocialReferrals.medium, gaSocialReferrals.sourceDimension)
+      .groupBy(gaSocialReferrals.source, gaSocialReferrals.medium, gaSocialReferrals.channelGroup)
       .orderBy(sql`SUM(${gaSocialReferrals.sessions}) DESC`)
       .all()
 
-    const socialDeduped = app.db
+    // Session-scoped totals — no cross-dimension dedup needed since we only
+    // query sessionDefaultChannelGroup (single attribution lens).
+    const socialTotals = app.db
       .select({
-        sessions: sql<number>`SUM(max_sessions)`,
-        users: sql<number>`SUM(max_users)`,
+        sessions: sql<number>`SUM(${gaSocialReferrals.sessions})`,
+        users: sql<number>`SUM(${gaSocialReferrals.users})`,
       })
-      .from(
-        sql`(
-          SELECT date, source, medium,
-                 MAX(sessions) AS max_sessions,
-                 MAX(users) AS max_users
-          FROM ga_social_referrals
-          WHERE project_id = ${project.id}
-          GROUP BY date, source, medium
-        )`
-      )
+      .from(gaSocialReferrals)
+      .where(eq(gaSocialReferrals.projectId, project.id))
       .get()
 
     const latestSync = app.db
@@ -602,12 +596,12 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       socialReferrals: socialReferrals.map((r) => ({
         source: r.source,
         medium: r.medium,
-        sourceDimension: r.sourceDimension,
+        channelGroup: r.channelGroup,
         sessions: r.sessions ?? 0,
         users: r.users ?? 0,
       })),
-      socialSessionsDeduped: socialDeduped?.sessions ?? 0,
-      socialUsersDeduped: socialDeduped?.users ?? 0,
+      socialSessions: socialTotals?.sessions ?? 0,
+      socialUsers: socialTotals?.users ?? 0,
       lastSyncedAt: latestSync?.syncedAt ?? null,
     }
   })
@@ -648,7 +642,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         date: gaSocialReferrals.date,
         source: gaSocialReferrals.source,
         medium: gaSocialReferrals.medium,
-        sourceDimension: gaSocialReferrals.sourceDimension,
+        channelGroup: gaSocialReferrals.channelGroup,
         sessions: gaSocialReferrals.sessions,
         users: gaSocialReferrals.users,
       })

--- a/packages/api-routes/src/ga.ts
+++ b/packages/api-routes/src/ga.ts
@@ -761,6 +761,126 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
     }
   })
 
+  // GET /projects/:name/ga/attribution-trend
+  app.get<{
+    Params: { name: string }
+  }>('/projects/:name/ga/attribution-trend', async (request, _reply) => {
+    const project = resolveProject(app.db, request.params.name)
+    requireGa4Connection(opts, project.name, project.canonicalDomain)
+
+    const today = new Date()
+    const fmt = (d: Date) => d.toISOString().split('T')[0]!
+    const daysAgo = (n: number) => { const d = new Date(today); d.setDate(d.getDate() - n); return fmt(d) }
+    const pct = (cur: number, prev: number) => prev === 0 ? null : Math.round(((cur - prev) / prev) * 100)
+
+    // --- Total sessions (from gaTrafficSnapshots) ---
+    const sumTotal = (from: string, to: string) => app.db
+      .select({ sessions: sql<number>`COALESCE(SUM(${gaTrafficSnapshots.sessions}), 0)` })
+      .from(gaTrafficSnapshots)
+      .where(and(eq(gaTrafficSnapshots.projectId, project.id), sql`${gaTrafficSnapshots.date} >= ${from}`, sql`${gaTrafficSnapshots.date} < ${to}`))
+      .get()
+
+    // --- Organic sessions (from gaTrafficSnapshots) ---
+    const sumOrganic = (from: string, to: string) => app.db
+      .select({ sessions: sql<number>`COALESCE(SUM(${gaTrafficSnapshots.organicSessions}), 0)` })
+      .from(gaTrafficSnapshots)
+      .where(and(eq(gaTrafficSnapshots.projectId, project.id), sql`${gaTrafficSnapshots.date} >= ${from}`, sql`${gaTrafficSnapshots.date} < ${to}`))
+      .get()
+
+    // --- AI sessions (deduped: MAX per date+source+medium across dimensions, then SUM) ---
+    const sumAi = (from: string, to: string) => app.db
+      .select({ sessions: sql<number>`COALESCE(SUM(max_sessions), 0)` })
+      .from(sql`(
+        SELECT date, source, medium, MAX(sessions) AS max_sessions
+        FROM ga_ai_referrals
+        WHERE project_id = ${project.id} AND date >= ${from} AND date < ${to}
+        GROUP BY date, source, medium
+      )`)
+      .get()
+
+    // --- Social sessions ---
+    const sumSocial = (from: string, to: string) => app.db
+      .select({ sessions: sql<number>`COALESCE(SUM(${gaSocialReferrals.sessions}), 0)` })
+      .from(gaSocialReferrals)
+      .where(and(eq(gaSocialReferrals.projectId, project.id), sql`${gaSocialReferrals.date} >= ${from}`, sql`${gaSocialReferrals.date} < ${to}`))
+      .get()
+
+    const todayStr = fmt(today)
+
+    const buildTrend = (sum: (from: string, to: string) => { sessions: number } | undefined) => {
+      const c7 = sum(daysAgo(7), todayStr)?.sessions ?? 0
+      const p7 = sum(daysAgo(14), daysAgo(7))?.sessions ?? 0
+      const c30 = sum(daysAgo(30), todayStr)?.sessions ?? 0
+      const p30 = sum(daysAgo(60), daysAgo(30))?.sessions ?? 0
+      return { sessions7d: c7, sessionsPrev7d: p7, trend7dPct: pct(c7, p7), sessions30d: c30, sessionsPrev30d: p30, trend30dPct: pct(c30, p30) }
+    }
+
+    // --- Biggest movers (AI) ---
+    const aiSourceCurrent = app.db
+      .select({ source: sql<string>`source`, sessions: sql<number>`COALESCE(SUM(max_sessions), 0)` })
+      .from(sql`(
+        SELECT date, source, medium, MAX(sessions) AS max_sessions
+        FROM ga_ai_referrals
+        WHERE project_id = ${project.id} AND date >= ${daysAgo(7)} AND date < ${todayStr}
+        GROUP BY date, source, medium
+      )`)
+      .groupBy(sql`source`)
+      .all()
+
+    const aiSourcePrev = app.db
+      .select({ source: sql<string>`source`, sessions: sql<number>`COALESCE(SUM(max_sessions), 0)` })
+      .from(sql`(
+        SELECT date, source, medium, MAX(sessions) AS max_sessions
+        FROM ga_ai_referrals
+        WHERE project_id = ${project.id} AND date >= ${daysAgo(14)} AND date < ${daysAgo(7)}
+        GROUP BY date, source, medium
+      )`)
+      .groupBy(sql`source`)
+      .all()
+
+    const findBiggestMover = (
+      current: Array<{ source: string; sessions: number }>,
+      prev: Array<{ source: string; sessions: number }>,
+    ) => {
+      const prevMap = new Map(prev.map((r) => [r.source, r.sessions]))
+      let mover: { source: string; sessions7d: number; sessionsPrev7d: number; changePct: number } | null = null
+      let maxDelta = 0
+      for (const row of current) {
+        const p = prevMap.get(row.source) ?? 0
+        const delta = Math.abs(row.sessions - p)
+        if (delta > maxDelta) {
+          maxDelta = delta
+          mover = { source: row.source, sessions7d: row.sessions, sessionsPrev7d: p, changePct: pct(row.sessions, p) ?? (row.sessions > 0 ? 100 : 0) }
+        }
+      }
+      return mover
+    }
+
+    // --- Biggest movers (Social) ---
+    const socialSourceCurrent = app.db
+      .select({ source: gaSocialReferrals.source, sessions: sql<number>`SUM(${gaSocialReferrals.sessions})` })
+      .from(gaSocialReferrals)
+      .where(and(eq(gaSocialReferrals.projectId, project.id), sql`${gaSocialReferrals.date} >= ${daysAgo(7)}`, sql`${gaSocialReferrals.date} < ${todayStr}`))
+      .groupBy(gaSocialReferrals.source)
+      .all()
+
+    const socialSourcePrev = app.db
+      .select({ source: gaSocialReferrals.source, sessions: sql<number>`SUM(${gaSocialReferrals.sessions})` })
+      .from(gaSocialReferrals)
+      .where(and(eq(gaSocialReferrals.projectId, project.id), sql`${gaSocialReferrals.date} >= ${daysAgo(14)}`, sql`${gaSocialReferrals.date} < ${daysAgo(7)}`))
+      .groupBy(gaSocialReferrals.source)
+      .all()
+
+    return {
+      total: buildTrend(sumTotal),
+      organic: buildTrend(sumOrganic),
+      ai: buildTrend(sumAi),
+      social: buildTrend(sumSocial),
+      aiBiggestMover: findBiggestMover(aiSourceCurrent, aiSourcePrev),
+      socialBiggestMover: findBiggestMover(socialSourceCurrent, socialSourcePrev),
+    }
+  })
+
   // GET /projects/:name/ga/session-history
   app.get<{
     Params: { name: string }

--- a/packages/api-routes/src/ga.ts
+++ b/packages/api-routes/src/ga.ts
@@ -337,6 +337,11 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
     const days = request.body?.days ?? 30
     const only = request.body?.only
 
+    const validOnlyValues = ['traffic', 'ai', 'social'] as const
+    if (only !== undefined && !validOnlyValues.includes(only as typeof validOnlyValues[number])) {
+      throw validationError(`Invalid "only" value "${only}". Must be one of: ${validOnlyValues.join(', ')}`)
+    }
+
     // Determine which components to sync
     const syncTraffic = !only || only === 'traffic'
     const syncAi = !only || only === 'ai'
@@ -596,8 +601,10 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       .limit(1)
       .get()
 
+    const total = summary?.totalSessions ?? 0
+
     return {
-      totalSessions: summary?.totalSessions ?? 0,
+      totalSessions: total,
       totalOrganicSessions: summary?.totalOrganicSessions ?? 0,
       totalUsers: summary?.totalUsers ?? 0,
       topPages: rows.map((r) => ({
@@ -624,6 +631,9 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       })),
       socialSessions: socialTotals?.sessions ?? 0,
       socialUsers: socialTotals?.users ?? 0,
+      organicSharePct: total > 0 ? Math.round(((summary?.totalOrganicSessions ?? 0) / total) * 100) : 0,
+      aiSharePct: total > 0 ? Math.round(((aiDeduped?.sessions ?? 0) / total) * 100) : 0,
+      socialSharePct: total > 0 ? Math.round(((socialTotals?.sessions ?? 0) / total) * 100) : 0,
       lastSyncedAt: latestSync?.syncedAt ?? null,
     }
   })

--- a/packages/api-routes/src/ga.ts
+++ b/packages/api-routes/src/ga.ts
@@ -326,27 +326,43 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
   })
 
   // POST /projects/:name/ga/sync
+  // Supports `only` field to selectively sync a subset of data (e.g. "social").
+  // Valid components: "traffic", "ai", "social". Omit for full sync.
   app.post<{
     Params: { name: string }
-    Body: { days?: number }
+    Body: { days?: number; only?: string }
   }>('/projects/:name/ga/sync', async (request, _reply) => {
     const project = resolveProject(app.db, request.params.name)
 
     const days = request.body?.days ?? 30
+    const only = request.body?.only
+
+    // Determine which components to sync
+    const syncTraffic = !only || only === 'traffic'
+    const syncAi = !only || only === 'ai'
+    const syncSocial = !only || only === 'social'
+    const syncSummary = !only // always sync summary on full sync
 
     const { accessToken, propertyId } = await resolveGa4AccessToken(opts, project.name, project.canonicalDomain)
 
-    let rows
-    let summary
-    let aiReferrals
-    let socialReferrals
+    let rows: Awaited<ReturnType<typeof fetchTrafficByLandingPage>> = []
+    let summary: Awaited<ReturnType<typeof fetchAggregateSummary>>
+    let aiReferrals: Awaited<ReturnType<typeof fetchAiReferrals>> = []
+    let socialReferrals: Awaited<ReturnType<typeof fetchSocialReferrals>> = []
+
     try {
-      ;[rows, summary, aiReferrals, socialReferrals] = await Promise.all([
-        fetchTrafficByLandingPage(accessToken, propertyId, days),
-        fetchAggregateSummary(accessToken, propertyId, days),
-        fetchAiReferrals(accessToken, propertyId, days),
-        fetchSocialReferrals(accessToken, propertyId, days),
-      ])
+      // Always need summary for date range (periodStart/periodEnd), even for partial sync
+      const fetches: Promise<unknown>[] = [fetchAggregateSummary(accessToken, propertyId, days)]
+      if (syncTraffic) fetches.push(fetchTrafficByLandingPage(accessToken, propertyId, days))
+      if (syncAi) fetches.push(fetchAiReferrals(accessToken, propertyId, days))
+      if (syncSocial) fetches.push(fetchSocialReferrals(accessToken, propertyId, days))
+
+      const results = await Promise.all(fetches)
+      summary = results[0] as Awaited<ReturnType<typeof fetchAggregateSummary>>
+      let idx = 1
+      if (syncTraffic) { rows = results[idx++] as typeof rows }
+      if (syncAi) { aiReferrals = results[idx++] as typeof aiReferrals }
+      if (syncSocial) { socialReferrals = results[idx++] as typeof socialReferrals }
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e)
       gaLog('error', 'sync.fetch-failed', { projectId: project.id, error: msg })
@@ -358,17 +374,17 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
     // Clear old data for this project in the synced date range, then insert fresh
     // Wrapped in a transaction to ensure atomicity — a crash mid-insert won't lose data
     app.db.transaction((tx) => {
-      tx.delete(gaTrafficSnapshots)
-        .where(
-          and(
-            eq(gaTrafficSnapshots.projectId, project.id),
-            sql`${gaTrafficSnapshots.date} >= ${summary.periodStart}`,
-            sql`${gaTrafficSnapshots.date} <= ${summary.periodEnd}`,
-          ),
-        )
-        .run()
+      if (syncTraffic) {
+        tx.delete(gaTrafficSnapshots)
+          .where(
+            and(
+              eq(gaTrafficSnapshots.projectId, project.id),
+              sql`${gaTrafficSnapshots.date} >= ${summary.periodStart}`,
+              sql`${gaTrafficSnapshots.date} <= ${summary.periodEnd}`,
+            ),
+          )
+          .run()
 
-      if (rows.length > 0) {
         for (const row of rows) {
           tx.insert(gaTrafficSnapshots).values({
             id: crypto.randomUUID(),
@@ -383,18 +399,17 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         }
       }
 
-      tx.delete(gaAiReferrals)
-        .where(
-          and(
-            eq(gaAiReferrals.projectId, project.id),
-            sql`${gaAiReferrals.date} >= ${summary.periodStart}`,
-            sql`${gaAiReferrals.date} <= ${summary.periodEnd}`,
-          ),
-        )
-        .run()
+      if (syncAi) {
+        tx.delete(gaAiReferrals)
+          .where(
+            and(
+              eq(gaAiReferrals.projectId, project.id),
+              sql`${gaAiReferrals.date} >= ${summary.periodStart}`,
+              sql`${gaAiReferrals.date} <= ${summary.periodEnd}`,
+            ),
+          )
+          .run()
 
-      // Sync AI referrals
-      if (aiReferrals.length > 0) {
         for (const row of aiReferrals) {
           tx.insert(gaAiReferrals).values({
             id: crypto.randomUUID(),
@@ -410,18 +425,17 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         }
       }
 
-      // Sync social referrals
-      tx.delete(gaSocialReferrals)
-        .where(
-          and(
-            eq(gaSocialReferrals.projectId, project.id),
-            sql`${gaSocialReferrals.date} >= ${summary.periodStart}`,
-            sql`${gaSocialReferrals.date} <= ${summary.periodEnd}`,
-          ),
-        )
-        .run()
+      if (syncSocial) {
+        tx.delete(gaSocialReferrals)
+          .where(
+            and(
+              eq(gaSocialReferrals.projectId, project.id),
+              sql`${gaSocialReferrals.date} >= ${summary.periodStart}`,
+              sql`${gaSocialReferrals.date} <= ${summary.periodEnd}`,
+            ),
+          )
+          .run()
 
-      if (socialReferrals.length > 0) {
         for (const row of socialReferrals) {
           tx.insert(gaSocialReferrals).values({
             id: crypto.randomUUID(),
@@ -437,22 +451,28 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         }
       }
 
-      // Replace aggregate summary for this project — always one row per project.
-      tx.delete(gaTrafficSummaries)
-        .where(eq(gaTrafficSummaries.projectId, project.id))
-        .run()
+      if (syncSummary) {
+        // Replace aggregate summary for this project — always one row per project.
+        tx.delete(gaTrafficSummaries)
+          .where(eq(gaTrafficSummaries.projectId, project.id))
+          .run()
 
-      tx.insert(gaTrafficSummaries).values({
-        id: crypto.randomUUID(),
-        projectId: project.id,
-        periodStart: summary.periodStart,
-        periodEnd: summary.periodEnd,
-        totalSessions: summary.totalSessions,
-        totalOrganicSessions: summary.totalOrganicSessions,
-        totalUsers: summary.totalUsers,
-        syncedAt: now,
-      }).run()
+        tx.insert(gaTrafficSummaries).values({
+          id: crypto.randomUUID(),
+          projectId: project.id,
+          periodStart: summary.periodStart,
+          periodEnd: summary.periodEnd,
+          totalSessions: summary.totalSessions,
+          totalOrganicSessions: summary.totalOrganicSessions,
+          totalUsers: summary.totalUsers,
+          syncedAt: now,
+        }).run()
+      }
     })
+
+    const syncedComponents = only
+      ? [only, ...(only !== 'social' && only !== 'ai' && only !== 'traffic' ? [] : [])]
+      : undefined
 
     gaLog('info', 'sync.complete', {
       projectId: project.id,
@@ -461,6 +481,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       socialReferralCount: socialReferrals.length,
       days,
       totalUsers: summary.totalUsers,
+      ...(only ? { only } : {}),
     })
 
     return {
@@ -470,6 +491,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       socialReferralCount: socialReferrals.length,
       days,
       syncedAt: now,
+      ...(syncedComponents ? { syncedComponents } : {}),
     }
   })
 
@@ -652,6 +674,91 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       .all()
 
     return rows
+  })
+
+  // GET /projects/:name/ga/social-referral-trend
+  app.get<{
+    Params: { name: string }
+  }>('/projects/:name/ga/social-referral-trend', async (request, _reply) => {
+    const project = resolveProject(app.db, request.params.name)
+    requireGa4Connection(opts, project.name, project.canonicalDomain)
+
+    const today = new Date()
+    const fmt = (d: Date) => d.toISOString().split('T')[0]!
+    const daysAgo = (n: number) => { const d = new Date(today); d.setDate(d.getDate() - n); return fmt(d) }
+
+    const sumSocial = (from: string, to: string) => app.db
+      .select({ sessions: sql<number>`COALESCE(SUM(${gaSocialReferrals.sessions}), 0)` })
+      .from(gaSocialReferrals)
+      .where(and(
+        eq(gaSocialReferrals.projectId, project.id),
+        sql`${gaSocialReferrals.date} >= ${from}`,
+        sql`${gaSocialReferrals.date} < ${to}`,
+      ))
+      .get()
+
+    const current7d = sumSocial(daysAgo(7), fmt(today))
+    const prev7d = sumSocial(daysAgo(14), daysAgo(7))
+    const current30d = sumSocial(daysAgo(30), fmt(today))
+    const prev30d = sumSocial(daysAgo(60), daysAgo(30))
+
+    const pct = (cur: number, prev: number) => prev === 0 ? null : Math.round(((cur - prev) / prev) * 100)
+
+    // Biggest mover: source with largest absolute session change in 7d vs prev 7d
+    const sourceCurrent = app.db
+      .select({
+        source: gaSocialReferrals.source,
+        sessions: sql<number>`SUM(${gaSocialReferrals.sessions})`,
+      })
+      .from(gaSocialReferrals)
+      .where(and(
+        eq(gaSocialReferrals.projectId, project.id),
+        sql`${gaSocialReferrals.date} >= ${daysAgo(7)}`,
+        sql`${gaSocialReferrals.date} < ${fmt(today)}`,
+      ))
+      .groupBy(gaSocialReferrals.source)
+      .all()
+
+    const sourcePrev = app.db
+      .select({
+        source: gaSocialReferrals.source,
+        sessions: sql<number>`SUM(${gaSocialReferrals.sessions})`,
+      })
+      .from(gaSocialReferrals)
+      .where(and(
+        eq(gaSocialReferrals.projectId, project.id),
+        sql`${gaSocialReferrals.date} >= ${daysAgo(14)}`,
+        sql`${gaSocialReferrals.date} < ${daysAgo(7)}`,
+      ))
+      .groupBy(gaSocialReferrals.source)
+      .all()
+
+    const prevMap = new Map(sourcePrev.map((r) => [r.source, r.sessions]))
+    let biggestMover: { source: string; sessions7d: number; sessionsPrev7d: number; changePct: number } | null = null
+    let maxDelta = 0
+    for (const row of sourceCurrent) {
+      const prev = prevMap.get(row.source) ?? 0
+      const delta = Math.abs(row.sessions - prev)
+      if (delta > maxDelta) {
+        maxDelta = delta
+        biggestMover = {
+          source: row.source,
+          sessions7d: row.sessions,
+          sessionsPrev7d: prev,
+          changePct: pct(row.sessions, prev) ?? (row.sessions > 0 ? 100 : 0),
+        }
+      }
+    }
+
+    return {
+      socialSessions7d: current7d?.sessions ?? 0,
+      socialSessionsPrev7d: prev7d?.sessions ?? 0,
+      trend7dPct: pct(current7d?.sessions ?? 0, prev7d?.sessions ?? 0),
+      socialSessions30d: current30d?.sessions ?? 0,
+      socialSessionsPrev30d: prev30d?.sessions ?? 0,
+      trend30dPct: pct(current30d?.sessions ?? 0, prev30d?.sessions ?? 0),
+      biggestMover,
+    }
   })
 
   // GET /projects/:name/ga/session-history

--- a/packages/api-routes/src/ga.ts
+++ b/packages/api-routes/src/ga.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto'
 import { eq, desc, and, sql } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
-import { gaTrafficSnapshots, gaTrafficSummaries, gaAiReferrals } from '@ainyc/canonry-db'
+import { gaTrafficSnapshots, gaTrafficSummaries, gaAiReferrals, gaSocialReferrals } from '@ainyc/canonry-db'
 import { validationError, notFound } from '@ainyc/canonry-contracts'
 import { resolveProject, writeAuditLog } from './helpers.js'
 import {
@@ -9,6 +9,7 @@ import {
   fetchTrafficByLandingPage,
   fetchAggregateSummary,
   fetchAiReferrals,
+  fetchSocialReferrals,
   verifyConnection,
   verifyConnectionWithToken,
 } from '@ainyc/canonry-integration-google-analytics'
@@ -264,7 +265,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       throw notFound('GA4 connection', project.name)
     }
 
-    // Delete traffic data, summaries, and AI referral rows along with the connection.
+    // Delete traffic data, summaries, AI and social referral rows along with the connection.
     app.db.delete(gaTrafficSnapshots)
       .where(eq(gaTrafficSnapshots.projectId, project.id))
       .run()
@@ -273,6 +274,9 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       .run()
     app.db.delete(gaAiReferrals)
       .where(eq(gaAiReferrals.projectId, project.id))
+      .run()
+    app.db.delete(gaSocialReferrals)
+      .where(eq(gaSocialReferrals.projectId, project.id))
       .run()
 
     const propertyId = saConn?.propertyId ?? oauthConn?.propertyId ?? null
@@ -335,11 +339,13 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
     let rows
     let summary
     let aiReferrals
+    let socialReferrals
     try {
-      ;[rows, summary, aiReferrals] = await Promise.all([
+      ;[rows, summary, aiReferrals, socialReferrals] = await Promise.all([
         fetchTrafficByLandingPage(accessToken, propertyId, days),
         fetchAggregateSummary(accessToken, propertyId, days),
         fetchAiReferrals(accessToken, propertyId, days),
+        fetchSocialReferrals(accessToken, propertyId, days),
       ])
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e)
@@ -404,6 +410,33 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         }
       }
 
+      // Sync social referrals
+      tx.delete(gaSocialReferrals)
+        .where(
+          and(
+            eq(gaSocialReferrals.projectId, project.id),
+            sql`${gaSocialReferrals.date} >= ${summary.periodStart}`,
+            sql`${gaSocialReferrals.date} <= ${summary.periodEnd}`,
+          ),
+        )
+        .run()
+
+      if (socialReferrals.length > 0) {
+        for (const row of socialReferrals) {
+          tx.insert(gaSocialReferrals).values({
+            id: crypto.randomUUID(),
+            projectId: project.id,
+            date: row.date,
+            source: row.source,
+            medium: row.medium,
+            sourceDimension: row.sourceDimension,
+            sessions: row.sessions,
+            users: row.users,
+            syncedAt: now,
+          }).run()
+        }
+      }
+
       // Replace aggregate summary for this project — always one row per project.
       tx.delete(gaTrafficSummaries)
         .where(eq(gaTrafficSummaries.projectId, project.id))
@@ -425,6 +458,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       projectId: project.id,
       rowCount: rows.length,
       aiReferralCount: aiReferrals.length,
+      socialReferralCount: socialReferrals.length,
       days,
       totalUsers: summary.totalUsers,
     })
@@ -433,6 +467,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       synced: true,
       rowCount: rows.length,
       aiReferralCount: aiReferrals.length,
+      socialReferralCount: socialReferrals.length,
       days,
       syncedAt: now,
     }
@@ -506,6 +541,37 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       )
       .get()
 
+    const socialReferrals = app.db
+      .select({
+        source: gaSocialReferrals.source,
+        medium: gaSocialReferrals.medium,
+        sourceDimension: gaSocialReferrals.sourceDimension,
+        sessions: sql<number>`SUM(${gaSocialReferrals.sessions})`,
+        users: sql<number>`SUM(${gaSocialReferrals.users})`,
+      })
+      .from(gaSocialReferrals)
+      .where(eq(gaSocialReferrals.projectId, project.id))
+      .groupBy(gaSocialReferrals.source, gaSocialReferrals.medium, gaSocialReferrals.sourceDimension)
+      .orderBy(sql`SUM(${gaSocialReferrals.sessions}) DESC`)
+      .all()
+
+    const socialDeduped = app.db
+      .select({
+        sessions: sql<number>`SUM(max_sessions)`,
+        users: sql<number>`SUM(max_users)`,
+      })
+      .from(
+        sql`(
+          SELECT date, source, medium,
+                 MAX(sessions) AS max_sessions,
+                 MAX(users) AS max_users
+          FROM ga_social_referrals
+          WHERE project_id = ${project.id}
+          GROUP BY date, source, medium
+        )`
+      )
+      .get()
+
     const latestSync = app.db
       .select({ syncedAt: gaTrafficSummaries.syncedAt })
       .from(gaTrafficSummaries)
@@ -533,6 +599,15 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       })),
       aiSessionsDeduped: aiDeduped?.sessions ?? 0,
       aiUsersDeduped: aiDeduped?.users ?? 0,
+      socialReferrals: socialReferrals.map((r) => ({
+        source: r.source,
+        medium: r.medium,
+        sourceDimension: r.sourceDimension,
+        sessions: r.sessions ?? 0,
+        users: r.users ?? 0,
+      })),
+      socialSessionsDeduped: socialDeduped?.sessions ?? 0,
+      socialUsersDeduped: socialDeduped?.users ?? 0,
       lastSyncedAt: latestSync?.syncedAt ?? null,
     }
   })
@@ -556,6 +631,30 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       .from(gaAiReferrals)
       .where(eq(gaAiReferrals.projectId, project.id))
       .orderBy(gaAiReferrals.date)
+      .all()
+
+    return rows
+  })
+
+  // GET /projects/:name/ga/social-referral-history
+  app.get<{
+    Params: { name: string }
+  }>('/projects/:name/ga/social-referral-history', async (request, _reply) => {
+    const project = resolveProject(app.db, request.params.name)
+    requireGa4Connection(opts, project.name, project.canonicalDomain)
+
+    const rows = app.db
+      .select({
+        date: gaSocialReferrals.date,
+        source: gaSocialReferrals.source,
+        medium: gaSocialReferrals.medium,
+        sourceDimension: gaSocialReferrals.sourceDimension,
+        sessions: gaSocialReferrals.sessions,
+        users: gaSocialReferrals.users,
+      })
+      .from(gaSocialReferrals)
+      .where(eq(gaSocialReferrals.projectId, project.id))
+      .orderBy(gaSocialReferrals.date)
       .all()
 
     return rows

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -2048,6 +2048,18 @@ const routeCatalog: OpenApiOperation[] = [
   },
   {
     method: 'get',
+    path: '/api/v1/projects/{name}/ga/social-referral-history',
+    summary: 'Get social media referral sessions per day grouped by source',
+    tags: ['ga4'],
+    parameters: [nameParameter],
+    responses: {
+      200: { description: 'Social referral history returned.' },
+      400: { description: 'GA4 is not connected.' },
+      404: { description: 'Project not found.' },
+    },
+  },
+  {
+    method: 'get',
     path: '/api/v1/projects/{name}/ga/session-history',
     summary: 'Get total sessions per day for the project',
     tags: ['ga4'],

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -2072,6 +2072,18 @@ const routeCatalog: OpenApiOperation[] = [
   },
   {
     method: 'get',
+    path: '/api/v1/projects/{name}/ga/attribution-trend',
+    summary: 'Get per-channel attribution trends (7d/30d) for organic, AI, and social',
+    tags: ['ga4'],
+    parameters: [nameParameter],
+    responses: {
+      200: { description: 'Attribution trend returned.' },
+      400: { description: 'GA4 is not connected.' },
+      404: { description: 'Project not found.' },
+    },
+  },
+  {
+    method: 'get',
     path: '/api/v1/projects/{name}/ga/session-history',
     summary: 'Get total sessions per day for the project',
     tags: ['ga4'],

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -2060,6 +2060,18 @@ const routeCatalog: OpenApiOperation[] = [
   },
   {
     method: 'get',
+    path: '/api/v1/projects/{name}/ga/social-referral-trend',
+    summary: 'Get social referral trend (7d/30d) with biggest mover',
+    tags: ['ga4'],
+    parameters: [nameParameter],
+    responses: {
+      200: { description: 'Social referral trend returned.' },
+      400: { description: 'GA4 is not connected.' },
+      404: { description: 'Project not found.' },
+    },
+  },
+  {
+    method: 'get',
     path: '/api/v1/projects/{name}/ga/session-history',
     summary: 'Get total sessions per day for the project',
     tags: ['ga4'],

--- a/packages/api-routes/test/ga.test.ts
+++ b/packages/api-routes/test/ga.test.ts
@@ -371,6 +371,29 @@ describe('GA4 routes', () => {
       .run()
   })
 
+  it('POST /ga/sync rejects invalid only parameter', async () => {
+    const now = new Date().toISOString()
+    credentials.set('test-project', {
+      projectName: 'test-project',
+      propertyId: '999888',
+      clientEmail: 'sa@test.iam.gserviceaccount.com',
+      privateKey: 'fake-key',
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/test-project/ga/sync',
+      payload: { only: 'socal' },
+    })
+    expect(res.statusCode).toBe(400)
+    const body = JSON.parse(res.payload)
+    expect(body.error.message).toMatch(/Invalid "only" value/)
+
+    credentials.delete('test-project')
+  })
+
   it('GET /ga/traffic returns error when no connection', async () => {
     const res = await app.inject({
       method: 'GET',
@@ -468,6 +491,9 @@ describe('GA4 routes', () => {
     expect(body.socialReferrals).toEqual([])
     expect(body.socialSessions).toBe(0)
     expect(body.socialUsers).toBe(0)
+    expect(body.organicSharePct).toBe(50)
+    expect(body.aiSharePct).toBe(5)
+    expect(body.socialSharePct).toBe(0)
     expect(body.lastSyncedAt).toBe(now)
 
     credentials.delete('test-project')

--- a/packages/api-routes/test/ga.test.ts
+++ b/packages/api-routes/test/ga.test.ts
@@ -241,7 +241,7 @@ describe('GA4 routes', () => {
       { date: '2026-03-20', source: 'chatgpt.com', medium: 'referral', sessions: 12, users: 9, sourceDimension: 'session' },
     ])
     const fetchSocialReferralsSpy = vi.spyOn(gaModule, 'fetchSocialReferrals').mockResolvedValue([
-      { date: '2026-03-20', source: 'facebook.com', medium: 'social', sessions: 8, users: 6, sourceDimension: 'session' },
+      { date: '2026-03-20', source: 'facebook.com', medium: 'social', sessions: 8, users: 6, channelGroup: 'Organic Social' },
     ])
 
     const res = await app.inject({
@@ -466,8 +466,8 @@ describe('GA4 routes', () => {
     expect(body.aiSessionsDeduped).toBe(17)
     expect(body.aiUsersDeduped).toBe(10)
     expect(body.socialReferrals).toEqual([])
-    expect(body.socialSessionsDeduped).toBe(0)
-    expect(body.socialUsersDeduped).toBe(0)
+    expect(body.socialSessions).toBe(0)
+    expect(body.socialUsers).toBe(0)
     expect(body.lastSyncedAt).toBe(now)
 
     credentials.delete('test-project')

--- a/packages/api-routes/test/ga.test.ts
+++ b/packages/api-routes/test/ga.test.ts
@@ -5,7 +5,7 @@ import os from 'node:os'
 import crypto from 'node:crypto'
 import Fastify from 'fastify'
 import { eq, inArray } from 'drizzle-orm'
-import { createClient, migrate, gaAiReferrals, gaTrafficSnapshots, gaTrafficSummaries } from '@ainyc/canonry-db'
+import { createClient, migrate, gaAiReferrals, gaSocialReferrals, gaTrafficSnapshots, gaTrafficSummaries } from '@ainyc/canonry-db'
 import { apiRoutes } from '../src/index.js'
 import type { Ga4CredentialStore, Ga4CredentialRecord } from '../src/ga.js'
 
@@ -240,6 +240,9 @@ describe('GA4 routes', () => {
     const fetchAiReferralsSpy = vi.spyOn(gaModule, 'fetchAiReferrals').mockResolvedValue([
       { date: '2026-03-20', source: 'chatgpt.com', medium: 'referral', sessions: 12, users: 9, sourceDimension: 'session' },
     ])
+    const fetchSocialReferralsSpy = vi.spyOn(gaModule, 'fetchSocialReferrals').mockResolvedValue([
+      { date: '2026-03-20', source: 'facebook.com', medium: 'social', sessions: 8, users: 6, sourceDimension: 'session' },
+    ])
 
     const res = await app.inject({
       method: 'POST',
@@ -251,6 +254,7 @@ describe('GA4 routes', () => {
     expect(body.synced).toBe(true)
     expect(body.rowCount).toBe(2)
     expect(body.aiReferralCount).toBe(1)
+    expect(body.socialReferralCount).toBe(1)
 
     // Verify per-page rows were written
     const snapshots = db.select().from(gaTrafficSnapshots)
@@ -273,11 +277,18 @@ describe('GA4 routes', () => {
     expect(aiReferrals).toHaveLength(1)
     expect(aiReferrals[0]!.source).toBe('chatgpt.com')
 
+    const socialRefs = db.select().from(gaSocialReferrals)
+      .where(eq(gaSocialReferrals.projectId, projectId))
+      .all()
+    expect(socialRefs).toHaveLength(1)
+    expect(socialRefs[0]!.source).toBe('facebook.com')
+
     // Cleanup
     getAccessTokenSpy.mockRestore()
     fetchTrafficSpy.mockRestore()
     fetchAggregateSpy.mockRestore()
     fetchAiReferralsSpy.mockRestore()
+    fetchSocialReferralsSpy.mockRestore()
     credentials.delete('test-project')
     // Clean up synced data so it doesn't interfere with later tests
     db.delete(gaTrafficSnapshots)
@@ -285,6 +296,9 @@ describe('GA4 routes', () => {
       .run()
     db.delete(gaAiReferrals)
       .where(eq(gaAiReferrals.projectId, projectId))
+      .run()
+    db.delete(gaSocialReferrals)
+      .where(eq(gaSocialReferrals.projectId, projectId))
       .run()
     db.delete(gaTrafficSummaries)
       .where(eq(gaTrafficSummaries.projectId, projectId))
@@ -334,6 +348,7 @@ describe('GA4 routes', () => {
       totalUsers: 0,
     })
     const fetchAiReferralsSpy = vi.spyOn(gaModule, 'fetchAiReferrals').mockResolvedValue([])
+    const fetchSocialReferralsSpy = vi.spyOn(gaModule, 'fetchSocialReferrals').mockResolvedValue([])
 
     const res = await app.inject({
       method: 'POST',
@@ -349,6 +364,7 @@ describe('GA4 routes', () => {
     fetchTrafficSpy.mockRestore()
     fetchAggregateSpy.mockRestore()
     fetchAiReferralsSpy.mockRestore()
+    fetchSocialReferralsSpy.mockRestore()
     credentials.delete('test-project')
     db.delete(gaTrafficSummaries)
       .where(eq(gaTrafficSummaries.projectId, projectId))
@@ -449,6 +465,9 @@ describe('GA4 routes', () => {
     ])
     expect(body.aiSessionsDeduped).toBe(17)
     expect(body.aiUsersDeduped).toBe(10)
+    expect(body.socialReferrals).toEqual([])
+    expect(body.socialSessionsDeduped).toBe(0)
+    expect(body.socialUsersDeduped).toBe(0)
     expect(body.lastSyncedAt).toBe(now)
 
     credentials.delete('test-project')

--- a/packages/api-routes/test/ga.test.ts
+++ b/packages/api-routes/test/ga.test.ts
@@ -584,6 +584,70 @@ describe('GA4 routes', () => {
     credentials.delete('test-project')
   })
 
+  it('GET /ga/social-referral-history returns error when no connection', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/projects/test-project/ga/social-referral-history',
+    })
+    expect(res.statusCode).toBe(400)
+    const body = JSON.parse(res.payload)
+    expect(body.error.message).toMatch(/No GA4 connection/)
+  })
+
+  it('GET /ga/social-referral-history returns per-date rows', async () => {
+    const now = new Date().toISOString()
+    credentials.set('test-project', {
+      projectName: 'test-project',
+      propertyId: '999888',
+      clientEmail: 'sa@test.iam.gserviceaccount.com',
+      privateKey: 'fake-key',
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    // Insert multi-date social referral data from two different sources
+    db.insert(gaSocialReferrals).values({
+      id: crypto.randomUUID(),
+      projectId,
+      date: '2026-03-17',
+      source: 'facebook.com',
+      medium: 'social',
+      sessions: 5,
+      users: 4,
+      syncedAt: now,
+    }).run()
+    db.insert(gaSocialReferrals).values({
+      id: crypto.randomUUID(),
+      projectId,
+      date: '2026-03-18',
+      source: 'linkedin.com',
+      medium: 'social',
+      sessions: 3,
+      users: 2,
+      syncedAt: now,
+    }).run()
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/projects/test-project/ga/social-referral-history',
+    })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.payload) as Array<{ date: string; source: string; medium: string; sessions: number; users: number }>
+    expect(body.length).toBeGreaterThanOrEqual(2)
+    // Should be ordered by date
+    const dates = body.map((r) => r.date)
+    expect(dates).toEqual([...dates].sort())
+    // Should include both sources
+    const sources = body.map((r) => r.source)
+    expect(sources).toContain('facebook.com')
+    expect(sources).toContain('linkedin.com')
+
+    credentials.delete('test-project')
+    db.delete(gaSocialReferrals)
+      .where(eq(gaSocialReferrals.projectId, projectId))
+      .run()
+  })
+
   it('GET /ga/session-history returns error when no connection', async () => {
     const res = await app.inject({
       method: 'GET',

--- a/packages/canonry/AGENTS.md
+++ b/packages/canonry/AGENTS.md
@@ -22,6 +22,7 @@ The publishable npm package (`@ainyc/canonry`). Bundles the CLI, local Fastify s
 | `src/commands/insights.ts` | `insights` and `insights dismiss` command implementations |
 | `src/commands/health-cmd.ts` | `health` command implementation |
 | `src/commands/backfill.ts` | Historical recomputation for answer visibility fields and insights |
+| `src/commands/ga.ts` | GA4 commands: `ga sync`, `ga traffic`, `ga status`, `ga social-referral-history`, `ga social-referral-summary`, `ga attribution` |
 
 ## Patterns
 

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "1.41.0",
+  "version": "1.42.0",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "1.42.0",
+  "version": "1.43.0",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "1.43.0",
+  "version": "1.44.0",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/cli-commands/ga.ts
+++ b/packages/canonry/src/cli-commands/ga.ts
@@ -1,9 +1,11 @@
 import {
   gaAiReferralHistory,
+  gaAttribution,
   gaConnect,
   gaCoverage,
   gaDisconnect,
   gaSocialReferralHistory,
+  gaSocialReferralSummary,
   gaStatus,
   gaSync,
   gaTraffic,
@@ -52,16 +54,19 @@ export const GA_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['ga', 'sync'],
-    usage: 'canonry ga sync <project> [--days 30] [--format json]',
+    usage: 'canonry ga sync <project> [--days 30] [--only traffic|ai|social] [--format json]',
     options: {
       days: stringOption(),
+      only: stringOption(),
     },
     run: async (input) => {
-      const project = requireProject(input, 'ga.sync', 'canonry ga sync <project> [--days 30] [--format json]')
+      const project = requireProject(input, 'ga.sync', 'canonry ga sync <project> [--days 30] [--only traffic|ai|social] [--format json]')
       const daysStr = getString(input.values, 'days')
       const days = daysStr ? parseInt(daysStr, 10) : undefined
+      const only = getString(input.values, 'only')
       await gaSync(project, {
         days,
+        only,
         format: input.format,
       })
     },
@@ -107,13 +112,35 @@ export const GA_CLI_COMMANDS: readonly CliCommandSpec[] = [
     },
   },
   {
+    path: ['ga', 'social-referral-summary'],
+    usage: 'canonry ga social-referral-summary <project> [--trend] [--format json]',
+    options: {
+      trend: { type: 'boolean', default: false },
+    },
+    run: async (input) => {
+      const project = requireProject(input, 'ga.social-referral-summary', 'canonry ga social-referral-summary <project> [--trend] [--format json]')
+      await gaSocialReferralSummary(project, {
+        trend: input.values.trend === true,
+        format: input.format,
+      })
+    },
+  },
+  {
+    path: ['ga', 'attribution'],
+    usage: 'canonry ga attribution <project> [--format json]',
+    run: async (input) => {
+      const project = requireProject(input, 'ga.attribution', 'canonry ga attribution <project> [--format json]')
+      await gaAttribution(project, input.format)
+    },
+  },
+  {
     path: ['ga'],
-    usage: 'canonry ga <connect|disconnect|status|sync|traffic|coverage|ai-referral-history|social-referral-history> <project> [args]',
+    usage: 'canonry ga <subcommand> <project> [args]',
     run: async (input) => {
       unknownSubcommand(input.positionals[0], {
         command: 'ga',
-        usage: 'canonry ga <connect|disconnect|status|sync|traffic|coverage|ai-referral-history|social-referral-history> <project> [args]',
-        available: ['connect', 'disconnect', 'status', 'sync', 'traffic', 'coverage', 'ai-referral-history', 'social-referral-history'],
+        usage: 'canonry ga <subcommand> <project> [args]',
+        available: ['connect', 'disconnect', 'status', 'sync', 'traffic', 'coverage', 'ai-referral-history', 'social-referral-history', 'social-referral-summary', 'attribution'],
       })
     },
   },

--- a/packages/canonry/src/cli-commands/ga.ts
+++ b/packages/canonry/src/cli-commands/ga.ts
@@ -127,10 +127,16 @@ export const GA_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['ga', 'attribution'],
-    usage: 'canonry ga attribution <project> [--format json]',
+    usage: 'canonry ga attribution <project> [--trend] [--format json]',
+    options: {
+      trend: { type: 'boolean', default: false },
+    },
     run: async (input) => {
-      const project = requireProject(input, 'ga.attribution', 'canonry ga attribution <project> [--format json]')
-      await gaAttribution(project, input.format)
+      const project = requireProject(input, 'ga.attribution', 'canonry ga attribution <project> [--trend] [--format json]')
+      await gaAttribution(project, {
+        trend: input.values.trend === true,
+        format: input.format,
+      })
     },
   },
   {

--- a/packages/canonry/src/cli-commands/ga.ts
+++ b/packages/canonry/src/cli-commands/ga.ts
@@ -3,6 +3,7 @@ import {
   gaConnect,
   gaCoverage,
   gaDisconnect,
+  gaSocialReferralHistory,
   gaStatus,
   gaSync,
   gaTraffic,
@@ -98,13 +99,21 @@ export const GA_CLI_COMMANDS: readonly CliCommandSpec[] = [
     },
   },
   {
+    path: ['ga', 'social-referral-history'],
+    usage: 'canonry ga social-referral-history <project> [--format json]',
+    run: async (input) => {
+      const project = requireProject(input, 'ga.social-referral-history', 'canonry ga social-referral-history <project> [--format json]')
+      await gaSocialReferralHistory(project, input.format)
+    },
+  },
+  {
     path: ['ga'],
-    usage: 'canonry ga <connect|disconnect|status|sync|traffic|coverage|ai-referral-history> <project> [args]',
+    usage: 'canonry ga <connect|disconnect|status|sync|traffic|coverage|ai-referral-history|social-referral-history> <project> [args]',
     run: async (input) => {
       unknownSubcommand(input.positionals[0], {
         command: 'ga',
-        usage: 'canonry ga <connect|disconnect|status|sync|traffic|coverage|ai-referral-history> <project> [args]',
-        available: ['connect', 'disconnect', 'status', 'sync', 'traffic', 'coverage', 'ai-referral-history'],
+        usage: 'canonry ga <connect|disconnect|status|sync|traffic|coverage|ai-referral-history|social-referral-history> <project> [args]',
+        available: ['connect', 'disconnect', 'status', 'sync', 'traffic', 'coverage', 'ai-referral-history', 'social-referral-history'],
       })
     },
   },

--- a/packages/canonry/src/client.ts
+++ b/packages/canonry/src/client.ts
@@ -30,6 +30,7 @@ import type {
   GaTrafficResponse,
   GaCoverageResponse,
   GaSocialReferralTrendResponse,
+  GaAttributionTrendResponse,
   GA4AiReferralHistoryEntry,
   GA4SocialReferralHistoryEntry,
   GA4SessionHistoryEntry,
@@ -576,6 +577,10 @@ export class ApiClient {
 
   async gaSocialReferralTrend(project: string): Promise<GaSocialReferralTrendResponse> {
     return this.request<GaSocialReferralTrendResponse>('GET', `/projects/${encodeURIComponent(project)}/ga/social-referral-trend`)
+  }
+
+  async gaAttributionTrend(project: string): Promise<GaAttributionTrendResponse> {
+    return this.request<GaAttributionTrendResponse>('GET', `/projects/${encodeURIComponent(project)}/ga/attribution-trend`)
   }
 
   async gaSessionHistory(project: string): Promise<GA4SessionHistoryEntry[]> {

--- a/packages/canonry/src/client.ts
+++ b/packages/canonry/src/client.ts
@@ -30,6 +30,7 @@ import type {
   GaTrafficResponse,
   GaCoverageResponse,
   GA4AiReferralHistoryEntry,
+  GA4SocialReferralHistoryEntry,
   GA4SessionHistoryEntry,
   AuditLogEntry,
   GoogleConnectionDto,
@@ -566,6 +567,10 @@ export class ApiClient {
 
   async gaAiReferralHistory(project: string): Promise<GA4AiReferralHistoryEntry[]> {
     return this.request<GA4AiReferralHistoryEntry[]>('GET', `/projects/${encodeURIComponent(project)}/ga/ai-referral-history`)
+  }
+
+  async gaSocialReferralHistory(project: string): Promise<GA4SocialReferralHistoryEntry[]> {
+    return this.request<GA4SocialReferralHistoryEntry[]>('GET', `/projects/${encodeURIComponent(project)}/ga/social-referral-history`)
   }
 
   async gaSessionHistory(project: string): Promise<GA4SessionHistoryEntry[]> {

--- a/packages/canonry/src/client.ts
+++ b/packages/canonry/src/client.ts
@@ -29,6 +29,7 @@ import type {
   GaSyncResponse,
   GaTrafficResponse,
   GaCoverageResponse,
+  GaSocialReferralTrendResponse,
   GA4AiReferralHistoryEntry,
   GA4SocialReferralHistoryEntry,
   GA4SessionHistoryEntry,
@@ -552,7 +553,7 @@ export class ApiClient {
     return this.request<GaStatusResponse>('GET', `/projects/${encodeURIComponent(project)}/ga/status`)
   }
 
-  async gaSync(project: string, body?: { days?: number }): Promise<GaSyncResponse> {
+  async gaSync(project: string, body?: { days?: number; only?: string }): Promise<GaSyncResponse> {
     return this.request<GaSyncResponse>('POST', `/projects/${encodeURIComponent(project)}/ga/sync`, body ?? {})
   }
 
@@ -571,6 +572,10 @@ export class ApiClient {
 
   async gaSocialReferralHistory(project: string): Promise<GA4SocialReferralHistoryEntry[]> {
     return this.request<GA4SocialReferralHistoryEntry[]>('GET', `/projects/${encodeURIComponent(project)}/ga/social-referral-history`)
+  }
+
+  async gaSocialReferralTrend(project: string): Promise<GaSocialReferralTrendResponse> {
+    return this.request<GaSocialReferralTrendResponse>('GET', `/projects/${encodeURIComponent(project)}/ga/social-referral-trend`)
   }
 
   async gaSessionHistory(project: string): Promise<GA4SessionHistoryEntry[]> {

--- a/packages/canonry/src/commands/ga.ts
+++ b/packages/canonry/src/commands/ga.ts
@@ -305,16 +305,15 @@ export async function gaSocialReferralSummary(project: string, opts?: { trend?: 
         socialSessions: traffic.socialSessions,
         socialUsers: traffic.socialUsers,
         totalSessions: traffic.totalSessions,
-        socialSharePct: traffic.totalSessions > 0 ? Math.round((traffic.socialSessions / traffic.totalSessions) * 100) : 0,
+        socialSharePct: traffic.socialSharePct,
         topSources: traffic.socialReferrals.slice(0, 5).map((r) => ({ source: r.source, sessions: r.sessions, channel: r.channelGroup })),
         trend: trend,
       }, null, 2))
       return
     }
 
-    const share = traffic.totalSessions > 0 ? Math.round((traffic.socialSessions / traffic.totalSessions) * 100) : 0
     console.log(`Social Traffic Summary for "${project}"\n`)
-    console.log(`  Sessions: ${traffic.socialSessions} (${share}% of ${traffic.totalSessions} total)`)
+    console.log(`  Sessions: ${traffic.socialSessions} (${traffic.socialSharePct}% of ${traffic.totalSessions} total)`)
     console.log(`  Users:    ${traffic.socialUsers}`)
     console.log()
 
@@ -342,15 +341,14 @@ export async function gaSocialReferralSummary(project: string, opts?: { trend?: 
       socialSessions: traffic.socialSessions,
       socialUsers: traffic.socialUsers,
       totalSessions: traffic.totalSessions,
-      socialSharePct: traffic.totalSessions > 0 ? Math.round((traffic.socialSessions / traffic.totalSessions) * 100) : 0,
+      socialSharePct: traffic.socialSharePct,
       topSources: traffic.socialReferrals.slice(0, 5).map((r) => ({ source: r.source, sessions: r.sessions, channel: r.channelGroup })),
     }, null, 2))
     return
   }
 
-  const share = traffic.totalSessions > 0 ? Math.round((traffic.socialSessions / traffic.totalSessions) * 100) : 0
   console.log(`Social Traffic Summary for "${project}"\n`)
-  console.log(`  Sessions: ${traffic.socialSessions} (${share}% of ${traffic.totalSessions} total)`)
+  console.log(`  Sessions: ${traffic.socialSessions} (${traffic.socialSharePct}% of ${traffic.totalSessions} total)`)
   console.log(`  Users:    ${traffic.socialUsers}`)
   if (traffic.socialReferrals.length > 0) {
     console.log()
@@ -380,9 +378,9 @@ export async function gaAttribution(project: string, opts?: { trend?: boolean; f
         aiUsers: traffic.aiUsersDeduped,
         socialSessions: traffic.socialSessions,
         socialUsers: traffic.socialUsers,
-        aiSharePct: traffic.totalSessions > 0 ? Math.round((traffic.aiSessionsDeduped / traffic.totalSessions) * 100) : 0,
-        socialSharePct: traffic.totalSessions > 0 ? Math.round((traffic.socialSessions / traffic.totalSessions) * 100) : 0,
-        organicSharePct: traffic.totalSessions > 0 ? Math.round((traffic.totalOrganicSessions / traffic.totalSessions) * 100) : 0,
+        aiSharePct: traffic.aiSharePct,
+        socialSharePct: traffic.socialSharePct,
+        organicSharePct: traffic.organicSharePct,
         aiReferrals: traffic.aiReferrals,
         socialReferrals: traffic.socialReferrals,
         trend,
@@ -395,19 +393,18 @@ export async function gaAttribution(project: string, opts?: { trend?: boolean; f
       return
     }
 
-    const pct = (n: number) => traffic.totalSessions > 0 ? Math.round((n / traffic.totalSessions) * 100) : 0
-
     console.log(`GA4 Attribution Overview for "${project}"\n`)
     console.log(`  Total Sessions:   ${traffic.totalSessions}`)
     console.log(`  Total Users:      ${traffic.totalUsers}`)
     console.log()
     console.log('  CHANNEL BREAKDOWN                  7d trend     30d trend')
-    console.log(`    Organic Search: ${String(traffic.totalOrganicSessions).padEnd(6)} (${String(pct(traffic.totalOrganicSessions)).padStart(2)}%)    ${fmtTrend(trend.organic.trend7dPct).padEnd(12)} ${fmtTrend(trend.organic.trend30dPct)}`)
-    console.log(`    AI Referrals:   ${String(traffic.aiSessionsDeduped).padEnd(6)} (${String(pct(traffic.aiSessionsDeduped)).padStart(2)}%)    ${fmtTrend(trend.ai.trend7dPct).padEnd(12)} ${fmtTrend(trend.ai.trend30dPct)}`)
-    console.log(`    Social:         ${String(traffic.socialSessions).padEnd(6)} (${String(pct(traffic.socialSessions)).padStart(2)}%)    ${fmtTrend(trend.social.trend7dPct).padEnd(12)} ${fmtTrend(trend.social.trend30dPct)}`)
+    console.log(`    Organic Search: ${String(traffic.totalOrganicSessions).padEnd(6)} (${String(traffic.organicSharePct).padStart(2)}%)    ${fmtTrend(trend.organic.trend7dPct).padEnd(12)} ${fmtTrend(trend.organic.trend30dPct)}`)
+    console.log(`    AI Referrals:   ${String(traffic.aiSessionsDeduped).padEnd(6)} (${String(traffic.aiSharePct).padStart(2)}%)    ${fmtTrend(trend.ai.trend7dPct).padEnd(12)} ${fmtTrend(trend.ai.trend30dPct)}`)
+    console.log(`    Social:         ${String(traffic.socialSessions).padEnd(6)} (${String(traffic.socialSharePct).padStart(2)}%)    ${fmtTrend(trend.social.trend7dPct).padEnd(12)} ${fmtTrend(trend.social.trend30dPct)}`)
     const otherSessions = traffic.totalSessions - traffic.totalOrganicSessions - traffic.aiSessionsDeduped - traffic.socialSessions
     if (otherSessions > 0) {
-      console.log(`    Other:          ${String(otherSessions).padEnd(6)} (${String(pct(otherSessions)).padStart(2)}%)`)
+      const otherPct = traffic.totalSessions > 0 ? Math.round((otherSessions / traffic.totalSessions) * 100) : 0
+      console.log(`    Other:          ${String(otherSessions).padEnd(6)} (${String(otherPct).padStart(2)}%)`)
     }
     console.log(`    ─────────────────────────────────────────────────────`)
     console.log(`    Total:          ${String(traffic.totalSessions).padEnd(6)}         ${fmtTrend(trend.total.trend7dPct).padEnd(12)} ${fmtTrend(trend.total.trend30dPct)}`)
@@ -436,9 +433,9 @@ export async function gaAttribution(project: string, opts?: { trend?: boolean; f
       aiUsers: traffic.aiUsersDeduped,
       socialSessions: traffic.socialSessions,
       socialUsers: traffic.socialUsers,
-      aiSharePct: traffic.totalSessions > 0 ? Math.round((traffic.aiSessionsDeduped / traffic.totalSessions) * 100) : 0,
-      socialSharePct: traffic.totalSessions > 0 ? Math.round((traffic.socialSessions / traffic.totalSessions) * 100) : 0,
-      organicSharePct: traffic.totalSessions > 0 ? Math.round((traffic.totalOrganicSessions / traffic.totalSessions) * 100) : 0,
+      aiSharePct: traffic.aiSharePct,
+      socialSharePct: traffic.socialSharePct,
+      organicSharePct: traffic.organicSharePct,
       aiReferrals: traffic.aiReferrals,
       socialReferrals: traffic.socialReferrals,
     }, null, 2))
@@ -450,19 +447,18 @@ export async function gaAttribution(project: string, opts?: { trend?: boolean; f
     return
   }
 
-  const pct = (n: number) => traffic.totalSessions > 0 ? Math.round((n / traffic.totalSessions) * 100) : 0
-
   console.log(`GA4 Attribution Overview for "${project}"\n`)
   console.log(`  Total Sessions:   ${traffic.totalSessions}`)
   console.log(`  Total Users:      ${traffic.totalUsers}`)
   console.log()
   console.log('  CHANNEL BREAKDOWN')
-  console.log(`    Organic Search: ${traffic.totalOrganicSessions} sessions (${pct(traffic.totalOrganicSessions)}%)`)
-  console.log(`    AI Referrals:   ${traffic.aiSessionsDeduped} sessions (${pct(traffic.aiSessionsDeduped)}%)`)
-  console.log(`    Social:         ${traffic.socialSessions} sessions (${pct(traffic.socialSessions)}%)`)
+  console.log(`    Organic Search: ${traffic.totalOrganicSessions} sessions (${traffic.organicSharePct}%)`)
+  console.log(`    AI Referrals:   ${traffic.aiSessionsDeduped} sessions (${traffic.aiSharePct}%)`)
+  console.log(`    Social:         ${traffic.socialSessions} sessions (${traffic.socialSharePct}%)`)
   const otherSessions = traffic.totalSessions - traffic.totalOrganicSessions - traffic.aiSessionsDeduped - traffic.socialSessions
   if (otherSessions > 0) {
-    console.log(`    Other:          ${otherSessions} sessions (${pct(otherSessions)}%)`)
+    const otherPct = traffic.totalSessions > 0 ? Math.round((otherSessions / traffic.totalSessions) * 100) : 0
+    console.log(`    Other:          ${otherSessions} sessions (${otherPct}%)`)
   }
 
   if (traffic.aiReferrals.length > 0) {

--- a/packages/canonry/src/commands/ga.ts
+++ b/packages/canonry/src/commands/ga.ts
@@ -1,4 +1,4 @@
-import type { GaConnectResponse, GaStatusResponse, GaSyncResponse, GaTrafficResponse, GaCoverageResponse, GA4AiReferralHistoryEntry, GA4SocialReferralHistoryEntry } from '@ainyc/canonry-contracts'
+import type { GaConnectResponse, GaStatusResponse, GaSyncResponse, GaTrafficResponse, GaCoverageResponse, GaSocialReferralTrendResponse, GA4AiReferralHistoryEntry, GA4SocialReferralHistoryEntry } from '@ainyc/canonry-contracts'
 import { createApiClient } from '../client.js'
 import { CliError } from '../cli-error.js'
 
@@ -107,9 +107,12 @@ export async function gaStatus(project: string, format?: string): Promise<void> 
   console.log(`  Connected:    ${result.createdAt ?? 'unknown'}`)
 }
 
-export async function gaSync(project: string, opts?: { days?: number; format?: string }): Promise<void> {
+export async function gaSync(project: string, opts?: { days?: number; only?: string; format?: string }): Promise<void> {
   const client = getClient()
-  const result: GaSyncResponse = await client.gaSync(project, { days: opts?.days })
+  const body: { days?: number; only?: string } = {}
+  if (opts?.days) body.days = opts.days
+  if (opts?.only) body.only = opts.only
+  const result: GaSyncResponse = await client.gaSync(project, body)
 
   if (opts?.format === 'json') {
     console.log(JSON.stringify(result, null, 2))
@@ -117,6 +120,9 @@ export async function gaSync(project: string, opts?: { days?: number; format?: s
   }
 
   console.log(`GA4 sync complete for "${project}".`)
+  if (result.syncedComponents) {
+    console.log(`  Components:  ${result.syncedComponents.join(', ')}`)
+  }
   console.log(`  Page rows:   ${result.rowCount}`)
   console.log(`  AI rows:     ${result.aiReferralCount}`)
   console.log(`  Social rows: ${result.socialReferralCount}`)
@@ -285,5 +291,138 @@ export async function gaCoverage(project: string, format?: string): Promise<void
     console.log(
       `  ${page.padEnd(pageWidth)}  ${String(row.sessions).padEnd(10)}${String(row.organicSessions).padEnd(10)}${String(row.users).padEnd(8)}`,
     )
+  }
+}
+
+export async function gaSocialReferralSummary(project: string, opts?: { trend?: boolean; format?: string }): Promise<void> {
+  const client = getClient()
+  const traffic: GaTrafficResponse = await client.gaTraffic(project)
+
+  if (opts?.trend) {
+    const trend: GaSocialReferralTrendResponse = await client.gaSocialReferralTrend(project)
+    if (opts.format === 'json') {
+      console.log(JSON.stringify({
+        socialSessions: traffic.socialSessions,
+        socialUsers: traffic.socialUsers,
+        totalSessions: traffic.totalSessions,
+        socialSharePct: traffic.totalSessions > 0 ? Math.round((traffic.socialSessions / traffic.totalSessions) * 100) : 0,
+        topSources: traffic.socialReferrals.slice(0, 5).map((r) => ({ source: r.source, sessions: r.sessions, channel: r.channelGroup })),
+        trend: trend,
+      }, null, 2))
+      return
+    }
+
+    const share = traffic.totalSessions > 0 ? Math.round((traffic.socialSessions / traffic.totalSessions) * 100) : 0
+    console.log(`Social Traffic Summary for "${project}"\n`)
+    console.log(`  Sessions: ${traffic.socialSessions} (${share}% of ${traffic.totalSessions} total)`)
+    console.log(`  Users:    ${traffic.socialUsers}`)
+    console.log()
+
+    const fmtTrend = (pct: number | null) => pct === null ? 'n/a' : `${pct >= 0 ? '+' : ''}${pct}%`
+    console.log(`  7d trend:  ${fmtTrend(trend.trend7dPct)} (${trend.socialSessions7d} vs ${trend.socialSessionsPrev7d})`)
+    console.log(`  30d trend: ${fmtTrend(trend.trend30dPct)} (${trend.socialSessions30d} vs ${trend.socialSessionsPrev30d})`)
+    if (trend.biggestMover) {
+      const m = trend.biggestMover
+      console.log(`  Mover:     ${m.source} (${m.changePct >= 0 ? '+' : ''}${m.changePct}%, ${m.sessionsPrev7d}→${m.sessions7d})`)
+    }
+    console.log()
+
+    if (traffic.socialReferrals.length > 0) {
+      console.log('  TOP SOURCES')
+      for (const ref of traffic.socialReferrals.slice(0, 5)) {
+        const chanLabel = ref.channelGroup === 'Paid Social' ? 'paid' : 'organic'
+        console.log(`    ${ref.source.padEnd(20)} ${String(ref.sessions).padEnd(8)} sessions  (${chanLabel})`)
+      }
+    }
+    return
+  }
+
+  if (opts?.format === 'json') {
+    console.log(JSON.stringify({
+      socialSessions: traffic.socialSessions,
+      socialUsers: traffic.socialUsers,
+      totalSessions: traffic.totalSessions,
+      socialSharePct: traffic.totalSessions > 0 ? Math.round((traffic.socialSessions / traffic.totalSessions) * 100) : 0,
+      topSources: traffic.socialReferrals.slice(0, 5).map((r) => ({ source: r.source, sessions: r.sessions, channel: r.channelGroup })),
+    }, null, 2))
+    return
+  }
+
+  const share = traffic.totalSessions > 0 ? Math.round((traffic.socialSessions / traffic.totalSessions) * 100) : 0
+  console.log(`Social Traffic Summary for "${project}"\n`)
+  console.log(`  Sessions: ${traffic.socialSessions} (${share}% of ${traffic.totalSessions} total)`)
+  console.log(`  Users:    ${traffic.socialUsers}`)
+  if (traffic.socialReferrals.length > 0) {
+    console.log()
+    console.log('  TOP SOURCES')
+    for (const ref of traffic.socialReferrals.slice(0, 5)) {
+      const chanLabel = ref.channelGroup === 'Paid Social' ? 'paid' : 'organic'
+      console.log(`    ${ref.source.padEnd(20)} ${String(ref.sessions).padEnd(8)} sessions  (${chanLabel})`)
+    }
+  }
+}
+
+export async function gaAttribution(project: string, format?: string): Promise<void> {
+  const client = getClient()
+  const traffic: GaTrafficResponse = await client.gaTraffic(project)
+
+  if (format === 'json') {
+    console.log(JSON.stringify({
+      totalSessions: traffic.totalSessions,
+      totalUsers: traffic.totalUsers,
+      organicSessions: traffic.totalOrganicSessions,
+      aiSessions: traffic.aiSessionsDeduped,
+      aiUsers: traffic.aiUsersDeduped,
+      socialSessions: traffic.socialSessions,
+      socialUsers: traffic.socialUsers,
+      aiSharePct: traffic.totalSessions > 0 ? Math.round((traffic.aiSessionsDeduped / traffic.totalSessions) * 100) : 0,
+      socialSharePct: traffic.totalSessions > 0 ? Math.round((traffic.socialSessions / traffic.totalSessions) * 100) : 0,
+      organicSharePct: traffic.totalSessions > 0 ? Math.round((traffic.totalOrganicSessions / traffic.totalSessions) * 100) : 0,
+      aiReferrals: traffic.aiReferrals,
+      socialReferrals: traffic.socialReferrals,
+    }, null, 2))
+    return
+  }
+
+  if (traffic.totalSessions === 0) {
+    console.log('No GA4 traffic data. Run "canonry ga sync <project>" first.')
+    return
+  }
+
+  const pct = (n: number) => traffic.totalSessions > 0 ? Math.round((n / traffic.totalSessions) * 100) : 0
+
+  console.log(`GA4 Attribution Overview for "${project}"\n`)
+  console.log(`  Total Sessions:   ${traffic.totalSessions}`)
+  console.log(`  Total Users:      ${traffic.totalUsers}`)
+  console.log()
+  console.log('  CHANNEL BREAKDOWN')
+  console.log(`    Organic Search: ${traffic.totalOrganicSessions} sessions (${pct(traffic.totalOrganicSessions)}%)`)
+  console.log(`    AI Referrals:   ${traffic.aiSessionsDeduped} sessions (${pct(traffic.aiSessionsDeduped)}%)`)
+  console.log(`    Social:         ${traffic.socialSessions} sessions (${pct(traffic.socialSessions)}%)`)
+  const otherSessions = traffic.totalSessions - traffic.totalOrganicSessions - traffic.aiSessionsDeduped - traffic.socialSessions
+  if (otherSessions > 0) {
+    console.log(`    Other:          ${otherSessions} sessions (${pct(otherSessions)}%)`)
+  }
+
+  if (traffic.aiReferrals.length > 0) {
+    console.log()
+    console.log('  AI SOURCES')
+    for (const ref of traffic.aiReferrals.slice(0, 10)) {
+      const dimLabel = ref.sourceDimension === 'first_user' ? 'first-visit' : ref.sourceDimension === 'manual_utm' ? 'utm' : 'session'
+      console.log(`    ${ref.source.padEnd(25)} ${String(ref.sessions).padEnd(8)} sessions  (${dimLabel})`)
+    }
+  }
+
+  if (traffic.socialReferrals.length > 0) {
+    console.log()
+    console.log('  SOCIAL SOURCES')
+    for (const ref of traffic.socialReferrals.slice(0, 10)) {
+      const chanLabel = ref.channelGroup === 'Paid Social' ? 'paid' : 'organic'
+      console.log(`    ${ref.source.padEnd(25)} ${String(ref.sessions).padEnd(8)} sessions  (${chanLabel})`)
+    }
+  }
+
+  if (traffic.lastSyncedAt) {
+    console.log(`\n  Last synced: ${traffic.lastSyncedAt}`)
   }
 }

--- a/packages/canonry/src/commands/ga.ts
+++ b/packages/canonry/src/commands/ga.ts
@@ -1,4 +1,4 @@
-import type { GaConnectResponse, GaStatusResponse, GaSyncResponse, GaTrafficResponse, GaCoverageResponse, GaSocialReferralTrendResponse, GA4AiReferralHistoryEntry, GA4SocialReferralHistoryEntry } from '@ainyc/canonry-contracts'
+import type { GaConnectResponse, GaStatusResponse, GaSyncResponse, GaTrafficResponse, GaCoverageResponse, GaSocialReferralTrendResponse, GaAttributionTrendResponse, GA4AiReferralHistoryEntry, GA4SocialReferralHistoryEntry } from '@ainyc/canonry-contracts'
 import { createApiClient } from '../client.js'
 import { CliError } from '../cli-error.js'
 
@@ -362,11 +362,72 @@ export async function gaSocialReferralSummary(project: string, opts?: { trend?: 
   }
 }
 
-export async function gaAttribution(project: string, format?: string): Promise<void> {
+export async function gaAttribution(project: string, opts?: { trend?: boolean; format?: string }): Promise<void> {
   const client = getClient()
   const traffic: GaTrafficResponse = await client.gaTraffic(project)
 
-  if (format === 'json') {
+  const fmtTrend = (pct: number | null) => pct === null ? 'n/a' : `${pct >= 0 ? '+' : ''}${pct}%`
+
+  if (opts?.trend) {
+    const trend: GaAttributionTrendResponse = await client.gaAttributionTrend(project)
+
+    if (opts.format === 'json') {
+      console.log(JSON.stringify({
+        totalSessions: traffic.totalSessions,
+        totalUsers: traffic.totalUsers,
+        organicSessions: traffic.totalOrganicSessions,
+        aiSessions: traffic.aiSessionsDeduped,
+        aiUsers: traffic.aiUsersDeduped,
+        socialSessions: traffic.socialSessions,
+        socialUsers: traffic.socialUsers,
+        aiSharePct: traffic.totalSessions > 0 ? Math.round((traffic.aiSessionsDeduped / traffic.totalSessions) * 100) : 0,
+        socialSharePct: traffic.totalSessions > 0 ? Math.round((traffic.socialSessions / traffic.totalSessions) * 100) : 0,
+        organicSharePct: traffic.totalSessions > 0 ? Math.round((traffic.totalOrganicSessions / traffic.totalSessions) * 100) : 0,
+        aiReferrals: traffic.aiReferrals,
+        socialReferrals: traffic.socialReferrals,
+        trend,
+      }, null, 2))
+      return
+    }
+
+    if (traffic.totalSessions === 0) {
+      console.log('No GA4 traffic data. Run "canonry ga sync <project>" first.')
+      return
+    }
+
+    const pct = (n: number) => traffic.totalSessions > 0 ? Math.round((n / traffic.totalSessions) * 100) : 0
+
+    console.log(`GA4 Attribution Overview for "${project}"\n`)
+    console.log(`  Total Sessions:   ${traffic.totalSessions}`)
+    console.log(`  Total Users:      ${traffic.totalUsers}`)
+    console.log()
+    console.log('  CHANNEL BREAKDOWN                  7d trend     30d trend')
+    console.log(`    Organic Search: ${String(traffic.totalOrganicSessions).padEnd(6)} (${String(pct(traffic.totalOrganicSessions)).padStart(2)}%)    ${fmtTrend(trend.organic.trend7dPct).padEnd(12)} ${fmtTrend(trend.organic.trend30dPct)}`)
+    console.log(`    AI Referrals:   ${String(traffic.aiSessionsDeduped).padEnd(6)} (${String(pct(traffic.aiSessionsDeduped)).padStart(2)}%)    ${fmtTrend(trend.ai.trend7dPct).padEnd(12)} ${fmtTrend(trend.ai.trend30dPct)}`)
+    console.log(`    Social:         ${String(traffic.socialSessions).padEnd(6)} (${String(pct(traffic.socialSessions)).padStart(2)}%)    ${fmtTrend(trend.social.trend7dPct).padEnd(12)} ${fmtTrend(trend.social.trend30dPct)}`)
+    const otherSessions = traffic.totalSessions - traffic.totalOrganicSessions - traffic.aiSessionsDeduped - traffic.socialSessions
+    if (otherSessions > 0) {
+      console.log(`    Other:          ${String(otherSessions).padEnd(6)} (${String(pct(otherSessions)).padStart(2)}%)`)
+    }
+    console.log(`    ─────────────────────────────────────────────────────`)
+    console.log(`    Total:          ${String(traffic.totalSessions).padEnd(6)}         ${fmtTrend(trend.total.trend7dPct).padEnd(12)} ${fmtTrend(trend.total.trend30dPct)}`)
+
+    if (trend.aiBiggestMover) {
+      const m = trend.aiBiggestMover
+      console.log(`\n  AI Mover:     ${m.source} (${m.changePct >= 0 ? '+' : ''}${m.changePct}%, ${m.sessionsPrev7d}→${m.sessions7d} sessions/7d)`)
+    }
+    if (trend.socialBiggestMover) {
+      const m = trend.socialBiggestMover
+      console.log(`  Social Mover: ${m.source} (${m.changePct >= 0 ? '+' : ''}${m.changePct}%, ${m.sessionsPrev7d}→${m.sessions7d} sessions/7d)`)
+    }
+
+    if (traffic.lastSyncedAt) {
+      console.log(`\n  Last synced: ${traffic.lastSyncedAt}`)
+    }
+    return
+  }
+
+  if (opts?.format === 'json') {
     console.log(JSON.stringify({
       totalSessions: traffic.totalSessions,
       totalUsers: traffic.totalUsers,

--- a/packages/canonry/src/commands/ga.ts
+++ b/packages/canonry/src/commands/ga.ts
@@ -167,19 +167,19 @@ export async function gaTraffic(project: string, opts?: { limit?: number; format
   }
 
   if (result.socialReferrals.length > 0) {
-    const attrWidth = 12
-    if (result.socialSessionsDeduped > 0) {
-      const share = result.totalSessions > 0 ? Math.round((result.socialSessionsDeduped / result.totalSessions) * 100) : 0
-      console.log(`  Social Sessions (deduped): ${result.socialSessionsDeduped} (${share}% of total)`)
+    const chanWidth = 12
+    if (result.socialSessions > 0) {
+      const share = result.totalSessions > 0 ? Math.round((result.socialSessions / result.totalSessions) * 100) : 0
+      console.log(`  Social Sessions:         ${result.socialSessions} (${share}% of total)`)
     }
     console.log('  SOCIAL REFERRAL SOURCES')
-    console.log(`  ${'SOURCE'.padEnd(25)}  ${'MEDIUM'.padEnd(15)}  ${'ATTRIBUTION'.padEnd(attrWidth)}  ${'SESSIONS'.padEnd(10)}${'USERS'.padEnd(8)}`)
-    console.log(`  ${'─'.repeat(25)}  ${'─'.repeat(15)}  ${'─'.repeat(attrWidth)}  ${'─'.repeat(10)}${'─'.repeat(8)}`)
+    console.log(`  ${'SOURCE'.padEnd(25)}  ${'MEDIUM'.padEnd(15)}  ${'CHANNEL'.padEnd(chanWidth)}  ${'SESSIONS'.padEnd(10)}${'USERS'.padEnd(8)}`)
+    console.log(`  ${'─'.repeat(25)}  ${'─'.repeat(15)}  ${'─'.repeat(chanWidth)}  ${'─'.repeat(10)}${'─'.repeat(8)}`)
 
     for (const ref of result.socialReferrals) {
-      const dimLabel = ref.sourceDimension === 'first_user' ? 'first-visit' : ref.sourceDimension === 'manual_utm' ? 'utm' : 'session'
+      const chanLabel = ref.channelGroup === 'Paid Social' ? 'paid' : 'organic'
       console.log(
-        `  ${ref.source.padEnd(25)}  ${ref.medium.padEnd(15)}  ${dimLabel.padEnd(attrWidth)}  ${String(ref.sessions).padEnd(10)}${String(ref.users).padEnd(8)}`,
+        `  ${ref.source.padEnd(25)}  ${ref.medium.padEnd(15)}  ${chanLabel.padEnd(chanWidth)}  ${String(ref.sessions).padEnd(10)}${String(ref.users).padEnd(8)}`,
       )
     }
     console.log()
@@ -248,14 +248,14 @@ export async function gaSocialReferralHistory(project: string, format?: string):
 
   const dateWidth = 12
   const sourceWidth = Math.min(30, Math.max(10, ...result.map((r) => r.source.length)))
-  const attrWidth = 12
+  const chanWidth = 12
   console.log(`GA4 Social Referral History for "${project}":\n`)
-  console.log(`  ${'DATE'.padEnd(dateWidth)}  ${'SOURCE'.padEnd(sourceWidth)}  ${'ATTRIBUTION'.padEnd(attrWidth)}  ${'SESSIONS'.padEnd(10)}${'USERS'.padEnd(8)}`)
-  console.log(`  ${'─'.repeat(dateWidth)}  ${'─'.repeat(sourceWidth)}  ${'─'.repeat(attrWidth)}  ${'─'.repeat(10)}${'─'.repeat(8)}`)
+  console.log(`  ${'DATE'.padEnd(dateWidth)}  ${'SOURCE'.padEnd(sourceWidth)}  ${'CHANNEL'.padEnd(chanWidth)}  ${'SESSIONS'.padEnd(10)}${'USERS'.padEnd(8)}`)
+  console.log(`  ${'─'.repeat(dateWidth)}  ${'─'.repeat(sourceWidth)}  ${'─'.repeat(chanWidth)}  ${'─'.repeat(10)}${'─'.repeat(8)}`)
   for (const row of result) {
-    const dimLabel = row.sourceDimension === 'first_user' ? 'first-visit' : row.sourceDimension === 'manual_utm' ? 'utm' : 'session'
+    const chanLabel = row.channelGroup === 'Paid Social' ? 'paid' : 'organic'
     console.log(
-      `  ${row.date.padEnd(dateWidth)}  ${row.source.padEnd(sourceWidth)}  ${dimLabel.padEnd(attrWidth)}  ${String(row.sessions).padEnd(10)}${String(row.users).padEnd(8)}`,
+      `  ${row.date.padEnd(dateWidth)}  ${row.source.padEnd(sourceWidth)}  ${chanLabel.padEnd(chanWidth)}  ${String(row.sessions).padEnd(10)}${String(row.users).padEnd(8)}`,
     )
   }
 }

--- a/packages/canonry/src/commands/ga.ts
+++ b/packages/canonry/src/commands/ga.ts
@@ -1,4 +1,4 @@
-import type { GaConnectResponse, GaStatusResponse, GaSyncResponse, GaTrafficResponse, GaCoverageResponse, GA4AiReferralHistoryEntry } from '@ainyc/canonry-contracts'
+import type { GaConnectResponse, GaStatusResponse, GaSyncResponse, GaTrafficResponse, GaCoverageResponse, GA4AiReferralHistoryEntry, GA4SocialReferralHistoryEntry } from '@ainyc/canonry-contracts'
 import { createApiClient } from '../client.js'
 import { CliError } from '../cli-error.js'
 
@@ -119,6 +119,7 @@ export async function gaSync(project: string, opts?: { days?: number; format?: s
   console.log(`GA4 sync complete for "${project}".`)
   console.log(`  Page rows:   ${result.rowCount}`)
   console.log(`  AI rows:     ${result.aiReferralCount}`)
+  console.log(`  Social rows: ${result.socialReferralCount}`)
   console.log(`  Period:      ${result.days} days`)
   console.log(`  Synced at:   ${result.syncedAt}`)
 }
@@ -135,7 +136,7 @@ export async function gaTraffic(project: string, opts?: { limit?: number; format
     return
   }
 
-  if (result.topPages.length === 0 && result.aiReferrals.length === 0) {
+  if (result.topPages.length === 0 && result.aiReferrals.length === 0 && result.socialReferrals.length === 0) {
     console.log('No GA4 traffic data. Run "canonry ga sync <project>" first.')
     return
   }
@@ -157,6 +158,25 @@ export async function gaTraffic(project: string, opts?: { limit?: number; format
     console.log(`  ${'─'.repeat(25)}  ${'─'.repeat(15)}  ${'─'.repeat(attrWidth)}  ${'─'.repeat(10)}${'─'.repeat(8)}`)
 
     for (const ref of result.aiReferrals) {
+      const dimLabel = ref.sourceDimension === 'first_user' ? 'first-visit' : ref.sourceDimension === 'manual_utm' ? 'utm' : 'session'
+      console.log(
+        `  ${ref.source.padEnd(25)}  ${ref.medium.padEnd(15)}  ${dimLabel.padEnd(attrWidth)}  ${String(ref.sessions).padEnd(10)}${String(ref.users).padEnd(8)}`,
+      )
+    }
+    console.log()
+  }
+
+  if (result.socialReferrals.length > 0) {
+    const attrWidth = 12
+    if (result.socialSessionsDeduped > 0) {
+      const share = result.totalSessions > 0 ? Math.round((result.socialSessionsDeduped / result.totalSessions) * 100) : 0
+      console.log(`  Social Sessions (deduped): ${result.socialSessionsDeduped} (${share}% of total)`)
+    }
+    console.log('  SOCIAL REFERRAL SOURCES')
+    console.log(`  ${'SOURCE'.padEnd(25)}  ${'MEDIUM'.padEnd(15)}  ${'ATTRIBUTION'.padEnd(attrWidth)}  ${'SESSIONS'.padEnd(10)}${'USERS'.padEnd(8)}`)
+    console.log(`  ${'─'.repeat(25)}  ${'─'.repeat(15)}  ${'─'.repeat(attrWidth)}  ${'─'.repeat(10)}${'─'.repeat(8)}`)
+
+    for (const ref of result.socialReferrals) {
       const dimLabel = ref.sourceDimension === 'first_user' ? 'first-visit' : ref.sourceDimension === 'manual_utm' ? 'utm' : 'session'
       console.log(
         `  ${ref.source.padEnd(25)}  ${ref.medium.padEnd(15)}  ${dimLabel.padEnd(attrWidth)}  ${String(ref.sessions).padEnd(10)}${String(ref.users).padEnd(8)}`,
@@ -202,6 +222,34 @@ export async function gaAiReferralHistory(project: string, format?: string): Pro
   const sourceWidth = Math.min(30, Math.max(10, ...result.map((r) => r.source.length)))
   const attrWidth = 12
   console.log(`GA4 AI Referral History for "${project}":\n`)
+  console.log(`  ${'DATE'.padEnd(dateWidth)}  ${'SOURCE'.padEnd(sourceWidth)}  ${'ATTRIBUTION'.padEnd(attrWidth)}  ${'SESSIONS'.padEnd(10)}${'USERS'.padEnd(8)}`)
+  console.log(`  ${'─'.repeat(dateWidth)}  ${'─'.repeat(sourceWidth)}  ${'─'.repeat(attrWidth)}  ${'─'.repeat(10)}${'─'.repeat(8)}`)
+  for (const row of result) {
+    const dimLabel = row.sourceDimension === 'first_user' ? 'first-visit' : row.sourceDimension === 'manual_utm' ? 'utm' : 'session'
+    console.log(
+      `  ${row.date.padEnd(dateWidth)}  ${row.source.padEnd(sourceWidth)}  ${dimLabel.padEnd(attrWidth)}  ${String(row.sessions).padEnd(10)}${String(row.users).padEnd(8)}`,
+    )
+  }
+}
+
+export async function gaSocialReferralHistory(project: string, format?: string): Promise<void> {
+  const client = getClient()
+  const result: GA4SocialReferralHistoryEntry[] = await client.gaSocialReferralHistory(project)
+
+  if (format === 'json') {
+    console.log(JSON.stringify(result, null, 2))
+    return
+  }
+
+  if (result.length === 0) {
+    console.log('No social referral history. Run "canonry ga sync <project>" first.')
+    return
+  }
+
+  const dateWidth = 12
+  const sourceWidth = Math.min(30, Math.max(10, ...result.map((r) => r.source.length)))
+  const attrWidth = 12
+  console.log(`GA4 Social Referral History for "${project}":\n`)
   console.log(`  ${'DATE'.padEnd(dateWidth)}  ${'SOURCE'.padEnd(sourceWidth)}  ${'ATTRIBUTION'.padEnd(attrWidth)}  ${'SESSIONS'.padEnd(10)}${'USERS'.padEnd(8)}`)
   console.log(`  ${'─'.repeat(dateWidth)}  ${'─'.repeat(sourceWidth)}  ${'─'.repeat(attrWidth)}  ${'─'.repeat(10)}${'─'.repeat(8)}`)
   for (const row of result) {

--- a/packages/contracts/src/ga.ts
+++ b/packages/contracts/src/ga.ts
@@ -93,6 +93,18 @@ export interface GaSyncResponse {
   socialReferralCount: number
   days: number
   syncedAt: string
+  /** Which data components were synced (present when --only is used) */
+  syncedComponents?: string[]
+}
+
+export interface GaSocialReferralTrendResponse {
+  socialSessions7d: number
+  socialSessionsPrev7d: number
+  trend7dPct: number | null
+  socialSessions30d: number
+  socialSessionsPrev30d: number
+  trend30dPct: number | null
+  biggestMover: { source: string; sessions7d: number; sessionsPrev7d: number; changePct: number } | null
 }
 
 export interface GaTrafficResponse {

--- a/packages/contracts/src/ga.ts
+++ b/packages/contracts/src/ga.ts
@@ -33,6 +33,15 @@ export const ga4AiReferralDtoSchema = z.object({
 })
 export type GA4AiReferralDto = z.infer<typeof ga4AiReferralDtoSchema>
 
+export const ga4SocialReferralDtoSchema = z.object({
+  source: z.string(),
+  medium: z.string(),
+  sessions: z.number(),
+  users: z.number(),
+  sourceDimension: ga4SourceDimensionSchema,
+})
+export type GA4SocialReferralDto = z.infer<typeof ga4SocialReferralDtoSchema>
+
 export const ga4TrafficSummaryDtoSchema = z.object({
   totalSessions: z.number(),
   totalOrganicSessions: z.number(),
@@ -48,6 +57,11 @@ export const ga4TrafficSummaryDtoSchema = z.object({
   aiSessionsDeduped: z.number(),
   /** Deduped AI user total: MAX(users) per date+source+medium across attribution dimensions, then summed. */
   aiUsersDeduped: z.number(),
+  socialReferrals: z.array(ga4SocialReferralDtoSchema),
+  /** Deduped social session total: MAX(sessions) per date+source+medium across attribution dimensions, then summed. */
+  socialSessionsDeduped: z.number(),
+  /** Deduped social user total: MAX(users) per date+source+medium across attribution dimensions, then summed. */
+  socialUsersDeduped: z.number(),
   lastSyncedAt: z.string().nullable(),
 })
 export type GA4TrafficSummaryDto = z.infer<typeof ga4TrafficSummaryDtoSchema>
@@ -75,6 +89,7 @@ export interface GaSyncResponse {
   synced: boolean
   rowCount: number
   aiReferralCount: number
+  socialReferralCount: number
   days: number
   syncedAt: string
 }
@@ -89,6 +104,11 @@ export interface GaTrafficResponse {
   aiSessionsDeduped: number
   /** Deduped AI user total: MAX(users) per date+source+medium across attribution dimensions, then summed. */
   aiUsersDeduped: number
+  socialReferrals: Array<{ source: string; medium: string; sessions: number; users: number; sourceDimension: GA4SourceDimension }>
+  /** Deduped social session total */
+  socialSessionsDeduped: number
+  /** Deduped social user total */
+  socialUsersDeduped: number
   lastSyncedAt: string | null
 }
 
@@ -106,6 +126,16 @@ export const ga4AiReferralHistoryEntrySchema = z.object({
   sourceDimension: ga4SourceDimensionSchema,
 })
 export type GA4AiReferralHistoryEntry = z.infer<typeof ga4AiReferralHistoryEntrySchema>
+
+export const ga4SocialReferralHistoryEntrySchema = z.object({
+  date: z.string(),
+  source: z.string(),
+  medium: z.string(),
+  sessions: z.number(),
+  users: z.number(),
+  sourceDimension: ga4SourceDimensionSchema,
+})
+export type GA4SocialReferralHistoryEntry = z.infer<typeof ga4SocialReferralHistoryEntrySchema>
 
 export const ga4SessionHistoryEntrySchema = z.object({
   date: z.string(),

--- a/packages/contracts/src/ga.ts
+++ b/packages/contracts/src/ga.ts
@@ -107,6 +107,26 @@ export interface GaSocialReferralTrendResponse {
   biggestMover: { source: string; sessions7d: number; sessionsPrev7d: number; changePct: number } | null
 }
 
+export interface GaChannelTrend {
+  sessions7d: number
+  sessionsPrev7d: number
+  trend7dPct: number | null
+  sessions30d: number
+  sessionsPrev30d: number
+  trend30dPct: number | null
+}
+
+export interface GaAttributionTrendResponse {
+  organic: GaChannelTrend
+  ai: GaChannelTrend
+  social: GaChannelTrend
+  total: GaChannelTrend
+  /** AI source with largest absolute session change in 7d vs prev 7d */
+  aiBiggestMover: { source: string; sessions7d: number; sessionsPrev7d: number; changePct: number } | null
+  /** Social source with largest absolute session change in 7d vs prev 7d */
+  socialBiggestMover: { source: string; sessions7d: number; sessionsPrev7d: number; changePct: number } | null
+}
+
 export interface GaTrafficResponse {
   totalSessions: number
   totalOrganicSessions: number

--- a/packages/contracts/src/ga.ts
+++ b/packages/contracts/src/ga.ts
@@ -38,7 +38,8 @@ export const ga4SocialReferralDtoSchema = z.object({
   medium: z.string(),
   sessions: z.number(),
   users: z.number(),
-  sourceDimension: ga4SourceDimensionSchema,
+  /** GA4 default channel group (e.g. 'Organic Social', 'Paid Social') */
+  channelGroup: z.string(),
 })
 export type GA4SocialReferralDto = z.infer<typeof ga4SocialReferralDtoSchema>
 
@@ -58,10 +59,10 @@ export const ga4TrafficSummaryDtoSchema = z.object({
   /** Deduped AI user total: MAX(users) per date+source+medium across attribution dimensions, then summed. */
   aiUsersDeduped: z.number(),
   socialReferrals: z.array(ga4SocialReferralDtoSchema),
-  /** Deduped social session total: MAX(sessions) per date+source+medium across attribution dimensions, then summed. */
-  socialSessionsDeduped: z.number(),
-  /** Deduped social user total: MAX(users) per date+source+medium across attribution dimensions, then summed. */
-  socialUsersDeduped: z.number(),
+  /** Total social sessions (session-scoped, no cross-dimension dedup needed). */
+  socialSessions: z.number(),
+  /** Total social users (session-scoped, no cross-dimension dedup needed). */
+  socialUsers: z.number(),
   lastSyncedAt: z.string().nullable(),
 })
 export type GA4TrafficSummaryDto = z.infer<typeof ga4TrafficSummaryDtoSchema>
@@ -104,11 +105,11 @@ export interface GaTrafficResponse {
   aiSessionsDeduped: number
   /** Deduped AI user total: MAX(users) per date+source+medium across attribution dimensions, then summed. */
   aiUsersDeduped: number
-  socialReferrals: Array<{ source: string; medium: string; sessions: number; users: number; sourceDimension: GA4SourceDimension }>
-  /** Deduped social session total */
-  socialSessionsDeduped: number
-  /** Deduped social user total */
-  socialUsersDeduped: number
+  socialReferrals: Array<{ source: string; medium: string; sessions: number; users: number; channelGroup: string }>
+  /** Total social sessions (session-scoped via sessionDefaultChannelGroup). */
+  socialSessions: number
+  /** Total social users (session-scoped via sessionDefaultChannelGroup). */
+  socialUsers: number
   lastSyncedAt: string | null
 }
 
@@ -133,7 +134,8 @@ export const ga4SocialReferralHistoryEntrySchema = z.object({
   medium: z.string(),
   sessions: z.number(),
   users: z.number(),
-  sourceDimension: ga4SourceDimensionSchema,
+  /** GA4 default channel group (e.g. 'Organic Social', 'Paid Social') */
+  channelGroup: z.string(),
 })
 export type GA4SocialReferralHistoryEntry = z.infer<typeof ga4SocialReferralHistoryEntrySchema>
 

--- a/packages/contracts/src/ga.ts
+++ b/packages/contracts/src/ga.ts
@@ -63,6 +63,12 @@ export const ga4TrafficSummaryDtoSchema = z.object({
   socialSessions: z.number(),
   /** Total social users (session-scoped, no cross-dimension dedup needed). */
   socialUsers: z.number(),
+  /** Organic sessions as a percentage of total sessions (0–100, rounded). */
+  organicSharePct: z.number(),
+  /** Deduped AI sessions as a percentage of total sessions (0–100, rounded). */
+  aiSharePct: z.number(),
+  /** Social sessions as a percentage of total sessions (0–100, rounded). */
+  socialSharePct: z.number(),
   lastSyncedAt: z.string().nullable(),
 })
 export type GA4TrafficSummaryDto = z.infer<typeof ga4TrafficSummaryDtoSchema>
@@ -142,6 +148,12 @@ export interface GaTrafficResponse {
   socialSessions: number
   /** Total social users (session-scoped via sessionDefaultChannelGroup). */
   socialUsers: number
+  /** Organic sessions as a percentage of total sessions (0–100, rounded). */
+  organicSharePct: number
+  /** Deduped AI sessions as a percentage of total sessions (0–100, rounded). */
+  aiSharePct: number
+  /** Social sessions as a percentage of total sessions (0–100, rounded). */
+  socialSharePct: number
   lastSyncedAt: string | null
 }
 

--- a/packages/db/AGENTS.md
+++ b/packages/db/AGENTS.md
@@ -18,7 +18,7 @@ Drizzle ORM schema, migrations, and database client. SQLite locally (via better-
 
 - **Core domain**: projects, keywords, competitors, runs, querySnapshots, auditLog
 - **Scheduling**: schedules, notifications, webhooks
-- **Integrations**: googleConnections, gscData, urlInspections, gscCoverage, gscTraffic, bingConnections, bingUrlInspections, bingKeywordStats, ga4Connections, ga4TrafficSnapshots, ga4AiReferrals, ga4Summaries
+- **Integrations**: googleConnections, gscData, urlInspections, gscCoverage, gscTraffic, bingConnections, bingUrlInspections, bingKeywordStats, ga4Connections, ga4TrafficSnapshots, ga4AiReferrals, ga4Summaries, gaSocialReferrals
 - **System**: apiKeys, usageCounters
 
 ## Patterns

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -375,20 +375,21 @@ const MIGRATIONS = [
   `CREATE INDEX IF NOT EXISTS idx_health_snapshots_run ON health_snapshots(run_id)`,
 
   // v25: Social media referral tracking — ga_social_referrals table
+  // Uses GA4's native sessionDefaultChannelGroup for social classification
   `CREATE TABLE IF NOT EXISTS ga_social_referrals (
-    id                TEXT PRIMARY KEY,
-    project_id        TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
-    date              TEXT NOT NULL,
-    source            TEXT NOT NULL,
-    medium            TEXT NOT NULL,
-    source_dimension  TEXT NOT NULL DEFAULT 'session',
-    sessions          INTEGER NOT NULL DEFAULT 0,
-    users             INTEGER NOT NULL DEFAULT 0,
-    synced_at         TEXT NOT NULL
+    id              TEXT PRIMARY KEY,
+    project_id      TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    date            TEXT NOT NULL,
+    source          TEXT NOT NULL,
+    medium          TEXT NOT NULL,
+    channel_group   TEXT NOT NULL DEFAULT 'Organic Social',
+    sessions        INTEGER NOT NULL DEFAULT 0,
+    users           INTEGER NOT NULL DEFAULT 0,
+    synced_at       TEXT NOT NULL
   )`,
   `CREATE INDEX IF NOT EXISTS idx_ga_social_ref_project_date ON ga_social_referrals(project_id, date)`,
   `CREATE INDEX IF NOT EXISTS idx_ga_social_ref_source ON ga_social_referrals(source)`,
-  `CREATE UNIQUE INDEX IF NOT EXISTS idx_ga_social_ref_unique ON ga_social_referrals(project_id, date, source, medium, source_dimension)`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS idx_ga_social_ref_unique ON ga_social_referrals(project_id, date, source, medium, channel_group)`,
 ]
 
 /**

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -373,6 +373,22 @@ const MIGRATIONS = [
   `CREATE INDEX IF NOT EXISTS idx_insights_run ON insights(run_id)`,
   `ALTER TABLE health_snapshots ADD COLUMN run_id TEXT REFERENCES runs(id) ON DELETE CASCADE`,
   `CREATE INDEX IF NOT EXISTS idx_health_snapshots_run ON health_snapshots(run_id)`,
+
+  // v25: Social media referral tracking — ga_social_referrals table
+  `CREATE TABLE IF NOT EXISTS ga_social_referrals (
+    id                TEXT PRIMARY KEY,
+    project_id        TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    date              TEXT NOT NULL,
+    source            TEXT NOT NULL,
+    medium            TEXT NOT NULL,
+    source_dimension  TEXT NOT NULL DEFAULT 'session',
+    sessions          INTEGER NOT NULL DEFAULT 0,
+    users             INTEGER NOT NULL DEFAULT 0,
+    synced_at         TEXT NOT NULL
+  )`,
+  `CREATE INDEX IF NOT EXISTS idx_ga_social_ref_project_date ON ga_social_referrals(project_id, date)`,
+  `CREATE INDEX IF NOT EXISTS idx_ga_social_ref_source ON ga_social_referrals(source)`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS idx_ga_social_ref_unique ON ga_social_referrals(project_id, date, source, medium, source_dimension)`,
 ]
 
 /**

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -296,22 +296,23 @@ export const gaAiReferrals = sqliteTable('ga_ai_referrals', {
   uniqueIndex('idx_ga_ai_ref_unique_v2').on(table.projectId, table.date, table.source, table.medium, table.sourceDimension),
 ])
 
-// Social media referral traffic from GA4 — mirrors gaAiReferrals for social platforms.
+// Social media referral traffic from GA4 — uses GA4's native sessionDefaultChannelGroup
+// to classify social traffic rather than hardcoded source patterns.
 export const gaSocialReferrals = sqliteTable('ga_social_referrals', {
   id: text('id').primaryKey(),
   projectId: text('project_id').notNull().references(() => projects.id, { onDelete: 'cascade' }),
   date: text('date').notNull(),
   source: text('source').notNull(),
   medium: text('medium').notNull(),
-  /** Which GA4 dimension produced this row: 'session' | 'first_user' | 'manual_utm' */
-  sourceDimension: text('source_dimension').notNull().default('session'),
+  /** GA4 default channel group (e.g. 'Organic Social', 'Paid Social') */
+  channelGroup: text('channel_group').notNull().default('Organic Social'),
   sessions: integer('sessions').notNull().default(0),
   users: integer('users').notNull().default(0),
   syncedAt: text('synced_at').notNull(),
 }, (table) => [
   index('idx_ga_social_ref_project_date').on(table.projectId, table.date),
   index('idx_ga_social_ref_source').on(table.source),
-  uniqueIndex('idx_ga_social_ref_unique').on(table.projectId, table.date, table.source, table.medium, table.sourceDimension),
+  uniqueIndex('idx_ga_social_ref_unique').on(table.projectId, table.date, table.source, table.medium, table.channelGroup),
 ])
 
 // Aggregate GA4 totals for a sync period — stores true unique user count

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -296,6 +296,24 @@ export const gaAiReferrals = sqliteTable('ga_ai_referrals', {
   uniqueIndex('idx_ga_ai_ref_unique_v2').on(table.projectId, table.date, table.source, table.medium, table.sourceDimension),
 ])
 
+// Social media referral traffic from GA4 — mirrors gaAiReferrals for social platforms.
+export const gaSocialReferrals = sqliteTable('ga_social_referrals', {
+  id: text('id').primaryKey(),
+  projectId: text('project_id').notNull().references(() => projects.id, { onDelete: 'cascade' }),
+  date: text('date').notNull(),
+  source: text('source').notNull(),
+  medium: text('medium').notNull(),
+  /** Which GA4 dimension produced this row: 'session' | 'first_user' | 'manual_utm' */
+  sourceDimension: text('source_dimension').notNull().default('session'),
+  sessions: integer('sessions').notNull().default(0),
+  users: integer('users').notNull().default(0),
+  syncedAt: text('synced_at').notNull(),
+}, (table) => [
+  index('idx_ga_social_ref_project_date').on(table.projectId, table.date),
+  index('idx_ga_social_ref_source').on(table.source),
+  uniqueIndex('idx_ga_social_ref_unique').on(table.projectId, table.date, table.source, table.medium, table.sourceDimension),
+])
+
 // Aggregate GA4 totals for a sync period — stores true unique user count
 // (not derivable by summing per-page rows, which inflates the metric).
 export const gaTrafficSummaries = sqliteTable('ga_traffic_summaries', {

--- a/packages/integration-google-analytics/src/ga4-client.ts
+++ b/packages/integration-google-analytics/src/ga4-client.ts
@@ -579,35 +579,20 @@ export async function fetchAiReferrals(
   return dedupedRows
 }
 
-// Social media referral source patterns — major social platforms.
-const SOCIAL_REFERRAL_SOURCE_FILTERS: Array<{ matchType: 'CONTAINS' | 'EXACT'; value: string }> = [
-  { matchType: 'CONTAINS', value: 'facebook' },
-  { matchType: 'EXACT', value: 'fb.com' },
-  { matchType: 'EXACT', value: 'fb.me' },
-  { matchType: 'EXACT', value: 'l.facebook.com' },
-  { matchType: 'EXACT', value: 'lm.facebook.com' },
-  { matchType: 'CONTAINS', value: 'instagram' },
-  { matchType: 'EXACT', value: 'l.instagram.com' },
-  { matchType: 'CONTAINS', value: 'twitter' },
-  { matchType: 'EXACT', value: 't.co' },
-  { matchType: 'EXACT', value: 'x.com' },
-  { matchType: 'CONTAINS', value: 'linkedin' },
-  { matchType: 'EXACT', value: 'lnkd.in' },
-  { matchType: 'CONTAINS', value: 'youtube' },
-  { matchType: 'EXACT', value: 'youtu.be' },
-  { matchType: 'CONTAINS', value: 'tiktok' },
-  { matchType: 'CONTAINS', value: 'reddit' },
-  { matchType: 'CONTAINS', value: 'pinterest' },
-  { matchType: 'CONTAINS', value: 'threads.net' },
-  { matchType: 'CONTAINS', value: 'mastodon' },
-  { matchType: 'CONTAINS', value: 'bsky.app' },
-  { matchType: 'CONTAINS', value: 'snapchat' },
-]
+// Social channel groups from GA4's default channel grouping.
+// Google maintains the source→channel mapping; we filter on their classification
+// rather than hardcoding source patterns. See:
+// https://support.google.com/analytics/answer/9756891
+const SOCIAL_CHANNEL_GROUPS = ['Organic Social', 'Paid Social']
 
 /**
- * Fetch traffic from social media referral sources.
- * Mirrors the AI referral approach: queries sessionSource, firstUserSource,
- * and sessionManualSource dimensions for social platform patterns.
+ * Fetch traffic from social media referral sources using GA4's native
+ * sessionDefaultChannelGroup classification. This uses Google's maintained
+ * source→channel mapping rather than hardcoded source patterns.
+ *
+ * Uses sessionSource/sessionMedium for per-source breakdowns within the
+ * social channel groups. Does NOT query firstUserSource (acquisition, not
+ * referral) or sessionManualSource (UTM-only edge case).
  */
 export async function fetchSocialReferrals(
   accessToken: string,
@@ -625,83 +610,59 @@ export async function fetchSocialReferrals(
 
   const PAGE_SIZE = 1000
   const rows: GA4SocialReferralRow[] = []
+  let offset = 0
 
-  const dimensionPairs: Array<[string, string, GA4SourceDimension]> = [
-    ['sessionSource', 'sessionMedium', 'session'],
-    ['firstUserSource', 'firstUserMedium', 'first_user'],
-    ['sessionManualSource', 'sessionManualMedium', 'manual_utm'],
-  ]
-
-  for (const [sourceDim, mediumDim, dimLabel] of dimensionPairs) {
-    let offset = 0
-    while (true) {
-      const request: GA4RunReportRequest = {
-        dateRanges: [{ startDate: formatDate(startDate), endDate: formatDate(endDate) }],
-        dimensions: [
-          { name: 'date' },
-          { name: sourceDim },
-          { name: mediumDim },
-        ],
-        metrics: [
-          { name: 'sessions' },
-          { name: 'totalUsers' },
-        ],
-        dimensionFilter: {
-          orGroup: {
-            expressions: SOCIAL_REFERRAL_SOURCE_FILTERS.map(({ matchType, value }) => ({
-              filter: {
-                fieldName: sourceDim,
-                stringFilter: { matchType, value },
-              },
-            })),
-          },
+  while (true) {
+    const request: GA4RunReportRequest = {
+      dateRanges: [{ startDate: formatDate(startDate), endDate: formatDate(endDate) }],
+      dimensions: [
+        { name: 'date' },
+        { name: 'sessionSource' },
+        { name: 'sessionMedium' },
+        { name: 'sessionDefaultChannelGroup' },
+      ],
+      metrics: [
+        { name: 'sessions' },
+        { name: 'totalUsers' },
+      ],
+      dimensionFilter: {
+        orGroup: {
+          expressions: SOCIAL_CHANNEL_GROUPS.map((value) => ({
+            filter: {
+              fieldName: 'sessionDefaultChannelGroup',
+              stringFilter: { matchType: 'EXACT' as const, value },
+            },
+          })),
         },
-        limit: PAGE_SIZE,
-        offset,
-      }
-
-      const response = await runReport(accessToken, propertyId, request)
-      const pageRows: GA4SocialReferralRow[] = (response.rows ?? []).map((row) => ({
-        date: row.dimensionValues[0]!.value,
-        source: row.dimensionValues[1]!.value,
-        medium: row.dimensionValues[2]!.value,
-        sessions: parseInt(row.metricValues[0]!.value, 10) || 0,
-        users: parseInt(row.metricValues[1]!.value, 10) || 0,
-        sourceDimension: dimLabel,
-      }))
-
-      rows.push(...pageRows)
-
-      const totalRows = response.rowCount ?? 0
-      offset += pageRows.length
-      if (pageRows.length < PAGE_SIZE || offset >= totalRows) break
+      },
+      limit: PAGE_SIZE,
+      offset,
     }
-  }
 
-  // Deduplicate within each dimension
-  const deduped = new Map<string, GA4SocialReferralRow>()
-  for (const row of rows) {
-    const key = `${row.date}::${row.source}::${row.medium}::${row.sourceDimension}`
-    const existing = deduped.get(key)
-    if (!existing) {
-      deduped.set(key, row)
-    } else {
-      deduped.set(key, {
-        ...existing,
-        sessions: Math.max(existing.sessions, row.sessions),
-        users: Math.max(existing.users, row.users),
-      })
-    }
+    const response = await runReport(accessToken, propertyId, request)
+    const pageRows: GA4SocialReferralRow[] = (response.rows ?? []).map((row) => ({
+      date: row.dimensionValues[0]!.value,
+      source: row.dimensionValues[1]!.value,
+      medium: row.dimensionValues[2]!.value,
+      sessions: parseInt(row.metricValues[0]!.value, 10) || 0,
+      users: parseInt(row.metricValues[1]!.value, 10) || 0,
+      channelGroup: row.dimensionValues[3]!.value,
+    }))
+
+    rows.push(...pageRows)
+
+    const totalRows = response.rowCount ?? 0
+    offset += pageRows.length
+    if (pageRows.length < PAGE_SIZE || offset >= totalRows) break
   }
-  const dedupedRows = [...deduped.values()]
 
   // Convert YYYYMMDD to YYYY-MM-DD
-  for (const row of dedupedRows) {
+  for (const row of rows) {
     if (row.date.length === 8 && !row.date.includes('-')) {
       row.date = `${row.date.slice(0, 4)}-${row.date.slice(4, 6)}-${row.date.slice(6, 8)}`
     }
   }
 
-  ga4Log('info', 'fetch-social-referrals.done', { propertyId, rowCount: dedupedRows.length })
-  return dedupedRows
+  ga4Log('info', 'fetch-social-referrals.done', { propertyId, rowCount: rows.length })
+  return rows
 }

--- a/packages/integration-google-analytics/src/ga4-client.ts
+++ b/packages/integration-google-analytics/src/ga4-client.ts
@@ -9,6 +9,7 @@ import {
 } from './constants.js'
 import type {
   GA4AiReferralRow,
+  GA4SocialReferralRow,
   GA4RunReportRequest,
   GA4RunReportResponse,
   GA4SourceDimension,
@@ -575,5 +576,132 @@ export async function fetchAiReferrals(
   }
 
   ga4Log('info', 'fetch-ai-referrals.done', { propertyId, rowCount: dedupedRows.length })
+  return dedupedRows
+}
+
+// Social media referral source patterns — major social platforms.
+const SOCIAL_REFERRAL_SOURCE_FILTERS: Array<{ matchType: 'CONTAINS' | 'EXACT'; value: string }> = [
+  { matchType: 'CONTAINS', value: 'facebook' },
+  { matchType: 'EXACT', value: 'fb.com' },
+  { matchType: 'EXACT', value: 'fb.me' },
+  { matchType: 'EXACT', value: 'l.facebook.com' },
+  { matchType: 'EXACT', value: 'lm.facebook.com' },
+  { matchType: 'CONTAINS', value: 'instagram' },
+  { matchType: 'EXACT', value: 'l.instagram.com' },
+  { matchType: 'CONTAINS', value: 'twitter' },
+  { matchType: 'EXACT', value: 't.co' },
+  { matchType: 'EXACT', value: 'x.com' },
+  { matchType: 'CONTAINS', value: 'linkedin' },
+  { matchType: 'EXACT', value: 'lnkd.in' },
+  { matchType: 'CONTAINS', value: 'youtube' },
+  { matchType: 'EXACT', value: 'youtu.be' },
+  { matchType: 'CONTAINS', value: 'tiktok' },
+  { matchType: 'CONTAINS', value: 'reddit' },
+  { matchType: 'CONTAINS', value: 'pinterest' },
+  { matchType: 'CONTAINS', value: 'threads.net' },
+  { matchType: 'CONTAINS', value: 'mastodon' },
+  { matchType: 'CONTAINS', value: 'bsky.app' },
+  { matchType: 'CONTAINS', value: 'snapchat' },
+]
+
+/**
+ * Fetch traffic from social media referral sources.
+ * Mirrors the AI referral approach: queries sessionSource, firstUserSource,
+ * and sessionManualSource dimensions for social platform patterns.
+ */
+export async function fetchSocialReferrals(
+  accessToken: string,
+  propertyId: string,
+  days?: number,
+): Promise<GA4SocialReferralRow[]> {
+  validateAccessToken(accessToken)
+  validatePropertyId(propertyId)
+  const syncDays = Math.min(Math.max(1, days ?? GA4_DEFAULT_SYNC_DAYS), GA4_MAX_SYNC_DAYS)
+  const endDate = new Date()
+  const startDate = new Date()
+  startDate.setDate(startDate.getDate() - syncDays)
+
+  ga4Log('info', 'fetch-social-referrals.start', { propertyId, days: syncDays })
+
+  const PAGE_SIZE = 1000
+  const rows: GA4SocialReferralRow[] = []
+
+  const dimensionPairs: Array<[string, string, GA4SourceDimension]> = [
+    ['sessionSource', 'sessionMedium', 'session'],
+    ['firstUserSource', 'firstUserMedium', 'first_user'],
+    ['sessionManualSource', 'sessionManualMedium', 'manual_utm'],
+  ]
+
+  for (const [sourceDim, mediumDim, dimLabel] of dimensionPairs) {
+    let offset = 0
+    while (true) {
+      const request: GA4RunReportRequest = {
+        dateRanges: [{ startDate: formatDate(startDate), endDate: formatDate(endDate) }],
+        dimensions: [
+          { name: 'date' },
+          { name: sourceDim },
+          { name: mediumDim },
+        ],
+        metrics: [
+          { name: 'sessions' },
+          { name: 'totalUsers' },
+        ],
+        dimensionFilter: {
+          orGroup: {
+            expressions: SOCIAL_REFERRAL_SOURCE_FILTERS.map(({ matchType, value }) => ({
+              filter: {
+                fieldName: sourceDim,
+                stringFilter: { matchType, value },
+              },
+            })),
+          },
+        },
+        limit: PAGE_SIZE,
+        offset,
+      }
+
+      const response = await runReport(accessToken, propertyId, request)
+      const pageRows: GA4SocialReferralRow[] = (response.rows ?? []).map((row) => ({
+        date: row.dimensionValues[0]!.value,
+        source: row.dimensionValues[1]!.value,
+        medium: row.dimensionValues[2]!.value,
+        sessions: parseInt(row.metricValues[0]!.value, 10) || 0,
+        users: parseInt(row.metricValues[1]!.value, 10) || 0,
+        sourceDimension: dimLabel,
+      }))
+
+      rows.push(...pageRows)
+
+      const totalRows = response.rowCount ?? 0
+      offset += pageRows.length
+      if (pageRows.length < PAGE_SIZE || offset >= totalRows) break
+    }
+  }
+
+  // Deduplicate within each dimension
+  const deduped = new Map<string, GA4SocialReferralRow>()
+  for (const row of rows) {
+    const key = `${row.date}::${row.source}::${row.medium}::${row.sourceDimension}`
+    const existing = deduped.get(key)
+    if (!existing) {
+      deduped.set(key, row)
+    } else {
+      deduped.set(key, {
+        ...existing,
+        sessions: Math.max(existing.sessions, row.sessions),
+        users: Math.max(existing.users, row.users),
+      })
+    }
+  }
+  const dedupedRows = [...deduped.values()]
+
+  // Convert YYYYMMDD to YYYY-MM-DD
+  for (const row of dedupedRows) {
+    if (row.date.length === 8 && !row.date.includes('-')) {
+      row.date = `${row.date.slice(0, 4)}-${row.date.slice(4, 6)}-${row.date.slice(6, 8)}`
+    }
+  }
+
+  ga4Log('info', 'fetch-social-referrals.done', { propertyId, rowCount: dedupedRows.length })
   return dedupedRows
 }

--- a/packages/integration-google-analytics/src/index.ts
+++ b/packages/integration-google-analytics/src/index.ts
@@ -4,6 +4,7 @@ export {
   fetchTrafficByLandingPage,
   fetchAggregateSummary,
   fetchAiReferrals,
+  fetchSocialReferrals,
   verifyConnection,
   verifyConnectionWithToken,
 } from './ga4-client.js'

--- a/packages/integration-google-analytics/src/types.ts
+++ b/packages/integration-google-analytics/src/types.ts
@@ -60,6 +60,15 @@ export interface GA4AiReferralRow {
   sourceDimension: GA4SourceDimension
 }
 
+export interface GA4SocialReferralRow {
+  date: string
+  source: string
+  medium: string
+  sessions: number
+  users: number
+  sourceDimension: GA4SourceDimension
+}
+
 export class GA4ApiError extends Error {
   public status: number
   constructor(message: string, status: number) {

--- a/packages/integration-google-analytics/src/types.ts
+++ b/packages/integration-google-analytics/src/types.ts
@@ -66,7 +66,8 @@ export interface GA4SocialReferralRow {
   medium: string
   sessions: number
   users: number
-  sourceDimension: GA4SourceDimension
+  /** GA4 default channel group that classified this as social (e.g. 'Organic Social', 'Paid Social') */
+  channelGroup: string
 }
 
 export class GA4ApiError extends Error {

--- a/skills/canonry-setup/references/canonry-cli.md
+++ b/skills/canonry-setup/references/canonry-cli.md
@@ -261,7 +261,7 @@ canonry ga coverage <project>                    # indexed pages with traffic ov
 canonry ga ai-referral-history <project>         # daily AI referral history by source
 canonry ga social-referral-history <project>     # daily social referral history by source
 canonry ga social-referral-summary <project> [--trend]  # one-line social summary + optional trend
-canonry ga attribution <project>                 # unified channel attribution overview
+canonry ga attribution <project> [--trend]        # unified channel attribution overview + optional trends
 ```
 
 ## CDP / Browser Provider

--- a/skills/canonry-setup/references/canonry-cli.md
+++ b/skills/canonry-setup/references/canonry-cli.md
@@ -255,9 +255,13 @@ GA4 integration uses service account authentication (no OAuth). The service acco
 canonry ga connect <project> --property-id <id> --key-file ./sa-key.json  # connect GA4
 canonry ga disconnect <project>                  # disconnect
 canonry ga status <project>                      # connection status
-canonry ga sync <project> [--days 30]            # pull traffic + AI referral data
-canonry ga traffic <project>                     # landing pages + AI referral sources
+canonry ga sync <project> [--days 30] [--only traffic|ai|social]  # pull GA4 data (selective or full)
+canonry ga traffic <project>                     # landing pages + AI/social referral sources
 canonry ga coverage <project>                    # indexed pages with traffic overlay
+canonry ga ai-referral-history <project>         # daily AI referral history by source
+canonry ga social-referral-history <project>     # daily social referral history by source
+canonry ga social-referral-summary <project> [--trend]  # one-line social summary + optional trend
+canonry ga attribution <project>                 # unified channel attribution overview
 ```
 
 ## CDP / Browser Provider


### PR DESCRIPTION
## Summary
- Adds social media referral tracking to the GA4 traffic section using GA4's native `sessionDefaultChannelGroup` dimension filtered to `Organic Social` and `Paid Social`
- Google maintains the source-to-channel mapping — no hardcoded source list to keep up-to-date
- Uses `sessionSource`/`sessionMedium` for per-source breakdowns within the social channel groups
- New `ga_social_referrals` DB table (keyed on `channelGroup`), API endpoints (`/ga/social-referral-history`, extended `/ga/traffic` and `/ga/sync`), CLI command (`canonry ga social-referral-history`), and UI section with summary stats + sortable source/medium table
- Full CLI coverage: `ga sync` and `ga traffic` output includes social metrics; typed `ApiClient.gaSocialReferralHistory()` method exposed for agent consumers

### Why `sessionDefaultChannelGroup` instead of source-pattern matching
- GA4's channel grouping is the upstream-recommended approach for classifying traffic by channel
- Avoids overcounting from `firstUserSource` (measures first-touch acquisition, not current session referral)
- Avoids misclassification (e.g. YouTube is "Video" in GA4, not social)
- For emerging platforms not yet in GA4's default mapping, users can configure custom channel groups

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run test` passes (93/93 test files, 898 tests)
- [x] Tests for `GET /ga/social-referral-history` (error + happy path)
- [x] Manual: connect GA4, sync, verify social referral data appears in the new section
- [x] Manual: verify empty state renders correctly when no social traffic is detected