### PR TITLE
fix: prevent double basePath in OAuth redirect URI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "1.46.0",
+  "version": "1.46.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/google.ts
+++ b/packages/api-routes/src/google.ts
@@ -167,11 +167,11 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
 
     let redirectUri: string
     if (publicUrl) {
-      // CLI override — use the provided public URL as the base
-      redirectUri = publicUrl.replace(/\/$/, '') + (opts.routePrefix ?? '/api/v1') + '/google/callback'
+      // CLI override — user-supplied URL already includes any base path
+      redirectUri = publicUrl.replace(/\/$/, '') + '/api/v1/google/callback'
     } else if (opts.publicUrl) {
-      // Config-level publicUrl — use for all OAuth redirects
-      redirectUri = opts.publicUrl.replace(/\/$/, '') + (opts.routePrefix ?? '/api/v1') + '/google/callback'
+      // Config-level publicUrl already includes any base path
+      redirectUri = opts.publicUrl.replace(/\/$/, '') + '/api/v1/google/callback'
     } else {
       // Auto-detect from request headers — use legacy per-project URI for backward compat
       const proto = request.headers['x-forwarded-proto'] ?? 'http'

--- a/packages/api-routes/test/google.test.ts
+++ b/packages/api-routes/test/google.test.ts
@@ -356,6 +356,80 @@ describe('googleRoutes: connect uses publicUrl', () => {
   })
 })
 
+describe('googleRoutes: connect does not double basePath in redirectUri', () => {
+  let app: ReturnType<typeof Fastify>
+  let tmpDir: string
+
+  beforeAll(async () => {
+    const tmpDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'google-routes-basepath-'))
+    const dbPath = path.join(tmpDirPath, 'test.db')
+    const db = createClient(dbPath)
+    migrate(db)
+
+    const now = new Date().toISOString()
+    db.insert(projects).values({
+      id: 'p1',
+      name: 'testproj',
+      displayName: 'Test Project',
+      canonicalDomain: 'example.com',
+      country: 'US',
+      language: 'en',
+      createdAt: now,
+      updatedAt: now,
+    }).run()
+
+    const fastify = Fastify()
+    fastify.decorate('db', db)
+    fastify.register(googleRoutes, {
+      getGoogleAuthConfig: () => ({
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+      }),
+      googleConnectionStore: {
+        listConnections: () => [],
+        getConnection: () => undefined,
+        upsertConnection: (c) => c,
+        updateConnection: () => undefined,
+        deleteConnection: () => false,
+      },
+      googleStateSecret: 'test-secret-32-bytes-long-enough!',
+      publicUrl: 'https://example.com/canonry',
+      routePrefix: '/canonry/api/v1',
+    })
+
+    app = fastify
+    tmpDir = tmpDirPath
+    await app.ready()
+  })
+
+  afterAll(async () => {
+    await app.close()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('config publicUrl with basePath does not duplicate prefix', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/projects/testproj/google/connect',
+      payload: { type: 'gsc' },
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as { authUrl: string; redirectUri: string }
+    expect(body.redirectUri).toBe('https://example.com/canonry/api/v1/google/callback')
+  })
+
+  it('CLI publicUrl with basePath does not duplicate prefix', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/projects/testproj/google/connect',
+      payload: { type: 'gsc', publicUrl: 'https://override.example.com/canonry' },
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as { authUrl: string; redirectUri: string }
+    expect(body.redirectUri).toBe('https://override.example.com/canonry/api/v1/google/callback')
+  })
+})
+
 describe('googleRoutes: connect auto-detect uses per-project URI', () => {
   let app: ReturnType<typeof Fastify>
   let tmpDir: string

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "1.46.0",
+  "version": "1.46.1",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Summary

- Fixes #306 — when `--public-url` or config `publicUrl` already includes the base path (e.g. `https://example.com/canonry`), the OAuth redirect URI was doubled: `/canonry/canonry/api/v1/google/callback`
- Changed both the CLI `publicUrl` and config `opts.publicUrl` branches in `packages/api-routes/src/google.ts` to use the fixed `/api/v1` prefix, since those URLs already embed any user-configured base path
- Added tests verifying no double-prefix when `routePrefix` includes a base path

## Test plan

- [x] All 976 existing tests pass
- [x] New test: config `publicUrl` with basePath produces correct redirect URI
- [x] New test: CLI `publicUrl` with basePath produces correct redirect URI

🤖 Generated with [Claude Code](https://claude.com/claude-code)