### PR TITLE
feat(bing): add coverage history tracking with daily snapshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "1.44.0",
+  "version": "1.45.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/bing.ts
+++ b/packages/api-routes/src/bing.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto'
 import { eq, and, desc } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
-import { bingUrlInspections } from '@ainyc/canonry-db'
+import { bingUrlInspections, bingCoverageSnapshots } from '@ainyc/canonry-db'
 import { validationError, notFound } from '@ainyc/canonry-contracts'
 import { resolveProject, writeAuditLog } from './helpers.js'
 import {
@@ -285,6 +285,24 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
       discoveryDate: r.discoveryDate ?? null,
     })
 
+    // Save a daily coverage snapshot (idempotent per day via upsert)
+    if (total > 0) {
+      const snapshotDate = new Date().toISOString().split('T')[0]!
+      const now = new Date().toISOString()
+      app.db.insert(bingCoverageSnapshots).values({
+        id: crypto.randomUUID(),
+        projectId: project.id,
+        date: snapshotDate,
+        indexed,
+        notIndexed,
+        unknown,
+        createdAt: now,
+      }).onConflictDoUpdate({
+        target: [bingCoverageSnapshots.projectId, bingCoverageSnapshots.date],
+        set: { indexed, notIndexed, unknown, createdAt: now },
+      }).run()
+    }
+
     return {
       summary: {
         total,
@@ -298,6 +316,34 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
       notIndexed: notIndexedUrls.map(formatRow),
       unknown: unknownUrls.map(formatRow),
     }
+  })
+
+  // GET /projects/:name/bing/coverage/history
+  app.get<{
+    Params: { name: string }
+    Querystring: { limit?: string }
+  }>('/projects/:name/bing/coverage/history', async (request, reply) => {
+    const store = requireConnectionStore(reply)
+    if (!store) return
+
+    const project = resolveProject(app.db, request.params.name)
+    const parsed = parseInt(request.query.limit ?? '90', 10)
+    const limit = Number.isNaN(parsed) || parsed <= 0 ? 90 : parsed
+
+    const rows = app.db
+      .select()
+      .from(bingCoverageSnapshots)
+      .where(eq(bingCoverageSnapshots.projectId, project.id))
+      .orderBy(desc(bingCoverageSnapshots.date))
+      .limit(limit)
+      .all()
+
+    return rows.map((r) => ({
+      date: r.date,
+      indexed: r.indexed,
+      notIndexed: r.notIndexed,
+      unknown: r.unknown,
+    }))
   })
 
   // GET /projects/:name/bing/inspections

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -1464,6 +1464,18 @@ const routeCatalog: OpenApiOperation[] = [
   },
   {
     method: 'get',
+    path: '/api/v1/projects/{name}/bing/coverage/history',
+    summary: 'Get Bing coverage history snapshots',
+    tags: ['bing'],
+    parameters: [nameParameter, limitQueryParameter],
+    responses: {
+      200: { description: 'Bing coverage history returned.' },
+      400: { description: 'Bing is not configured for this project.' },
+      404: { description: 'Project not found.' },
+    },
+  },
+  {
+    method: 'get',
     path: '/api/v1/projects/{name}/bing/inspections',
     summary: 'List Bing URL inspections',
     tags: ['bing'],

--- a/packages/api-routes/test/bing.test.ts
+++ b/packages/api-routes/test/bing.test.ts
@@ -4,7 +4,7 @@ import os from 'node:os'
 import path from 'node:path'
 import Fastify from 'fastify'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
-import { bingUrlInspections, createClient, migrate, projects } from '@ainyc/canonry-db'
+import { bingUrlInspections, bingCoverageSnapshots, createClient, migrate, projects } from '@ainyc/canonry-db'
 import { bingRoutes } from '../src/bing.js'
 import type { BingConnectionRecord, BingConnectionStore } from '../src/bing.js'
 
@@ -77,6 +77,7 @@ describe('Bing routes', () => {
 
   beforeEach(() => {
     db.delete(bingUrlInspections).run()
+    db.delete(bingCoverageSnapshots).run()
     connections.clear()
 
     const now = new Date().toISOString()
@@ -292,5 +293,94 @@ describe('Bing routes', () => {
     expect(res.statusCode).toBe(200)
     expect(submitUrlSpy).toHaveBeenCalledTimes(1)
     expect(submitUrlSpy).toHaveBeenCalledWith('test-key', 'https://example.com/', 'https://example.com/not-indexed')
+  })
+
+  it('coverage endpoint saves a daily snapshot', async () => {
+    const now = new Date().toISOString()
+    db.insert(bingUrlInspections).values([
+      {
+        id: crypto.randomUUID(),
+        projectId,
+        url: 'https://example.com/indexed',
+        httpCode: 200,
+        inIndex: 1,
+        lastCrawledDate: '2026-03-15T10:00:00Z',
+        inIndexDate: null,
+        inspectedAt: '2026-03-20T10:00:00Z',
+        createdAt: now,
+        documentSize: 2048,
+        anchorCount: null,
+        discoveryDate: null,
+      },
+      {
+        id: crypto.randomUUID(),
+        projectId,
+        url: 'https://example.com/not-indexed',
+        httpCode: 404,
+        inIndex: 0,
+        lastCrawledDate: null,
+        inIndexDate: null,
+        inspectedAt: '2026-03-20T11:00:00Z',
+        createdAt: now,
+        documentSize: 0,
+        anchorCount: null,
+        discoveryDate: null,
+      },
+    ]).run()
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/projects/test-project/bing/coverage',
+    })
+    expect(res.statusCode).toBe(200)
+
+    const snapshots = db.select().from(bingCoverageSnapshots).all()
+    expect(snapshots).toHaveLength(1)
+    expect(snapshots[0]!.indexed).toBe(1)
+    expect(snapshots[0]!.notIndexed).toBe(1)
+    expect(snapshots[0]!.unknown).toBe(0)
+    expect(snapshots[0]!.date).toBe(new Date().toISOString().split('T')[0])
+  })
+
+  it('coverage-history returns snapshots in descending date order', async () => {
+    const now = new Date().toISOString()
+    db.insert(bingCoverageSnapshots).values([
+      { id: crypto.randomUUID(), projectId, date: '2026-03-18', indexed: 5, notIndexed: 2, unknown: 1, createdAt: now },
+      { id: crypto.randomUUID(), projectId, date: '2026-03-19', indexed: 6, notIndexed: 1, unknown: 0, createdAt: now },
+      { id: crypto.randomUUID(), projectId, date: '2026-03-20', indexed: 7, notIndexed: 1, unknown: 0, createdAt: now },
+    ]).run()
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/projects/test-project/bing/coverage/history',
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as Array<{ date: string; indexed: number; notIndexed: number; unknown: number }>
+    expect(body).toHaveLength(3)
+    expect(body[0]!.date).toBe('2026-03-20')
+    expect(body[0]!.indexed).toBe(7)
+    expect(body[2]!.date).toBe('2026-03-18')
+    expect(body[2]!.indexed).toBe(5)
+  })
+
+  it('coverage-history respects limit parameter', async () => {
+    const now = new Date().toISOString()
+    db.insert(bingCoverageSnapshots).values([
+      { id: crypto.randomUUID(), projectId, date: '2026-03-18', indexed: 5, notIndexed: 2, unknown: 1, createdAt: now },
+      { id: crypto.randomUUID(), projectId, date: '2026-03-19', indexed: 6, notIndexed: 1, unknown: 0, createdAt: now },
+      { id: crypto.randomUUID(), projectId, date: '2026-03-20', indexed: 7, notIndexed: 1, unknown: 0, createdAt: now },
+    ]).run()
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/projects/test-project/bing/coverage/history?limit=2',
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as Array<{ date: string }>
+    expect(body).toHaveLength(2)
+    expect(body[0]!.date).toBe('2026-03-20')
+    expect(body[1]!.date).toBe('2026-03-19')
   })
 })

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "1.44.0",
+  "version": "1.45.0",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/cli-commands/bing.ts
+++ b/packages/canonry/src/cli-commands/bing.ts
@@ -1,6 +1,7 @@
 import {
   bingConnect,
   bingCoverage,
+  bingCoverageHistory,
   bingDisconnect,
   bingInspect,
   bingInspections,
@@ -12,7 +13,7 @@ import {
   bingStatus,
 } from '../commands/bing.js'
 import type { CliCommandSpec } from '../cli-dispatch.js'
-import { getBoolean, getString, requirePositional, requireProject, stringOption, unknownSubcommand } from '../cli-command-helpers.js'
+import { getBoolean, getString, parseIntegerOption, requirePositional, requireProject, stringOption, unknownSubcommand } from '../cli-command-helpers.js'
 import { usageError } from '../cli-error.js'
 
 export const BING_CLI_COMMANDS: readonly CliCommandSpec[] = [
@@ -65,6 +66,22 @@ export const BING_CLI_COMMANDS: readonly CliCommandSpec[] = [
         message: 'project name and site URL are required',
       })
       await bingSetSite(project, siteUrl, input.format)
+    },
+  },
+  {
+    path: ['bing', 'coverage-history'],
+    usage: 'canonry bing coverage-history <project> [--limit <n>] [--format json]',
+    options: { limit: stringOption() },
+    run: async (input) => {
+      const project = requireProject(input, 'bing.coverage-history', 'canonry bing coverage-history <project> [--limit <n>] [--format json]')
+      await bingCoverageHistory(project, {
+        limit: parseIntegerOption(input, 'limit', {
+          command: 'bing.coverage-history',
+          message: '--limit must be a positive integer',
+          usage: 'canonry bing coverage-history <project> [--limit <n>] [--format json]',
+        }),
+        format: input.format,
+      })
     },
   },
   {
@@ -146,12 +163,12 @@ export const BING_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['bing'],
-    usage: 'canonry bing <connect|disconnect|status|sites|set-site|coverage|inspect|inspections|request-indexing|performance|refresh> <project> [args]',
+    usage: 'canonry bing <connect|disconnect|status|sites|set-site|coverage|coverage-history|inspect|inspections|request-indexing|performance|refresh> <project> [args]',
     run: async (input) => {
       unknownSubcommand(input.positionals[0], {
         command: 'bing',
-        usage: 'canonry bing <connect|disconnect|status|sites|set-site|coverage|inspect|inspections|request-indexing|performance|refresh> <project> [args]',
-        available: ['connect', 'disconnect', 'status', 'sites', 'set-site', 'coverage', 'inspect', 'inspections', 'request-indexing', 'performance', 'refresh'],
+        usage: 'canonry bing <connect|disconnect|status|sites|set-site|coverage|coverage-history|inspect|inspections|request-indexing|performance|refresh> <project> [args]',
+        available: ['connect', 'disconnect', 'status', 'sites', 'set-site', 'coverage', 'coverage-history', 'inspect', 'inspections', 'request-indexing', 'performance', 'refresh'],
       })
     },
   },

