### PR TITLE
chore(integrations): improve OAuth/API security, rate limit handling, and sanitization

### DIFF
--- a/packages/integration-bing/src/bing-client.ts
+++ b/packages/integration-bing/src/bing-client.ts
@@ -67,6 +67,10 @@ function bingClientLog(level: 'info' | 'error', action: string, ctx?: Record<str
   stream.write(JSON.stringify(entry) + '\n')
 }
 
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 async function bingFetch<T>(apiKey: string, endpoint: string, opts?: { method?: string; body?: unknown }): Promise<T> {
   const method = opts?.method ?? 'GET'
   const separator = endpoint.includes('?') ? '&' : '?'
@@ -96,8 +100,9 @@ async function bingFetch<T>(apiKey: string, endpoint: string, opts?: { method?: 
   if (!res.ok) {
     const body = await res.text()
     bingClientLog('error', 'http.error', { endpoint, method, httpStatus: res.status })
-    // Truncate large error bodies to avoid carrying huge payloads in thrown errors
-    const detail = body.length <= 500 ? body : `${body.slice(0, 500)}... [truncated]`
+    // Sanitize: avoid leaking API key from error messages if it appears in the body
+    let detail = body.length <= 500 ? body : `${body.slice(0, 500)}... [truncated]`
+    detail = detail.replace(new RegExp(escapeRegExp(apiKey), 'g'), '***')
     throw new BingApiError(`Bing API error (${res.status}): ${detail}`, res.status)
   }
 

--- a/packages/integration-google/src/gsc-client.ts
+++ b/packages/integration-google/src/gsc-client.ts
@@ -79,6 +79,22 @@ function gscClientLog(level: 'info' | 'error', action: string, ctx?: Record<stri
   }
   // Sanitize potential secrets
   if (entry.accessToken) entry.accessToken = '***'
+  if (typeof entry.siteUrl === 'string') {
+    // Basic sanitization if siteUrl happens to contain query params with tokens (unlikely for GSC but good practice)
+    try {
+      const url = new URL(entry.siteUrl)
+      if (url.search) {
+        url.searchParams.forEach((_, key) => {
+          if (key.toLowerCase().includes('token') || key.toLowerCase().includes('key') || key.toLowerCase().includes('auth')) {
+            url.searchParams.set(key, '***')
+          }
+        })
+        entry.siteUrl = url.toString()
+      }
+    } catch {
+      // ignore
+    }
+  }
 
   const stream = level === 'error' ? process.stderr : process.stdout
   stream.write(JSON.stringify(entry) + '\n')

--- a/packages/integration-google/src/oauth.ts
+++ b/packages/integration-google/src/oauth.ts
@@ -98,6 +98,10 @@ export async function exchangeCode(
     signal: AbortSignal.timeout(GOOGLE_REQUEST_TIMEOUT_MS),
   })
 
+  if (res.status === 429) {
+    throw new GoogleAuthError('Google OAuth rate limit exceeded', 429)
+  }
+
   if (!res.ok) {
     const body = await res.text()
     // Sanitize: Google OAuth errors may include client_secret or redirect_uri details
@@ -110,6 +114,7 @@ export async function exchangeCode(
         const sanitized = parsed.error_description
           .replace(new RegExp(escapeRegExp(clientId), 'g'), '***')
           .replace(new RegExp(escapeRegExp(clientSecret), 'g'), '***')
+          .replace(new RegExp(escapeRegExp(code), 'g'), '***')
         detail += detail ? `: ${sanitized}` : sanitized
       }
     } catch {
@@ -145,6 +150,10 @@ export async function refreshAccessToken(
     signal: AbortSignal.timeout(GOOGLE_REQUEST_TIMEOUT_MS),
   })
 
+  if (res.status === 429) {
+    throw new GoogleAuthError('Google OAuth rate limit exceeded', 429)
+  }
+
   if (!res.ok) {
     const body = await res.text()
     // Sanitize: avoid leaking sensitive details from raw OAuth error responses
@@ -157,6 +166,7 @@ export async function refreshAccessToken(
         const sanitized = parsed.error_description
           .replace(new RegExp(escapeRegExp(clientId), 'g'), '***')
           .replace(new RegExp(escapeRegExp(clientSecret), 'g'), '***')
+          .replace(new RegExp(escapeRegExp(currentRefreshToken), 'g'), '***')
         detail += detail ? `: ${sanitized}` : sanitized
       }
     } catch {

--- a/packages/integration-google/src/types.ts
+++ b/packages/integration-google/src/types.ts
@@ -106,9 +106,11 @@ export interface IndexingApiResponse {
 }
 
 export class GoogleAuthError extends Error {
-  constructor(message: string) {
+  public statusCode?: number
+  constructor(message: string, statusCode?: number) {
     super(message)
     this.name = 'GoogleAuthError'
+    this.statusCode = statusCode
   }
 }
 

--- a/packages/integration-wordpress/src/wordpress-client.ts
+++ b/packages/integration-wordpress/src/wordpress-client.ts
@@ -157,6 +157,10 @@ async function fetchJson<T>(
     throw new WordpressApiError('AUTH_INVALID', errorMessage, res.status)
   }
 
+  if (res.status === 429) {
+    throw new WordpressApiError('UPSTREAM_ERROR', 'WordPress API rate limit exceeded', 429)
+  }
+
   if (res.status === 404) {
     throw new WordpressApiError('NOT_FOUND', 'WordPress endpoint not found', 404)
   }


### PR DESCRIPTION
## Overview
This PR improves the security and resilience of several integration clients (Google Search Console, WordPress, and Bing) by addressing OAuth token sanitization, enhancing rate limit handling, and preventing sensitive data leakage in error messages and logs.

## Changes

### `packages/integration-google`
- **OAuth Sanitization**: Updated `exchangeCode` and `refreshAccessToken` to explicitly redact `code` and `refresh_token` from error descriptions if they appear in Google OAuth error responses.
- **Rate Limit Handling**: Added explicit checks for HTTP 429 (Rate Limit Exceeded) in OAuth flows, throwing a `GoogleAuthError` with a 429 status code.
- **Type Safety**: Updated `GoogleAuthError` to support an optional `statusCode` property.
- **Logging Sanitization**: Enhanced `gscClientLog` to sanitize query parameters in `siteUrl` that might contain sensitive keys (e.g., token, key, auth).

### `packages/integration-wordpress`
- **Rate Limit Handling**: Added HTTP 429 detection in the core `fetchJson` helper, throwing a `WordpressApiError` when the upstream WordPress site rate limits requests.

### `packages/integration-bing`
- **Error Sanitization**: Updated `bingFetch` to redact the `apiKey` from error bodies before including them in the thrown `BingApiError`.
- **Sanitization Utility**: Added a `escapeRegExp` utility to ensure safe redaction of API keys.

## Validation
- Verified all changes against common OAuth security best practices.
- Ran `pnpm typecheck`, `pnpm lint`, and `pnpm test` from the repo root; all passed.
- Verified that GSC and WordPress tests still pass with the new error handling logic.