### PR TITLE
fix(core): pass competitorDomains instead of overlap to extractRecommendedCompetitors

### DIFF
--- a/packages/canonry/src/job-runner.ts
+++ b/packages/canonry/src/job-runner.ts
@@ -314,7 +314,7 @@ export class JobRunner {
               normalized.answerText,
               allDomains,
               normalized.citedDomains,
-              overlap,
+              competitorDomains,
             )
 
             // Move screenshot to canonical location if present


### PR DESCRIPTION
## Overnight Code Audit — packages/canonry/src/

**Date:** 2026-04-14
**Scope:** All ~75 TypeScript files under \`packages/canonry/src/\`

### Issue Found & Fixed

**Wrong argument passed to \`extractRecommendedCompetitors\` in \`job-runner.ts\`** (line 315)

The 4th parameter of \`extractRecommendedCompetitors(answerText, ownDomains, citedDomains, competitorDomains)\` was incorrectly receiving the precomputed \`overlap\` array (output of \`computeCompetitorOverlap\`) instead of the full \`competitorDomains\` array.

- **Impact:** \`overlap\` only contains competitor domains that were *already* cited or mentioned in the AI response. By passing it instead of \`competitorDomains\`, the function had an incomplete set of known competitor brand keys, causing it to miss some competitor recommendations extracted from AI answers.
- **Consistency:** The backfill command (\`backfill.ts\`) already passed the correct \`competitorDomains\` argument — this fix aligns \`job-runner.ts\` with the same pattern.

### Audit Summary (no issues found)

- ✅ No direct \`ApiClient\` instantiation (all commands use \`createApiClient()\`)
- ✅ No hardcoded \`/api/v1\` paths outside \`ApiClient\` internals (intentional, with basePath auto-discovery)
- ✅ All CLI commands support \`--format json\`
- ✅ Error handling is comprehensive (\`CliError\` hierarchy with exit codes)
- ✅ Proper shutdown guards in \`serve.ts\` (double-fire protection)
- ✅ PID-reuse protection in \`agent-manager.ts\`
- ✅ Webhook retry with exponential backoff in \`notifier.ts\`
- ✅ No \`any\` types
- ✅ Config read-modify-write pattern prevents env-var override leakage
- ✅ All 989 tests pass, typecheck and lint clean