--- a/packages/canonry/src/client.ts
+++ b/packages/canonry/src/client.ts
@@ -44,6 +44,7 @@ import type {
   IndexingRequestResultDto,
   InsightDto,
   HealthSnapshotDto,
+  BingCoverageSnapshotDto,
 } from '@ainyc/canonry-contracts'
 
 export type { BrandMetricsDto, GapAnalysisDto, SourceBreakdownDto, AuditLogEntry }
@@ -509,6 +510,11 @@ export class ApiClient {
 
   async bingCoverage(project: string): Promise<object> {
     return this.request<object>('GET', `/projects/${encodeURIComponent(project)}/bing/coverage`)
+  }
+
+  async bingCoverageHistory(project: string, params?: { limit?: number }): Promise<BingCoverageSnapshotDto[]> {
+    const qs = params?.limit != null ? `?limit=${params.limit}` : ''
+    return this.request<BingCoverageSnapshotDto[]>('GET', `/projects/${encodeURIComponent(project)}/bing/coverage/history${qs}`)
   }
 
   async bingInspections(project: string, params?: Record<string, string>): Promise<object[]> {

--- a/packages/canonry/src/commands/bing.ts
+++ b/packages/canonry/src/commands/bing.ts
@@ -183,6 +183,28 @@ export async function bingCoverage(project: string, format?: string): Promise<vo
   }
 }
 
