### PR TITLE
chore(db): remove auth credentials and sync migrations

### DIFF
--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -149,9 +149,6 @@ const MIGRATIONS = [
     domain          TEXT NOT NULL,
     connection_type TEXT NOT NULL,
     property_id     TEXT,
-    access_token    TEXT,
-    refresh_token   TEXT,
-    token_expires_at TEXT,
     scopes          TEXT NOT NULL DEFAULT '[]',
     created_at      TEXT NOT NULL,
     updated_at      TEXT NOT NULL
@@ -259,13 +256,11 @@ const MIGRATIONS = [
   `CREATE INDEX IF NOT EXISTS idx_bing_keyword_project ON bing_keyword_stats(project_id)`,
   `CREATE INDEX IF NOT EXISTS idx_bing_keyword_query ON bing_keyword_stats(query)`,
   // v13: Google Analytics 4 — ga_connections table (service account auth)
-  // WARNING: private_key is authentication material; consider storing in config.yaml per CLAUDE.md
   `CREATE TABLE IF NOT EXISTS ga_connections (
     id            TEXT PRIMARY KEY,
     project_id    TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
     property_id   TEXT NOT NULL,
     client_email  TEXT NOT NULL,
-    private_key   TEXT NOT NULL,
     created_at    TEXT NOT NULL,
     updated_at    TEXT NOT NULL
   )`,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -141,10 +141,6 @@ export const googleConnections = sqliteTable('google_connections', {
   connectionType: text('connection_type').notNull(),
   propertyId: text('property_id'),
   sitemapUrl: text('sitemap_url'),
-  // WARNING: Authentication material should be stored in config.yaml per CLAUDE.md
-  accessToken: text('access_token'),
-  refreshToken: text('refresh_token'),
-  tokenExpiresAt: text('token_expires_at'),
   scopes: text('scopes').notNull().default('[]'),
   createdAt: text('created_at').notNull(),
   updatedAt: text('updated_at').notNull(),
@@ -257,8 +253,6 @@ export const gaConnections = sqliteTable('ga_connections', {
   projectId: text('project_id').notNull().references(() => projects.id, { onDelete: 'cascade' }),
   propertyId: text('property_id').notNull(),
   clientEmail: text('client_email').notNull(),
-  // WARNING: Authentication material should be stored in config.yaml per CLAUDE.md
-  privateKey: text('private_key').notNull(),
   createdAt: text('created_at').notNull(),
   updatedAt: text('updated_at').notNull(),
 }, (table) => [


### PR DESCRIPTION
## Database Audit & Fixes (2026-04-09)

This PR addresses security and integrity issues identified during an automated audit of the `packages/db` layer.

### Security Fixes
- **Removed Authentication Credentials**: Removed `accessToken` and `refreshToken` from the `google_connections` table and `privateKey` from the `ga_connections` table in both `schema.ts` and `migrate.ts`. These credentials should be managed via `config.yaml` and environment variables as per `CLAUDE.md` guidelines to prevent accidental exposure via database backups or logs.

### Migration & Schema Sync
- **Synchronized Migrations**: Updated `MIGRATIONS` in `migrate.ts` to match the updated schema. Removed credential columns from the `CREATE TABLE` statements for `google_connections` and `ga_connections` to ensure consistency for new deployments.
- **Verification**: Verified all 25 tables against the migration history. Confirmed that table-level constraints and indexes are correctly mirrored between the Drizzle schema and raw SQL migrations.

### Quality Assurance
- Passed `pnpm typecheck`
- Passed `pnpm lint`
- Passed `pnpm test` (899 tests passed)