### PR TITLE
fix(bing): calculate CTR from clicks/impressions

### DIFF
--- a/packages/api-routes/src/bing.ts
+++ b/packages/api-routes/src/bing.ts
@@ -632,7 +632,7 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
       query: s.Query,
       impressions: s.Impressions,
       clicks: s.Clicks,
-      ctr: Number.isFinite(s.Ctr) ? s.Ctr : 0,
+      ctr: s.Impressions > 0 ? s.Clicks / s.Impressions : 0,
       averagePosition: s.AverageClickPosition ?? s.AverageImpressionPosition ?? 0,
     }))
   })


### PR DESCRIPTION
## Summary

- The Bing Webmaster API's `GetQueryStats` endpoint does not return a `Ctr` field in its response
- The previous code read `s.Ctr` which was always `undefined`, causing `Number.isFinite(undefined)` to return `false` and defaulting all CTR values to 0
- CTR is now calculated directly as `clicks / impressions`, matching how GSC handles it