+export async function bingCoverageHistory(project: string, opts: { limit?: number; format?: string }): Promise<void> {
+  const client = getClient()
+  const rows = await client.bingCoverageHistory(project, { limit: opts.limit })
+
+  if (opts.format === 'json') {
+    console.log(JSON.stringify(rows, null, 2))
+    return
+  }
+
+  if (rows.length === 0) {
+    console.log('No coverage history found. Run "canonry bing coverage" or "canonry bing refresh" first to capture a snapshot.')
+    return
+  }
+
+  console.log(`\nBing Coverage History for "${project}" (${rows.length} snapshots):\n`)
+  console.log(`  ${'DATE'.padEnd(12)}${'INDEXED'.padEnd(10)}${'NOT INDEXED'.padEnd(14)}UNKNOWN`)
+  console.log(`  ${'─'.repeat(12)}${'─'.repeat(10)}${'─'.repeat(14)}${'─'.repeat(10)}`)
+  for (const row of rows) {
+    console.log(`  ${row.date.padEnd(12)}${String(row.indexed).padEnd(10)}${String(row.notIndexed).padEnd(14)}${String(row.unknown)}`)
+  }
+}
+
 export async function bingInspect(project: string, url: string, format?: string): Promise<void> {
   const client = getClient()
   const result = await client.bingInspectUrl(project, url) as {

--- a/packages/contracts/src/bing.ts
+++ b/packages/contracts/src/bing.ts
@@ -48,6 +48,14 @@ export const bingKeywordStatsDtoSchema = z.object({
 })
 export type BingKeywordStatsDto = z.infer<typeof bingKeywordStatsDtoSchema>
 
+export const bingCoverageSnapshotDtoSchema = z.object({
+  date: z.string(),
+  indexed: z.number(),
+  notIndexed: z.number(),
+  unknown: z.number(),
+})
+export type BingCoverageSnapshotDto = z.infer<typeof bingCoverageSnapshotDtoSchema>
+
 export const bingSubmitResultDtoSchema = z.object({
   url: z.string(),
   status: z.enum(['success', 'error']),

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -390,6 +390,18 @@ const MIGRATIONS = [
   `CREATE INDEX IF NOT EXISTS idx_ga_social_ref_project_date ON ga_social_referrals(project_id, date)`,
   `CREATE INDEX IF NOT EXISTS idx_ga_social_ref_source ON ga_social_referrals(source)`,
   `CREATE UNIQUE INDEX IF NOT EXISTS idx_ga_social_ref_unique ON ga_social_referrals(project_id, date, source, medium, channel_group)`,
+
+  // v26: Bing coverage snapshots for historical tracking (mirrors gsc_coverage_snapshots)
+  `CREATE TABLE IF NOT EXISTS bing_coverage_snapshots (
+    id              TEXT PRIMARY KEY,
+    project_id      TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    date            TEXT NOT NULL,
+    indexed         INTEGER NOT NULL DEFAULT 0,
+    not_indexed     INTEGER NOT NULL DEFAULT 0,
+    unknown         INTEGER NOT NULL DEFAULT 0,
+    created_at      TEXT NOT NULL
+  )`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS idx_bing_coverage_snap_project_date ON bing_coverage_snapshots(project_id, date)`,
 ]
 
 /**

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -209,6 +209,18 @@ export const gscCoverageSnapshots = sqliteTable('gsc_coverage_snapshots', {
   index('idx_gsc_coverage_snap_run').on(table.syncRunId),
 ])
 
+export const bingCoverageSnapshots = sqliteTable('bing_coverage_snapshots', {
+  id: text('id').primaryKey(),
+  projectId: text('project_id').notNull().references(() => projects.id, { onDelete: 'cascade' }),
+  date: text('date').notNull(),
+  indexed: integer('indexed').notNull().default(0),
+  notIndexed: integer('not_indexed').notNull().default(0),
+  unknown: integer('unknown').notNull().default(0),
+  createdAt: text('created_at').notNull(),
+}, (table) => [
+  uniqueIndex('idx_bing_coverage_snap_project_date').on(table.projectId, table.date),
+])
+
 export const bingConnections = sqliteTable('bing_connections', {
   id: text('id').primaryKey(),
   domain: text('domain').notNull(),


### PR DESCRIPTION
## Summary

- Adds a `bing_coverage_snapshots` table with a unique index on `(project_id, date)` to track daily Bing indexing coverage over time
- Saves a snapshot atomically (INSERT ON CONFLICT upsert) each time the existing coverage endpoint is called
- New API endpoint `GET /projects/:name/bing/coverage/history` and CLI command `canonry bing coverage-history` to retrieve historical snapshots
- Includes `BingCoverageSnapshotDto` contract, typed API client method, OpenAPI spec entry, and tests

## Test plan

- [x] Existing tests pass (902 tests)
- [x] New tests verify snapshot creation, descending date order, and limit parameter
- [x] Typecheck and lint pass