### PR TITLE
fix(agent): avoid defaulting Aero to gemini-2.5-pro

### DIFF
--- a/packages/canonry/src/agent/providers.ts
+++ b/packages/canonry/src/agent/providers.ts
@@ -47,7 +47,7 @@ export const AGENT_PROVIDERS = {
   [AgentProviderIds.gemini]: {
     piAiProvider: 'google',
     label: 'Google (Gemini)',
-    defaultModel: 'gemini-2.5-pro',
+    defaultModel: 'gemini-2.5-flash',
     autoDetectPriority: 2,
   },
   [AgentProviderIds.zai]: {

--- a/packages/canonry/test/agent-providers.test.ts
+++ b/packages/canonry/test/agent-providers.test.ts
@@ -40,6 +40,11 @@ describe('agent provider registry', () => {
     }
   })
 
+
+  it('uses a Gemini default model that does not require separate thinking-mode config', () => {
+    expect(getAgentProvider('gemini').defaultModel).toBe('gemini-2.5-flash')
+  })
+
   it('registry rows each carry every required field', () => {
     for (const provider of listAgentProviders()) {
       const e = getAgentProvider(provider)


### PR DESCRIPTION
## Summary
- change the built-in Aero Gemini default from  to 
- add a narrow regression test covering the Gemini default model

## Why
The live Aero agent path persisted  and , then failed turns with:



Canonry's built-in agent path does not currently send Gemini thinking-mode config, so defaulting the agent to  is unsafe.

## Scope
This is intentionally narrow. It does not change chat-panel code or add new provider support. It only changes the default Gemini model the built-in agent picks when no explicit model is supplied.

## Validation
- inspected upstream main agent registry and request path
- confirmed upstream already supports  in 
- attempted targeted  run in this checkout, but local dependency resolution is incomplete in the current workspace (, ,  missing during test import)
