### PR TITLE
chore(providers): implement grounding source synthesis for local provider

### DIFF
--- a/packages/provider-local/src/normalize.ts
+++ b/packages/provider-local/src/normalize.ts
@@ -1,6 +1,7 @@
 import OpenAI from 'openai'
 import { withRetry } from './utils.js'
 import type {
+  GroundingSource,
   LocalConfig,
   LocalHealthcheckResult,
   LocalNormalizedResult,
@@ -96,12 +97,16 @@ export async function executeTrackedQuery(input: LocalTrackedQueryInput): Promis
 export function normalizeResult(raw: LocalRawResult): LocalNormalizedResult {
   const answerText = extractAnswerText(raw.rawResponse)
   const citedDomains = extractDomainMentions(answerText)
+  const groundingSources: GroundingSource[] = citedDomains.map(domain => ({
+    uri: `http://${domain}`,
+    title: domain
+  }))
 
   return {
     provider: 'local',
     answerText,
     citedDomains,
-    groundingSources: raw.groundingSources,
+    groundingSources,
     searchQueries: raw.searchQueries,
   }
 }

--- a/packages/provider-local/test/index.test.ts
+++ b/packages/provider-local/test/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { validateConfig } from '../src/normalize.js'
+import { validateConfig, normalizeResult } from '../src/normalize.js'
 
 describe('provider-local validateConfig', () => {
   it('rejects missing base URL', () => {
@@ -17,5 +17,26 @@ describe('provider-local validateConfig', () => {
       quotaPolicy: { maxConcurrency: 2, maxRequestsPerMinute: 10, maxRequestsPerDay: 1000 },
     })
     expect(result.ok).toBe(true)
+  })
+})
+
+describe('provider-local normalizeResult', () => {
+  it('synthesizes grounding sources from domain mentions', () => {
+    const raw = {
+      provider: 'local' as const,
+      model: 'llama3',
+      rawResponse: {
+        choices: [{ message: { content: 'Check out example.com and https://test.org' } }]
+      },
+      groundingSources: [],
+      searchQueries: []
+    }
+    const result = normalizeResult(raw)
+    expect(result.citedDomains).toContain('example.com')
+    expect(result.citedDomains).toContain('test.org')
+    expect(result.citedDomains.length).toBe(2)
+    expect(result.groundingSources).toContainEqual({ uri: 'http://example.com', title: 'example.com' })
+    expect(result.groundingSources).toContainEqual({ uri: 'http://test.org', title: 'test.org' })
+    expect(result.groundingSources.length).toBe(2)
   })
 })


### PR DESCRIPTION
## Summary
This PR implements grounding source synthesis for the `local` provider.

## Issues Found
- The `local` provider (typically used with Ollama or other local OpenAI-compatible backends) did not populate `groundingSources` in its normalized result.
- While local LLMs often do not provide structured citations, the `extractDomainMentions` utility already identifies cited domains in the answer text.
- Missing `groundingSources` can lead to downstream inconsistencies in UIs or analytics that expect this field to be populated when domains are cited.

## Changes
- Updated `packages/provider-local/src/normalize.ts` to synthesize `GroundingSource` objects from the domains extracted via `extractDomainMentions`.
- Added a regression test in `packages/provider-local/test/index.test.ts` to verify that grounding sources are correctly synthesized.

## Validation
- Verified that `pnpm typecheck`, `pnpm lint`, and `pnpm test` pass for the `provider-local` package.
- Confirmed that the synthesis logic aligns with the `GroundingSource` interface defined in `@ainyc/canonry-contracts`.
- Other provider packages (`cdp`, `claude`, `gemini`, `openai`, `perplexity`) were audited and found to have consistent adapter interfaces and error handling within the scope of this audit.