### PR TITLE
chore(core-cli): standardize usage messages and fix async execution

### DIFF
--- a/packages/canonry/src/cli-commands/keyword.ts
+++ b/packages/canonry/src/cli-commands/keyword.ts
@@ -68,9 +68,9 @@ export const KEYWORD_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['keyword', 'list'],
-    usage: 'canonry keyword list <project>',
+    usage: 'canonry keyword list <project> [--format json]',
     run: async (input) => {
-      const project = requireProject(input, 'keyword.list', 'canonry keyword list <project>')
+      const project = requireProject(input, 'keyword.list', 'canonry keyword list <project> [--format json]')
       await listKeywords(project, input.format)
     },
   },

--- a/packages/canonry/src/cli-commands/notify.ts
+++ b/packages/canonry/src/cli-commands/notify.ts
@@ -5,9 +5,9 @@ import { requirePositional, requireProject, requireStringOption, stringOption, u
 export const NOTIFY_CLI_COMMANDS: readonly CliCommandSpec[] = [
   {
     path: ['notify', 'events'],
-    usage: 'canonry notify events',
+    usage: 'canonry notify events [--format json]',
     run: async (input) => {
-      listEvents(input.format)
+      await listEvents(input.format)
     },
   },
   {
@@ -38,20 +38,20 @@ export const NOTIFY_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['notify', 'list'],
-    usage: 'canonry notify list <project>',
+    usage: 'canonry notify list <project> [--format json]',
     run: async (input) => {
-      const project = requireProject(input, 'notify.list', 'canonry notify list <project>')
+      const project = requireProject(input, 'notify.list', 'canonry notify list <project> [--format json]')
       await listNotifications(project, input.format)
     },
   },
   {
     path: ['notify', 'remove'],
-    usage: 'canonry notify remove <project> <id>',
+    usage: 'canonry notify remove <project> <id> [--format json]',
     run: async (input) => {
-      const project = requireProject(input, 'notify.remove', 'canonry notify remove <project> <id>')
+      const project = requireProject(input, 'notify.remove', 'canonry notify remove <project> <id> [--format json]')
       const id = requirePositional(input, 1, {
         command: 'notify.remove',
-        usage: 'canonry notify remove <project> <id>',
+        usage: 'canonry notify remove <project> <id> [--format json]',
         message: 'notification ID is required',
       })
       await removeNotification(project, id, input.format)
@@ -59,12 +59,12 @@ export const NOTIFY_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['notify', 'test'],
-    usage: 'canonry notify test <project> <id>',
+    usage: 'canonry notify test <project> <id> [--format json]',
     run: async (input) => {
-      const project = requireProject(input, 'notify.test', 'canonry notify test <project> <id>')
+      const project = requireProject(input, 'notify.test', 'canonry notify test <project> <id> [--format json]')
       const id = requirePositional(input, 1, {
         command: 'notify.test',
-        usage: 'canonry notify test <project> <id>',
+        usage: 'canonry notify test <project> <id> [--format json]',
         message: 'notification ID is required',
       })
       await testNotification(project, id, input.format)

--- a/packages/canonry/src/cli-commands/run.ts
+++ b/packages/canonry/src/cli-commands/run.ts
@@ -6,11 +6,11 @@ import { usageError } from '../cli-error.js'
 export const RUN_CLI_COMMANDS: readonly CliCommandSpec[] = [
   {
     path: ['run', 'show'],
-    usage: 'canonry run show <id>',
+    usage: 'canonry run show <id> [--format json]',
     run: async (input) => {
       const id = requirePositional(input, 0, {
         command: 'run.show',
-        usage: 'canonry run show <id>',
+        usage: 'canonry run show <id> [--format json]',
         message: 'run ID is required',
       })
       await showRun(id, input.format)
@@ -18,9 +18,9 @@ export const RUN_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['run', 'cancel'],
-    usage: 'canonry run cancel <project> [run-id]',
+    usage: 'canonry run cancel <project> [run-id] [--format json]',
     run: async (input) => {
-      const project = requireProject(input, 'run.cancel', 'canonry run cancel <project> [run-id]')
+      const project = requireProject(input, 'run.cancel', 'canonry run cancel <project> [run-id] [--format json]')
       await cancelRun(project, input.positionals[1], input.format)
     },
   },

--- a/packages/canonry/src/cli-commands/schedule.ts
+++ b/packages/canonry/src/cli-commands/schedule.ts
@@ -40,33 +40,33 @@ export const SCHEDULE_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['schedule', 'show'],
-    usage: 'canonry schedule show <project>',
+    usage: 'canonry schedule show <project> [--format json]',
     run: async (input) => {
-      const project = requireProject(input, 'schedule.show', 'canonry schedule show <project>')
+      const project = requireProject(input, 'schedule.show', 'canonry schedule show <project> [--format json]')
       await showSchedule(project, input.format)
     },
   },
   {
     path: ['schedule', 'enable'],
-    usage: 'canonry schedule enable <project>',
+    usage: 'canonry schedule enable <project> [--format json]',
     run: async (input) => {
-      const project = requireProject(input, 'schedule.enable', 'canonry schedule enable <project>')
+      const project = requireProject(input, 'schedule.enable', 'canonry schedule enable <project> [--format json]')
       await enableSchedule(project, input.format)
     },
   },
   {
     path: ['schedule', 'disable'],
-    usage: 'canonry schedule disable <project>',
+    usage: 'canonry schedule disable <project> [--format json]',
     run: async (input) => {
-      const project = requireProject(input, 'schedule.disable', 'canonry schedule disable <project>')
+      const project = requireProject(input, 'schedule.disable', 'canonry schedule disable <project> [--format json]')
       await disableSchedule(project, input.format)
     },
   },
   {
     path: ['schedule', 'remove'],
-    usage: 'canonry schedule remove <project>',
+    usage: 'canonry schedule remove <project> [--format json]',
     run: async (input) => {
-      const project = requireProject(input, 'schedule.remove', 'canonry schedule remove <project>')
+      const project = requireProject(input, 'schedule.remove', 'canonry schedule remove <project> [--format json]')
       await removeSchedule(project, input.format)
     },
   },

--- a/packages/canonry/src/cli-commands/system.ts
+++ b/packages/canonry/src/cli-commands/system.ts
@@ -102,7 +102,7 @@ export const SYSTEM_CLI_COMMANDS: readonly CliCommandSpec[] = [
     usage: 'canonry stop [--format json]',
     allowPositionals: false,
     run: async (input) => {
-      stopDaemon(input.format)
+      await stopDaemon(input.format)
     },
   },
   {
@@ -110,7 +110,7 @@ export const SYSTEM_CLI_COMMANDS: readonly CliCommandSpec[] = [
     usage: 'canonry telemetry status [--format json]',
     allowPositionals: false,
     run: async (input) => {
-      telemetryCommand('status', input.format)
+      await telemetryCommand('status', input.format)
     },
   },
   {
@@ -118,7 +118,7 @@ export const SYSTEM_CLI_COMMANDS: readonly CliCommandSpec[] = [
     usage: 'canonry telemetry enable [--format json]',
     allowPositionals: false,
     run: async (input) => {
-      telemetryCommand('enable', input.format)
+      await telemetryCommand('enable', input.format)
     },
   },
   {
@@ -126,14 +126,14 @@ export const SYSTEM_CLI_COMMANDS: readonly CliCommandSpec[] = [
     usage: 'canonry telemetry disable [--format json]',
     allowPositionals: false,
     run: async (input) => {
-      telemetryCommand('disable', input.format)
+      await telemetryCommand('disable', input.format)
     },
   },
   {
     path: ['telemetry'],
     usage: 'canonry telemetry <status|enable|disable> [--format json]',
     run: async (input) => {
-      unknownSubcommand(input.positionals[0], {
+      await unknownSubcommand(input.positionals[0], {
         command: 'telemetry',
         usage: 'canonry telemetry <status|enable|disable> [--format json]',
         available: ['status', 'enable', 'disable'],

--- a/packages/canonry/test/cli-run-contract.test.ts
+++ b/packages/canonry/test/cli-run-contract.test.ts
@@ -120,7 +120,7 @@ describe('run lifecycle CLI contract', () => {
     expect(parsed.error.code).toBe('CLI_USAGE_ERROR')
     expect(parsed.error.message).toBe('project name is required')
     expect(parsed.error.details.command).toBe('run.cancel')
-    expect(parsed.error.details.usage).toBe('canonry run cancel <project> [run-id]')
+    expect(parsed.error.details.usage).toBe('canonry run cancel <project> [run-id] [--format json]')
   })
 
   it('prints a JSON error envelope when run cancel has no active run', async () => {


### PR DESCRIPTION
This PR addresses several minor issues found during a core CLI audit:

- **Usage Consistency**: Added `[--format json]` to usage strings for commands that already support the flag but did not list it in their help text.
- **Async Safety**: Ensured several CLI commands (`notify events`, `telemetry status/enable/disable`, `stop`) are properly awaited in the dispatcher.
- **Contract Testing**: Updated `cli-run-contract.test.ts` to match the new standardized usage strings.

Validated via `pnpm typecheck`, `pnpm lint`, and `pnpm test`.