### PR TITLE
fix(core-cli): prevent double shutdown on repeated signals in serve command

### DIFF
--- a/packages/canonry/src/commands/serve.ts
+++ b/packages/canonry/src/commands/serve.ts
@@ -18,7 +18,12 @@ export async function serveCommand(format: CliFormat = 'text'): Promise<void> {
   const app = await createServer({ config, db })
 
   // Graceful shutdown on SIGTERM (sent by `canonry stop`) and SIGINT (Ctrl+C)
+  // Guard against double-fire: rapid Ctrl+C or concurrent SIGTERM+SIGINT
+  // would call app.close() multiple times, causing unhandled rejections.
+  let shuttingDown = false
   const shutdown = (): void => {
+    if (shuttingDown) return
+    shuttingDown = true
     app.close().then(() => {
       process.exit(0)
     }).catch(() => {


### PR DESCRIPTION
## Overnight Audit: packages/canonry/src/

### Scope
All files under \`packages/canonry/src/\` — CLI commands, config, serve/daemon logic.

### Issue Found & Fixed

**1. Double signal handler invocation in \`serve.ts\`** (bug: unhandled promise rejection)

The \`shutdown\` function registered on both \`SIGTERM\` and \`SIGINT\` had no re-entrancy guard. When a user presses Ctrl+C twice in quick succession, or when \`canonry stop\` (SIGTERM) arrives while the user is also pressing Ctrl+C (SIGINT), \`app.close()\` gets called a second time on an already-closing Fastify instance. This produces unhandled promise rejections and non-deterministic exit codes.

**Fix:** Added a \`shuttingDown\` boolean guard so subsequent signals are no-ops once the first shutdown has begun.

### Reviewed & Clean

- ✅ All CLI commands use \`createApiClient()\` — no direct \`ApiClient\` instantiation
- ✅ No hardcoded \`/api/v1\` in CLI command files
- ✅ All commands support \`--format json\`
- ✅ Error handling uses \`CliError\` with proper exit codes (0/1/2)
- ✅ Version sync: root \`package.json\` = \`packages/canonry/package.json\` = npm \`1.41.0\`
- ✅ Config save/load uses read-modify-write pattern (no env-var leakage)
- ✅ Base path handling correct in both server and client
- ✅ \`typecheck\`, \`lint\`, \`test\` all pass (896 tests)

### Not Changed (non-blocking observations)

- \`ProviderExecutionGate\` is duplicated between \`job-runner.ts\` and \`snapshot-service.ts\` — a shared utility would reduce duplication but is not a bug