### PR TITLE
fix(agent): pin OpenClaw and require Node 22.14

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ Canonry integrates with [OpenClaw](https://openclaw.ai) to provide an AI agent (
 `canonry agent setup` is the single entry point. It handles:
 
 1. Canonry initialization (if no config exists) — prompts for monitoring provider keys and agent LLM credentials, or accepts them via flags/env vars.
-2. OpenClaw installation via `npm install -g openclaw@latest` (if not found), after checking the published OpenClaw Node engine requirement so setup fails clearly on unsupported runtimes instead of installing the placeholder `openclaw@0.0.1`.
+2. OpenClaw installation via `npm install -g openclaw@2026.4.14` (if not found), with a pinned Canonry/OpenClaw Node floor of `>=22.14.0` so setup fails clearly on unsupported runtimes instead of installing the placeholder `openclaw@0.0.1`.
 3. OpenClaw profile configuration — runs `openclaw onboard --non-interactive --accept-risk --mode local`.
 4. Gateway configuration — sets `gateway.mode=local` and `gateway.port` via `openclaw config set`.
 5. Agent LLM credentials — stored in `~/.openclaw-aero/.env` (e.g. `ANTHROPIC_API_KEY=...`), model set via `openclaw models set`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ Canonry integrates with [OpenClaw](https://openclaw.ai) to provide an AI agent (
 `canonry agent setup` is the single entry point. It handles:
 
 1. Canonry initialization (if no config exists) — prompts for monitoring provider keys and agent LLM credentials, or accepts them via flags/env vars.
-2. OpenClaw installation via `npm install -g openclaw` (if not found).
+2. OpenClaw installation via `npm install -g openclaw@latest` (if not found), after checking the published OpenClaw Node engine requirement so setup fails clearly on unsupported runtimes instead of installing the placeholder `openclaw@0.0.1`.
 3. OpenClaw profile configuration — runs `openclaw onboard --non-interactive --accept-risk --mode local`.
 4. Gateway configuration — sets `gateway.mode=local` and `gateway.port` via `openclaw config set`.
 5. Agent LLM credentials — stored in `~/.openclaw-aero/.env` (e.g. `ANTHROPIC_API_KEY=...`), model set via `openclaw models set`.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install -g @ainyc/canonry
 canonry agent setup
 ```
 
-One command. It installs the pinned [OpenClaw](https://openclaw.ai) release `2026.4.14`, configures the agent's LLM, sets up monitoring providers, and seeds the workspace. Interactive prompts guide you through everything, or pass flags for fully automated setup:
+One command. It installs [OpenClaw](https://openclaw.ai), configures the agent's LLM, sets up monitoring providers, and seeds the workspace. Interactive prompts guide you through everything, or pass flags for fully automated setup:
 
 ```bash
 canonry agent setup --gemini-key <key> --agent-key <key> --format json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Canonry <img src="apps/web/public/favicon-32.png" alt="Canonry canary icon" width="24" />
 
-[![npm version](https://img.shields.io/npm/v/@ainyc/canonry)](https://www.npmjs.com/package/@ainyc/canonry) [![License: FSL-1.1-ALv2](https://img.shields.io/badge/License-FSL--1.1--ALv2-blue.svg)](https://fsl.software/) [![Node.js CLI >= 20 | agent >= 22.14](https://img.shields.io/badge/node-CLI_%3E%3D20_%7C_agent_%3E%3D22.14-brightgreen)](https://nodejs.org)
+[![npm version](https://img.shields.io/npm/v/@ainyc/canonry)](https://www.npmjs.com/package/@ainyc/canonry) [![License: FSL-1.1-ALv2](https://img.shields.io/badge/License-FSL--1.1--ALv2-blue.svg)](https://fsl.software/) [![Node.js >= 22.14](https://img.shields.io/badge/node-%3E%3D22.14-brightgreen)](https://nodejs.org)
 
 Canonry is an agent-first AEO platform powered by [OpenClaw](https://openclaw.ai). It tracks how ChatGPT, Gemini, Claude, and Perplexity cite your site, detects regressions, diagnoses causes, coordinates fixes, and reports results.
 
@@ -15,9 +15,7 @@ npm install -g @ainyc/canonry
 canonry agent setup
 ```
 
-One command. It installs [OpenClaw](https://openclaw.ai), configures the agent's LLM, sets up monitoring providers, and seeds the workspace. Interactive prompts guide you through everything, or pass flags for fully automated setup:
-
-`canonry agent setup` requires Node.js `>=22.14.0` because that is the current engine floor declared by `openclaw@latest`. The monitoring-only CLI and API still support Node.js `>=20`.
+One command. It installs the pinned [OpenClaw](https://openclaw.ai) release `2026.4.14`, configures the agent's LLM, sets up monitoring providers, and seeds the workspace. Interactive prompts guide you through everything, or pass flags for fully automated setup:
 
 ```bash
 canonry agent setup --gemini-key <key> --agent-key <key> --format json
@@ -179,8 +177,7 @@ Create a Web Service with runtime Docker, attach a disk at `/data`. Health check
 
 ## Requirements
 
-- Node.js >= 20
-- Node.js >= 22.14.0 for `canonry agent setup` / OpenClaw features
+- Node.js >= 22.14.0
 - At least one provider API key (configurable after startup)
 
 If `npm install` fails with `node-gyp` errors, install build tools for `better-sqlite3`: `xcode-select --install` (macOS), `apt-get install python3 make g++` (Debian), or see the [troubleshooting guide](https://github.com/WiseLibs/better-sqlite3/blob/master/docs/troubleshooting.md).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Canonry <img src="apps/web/public/favicon-32.png" alt="Canonry canary icon" width="24" />
 
-[![npm version](https://img.shields.io/npm/v/@ainyc/canonry)](https://www.npmjs.com/package/@ainyc/canonry) [![License: FSL-1.1-ALv2](https://img.shields.io/badge/License-FSL--1.1--ALv2-blue.svg)](https://fsl.software/) [![Node.js >= 20](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](https://nodejs.org)
+[![npm version](https://img.shields.io/npm/v/@ainyc/canonry)](https://www.npmjs.com/package/@ainyc/canonry) [![License: FSL-1.1-ALv2](https://img.shields.io/badge/License-FSL--1.1--ALv2-blue.svg)](https://fsl.software/) [![Node.js CLI >= 20 | agent >= 22.14](https://img.shields.io/badge/node-CLI_%3E%3D20_%7C_agent_%3E%3D22.14-brightgreen)](https://nodejs.org)
 
 Canonry is an agent-first AEO platform powered by [OpenClaw](https://openclaw.ai). It tracks how ChatGPT, Gemini, Claude, and Perplexity cite your site, detects regressions, diagnoses causes, coordinates fixes, and reports results.
 
@@ -16,6 +16,8 @@ canonry agent setup
 ```
 
 One command. It installs [OpenClaw](https://openclaw.ai), configures the agent's LLM, sets up monitoring providers, and seeds the workspace. Interactive prompts guide you through everything, or pass flags for fully automated setup:
+
+`canonry agent setup` requires Node.js `>=22.14.0` because that is the current engine floor declared by `openclaw@latest`. The monitoring-only CLI and API still support Node.js `>=20`.
 
 ```bash
 canonry agent setup --gemini-key <key> --agent-key <key> --format json
@@ -178,6 +180,7 @@ Create a Web Service with runtime Docker, attach a disk at `/data`. Health check
 ## Requirements
 
 - Node.js >= 20
+- Node.js >= 22.14.0 for `canonry agent setup` / OpenClaw features
 - At least one provider API key (configurable after startup)
 
 If `npm install` fails with `node-gyp` errors, install build tools for `better-sqlite3`: `xcode-select --install` (macOS), `apt-get install python3 make g++` (Debian), or see the [troubleshooting guide](https://github.com/WiseLibs/better-sqlite3/blob/master/docs/troubleshooting.md).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "1.48.0",
+  "version": "1.48.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "1.48.1",
+  "version": "1.48.2",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {
@@ -35,6 +35,6 @@
     ]
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22.14.0"
   }
 }

--- a/packages/canonry/AGENTS.md
+++ b/packages/canonry/AGENTS.md
@@ -83,7 +83,7 @@ Providers are registered at server startup in `server.ts`. Each provider adapter
 `canonry agent setup` is the single entry point. The orchestrator in `commands/agent.ts` calls helpers from `agent-bootstrap.ts`:
 
 1. **Init canonry** — calls `initCommand()` if no `config.yaml` exists. Prompts for monitoring provider keys and agent LLM credentials (provider, key, model). Accepts all values via flags or env vars for non-interactive use.
-2. **Detect/install OpenClaw** — checks PATH, installs via `npm install -g openclaw@latest` if missing, preflights the published Node engine requirement, and verifies that the detected binary version matches the npm-resolved package version.
+2. **Detect/install OpenClaw** — checks PATH, installs via `npm install -g openclaw@2026.4.14` if missing, enforces Canonry's pinned Node floor of `>=22.14.0`, and verifies that the detected binary version matches the pinned package version.
 3. **Save agent config** — persists `{binary, profile, gatewayPort}` to canonry `config.yaml` via `saveConfigPatch()`.
 4. **Initialize profile** — `initializeOpenClawProfile()` runs `openclaw onboard --non-interactive --accept-risk --mode local`.
 5. **Configure gateway** — `configureOpenClawGateway()` sets `gateway.mode=local` and `gateway.port` via `openclaw config set`.

--- a/packages/canonry/AGENTS.md
+++ b/packages/canonry/AGENTS.md
@@ -83,7 +83,7 @@ Providers are registered at server startup in `server.ts`. Each provider adapter
 `canonry agent setup` is the single entry point. The orchestrator in `commands/agent.ts` calls helpers from `agent-bootstrap.ts`:
 
 1. **Init canonry** — calls `initCommand()` if no `config.yaml` exists. Prompts for monitoring provider keys and agent LLM credentials (provider, key, model). Accepts all values via flags or env vars for non-interactive use.
-2. **Detect/install OpenClaw** — checks PATH, installs via `npm install -g openclaw` if missing.
+2. **Detect/install OpenClaw** — checks PATH, installs via `npm install -g openclaw@latest` if missing, preflights the published Node engine requirement, and verifies that the detected binary version matches the npm-resolved package version.
 3. **Save agent config** — persists `{binary, profile, gatewayPort}` to canonry `config.yaml` via `saveConfigPatch()`.
 4. **Initialize profile** — `initializeOpenClawProfile()` runs `openclaw onboard --non-interactive --accept-risk --mode local`.
 5. **Configure gateway** — `configureOpenClawGateway()` sets `gateway.mode=local` and `gateway.port` via `openclaw config set`.

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "1.48.1",
+  "version": "1.48.2",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",
@@ -31,7 +31,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22.14.0"
   },
   "scripts": {
     "build": "tsx scripts/copy-agent-assets.ts && tsup && tsx build-web.ts",

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "1.48.0",
+  "version": "1.48.1",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/agent-bootstrap.ts
+++ b/packages/canonry/src/agent-bootstrap.ts
@@ -13,7 +13,9 @@ export interface DetectionResult {
 }
 
 const CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes (DenchClaw pattern)
-const OPENCLAW_PACKAGE_SPEC = 'openclaw@latest'
+const OPENCLAW_VERSION = '2026.4.14'
+const OPENCLAW_PACKAGE_SPEC = `openclaw@${OPENCLAW_VERSION}`
+const MIN_NODE_VERSION = '22.14.0'
 let cachedResult: DetectionResult | null = null
 let cachedAt = 0
 
@@ -115,20 +117,12 @@ export interface InstallResult {
   error?: string
 }
 
-interface OpenClawRegistryMetadata {
-  version?: string
-  engines?: {
-    node?: string
-  }
-}
-
 /**
  * Install OpenClaw globally via npm and return the detection result.
  * Resets the detection cache before re-probing.
  */
-export async function installOpenClaw(opts?: { silent?: boolean }): Promise<InstallResult> {
-  const metadata = readPublishedOpenClawMetadata()
-  const unsupportedNodeError = getUnsupportedNodeError(metadata)
+export async function installOpenClaw(opts?: { silent?: boolean; nodeVersion?: string }): Promise<InstallResult> {
+  const unsupportedNodeError = getUnsupportedNodeError(opts?.nodeVersion)
   if (unsupportedNodeError) {
     return {
       success: false,
@@ -159,13 +153,13 @@ export async function installOpenClaw(opts?: { silent?: boolean }): Promise<Inst
     }
   }
 
-  if (metadata?.version && detection.version) {
-    const expectedVersion = parseVersionTuple(metadata.version)
+  if (detection.version) {
+    const expectedVersion = parseVersionTuple(OPENCLAW_VERSION)
     const detectedVersion = parseVersionTuple(detection.version)
     if (expectedVersion && detectedVersion && compareVersionTuples(detectedVersion, expectedVersion) !== 0) {
       return {
         success: false,
-        error: `Installed OpenClaw binary reports version ${detection.version}, but npm resolved ${metadata.version}. A different openclaw binary may be shadowing the npm-installed package in PATH.`,
+        error: `Installed OpenClaw binary reports version ${detection.version}, but Canonry pinned ${OPENCLAW_VERSION}. A different openclaw binary may be shadowing the npm-installed package in PATH.`,
       }
     }
   }
@@ -173,46 +167,15 @@ export async function installOpenClaw(opts?: { silent?: boolean }): Promise<Inst
   return { success: true, detection }
 }
 
-function readPublishedOpenClawMetadata(): OpenClawRegistryMetadata | null {
-  try {
-    const output = execSync(`npm view ${OPENCLAW_PACKAGE_SPEC} version engines --json`, {
-      timeout: 10_000,
-      encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    })
-    const parsed = JSON.parse(output)
-    if (!parsed || typeof parsed !== 'object') {
-      return null
-    }
-    return parsed as OpenClawRegistryMetadata
-  } catch {
-    return null
-  }
-}
-
-function getUnsupportedNodeError(metadata: OpenClawRegistryMetadata | null): string | null {
-  const nodeRange = metadata?.engines?.node?.trim()
-  const minimumNodeVersion = nodeRange ? extractMinimumVersion(nodeRange) : null
-  if (!nodeRange || !minimumNodeVersion) {
-    return null
-  }
-
-  const currentNodeVersion = normalizeVersion(process.versions.node)
-  const minimumTuple = parseVersionTuple(minimumNodeVersion)
+function getUnsupportedNodeError(currentNodeVersionOverride?: string): string | null {
+  const currentNodeVersion = normalizeVersion(currentNodeVersionOverride ?? process.versions.node)
+  const minimumTuple = parseVersionTuple(MIN_NODE_VERSION)
   const currentTuple = parseVersionTuple(currentNodeVersion)
   if (!minimumTuple || !currentTuple || compareVersionTuples(currentTuple, minimumTuple) >= 0) {
     return null
   }
 
-  const descriptor = metadata?.version
-    ? `OpenClaw ${metadata.version}`
-    : OPENCLAW_PACKAGE_SPEC
-  return `${descriptor} requires Node.js ${nodeRange}, but the current runtime is ${currentNodeVersion}. Upgrade Node.js before running "canonry agent setup".`
-}
-
-function extractMinimumVersion(range: string): string | null {
-  const match = range.match(/>=\s*v?(\d+(?:\.\d+){0,2})/)
-  return match ? normalizeVersion(match[1]) : null
+  return `Canonry requires Node.js >=${MIN_NODE_VERSION} and installs pinned OpenClaw ${OPENCLAW_VERSION}, but the current runtime is ${currentNodeVersion}. Upgrade Node.js before running "canonry agent setup".`
 }
 
 function normalizeVersion(version: string): string {

--- a/packages/canonry/src/agent-bootstrap.ts
+++ b/packages/canonry/src/agent-bootstrap.ts
@@ -13,6 +13,7 @@ export interface DetectionResult {
 }
 
 const CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes (DenchClaw pattern)
+const OPENCLAW_PACKAGE_SPEC = 'openclaw@latest'
 let cachedResult: DetectionResult | null = null
 let cachedAt = 0
 
@@ -114,13 +115,29 @@ export interface InstallResult {
   error?: string
 }
 
+interface OpenClawRegistryMetadata {
+  version?: string
+  engines?: {
+    node?: string
+  }
+}
+
 /**
  * Install OpenClaw globally via npm and return the detection result.
  * Resets the detection cache before re-probing.
  */
 export async function installOpenClaw(opts?: { silent?: boolean }): Promise<InstallResult> {
+  const metadata = readPublishedOpenClawMetadata()
+  const unsupportedNodeError = getUnsupportedNodeError(metadata)
+  if (unsupportedNodeError) {
+    return {
+      success: false,
+      error: unsupportedNodeError,
+    }
+  }
+
   try {
-    execSync('npm install -g openclaw', {
+    execSync(`npm install -g ${OPENCLAW_PACKAGE_SPEC}`, {
       timeout: 120_000,
       stdio: opts?.silent ? 'pipe' : 'inherit',
     })
@@ -138,11 +155,95 @@ export async function installOpenClaw(opts?: { silent?: boolean }): Promise<Inst
   if (!detection.found) {
     return {
       success: false,
-      error: 'npm install succeeded but openclaw binary was not found in PATH',
+      error: `npm install succeeded but the ${OPENCLAW_PACKAGE_SPEC} binary was not found in PATH`,
+    }
+  }
+
+  if (metadata?.version && detection.version) {
+    const expectedVersion = parseVersionTuple(metadata.version)
+    const detectedVersion = parseVersionTuple(detection.version)
+    if (expectedVersion && detectedVersion && compareVersionTuples(detectedVersion, expectedVersion) !== 0) {
+      return {
+        success: false,
+        error: `Installed OpenClaw binary reports version ${detection.version}, but npm resolved ${metadata.version}. A different openclaw binary may be shadowing the npm-installed package in PATH.`,
+      }
     }
   }
 
   return { success: true, detection }
+}
+
+function readPublishedOpenClawMetadata(): OpenClawRegistryMetadata | null {
+  try {
+    const output = execSync(`npm view ${OPENCLAW_PACKAGE_SPEC} version engines --json`, {
+      timeout: 10_000,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    const parsed = JSON.parse(output)
+    if (!parsed || typeof parsed !== 'object') {
+      return null
+    }
+    return parsed as OpenClawRegistryMetadata
+  } catch {
+    return null
+  }
+}
+
+function getUnsupportedNodeError(metadata: OpenClawRegistryMetadata | null): string | null {
+  const nodeRange = metadata?.engines?.node?.trim()
+  const minimumNodeVersion = nodeRange ? extractMinimumVersion(nodeRange) : null
+  if (!nodeRange || !minimumNodeVersion) {
+    return null
+  }
+
+  const currentNodeVersion = normalizeVersion(process.versions.node)
+  const minimumTuple = parseVersionTuple(minimumNodeVersion)
+  const currentTuple = parseVersionTuple(currentNodeVersion)
+  if (!minimumTuple || !currentTuple || compareVersionTuples(currentTuple, minimumTuple) >= 0) {
+    return null
+  }
+
+  const descriptor = metadata?.version
+    ? `OpenClaw ${metadata.version}`
+    : OPENCLAW_PACKAGE_SPEC
+  return `${descriptor} requires Node.js ${nodeRange}, but the current runtime is ${currentNodeVersion}. Upgrade Node.js before running "canonry agent setup".`
+}
+
+function extractMinimumVersion(range: string): string | null {
+  const match = range.match(/>=\s*v?(\d+(?:\.\d+){0,2})/)
+  return match ? normalizeVersion(match[1]) : null
+}
+
+function normalizeVersion(version: string): string {
+  const tuple = parseVersionTuple(version)
+  if (!tuple) {
+    return version.trim().replace(/^v/i, '')
+  }
+  return tuple.join('.')
+}
+
+function parseVersionTuple(version: string): [number, number, number] | null {
+  const match = version.trim().replace(/^v/i, '').match(/^(\d+)(?:\.(\d+))?(?:\.(\d+))?$/)
+  if (!match) {
+    return null
+  }
+
+  return [
+    Number(match[1]),
+    Number(match[2] ?? 0),
+    Number(match[3] ?? 0),
+  ]
+}
+
+function compareVersionTuples(left: [number, number, number], right: [number, number, number]): number {
+  for (let index = 0; index < left.length; index++) {
+    const delta = left[index] - right[index]
+    if (delta !== 0) {
+      return delta
+    }
+  }
+  return 0
 }
 
 /**

--- a/packages/canonry/src/commands/agent.ts
+++ b/packages/canonry/src/commands/agent.ts
@@ -350,7 +350,7 @@ export async function agentDetach(opts: { project: string; format?: string }): P
 
 async function autoInstallOrFail(format?: string) {
   if (format !== 'json') {
-    console.log('OpenClaw not found, installing openclaw@latest via npm...')
+    console.log('OpenClaw not found, installing pinned openclaw@2026.4.14 via npm...')
   }
 
   const install = await installOpenClaw({ silent: format === 'json' })

--- a/packages/canonry/src/commands/agent.ts
+++ b/packages/canonry/src/commands/agent.ts
@@ -350,7 +350,7 @@ export async function agentDetach(opts: { project: string; format?: string }): P
 
 async function autoInstallOrFail(format?: string) {
   if (format !== 'json') {
-    console.log('OpenClaw not found, installing via npm...')
+    console.log('OpenClaw not found, installing openclaw@latest via npm...')
   }
 
   const install = await installOpenClaw({ silent: format === 'json' })

--- a/packages/canonry/test/agent-bootstrap.test.ts
+++ b/packages/canonry/test/agent-bootstrap.test.ts
@@ -7,11 +7,12 @@ import type { AgentConfigEntry } from '../src/config.js'
 // Mock child_process before importing the module under test
 vi.mock('node:child_process', () => ({
   execFileSync: vi.fn(),
+  execSync: vi.fn(),
 }))
 
 // Lazy import so mocks are in place
-const { detectOpenClaw, getAeroStateDir } = await import('../src/agent-bootstrap.js')
-const { execFileSync } = await import('node:child_process')
+const { detectOpenClaw, getAeroStateDir, installOpenClaw } = await import('../src/agent-bootstrap.js')
+const { execFileSync, execSync } = await import('node:child_process')
 
 let tmpDir: string
 
@@ -112,5 +113,74 @@ describe('getAeroStateDir', () => {
   it('uses custom profile name when provided', () => {
     const result = getAeroStateDir('custom')
     expect(result).toBe(path.join(os.homedir(), '.openclaw-custom'))
+  })
+})
+
+describe('installOpenClaw', () => {
+  it('installs openclaw@latest and verifies the detected version', async () => {
+    vi.mocked(execSync)
+      .mockReturnValueOnce(JSON.stringify({
+        version: '2026.4.14',
+        engines: { node: '>=20.0.0' },
+      }) as ReturnType<typeof execSync>)
+      .mockReturnValueOnce('' as ReturnType<typeof execSync>)
+
+    vi.mocked(execFileSync)
+      .mockImplementationOnce(((cmd: string) => {
+        if (cmd === 'which') return '/usr/local/bin/openclaw\n'
+        throw new Error('unexpected')
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any)
+      .mockImplementationOnce(((cmd: string) => {
+        if (cmd === '/usr/local/bin/openclaw') return 'openclaw 2026.4.14\n'
+        throw new Error('unexpected')
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any)
+
+    const result = await installOpenClaw({ silent: true })
+
+    expect(result.success).toBe(true)
+    expect(result.detection?.version).toBe('2026.4.14')
+    expect(vi.mocked(execSync).mock.calls[0]?.[0]).toBe('npm view openclaw@latest version engines --json')
+    expect(vi.mocked(execSync).mock.calls[1]?.[0]).toBe('npm install -g openclaw@latest')
+  })
+
+  it('fails early when the published OpenClaw engine exceeds the current Node runtime', async () => {
+    vi.mocked(execSync).mockReturnValueOnce(JSON.stringify({
+      version: '2099.1.0',
+      engines: { node: '>=99.0.0' },
+    }) as ReturnType<typeof execSync>)
+
+    const result = await installOpenClaw({ silent: true })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('requires Node.js >=99.0.0')
+    expect(vi.mocked(execSync).mock.calls).toHaveLength(1)
+  })
+
+  it('fails when the detected OpenClaw version does not match the resolved npm package version', async () => {
+    vi.mocked(execSync)
+      .mockReturnValueOnce(JSON.stringify({
+        version: '2026.4.14',
+        engines: { node: '>=20.0.0' },
+      }) as ReturnType<typeof execSync>)
+      .mockReturnValueOnce('' as ReturnType<typeof execSync>)
+
+    vi.mocked(execFileSync)
+      .mockImplementationOnce(((cmd: string) => {
+        if (cmd === 'which') return '/usr/local/bin/openclaw\n'
+        throw new Error('unexpected')
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any)
+      .mockImplementationOnce(((cmd: string) => {
+        if (cmd === '/usr/local/bin/openclaw') return 'openclaw 2026.4.13\n'
+        throw new Error('unexpected')
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any)
+
+    const result = await installOpenClaw({ silent: true })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('npm resolved 2026.4.14')
   })
 })

--- a/packages/canonry/test/agent-bootstrap.test.ts
+++ b/packages/canonry/test/agent-bootstrap.test.ts
@@ -117,13 +117,8 @@ describe('getAeroStateDir', () => {
 })
 
 describe('installOpenClaw', () => {
-  it('installs openclaw@latest and verifies the detected version', async () => {
-    vi.mocked(execSync)
-      .mockReturnValueOnce(JSON.stringify({
-        version: '2026.4.14',
-        engines: { node: '>=20.0.0' },
-      }) as ReturnType<typeof execSync>)
-      .mockReturnValueOnce('' as ReturnType<typeof execSync>)
+  it('installs the pinned openclaw version and verifies the detected version', async () => {
+    vi.mocked(execSync).mockReturnValueOnce('' as ReturnType<typeof execSync>)
 
     vi.mocked(execFileSync)
       .mockImplementationOnce(((cmd: string) => {
@@ -141,30 +136,20 @@ describe('installOpenClaw', () => {
 
     expect(result.success).toBe(true)
     expect(result.detection?.version).toBe('2026.4.14')
-    expect(vi.mocked(execSync).mock.calls[0]?.[0]).toBe('npm view openclaw@latest version engines --json')
-    expect(vi.mocked(execSync).mock.calls[1]?.[0]).toBe('npm install -g openclaw@latest')
+    expect(vi.mocked(execSync).mock.calls[0]?.[0]).toBe('npm install -g openclaw@2026.4.14')
   })
 
-  it('fails early when the published OpenClaw engine exceeds the current Node runtime', async () => {
-    vi.mocked(execSync).mockReturnValueOnce(JSON.stringify({
-      version: '2099.1.0',
-      engines: { node: '>=99.0.0' },
-    }) as ReturnType<typeof execSync>)
-
-    const result = await installOpenClaw({ silent: true })
+  it('fails early when the runtime is below the pinned minimum node version', async () => {
+    const result = await installOpenClaw({ silent: true, nodeVersion: '22.13.0' })
 
     expect(result.success).toBe(false)
-    expect(result.error).toContain('requires Node.js >=99.0.0')
-    expect(vi.mocked(execSync).mock.calls).toHaveLength(1)
+    expect(result.error).toContain('requires Node.js >=22.14.0')
+    expect(result.error).toContain('pinned OpenClaw 2026.4.14')
+    expect(vi.mocked(execSync).mock.calls).toHaveLength(0)
   })
 
-  it('fails when the detected OpenClaw version does not match the resolved npm package version', async () => {
-    vi.mocked(execSync)
-      .mockReturnValueOnce(JSON.stringify({
-        version: '2026.4.14',
-        engines: { node: '>=20.0.0' },
-      }) as ReturnType<typeof execSync>)
-      .mockReturnValueOnce('' as ReturnType<typeof execSync>)
+  it('fails when the detected OpenClaw version does not match the pinned package version', async () => {
+    vi.mocked(execSync).mockReturnValueOnce('' as ReturnType<typeof execSync>)
 
     vi.mocked(execFileSync)
       .mockImplementationOnce(((cmd: string) => {
@@ -181,6 +166,6 @@ describe('installOpenClaw', () => {
     const result = await installOpenClaw({ silent: true })
 
     expect(result.success).toBe(false)
-    expect(result.error).toContain('npm resolved 2026.4.14')
+    expect(result.error).toContain('Canonry pinned 2026.4.14')
   })
 })

--- a/packages/canonry/tsup.config.ts
+++ b/packages/canonry/tsup.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     index: 'src/index.ts',
   },
   format: ['esm'],
-  target: 'node20',
+  target: 'node22',
   platform: 'node',
   splitting: true,
   clean: true,


### PR DESCRIPTION
Fixes #323

## Summary

- pin `canonry agent setup` to install `openclaw@2026.4.14` instead of resolving `openclaw@latest` or the bare `openclaw` package name
- make Canonry itself require Node.js `>=22.14.0` in both published package metadata and the build target
- fail agent setup early with a clear message when the runtime is below the pinned Node floor
- verify that the detected `openclaw` binary version matches the pinned package version to avoid PATH-shadowed installs
- update README and AGENTS docs to reflect the pinned OpenClaw version and the package-wide Node requirement
- keep regression coverage for the pinned install path, Node floor enforcement, and version mismatch handling

## Root Cause

`agent setup` was previously doing a loose OpenClaw install, which allowed npm to resolve the placeholder `openclaw@0.0.1` package. The first fix switched to `@latest`, but that still left Canonry coupled to whatever OpenClaw version the registry tag pointed at. This patch pins a specific recent OpenClaw release and aligns Canonry itself with that release's Node requirement.

## Impact

- Canonry now has a single runtime floor: Node.js `>=22.14.0`
- agent setup installs a controlled OpenClaw version instead of following the moving `latest` tag
- users get a direct error before install if they are on an unsupported Node runtime
- Canonry rejects PATH-shadowed OpenClaw binaries that do not match the pinned version

## Validation

- `pnpm -r run lint` via the commit hook
- `pnpm exec vitest run packages/canonry/test/agent-bootstrap.test.ts packages/canonry/test/agent-commands.test.ts`
- `pnpm exec eslint packages/canonry/src/agent-bootstrap.ts packages/canonry/src/commands/agent.ts packages/canonry/test/agent-bootstrap.test.ts packages/canonry/tsup.config.ts`
- package-wide `pnpm --filter @ainyc/canonry run typecheck` is still blocked locally by the existing `@ainyc/canonry-intelligence` workspace resolution error unrelated to this diff
