### PR TITLE
chore(providers): fix reparseStoredResult normalization

### DIFF
--- a/packages/provider-claude/src/normalize.ts
+++ b/packages/provider-claude/src/normalize.ts
@@ -181,16 +181,26 @@ function extractTextFromResponse(response: Anthropic.Message): string {
   }
 }
 
+function extractNestedApiResponse(rawResponse: Record<string, unknown>): Record<string, unknown> | null {
+  const apiResponse = rawResponse.apiResponse
+  if (apiResponse !== null && typeof apiResponse === 'object' && !Array.isArray(apiResponse)) {
+    return apiResponse as Record<string, unknown>
+  }
+  return null
+}
+
 function extractGroundingSourcesFromRaw(rawResponse: Record<string, unknown>): GroundingSource[] {
   const sources: GroundingSource[] = []
   const seen = new Set<string>()
   try {
+    const nested = extractNestedApiResponse(rawResponse)
+    const effectiveResponse = nested ?? rawResponse
     // Anthropic distinguishes retrieved `web_search_result` entries from final citations on
     // `text.citations` entries with `type: "web_search_result_location"`, so we only count
     // the latter as citation evidence.
     // Docs: https://docs.claude.com/en/docs/agents-and-tools/tool-use/web-search-tool
     // SDK: https://github.com/anthropics/anthropic-sdk-typescript/blob/main/src/resources/messages/messages.ts
-    const content = rawResponse.content as Array<{
+    const content = effectiveResponse.content as Array<{
       type?: string
       citations?: Array<{
         type?: string
@@ -222,11 +232,13 @@ function extractGroundingSourcesFromRaw(rawResponse: Record<string, unknown>): G
 function extractSearchQueriesFromRaw(rawResponse: Record<string, unknown>): string[] {
   const queries = new Set<string>()
   try {
+    const nested = extractNestedApiResponse(rawResponse)
+    const effectiveResponse = nested ?? rawResponse
     // Anthropic's web-search response examples show the executed search on the preceding
     // `server_tool_use.input.query` block, so we recover telemetry from that block instead
     // of from `web_search_tool_result`.
     // Docs: https://docs.claude.com/en/docs/agents-and-tools/tool-use/web-search-tool
-    const content = rawResponse.content as Array<{
+    const content = effectiveResponse.content as Array<{
       type?: string
       name?: string
       input?: {
@@ -258,7 +270,9 @@ function extractSearchQueriesFromRaw(rawResponse: Record<string, unknown>): stri
 
 function extractAnswerTextFromRaw(rawResponse: Record<string, unknown>): string {
   try {
-    const content = rawResponse.content as Array<{
+    const nested = extractNestedApiResponse(rawResponse)
+    const effectiveResponse = nested ?? rawResponse
+    const content = effectiveResponse.content as Array<{
       type: string
       text?: string
     }> | undefined
@@ -280,12 +294,14 @@ function extractAnswerTextFromRaw(rawResponse: Record<string, unknown>): string 
 function extractWebSearchToolErrors(rawResponse: Record<string, unknown>): string[] {
   const errors = new Set<string>()
   try {
+    const nested = extractNestedApiResponse(rawResponse)
+    const effectiveResponse = nested ?? rawResponse
     // Anthropic documents that web-search failures can still arrive in a successful message
     // response as `web_search_tool_result` blocks whose `content` is a
     // `web_search_tool_result_error`.
     // Docs: https://docs.claude.com/en/docs/agents-and-tools/tool-use/web-search-tool
     // SDK: https://github.com/anthropics/anthropic-sdk-typescript/blob/main/src/resources/messages/messages.ts
-    const content = rawResponse.content as Array<{
+    const content = effectiveResponse.content as Array<{
       type?: string
       content?: unknown
     }> | undefined

--- a/packages/provider-gemini/src/normalize.ts
+++ b/packages/provider-gemini/src/normalize.ts
@@ -181,9 +181,19 @@ function buildPrompt(keyword: string, location?: GeminiTrackedQueryInput['locati
   return keyword
 }
 
+function extractNestedApiResponse(rawResponse: Record<string, unknown>): Record<string, unknown> | null {
+  const apiResponse = rawResponse.apiResponse
+  if (apiResponse !== null && typeof apiResponse === 'object' && !Array.isArray(apiResponse)) {
+    return apiResponse as Record<string, unknown>
+  }
+  return null
+}
+
 function extractAnswerText(rawResponse: Record<string, unknown>): string {
   try {
-    const candidates = rawResponse.candidates as Array<{
+    const nested = extractNestedApiResponse(rawResponse)
+    const effectiveResponse = nested ?? rawResponse
+    const candidates = effectiveResponse.candidates as Array<{
       content?: { parts?: Array<{ text?: string }> }
     }> | undefined
 
@@ -200,12 +210,14 @@ function extractAnswerText(rawResponse: Record<string, unknown>): string {
 
 function extractGroundingMetadataFromRaw(rawResponse: Record<string, unknown>): GroundingSource[] {
   try {
+    const nested = extractNestedApiResponse(rawResponse)
+    const effectiveResponse = nested ?? rawResponse
     // Google documents `groundingChunks` as the pool of retrieved sources and
     // `groundingSupports` as the mapping from answer segments to
     // `groundingChunkIndices`, which is the basis for inline citations.
     // Docs: https://ai.google.dev/gemini-api/docs/google-search
     // SDK: https://github.com/googleapis/js-genai/blob/main/src/types.ts
-    const candidates = rawResponse.candidates as Array<{
+    const candidates = effectiveResponse.candidates as Array<{
       groundingMetadata?: {
         groundingChunks?: Array<{
           web?: {
@@ -259,7 +271,9 @@ function extractGroundingMetadataFromRaw(rawResponse: Record<string, unknown>): 
 
 function extractSearchQueriesFromRaw(rawResponse: Record<string, unknown>): string[] {
   try {
-    const candidates = rawResponse.candidates as Array<{
+    const nested = extractNestedApiResponse(rawResponse)
+    const effectiveResponse = nested ?? rawResponse
+    const candidates = effectiveResponse.candidates as Array<{
       groundingMetadata?: {
         webSearchQueries?: string[]
       }

--- a/packages/provider-openai/src/normalize.ts
+++ b/packages/provider-openai/src/normalize.ts
@@ -150,15 +150,25 @@ function extractResponseText(response: OpenAI.Responses.Response): string {
   }
 }
 
+function extractNestedApiResponse(rawResponse: Record<string, unknown>): Record<string, unknown> | null {
+  const apiResponse = rawResponse.apiResponse
+  if (apiResponse !== null && typeof apiResponse === 'object' && !Array.isArray(apiResponse)) {
+    return apiResponse as Record<string, unknown>
+  }
+  return null
+}
+
 function extractGroundingSourcesFromRaw(rawResponse: Record<string, unknown>): GroundingSource[] {
   const sources: GroundingSource[] = []
   const seen = new Set<string>()
   try {
+    const nested = extractNestedApiResponse(rawResponse)
+    const effectiveResponse = nested ?? rawResponse
     // OpenAI's web-search guide returns citations in the final message, and the official
     // SDK types model those as `output_text.annotations` entries with `type: "url_citation"`.
     // Docs: https://developers.openai.com/api/docs/guides/tools-web-search
     // SDK: https://github.com/openai/openai-python/blob/main/src/openai/types/responses/response_output_text.py
-    const output = rawResponse.output as Array<{
+    const output = effectiveResponse.output as Array<{
       type?: string
       content?: Array<{
         type?: string
@@ -197,12 +207,14 @@ function extractGroundingSourcesFromRaw(rawResponse: Record<string, unknown>): G
 function extractSearchQueriesFromRaw(rawResponse: Record<string, unknown>): string[] {
   const queries = new Set<string>()
   try {
+    const nested = extractNestedApiResponse(rawResponse)
+    const effectiveResponse = nested ?? rawResponse
     // The official Responses SDK types put search telemetry on `web_search_call.action`
     // rather than on the top-level item. `query` is deprecated in favor of `queries`, so
     // we accept both when reparsing stored payloads.
     // Docs: https://developers.openai.com/api/docs/guides/tools-web-search
     // SDK: https://github.com/openai/openai-python/blob/main/src/openai/types/responses/response_function_web_search.py
-    const output = rawResponse.output as Array<{
+    const output = effectiveResponse.output as Array<{
       type?: string
       action?: {
         type?: string
@@ -234,7 +246,9 @@ function extractSearchQueriesFromRaw(rawResponse: Record<string, unknown>): stri
 
 function extractAnswerTextFromRaw(rawResponse: Record<string, unknown>): string {
   try {
-    const output = rawResponse.output as Array<{
+    const nested = extractNestedApiResponse(rawResponse)
+    const effectiveResponse = nested ?? rawResponse
+    const output = effectiveResponse.output as Array<{
       type: string
       content?: Array<{ type: string; text?: string }>
     }> | undefined


### PR DESCRIPTION
## Overview
This PR fixes an issue where `reparseStoredResult` in the OpenAI, Gemini, and Claude provider adapters would fail to extract data from stored query snapshots.

## Changes
- **Provider Adapters (OpenAI, Gemini, Claude)**: Updated `reparseStoredResult` and its helper functions to check for a nested `apiResponse` key in the raw response object.
- **Consistency**: This brings these providers in line with the Perplexity adapter, which already correctly handles the `apiResponse` envelope added by the `job-runner` before persistence.

## Fixes
- Fixed missing answer text, grounding sources, and search queries when viewing or backfilling historical data for OpenAI, Gemini, and Claude providers.