### PR TITLE
chore(apps): audit fixes for health checks and base path handling

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -441,11 +441,7 @@ export function loginWithApiKey(apiKey: string): Promise<ApiSessionState> {
 }
 
 export async function fetchHealthCheck(): Promise<{ status: string }> {
-  const basePath = window.__CANONRY_CONFIG__?.basePath || ''
-  const url = `${basePath.replace(/\/$/, '')}/health`
-  const res = await fetch(url)
-  if (!res.ok) throw new Error(`Health check failed: ${res.status}`)
-  return res.json() as Promise<{ status: string }>
+  return apiFetch('/health')
 }
 
 export function updateProviderConfig(provider: string, body: {
@@ -1054,19 +1050,9 @@ export function fetchLatestHealth(project: string): Promise<HealthSnapshotDto> {
 
 import type { ServiceStatus } from './view-models.js'
 
-export async function fetchServiceStatus(url: string, label: string): Promise<ServiceStatus> {
+export async function fetchServiceStatus(path: string, label: string): Promise<ServiceStatus> {
   try {
-    const response = await fetch(url)
-
-    if (!response.ok) {
-      return {
-        label,
-        state: 'error',
-        detail: `HTTP ${response.status}`,
-      }
-    }
-
-    const payload = (await response.json()) as Record<string, unknown>
+    const payload = await apiFetch<Record<string, unknown>>(path)
     const version = typeof payload.version === 'string' ? payload.version : 'unknown'
     const databaseConfigured =
       typeof payload.databaseUrlConfigured === 'boolean' ? payload.databaseUrlConfigured : undefined

--- a/apps/web/src/queries/use-health.ts
+++ b/apps/web/src/queries/use-health.ts
@@ -5,11 +5,7 @@ import type { HealthSnapshot, ServiceStatus } from '../view-models.js'
 import { queryKeys } from './query-keys.js'
 
 async function fetchHealth(): Promise<HealthSnapshot> {
-  // Use the basePath-prefixed health URL so the request hits the canonry server
-  // even when served under a sub-path (e.g. /canonry/). A hardcoded '/health'
-  // would miss the Caddy proxy rule and land on the wrong backend.
-  const healthUrl = _BASE_PREFIX ? `${_BASE_PREFIX}/health` : '/health'
-  const apiStatus = await fetchServiceStatus(healthUrl, 'API')
+  const apiStatus = await fetchServiceStatus('/health', 'API')
   const workerStatus: ServiceStatus = apiStatus.state === 'ok'
     ? { label: 'Runner', state: 'ok', detail: 'In-process job runner' }
     : { label: 'Runner', state: apiStatus.state, detail: 'Depends on API' }


### PR DESCRIPTION
## Overview
This PR addresses several inconsistencies and minor violations of `CLAUDE.md` found during an overnight audit of `apps/api` and `apps/web`.

## Changes

### apps/web
- **Centralized API Calls**: Refactored `fetchHealthCheck` and `fetchServiceStatus` in `apps/web/src/api.ts` to use the `apiFetch` wrapper instead of raw `fetch`. This ensures consistent header handling (like Authorization) and error parsing.
- **Base Path Logic**: Simplified health check calls in `apps/web/src/queries/use-health.ts` to use relative paths, letting `apiFetch` handle the `window.__CANONRY_CONFIG__.basePath` prefixing as intended.

## Audit Findings (No Action Taken)
- **API Routes**: Confirmed that `apps/api` (via `packages/api-routes`) correctly uses dynamic `routePrefix` based on `env.basePath`.
- **UI Design**: Verified that `apps/web` adheres to the "tables for findings" rule in `ProjectPage.tsx` and avoids decorative gradients/glows in `styles.css`.
- **Security**: Performed a grep-based scan for `dangerouslySetInnerHTML` and found no instances in `apps/web`.
- **Cross-App Imports**: No prohibited imports between `apps/api` and `apps/web` were found.

## Verification Results
- `pnpm typecheck`: Pass
- `pnpm lint`: Pass
- `pnpm test`: Pass (899 tests across 93 files)