### PR TITLE
feat(web,api,cli): add period selector pills to Traffic and GSC sections

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -672,11 +672,12 @@ export function triggerGscSync(project: string, opts?: { days?: number; full?: b
 
 export function fetchGscPerformance(
   project: string,
-  params?: { startDate?: string; endDate?: string; query?: string; page?: string; limit?: number },
+  params?: { startDate?: string; endDate?: string; query?: string; page?: string; limit?: number; window?: MetricsWindow },
 ): Promise<ApiGscPerformanceRow[]> {
   const qs = new URLSearchParams()
   if (params?.startDate) qs.set('startDate', params.startDate)
   if (params?.endDate) qs.set('endDate', params.endDate)
+  if (params?.window && params.window !== 'all' && !params.startDate) qs.set('window', params.window)
   if (params?.query) qs.set('query', params.query)
   if (params?.page) qs.set('page', params.page)
   if (params?.limit !== undefined) qs.set('limit', String(params.limit))
@@ -1002,6 +1003,10 @@ export interface ApiGaTraffic {
   /** Social sessions as a percentage of total sessions (0–100, rounded). */
   socialSharePct: number
   lastSyncedAt: string | null
+  /** Start of the synced date range (YYYY-MM-DD), null if no data. */
+  periodStart: string | null
+  /** End of the synced date range (YYYY-MM-DD), null if no data. */
+  periodEnd: string | null
 }
 
 export interface ApiGaSyncResult {
@@ -1017,8 +1022,11 @@ export function fetchGaStatus(project: string): Promise<ApiGaStatus> {
   return apiFetch(`/projects/${encodeURIComponent(project)}/ga/status`)
 }
 
-export function fetchGaTraffic(project: string, limit?: number): Promise<ApiGaTraffic> {
-  const qs = limit ? `?limit=${limit}` : ''
+export function fetchGaTraffic(project: string, limit?: number, window?: MetricsWindow): Promise<ApiGaTraffic> {
+  const params = new URLSearchParams()
+  if (limit) params.set('limit', String(limit))
+  if (window && window !== 'all') params.set('window', window)
+  const qs = params.toString() ? `?${params}` : ''
   return apiFetch(`/projects/${encodeURIComponent(project)}/ga/traffic${qs}`)
 }
 
@@ -1038,16 +1046,19 @@ export function connectGa(project: string, body: { propertyId: string; keyJson: 
 
 export type { GA4AiReferralHistoryEntry, GA4SessionHistoryEntry, GA4SocialReferralHistoryEntry }
 
-export function fetchGaAiReferralHistory(project: string): Promise<GA4AiReferralHistoryEntry[]> {
-  return apiFetch(`/projects/${encodeURIComponent(project)}/ga/ai-referral-history`)
+export function fetchGaAiReferralHistory(project: string, window?: MetricsWindow): Promise<GA4AiReferralHistoryEntry[]> {
+  const qs = window && window !== 'all' ? `?window=${window}` : ''
+  return apiFetch(`/projects/${encodeURIComponent(project)}/ga/ai-referral-history${qs}`)
 }
 
-export function fetchGaSocialReferralHistory(project: string): Promise<GA4SocialReferralHistoryEntry[]> {
-  return apiFetch(`/projects/${encodeURIComponent(project)}/ga/social-referral-history`)
+export function fetchGaSocialReferralHistory(project: string, window?: MetricsWindow): Promise<GA4SocialReferralHistoryEntry[]> {
+  const qs = window && window !== 'all' ? `?window=${window}` : ''
+  return apiFetch(`/projects/${encodeURIComponent(project)}/ga/social-referral-history${qs}`)
 }
 
-export function fetchGaSessionHistory(project: string): Promise<GA4SessionHistoryEntry[]> {
-  return apiFetch(`/projects/${encodeURIComponent(project)}/ga/session-history`)
+export function fetchGaSessionHistory(project: string, window?: MetricsWindow): Promise<GA4SessionHistoryEntry[]> {
+  const qs = window && window !== 'all' ? `?window=${window}` : ''
+  return apiFetch(`/projects/${encodeURIComponent(project)}/ga/session-history${qs}`)
 }
 
 export function disconnectGa(project: string): Promise<void> {

--- a/apps/web/src/components/project/GscSection.tsx
+++ b/apps/web/src/components/project/GscSection.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link } from '@tanstack/react-router'
+import type { MetricsWindow } from '@ainyc/canonry-contracts'
 
 import { Button } from '../ui/button.js'
 import { Card } from '../ui/card.js'
@@ -36,6 +37,8 @@ import {
   useTriggerInspectSitemap,
 } from '../../queries/mutations.js'
 
+const GSC_WINDOWS: MetricsWindow[] = ['7d', '30d', '90d', 'all']
+
 export function GscSection({
   projectName,
 }: {
@@ -52,6 +55,7 @@ export function GscSection({
   const [inspectionUrl, setInspectionUrl] = useState('')
   const [syncDays, setSyncDays] = useState('30')
   const [fullSync, setFullSync] = useState(false)
+  const [gscWindow, setGscWindow] = useState<MetricsWindow>('30d')
   const [performanceFilters, setPerformanceFilters] = useState({
     startDate: '',
     endDate: '',
@@ -127,6 +131,7 @@ export function GscSection({
         query: performanceFilters.query || undefined,
         page: performanceFilters.page || undefined,
         limit: parseInt(performanceFilters.limit, 10) || 20,
+        window: gscWindow,
       })
       setPerformance(rows)
     } catch (err) {
@@ -303,6 +308,10 @@ export function GscSection({
     void loadSection()
   }, [projectName])
 
+  useEffect(() => {
+    void loadPerformanceRows()
+  }, [gscWindow])
+
   async function handleConnect() {
     if (!googleConfigured) {
       setError('Google OAuth app credentials are not configured yet. Set them on the Settings page first.')
@@ -418,6 +427,22 @@ export function GscSection({
           <h2>Google Search Console</h2>
         </div>
         <div className="flex items-center gap-2">
+          <div className="flex gap-1">
+            {GSC_WINDOWS.map(w => (
+              <button
+                key={w}
+                type="button"
+                className={`px-3 py-1 text-xs rounded-full border transition-colors ${
+                  gscWindow === w
+                    ? 'bg-zinc-700 border-zinc-600 text-zinc-50'
+                    : 'border-zinc-800 text-zinc-400 hover:border-zinc-700 hover:text-zinc-300'
+                }`}
+                onClick={() => setGscWindow(w)}
+              >
+                {w === 'all' ? 'All' : w}
+              </button>
+            ))}
+          </div>
           {gscConn && (
             <Button type="button" variant="outline" size="sm" disabled={loadingPerformance} onClick={() => void loadPerformanceRows()}>
               {loadingPerformance ? 'Refreshing\u2026' : 'Refresh data'}

--- a/apps/web/src/components/project/TrafficSection.tsx
+++ b/apps/web/src/components/project/TrafficSection.tsx
@@ -19,6 +19,7 @@ import {
 import { Button } from '../ui/button.js'
 import { Card } from '../ui/card.js'
 import { InfoTooltip } from '../shared/InfoTooltip.js'
+import type { MetricsWindow } from '@ainyc/canonry-contracts'
 import type { MetricTone } from '../../view-models.js'
 import {
   connectGa,
@@ -31,6 +32,8 @@ import {
   disconnectGa,
 } from '../../api.js'
 import type { ApiGaStatus, ApiGaTraffic, ApiGaTrafficPage, ApiGaTrafficReferral, ApiGaSocialReferral, GA4AiReferralHistoryEntry, GA4SessionHistoryEntry, GA4SocialReferralHistoryEntry } from '../../api.js'
+
+const TRAFFIC_WINDOWS: MetricsWindow[] = ['7d', '30d', '90d', 'all']
 
 const SOURCE_COLORS = CHART_SERIES_COLORS
 
@@ -73,6 +76,7 @@ export function TrafficSection({ projectName }: { projectName: string }) {
   const [aiHistory, setAiHistory] = useState<GA4AiReferralHistoryEntry[]>([])
   const [sessionHistory, setSessionHistory] = useState<GA4SessionHistoryEntry[]>([])
   const [socialHistory, setSocialHistory] = useState<GA4SocialReferralHistoryEntry[]>([])
+  const [trafficWindow, setTrafficWindow] = useState<MetricsWindow>('30d')
 
   function loadData(cancelled: { current: boolean }) {
     setLoading(true)
@@ -82,10 +86,10 @@ export function TrafficSection({ projectName }: { projectName: string }) {
         setStatus(s)
         if (s.connected) {
           return Promise.all([
-            fetchGaTraffic(projectName),
-            fetchGaAiReferralHistory(projectName).catch(() => [] as GA4AiReferralHistoryEntry[]),
-            fetchGaSessionHistory(projectName).catch(() => [] as GA4SessionHistoryEntry[]),
-            fetchGaSocialReferralHistory(projectName).catch(() => [] as GA4SocialReferralHistoryEntry[]),
+            fetchGaTraffic(projectName, undefined, trafficWindow),
+            fetchGaAiReferralHistory(projectName, trafficWindow).catch(() => [] as GA4AiReferralHistoryEntry[]),
+            fetchGaSessionHistory(projectName, trafficWindow).catch(() => [] as GA4SessionHistoryEntry[]),
+            fetchGaSocialReferralHistory(projectName, trafficWindow).catch(() => [] as GA4SocialReferralHistoryEntry[]),
           ])
         }
         return null
@@ -118,7 +122,7 @@ export function TrafficSection({ projectName }: { projectName: string }) {
     return () => {
       cancelled.current = true
     }
-  }, [projectName])
+  }, [projectName, trafficWindow])
 
   async function handleSync() {
     setSyncing(true)
@@ -128,10 +132,10 @@ export function TrafficSection({ projectName }: { projectName: string }) {
       const result = await triggerGaSync(projectName)
       setNotice(`Synced ${result.rowCount.toLocaleString()} page rows, ${result.aiReferralCount.toLocaleString()} AI and ${result.socialReferralCount.toLocaleString()} social referral rows (${result.days} days)`)
       const [t, h, sh, soh] = await Promise.all([
-        fetchGaTraffic(projectName),
-        fetchGaAiReferralHistory(projectName).catch(() => [] as GA4AiReferralHistoryEntry[]),
-        fetchGaSessionHistory(projectName).catch(() => [] as GA4SessionHistoryEntry[]),
-        fetchGaSocialReferralHistory(projectName).catch(() => [] as GA4SocialReferralHistoryEntry[]),
+        fetchGaTraffic(projectName, undefined, trafficWindow),
+        fetchGaAiReferralHistory(projectName, trafficWindow).catch(() => [] as GA4AiReferralHistoryEntry[]),
+        fetchGaSessionHistory(projectName, trafficWindow).catch(() => [] as GA4SessionHistoryEntry[]),
+        fetchGaSocialReferralHistory(projectName, trafficWindow).catch(() => [] as GA4SocialReferralHistoryEntry[]),
       ])
       setTraffic(t)
       setAiHistory(h)
@@ -361,12 +365,30 @@ export function TrafficSection({ projectName }: { projectName: string }) {
 
       {/* Summary gauges */}
       <section>
-        <div className="mb-4">
-          <p className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 mb-1">Traffic Overview</p>
-          <h2 className="text-base font-semibold text-zinc-50 flex items-center gap-1.5">
-            Site Traffic
-            <InfoTooltip text="Aggregated traffic metrics from Google Analytics 4. Sessions and users are summed across all synced dates. Organic sessions are Google organic search sessions specifically." />
-          </h2>
+        <div className="mb-4 flex items-start justify-between">
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 mb-1">Traffic Overview</p>
+            <h2 className="text-base font-semibold text-zinc-50 flex items-center gap-1.5">
+              Site Traffic
+              <InfoTooltip text={`Aggregated traffic metrics from Google Analytics 4. Sessions and users are summed across the selected period.${traffic?.periodStart && traffic?.periodEnd ? ` Data available: ${new Date(traffic.periodStart + 'T00:00:00').toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })} – ${new Date(traffic.periodEnd + 'T00:00:00').toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}.` : ''} Organic sessions are Google organic search sessions specifically.`} />
+            </h2>
+          </div>
+          <div className="flex gap-1">
+            {TRAFFIC_WINDOWS.map(w => (
+              <button
+                key={w}
+                type="button"
+                className={`px-3 py-1 text-xs rounded-full border transition-colors ${
+                  trafficWindow === w
+                    ? 'bg-zinc-700 border-zinc-600 text-zinc-50'
+                    : 'border-zinc-800 text-zinc-400 hover:border-zinc-700 hover:text-zinc-300'
+                }`}
+                onClick={() => setTrafficWindow(w)}
+              >
+                {w === 'all' ? 'All' : w}
+              </button>
+            ))}
+          </div>
         </div>
 
         {traffic ? (

--- a/apps/web/test/traffic-section.test.tsx
+++ b/apps/web/test/traffic-section.test.tsx
@@ -35,7 +35,8 @@ function jsonResponse(body: unknown, status = 200) {
 
 test('loads connected GA4 data without changing hook order', async () => {
   const restoreFetch = mockFetch((url) => {
-    if (url.endsWith('/projects/test-project/ga/status')) {
+    const urlPath = url.split('?')[0]!
+    if (urlPath.endsWith('/projects/test-project/ga/status')) {
       return jsonResponse({
         connected: true,
         propertyId: '999888',
@@ -46,7 +47,7 @@ test('loads connected GA4 data without changing hook order', async () => {
         updatedAt: '2026-03-31T12:00:00.000Z',
       })
     }
-    if (url.endsWith('/projects/test-project/ga/traffic')) {
+    if (urlPath.endsWith('/projects/test-project/ga/traffic')) {
       return jsonResponse({
         totalSessions: 120,
         totalOrganicSessions: 70,
@@ -67,17 +68,20 @@ test('loads connected GA4 data without changing hook order', async () => {
         lastSyncedAt: '2026-03-31T12:00:00.000Z',
       })
     }
-    if (url.endsWith('/projects/test-project/ga/ai-referral-history')) {
+    if (urlPath.endsWith('/projects/test-project/ga/ai-referral-history')) {
       return jsonResponse([
         { date: '2026-03-30', source: 'chatgpt.com', medium: 'referral', sourceDimension: 'session', sessions: 5, users: 4 },
         { date: '2026-03-31', source: 'chatgpt.com', medium: 'referral', sourceDimension: 'session', sessions: 7, users: 5 },
       ])
     }
-    if (url.endsWith('/projects/test-project/ga/session-history')) {
+    if (urlPath.endsWith('/projects/test-project/ga/session-history')) {
       return jsonResponse([
         { date: '2026-03-30', sessions: 50, organicSessions: 30, users: 40 },
         { date: '2026-03-31', sessions: 70, organicSessions: 40, users: 55 },
       ])
+    }
+    if (urlPath.endsWith('/projects/test-project/ga/social-referral-history')) {
+      return jsonResponse([])
     }
     throw new Error(`Unexpected fetch: ${url}`)
   })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "1.45.3",
+  "version": "1.46.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/analytics.ts
+++ b/packages/api-routes/src/analytics.ts
@@ -1,7 +1,7 @@
 import { eq, desc, inArray } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import { querySnapshots, runs, keywords, parseJsonColumn } from '@ainyc/canonry-db'
-import { categorizeSource, categoryLabel } from '@ainyc/canonry-contracts'
+import { categorizeSource, categoryLabel, parseWindow, windowCutoff } from '@ainyc/canonry-contracts'
 import type {
   BrandMetricsDto, GapAnalysisDto, SourceBreakdownDto,
   MetricsWindow, TimeBucket, TrendDirection, GapKeyword, GapCategory,
@@ -374,19 +374,6 @@ function parseGroundingSources(rawResponse: string | null): Array<{ uri: string;
     (s): s is { uri: string; title: string } =>
       typeof s.uri === 'string' && !isProviderInfraDomain(s.uri),
   )
-}
-
-function parseWindow(value?: string): MetricsWindow {
-  if (value === '7d' || value === '30d' || value === '90d' || value === 'all') return value
-  return 'all'
-}
-
-function windowCutoff(window: MetricsWindow): string | null {
-  if (window === 'all') return null
-  const days = window === '7d' ? 7 : window === '30d' ? 30 : 90
-  const d = new Date()
-  d.setDate(d.getDate() - days)
-  return d.toISOString()
 }
 
 function bucketSizeForSpan(spanDays: number): number {

--- a/packages/api-routes/src/ga.ts
+++ b/packages/api-routes/src/ga.ts
@@ -694,7 +694,13 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       aiSharePct: total > 0 ? Math.round(((aiDeduped?.sessions ?? 0) / total) * 100) : 0,
       socialSharePct: total > 0 ? Math.round(((socialTotals?.sessions ?? 0) / total) * 100) : 0,
       lastSyncedAt: latestSync?.syncedAt ?? null,
-      periodStart: cutoffDate ?? summaryMeta?.periodStart ?? null,
+      periodStart: (() => {
+        const start = cutoffDate ?? summaryMeta?.periodStart ?? null
+        const end = summaryMeta?.periodEnd ?? null
+        // Clamp: if the cutoff is after the last synced date, use the synced start instead
+        if (start && end && start > end) return summaryMeta?.periodStart ?? null
+        return start
+      })(),
       periodEnd: summaryMeta?.periodEnd ?? null,
     }
   })

--- a/packages/api-routes/src/ga.ts
+++ b/packages/api-routes/src/ga.ts
@@ -2,7 +2,7 @@ import crypto from 'node:crypto'
 import { eq, desc, and, sql } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import { gaTrafficSnapshots, gaTrafficSummaries, gaAiReferrals, gaSocialReferrals, runs } from '@ainyc/canonry-db'
-import { validationError, notFound, RunKinds, RunStatuses, RunTriggers } from '@ainyc/canonry-contracts'
+import { validationError, notFound, RunKinds, RunStatuses, RunTriggers, parseWindow, windowCutoff } from '@ainyc/canonry-contracts'
 import { resolveProject, writeAuditLog } from './helpers.js'
 import {
   getAccessToken,
@@ -528,18 +528,52 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
   // GET /projects/:name/ga/traffic
   app.get<{
     Params: { name: string }
-    Querystring: { limit?: string; days?: string }
+    Querystring: { limit?: string; days?: string; window?: string }
   }>('/projects/:name/ga/traffic', async (request, _reply) => {
     const project = resolveProject(app.db, request.params.name)
     requireGa4Connection(opts, project.name, project.canonicalDomain)
 
     const limit = Math.max(1, Math.min(parseInt(request.query.limit ?? '50', 10) || 50, 500))
+    const window = parseWindow(request.query.window)
+    const cutoff = windowCutoff(window)
+    const cutoffDate = cutoff?.slice(0, 10) ?? null
 
-    const summary = app.db
+    const snapshotConditions = [eq(gaTrafficSnapshots.projectId, project.id)]
+    if (cutoffDate) snapshotConditions.push(sql`${gaTrafficSnapshots.date} >= ${cutoffDate}`)
+
+    const aiConditions = [eq(gaAiReferrals.projectId, project.id)]
+    if (cutoffDate) aiConditions.push(sql`${gaAiReferrals.date} >= ${cutoffDate}`)
+
+    const socialConditions = [eq(gaSocialReferrals.projectId, project.id)]
+    if (cutoffDate) socialConditions.push(sql`${gaSocialReferrals.date} >= ${cutoffDate}`)
+
+    // When filtering by window, compute totals from snapshots instead of the
+    // pre-aggregated summary (which covers the full synced range).
+    const summaryRow = cutoffDate
+      ? app.db
+          .select({
+            totalSessions: sql<number>`COALESCE(SUM(${gaTrafficSnapshots.sessions}), 0)`,
+            totalOrganicSessions: sql<number>`COALESCE(SUM(${gaTrafficSnapshots.organicSessions}), 0)`,
+            totalUsers: sql<number>`COALESCE(SUM(${gaTrafficSnapshots.users}), 0)`,
+          })
+          .from(gaTrafficSnapshots)
+          .where(and(...snapshotConditions))
+          .get()
+      : app.db
+          .select({
+            totalSessions: gaTrafficSummaries.totalSessions,
+            totalOrganicSessions: gaTrafficSummaries.totalOrganicSessions,
+            totalUsers: gaTrafficSummaries.totalUsers,
+          })
+          .from(gaTrafficSummaries)
+          .where(eq(gaTrafficSummaries.projectId, project.id))
+          .get()
+
+    // Always fetch period bounds from the summary table (reflects full synced range).
+    const summaryMeta = app.db
       .select({
-        totalSessions: gaTrafficSummaries.totalSessions,
-        totalOrganicSessions: gaTrafficSummaries.totalOrganicSessions,
-        totalUsers: gaTrafficSummaries.totalUsers,
+        periodStart: gaTrafficSummaries.periodStart,
+        periodEnd: gaTrafficSummaries.periodEnd,
       })
       .from(gaTrafficSummaries)
       .where(eq(gaTrafficSummaries.projectId, project.id))
@@ -553,7 +587,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         users: sql<number>`SUM(${gaTrafficSnapshots.users})`,
       })
       .from(gaTrafficSnapshots)
-      .where(eq(gaTrafficSnapshots.projectId, project.id))
+      .where(and(...snapshotConditions))
       .groupBy(gaTrafficSnapshots.landingPage)
       .orderBy(sql`SUM(${gaTrafficSnapshots.sessions}) DESC`)
       .limit(limit)
@@ -568,7 +602,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         users: sql<number>`SUM(${gaAiReferrals.users})`,
       })
       .from(gaAiReferrals)
-      .where(eq(gaAiReferrals.projectId, project.id))
+      .where(and(...aiConditions))
       .groupBy(gaAiReferrals.source, gaAiReferrals.medium, gaAiReferrals.sourceDimension)
       .orderBy(sql`SUM(${gaAiReferrals.sessions}) DESC`)
       .all()
@@ -587,7 +621,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
                  MAX(sessions) AS max_sessions,
                  MAX(users) AS max_users
           FROM ga_ai_referrals
-          WHERE project_id = ${project.id}
+          WHERE project_id = ${project.id}${cutoffDate ? sql` AND date >= ${cutoffDate}` : sql``}
           GROUP BY date, source, medium
         )`
       )
@@ -602,7 +636,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         users: sql<number>`SUM(${gaSocialReferrals.users})`,
       })
       .from(gaSocialReferrals)
-      .where(eq(gaSocialReferrals.projectId, project.id))
+      .where(and(...socialConditions))
       .groupBy(gaSocialReferrals.source, gaSocialReferrals.medium, gaSocialReferrals.channelGroup)
       .orderBy(sql`SUM(${gaSocialReferrals.sessions}) DESC`)
       .all()
@@ -615,7 +649,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         users: sql<number>`SUM(${gaSocialReferrals.users})`,
       })
       .from(gaSocialReferrals)
-      .where(eq(gaSocialReferrals.projectId, project.id))
+      .where(and(...socialConditions))
       .get()
 
     const latestSync = app.db
@@ -626,12 +660,12 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       .limit(1)
       .get()
 
-    const total = summary?.totalSessions ?? 0
+    const total = summaryRow?.totalSessions ?? 0
 
     return {
       totalSessions: total,
-      totalOrganicSessions: summary?.totalOrganicSessions ?? 0,
-      totalUsers: summary?.totalUsers ?? 0,
+      totalOrganicSessions: summaryRow?.totalOrganicSessions ?? 0,
+      totalUsers: summaryRow?.totalUsers ?? 0,
       topPages: rows.map((r) => ({
         landingPage: r.landingPage,
         sessions: r.sessions ?? 0,
@@ -656,19 +690,26 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       })),
       socialSessions: socialTotals?.sessions ?? 0,
       socialUsers: socialTotals?.users ?? 0,
-      organicSharePct: total > 0 ? Math.round(((summary?.totalOrganicSessions ?? 0) / total) * 100) : 0,
+      organicSharePct: total > 0 ? Math.round(((summaryRow?.totalOrganicSessions ?? 0) / total) * 100) : 0,
       aiSharePct: total > 0 ? Math.round(((aiDeduped?.sessions ?? 0) / total) * 100) : 0,
       socialSharePct: total > 0 ? Math.round(((socialTotals?.sessions ?? 0) / total) * 100) : 0,
       lastSyncedAt: latestSync?.syncedAt ?? null,
+      periodStart: cutoffDate ?? summaryMeta?.periodStart ?? null,
+      periodEnd: summaryMeta?.periodEnd ?? null,
     }
   })
 
   // GET /projects/:name/ga/ai-referral-history
   app.get<{
     Params: { name: string }
+    Querystring: { window?: string }
   }>('/projects/:name/ga/ai-referral-history', async (request, _reply) => {
     const project = resolveProject(app.db, request.params.name)
     requireGa4Connection(opts, project.name, project.canonicalDomain)
+
+    const cutoffDate = windowCutoff(parseWindow(request.query.window))?.slice(0, 10) ?? null
+    const conditions = [eq(gaAiReferrals.projectId, project.id)]
+    if (cutoffDate) conditions.push(sql`${gaAiReferrals.date} >= ${cutoffDate}`)
 
     const rows = app.db
       .select({
@@ -680,7 +721,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         users: gaAiReferrals.users,
       })
       .from(gaAiReferrals)
-      .where(eq(gaAiReferrals.projectId, project.id))
+      .where(and(...conditions))
       .orderBy(gaAiReferrals.date)
       .all()
 
@@ -690,9 +731,14 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
   // GET /projects/:name/ga/social-referral-history
   app.get<{
     Params: { name: string }
+    Querystring: { window?: string }
   }>('/projects/:name/ga/social-referral-history', async (request, _reply) => {
     const project = resolveProject(app.db, request.params.name)
     requireGa4Connection(opts, project.name, project.canonicalDomain)
+
+    const cutoffDate = windowCutoff(parseWindow(request.query.window))?.slice(0, 10) ?? null
+    const conditions = [eq(gaSocialReferrals.projectId, project.id)]
+    if (cutoffDate) conditions.push(sql`${gaSocialReferrals.date} >= ${cutoffDate}`)
 
     const rows = app.db
       .select({
@@ -704,7 +750,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         users: gaSocialReferrals.users,
       })
       .from(gaSocialReferrals)
-      .where(eq(gaSocialReferrals.projectId, project.id))
+      .where(and(...conditions))
       .orderBy(gaSocialReferrals.date)
       .all()
 
@@ -919,9 +965,14 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
   // GET /projects/:name/ga/session-history
   app.get<{
     Params: { name: string }
+    Querystring: { window?: string }
   }>('/projects/:name/ga/session-history', async (request, _reply) => {
     const project = resolveProject(app.db, request.params.name)
     requireGa4Connection(opts, project.name, project.canonicalDomain)
+
+    const cutoffDate = windowCutoff(parseWindow(request.query.window))?.slice(0, 10) ?? null
+    const conditions = [eq(gaTrafficSnapshots.projectId, project.id)]
+    if (cutoffDate) conditions.push(sql`${gaTrafficSnapshots.date} >= ${cutoffDate}`)
 
     const rows = app.db
       .select({
@@ -931,7 +982,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         users: sql<number>`SUM(${gaTrafficSnapshots.users})`,
       })
       .from(gaTrafficSnapshots)
-      .where(eq(gaTrafficSnapshots.projectId, project.id))
+      .where(and(...conditions))
       .groupBy(gaTrafficSnapshots.date)
       .orderBy(gaTrafficSnapshots.date)
       .all()

--- a/packages/api-routes/src/google.ts
+++ b/packages/api-routes/src/google.ts
@@ -2,7 +2,7 @@ import crypto from 'node:crypto'
 import { eq, and, desc, sql } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import { gscSearchData, gscUrlInspections, gscCoverageSnapshots, runs } from '@ainyc/canonry-db'
-import { validationError, notFound, normalizeProjectDomain } from '@ainyc/canonry-contracts'
+import { validationError, notFound, normalizeProjectDomain, parseWindow, windowCutoff } from '@ainyc/canonry-contracts'
 import { resolveProject, writeAuditLog } from './helpers.js'
 import {
   getAuthUrl,
@@ -386,13 +386,18 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
   // GET /projects/:name/google/gsc/performance
   app.get<{
     Params: { name: string }
-    Querystring: { startDate?: string; endDate?: string; query?: string; page?: string; limit?: string }
+    Querystring: { startDate?: string; endDate?: string; query?: string; page?: string; limit?: string; window?: string }
   }>('/projects/:name/google/gsc/performance', async (request) => {
     const project = resolveProject(app.db, request.params.name)
     const { startDate, endDate, query, page, limit } = request.query
 
+    // Window-based filtering: when no explicit startDate is provided,
+    // use the window param to compute a cutoff date.
+    const cutoffDate = !startDate ? windowCutoff(parseWindow(request.query.window))?.slice(0, 10) ?? null : null
+
     const conditions = [eq(gscSearchData.projectId, project.id)]
     if (startDate) conditions.push(sql`${gscSearchData.date} >= ${startDate}`)
+    else if (cutoffDate) conditions.push(sql`${gscSearchData.date} >= ${cutoffDate}`)
     if (endDate) conditions.push(sql`${gscSearchData.date} <= ${endDate}`)
     if (query) conditions.push(sql`${gscSearchData.query} LIKE ${'%' + query + '%'}`)
     if (page) conditions.push(sql`${gscSearchData.page} LIKE ${'%' + page + '%'}`)

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -1214,6 +1214,7 @@ const routeCatalog: OpenApiOperation[] = [
       { name: 'query', in: 'query', description: 'Filter by search query.', schema: stringSchema },
       { name: 'page', in: 'query', description: 'Filter by page URL.', schema: stringSchema },
       limitQueryParameter,
+      analyticsWindowParameter,
     ],
     responses: {
       200: { description: 'GSC performance rows returned.' },
@@ -2039,7 +2040,7 @@ const routeCatalog: OpenApiOperation[] = [
     path: '/api/v1/projects/{name}/ga/traffic',
     summary: 'Get GA4 landing page traffic and AI referral sources',
     tags: ['ga4'],
-    parameters: [nameParameter, limitQueryParameter],
+    parameters: [nameParameter, limitQueryParameter, analyticsWindowParameter],
     responses: {
       200: { description: 'GA4 traffic data returned.' },
       400: { description: 'GA4 is not connected.' },
@@ -2051,7 +2052,7 @@ const routeCatalog: OpenApiOperation[] = [
     path: '/api/v1/projects/{name}/ga/ai-referral-history',
     summary: 'Get AI referral sessions per day grouped by source',
     tags: ['ga4'],
-    parameters: [nameParameter],
+    parameters: [nameParameter, analyticsWindowParameter],
     responses: {
       200: { description: 'AI referral history returned.' },
       400: { description: 'GA4 is not connected.' },
@@ -2063,7 +2064,7 @@ const routeCatalog: OpenApiOperation[] = [
     path: '/api/v1/projects/{name}/ga/social-referral-history',
     summary: 'Get social media referral sessions per day grouped by source',
     tags: ['ga4'],
-    parameters: [nameParameter],
+    parameters: [nameParameter, analyticsWindowParameter],
     responses: {
       200: { description: 'Social referral history returned.' },
       400: { description: 'GA4 is not connected.' },
@@ -2099,7 +2100,7 @@ const routeCatalog: OpenApiOperation[] = [
     path: '/api/v1/projects/{name}/ga/session-history',
     summary: 'Get total sessions per day for the project',
     tags: ['ga4'],
-    parameters: [nameParameter],
+    parameters: [nameParameter, analyticsWindowParameter],
     responses: {
       200: { description: 'Session history returned.' },
       400: { description: 'GA4 is not connected.' },

--- a/packages/api-routes/test/ga.test.ts
+++ b/packages/api-routes/test/ga.test.ts
@@ -507,6 +507,8 @@ describe('GA4 routes', () => {
     expect(body.aiSharePct).toBe(5)
     expect(body.socialSharePct).toBe(0)
     expect(body.lastSyncedAt).toBe(now)
+    expect(body.periodStart).toBe('2026-02-19')
+    expect(body.periodEnd).toBe('2026-03-20')
 
     credentials.delete('test-project')
   })
@@ -534,6 +536,36 @@ describe('GA4 routes', () => {
     expect(body.totalSessions).toBe(350)
     expect(body.totalOrganicSessions).toBe(175)
     expect(body.totalUsers).toBe(270)
+
+    credentials.delete('test-project')
+  })
+
+  it('GET /ga/traffic filters by window parameter', async () => {
+    const now = new Date().toISOString()
+    credentials.set('test-project', {
+      projectName: 'test-project',
+      propertyId: '999888',
+      clientEmail: 'sa@test.iam.gserviceaccount.com',
+      privateKey: 'fake-key',
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    // The existing test data has snapshots from 2026-03-19 and 2026-03-20.
+    // Query with window=7d — the cutoff will be ~7 days ago from today (2026-04-11),
+    // so all the old data from March should be excluded.
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/projects/test-project/ga/traffic?window=7d',
+    })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.payload)
+    // No snapshots within last 7 days → totals should be 0
+    expect(body.totalSessions).toBe(0)
+    expect(body.topPages).toHaveLength(0)
+    expect(body.aiReferrals).toEqual([])
+    // periodEnd still reflects full synced range
+    expect(body.periodEnd).toBe('2026-03-20')
 
     credentials.delete('test-project')
   })

--- a/packages/api-routes/test/ga.test.ts
+++ b/packages/api-routes/test/ga.test.ts
@@ -566,6 +566,8 @@ describe('GA4 routes', () => {
     expect(body.aiReferrals).toEqual([])
     // periodEnd still reflects full synced range
     expect(body.periodEnd).toBe('2026-03-20')
+    // periodStart is clamped: cutoff (~2026-04-04) > periodEnd, so falls back to summary start
+    expect(body.periodStart).toBe('2026-02-19')
 
     credentials.delete('test-project')
   })

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "1.45.3",
+  "version": "1.46.0",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/cli-commands/ga.ts
+++ b/packages/canonry/src/cli-commands/ga.ts
@@ -73,16 +73,19 @@ export const GA_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['ga', 'traffic'],
-    usage: 'canonry ga traffic <project> [--limit 50] [--format json]',
+    usage: 'canonry ga traffic <project> [--limit 50] [--window 30d] [--format json]',
     options: {
       limit: stringOption(),
+      window: stringOption(),
     },
     run: async (input) => {
-      const project = requireProject(input, 'ga.traffic', 'canonry ga traffic <project> [--limit 50] [--format json]')
+      const project = requireProject(input, 'ga.traffic', 'canonry ga traffic <project> [--limit 50] [--window 30d] [--format json]')
       const limitStr = getString(input.values, 'limit')
       const limit = limitStr ? parseInt(limitStr, 10) : undefined
+      const window = getString(input.values, 'window')
       await gaTraffic(project, {
         limit,
+        window,
         format: input.format,
       })
     },

--- a/packages/canonry/src/cli-commands/ga.ts
+++ b/packages/canonry/src/cli-commands/ga.ts
@@ -4,6 +4,7 @@ import {
   gaConnect,
   gaCoverage,
   gaDisconnect,
+  gaSessionHistory,
   gaSocialReferralHistory,
   gaSocialReferralSummary,
   gaStatus,
@@ -100,18 +101,44 @@ export const GA_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['ga', 'ai-referral-history'],
-    usage: 'canonry ga ai-referral-history <project> [--format json]',
+    usage: 'canonry ga ai-referral-history <project> [--window 30d] [--format json]',
+    options: {
+      window: stringOption(),
+    },
     run: async (input) => {
-      const project = requireProject(input, 'ga.ai-referral-history', 'canonry ga ai-referral-history <project> [--format json]')
-      await gaAiReferralHistory(project, input.format)
+      const project = requireProject(input, 'ga.ai-referral-history', 'canonry ga ai-referral-history <project> [--window 30d] [--format json]')
+      await gaAiReferralHistory(project, {
+        window: getString(input.values, 'window'),
+        format: input.format,
+      })
     },
   },
   {
     path: ['ga', 'social-referral-history'],
-    usage: 'canonry ga social-referral-history <project> [--format json]',
+    usage: 'canonry ga social-referral-history <project> [--window 30d] [--format json]',
+    options: {
+      window: stringOption(),
+    },
     run: async (input) => {
-      const project = requireProject(input, 'ga.social-referral-history', 'canonry ga social-referral-history <project> [--format json]')
-      await gaSocialReferralHistory(project, input.format)
+      const project = requireProject(input, 'ga.social-referral-history', 'canonry ga social-referral-history <project> [--window 30d] [--format json]')
+      await gaSocialReferralHistory(project, {
+        window: getString(input.values, 'window'),
+        format: input.format,
+      })
+    },
+  },
+  {
+    path: ['ga', 'session-history'],
+    usage: 'canonry ga session-history <project> [--window 30d] [--format json]',
+    options: {
+      window: stringOption(),
+    },
+    run: async (input) => {
+      const project = requireProject(input, 'ga.session-history', 'canonry ga session-history <project> [--window 30d] [--format json]')
+      await gaSessionHistory(project, {
+        window: getString(input.values, 'window'),
+        format: input.format,
+      })
     },
   },
   {
@@ -149,7 +176,7 @@ export const GA_CLI_COMMANDS: readonly CliCommandSpec[] = [
       unknownSubcommand(input.positionals[0], {
         command: 'ga',
         usage: 'canonry ga <subcommand> <project> [args]',
-        available: ['connect', 'disconnect', 'status', 'sync', 'traffic', 'coverage', 'ai-referral-history', 'social-referral-history', 'social-referral-summary', 'attribution'],
+        available: ['connect', 'disconnect', 'status', 'sync', 'traffic', 'coverage', 'ai-referral-history', 'social-referral-history', 'session-history', 'social-referral-summary', 'attribution'],
       })
     },
   },

--- a/packages/canonry/src/client.ts
+++ b/packages/canonry/src/client.ts
@@ -574,12 +574,14 @@ export class ApiClient {
     return this.request<GaCoverageResponse>('GET', `/projects/${encodeURIComponent(project)}/ga/coverage`)
   }
 
-  async gaAiReferralHistory(project: string): Promise<GA4AiReferralHistoryEntry[]> {
-    return this.request<GA4AiReferralHistoryEntry[]>('GET', `/projects/${encodeURIComponent(project)}/ga/ai-referral-history`)
+  async gaAiReferralHistory(project: string, params?: Record<string, string>): Promise<GA4AiReferralHistoryEntry[]> {
+    const qs = params ? '?' + new URLSearchParams(params).toString() : ''
+    return this.request<GA4AiReferralHistoryEntry[]>('GET', `/projects/${encodeURIComponent(project)}/ga/ai-referral-history${qs}`)
   }
 
-  async gaSocialReferralHistory(project: string): Promise<GA4SocialReferralHistoryEntry[]> {
-    return this.request<GA4SocialReferralHistoryEntry[]>('GET', `/projects/${encodeURIComponent(project)}/ga/social-referral-history`)
+  async gaSocialReferralHistory(project: string, params?: Record<string, string>): Promise<GA4SocialReferralHistoryEntry[]> {
+    const qs = params ? '?' + new URLSearchParams(params).toString() : ''
+    return this.request<GA4SocialReferralHistoryEntry[]>('GET', `/projects/${encodeURIComponent(project)}/ga/social-referral-history${qs}`)
   }
 
   async gaSocialReferralTrend(project: string): Promise<GaSocialReferralTrendResponse> {
@@ -590,8 +592,9 @@ export class ApiClient {
     return this.request<GaAttributionTrendResponse>('GET', `/projects/${encodeURIComponent(project)}/ga/attribution-trend`)
   }
 
-  async gaSessionHistory(project: string): Promise<GA4SessionHistoryEntry[]> {
-    return this.request<GA4SessionHistoryEntry[]>('GET', `/projects/${encodeURIComponent(project)}/ga/session-history`)
+  async gaSessionHistory(project: string, params?: Record<string, string>): Promise<GA4SessionHistoryEntry[]> {
+    const qs = params ? '?' + new URLSearchParams(params).toString() : ''
+    return this.request<GA4SessionHistoryEntry[]>('GET', `/projects/${encodeURIComponent(project)}/ga/session-history${qs}`)
   }
 
   async wordpressConnect(

--- a/packages/canonry/src/commands/ga.ts
+++ b/packages/canonry/src/commands/ga.ts
@@ -1,4 +1,4 @@
-import type { GaConnectResponse, GaStatusResponse, GaSyncResponse, GaTrafficResponse, GaCoverageResponse, GaSocialReferralTrendResponse, GaAttributionTrendResponse, GA4AiReferralHistoryEntry, GA4SocialReferralHistoryEntry } from '@ainyc/canonry-contracts'
+import type { GaConnectResponse, GaStatusResponse, GaSyncResponse, GaTrafficResponse, GaCoverageResponse, GaSocialReferralTrendResponse, GaAttributionTrendResponse, GA4AiReferralHistoryEntry, GA4SessionHistoryEntry, GA4SocialReferralHistoryEntry } from '@ainyc/canonry-contracts'
 import { createApiClient } from '../client.js'
 import { CliError } from '../cli-error.js'
 
@@ -144,7 +144,11 @@ export async function gaTraffic(project: string, opts?: { limit?: number; window
   }
 
   if (result.topPages.length === 0 && result.aiReferrals.length === 0 && result.socialReferrals.length === 0) {
-    console.log('No GA4 traffic data. Run "canonry ga sync <project>" first.')
+    if (!result.lastSyncedAt) {
+      console.log('No GA4 traffic data. Run "canonry ga sync <project>" first.')
+    } else {
+      console.log(`No GA4 traffic data for the selected period.${opts?.window ? ` Try a wider window or omit --window.` : ''}`)
+    }
     return
   }
 
@@ -211,17 +215,17 @@ export async function gaTraffic(project: string, opts?: { limit?: number; window
   }
 }
 
-export async function gaAiReferralHistory(project: string, format?: string): Promise<void> {
+export async function gaAiReferralHistory(project: string, opts?: { window?: string; format?: string }): Promise<void> {
   const client = getClient()
-  const result: GA4AiReferralHistoryEntry[] = await client.gaAiReferralHistory(project)
+  const result: GA4AiReferralHistoryEntry[] = await client.gaAiReferralHistory(project, opts?.window ? { window: opts.window } : undefined)
 
-  if (format === 'json') {
+  if (opts?.format === 'json') {
     console.log(JSON.stringify(result, null, 2))
     return
   }
 
   if (result.length === 0) {
-    console.log('No AI referral history. Run "canonry ga sync <project>" first.')
+    console.log(`No AI referral history.${opts?.window ? ' Try a wider window or omit --window.' : ' Run "canonry ga sync <project>" first.'}`)
     return
   }
 
@@ -239,17 +243,17 @@ export async function gaAiReferralHistory(project: string, format?: string): Pro
   }
 }
 
-export async function gaSocialReferralHistory(project: string, format?: string): Promise<void> {
+export async function gaSocialReferralHistory(project: string, opts?: { window?: string; format?: string }): Promise<void> {
   const client = getClient()
-  const result: GA4SocialReferralHistoryEntry[] = await client.gaSocialReferralHistory(project)
+  const result: GA4SocialReferralHistoryEntry[] = await client.gaSocialReferralHistory(project, opts?.window ? { window: opts.window } : undefined)
 
-  if (format === 'json') {
+  if (opts?.format === 'json') {
     console.log(JSON.stringify(result, null, 2))
     return
   }
 
   if (result.length === 0) {
-    console.log('No social referral history. Run "canonry ga sync <project>" first.')
+    console.log(`No social referral history.${opts?.window ? ' Try a wider window or omit --window.' : ' Run "canonry ga sync <project>" first.'}`)
     return
   }
 
@@ -263,6 +267,31 @@ export async function gaSocialReferralHistory(project: string, format?: string):
     const chanLabel = row.channelGroup === 'Paid Social' ? 'paid' : 'organic'
     console.log(
       `  ${row.date.padEnd(dateWidth)}  ${row.source.padEnd(sourceWidth)}  ${chanLabel.padEnd(chanWidth)}  ${String(row.sessions).padEnd(10)}${String(row.users).padEnd(8)}`,
+    )
+  }
+}
+
+export async function gaSessionHistory(project: string, opts?: { window?: string; format?: string }): Promise<void> {
+  const client = getClient()
+  const result: GA4SessionHistoryEntry[] = await client.gaSessionHistory(project, opts?.window ? { window: opts.window } : undefined)
+
+  if (opts?.format === 'json') {
+    console.log(JSON.stringify(result, null, 2))
+    return
+  }
+
+  if (result.length === 0) {
+    console.log(`No session history.${opts?.window ? ' Try a wider window or omit --window.' : ' Run "canonry ga sync <project>" first.'}`)
+    return
+  }
+
+  const dateWidth = 12
+  console.log(`GA4 Session History for "${project}":\n`)
+  console.log(`  ${'DATE'.padEnd(dateWidth)}  ${'SESSIONS'.padEnd(10)}${'ORGANIC'.padEnd(10)}${'USERS'.padEnd(8)}`)
+  console.log(`  ${'─'.repeat(dateWidth)}  ${'─'.repeat(10)}${'─'.repeat(10)}${'─'.repeat(8)}`)
+  for (const row of result) {
+    console.log(
+      `  ${row.date.padEnd(dateWidth)}  ${String(row.sessions).padEnd(10)}${String(row.organicSessions).padEnd(10)}${String(row.users).padEnd(8)}`,
     )
   }
 }

--- a/packages/canonry/src/commands/ga.ts
+++ b/packages/canonry/src/commands/ga.ts
@@ -130,10 +130,11 @@ export async function gaSync(project: string, opts?: { days?: number; only?: str
   console.log(`  Synced at:   ${result.syncedAt}`)
 }
 
-export async function gaTraffic(project: string, opts?: { limit?: number; format?: string }): Promise<void> {
+export async function gaTraffic(project: string, opts?: { limit?: number; window?: string; format?: string }): Promise<void> {
   const client = getClient()
   const params: Record<string, string> = {}
   if (opts?.limit) params.limit = String(opts.limit)
+  if (opts?.window) params.window = opts.window
 
   const result: GaTrafficResponse = await client.gaTraffic(project, Object.keys(params).length > 0 ? params : undefined)
 
@@ -418,8 +419,11 @@ export async function gaAttribution(project: string, opts?: { trend?: boolean; f
       console.log(`  Social Mover: ${m.source} (${m.changePct >= 0 ? '+' : ''}${m.changePct}%, ${m.sessionsPrev7d}→${m.sessions7d} sessions/7d)`)
     }
 
+    if (traffic.periodStart && traffic.periodEnd) {
+      console.log(`\n  Period: ${traffic.periodStart} to ${traffic.periodEnd}`)
+    }
     if (traffic.lastSyncedAt) {
-      console.log(`\n  Last synced: ${traffic.lastSyncedAt}`)
+      console.log(`  Last synced: ${traffic.lastSyncedAt}`)
     }
     return
   }
@@ -438,6 +442,8 @@ export async function gaAttribution(project: string, opts?: { trend?: boolean; f
       organicSharePct: traffic.organicSharePct,
       aiReferrals: traffic.aiReferrals,
       socialReferrals: traffic.socialReferrals,
+      periodStart: traffic.periodStart,
+      periodEnd: traffic.periodEnd,
     }, null, 2))
     return
   }
@@ -479,7 +485,10 @@ export async function gaAttribution(project: string, opts?: { trend?: boolean; f
     }
   }
 
+  if (traffic.periodStart && traffic.periodEnd) {
+    console.log(`\n  Period: ${traffic.periodStart} to ${traffic.periodEnd}`)
+  }
   if (traffic.lastSyncedAt) {
-    console.log(`\n  Last synced: ${traffic.lastSyncedAt}`)
+    console.log(`  Last synced: ${traffic.lastSyncedAt}`)
   }
 }

--- a/packages/contracts/src/analytics.ts
+++ b/packages/contracts/src/analytics.ts
@@ -78,3 +78,16 @@ export interface SourceBreakdownDto {
   runId: string
   window: MetricsWindow
 }
+
+export function parseWindow(value?: string): MetricsWindow {
+  if (value === '7d' || value === '30d' || value === '90d' || value === 'all') return value
+  return 'all'
+}
+
+export function windowCutoff(window: MetricsWindow): string | null {
+  if (window === 'all') return null
+  const days = window === '7d' ? 7 : window === '30d' ? 30 : 90
+  const d = new Date()
+  d.setDate(d.getDate() - days)
+  return d.toISOString()
+}

--- a/packages/contracts/src/ga.ts
+++ b/packages/contracts/src/ga.ts
@@ -155,6 +155,10 @@ export interface GaTrafficResponse {
   /** Social sessions as a percentage of total sessions (0–100, rounded). */
   socialSharePct: number
   lastSyncedAt: string | null
+  /** Start of the synced date range (YYYY-MM-DD), null if no data. */
+  periodStart: string | null
+  /** End of the synced date range (YYYY-MM-DD), null if no data. */
+  periodEnd: string | null
 }
 
 export interface GaCoverageResponse {


### PR DESCRIPTION
## Summary

- Adds 7d / 30d / 90d / All period pill buttons to the Traffic and GSC sections, matching the existing Analytics section pattern (default: 30d)
- Adds `?window=` query param support to GA traffic, AI/session/social referral history, and GSC performance API endpoints
- Extracts `parseWindow`/`windowCutoff` from analytics routes into shared contracts for reuse
- Adds `--window` flag to `canonry ga traffic` CLI command
- Adds `periodStart`/`periodEnd` fields to the GA traffic API response for date range visibility

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (947 tests, +1 new window filtering test)
- [x] `pnpm lint` passes
- [ ] Verify pill buttons render and toggle correctly in Traffic and GSC sections
- [ ] Verify window=7d narrows chart/table data as expected