### PR TITLE
fix(web): improve health check failure feedback

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -15,6 +15,7 @@ import {
 
 import { formatErrorLog } from './lib/format-helpers.js'
 import { fetchAllRuns, fetchProjects, type ApiProject, type ApiRun } from './api.js'
+import { serviceStatusTooltip } from './lib/health-helpers.js'
 import { addToast, type ToastTone } from './lib/toast-store.js'
 import {
   getRunTrackerState,
@@ -424,10 +425,16 @@ export function RootLayout() {
 
           <div className="topbar-actions">
             <div className="health-pill-row">
-              <span className={`health-pill health-pill-${healthSnapshot.apiStatus.state}`}>
+              <span
+                className={`health-pill health-pill-${healthSnapshot.apiStatus.state}`}
+                title={serviceStatusTooltip(healthSnapshot.apiStatus)}
+              >
                 API {healthSnapshot.apiStatus.state === 'ok' ? 'ok' : healthSnapshot.apiStatus.state}
               </span>
-              <span className={`health-pill health-pill-${healthSnapshot.workerStatus.state}`}>
+              <span
+                className={`health-pill health-pill-${healthSnapshot.workerStatus.state}`}
+                title={serviceStatusTooltip(healthSnapshot.workerStatus)}
+              >
                 Worker {healthSnapshot.workerStatus.state === 'ok' ? 'ok' : healthSnapshot.workerStatus.state}
               </span>
             </div>

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -42,6 +42,24 @@ function getApiBase(): string {
 
 const API_BASE = getApiBase()
 
+function getPublicBase(): string {
+  if (typeof window !== 'undefined' && window.__CANONRY_CONFIG__?.basePath) {
+    return window.__CANONRY_CONFIG__.basePath.replace(/\/$/, '')
+  }
+  return ''
+}
+
+function publicPath(path: string): string {
+  return `${getPublicBase()}${path}`
+}
+
+function healthFailureHint(path: string, statusCode: number): string | undefined {
+  if (path === '/health' && statusCode === 404) {
+    return 'Health endpoint returned 404. Check basePath or reverse-proxy configuration and make sure the dashboard reaches /health instead of an API-prefixed route.'
+  }
+  return undefined
+}
+
 function getApiKey(): string {
   return import.meta.env.VITE_API_KEY ?? ''
 }
@@ -441,7 +459,11 @@ export function loginWithApiKey(apiKey: string): Promise<ApiSessionState> {
 }
 
 export async function fetchHealthCheck(): Promise<{ status: string }> {
-  return apiFetch('/health')
+  const res = await fetch(publicPath('/health'), { credentials: 'same-origin' })
+  if (!res.ok) {
+    throw new Error(`Health check failed: ${res.status} ${res.statusText}`)
+  }
+  return res.json() as Promise<{ status: string }>
 }
 
 export function updateProviderConfig(provider: string, body: {
@@ -1051,8 +1073,21 @@ export function fetchLatestHealth(project: string): Promise<HealthSnapshotDto> {
 import type { ServiceStatus } from './view-models.js'
 
 export async function fetchServiceStatus(path: string, label: string): Promise<ServiceStatus> {
+  const requestPath = publicPath(path)
+
   try {
-    const payload = await apiFetch<Record<string, unknown>>(path)
+    const res = await fetch(requestPath, { credentials: 'same-origin' })
+    if (!res.ok) {
+      return {
+        label,
+        state: 'error',
+        detail: `${label} ${res.status}: ${res.statusText}`,
+        statusCode: res.status,
+        hint: healthFailureHint(path, res.status),
+      }
+    }
+
+    const payload = await res.json() as Record<string, unknown>
     const version = typeof payload.version === 'string' ? payload.version : 'unknown'
     const databaseConfigured =
       typeof payload.databaseUrlConfigured === 'boolean' ? payload.databaseUrlConfigured : undefined
@@ -1078,6 +1113,9 @@ export async function fetchServiceStatus(path: string, label: string): Promise<S
       label,
       state: 'error',
       detail: error instanceof Error ? error.message : 'unreachable',
+      hint: path === '/health'
+        ? `Request failed while checking ${requestPath}. If this instance is served behind a sub-path, verify the dashboard basePath and reverse-proxy rewrites.`
+        : undefined,
     }
   }
 }

--- a/apps/web/src/components/shared/ToneBadge.tsx
+++ b/apps/web/src/components/shared/ToneBadge.tsx
@@ -1,10 +1,16 @@
 import type { ReactNode } from 'react'
 import type { MetricTone } from '../../view-models.js'
+import type { BadgeProps } from '../ui/badge.js'
 import { Badge } from '../ui/badge.js'
 
-export function ToneBadge({ tone, children }: { tone: MetricTone; children: ReactNode }) {
+type ToneBadgeProps = Omit<BadgeProps, 'variant'> & {
+  tone: MetricTone
+  children: ReactNode
+}
+
+export function ToneBadge({ tone, children, ...props }: ToneBadgeProps) {
   const variant =
     tone === 'positive' ? 'success' : tone === 'caution' ? 'warning' : tone === 'negative' ? 'destructive' : 'neutral'
 
-  return <Badge variant={variant}>{children}</Badge>
+  return <Badge variant={variant} {...props}>{children}</Badge>
 }

--- a/apps/web/src/lib/health-helpers.ts
+++ b/apps/web/src/lib/health-helpers.ts
@@ -1,9 +1,14 @@
-import type { HealthSnapshot, MetricTone, SettingsVm, SetupWizardVm, SystemHealthCardVm } from '../view-models.js'
+import type { HealthSnapshot, MetricTone, ServiceStatus, SettingsVm, SetupWizardVm, SystemHealthCardVm } from '../view-models.js'
 import { toneFromService } from './tone-helpers.js'
 
 /** Display name comes from the API (adapter.displayName). Capitalize as fallback. */
 function providerDisplayName(p: { name: string; displayName?: string }): string {
   return p.displayName ?? p.name.charAt(0).toUpperCase() + p.name.slice(1)
+}
+
+export function serviceStatusTooltip(status: ServiceStatus): string | undefined {
+  const parts = [status.detail, status.hint].filter(Boolean)
+  return parts.length > 0 ? parts.join('\n') : undefined
 }
 
 export function buildSystemHealthCards(

--- a/apps/web/src/pages/OverviewPage.tsx
+++ b/apps/web/src/pages/OverviewPage.tsx
@@ -8,7 +8,7 @@ import { StatusBadge } from '../components/shared/StatusBadge.js'
 import { ToneBadge } from '../components/shared/ToneBadge.js'
 import { toneFromRunStatus } from '../lib/tone-helpers.js'
 import { toTitleCase } from '../lib/format-helpers.js'
-import { buildSystemHealthCards } from '../lib/health-helpers.js'
+import { buildSystemHealthCards, serviceStatusTooltip } from '../lib/health-helpers.js'
 import { useDashboard } from '../queries/use-dashboard.js'
 import { useHealth } from '../queries/use-health.js'
 import { useDrawer } from '../hooks/use-drawer.js'
@@ -195,7 +195,18 @@ export function OverviewPage() {
                   <p className="eyebrow eyebrow-soft">{item.label}</p>
                   <h3>{item.detail}</h3>
                 </div>
-                <ToneBadge tone={item.tone}>{item.label}</ToneBadge>
+                <ToneBadge
+                  tone={item.tone}
+                  title={
+                    item.id === 'api'
+                      ? serviceStatusTooltip(healthSnapshot.apiStatus)
+                      : item.id === 'worker'
+                        ? serviceStatusTooltip(healthSnapshot.workerStatus)
+                        : undefined
+                  }
+                >
+                  {item.label}
+                </ToneBadge>
               </div>
               <p className="supporting-copy">{item.meta}</p>
             </Card>

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -7,6 +7,7 @@ import { ProviderConfigForm } from '../components/settings/ProviderConfigForm.js
 import { GoogleOAuthConfigForm } from '../components/settings/GoogleOAuthConfigForm.js'
 import { updateBingApiKey } from '../api.js'
 import { CdpConfigCard } from '../components/settings/CdpConfigCard.js'
+import { serviceStatusTooltip } from '../lib/health-helpers.js'
 import { toneFromService } from '../lib/tone-helpers.js'
 import { addToast } from '../lib/toast-store.js'
 import { useDashboard } from '../queries/use-dashboard.js'
@@ -243,7 +244,7 @@ export function SettingsPage() {
                 <p className="run-row-title">API</p>
                 <p className="supporting-copy">{healthSnapshot.apiStatus.detail}</p>
               </div>
-              <ToneBadge tone={toneFromService(healthSnapshot.apiStatus)}>
+              <ToneBadge tone={toneFromService(healthSnapshot.apiStatus)} title={serviceStatusTooltip(healthSnapshot.apiStatus)}>
                 {healthSnapshot.apiStatus.state === 'ok' ? 'Healthy' : 'Attention'}
               </ToneBadge>
             </div>
@@ -252,7 +253,7 @@ export function SettingsPage() {
                 <p className="run-row-title">Worker</p>
                 <p className="supporting-copy">{healthSnapshot.workerStatus.detail}</p>
               </div>
-              <ToneBadge tone={toneFromService(healthSnapshot.workerStatus)}>
+              <ToneBadge tone={toneFromService(healthSnapshot.workerStatus)} title={serviceStatusTooltip(healthSnapshot.workerStatus)}>
                 {healthSnapshot.workerStatus.state === 'ok' ? 'Healthy' : 'Attention'}
               </ToneBadge>
             </div>

--- a/apps/web/src/pages/SetupPage.tsx
+++ b/apps/web/src/pages/SetupPage.tsx
@@ -16,7 +16,7 @@ import { useTriggerRun } from '../queries/mutations.js'
 import { useDashboard } from '../queries/use-dashboard.js'
 import { useHealth } from '../queries/use-health.js'
 import { useInitialDashboard } from '../contexts/dashboard-context.js'
-import { buildSetupModel } from '../lib/health-helpers.js'
+import { buildSetupModel, serviceStatusTooltip } from '../lib/health-helpers.js'
 
 const SETUP_STEPS = [
   { label: 'System check', description: 'Verify your instance is ready' },
@@ -251,7 +251,16 @@ export function SetupPage() {
                       </Link>
                     )}
                   </div>
-                  <ToneBadge tone={check.state === 'ready' ? 'positive' : 'caution'}>
+                  <ToneBadge
+                    tone={check.state === 'ready' ? 'positive' : 'caution'}
+                    title={
+                      check.id === 'api'
+                        ? serviceStatusTooltip(healthSnapshot.apiStatus)
+                        : check.id === 'worker'
+                          ? serviceStatusTooltip(healthSnapshot.workerStatus)
+                          : check.detail
+                    }
+                  >
                     {check.state === 'ready' ? 'Ready' : 'Attention'}
                   </ToneBadge>
                 </div>

--- a/apps/web/src/queries/use-health.ts
+++ b/apps/web/src/queries/use-health.ts
@@ -1,14 +1,21 @@
 import { useQuery } from '@tanstack/react-query'
 import { fetchServiceStatus } from '../api.js'
-import { _BASE_PREFIX } from '../lib/base-path.js'
 import type { HealthSnapshot, ServiceStatus } from '../view-models.js'
 import { queryKeys } from './query-keys.js'
 
 async function fetchHealth(): Promise<HealthSnapshot> {
   const apiStatus = await fetchServiceStatus('/health', 'API')
   const workerStatus: ServiceStatus = apiStatus.state === 'ok'
-    ? { label: 'Runner', state: 'ok', detail: 'In-process job runner' }
-    : { label: 'Runner', state: apiStatus.state, detail: 'Depends on API' }
+    ? { label: 'Worker', state: 'ok', detail: 'In-process job runner' }
+    : {
+        label: 'Worker',
+        state: apiStatus.state,
+        detail: `Depends on API health check · ${apiStatus.detail}`,
+        statusCode: apiStatus.statusCode,
+        hint: apiStatus.hint
+          ? `Worker status is inferred from API health in this deployment mode. ${apiStatus.hint}`
+          : 'Worker status is inferred from API health in this deployment mode.',
+      }
 
   return { apiStatus, workerStatus }
 }

--- a/apps/web/src/view-models.ts
+++ b/apps/web/src/view-models.ts
@@ -12,6 +12,8 @@ export interface ServiceStatus {
   version?: string
   databaseConfigured?: boolean
   lastHeartbeatAt?: string
+  statusCode?: number
+  hint?: string
 }
 
 export interface HealthSnapshot {

--- a/apps/web/test/app.test.tsx
+++ b/apps/web/test/app.test.tsx
@@ -1,20 +1,28 @@
-import { test, expect, onTestFinished } from 'vitest'
+import { test, expect, onTestFinished, vi } from 'vitest'
 
 import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { RouterProvider } from '@tanstack/react-router'
 
-import { fetchServiceStatus } from '../src/api.js'
+import { fetchHealthCheck, fetchServiceStatus } from '../src/api.js'
 import { createDashboardFixture } from '../src/mock-data.js'
 import { createAppRouter } from '../src/router/router.js'
 import { DashboardProvider } from '../src/contexts/dashboard-context.js'
 
+type TestWindowConfig = {
+  __CANONRY_CONFIG__?: {
+    basePath?: string
+  }
+}
+
 async function renderApp(
   pathname: string,
   options: Parameters<typeof createDashboardFixture>[0] = {},
+  mutateFixture?: (fixture: ReturnType<typeof createDashboardFixture>) => void,
 ): Promise<string> {
   const fixture = createDashboardFixture(options)
+  mutateFixture?.(fixture)
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   })
@@ -147,7 +155,7 @@ test('project search console route renders the Search Engine Intelligence sectio
 
 test('fetchServiceStatus reports ok details from a health payload', async () => {
   const realFetch = globalThis.fetch
-  globalThis.fetch = (async () =>
+  const fetchMock = vi.fn(async () =>
     new Response(
       JSON.stringify({
         version: 'phase-1',
@@ -160,7 +168,8 @@ test('fetchServiceStatus reports ok details from a health payload', async () => 
           'content-type': 'application/json',
         },
       },
-    )) as typeof fetch
+    ))
+  globalThis.fetch = fetchMock as unknown as typeof fetch
 
   onTestFinished(() => {
     globalThis.fetch = realFetch
@@ -176,6 +185,7 @@ test('fetchServiceStatus reports ok details from a health payload', async () => 
     databaseConfigured: true,
     lastHeartbeatAt: '2026-03-09T00:00:00.000Z',
   })
+  expect(fetchMock).toHaveBeenCalledWith('/worker-health', { credentials: 'same-origin' })
 })
 
 test('fetchServiceStatus reports transport failures', async () => {
@@ -195,4 +205,103 @@ test('fetchServiceStatus reports transport failures', async () => {
     state: 'error',
     detail: 'connection refused',
   })
+})
+
+test('fetchServiceStatus respects basePath for public health endpoints', async () => {
+  const realFetch = globalThis.fetch
+  const originalWindow = (globalThis as typeof globalThis & { window?: TestWindowConfig }).window
+  const fetchMock = vi.fn(async () =>
+    new Response(
+      JSON.stringify({
+        version: 'phase-1',
+        databaseUrlConfigured: true,
+      }),
+      {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      },
+    ))
+  globalThis.fetch = fetchMock as unknown as typeof fetch
+  ;(globalThis as typeof globalThis & { window?: TestWindowConfig }).window = { __CANONRY_CONFIG__: { basePath: '/canonry/' } }
+
+  onTestFinished(() => {
+    globalThis.fetch = realFetch
+    ;(globalThis as typeof globalThis & { window?: TestWindowConfig }).window = originalWindow
+  })
+
+  await fetchServiceStatus('/health', 'API')
+
+  expect(fetchMock).toHaveBeenCalledWith('/canonry/health', { credentials: 'same-origin' })
+})
+
+test('fetchServiceStatus adds troubleshooting hint for 404 health responses', async () => {
+  const realFetch = globalThis.fetch
+  const fetchMock = vi.fn(async () =>
+    new Response(null, {
+      status: 404,
+      statusText: 'Not Found',
+    }))
+  globalThis.fetch = fetchMock as unknown as typeof fetch
+
+  onTestFinished(() => {
+    globalThis.fetch = realFetch
+  })
+
+  await expect(fetchServiceStatus('/health', 'API')).resolves.toMatchObject({
+    label: 'API',
+    state: 'error',
+    detail: 'API 404: Not Found',
+    statusCode: 404,
+    hint: expect.stringMatching(/basePath|reverse-proxy|API-prefixed route/i),
+  })
+})
+
+test('fetchHealthCheck uses the public health endpoint', async () => {
+  const realFetch = globalThis.fetch
+  const originalWindow = (globalThis as typeof globalThis & { window?: TestWindowConfig }).window
+  const fetchMock = vi.fn(async () =>
+    new Response(
+      JSON.stringify({ status: 'ok' }),
+      {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      },
+    ))
+  globalThis.fetch = fetchMock as unknown as typeof fetch
+  ;(globalThis as typeof globalThis & { window?: TestWindowConfig }).window = { __CANONRY_CONFIG__: { basePath: '/canonry/' } }
+
+  onTestFinished(() => {
+    globalThis.fetch = realFetch
+    ;(globalThis as typeof globalThis & { window?: TestWindowConfig }).window = originalWindow
+  })
+
+  await expect(fetchHealthCheck()).resolves.toEqual({ status: 'ok' })
+  expect(fetchMock).toHaveBeenCalledWith('/canonry/health', { credentials: 'same-origin' })
+})
+
+test('settings route exposes health failure details on the badge tooltip', async () => {
+  const html = await renderApp('/settings', {}, (fixture) => {
+    fixture.health.apiStatus = {
+      label: 'API',
+      state: 'error',
+      detail: 'API 404: Not Found',
+      statusCode: 404,
+      hint: 'Health endpoint returned 404. Check basePath configuration.',
+    }
+    fixture.health.workerStatus = {
+      label: 'Worker',
+      state: 'error',
+      detail: 'Depends on API health check · API 404: Not Found',
+      statusCode: 404,
+      hint: 'Worker status is inferred from API health in this deployment mode. Check basePath configuration.',
+    }
+  })
+
+  expect(html).toMatch(/title="API 404: Not Found/)
+  expect(html).toMatch(/Check basePath configuration/)
+  expect(html).toMatch(/Depends on API health check · API 404: Not Found/)
 })

--- a/apps/web/test/health-helpers.test.ts
+++ b/apps/web/test/health-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getLaunchBlockedReason, buildSetupModel } from '../src/lib/health-helpers.js'
+import { getLaunchBlockedReason, buildSetupModel, serviceStatusTooltip } from '../src/lib/health-helpers.js'
 import type { HealthSnapshot, SettingsVm, SetupWizardVm } from '../src/view-models.js'
 
 function makeHealth(overrides?: Partial<HealthSnapshot>): HealthSnapshot {
@@ -47,6 +47,17 @@ describe('getLaunchBlockedReason', () => {
       providerStatuses: [{ name: 'gemini', state: 'not-configured', detail: '' }],
     })
     expect(getLaunchBlockedReason(makeHealth(), settings)).toContain('provider')
+  })
+})
+
+describe('serviceStatusTooltip', () => {
+  it('combines detail and troubleshooting hint for failed checks', () => {
+    expect(serviceStatusTooltip({
+      label: 'API',
+      state: 'error',
+      detail: 'API 404: Not Found',
+      hint: 'Check basePath configuration.',
+    })).toBe('API 404: Not Found\nCheck basePath configuration.')
   })
 })
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "1.45.2",
+  "version": "1.45.3",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "1.45.2",
+  "version": "1.45.3",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Summary
Fixes the dashboard health UX regression described in #300.

## What changed
- routes browser health checks to the public `/<basePath>/health` endpoint instead of the API-prefixed path
- preserves HTTP status codes and adds a targeted base-path troubleshooting hint for `404` health responses
- carries the underlying API failure detail into the derived worker status instead of collapsing it to a generic `Depends on API`
- exposes the detailed health failure text on hover for the topbar pills and service health badges in setup, overview, and settings
- adds regression coverage for the public health path, `404` troubleshooting hint, and badge tooltip rendering
- bumps the package versions to `1.45.3`

## Root cause
The web client was probing `/api/v1/health`, but the app serves health at `/health` (or `/<basePath>/health`). In deployed environments that mismatch produced false red API/Worker indicators even though the instance was healthy.

## Validation
- `pnpm --filter @ainyc/canonry-web test -- --run apps/web/test/app.test.tsx apps/web/test/health-helpers.test.ts`
- `pnpm --filter @ainyc/canonry-web typecheck`
- `pnpm --filter @ainyc/canonry-web lint`
- `pnpm --filter @ainyc/canonry-web build`
- `pnpm run lint`

## Notes
- `pnpm run typecheck` still fails on the pre-existing local workspace issue in `packages/canonry/src/intelligence-service.ts` resolving `@ainyc/canonry-intelligence`; this is unrelated to this PR.

Closes #300