### PR TITLE
refactor(api-routes): throw AppError + cap provider fanout

### DIFF
--- a/docs/adr/0008-canonry-package-split.md
+++ b/docs/adr/0008-canonry-package-split.md
@@ -1,0 +1,83 @@
+# ADR 0008: Split `@ainyc/canonry` into smaller publishable packages
+
+## Status
+
+Proposed. Not yet accepted — this ADR exists to align on seams before any code moves.
+
+## Context
+
+`packages/canonry/` is the single publishable npm artifact. Today it contains:
+
+- CLI dispatch (`src/cli.ts`, `src/cli-commands.ts`, `src/commands/`, `src/cli-commands/`, `src/cli-error.ts`)
+- HTTP server (`src/server.ts`)
+- In-process job runner (`src/job-runner.ts`)
+- Scheduler (`src/scheduler.ts`)
+- Post-run coordinator + intelligence + notifier (`src/run-coordinator.ts`, `src/intelligence-service.ts`, `src/notifier.ts`)
+- Provider registry (`src/provider-registry.ts`)
+- Built-in Aero agent (`src/agent/*`)
+- Snapshot + PDF rendering (`src/snapshot-service.ts`, `src/snapshot-pdf.ts`, `src/snapshot-format.ts`)
+- Site-fetch + sitemap parsing (`src/site-fetch.ts`, `src/sitemap-parser.ts`)
+- GSC / GA4 / WordPress / backlinks sync glue (`src/gsc-*.ts`, `src/ga4-config.ts`, `src/wordpress-config.ts`, `src/commoncrawl-sync.ts`, `src/backlink-extract.ts`)
+- Web SPA assets bundled from `apps/web/` via `build-web.ts`
+
+`tsup.config.ts` bundles 13 workspace packages into the artifact. `pnpm publish` triggers a Vite build of the SPA as a side effect.
+
+## Problem
+
+1. Publishing the CLI forces a full SPA rebuild.
+2. An unrelated change (e.g., a new provider adapter) ships every other subsystem with it.
+3. Testing any subsystem in isolation requires instantiating nearby plumbing; `packages/api-routes/` passes callbacks (`queueRunIfProjectIdle`, `resolveWebhookTarget`) into `canonry` which then registers them back into the mounted plugin, creating a hidden cycle.
+4. New contributors face a 34-module flat `src/` tree with no obvious cohesion boundaries.
+5. Bundle size: consumers who only need one entry point (e.g., `canonry serve`) still pull in PDF rendering, CDP bindings, and agent transcript compaction.
+
+## Proposed Decision
+
+Split `@ainyc/canonry` into focused packages, keep a thin `@ainyc/canonry` umbrella for the default install experience, and break the callback-inversion cycle with api-routes.
+
+### Proposed seams
+
+| Package | Contents |
+|---------|----------|
+| `@ainyc/canonry-cli` | `cli.ts`, `cli-commands*`, `commands/`, `client.ts`, `cli-error.ts`, `logger.ts`, `telemetry.ts` |
+| `@ainyc/canonry-server` | `server.ts`, `config.ts`, provider-registry, scheduler, job-runner, run-coordinator, intelligence-service, notifier, snapshot service |
+| `@ainyc/canonry-agent` | `agent/*` (Aero session, tools, skill-tools, compaction, memory store) |
+| `@ainyc/canonry-integrations-glue` | `gsc-*.ts`, `ga4-config.ts`, `wordpress-config.ts`, `commoncrawl-sync.ts`, `backlink-extract.ts`, `site-fetch.ts`, `sitemap-parser.ts` |
+| `@ainyc/canonry-reporting` | `snapshot-pdf.ts`, `snapshot-format.ts` |
+| `@ainyc/canonry` (umbrella) | Re-exports + bin stub; installs the SPA assets as a peer artifact |
+| `@ainyc/canonry-web-assets` | Built SPA (tarball of `apps/web` output); independent release cadence |
+
+### Cycle fix
+
+`packages/api-routes/` should expose an abstract job-queue interface it owns, not accept a `queueRunIfProjectIdle` callback from the consumer. `canonry-server` then implements the interface and passes it in — dependency flows one direction (server → api-routes), not through round-trip callbacks.
+
+## Why
+
+- Any subsystem can ship on its own cadence. An agent patch doesn't force a new `canonry` release.
+- SPA changes don't trigger CLI/server rebuilds. Web assets become an independently versioned dependency.
+- Smaller surfaces are testable in isolation — `canonry-server` can boot without the CLI, `canonry-agent` can be unit-tested without Fastify.
+- The api-routes cycle disappears because the interface owner (routes) is also the interface definer.
+- Users installing the umbrella package still get the same CLI experience; no UX regression.
+
+## Tradeoffs / Costs
+
+- **Refactor scope:** ~34 source files to move, ~15 import-path churn in `server.ts`, new `package.json` for each split, publishing pipeline changes.
+- **Internal dep graph complexity:** 5+ new workspace packages to maintain.
+- **Initial build time may increase slightly** from extra tsup invocations (mitigated by project references and caching).
+- **Cross-package refactors become harder** because a change may now span 2-3 packages instead of one.
+- **Release coordination:** umbrella package must pin compatible ranges of its children. Without lockstep versioning, users could resolve a broken combination.
+
+## Explicitly Not Decided
+
+- Whether to publish each split package to npm or keep them private workspace packages that only the umbrella re-exports.
+- Final names — `-server` might become `-runtime`, `-cli` might stay inside umbrella. Names are a naming round, not this decision.
+- Timing. This ADR proposes the shape; execution is a separate planning exercise.
+
+## Open Questions
+
+1. Does the SPA asset split warrant its own registry entry, or is an internal workspace package (consumed only by the umbrella at publish time) simpler?
+2. Does the Aero agent move to a separate package if it stays tightly coupled to `canonry-server` tools? Or is the value purely conceptual?
+3. What happens to `bin/canonry.mjs` — stay in the umbrella, or move with `-cli`?
+
+## Next Step
+
+Discuss, revise, then accept or reject. Nothing moves in code until this ADR reaches Accepted.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "2.4.2",
+  "version": "2.4.3",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/auth.ts
+++ b/packages/api-routes/src/auth.ts
@@ -46,7 +46,7 @@ function parseCookies(header: string | undefined): Record<string, string> {
 }
 
 export async function authPlugin(app: FastifyInstance, opts: AuthPluginOptions = {}) {
-  app.addHook('onRequest', async (request, reply) => {
+  app.addHook('onRequest', async (request) => {
     const url = request.url.split('?')[0]!
     if (shouldSkipAuth(url)) return
 
@@ -56,8 +56,7 @@ export async function authPlugin(app: FastifyInstance, opts: AuthPluginOptions =
     if (header) {
       const parts = header.split(' ')
       if (parts.length !== 2 || parts[0] !== 'Bearer') {
-        const err = authRequired()
-        return reply.status(err.statusCode).send(err.toJSON())
+        throw authRequired()
       }
 
       const token = parts[1]!
@@ -70,8 +69,7 @@ export async function authPlugin(app: FastifyInstance, opts: AuthPluginOptions =
         .get()
 
       if (!key || key.revokedAt) {
-        const err = authInvalid()
-        return reply.status(err.statusCode).send(err.toJSON())
+        throw authInvalid()
       }
     } else if (opts.resolveSessionApiKeyId && opts.sessionCookieName) {
       const sessionId = parseCookies(request.headers.cookie)[opts.sessionCookieName]
@@ -87,12 +85,10 @@ export async function authPlugin(app: FastifyInstance, opts: AuthPluginOptions =
       }
 
       if (!key || key.revokedAt) {
-        const err = authRequired()
-        return reply.status(err.statusCode).send(err.toJSON())
+        throw authRequired()
       }
     } else {
-      const err = authRequired()
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw authRequired()
     }
 
     app.db

--- a/packages/api-routes/src/bing.ts
+++ b/packages/api-routes/src/bing.ts
@@ -58,19 +58,15 @@ export interface BingRoutesOptions {
 }
 
 export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) {
-  function requireConnectionStore(reply: { status: (code: number) => { send: (body: unknown) => unknown } }) {
+  function requireConnectionStore(): BingConnectionStore {
     if (opts.bingConnectionStore) return opts.bingConnectionStore
-    const err = validationError('Bing connection storage is not configured for this deployment')
-    reply.status(err.statusCode).send(err.toJSON())
-    return null
+    throw validationError('Bing connection storage is not configured for this deployment')
   }
 
-  function requireConnection(store: BingConnectionStore, domain: string, reply: { status: (code: number) => { send: (body: unknown) => unknown } }) {
+  function requireConnection(store: BingConnectionStore, domain: string): BingConnectionRecord {
     const conn = store.getConnection(domain)
     if (!conn) {
-      const err = validationError('No Bing connection found for this domain. Run "canonry bing connect <project>" first.')
-      reply.status(err.statusCode).send(err.toJSON())
-      return null
+      throw validationError('No Bing connection found for this domain. Run "canonry bing connect <project>" first.')
     }
     return conn
   }
@@ -79,14 +75,12 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
   app.post<{
     Params: { name: string }
     Body: { apiKey: string }
-  }>('/projects/:name/bing/connect', async (request, reply) => {
-    const store = requireConnectionStore(reply)
-    if (!store) return
+  }>('/projects/:name/bing/connect', async (request) => {
+    const store = requireConnectionStore()
 
     const { apiKey } = request.body ?? {}
     if (!apiKey || typeof apiKey !== 'string') {
-      const err = validationError('apiKey is required')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('apiKey is required')
     }
 
     const project = resolveProject(app.db, request.params.name)
@@ -99,8 +93,7 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e)
       bingLog('error', 'connect.verify-key-failed', { domain: project.canonicalDomain, error: msg })
-      const err = validationError(`Failed to verify Bing API key: ${msg}`)
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError(`Failed to verify Bing API key: ${msg}`)
     }
 
     const now = new Date().toISOString()
@@ -131,14 +124,12 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
 
   // DELETE /projects/:name/bing/disconnect
   app.delete<{ Params: { name: string } }>('/projects/:name/bing/disconnect', async (request, reply) => {
-    const store = requireConnectionStore(reply)
-    if (!store) return
+    const store = requireConnectionStore()
 
     const project = resolveProject(app.db, request.params.name)
     const deleted = store.deleteConnection(project.canonicalDomain)
     if (!deleted) {
-      const err = notFound('Bing connection', project.canonicalDomain)
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw notFound('Bing connection', project.canonicalDomain)
     }
 
     writeAuditLog(app.db, {
@@ -153,9 +144,8 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
   })
 
   // GET /projects/:name/bing/status
-  app.get<{ Params: { name: string } }>('/projects/:name/bing/status', async (request, reply) => {
-    const store = requireConnectionStore(reply)
-    if (!store) return
+  app.get<{ Params: { name: string } }>('/projects/:name/bing/status', async (request) => {
+    const store = requireConnectionStore()
 
     const project = resolveProject(app.db, request.params.name)
     const conn = store.getConnection(project.canonicalDomain)
@@ -170,13 +160,11 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
   })
 
   // GET /projects/:name/bing/sites
-  app.get<{ Params: { name: string } }>('/projects/:name/bing/sites', async (request, reply) => {
-    const store = requireConnectionStore(reply)
-    if (!store) return
+  app.get<{ Params: { name: string } }>('/projects/:name/bing/sites', async (request) => {
+    const store = requireConnectionStore()
 
     const project = resolveProject(app.db, request.params.name)
-    const conn = requireConnection(store, project.canonicalDomain, reply)
-    if (!conn) return
+    const conn = requireConnection(store, project.canonicalDomain)
 
     const sites = await getSites(conn.apiKey)
     return { sites: sites.map((s) => ({ url: s.Url, verified: s.Verified ?? false })) }
@@ -186,18 +174,15 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
   app.post<{
     Params: { name: string }
     Body: { siteUrl: string }
-  }>('/projects/:name/bing/set-site', async (request, reply) => {
-    const store = requireConnectionStore(reply)
-    if (!store) return
+  }>('/projects/:name/bing/set-site', async (request) => {
+    const store = requireConnectionStore()
 
     const project = resolveProject(app.db, request.params.name)
-    const conn = requireConnection(store, project.canonicalDomain, reply)
-    if (!conn) return
+    requireConnection(store, project.canonicalDomain)
 
     const { siteUrl } = request.body ?? {}
     if (!siteUrl || typeof siteUrl !== 'string') {
-      const err = validationError('siteUrl is required')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('siteUrl is required')
     }
 
     store.updateConnection(project.canonicalDomain, {
@@ -209,13 +194,11 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
   })
 
   // GET /projects/:name/bing/coverage
-  app.get<{ Params: { name: string } }>('/projects/:name/bing/coverage', async (request, reply) => {
-    const store = requireConnectionStore(reply)
-    if (!store) return
+  app.get<{ Params: { name: string } }>('/projects/:name/bing/coverage', async (request) => {
+    const store = requireConnectionStore()
 
     const project = resolveProject(app.db, request.params.name)
-    const conn = requireConnection(store, project.canonicalDomain, reply)
-    if (!conn) return
+    requireConnection(store, project.canonicalDomain)
 
     // Get latest inspection per URL
     const allInspections = app.db
@@ -325,9 +308,8 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
   app.get<{
     Params: { name: string }
     Querystring: { limit?: string }
-  }>('/projects/:name/bing/coverage/history', async (request, reply) => {
-    const store = requireConnectionStore(reply)
-    if (!store) return
+  }>('/projects/:name/bing/coverage/history', async (request) => {
+    requireConnectionStore()
 
     const project = resolveProject(app.db, request.params.name)
     const parsed = parseInt(request.query.limit ?? '90', 10)
@@ -353,9 +335,8 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
   app.get<{
     Params: { name: string }
     Querystring: { url?: string; limit?: string }
-  }>('/projects/:name/bing/inspections', async (request, reply) => {
-    const store = requireConnectionStore(reply)
-    if (!store) return
+  }>('/projects/:name/bing/inspections', async (request) => {
+    requireConnectionStore()
 
     const project = resolveProject(app.db, request.params.name)
     const { url, limit } = request.query
@@ -390,23 +371,19 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
   app.post<{
     Params: { name: string }
     Body: { url: string }
-  }>('/projects/:name/bing/inspect-url', async (request, reply) => {
-    const store = requireConnectionStore(reply)
-    if (!store) return
+  }>('/projects/:name/bing/inspect-url', async (request) => {
+    const store = requireConnectionStore()
 
     const project = resolveProject(app.db, request.params.name)
-    const conn = requireConnection(store, project.canonicalDomain, reply)
-    if (!conn) return
+    const conn = requireConnection(store, project.canonicalDomain)
 
     if (!conn.siteUrl) {
-      const err = validationError('No Bing site configured. Run "canonry bing set-site <project> <url>" first.')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('No Bing site configured. Run "canonry bing set-site <project> <url>" first.')
     }
 
     const { url } = request.body ?? {}
     if (!url) {
-      const err = validationError('url is required')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('url is required')
     }
 
     const startedAt = new Date().toISOString()
@@ -500,17 +477,14 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
   app.post<{
     Params: { name: string }
     Body: { urls?: string[]; allUnindexed?: boolean }
-  }>('/projects/:name/bing/request-indexing', async (request, reply) => {
-    const store = requireConnectionStore(reply)
-    if (!store) return
+  }>('/projects/:name/bing/request-indexing', async (request) => {
+    const store = requireConnectionStore()
 
     const project = resolveProject(app.db, request.params.name)
-    const conn = requireConnection(store, project.canonicalDomain, reply)
-    if (!conn) return
+    const conn = requireConnection(store, project.canonicalDomain)
 
     if (!conn.siteUrl) {
-      const err = validationError('No Bing site configured. Run "canonry bing set-site <project> <url>" first.')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('No Bing site configured. Run "canonry bing set-site <project> <url>" first.')
     }
 
     let urlsToSubmit: string[] = request.body?.urls ?? []
@@ -538,21 +512,18 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
       }
 
       if (unindexedUrls.length === 0) {
-        const err = validationError('No unindexed or unknown URLs found. Run "canonry bing inspect <project> <url>" first.')
-        return reply.status(err.statusCode).send(err.toJSON())
+        throw validationError('No unindexed or unknown URLs found. Run "canonry bing inspect <project> <url>" first.')
       }
 
       urlsToSubmit = unindexedUrls
     }
 
     if (urlsToSubmit.length === 0) {
-      const err = validationError('At least one URL is required (or use allUnindexed: true)')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('At least one URL is required (or use allUnindexed: true)')
     }
 
     if (urlsToSubmit.length > BING_SUBMIT_URL_DAILY_LIMIT) {
-      const err = validationError(`Cannot submit more than ${BING_SUBMIT_URL_DAILY_LIMIT} URLs per day (got ${urlsToSubmit.length})`)
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError(`Cannot submit more than ${BING_SUBMIT_URL_DAILY_LIMIT} URLs per day (got ${urlsToSubmit.length})`)
     }
 
     const results: Array<{
@@ -613,17 +584,14 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
   app.get<{
     Params: { name: string }
     Querystring: { limit?: string }
-  }>('/projects/:name/bing/performance', async (request, reply) => {
-    const store = requireConnectionStore(reply)
-    if (!store) return
+  }>('/projects/:name/bing/performance', async (request) => {
+    const store = requireConnectionStore()
 
     const project = resolveProject(app.db, request.params.name)
-    const conn = requireConnection(store, project.canonicalDomain, reply)
-    if (!conn) return
+    const conn = requireConnection(store, project.canonicalDomain)
 
     if (!conn.siteUrl) {
-      const err = validationError('No Bing site configured. Run "canonry bing set-site <project> <url>" first.')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('No Bing site configured. Run "canonry bing set-site <project> <url>" first.')
     }
 
     const stats = await getKeywordStats(conn.apiKey, conn.siteUrl)

--- a/packages/api-routes/src/google.ts
+++ b/packages/api-routes/src/google.ts
@@ -123,11 +123,9 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
     return opts.getGoogleAuthConfig?.() ?? {}
   }
 
-  function requireConnectionStore(reply: { status: (code: number) => { send: (body: unknown) => unknown } }) {
+  function requireConnectionStore(): GoogleConnectionStore {
     if (opts.googleConnectionStore) return opts.googleConnectionStore
-    const err = validationError('Google auth storage is not configured for this deployment')
-    reply.status(err.statusCode).send(err.toJSON())
-    return null
+    throw validationError('Google auth storage is not configured for this deployment')
   }
 
   // GET /projects/:name/google/connections
@@ -150,17 +148,15 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
   app.post<{
     Params: { name: string }
     Body: { type: string; propertyId?: string; publicUrl?: string }
-  }>('/projects/:name/google/connect', async (request, reply) => {
+  }>('/projects/:name/google/connect', async (request) => {
     const { clientId: googleClientId, clientSecret: googleClientSecret } = getAuthConfig()
     if (!googleClientId || !googleClientSecret) {
-      const err = validationError('Google OAuth is not configured. Set Google OAuth credentials in the local Canonry config.')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('Google OAuth is not configured. Set Google OAuth credentials in the local Canonry config.')
     }
 
     const { type, propertyId, publicUrl } = request.body ?? {}
     if (!type || (type !== 'gsc' && type !== 'ga4')) {
-      const err = validationError('type must be "gsc" or "ga4"')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('type must be "gsc" or "ga4"')
     }
 
     const project = resolveProject(app.db, request.params.name)
@@ -199,8 +195,7 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
       return reply.status(500).send('Google OAuth not configured')
     }
 
-    const store = requireConnectionStore(reply)
-    if (!store) return
+    const store = requireConnectionStore()
 
     const escapeHtml = (s: string) => s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]!))
 
@@ -310,14 +305,12 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
 
   // DELETE /projects/:name/google/connections/:type
   app.delete<{ Params: { name: string; type: string } }>('/projects/:name/google/connections/:type', async (request, reply) => {
-    const store = requireConnectionStore(reply)
-    if (!store) return
+    const store = requireConnectionStore()
 
     const project = resolveProject(app.db, request.params.name)
     const deleted = store.deleteConnection(project.canonicalDomain, request.params.type as 'gsc' | 'ga4')
     if (!deleted) {
-      const err = notFound('Google connection', request.params.type)
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw notFound('Google connection', request.params.type)
     }
 
     writeAuditLog(app.db, {
@@ -332,15 +325,13 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
   })
 
   // GET /projects/:name/google/properties
-  app.get<{ Params: { name: string } }>('/projects/:name/google/properties', async (request, reply) => {
+  app.get<{ Params: { name: string } }>('/projects/:name/google/properties', async (request) => {
     const { clientId: googleClientId, clientSecret: googleClientSecret } = getAuthConfig()
     if (!googleClientId || !googleClientSecret) {
-      const err = validationError('Google OAuth is not configured')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('Google OAuth is not configured')
     }
 
-    const store = requireConnectionStore(reply)
-    if (!store) return
+    const store = requireConnectionStore()
 
     const project = resolveProject(app.db, request.params.name)
     const { accessToken } = await getValidToken(store, project.canonicalDomain, 'gsc', googleClientId, googleClientSecret)
@@ -352,15 +343,13 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
   app.post<{
     Params: { name: string }
     Body: { days?: number; full?: boolean }
-  }>('/projects/:name/google/gsc/sync', async (request, reply) => {
-    const store = requireConnectionStore(reply)
-    if (!store) return
+  }>('/projects/:name/google/gsc/sync', async (request) => {
+    const store = requireConnectionStore()
 
     const project = resolveProject(app.db, request.params.name)
     const conn = store.getConnection(project.canonicalDomain, 'gsc')
     if (!conn) {
-      const err = validationError('No GSC connection found for this domain. Run "canonry google connect" first.')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('No GSC connection found for this domain. Run "canonry google connect" first.')
     }
 
     const now = new Date().toISOString()
@@ -427,27 +416,23 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
   app.post<{
     Params: { name: string }
     Body: { url: string }
-  }>('/projects/:name/google/gsc/inspect', async (request, reply) => {
+  }>('/projects/:name/google/gsc/inspect', async (request) => {
     const { clientId: googleClientId, clientSecret: googleClientSecret } = getAuthConfig()
     if (!googleClientId || !googleClientSecret) {
-      const err = validationError('Google OAuth is not configured')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('Google OAuth is not configured')
     }
 
-    const store = requireConnectionStore(reply)
-    if (!store) return
+    const store = requireConnectionStore()
 
     const project = resolveProject(app.db, request.params.name)
     const { url } = request.body ?? {}
     if (!url) {
-      const err = validationError('url is required')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('url is required')
     }
 
     const { accessToken, propertyId } = await getValidToken(store, project.canonicalDomain, 'gsc', googleClientId, googleClientSecret)
     if (!propertyId) {
-      const err = validationError('No GSC property configured for this connection')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('No GSC property configured for this connection')
     }
 
     const result = await gscInspectUrl(accessToken, url, propertyId)
@@ -736,21 +721,18 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
   })
 
   // GET /projects/:name/google/gsc/sitemaps
-  app.get<{ Params: { name: string } }>('/projects/:name/google/gsc/sitemaps', async (request, reply) => {
+  app.get<{ Params: { name: string } }>('/projects/:name/google/gsc/sitemaps', async (request) => {
     const { clientId: googleClientId, clientSecret: googleClientSecret } = getAuthConfig()
     if (!googleClientId || !googleClientSecret) {
-      const err = validationError('Google OAuth is not configured')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('Google OAuth is not configured')
     }
 
-    const store = requireConnectionStore(reply)
-    if (!store) return
+    const store = requireConnectionStore()
 
     const project = resolveProject(app.db, request.params.name)
     const { accessToken, propertyId } = await getValidToken(store, project.canonicalDomain, 'gsc', googleClientId, googleClientSecret)
     if (!propertyId) {
-      const err = validationError('No GSC property configured for this connection. Set one with "canonry google set-property".')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('No GSC property configured for this connection. Set one with "canonry google set-property".')
     }
 
     const sitemaps = await listSitemaps(accessToken, propertyId)
@@ -758,34 +740,29 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
   })
 
   // POST /projects/:name/google/gsc/discover-sitemaps
-  app.post<{ Params: { name: string } }>('/projects/:name/google/gsc/discover-sitemaps', async (request, reply) => {
+  app.post<{ Params: { name: string } }>('/projects/:name/google/gsc/discover-sitemaps', async (request) => {
     const { clientId: googleClientId, clientSecret: googleClientSecret } = getAuthConfig()
     if (!googleClientId || !googleClientSecret) {
-      const err = validationError('Google OAuth is not configured')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('Google OAuth is not configured')
     }
 
-    const store = requireConnectionStore(reply)
-    if (!store) return
+    const store = requireConnectionStore()
 
     const project = resolveProject(app.db, request.params.name)
     const conn = store.getConnection(project.canonicalDomain, 'gsc')
     if (!conn) {
-      const err = validationError('No GSC connection found for this domain. Run "canonry google connect" first.')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('No GSC connection found for this domain. Run "canonry google connect" first.')
     }
 
     if (!conn.propertyId) {
-      const err = validationError('No GSC property configured for this connection')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('No GSC property configured for this connection')
     }
 
     const { accessToken } = await getValidToken(store, project.canonicalDomain, 'gsc', googleClientId, googleClientSecret)
     const sitemaps = await listSitemaps(accessToken, conn.propertyId)
 
     if (sitemaps.length === 0) {
-      const err = validationError('No sitemaps found for this GSC property. Submit a sitemap in Google Search Console first.')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('No sitemaps found for this GSC property. Submit a sitemap in Google Search Console first.')
     }
 
     // Prefer non-index sitemaps, otherwise use the first one
@@ -822,20 +799,17 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
   app.post<{
     Params: { name: string }
     Body: { sitemapUrl?: string }
-  }>('/projects/:name/google/gsc/inspect-sitemap', async (request, reply) => {
-    const store = requireConnectionStore(reply)
-    if (!store) return
+  }>('/projects/:name/google/gsc/inspect-sitemap', async (request) => {
+    const store = requireConnectionStore()
 
     const project = resolveProject(app.db, request.params.name)
     const conn = store.getConnection(project.canonicalDomain, 'gsc')
     if (!conn) {
-      const err = validationError('No GSC connection found for this domain. Run "canonry google connect" first.')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('No GSC connection found for this domain. Run "canonry google connect" first.')
     }
 
     if (!conn.propertyId) {
-      const err = validationError('No GSC property configured for this connection')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('No GSC property configured for this connection')
     }
 
     const now = new Date().toISOString()
@@ -862,15 +836,13 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
   app.put<{
     Params: { name: string; type: string }
     Body: { sitemapUrl: string }
-  }>('/projects/:name/google/connections/:type/sitemap', async (request, reply) => {
-    const store = requireConnectionStore(reply)
-    if (!store) return
+  }>('/projects/:name/google/connections/:type/sitemap', async (request) => {
+    const store = requireConnectionStore()
 
     const project = resolveProject(app.db, request.params.name)
     const { sitemapUrl } = request.body ?? {}
     if (!sitemapUrl || !sitemapUrl.trim()) {
-      const err = validationError('sitemapUrl is required')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('sitemapUrl is required')
     }
 
     const conn = store.updateConnection(
@@ -879,8 +851,7 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
       { sitemapUrl: sitemapUrl.trim(), updatedAt: new Date().toISOString() },
     )
     if (!conn) {
-      const err = notFound('Google connection', request.params.type)
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw notFound('Google connection', request.params.type)
     }
 
     return { sitemapUrl: sitemapUrl.trim() }
@@ -890,15 +861,13 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
   app.put<{
     Params: { name: string; type: string }
     Body: { propertyId: string }
-  }>('/projects/:name/google/connections/:type/property', async (request, reply) => {
-    const store = requireConnectionStore(reply)
-    if (!store) return
+  }>('/projects/:name/google/connections/:type/property', async (request) => {
+    const store = requireConnectionStore()
 
     const project = resolveProject(app.db, request.params.name)
     const { propertyId } = request.body ?? {}
     if (!propertyId) {
-      const err = validationError('propertyId is required')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('propertyId is required')
     }
 
     const conn = store.updateConnection(
@@ -907,8 +876,7 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
       { propertyId, updatedAt: new Date().toISOString() },
     )
     if (!conn) {
-      const err = notFound('Google connection', request.params.type)
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw notFound('Google connection', request.params.type)
     }
 
     return { propertyId }
@@ -918,15 +886,13 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
   app.post<{
     Params: { name: string }
     Body: { urls: string[]; allUnindexed?: boolean }
-  }>('/projects/:name/google/indexing/request', async (request, reply) => {
+  }>('/projects/:name/google/indexing/request', async (request) => {
     const { clientId: googleClientId, clientSecret: googleClientSecret } = getAuthConfig()
     if (!googleClientId || !googleClientSecret) {
-      const err = validationError('Google OAuth is not configured')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('Google OAuth is not configured')
     }
 
-    const store = requireConnectionStore(reply)
-    if (!store) return
+    const store = requireConnectionStore()
 
     const project = resolveProject(app.db, request.params.name)
     const { accessToken } = await getValidToken(store, project.canonicalDomain, 'gsc', googleClientId, googleClientSecret)
@@ -957,21 +923,18 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
       }
 
       if (unindexedUrls.length === 0) {
-        const err = validationError('No unindexed URLs found. Run "canonry google inspect-sitemap" first.')
-        return reply.status(err.statusCode).send(err.toJSON())
+        throw validationError('No unindexed URLs found. Run "canonry google inspect-sitemap" first.')
       }
 
       urlsToNotify = unindexedUrls
     }
 
     if (urlsToNotify.length === 0) {
-      const err = validationError('At least one URL is required (or use allUnindexed: true)')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('At least one URL is required (or use allUnindexed: true)')
     }
 
     if (urlsToNotify.length > INDEXING_API_DAILY_LIMIT) {
-      const err = validationError(`Cannot request indexing for more than ${INDEXING_API_DAILY_LIMIT} URLs per request (got ${urlsToNotify.length})`)
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError(`Cannot request indexing for more than ${INDEXING_API_DAILY_LIMIT} URLs per request (got ${urlsToNotify.length})`)
     }
 
     // Validate that all URLs belong to the project's canonical domain
@@ -985,10 +948,9 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
       }
     })
     if (invalidUrls.length > 0) {
-      const err = validationError(
+      throw validationError(
         `URLs must belong to project domain "${project.canonicalDomain}". Invalid: ${invalidUrls.slice(0, 5).join(', ')}`,
       )
-      return reply.status(err.statusCode).send(err.toJSON())
     }
 
     const results: Array<{

--- a/packages/api-routes/src/keywords.ts
+++ b/packages/api-routes/src/keywords.ts
@@ -2,7 +2,7 @@ import crypto from 'node:crypto'
 import { eq } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import { keywords } from '@ainyc/canonry-db'
-import { validationError, notImplemented } from '@ainyc/canonry-contracts'
+import { validationError, notImplemented, internalError } from '@ainyc/canonry-contracts'
 import { resolveProject, writeAuditLog } from './helpers.js'
 
 export interface KeywordRoutesOptions {
@@ -192,12 +192,7 @@ export async function keywordRoutes(app: FastifyInstance, opts: KeywordRoutesOpt
       return reply.send({ keywords: generated, provider })
     } catch (err) {
       request.log.error({ err }, 'Key phrase generation failed')
-      return reply.status(500).send({
-        error: {
-          code: 'INTERNAL_ERROR',
-          message: err instanceof Error ? err.message : 'Failed to generate key phrases',
-        },
-      })
+      throw internalError(err instanceof Error ? err.message : 'Failed to generate key phrases')
     }
   })
 }

--- a/packages/api-routes/src/settings.ts
+++ b/packages/api-routes/src/settings.ts
@@ -3,6 +3,7 @@ import type { ProviderQuotaPolicy } from '@ainyc/canonry-contracts'
 import {
   validationError,
   notImplemented,
+  internalError,
 } from '@ainyc/canonry-contracts'
 
 export interface ProviderSummaryEntry {
@@ -54,84 +55,68 @@ export async function settingsRoutes(app: FastifyInstance, opts: SettingsRoutesO
   app.put<{
     Params: { name: string }
     Body: { apiKey?: string; baseUrl?: string; model?: string; quota?: Partial<ProviderQuotaPolicy> }
-  }>('/settings/providers/:name', async (request, reply) => {
+  }>('/settings/providers/:name', async (request) => {
     const { apiKey, baseUrl, model, quota } = request.body ?? {}
     const name = request.params.name
 
-    // Validate against registered API adapters (browser/CDP adapters are
-    // configured separately and cannot be updated through this endpoint)
     const adapters = opts.providerAdapters ?? []
     const apiAdapters = adapters.filter(a => a.mode === 'api')
     const adapterInfo = apiAdapters.find(a => a.name === name)
     if (!adapterInfo) {
       const validNames = apiAdapters.map(a => a.name)
-      const err = validationError(`Invalid provider: ${name}. Must be one of: ${validNames.join(', ')}`, {
+      throw validationError(`Invalid provider: ${name}. Must be one of: ${validNames.join(', ')}`, {
         provider: name,
         validProviders: validNames,
       })
-      return reply.status(err.statusCode).send(err.toJSON())
     }
 
-    // Local provider requires baseUrl; others require apiKey (except gemini which
-    // can be configured via Vertex AI project in config file / env vars instead)
     if (name === 'local') {
       if (!baseUrl || typeof baseUrl !== 'string') {
-        const err = validationError('baseUrl is required for local provider')
-        return reply.status(err.statusCode).send(err.toJSON())
+        throw validationError('baseUrl is required for local provider')
       }
     } else if (name === 'gemini' && !apiKey) {
-      // Gemini allows empty apiKey only when Vertex AI is already configured
       const geminiSummary = (opts.providerSummary ?? []).find(p => p.name === 'gemini')
       if (!geminiSummary?.vertexConfigured) {
-        const err = validationError(
+        throw validationError(
           'apiKey is required for Gemini unless Vertex AI is configured ' +
           '(set GEMINI_VERTEX_PROJECT env var or vertexProject in config file)',
         )
-        return reply.status(err.statusCode).send(err.toJSON())
       }
     } else {
       if (!apiKey || typeof apiKey !== 'string') {
-        const err = validationError('apiKey is required')
-        return reply.status(err.statusCode).send(err.toJSON())
+        throw validationError('apiKey is required')
       }
     }
 
     if (model !== undefined) {
       if (!adapterInfo.modelValidationPattern.test(model)) {
-        return reply.status(400).send({
-          error: { code: 'VALIDATION_ERROR', message: `Invalid model "${model}" for provider "${name}" — ${adapterInfo.modelValidationHint}` },
-        })
+        throw validationError(
+          `Invalid model "${model}" for provider "${name}" — ${adapterInfo.modelValidationHint}`,
+        )
       }
     }
 
     if (!opts.onProviderUpdate) {
-      const err = notImplemented('Provider configuration updates are not supported in this deployment')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw notImplemented('Provider configuration updates are not supported in this deployment')
     }
 
-    // Validate quota fields if provided
     if (quota !== undefined) {
       if (typeof quota !== 'object' || quota === null) {
-        return reply.status(400).send({ error: { code: 'VALIDATION_ERROR', message: 'quota must be an object' } })
+        throw validationError('quota must be an object')
       }
       for (const [key, val] of Object.entries(quota)) {
         if (!['maxConcurrency', 'maxRequestsPerMinute', 'maxRequestsPerDay'].includes(key)) {
-          return reply.status(400).send({ error: { code: 'VALIDATION_ERROR', message: `Unknown quota field: ${key}` } })
+          throw validationError(`Unknown quota field: ${key}`)
         }
         if (typeof val !== 'number' || !Number.isInteger(val) || val <= 0) {
-          return reply.status(400).send({ error: { code: 'VALIDATION_ERROR', message: `${key} must be a positive integer` } })
+          throw validationError(`${key} must be a positive integer`)
         }
       }
     }
 
     const result = opts.onProviderUpdate(name, apiKey ?? '', model, baseUrl, quota)
     if (!result) {
-      return reply.status(500).send({
-        error: {
-          code: 'INTERNAL_ERROR',
-          message: 'Failed to update provider configuration',
-        },
-      })
+      throw internalError('Failed to update provider configuration')
     }
 
     return result
@@ -139,28 +124,20 @@ export async function settingsRoutes(app: FastifyInstance, opts: SettingsRoutesO
 
   app.put<{
     Body: { clientId?: string; clientSecret?: string }
-  }>('/settings/google', async (request, reply) => {
+  }>('/settings/google', async (request) => {
     const { clientId, clientSecret } = request.body ?? {}
 
     if (!clientId || typeof clientId !== 'string' || !clientSecret || typeof clientSecret !== 'string') {
-      return reply.status(400).send({
-        error: { code: 'VALIDATION_ERROR', message: 'clientId and clientSecret are required' },
-      })
+      throw validationError('clientId and clientSecret are required')
     }
 
     if (!opts.onGoogleUpdate) {
-      const err = notImplemented('Google OAuth configuration updates are not supported in this deployment')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw notImplemented('Google OAuth configuration updates are not supported in this deployment')
     }
 
     const result = opts.onGoogleUpdate(clientId, clientSecret)
     if (!result) {
-      return reply.status(500).send({
-        error: {
-          code: 'INTERNAL_ERROR',
-          message: 'Failed to update Google OAuth configuration',
-        },
-      })
+      throw internalError('Failed to update Google OAuth configuration')
     }
 
     return result
@@ -168,28 +145,20 @@ export async function settingsRoutes(app: FastifyInstance, opts: SettingsRoutesO
 
   app.put<{
     Body: { apiKey?: string }
-  }>('/settings/bing', async (request, reply) => {
+  }>('/settings/bing', async (request) => {
     const { apiKey } = request.body ?? {}
 
     if (!apiKey || typeof apiKey !== 'string') {
-      return reply.status(400).send({
-        error: { code: 'VALIDATION_ERROR', message: 'apiKey is required' },
-      })
+      throw validationError('apiKey is required')
     }
 
     if (!opts.onBingUpdate) {
-      const err = notImplemented('Bing configuration updates are not supported in this deployment')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw notImplemented('Bing configuration updates are not supported in this deployment')
     }
 
     const result = opts.onBingUpdate(apiKey)
     if (!result) {
-      return reply.status(500).send({
-        error: {
-          code: 'INTERNAL_ERROR',
-          message: 'Failed to update Bing configuration',
-        },
-      })
+      throw internalError('Failed to update Bing configuration')
     }
 
     return result

--- a/packages/api-routes/src/snapshot.ts
+++ b/packages/api-routes/src/snapshot.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance } from 'fastify'
-import { notImplemented, snapshotRequestSchema, validationError, type SnapshotReportDto, type SnapshotRequestDto } from '@ainyc/canonry-contracts'
+import { internalError, notImplemented, snapshotRequestSchema, validationError, type SnapshotReportDto, type SnapshotRequestDto } from '@ainyc/canonry-contracts'
 
 export interface SnapshotRoutesOptions {
   onSnapshotRequested?: (input: SnapshotRequestDto) => Promise<SnapshotReportDto>
@@ -8,34 +8,26 @@ export interface SnapshotRoutesOptions {
 export async function snapshotRoutes(app: FastifyInstance, opts: SnapshotRoutesOptions) {
   app.post<{
     Body: SnapshotRequestDto
-  }>('/snapshot', async (request, reply) => {
+  }>('/snapshot', async (request) => {
     const parsed = snapshotRequestSchema.safeParse(request.body)
     if (!parsed.success) {
-      const err = validationError('Invalid snapshot payload', {
+      throw validationError('Invalid snapshot payload', {
         issues: parsed.error.issues.map(issue => ({
           path: issue.path.join('.'),
           message: issue.message,
         })),
       })
-      return reply.status(err.statusCode).send(err.toJSON())
     }
 
     if (!opts.onSnapshotRequested) {
-      const err = notImplemented('Snapshot reporting is not supported in this deployment')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw notImplemented('Snapshot reporting is not supported in this deployment')
     }
 
     try {
-      const report = await opts.onSnapshotRequested(parsed.data)
-      return reply.send(report)
+      return await opts.onSnapshotRequested(parsed.data)
     } catch (err) {
       request.log.error({ err }, 'Snapshot report generation failed')
-      return reply.status(500).send({
-        error: {
-          code: 'INTERNAL_ERROR',
-          message: err instanceof Error ? err.message : 'Failed to generate snapshot report',
-        },
-      })
+      throw internalError(err instanceof Error ? err.message : 'Failed to generate snapshot report')
     }
   })
 }

--- a/packages/api-routes/src/wordpress.ts
+++ b/packages/api-routes/src/wordpress.ts
@@ -1,4 +1,4 @@
-import type { FastifyInstance, FastifyReply } from 'fastify'
+import type { FastifyInstance } from 'fastify'
 import { AppError, notFound, providerError, validationError } from '@ainyc/canonry-contracts'
 import type { WordpressEnv } from '@ainyc/canonry-contracts'
 import {
@@ -53,63 +53,40 @@ function parseEnvInput(
   return env
 }
 
-function sendWordpressError(reply: FastifyReply, error: unknown): boolean {
-  if (!(error instanceof WordpressApiError)) return false
-
-  let appError: AppError
+function toAppError(error: WordpressApiError): AppError {
   switch (error.code) {
     case 'AUTH_INVALID':
-      appError = new AppError('AUTH_INVALID', error.message, error.statusCode)
-      break
+      return new AppError('AUTH_INVALID', error.message, error.statusCode)
     case 'NOT_FOUND':
-      appError = new AppError('NOT_FOUND', error.message, error.statusCode)
-      break
-    case 'UPSTREAM_ERROR':
-      appError = providerError(error.message, { statusCode: error.statusCode })
-      break
+      return new AppError('NOT_FOUND', error.message, error.statusCode)
     case 'UNSUPPORTED':
     case 'VALIDATION_ERROR':
-      appError = validationError(error.message)
-      break
+      return validationError(error.message)
+    case 'UPSTREAM_ERROR':
     default:
-      appError = providerError(error.message, { statusCode: error.statusCode })
-      break
+      return providerError(error.message, { statusCode: error.statusCode })
   }
-
-  reply.status(appError.statusCode).send(appError.toJSON())
-  return true
 }
 
-async function withWordpressErrorHandling<T>(
-  reply: FastifyReply,
-  handler: () => Promise<T>,
-): Promise<T | void> {
+async function withWordpressErrorHandling<T>(handler: () => Promise<T>): Promise<T> {
   try {
     return await handler()
   } catch (error) {
-    if (sendWordpressError(reply, error)) return
+    if (error instanceof WordpressApiError) throw toAppError(error)
     throw error
   }
 }
 
 export async function wordpressRoutes(app: FastifyInstance, opts: WordpressRoutesOptions) {
-  function requireStore(reply: { status: (code: number) => { send: (body: unknown) => unknown } }) {
+  function requireStore(): WordpressConnectionStore {
     if (opts.wordpressConnectionStore) return opts.wordpressConnectionStore
-    const err = validationError('WordPress connection storage is not configured for this deployment')
-    reply.status(err.statusCode).send(err.toJSON())
-    return null
+    throw validationError('WordPress connection storage is not configured for this deployment')
   }
 
-  function requireConnection(
-    store: WordpressConnectionStore,
-    projectName: string,
-    reply: { status: (code: number) => { send: (body: unknown) => unknown } },
-  ) {
+  function requireConnection(store: WordpressConnectionStore, projectName: string): WordpressConnectionRecord {
     const connection = store.getConnection(projectName)
     if (!connection) {
-      const err = validationError(`No WordPress connection found for project "${projectName}". Run "canonry wordpress connect ${projectName}" first.`)
-      reply.status(err.statusCode).send(err.toJSON())
-      return null
+      throw validationError(`No WordPress connection found for project "${projectName}". Run "canonry wordpress connect ${projectName}" first.`)
     }
     return connection
   }
@@ -123,23 +100,20 @@ export async function wordpressRoutes(app: FastifyInstance, opts: WordpressRoute
       appPassword: string
       defaultEnv?: WordpressEnv
     }
-  }>('/projects/:name/wordpress/connect', async (request, reply) => {
-    return withWordpressErrorHandling(reply, async () => {
-      const store = requireStore(reply)
-      if (!store) return
+  }>('/projects/:name/wordpress/connect', async (request) => {
+    return withWordpressErrorHandling(async () => {
+      const store = requireStore()
 
       const project = resolveProject(app.db, request.params.name)
       const { url, stagingUrl, username, appPassword } = request.body ?? {}
       if (!url || !username || !appPassword) {
-        const err = validationError('url, username, and appPassword are required')
-        return reply.status(err.statusCode).send(err.toJSON())
+        throw validationError('url, username, and appPassword are required')
       }
 
       const defaultEnv = parseEnvInput(request.body?.defaultEnv, 'defaultEnv')
         ?? (stagingUrl ? 'staging' : 'live')
       if (defaultEnv === 'staging' && !stagingUrl) {
-        const err = validationError('defaultEnv "staging" requires stagingUrl')
-        return reply.status(err.statusCode).send(err.toJSON())
+        throw validationError('defaultEnv "staging" requires stagingUrl')
       }
 
       const now = new Date().toISOString()
@@ -180,14 +154,12 @@ export async function wordpressRoutes(app: FastifyInstance, opts: WordpressRoute
   })
 
   app.delete<{ Params: { name: string } }>('/projects/:name/wordpress/disconnect', async (request, reply) => {
-    const store = requireStore(reply)
-    if (!store) return
+    const store = requireStore()
 
     const project = resolveProject(app.db, request.params.name)
     const deleted = store.deleteConnection(project.name)
     if (!deleted) {
-      const err = notFound('WordPress connection', project.name)
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw notFound('WordPress connection', project.name)
     }
 
     writeAuditLog(app.db, {
@@ -230,13 +202,11 @@ export async function wordpressRoutes(app: FastifyInstance, opts: WordpressRoute
   app.get<{
     Params: { name: string }
     Querystring: { env?: string }
-  }>('/projects/:name/wordpress/pages', async (request, reply) => {
-    return withWordpressErrorHandling(reply, async () => {
-      const store = requireStore(reply)
-      if (!store) return
+  }>('/projects/:name/wordpress/pages', async (request) => {
+    return withWordpressErrorHandling(async () => {
+      const store = requireStore()
       const project = resolveProject(app.db, request.params.name)
-      const connection = requireConnection(store, project.name, reply)
-      if (!connection) return
+      const connection = requireConnection(store, project.name)
       const env = parseEnvInput(request.query?.env)
       return {
         env: env ?? connection.defaultEnv,
@@ -248,17 +218,14 @@ export async function wordpressRoutes(app: FastifyInstance, opts: WordpressRoute
   app.get<{
     Params: { name: string }
     Querystring: { slug?: string; env?: string }
-  }>('/projects/:name/wordpress/page', async (request, reply) => {
-    return withWordpressErrorHandling(reply, async () => {
-      const store = requireStore(reply)
-      if (!store) return
+  }>('/projects/:name/wordpress/page', async (request) => {
+    return withWordpressErrorHandling(async () => {
+      const store = requireStore()
       const project = resolveProject(app.db, request.params.name)
-      const connection = requireConnection(store, project.name, reply)
-      if (!connection) return
+      const connection = requireConnection(store, project.name)
       const slug = request.query?.slug?.trim()
       if (!slug) {
-        const err = validationError('slug is required')
-        return reply.status(err.statusCode).send(err.toJSON())
+        throw validationError('slug is required')
       }
       const env = parseEnvInput(request.query?.env)
       return getPageDetail(connection, slug, env)
@@ -268,18 +235,15 @@ export async function wordpressRoutes(app: FastifyInstance, opts: WordpressRoute
   app.post<{
     Params: { name: string }
     Body: { title: string; slug: string; content: string; status?: string; env?: WordpressEnv }
-  }>('/projects/:name/wordpress/pages', async (request, reply) => {
-    return withWordpressErrorHandling(reply, async () => {
-      const store = requireStore(reply)
-      if (!store) return
+  }>('/projects/:name/wordpress/pages', async (request) => {
+    return withWordpressErrorHandling(async () => {
+      const store = requireStore()
       const project = resolveProject(app.db, request.params.name)
-      const connection = requireConnection(store, project.name, reply)
-      if (!connection) return
+      const connection = requireConnection(store, project.name)
       const { title, slug, content, status } = request.body ?? {}
       const env = parseEnvInput(request.body?.env)
       if (!title || !slug || !content) {
-        const err = validationError('title, slug, and content are required')
-        return reply.status(err.statusCode).send(err.toJSON())
+        throw validationError('title, slug, and content are required')
       }
       const created = await createPage(connection, { title, slug, content, status }, env)
       writeAuditLog(app.db, {
@@ -296,17 +260,14 @@ export async function wordpressRoutes(app: FastifyInstance, opts: WordpressRoute
   app.put<{
     Params: { name: string }
     Body: { currentSlug: string; title?: string; slug?: string; content?: string; status?: string; env?: WordpressEnv }
-  }>('/projects/:name/wordpress/page', async (request, reply) => {
-    return withWordpressErrorHandling(reply, async () => {
-      const store = requireStore(reply)
-      if (!store) return
+  }>('/projects/:name/wordpress/page', async (request) => {
+    return withWordpressErrorHandling(async () => {
+      const store = requireStore()
       const project = resolveProject(app.db, request.params.name)
-      const connection = requireConnection(store, project.name, reply)
-      if (!connection) return
+      const connection = requireConnection(store, project.name)
       const currentSlug = request.body?.currentSlug?.trim()
       if (!currentSlug) {
-        const err = validationError('currentSlug is required')
-        return reply.status(err.statusCode).send(err.toJSON())
+        throw validationError('currentSlug is required')
       }
       const env = parseEnvInput(request.body?.env)
       const updated = await updatePageBySlug(connection, currentSlug, {
@@ -329,17 +290,14 @@ export async function wordpressRoutes(app: FastifyInstance, opts: WordpressRoute
   app.post<{
     Params: { name: string }
     Body: { slug: string; title?: string; description?: string; noindex?: boolean; env?: WordpressEnv }
-  }>('/projects/:name/wordpress/page/meta', async (request, reply) => {
-    return withWordpressErrorHandling(reply, async () => {
-      const store = requireStore(reply)
-      if (!store) return
+  }>('/projects/:name/wordpress/page/meta', async (request) => {
+    return withWordpressErrorHandling(async () => {
+      const store = requireStore()
       const project = resolveProject(app.db, request.params.name)
-      const connection = requireConnection(store, project.name, reply)
-      if (!connection) return
+      const connection = requireConnection(store, project.name)
       const slug = request.body?.slug?.trim()
       if (!slug) {
-        const err = validationError('slug is required')
-        return reply.status(err.statusCode).send(err.toJSON())
+        throw validationError('slug is required')
       }
       const env = parseEnvInput(request.body?.env)
       const updated = await setSeoMeta(connection, slug, {
@@ -364,22 +322,18 @@ export async function wordpressRoutes(app: FastifyInstance, opts: WordpressRoute
       entries: Array<{ slug: string; title?: string; description?: string; noindex?: boolean }>
       env?: WordpressEnv
     }
-  }>('/projects/:name/wordpress/pages/meta/bulk', async (request, reply) => {
-    return withWordpressErrorHandling(reply, async () => {
-      const store = requireStore(reply)
-      if (!store) return
+  }>('/projects/:name/wordpress/pages/meta/bulk', async (request) => {
+    return withWordpressErrorHandling(async () => {
+      const store = requireStore()
       const project = resolveProject(app.db, request.params.name)
-      const connection = requireConnection(store, project.name, reply)
-      if (!connection) return
+      const connection = requireConnection(store, project.name)
       const entries = request.body?.entries
       if (!Array.isArray(entries) || entries.length === 0) {
-        const err = validationError('entries array is required and must not be empty')
-        return reply.status(err.statusCode).send(err.toJSON())
+        throw validationError('entries array is required and must not be empty')
       }
       for (const entry of entries) {
         if (!entry.slug?.trim()) {
-          const err = validationError('each entry must have a slug')
-          return reply.status(err.statusCode).send(err.toJSON())
+          throw validationError('each entry must have a slug')
         }
       }
       const env = parseEnvInput(request.body?.env)
@@ -401,17 +355,14 @@ export async function wordpressRoutes(app: FastifyInstance, opts: WordpressRoute
   app.get<{
     Params: { name: string }
     Querystring: { slug?: string; env?: string }
-  }>('/projects/:name/wordpress/schema', async (request, reply) => {
-    return withWordpressErrorHandling(reply, async () => {
-      const store = requireStore(reply)
-      if (!store) return
+  }>('/projects/:name/wordpress/schema', async (request) => {
+    return withWordpressErrorHandling(async () => {
+      const store = requireStore()
       const project = resolveProject(app.db, request.params.name)
-      const connection = requireConnection(store, project.name, reply)
-      if (!connection) return
+      const connection = requireConnection(store, project.name)
       const slug = request.query?.slug?.trim()
       if (!slug) {
-        const err = validationError('slug is required')
-        return reply.status(err.statusCode).send(err.toJSON())
+        throw validationError('slug is required')
       }
       const env = parseEnvInput(request.query?.env)
       return getPageSchema(connection, slug, env)
@@ -421,18 +372,15 @@ export async function wordpressRoutes(app: FastifyInstance, opts: WordpressRoute
   app.post<{
     Params: { name: string }
     Body: { slug: string; type?: string; json: string; env?: WordpressEnv }
-  }>('/projects/:name/wordpress/schema/manual', async (request, reply) => {
-    return withWordpressErrorHandling(reply, async () => {
-      const store = requireStore(reply)
-      if (!store) return
+  }>('/projects/:name/wordpress/schema/manual', async (request) => {
+    return withWordpressErrorHandling(async () => {
+      const store = requireStore()
       const project = resolveProject(app.db, request.params.name)
-      const connection = requireConnection(store, project.name, reply)
-      if (!connection) return
+      const connection = requireConnection(store, project.name)
       const slug = request.body?.slug?.trim()
       const json = request.body?.json
       if (!slug || !json) {
-        const err = validationError('slug and json are required')
-        return reply.status(err.statusCode).send(err.toJSON())
+        throw validationError('slug and json are required')
       }
       const env = parseEnvInput(request.body?.env)
       return buildManualSchemaUpdate(connection, slug, { type: request.body?.type, json }, env)
@@ -442,17 +390,14 @@ export async function wordpressRoutes(app: FastifyInstance, opts: WordpressRoute
   app.post<{
     Params: { name: string }
     Body: { profile: SchemaProfileFile; env?: WordpressEnv }
-  }>('/projects/:name/wordpress/schema/deploy', async (request, reply) => {
-    return withWordpressErrorHandling(reply, async () => {
-      const store = requireStore(reply)
-      if (!store) return
+  }>('/projects/:name/wordpress/schema/deploy', async (request) => {
+    return withWordpressErrorHandling(async () => {
+      const store = requireStore()
       const project = resolveProject(app.db, request.params.name)
-      const connection = requireConnection(store, project.name, reply)
-      if (!connection) return
+      const connection = requireConnection(store, project.name)
       const profile = request.body?.profile
       if (!profile?.business?.name || !profile?.pages || Object.keys(profile.pages).length === 0) {
-        const err = validationError('profile with business.name and non-empty pages is required')
-        return reply.status(err.statusCode).send(err.toJSON())
+        throw validationError('profile with business.name and non-empty pages is required')
       }
       const env = parseEnvInput(request.body?.env)
       return deploySchemaFromProfile(connection, profile, env)
@@ -462,13 +407,11 @@ export async function wordpressRoutes(app: FastifyInstance, opts: WordpressRoute
   app.get<{
     Params: { name: string }
     Querystring: { env?: string }
-  }>('/projects/:name/wordpress/schema/status', async (request, reply) => {
-    return withWordpressErrorHandling(reply, async () => {
-      const store = requireStore(reply)
-      if (!store) return
+  }>('/projects/:name/wordpress/schema/status', async (request) => {
+    return withWordpressErrorHandling(async () => {
+      const store = requireStore()
       const project = resolveProject(app.db, request.params.name)
-      const connection = requireConnection(store, project.name, reply)
-      if (!connection) return
+      const connection = requireConnection(store, project.name)
       const env = parseEnvInput(request.query?.env)
       return getSchemaStatus(connection, env)
     })
@@ -477,13 +420,11 @@ export async function wordpressRoutes(app: FastifyInstance, opts: WordpressRoute
   app.get<{
     Params: { name: string }
     Querystring: { env?: string }
-  }>('/projects/:name/wordpress/llms-txt', async (request, reply) => {
-    return withWordpressErrorHandling(reply, async () => {
-      const store = requireStore(reply)
-      if (!store) return
+  }>('/projects/:name/wordpress/llms-txt', async (request) => {
+    return withWordpressErrorHandling(async () => {
+      const store = requireStore()
       const project = resolveProject(app.db, request.params.name)
-      const connection = requireConnection(store, project.name, reply)
-      if (!connection) return
+      const connection = requireConnection(store, project.name)
       const env = parseEnvInput(request.query?.env)
       return getLlmsTxt(connection, env)
     })
@@ -492,17 +433,14 @@ export async function wordpressRoutes(app: FastifyInstance, opts: WordpressRoute
   app.post<{
     Params: { name: string }
     Body: { content: string; env?: WordpressEnv }
-  }>('/projects/:name/wordpress/llms-txt/manual', async (request, reply) => {
-    return withWordpressErrorHandling(reply, async () => {
-      const store = requireStore(reply)
-      if (!store) return
+  }>('/projects/:name/wordpress/llms-txt/manual', async (request) => {
+    return withWordpressErrorHandling(async () => {
+      const store = requireStore()
       const project = resolveProject(app.db, request.params.name)
-      const connection = requireConnection(store, project.name, reply)
-      if (!connection) return
+      const connection = requireConnection(store, project.name)
       const content = request.body?.content
       if (!content) {
-        const err = validationError('content is required')
-        return reply.status(err.statusCode).send(err.toJSON())
+        throw validationError('content is required')
       }
       const env = parseEnvInput(request.body?.env)
       return buildManualLlmsTxtUpdate(connection, content, env)
@@ -512,41 +450,34 @@ export async function wordpressRoutes(app: FastifyInstance, opts: WordpressRoute
   app.get<{
     Params: { name: string }
     Querystring: { env?: string }
-  }>('/projects/:name/wordpress/audit', async (request, reply) => {
-    return withWordpressErrorHandling(reply, async () => {
-      const store = requireStore(reply)
-      if (!store) return
+  }>('/projects/:name/wordpress/audit', async (request) => {
+    return withWordpressErrorHandling(async () => {
+      const store = requireStore()
       const project = resolveProject(app.db, request.params.name)
-      const connection = requireConnection(store, project.name, reply)
-      if (!connection) return
+      const connection = requireConnection(store, project.name)
       const env = parseEnvInput(request.query?.env)
       return runAudit(connection, env)
     })
   })
 
-  app.get<{ Params: { name: string }; Querystring: { slug?: string } }>('/projects/:name/wordpress/diff', async (request, reply) => {
-    return withWordpressErrorHandling(reply, async () => {
-      const store = requireStore(reply)
-      if (!store) return
+  app.get<{ Params: { name: string }; Querystring: { slug?: string } }>('/projects/:name/wordpress/diff', async (request) => {
+    return withWordpressErrorHandling(async () => {
+      const store = requireStore()
       const project = resolveProject(app.db, request.params.name)
-      const connection = requireConnection(store, project.name, reply)
-      if (!connection) return
+      const connection = requireConnection(store, project.name)
       const slug = request.query?.slug?.trim()
       if (!slug) {
-        const err = validationError('slug is required')
-        return reply.status(err.statusCode).send(err.toJSON())
+        throw validationError('slug is required')
       }
       return diffPageAcrossEnvironments(connection, slug)
     })
   })
 
-  app.get<{ Params: { name: string } }>('/projects/:name/wordpress/staging/status', async (request, reply) => {
-    return withWordpressErrorHandling(reply, async () => {
-      const store = requireStore(reply)
-      if (!store) return
+  app.get<{ Params: { name: string } }>('/projects/:name/wordpress/staging/status', async (request) => {
+    return withWordpressErrorHandling(async () => {
+      const store = requireStore()
       const project = resolveProject(app.db, request.params.name)
-      const connection = requireConnection(store, project.name, reply)
-      if (!connection) return
+      const connection = requireConnection(store, project.name)
 
       const plugins = await listActivePlugins(connection, 'live')
       return {
@@ -558,16 +489,13 @@ export async function wordpressRoutes(app: FastifyInstance, opts: WordpressRoute
     })
   })
 
-  app.post<{ Params: { name: string } }>('/projects/:name/wordpress/staging/push', async (request, reply) => {
-    return withWordpressErrorHandling(reply, async () => {
-      const store = requireStore(reply)
-      if (!store) return
+  app.post<{ Params: { name: string } }>('/projects/:name/wordpress/staging/push', async (request) => {
+    return withWordpressErrorHandling(async () => {
+      const store = requireStore()
       const project = resolveProject(app.db, request.params.name)
-      const connection = requireConnection(store, project.name, reply)
-      if (!connection) return
+      const connection = requireConnection(store, project.name)
       if (!connection.stagingUrl) {
-        const err = validationError('No staging URL configured for this project. Reconnect with --staging-url before using staging push.')
-        return reply.status(err.statusCode).send(err.toJSON())
+        throw validationError('No staging URL configured for this project. Reconnect with --staging-url before using staging push.')
       }
       return buildManualStagingPush(connection)
     })
@@ -586,25 +514,22 @@ export async function wordpressRoutes(app: FastifyInstance, opts: WordpressRoute
       skipSchema?: boolean
       skipSubmit?: boolean
     }
-  }>('/projects/:name/wordpress/onboard', async (request, reply) => {
-    return withWordpressErrorHandling(reply, async () => {
-    const store = requireStore(reply)
-    if (!store) return
+  }>('/projects/:name/wordpress/onboard', async (request) => {
+    return withWordpressErrorHandling(async () => {
+    const store = requireStore()
 
     const project = resolveProject(app.db, request.params.name)
     const { url, username, appPassword, stagingUrl, profile, skipSchema, skipSubmit } = request.body ?? {}
 
     if (!url || !username || !appPassword) {
-      const err = validationError('url, username, and appPassword are required')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('url, username, and appPassword are required')
     }
 
     const defaultEnv = parseEnvInput(request.body?.defaultEnv, 'defaultEnv')
       ?? (stagingUrl ? 'staging' : 'live')
 
     if (defaultEnv === 'staging' && !stagingUrl) {
-      const err = validationError('defaultEnv "staging" requires stagingUrl')
-      return reply.status(err.statusCode).send(err.toJSON())
+      throw validationError('defaultEnv "staging" requires stagingUrl')
     }
 
     type StepResult = { name: string; status: 'completed' | 'skipped' | 'failed'; summary?: string; error?: string }

--- a/packages/api-routes/test/google.test.ts
+++ b/packages/api-routes/test/google.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import os from 'node:os'
 import Fastify from 'fastify'
 import { createClient, migrate, projects, runs, gscCoverageSnapshots, gscUrlInspections } from '@ainyc/canonry-db'
+import { AppError } from '@ainyc/canonry-contracts'
 import { googleRoutes } from '../src/google.js'
 
 // Reproduce state signing functions from google.ts to verify behavior
@@ -48,6 +49,12 @@ function buildApp(opts: { googleClientId?: string; googleClientSecret?: string; 
 
   const app = Fastify()
   app.decorate('db', db)
+  app.setErrorHandler((error, _request, reply) => {
+    if (error instanceof AppError) {
+      return reply.status(error.statusCode).send(error.toJSON())
+    }
+    throw error
+  })
   app.register(googleRoutes, {
     getGoogleAuthConfig: () => ({
       clientId: opts.googleClientId,
@@ -304,6 +311,12 @@ describe('googleRoutes: connect uses publicUrl', () => {
     }).run()
 
     const fastify = Fastify()
+    fastify.setErrorHandler((error, _request, reply) => {
+      if (error instanceof AppError) {
+        return reply.status(error.statusCode).send(error.toJSON())
+      }
+      throw error
+    })
     fastify.decorate('db', db)
     fastify.register(googleRoutes, {
       getGoogleAuthConfig: () => ({
@@ -379,6 +392,12 @@ describe('googleRoutes: connect does not double basePath in redirectUri', () => 
     }).run()
 
     const fastify = Fastify()
+    fastify.setErrorHandler((error, _request, reply) => {
+      if (error instanceof AppError) {
+        return reply.status(error.statusCode).send(error.toJSON())
+      }
+      throw error
+    })
     fastify.decorate('db', db)
     fastify.register(googleRoutes, {
       getGoogleAuthConfig: () => ({
@@ -453,6 +472,12 @@ describe('googleRoutes: connect auto-detect uses per-project URI', () => {
     }).run()
 
     const fastify = Fastify()
+    fastify.setErrorHandler((error, _request, reply) => {
+      if (error instanceof AppError) {
+        return reply.status(error.statusCode).send(error.toJSON())
+      }
+      throw error
+    })
     fastify.decorate('db', db)
     fastify.register(googleRoutes, {
       getGoogleAuthConfig: () => ({
@@ -548,6 +573,12 @@ describe('googleRoutes: GET /projects/:name/google/gsc/coverage/history', () => 
     }).run()
 
     const fastify = Fastify()
+    fastify.setErrorHandler((error, _request, reply) => {
+      if (error instanceof AppError) {
+        return reply.status(error.statusCode).send(error.toJSON())
+      }
+      throw error
+    })
     fastify.decorate('db', db)
     fastify.register(googleRoutes, {
       getGoogleAuthConfig: () => ({ clientId: undefined, clientSecret: undefined }),
@@ -683,6 +714,12 @@ describe('googleRoutes: coverage snapshot deduplication', () => {
     }).run()
 
     const fastify = Fastify()
+    fastify.setErrorHandler((error, _request, reply) => {
+      if (error instanceof AppError) {
+        return reply.status(error.statusCode).send(error.toJSON())
+      }
+      throw error
+    })
     fastify.decorate('db', db)
     fastify.register(googleRoutes, {
       getGoogleAuthConfig: () => ({ clientId: undefined, clientSecret: undefined }),
@@ -828,6 +865,12 @@ describe('googleRoutes: POST /projects/:name/google/indexing/request', () => {
     const tokenExpires = new Date(Date.now() + 3600 * 1000).toISOString()
 
     const fastify = Fastify()
+    fastify.setErrorHandler((error, _request, reply) => {
+      if (error instanceof AppError) {
+        return reply.status(error.statusCode).send(error.toJSON())
+      }
+      throw error
+    })
     fastify.decorate('db', db)
     fastify.register(googleRoutes, {
       getGoogleAuthConfig: () => ({

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/job-runner.ts
+++ b/packages/canonry/src/job-runner.ts
@@ -97,6 +97,33 @@ class ProviderExecutionGate {
   }
 }
 
+export async function runWithConcurrency<T>(
+  items: readonly T[],
+  limit: number,
+  worker: (item: T) => Promise<void>,
+): Promise<void> {
+  if (items.length === 0) return
+  const cap = Math.max(1, Math.min(limit, items.length))
+  let cursor = 0
+  const next = async (): Promise<void> => {
+    while (true) {
+      const idx = cursor++
+      if (idx >= items.length) return
+      await worker(items[idx]!)
+    }
+  }
+  await Promise.all(Array.from({ length: cap }, next))
+}
+
+const PROVIDER_FANOUT_DEFAULT = 8
+
+function resolveProviderFanout(): number {
+  const raw = process.env.CANONRY_PROVIDER_FANOUT
+  if (!raw) return PROVIDER_FANOUT_DEFAULT
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : PROVIDER_FANOUT_DEFAULT
+}
+
 type RunExecutionContext = {
   providerCount: number
   providers: ProviderName[]
@@ -390,11 +417,11 @@ export class JobRunner {
         }
       }
 
-      await Promise.all(apiProviders.map(async (registeredProvider) => {
+      await runWithConcurrency(apiProviders, resolveProviderFanout(), async (registeredProvider) => {
         await Promise.all(projectKeywords.map(async (kw) => {
           await processKeywordForProvider(registeredProvider, kw)
         }))
-      }))
+      })
 
       // Browser providers still run keyword-by-keyword to preserve tab reuse semantics.
       for (const registeredProvider of browserProviders) {

--- a/packages/canonry/test/job-runner-concurrency.test.ts
+++ b/packages/canonry/test/job-runner-concurrency.test.ts
@@ -1,0 +1,60 @@
+import { test, expect } from 'vitest'
+import { runWithConcurrency } from '../src/job-runner.js'
+
+test('runWithConcurrency honors the concurrency cap', async () => {
+  const items = Array.from({ length: 20 }, (_, i) => i)
+  let active = 0
+  let peak = 0
+
+  await runWithConcurrency(items, 3, async () => {
+    active++
+    peak = Math.max(peak, active)
+    await new Promise(resolve => setTimeout(resolve, 5))
+    active--
+  })
+
+  expect(peak).toBeLessThanOrEqual(3)
+  expect(peak).toBeGreaterThan(0)
+})
+
+test('runWithConcurrency processes every item exactly once', async () => {
+  const items = ['a', 'b', 'c', 'd', 'e']
+  const seen: string[] = []
+
+  await runWithConcurrency(items, 2, async (item) => {
+    seen.push(item)
+  })
+
+  expect(seen.sort()).toEqual(['a', 'b', 'c', 'd', 'e'])
+})
+
+test('runWithConcurrency returns immediately for empty input', async () => {
+  let called = false
+  await runWithConcurrency([], 5, async () => {
+    called = true
+  })
+  expect(called).toBe(false)
+})
+
+test('runWithConcurrency clamps cap to item count', async () => {
+  const items = [1, 2]
+  let peak = 0
+  let active = 0
+
+  await runWithConcurrency(items, 100, async () => {
+    active++
+    peak = Math.max(peak, active)
+    await new Promise(resolve => setTimeout(resolve, 5))
+    active--
+  })
+
+  expect(peak).toBeLessThanOrEqual(2)
+})
+
+test('runWithConcurrency propagates worker errors', async () => {
+  await expect(
+    runWithConcurrency([1, 2, 3], 2, async (item) => {
+      if (item === 2) throw new Error('boom')
+    }),
+  ).rejects.toThrow('boom')
+})

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -108,3 +108,7 @@ export function agentBusy(projectName: string): AppError {
 export function missingDependency(message: string, details?: Record<string, unknown>): AppError {
   return new AppError('MISSING_DEPENDENCY', message, 422, details)
 }
+
+export function internalError(message: string, details?: Record<string, unknown>): AppError {
+  return new AppError('INTERNAL_ERROR', message, 500, details)
+}

--- a/packages/db/test/migration-parity.test.ts
+++ b/packages/db/test/migration-parity.test.ts
@@ -1,0 +1,66 @@
+import { test, expect } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import Database from 'better-sqlite3'
+import { getTableColumns, getTableName, is } from 'drizzle-orm'
+import { SQLiteTable } from 'drizzle-orm/sqlite-core'
+import { createClient, migrate } from '../src/index.js'
+import * as schema from '../src/schema.js'
+
+test('every schema.ts table and column is created by the migrations', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-parity-'))
+  const dbPath = path.join(tmpDir, 'parity.db')
+
+  try {
+    const drizzleDb = createClient(dbPath)
+    migrate(drizzleDb)
+
+    const raw = new Database(dbPath, { readonly: true })
+
+    const schemaTables: SQLiteTable[] = []
+    for (const value of Object.values(schema)) {
+      if (is(value, SQLiteTable)) {
+        schemaTables.push(value)
+      }
+    }
+
+    expect(schemaTables.length, 'schema.ts should declare at least one sqliteTable').toBeGreaterThan(0)
+
+    const missingTables: string[] = []
+    const missingColumns: Array<{ table: string; column: string }> = []
+
+    for (const table of schemaTables) {
+      const tableName = getTableName(table)
+      const rows = raw
+        .prepare(`PRAGMA table_info("${tableName}")`)
+        .all() as Array<{ name: string }>
+
+      if (rows.length === 0) {
+        missingTables.push(tableName)
+        continue
+      }
+
+      const dbColumnNames = new Set(rows.map((r) => r.name))
+      const cols = getTableColumns(table)
+      for (const col of Object.values(cols)) {
+        if (!dbColumnNames.has(col.name)) {
+          missingColumns.push({ table: tableName, column: col.name })
+        }
+      }
+    }
+
+    raw.close()
+
+    expect(
+      missingTables,
+      `Tables declared in schema.ts but not created by MIGRATIONS (missing CREATE TABLE): ${JSON.stringify(missingTables)}`,
+    ).toEqual([])
+    expect(
+      missingColumns,
+      `Columns declared in schema.ts but not present after MIGRATIONS (missing ALTER TABLE ADD COLUMN): ${JSON.stringify(missingColumns)}`,
+    ).toEqual([])
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary

- Convert `reply.status().send(err.toJSON())` patterns across `auth.ts`, `bing.ts`, `google.ts`, `keywords.ts`, `settings.ts`, `snapshot.ts`, and `wordpress.ts` to `throw <factory>()`, letting the global `AppError` handler do the serialization (per AGENTS.md "Error Handling in API Routes").
- Add `internalError()` factory in `packages/contracts/src/errors.ts` for the previously hand-built `INTERNAL_ERROR` 500 envelopes.
- Bound provider fanout in `packages/canonry/src/job-runner.ts` via a new `runWithConcurrency(items, limit, worker)` helper (default 8, override with `CANONRY_PROVIDER_FANOUT`); browser providers stay sequential.
- Add tests: `packages/canonry/test/job-runner-concurrency.test.ts` covers cap/clamp/empty/error-propagation; `packages/db/test/migration-parity.test.ts` enforces every Drizzle table has a matching migration; `packages/api-routes/test/google.test.ts` registers `setErrorHandler` so throw-based routes serialize correctly. Adds `docs/adr/0008-canonry-package-split.md` and bumps both `package.json` files to 2.4.3.

## Test plan

- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm lint`