### PR TITLE
fix(api): include unknown URLs in Bing submit-all indexing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "1.46.0",
+  "version": "1.46.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/bing.ts
+++ b/packages/api-routes/src/bing.ts
@@ -532,13 +532,13 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
 
       const unindexedUrls: string[] = []
       for (const [url, row] of latestByUrl) {
-        if (row.inIndex === 0) {
+        if (row.inIndex === 0 || row.inIndex === null) {
           unindexedUrls.push(url)
         }
       }
 
       if (unindexedUrls.length === 0) {
-        const err = validationError('No explicitly unindexed URLs found. Run "canonry bing inspect <project> <url>" first.')
+        const err = validationError('No unindexed or unknown URLs found. Run "canonry bing inspect <project> <url>" first.')
         return reply.status(err.statusCode).send(err.toJSON())
       }
 

--- a/packages/api-routes/test/bing.test.ts
+++ b/packages/api-routes/test/bing.test.ts
@@ -259,7 +259,7 @@ describe('Bing routes', () => {
     expect(body[2]!.ctr).toBe(0)
   })
 
-  it('allUnindexed only submits URLs with an explicit not-indexed status', async () => {
+  it('allUnindexed submits URLs with not-indexed or unknown status', async () => {
     const now = new Date().toISOString()
     db.insert(bingUrlInspections).values([
       {
@@ -293,7 +293,7 @@ describe('Bing routes', () => {
     ]).run()
 
     const bingModule = await import('@ainyc/canonry-integration-bing')
-    const submitUrlSpy = vi.spyOn(bingModule, 'submitUrl').mockResolvedValue()
+    const submitUrlBatchSpy = vi.spyOn(bingModule, 'submitUrlBatch').mockResolvedValue()
 
     const res = await app.inject({
       method: 'POST',
@@ -302,8 +302,11 @@ describe('Bing routes', () => {
     })
 
     expect(res.statusCode).toBe(200)
-    expect(submitUrlSpy).toHaveBeenCalledTimes(1)
-    expect(submitUrlSpy).toHaveBeenCalledWith('test-key', 'https://example.com/', 'https://example.com/not-indexed')
+    expect(submitUrlBatchSpy).toHaveBeenCalledTimes(1)
+    const submittedUrls = submitUrlBatchSpy.mock.calls[0]![2] as string[]
+    expect(submittedUrls).toContain('https://example.com/not-indexed')
+    expect(submittedUrls).toContain('https://example.com/unknown')
+    expect(submittedUrls).not.toContain('https://example.com/indexed')
   })
 
   it('coverage endpoint saves a daily snapshot', async () => {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "1.46.0",
+  "version": "1.46.1",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Summary
- The "Submit all to Bing" button in the Unknown section failed with "No explicitly unindexed URLs found" because the API only considered URLs with `inIndex === 0`, ignoring URLs with `inIndex === null` (unknown/uninspected status).
- Updated the filter to include both not-indexed and unknown URLs when submitting all to Bing.
- Updated the existing test to reflect the corrected behavior.

## Test plan
- [x] All 974 existing tests pass
- [x] Updated `allUnindexed` test verifies both not-indexed and unknown URLs are submitted
- [x] Typecheck and lint pass