### PR TITLE
fix(canonry): enable wildcard for static asset serving

### DIFF
--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -1058,7 +1058,7 @@ export async function createServer(opts: {
     await app.register(fastifyStatic.default, {
       root: assetsDir,
       prefix: basePath ?? '/',
-      wildcard: false,
+      wildcard: true,
       // Don't serve index.html automatically — we handle it with config injection
       serve: true,
       index: false,


### PR DESCRIPTION
## Problem
When a `basePath` is configured, the server was registered with `wildcard: false` for `@fastify/static`. This caused nested assets (like the Vite-generated `assets/assets/*.js` bundles) to fail to match the static provider, falling through to the SPA catch-all and returning HTML instead of JavaScript. This led to 'Failed to load module script' errors and a blank screen in the browser.

## Solution
Set `wildcard: true` in `packages/canonry/src/server.ts` to allow the static plugin to correctly resolve nested file paths under the assets root.

## Verification
- Verified on production instance that JS bundles now return `application/javascript` instead of `text/html`.
- UI renders correctly.