### PR TITLE
chore(providers): filter out internal AI domains from cited domains

### DIFF
--- a/packages/provider-claude/src/normalize.ts
+++ b/packages/provider-claude/src/normalize.ts
@@ -319,7 +319,12 @@ function extractCitedDomainsFromSources(groundingSources: GroundingSource[]): st
 function extractDomainFromUri(uri: string): string | null {
   try {
     const url = new URL(uri)
-    return url.hostname.replace(/^www\./, '').toLowerCase()
+    const hostname = url.hostname.replace(/^www\./, '').toLowerCase()
+    // Skip internal AI service domains
+    if (hostname.includes('chatgpt.com') || hostname.includes('openai.com')) {
+      return null
+    }
+    return hostname
   } catch {
     return null
   }

--- a/packages/provider-gemini/src/normalize.ts
+++ b/packages/provider-gemini/src/normalize.ts
@@ -306,7 +306,12 @@ function extractDomainFromTitle(title: string): string | null {
 function extractDomainFromUri(uri: string): string | null {
   try {
     const url = new URL(uri)
-    const hostname = url.hostname.replace(/^www\./, '')
+    const hostname = url.hostname.replace(/^www\./, '').toLowerCase()
+
+    // Skip internal AI service domains
+    if (hostname.includes('chatgpt.com') || hostname.includes('openai.com')) {
+      return null
+    }
 
     // Gemini returns grounding sources through a Google proxy:
     // vertexaisearch.cloud.google.com/grounding-api-redirect/...

--- a/packages/provider-openai/src/normalize.ts
+++ b/packages/provider-openai/src/normalize.ts
@@ -271,7 +271,12 @@ function extractCitedDomainsFromSources(groundingSources: GroundingSource[]): st
 function extractDomainFromUri(uri: string): string | null {
   try {
     const url = new URL(uri)
-    return url.hostname.replace(/^www\./, '').toLowerCase()
+    const hostname = url.hostname.replace(/^www\./, '').toLowerCase()
+    // Skip internal AI service domains
+    if (hostname.includes('chatgpt.com') || hostname.includes('openai.com')) {
+      return null
+    }
+    return hostname
   } catch {
     return null
   }

--- a/packages/provider-perplexity/src/normalize.ts
+++ b/packages/provider-perplexity/src/normalize.ts
@@ -256,7 +256,12 @@ export function extractCitedDomains(groundingSources: GroundingSource[]): string
 function extractDomainFromUri(uri: string): string | null {
   try {
     const url = new URL(uri)
-    return url.hostname.replace(/^www\./, '').toLowerCase()
+    const hostname = url.hostname.replace(/^www\./, '').toLowerCase()
+    // Skip internal AI service domains
+    if (hostname.includes('chatgpt.com') || hostname.includes('openai.com')) {
+      return null
+    }
+    return hostname
   } catch {
     return null
   }


### PR DESCRIPTION
This PR normalizes `citedDomains` extraction across all provider adapters by filtering out internal AI service domains (chatgpt.com, openai.com).

Specific changes:
- Updated `extractDomainFromUri` in Claude, Gemini, OpenAI, and Perplexity provider adapters.
- Ensured `hostname` is consistently lowercased before comparison.
- Added logic to skip domains containing `chatgpt.com` or `openai.com` as they represent the AI service itself rather than external grounding evidence.

This alignment improves data quality in AEO analysis by focusing on external citations.