### PR TITLE
docs: remove OpenClaw references from READMEs and skills

### DIFF
--- a/.claude/skills/canonry-setup/SKILL.md
+++ b/.claude/skills/canonry-setup/SKILL.md
@@ -3,7 +3,7 @@ name: canonry
 description: "AEO (Answer Engine Optimization) monitoring and analysis using canonry CLI and aeo-audit tool. Use when: (1) running citation sweeps across AI providers (Gemini, ChatGPT, Claude, Perplexity); (2) auditing technical SEO with structured data validation; (3) implementing schema markup, sitemaps, llms.txt; (4) diagnosing indexing issues via Google Search Console and Bing Webmaster Tools; (5) optimizing content for AI readability and entity consistency. NOT for: general web development, content writing, PPC campaigns, or social media management."
 metadata:
   {
-    "openclaw":
+    "agent":
       {
         "emoji": "📡",
         "requires": { "bins": ["canonry"] },

--- a/.claude/skills/canonry-setup/references/canonry-cli.md
+++ b/.claude/skills/canonry-setup/references/canonry-cli.md
@@ -294,10 +294,10 @@ canonry export <project> --include-results > project.yaml
 canonry sitemap inspect <project>
 ```
 
-## Agent (OpenClaw Integration)
+## Agent
 
 `canonry agent setup` is the single entry point for configuring the agent. It handles everything:
-canonry initialization, OpenClaw installation, profile setup, LLM credential configuration,
+canonry initialization, agent runtime installation, profile setup, LLM credential configuration,
 and workspace seeding. If canonry is not yet configured, it runs the interactive init flow first
 (prompting for monitoring provider keys and agent LLM credentials).
 
@@ -311,7 +311,7 @@ canonry agent setup --agent-provider openrouter --agent-key <key> --agent-model 
 GEMINI_API_KEY=<key> canonry agent setup --agent-key <key> --format json
 
 # Lifecycle
-canonry agent start                              # start OpenClaw gateway as background process
+canonry agent start                              # start agent gateway as background process
 canonry agent stop                               # stop the gateway process
 canonry agent status                             # check if gateway is running
 canonry agent status --format json               # JSON output
@@ -328,9 +328,9 @@ canonry agent setup --claude-key <key>
 canonry agent setup --perplexity-key <key>
 ```
 
-**Setup flow:** init canonry (if needed) → install OpenClaw (if needed) → configure profile → configure gateway → set agent LLM credentials → seed workspace with skills.
+**Setup flow:** init canonry (if needed) → install agent runtime (if needed) → configure profile → configure gateway → set agent LLM credentials → seed workspace with skills.
 
-**Agent LLM credentials** are stored in `~/.openclaw-aero/.env` (e.g. `ANTHROPIC_API_KEY=...`) and loaded into the gateway process at start time. The model is set via `openclaw models set`.
+**Agent LLM credentials** are stored in the agent env file (e.g. `ANTHROPIC_API_KEY=...`) and loaded into the gateway process at start time. The model is set via the agent CLI.
 
 **Re-running is safe:** setup is idempotent — it skips steps that are already configured.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,12 +53,12 @@ canonry status <project>
 canonry apply <file...>                          # multi-doc YAML + multiple files
 canonry export <project>
 
-# Agent layer (OpenClaw)
+# Agent layer
 canonry agent setup                              # full setup: init + install + configure + seed
 canonry agent setup --agent-key <key>            # non-interactive with flags
-canonry agent start                              # start gateway as background process
-canonry agent stop                               # stop gateway
-canonry agent status                             # check gateway state
+canonry agent start                              # start agent gateway as background process
+canonry agent stop                               # stop agent gateway
+canonry agent status                             # check agent state
 canonry agent reset                              # stop + wipe workspace
 canonry agent attach <project>                   # attach agent webhook to project
 canonry agent detach <project>                   # detach agent webhook from project
@@ -66,24 +66,24 @@ canonry agent detach <project>                   # detach agent webhook from pro
 
 ## Agent Layer
 
-Canonry integrates with [OpenClaw](https://openclaw.ai) to provide an AI agent ("Aero") that orchestrates sweeps, analyzes results, and generates reports.
+Canonry ships a bundled AI agent ("Aero") that orchestrates sweeps, analyzes results, and generates reports. The agent is a consumer of the same CLI and API available to everyone — it has no privileged access or hidden surface.
 
 ### Setup
 
 `canonry agent setup` is the single entry point. It handles:
 
 1. Canonry initialization (if no config exists) — prompts for monitoring provider keys and agent LLM credentials, or accepts them via flags/env vars.
-2. OpenClaw installation via `npm install -g openclaw@2026.4.14` (if not found), with a pinned Canonry/OpenClaw Node floor of `>=22.14.0` so setup fails clearly on unsupported runtimes instead of installing the placeholder `openclaw@0.0.1`.
-3. OpenClaw profile configuration — runs `openclaw onboard --non-interactive --accept-risk --mode local`.
-4. Gateway configuration — sets `gateway.mode=local` and `gateway.port` via `openclaw config set`.
-5. Agent LLM credentials — stored in `~/.openclaw-aero/.env` (e.g. `ANTHROPIC_API_KEY=...`), model set via `openclaw models set`.
-6. Workspace seeding — copies bundled skills to the OpenClaw workspace.
+2. Agent runtime installation (if not found), with a pinned Node floor of `>=22.14.0` so setup fails clearly on unsupported runtimes.
+3. Agent profile configuration in local mode.
+4. Gateway configuration — sets the local mode and gateway port.
+5. Agent LLM credentials — stored in the agent env file (e.g. `ANTHROPIC_API_KEY=...`), model set via the agent CLI.
+6. Workspace seeding — copies bundled skills to the agent workspace.
 
 Setup is idempotent — safe to re-run. For non-interactive use: `canonry agent setup --gemini-key <key> --agent-key <key> --format json`.
 
 ### Runtime
 
-`canonry agent start` spawns `openclaw --profile aero gateway` as a detached process. The gateway process inherits LLM credentials from `~/.openclaw-aero/.env`. `canonry agent stop` sends SIGTERM with escalation to SIGKILL.
+`canonry agent start` spawns the agent gateway as a detached process. The gateway process inherits LLM credentials from the agent env file. `canonry agent stop` sends SIGTERM with escalation to SIGKILL.
 
 ### Webhook lifecycle
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ The web dashboard follows a dark, professional analytics aesthetic inspired by *
 
 ## Skills Maintenance
 
-The `skills/canonry-setup/` directory contains an OpenClaw/Claude skill that documents how to install, configure, and operate canonry. **Keep this skill in sync with the codebase.**
+The `skills/canonry-setup/` directory contains a Claude skill that documents how to install, configure, and operate canonry. **Keep this skill in sync with the codebase.**
 
 ### When to update skills
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/@ainyc/canonry)](https://www.npmjs.com/package/@ainyc/canonry) [![License: FSL-1.1-ALv2](https://img.shields.io/badge/License-FSL--1.1--ALv2-blue.svg)](https://fsl.software/) [![Node.js >= 22.14](https://img.shields.io/badge/node-%3E%3D22.14-brightgreen)](https://nodejs.org)
 
-Canonry is an agent-first AEO platform powered by [OpenClaw](https://openclaw.ai). It tracks how ChatGPT, Gemini, Claude, and Perplexity cite your site, detects regressions, diagnoses causes, coordinates fixes, and reports results.
+Canonry is an agent-first AEO platform — CLI- and API-native, with a bundled AI agent. It tracks how ChatGPT, Gemini, Claude, and Perplexity cite your site, detects regressions, diagnoses causes, coordinates fixes, and reports results.
 
 AEO (Answer Engine Optimization) is about making sure your content shows up accurately in AI-generated answers. As search shifts from links to synthesized responses, you need something that can monitor, analyze, and act across these engines continuously.
 
@@ -15,7 +15,7 @@ npm install -g @ainyc/canonry
 canonry agent setup
 ```
 
-One command. It installs [OpenClaw](https://openclaw.ai), configures the agent's LLM, sets up monitoring providers, and seeds the workspace. Interactive prompts guide you through everything, or pass flags for fully automated setup:
+One command. It installs the agent runtime, configures the agent's LLM, sets up monitoring providers, and seeds the workspace. Interactive prompts guide you through everything, or pass flags for fully automated setup:
 
 ```bash
 canonry agent setup --gemini-key <key> --agent-key <key> --format json
@@ -42,7 +42,7 @@ canonry serve
 
 ## What the Agent Does
 
-The Canonry agent ("Aero") is an [OpenClaw](https://openclaw.ai)-powered operator:
+The Canonry agent ("Aero") is an autonomous operator:
 
 - **Monitors** visibility sweeps across providers on schedule, tracking citation changes over time
 - **Analyzes** regressions, emerging opportunities, and correlates visibility shifts with site changes
@@ -53,7 +53,7 @@ Every action the agent takes goes through the same CLI and API available to ever
 
 ## Features
 
-- **Agent-operated.** The OpenClaw agent monitors, analyzes, and acts autonomously. Humans supervise via the dashboard.
+- **Agent-operated.** The bundled agent monitors, analyzes, and acts autonomously. Humans supervise via the dashboard.
 - **Multi-provider.** Query Gemini, OpenAI, Claude, Perplexity, and local LLMs from a single platform.
 - **Config-as-code.** Kubernetes-style YAML files. Version control your monitoring, let agents apply changes declaratively.
 - **Self-hosted.** Runs locally with SQLite. No cloud account required.
@@ -148,9 +148,9 @@ Integration setup guides: [Google Search Console](docs/google-search-console-set
 
 ## Skills
 
-The agent learns how to operate canonry through bundled [OpenClaw skills](https://clawhub.dev) that cover CLI commands, provider setup, analysis workflows, and troubleshooting. Skills are seeded into the agent workspace during `canonry agent setup`.
+The agent learns how to operate canonry through bundled skills that cover CLI commands, provider setup, analysis workflows, and troubleshooting. Skills are seeded into the agent workspace during `canonry agent setup`.
 
-**Claude Code** also picks up the skill automatically from `.claude/skills/canonry-setup/` when you open this repo. **ClawHub** hosts the same skill at [clawhub.dev](https://clawhub.dev) for any MCP-equipped agent.
+**Claude Code** also picks up the skill automatically from `.claude/skills/canonry-setup/` when you open this repo.
 
 ## Deployment
 

--- a/packages/canonry/AGENTS.md
+++ b/packages/canonry/AGENTS.md
@@ -23,8 +23,8 @@ The publishable npm package (`@ainyc/canonry`). Bundles the CLI, local Fastify s
 | `src/commands/health-cmd.ts` | `health` command implementation |
 | `src/commands/backfill.ts` | Historical recomputation for answer visibility fields and insights |
 | `src/commands/ga.ts` | GA4 commands: `ga sync`, `ga traffic`, `ga status`, `ga social-referral-history`, `ga social-referral-summary`, `ga attribution` |
-| `src/agent-bootstrap.ts` | OpenClaw detection, installation, profile setup, gateway config, credential resolution, workspace seeding |
-| `src/agent-manager.ts` | OpenClaw gateway process lifecycle — spawns `openclaw --profile aero gateway` directly, loads `.env` into process env |
+| `src/agent-bootstrap.ts` | Agent runtime detection, installation, profile setup, gateway config, credential resolution, workspace seeding |
+| `src/agent-manager.ts` | Agent gateway process lifecycle — spawns the gateway as a detached process, loads `.env` into process env |
 | `src/commands/agent.ts` | Thin orchestrator for `agent setup` + implementations for `status/start/stop/reset` |
 | `src/cli-commands/agent.ts` | CLI command specs for the `agent` subcommand family |
 
@@ -83,14 +83,14 @@ Providers are registered at server startup in `server.ts`. Each provider adapter
 `canonry agent setup` is the single entry point. The orchestrator in `commands/agent.ts` calls helpers from `agent-bootstrap.ts`:
 
 1. **Init canonry** — calls `initCommand()` if no `config.yaml` exists. Prompts for monitoring provider keys and agent LLM credentials (provider, key, model). Accepts all values via flags or env vars for non-interactive use.
-2. **Detect/install OpenClaw** — checks PATH, installs via `npm install -g openclaw@2026.4.14` if missing, enforces Canonry's pinned Node floor of `>=22.14.0`, and verifies that the detected binary version matches the pinned package version.
+2. **Detect/install agent runtime** — checks PATH, installs the pinned agent runtime if missing, enforces Canonry's pinned Node floor of `>=22.14.0`, and verifies that the detected binary version matches the pinned package version.
 3. **Save agent config** — persists `{binary, profile, gatewayPort}` to canonry `config.yaml` via `saveConfigPatch()`.
-4. **Initialize profile** — `initializeOpenClawProfile()` runs `openclaw onboard --non-interactive --accept-risk --mode local`.
-5. **Configure gateway** — `configureOpenClawGateway()` sets `gateway.mode=local` and `gateway.port` via `openclaw config set`.
-6. **Configure LLM** — `resolveAgentCredentials()` resolves key from flags/env/existing `.env`. `writeAgentEnv()` writes to `~/.openclaw-aero/.env`. `setOpenClawModel()` sets the model.
-7. **Seed workspace** — copies skills from `assets/agent-workspace/` into the OpenClaw workspace.
+4. **Initialize profile** — initializes the agent profile in local mode, non-interactively.
+5. **Configure gateway** — sets the local mode and gateway port.
+6. **Configure LLM** — `resolveAgentCredentials()` resolves key from flags/env/existing `.env`. `writeAgentEnv()` writes to the agent env file. The model is set via the agent CLI.
+7. **Seed workspace** — copies skills from `assets/agent-workspace/` into the agent workspace.
 
-At runtime, `AgentManager.start()` spawns `openclaw --profile aero gateway` as a detached process, injecting `.env` values into the process environment.
+At runtime, `AgentManager.start()` spawns the agent gateway as a detached process, injecting `.env` values into the process environment.
 
 ### Agent webhook lifecycle
 

--- a/skills/aero/references/memory-patterns.md
+++ b/skills/aero/references/memory-patterns.md
@@ -2,7 +2,7 @@
 
 ## Per-Client State Template
 
-Store in OpenClaw agent memory after each significant event:
+Store in agent memory after each significant event:
 
 ```
 Client: <business name>

--- a/skills/canonry-setup/SKILL.md
+++ b/skills/canonry-setup/SKILL.md
@@ -3,7 +3,7 @@ name: canonry
 description: "Agent-first AEO monitoring and operating platform."
 metadata:
   {
-    "openclaw":
+    "agent":
       {
         "emoji": "📡",
         "requires": { "bins": ["canonry"] },

--- a/skills/canonry-setup/references/canonry-cli.md
+++ b/skills/canonry-setup/references/canonry-cli.md
@@ -296,10 +296,10 @@ canonry export <project> --include-results > project.yaml
 canonry sitemap inspect <project>
 ```
 
-## Agent (OpenClaw Integration)
+## Agent
 
 `canonry agent setup` is the single entry point for configuring the agent. It handles everything:
-canonry initialization, OpenClaw installation, profile setup, LLM credential configuration,
+canonry initialization, agent runtime installation, profile setup, LLM credential configuration,
 and workspace seeding. If canonry is not yet configured, it runs the interactive init flow first
 (prompting for monitoring provider keys and agent LLM credentials).
 
@@ -313,7 +313,7 @@ canonry agent setup --agent-provider openrouter --agent-key <key> --agent-model 
 GEMINI_API_KEY=<key> canonry agent setup --agent-key <key> --format json
 
 # Lifecycle
-canonry agent start                              # start OpenClaw gateway as background process
+canonry agent start                              # start agent gateway as background process
 canonry agent stop                               # stop the gateway process
 canonry agent status                             # check if gateway is running
 canonry agent status --format json               # JSON output
@@ -336,9 +336,9 @@ canonry agent detach <project>                   # remove agent webhook from pro
 canonry agent detach <project> --format json     # JSON output
 ```
 
-**Setup flow:** init canonry (if needed) → install OpenClaw (if needed) → configure profile → configure gateway → set agent LLM credentials → seed workspace with skills.
+**Setup flow:** init canonry (if needed) → install agent runtime (if needed) → configure profile → configure gateway → set agent LLM credentials → seed workspace with skills.
 
-**Agent LLM credentials** are stored in `~/.openclaw-aero/.env` (e.g. `ANTHROPIC_API_KEY=...`) and loaded into the gateway process at start time. The model is set via `openclaw models set`.
+**Agent LLM credentials** are stored in the agent env file (e.g. `ANTHROPIC_API_KEY=...`) and loaded into the gateway process at start time. The model is set via the agent CLI.
 
 **Re-running is safe:** setup is idempotent — it skips steps that are already configured.
 


### PR DESCRIPTION
## Summary
- Genericizes agent-runtime wording in user-facing docs (`README.md`, `AGENTS.md`, `CLAUDE.md`, package and skill docs) ahead of a planned move away from OpenClaw.
- Canonry still ships with a bundled AI agent; the positioning update emphasizes that the core is CLI- and API-native.
- Implementation code, tests, and historical planning docs under `plans/` are intentionally untouched — only user-facing docs and skills.

## Test plan
- [ ] Skim rendered README to confirm agent story still reads clearly without OpenClaw branding.