### PR TITLE
feat(db): migrate credentials from DB to config.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "1.45.0",
+  "version": "1.45.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "1.45.0",
+  "version": "1.45.1",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -3,7 +3,7 @@ import crypto from 'node:crypto'
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { eq } from 'drizzle-orm'
+import { eq, sql } from 'drizzle-orm'
 
 const _require = createRequire(import.meta.url)
 const { version: PKG_VERSION } = _require('../package.json') as { version: string }
@@ -150,6 +150,103 @@ function serializeSessionCookie(opts: {
   return parts.join('; ')
 }
 
+/**
+ * One-time migration: move Google OAuth tokens and GA4 service account keys
+ * from the DB (legacy storage) to config.yaml. The physical DB columns still
+ * exist but are no longer mapped by the Drizzle schema, so we use raw SQL.
+ * Skips any connection that already exists in config to avoid overwriting
+ * refreshed tokens.
+ */
+export function migrateDbCredentialsToConfig(db: DatabaseClient, config: CanonryConfig): void {
+  try {
+    // Migrate google_connections OAuth tokens
+    const googleColCheck = db.all(sql.raw(
+      `SELECT COUNT(*) as c FROM pragma_table_info('google_connections') WHERE name = 'access_token'`,
+    )) as Array<{ c: number }>
+    if (googleColCheck[0]?.c) {
+      const rows = db.all(sql.raw(
+        `SELECT domain, connection_type, property_id, sitemap_url, access_token, refresh_token, token_expires_at, scopes, created_at, updated_at FROM google_connections WHERE refresh_token IS NOT NULL AND refresh_token != ''`,
+      )) as Array<{
+        domain: string
+        connection_type: string
+        property_id: string | null
+        sitemap_url: string | null
+        access_token: string | null
+        refresh_token: string | null
+        token_expires_at: string | null
+        scopes: string
+        created_at: string
+        updated_at: string
+      }>
+      let migrated = 0
+      for (const row of rows) {
+        const connType = row.connection_type as 'gsc' | 'ga4'
+        const existing = getGoogleConnection(config, row.domain, connType)
+        if (existing?.refreshToken) continue
+        upsertGoogleConnection(config, {
+          domain: row.domain,
+          connectionType: connType,
+          propertyId: row.property_id ?? null,
+          sitemapUrl: row.sitemap_url ?? null,
+          accessToken: row.access_token ?? undefined,
+          refreshToken: row.refresh_token ?? null,
+          tokenExpiresAt: row.token_expires_at ?? null,
+          scopes: parseJsonColumn<string[]>(row.scopes, []),
+          createdAt: row.created_at,
+          updatedAt: row.updated_at,
+        })
+        migrated++
+      }
+      if (migrated > 0) {
+        saveConfigPatch({ google: config.google })
+        log.info('credentials.migrated', { type: 'google', count: migrated })
+      }
+    }
+
+    // Migrate ga_connections service account keys
+    const gaColCheck = db.all(sql.raw(
+      `SELECT COUNT(*) as c FROM pragma_table_info('ga_connections') WHERE name = 'private_key'`,
+    )) as Array<{ c: number }>
+    if (gaColCheck[0]?.c) {
+      const rows = db.all(sql.raw(
+        `SELECT id, project_id, property_id, client_email, private_key, created_at, updated_at FROM ga_connections WHERE private_key IS NOT NULL AND private_key != ''`,
+      )) as Array<{
+        id: string
+        project_id: string
+        property_id: string
+        client_email: string
+        private_key: string
+        created_at: string
+        updated_at: string
+      }>
+      // We need project names, not IDs — look them up
+      let migrated = 0
+      for (const row of rows) {
+        const project = db.select({ name: projects.name }).from(projects).where(eq(projects.id, row.project_id)).get()
+        if (!project) continue
+        const existing = getGa4Connection(config, project.name)
+        if (existing?.privateKey) continue
+        upsertGa4Connection(config, {
+          projectName: project.name,
+          propertyId: row.property_id,
+          clientEmail: row.client_email,
+          privateKey: row.private_key,
+          createdAt: row.created_at,
+          updatedAt: row.updated_at,
+        })
+        migrated++
+      }
+      if (migrated > 0) {
+        saveConfigPatch({ ga4: config.ga4 })
+        log.info('credentials.migrated', { type: 'ga4', count: migrated })
+      }
+    }
+  } catch {
+    // Migration is best-effort — if the columns don't exist or the query fails,
+    // the user can re-authenticate. Don't block server startup.
+  }
+}
+
 export async function createServer(opts: {
   config: CanonryConfig
   db: DatabaseClient
@@ -188,6 +285,9 @@ export async function createServer(opts: {
       quota: opts.config.geminiQuota,
     }
   }
+
+  // Migrate credentials from DB to config.yaml (one-time upgrade for pre-1.45.1 installs)
+  migrateDbCredentialsToConfig(opts.db, opts.config)
 
   log.info('providers.configured', { providers: Object.keys(providers).filter(k => {
     const p = providers[k]

--- a/packages/canonry/test/migrate-credentials.test.ts
+++ b/packages/canonry/test/migrate-credentials.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import os from 'node:os'
+import fs from 'node:fs'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import { sql } from 'drizzle-orm'
+import { createClient, migrate, projects } from '@ainyc/canonry-db'
+import { parse } from 'yaml'
+import type { CanonryConfig } from '../src/config.js'
+import { migrateDbCredentialsToConfig } from '../src/server.js'
+import { getGoogleConnection } from '../src/google-config.js'
+import { getGa4Connection } from '../src/ga4-config.js'
+
+function setupDb(tmpDir: string) {
+  const dbPath = path.join(tmpDir, 'canonry.db')
+  const db = createClient(dbPath)
+  migrate(db)
+  return db
+}
+
+function makeConfig(): CanonryConfig {
+  return {
+    apiUrl: 'http://localhost:4100',
+    database: '/tmp/canonry.db',
+    apiKey: 'cnry_test',
+  }
+}
+
+describe('migrateDbCredentialsToConfig', () => {
+  const dirs: string[] = []
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    for (const d of dirs) fs.rmSync(d, { recursive: true, force: true })
+    dirs.length = 0
+  })
+
+  function makeTmpDir() {
+    const d = path.join(os.tmpdir(), `canonry-migrate-creds-${crypto.randomUUID()}`)
+    fs.mkdirSync(d, { recursive: true })
+    dirs.push(d)
+    return d
+  }
+
+  it('migrates Google OAuth tokens from DB to config', () => {
+    const tmpDir = makeTmpDir()
+    vi.stubEnv('CANONRY_CONFIG_DIR', tmpDir)
+    const db = setupDb(tmpDir)
+    const config = makeConfig()
+
+    // Insert legacy credential data via raw SQL (columns exist in migration but not Drizzle schema)
+    db.run(sql.raw(`INSERT INTO google_connections (id, domain, connection_type, property_id, access_token, refresh_token, token_expires_at, scopes, created_at, updated_at) VALUES ('gc1', 'example.com', 'gsc', 'sc-domain:example.com', 'access-tok', 'refresh-tok', '2026-12-01T00:00:00Z', '["https://www.googleapis.com/auth/webmasters"]', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')`))
+
+    migrateDbCredentialsToConfig(db, config)
+
+    const conn = getGoogleConnection(config, 'example.com', 'gsc')
+    expect(conn).toBeDefined()
+    expect(conn?.refreshToken).toBe('refresh-tok')
+    expect(conn?.accessToken).toBe('access-tok')
+    expect(conn?.propertyId).toBe('sc-domain:example.com')
+    expect(conn?.tokenExpiresAt).toBe('2026-12-01T00:00:00Z')
+  })
+
+  it('migrates GA4 service account keys from DB to config', () => {
+    const tmpDir = makeTmpDir()
+    vi.stubEnv('CANONRY_CONFIG_DIR', tmpDir)
+    const db = setupDb(tmpDir)
+    const config = makeConfig()
+
+    // Create a project first (ga_connections references projects)
+    const now = new Date().toISOString()
+    db.insert(projects).values({
+      id: 'proj-1',
+      name: 'test-project',
+      displayName: 'Test Project',
+      canonicalDomain: 'example.com',
+      country: 'US',
+      language: 'en',
+      keywords: '[]',
+      competitors: '[]',
+      providers: '["gemini"]',
+      locations: '[]',
+      tags: '[]',
+      labels: '{}',
+      createdAt: now,
+      updatedAt: now,
+    }).run()
+
+    db.run(sql.raw(`INSERT INTO ga_connections (id, project_id, property_id, client_email, private_key, created_at, updated_at) VALUES ('ga1', 'proj-1', '123456789', 'sa@proj.iam.gserviceaccount.com', '-----BEGIN PRIVATE KEY-----\\nMIIE...\\n-----END PRIVATE KEY-----', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')`))
+
+    migrateDbCredentialsToConfig(db, config)
+
+    const conn = getGa4Connection(config, 'test-project')
+    expect(conn).toBeDefined()
+    expect(conn?.clientEmail).toBe('sa@proj.iam.gserviceaccount.com')
+    expect(conn?.privateKey).toContain('BEGIN PRIVATE KEY')
+    expect(conn?.propertyId).toBe('123456789')
+  })
+
+  it('skips migration when config already has credentials', () => {
+    const tmpDir = makeTmpDir()
+    vi.stubEnv('CANONRY_CONFIG_DIR', tmpDir)
+    const db = setupDb(tmpDir)
+    const config = makeConfig()
+
+    // Pre-populate config with existing connection
+    config.google = {
+      connections: [{
+        domain: 'example.com',
+        connectionType: 'gsc',
+        propertyId: 'sc-domain:example.com',
+        accessToken: 'newer-access',
+        refreshToken: 'newer-refresh',
+        tokenExpiresAt: '2027-01-01T00:00:00Z',
+        scopes: [],
+        createdAt: '2026-06-01T00:00:00Z',
+        updatedAt: '2026-06-01T00:00:00Z',
+      }],
+    }
+
+    // Insert older credentials in DB
+    db.run(sql.raw(`INSERT INTO google_connections (id, domain, connection_type, property_id, access_token, refresh_token, token_expires_at, scopes, created_at, updated_at) VALUES ('gc1', 'example.com', 'gsc', 'sc-domain:example.com', 'old-access', 'old-refresh', '2026-01-01T00:00:00Z', '[]', '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z')`))
+
+    migrateDbCredentialsToConfig(db, config)
+
+    const conn = getGoogleConnection(config, 'example.com', 'gsc')
+    expect(conn?.refreshToken).toBe('newer-refresh')
+    expect(conn?.accessToken).toBe('newer-access')
+  })
+
+  it('handles empty DB gracefully', () => {
+    const tmpDir = makeTmpDir()
+    vi.stubEnv('CANONRY_CONFIG_DIR', tmpDir)
+    const db = setupDb(tmpDir)
+    const config = makeConfig()
+
+    // Should not throw
+    migrateDbCredentialsToConfig(db, config)
+
+    expect(config.google).toBeUndefined()
+    expect(config.ga4).toBeUndefined()
+  })
+
+  it('does not clobber existing config.yaml content during migration', () => {
+    const tmpDir = makeTmpDir()
+    vi.stubEnv('CANONRY_CONFIG_DIR', tmpDir)
+    const db = setupDb(tmpDir)
+
+    // Write a config.yaml with existing content that should survive
+    const existingYaml = [
+      'apiUrl: http://localhost:4100',
+      'database: /tmp/canonry.db',
+      'apiKey: cnry_existing_key',
+      'providers:',
+      '  gemini:',
+      '    apiKey: gemini-key-123',
+      '    model: gemini-2.0-flash',
+      'bing:',
+      '  connections:',
+      '    - domain: example.com',
+      '      apiKey: bing-key-456',
+      '      createdAt: "2026-01-01T00:00:00Z"',
+      '      updatedAt: "2026-01-01T00:00:00Z"',
+      'google:',
+      '  clientId: google-client-id',
+      '  clientSecret: google-client-secret',
+      '',
+    ].join('\n')
+    fs.writeFileSync(path.join(tmpDir, 'config.yaml'), existingYaml)
+
+    // Load config with existing google auth settings
+    const config: CanonryConfig = {
+      apiUrl: 'http://localhost:4100',
+      database: '/tmp/canonry.db',
+      apiKey: 'cnry_existing_key',
+      providers: { gemini: { apiKey: 'gemini-key-123', model: 'gemini-2.0-flash' } },
+      bing: {
+        connections: [{
+          domain: 'example.com',
+          apiKey: 'bing-key-456',
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        }],
+      },
+      google: {
+        clientId: 'google-client-id',
+        clientSecret: 'google-client-secret',
+      },
+    }
+
+    // Insert legacy Google OAuth tokens in DB
+    db.run(sql.raw(`INSERT INTO google_connections (id, domain, connection_type, property_id, access_token, refresh_token, token_expires_at, scopes, created_at, updated_at) VALUES ('gc1', 'example.com', 'gsc', 'sc-domain:example.com', 'migrated-access', 'migrated-refresh', '2026-12-01T00:00:00Z', '[]', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')`))
+
+    migrateDbCredentialsToConfig(db, config)
+
+    // Verify migrated connection landed in config
+    const conn = getGoogleConnection(config, 'example.com', 'gsc')
+    expect(conn?.refreshToken).toBe('migrated-refresh')
+
+    // Verify existing config.yaml content was preserved on disk
+    const savedRaw = fs.readFileSync(path.join(tmpDir, 'config.yaml'), 'utf-8')
+    const saved = parse(savedRaw) as Record<string, unknown>
+
+    // Critical: these existing fields must survive the migration write
+    expect(saved.apiKey).toBe('cnry_existing_key')
+    expect(saved.apiUrl).toBe('http://localhost:4100')
+    expect((saved.providers as Record<string, Record<string, string>>)?.gemini?.apiKey).toBe('gemini-key-123')
+    expect((saved.bing as Record<string, unknown[]>)?.connections).toHaveLength(1)
+    // Google clientId/clientSecret must survive alongside the new connections
+    expect((saved.google as Record<string, unknown>)?.clientId).toBe('google-client-id')
+    expect((saved.google as Record<string, unknown>)?.clientSecret).toBe('google-client-secret')
+    expect(((saved.google as Record<string, unknown>)?.connections as unknown[])?.length).toBe(1)
+  })
+})

--- a/packages/db/AGENTS.md
+++ b/packages/db/AGENTS.md
@@ -18,7 +18,7 @@ Drizzle ORM schema, migrations, and database client. SQLite locally (via better-
 
 - **Core domain**: projects, keywords, competitors, runs, querySnapshots, auditLog
 - **Scheduling**: schedules, notifications, webhooks
-- **Integrations**: googleConnections, gscData, urlInspections, gscCoverage, gscTraffic, bingConnections, bingUrlInspections, bingKeywordStats, ga4Connections, ga4TrafficSnapshots, ga4AiReferrals, ga4Summaries, gaSocialReferrals
+- **Integrations**: googleConnections (metadata only — credentials in config.yaml), gscData, urlInspections, gscCoverage, gscTraffic, bingConnections, bingUrlInspections, bingKeywordStats, ga4Connections (metadata only — credentials in config.yaml), ga4TrafficSnapshots, ga4AiReferrals, ga4Summaries, gaSocialReferrals
 - **System**: apiKeys, usageCounters
 
 ## Patterns

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -402,6 +402,11 @@ const MIGRATIONS = [
     created_at      TEXT NOT NULL
   )`,
   `CREATE UNIQUE INDEX IF NOT EXISTS idx_bing_coverage_snap_project_date ON bing_coverage_snapshots(project_id, date)`,
+
+  // v27: Credential columns removed from Drizzle schema — credentials now live in config.yaml.
+  // Physical columns (access_token, refresh_token, token_expires_at on google_connections;
+  // private_key on ga_connections) intentionally retained in DB for one-time migration in server.ts.
+  // SQLite does not support DROP COLUMN; no SQL to execute.
 ]
 
 /**

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -141,10 +141,6 @@ export const googleConnections = sqliteTable('google_connections', {
   connectionType: text('connection_type').notNull(),
   propertyId: text('property_id'),
   sitemapUrl: text('sitemap_url'),
-  // WARNING: Authentication material should be stored in config.yaml per CLAUDE.md
-  accessToken: text('access_token'),
-  refreshToken: text('refresh_token'),
-  tokenExpiresAt: text('token_expires_at'),
   scopes: text('scopes').notNull().default('[]'),
   createdAt: text('created_at').notNull(),
   updatedAt: text('updated_at').notNull(),
@@ -269,8 +265,6 @@ export const gaConnections = sqliteTable('ga_connections', {
   projectId: text('project_id').notNull().references(() => projects.id, { onDelete: 'cascade' }),
   propertyId: text('property_id').notNull(),
   clientEmail: text('client_email').notNull(),
-  // WARNING: Authentication material should be stored in config.yaml per CLAUDE.md
-  privateKey: text('private_key').notNull(),
   createdAt: text('created_at').notNull(),
   updatedAt: text('updated_at').notNull(),
 }, (table) => [


### PR DESCRIPTION
## Summary

- Adds a one-time startup migration (`migrateDbCredentialsToConfig`) that moves Google OAuth tokens and GA4 service account keys from the SQLite database to `config.yaml`, enforcing the authentication storage rule.
- Removes credential columns (`accessToken`, `refreshToken`, `tokenExpiresAt`, `privateKey`) from the Drizzle schema while retaining physical DB columns for the migration to read via raw SQL.
- Documents the column removal as a no-op comment (v27) in `migrate.ts` and updates `packages/db/AGENTS.md`.
- Includes 5 test cases covering both connection types, skip-when-existing, empty DB, and preservation of unrelated config content.
- Bumps version to 1.45.1.