### PR TITLE
fix(canonry): mock Linux /proc cmdline reads in agent tests

### DIFF
--- a/packages/canonry/test/agent-commands.test.ts
+++ b/packages/canonry/test/agent-commands.test.ts
@@ -24,6 +24,9 @@ vi.mock('node:child_process', async (importOriginal) => {
 
 const { agentStatus, agentSetup } = await import('../src/commands/agent.js')
 
+// Capture original before any spying
+const _readFileSync = fs.readFileSync.bind(fs)
+
 let tmpDir: string
 const origEnv: Record<string, string | undefined> = {}
 
@@ -49,10 +52,20 @@ function restoreEnv() {
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-agent-cmd-'))
   setEnv('CANONRY_CONFIG_DIR', tmpDir)
+  // On Linux CI, verifyProcessIdentity reads /proc/<pid>/cmdline instead of
+  // calling execFileSync('ps'). Intercept those reads so identity checks pass.
+  vi.spyOn(fs, 'readFileSync').mockImplementation((...args: Parameters<typeof fs.readFileSync>) => {
+    const filePath = args[0]
+    if (typeof filePath === 'string' && /^\/proc\/\d+\/cmdline$/.test(filePath)) {
+      return 'openclaw' as ReturnType<typeof fs.readFileSync>
+    }
+    return _readFileSync(...args)
+  })
 })
 
 afterEach(() => {
   restoreEnv()
+  vi.restoreAllMocks()
   fs.rmSync(tmpDir, { recursive: true, force: true })
 })
 

--- a/packages/canonry/test/agent-manager.test.ts
+++ b/packages/canonry/test/agent-manager.test.ts
@@ -19,6 +19,9 @@ vi.mock('node:child_process', () => ({
 const { AgentManager } = await import('../src/agent-manager.js')
 const { spawn } = await import('node:child_process')
 
+// Capture original before any spying
+const _readFileSync = fs.readFileSync.bind(fs)
+
 let tmpDir: string
 
 function defaultConfig(overrides: Partial<AgentConfigEntry> = {}): AgentConfigEntry {
@@ -32,9 +35,19 @@ function defaultConfig(overrides: Partial<AgentConfigEntry> = {}): AgentConfigEn
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-agent-mgr-'))
   vi.clearAllMocks()
+  // On Linux CI, verifyProcessIdentity reads /proc/<pid>/cmdline instead of
+  // calling execFileSync('ps'). Intercept those reads so identity checks pass.
+  vi.spyOn(fs, 'readFileSync').mockImplementation((...args: Parameters<typeof fs.readFileSync>) => {
+    const filePath = args[0]
+    if (typeof filePath === 'string' && /^\/proc\/\d+\/cmdline$/.test(filePath)) {
+      return 'openclaw' as ReturnType<typeof fs.readFileSync>
+    }
+    return _readFileSync(...args)
+  })
 })
 
 afterEach(() => {
+  vi.restoreAllMocks()
   fs.rmSync(tmpDir, { recursive: true, force: true })
 })
 


### PR DESCRIPTION
## Summary

- Fixes 3 failing agent tests on Linux CI (`agent-manager.test.ts` and `agent-commands.test.ts`)
- `verifyProcessIdentity()` uses `execFileSync('ps')` on macOS but `fs.readFileSync('/proc/<pid>/cmdline')` on Linux — tests only mocked the macOS path
- Adds `fs.readFileSync` spy that intercepts `/proc/<pid>/cmdline` reads to return `'openclaw'`, matching the existing `execFileSync` mock behavior

## Test plan
- [x] All 974 tests pass locally
- [ ] CI passes on Linux runner