### PR TITLE
chore(db): add missing index for query_snapshots createdAt

### DIFF
--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -433,6 +433,9 @@ const MIGRATIONS = [
   // v34: Rename unique index for bing_coverage_snapshots to follow convention
   `DROP INDEX IF EXISTS idx_bing_coverage_snap_project_date`,
   `CREATE UNIQUE INDEX IF NOT EXISTS idx_bing_coverage_snap_project_date_unique ON bing_coverage_snapshots(project_id, date)`,
+
+  // v35: Add missing index for query_snapshots createdAt for time-series filtering
+  `CREATE INDEX IF NOT EXISTS idx_snapshots_created_at ON query_snapshots(created_at)`,
 ]
 
 /**

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -77,6 +77,7 @@ export const querySnapshots = sqliteTable('query_snapshots', {
   index('idx_snapshots_citation_state').on(table.citationState),
   index('idx_snapshots_provider_model').on(table.provider, table.model),
   index('idx_snapshots_location').on(table.location),
+  index('idx_snapshots_created_at').on(table.createdAt),
 ])
 
 export const auditLog = sqliteTable('audit_log', {


### PR DESCRIPTION
This PR adds a missing index for the `createdAt` column in the `query_snapshots` table.

### Changes
- **packages/db/src/schema.ts**: Added `index("idx_snapshots_created_at").on(table.createdAt)` to the `query_snapshots` table definition.
- **packages/db/src/migrate.ts**: Appended the matching `CREATE INDEX IF NOT EXISTS idx_snapshots_created_at ON query_snapshots(created_at)` to the `MIGRATIONS` array (v35).

### Reason
The `query_snapshots` table is frequently filtered by `createdAt` for time-series analytics and dashboard displays. Adding this index will improve query performance as the database grows.