### PR TITLE
fix(bing): derive indexed from crawl signals + GetCrawlIssues cross-check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "2.4.4",
+  "version": "2.4.5",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "2.4.3",
+  "version": "2.4.4",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/bing.ts
+++ b/packages/api-routes/src/bing.ts
@@ -7,6 +7,7 @@ import { resolveProject, writeAuditLog } from './helpers.js'
 import {
   getSites,
   getUrlInfo,
+  getCrawlIssues,
   submitUrl,
   submitUrlBatch,
   getKeywordStats,
@@ -33,6 +34,47 @@ function bingLog(level: 'info' | 'warn' | 'error', action: string, ctx?: Record<
   const entry = { ts: new Date().toISOString(), level, module: 'BingRoutes', action, ...ctx }
   const stream = level === 'error' ? process.stderr : process.stdout
   stream.write(JSON.stringify(entry) + '\n')
+}
+
+// GetCrawlIssues cross-check — cache the list of URLs Bing has flagged with a
+// blocking crawl issue (robots, HTTP errors, DNS, malware, noindex) per site
+// for a short TTL so a bulk refresh of N URLs doesn't trigger N lookups.
+const CRAWL_ISSUES_CACHE_TTL_MS = 60_000
+const crawlIssuesCache = new Map<string, { blockedUrls: Set<string>; fetchedAt: number }>()
+
+export function __resetBingCrawlIssuesCacheForTest(): void {
+  crawlIssuesCache.clear()
+}
+
+// Bing's `IssueType` is a space-separated list of `CrawlIssueCategory` flag
+// names. Anything other than None / SeoIssues prevents the URL from being
+// served in search — downgrade those, but keep SEO-only warnings indexed.
+function isBlockingIssueType(issueType: string | null | undefined): boolean {
+  if (!issueType) return true
+  const trimmed = issueType.trim()
+  if (!trimmed) return true
+  return trimmed.split(/\s+/).some((flag) => !/^(None|Seo(Issues|Concerns))$/i.test(flag))
+}
+
+async function loadBlockingCrawlIssues(
+  apiKey: string,
+  siteUrl: string,
+  domain: string,
+): Promise<Set<string>> {
+  const now = Date.now()
+  const cached = crawlIssuesCache.get(domain)
+  if (cached && now - cached.fetchedAt < CRAWL_ISSUES_CACHE_TTL_MS) {
+    return cached.blockedUrls
+  }
+  const issues = await getCrawlIssues(apiKey, siteUrl)
+  const blockedUrls = new Set<string>()
+  for (const issue of issues) {
+    if (issue.Url && isBlockingIssueType(issue.IssueType ?? null)) {
+      blockedUrls.add(issue.Url)
+    }
+  }
+  crawlIssuesCache.set(domain, { blockedUrls, fetchedAt: now })
+  return blockedUrls
 }
 
 export interface BingConnectionRecord {
@@ -404,30 +446,53 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
         domain: project.canonicalDomain,
         url,
         httpStatus: result.HttpStatus ?? result.HttpCode ?? null,
-        inIndex: result.InIndex ?? null,
         documentSize: result.DocumentSize ?? null,
         lastCrawledDate: result.LastCrawledDate ?? null,
+        discoveryDate: result.DiscoveryDate ?? null,
       })
       const now = new Date().toISOString()
       const id = crypto.randomUUID()
       const httpCode = result.HttpStatus ?? result.HttpCode ?? null
 
-      // Bing's published GetUrlInfo contract documents UrlInfo via:
-      // https://learn.microsoft.com/en-us/dotnet/api/microsoft.bing.webmaster.api.interfaces.iwebmasterapi.geturlinfo?view=bing-webmaster-dotnet
-      // WSDL: https://ssl.bing.com/webmaster/api.svc?singleWsdl
-      // Use any explicit legacy InIndex flag if it is present. Otherwise, only a
-      // positive DocumentSize is strong enough to treat the URL as indexed.
-      // Zero-byte responses stay unknown instead of being forced to "not indexed".
-      let derivedInIndex: boolean | null = null
-      if (result.InIndex != null) {
-        derivedInIndex = result.InIndex
-      } else if (result.DocumentSize != null && result.DocumentSize > 0) {
-        derivedInIndex = true
-      }
-
       const lastCrawledDate = parseBingDate(result.LastCrawledDate)
       const inIndexDate = parseBingDate(result.InIndexDate)
       const discoveryDate = parseBingDate(result.DiscoveryDate)
+
+      // Bing's GetUrlInfo (https://learn.microsoft.com/en-us/dotnet/api/microsoft.bing.webmaster.api.interfaces.iwebmasterapi.geturlinfo)
+      // no longer ships an `InIndex` flag and routinely returns DocumentSize=0
+      // for URLs that the Webmaster UI clearly lists as indexed. LastCrawledDate
+      // is the only positive signal the current contract exposes — treat a
+      // recorded crawl timestamp as "indexed" unless the crawl itself came back
+      // with a 4xx/5xx.
+      let derivedInIndex: boolean | null = null
+      if (result.DocumentSize != null && result.DocumentSize > 0) {
+        derivedInIndex = true
+      } else if (lastCrawledDate != null) {
+        const httpStatus = result.HttpStatus ?? result.HttpCode
+        derivedInIndex = httpStatus != null && httpStatus >= 400 ? false : true
+      } else if (discoveryDate != null) {
+        derivedInIndex = false
+      }
+
+      // Cross-reference GetCrawlIssues: if Bing has flagged this URL with a
+      // blocking issue (robots, HTTP errors, DNS failures, malware, noindex),
+      // downgrade to not-indexed regardless of the crawl timestamp. This is the
+      // only public mechanism for catching URLs that were crawled but excluded.
+      // Fail open — crawl-issue lookup errors must not poison the primary
+      // inspection result.
+      if (derivedInIndex === true) {
+        try {
+          const blockedUrls = await loadBlockingCrawlIssues(conn.apiKey, conn.siteUrl, project.canonicalDomain)
+          if (blockedUrls.has(url)) {
+            derivedInIndex = false
+          }
+        } catch (e) {
+          bingLog('warn', 'inspect-url.crawl-issues-lookup-failed', {
+            domain: project.canonicalDomain,
+            error: e instanceof Error ? e.message : String(e),
+          })
+        }
+      }
 
       app.db.insert(bingUrlInspections).values({
         id,

--- a/packages/api-routes/test/bing.test.ts
+++ b/packages/api-routes/test/bing.test.ts
@@ -7,7 +7,7 @@ import { eq } from 'drizzle-orm'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { RunKinds, RunStatuses, RunTriggers } from '@ainyc/canonry-contracts'
 import { bingUrlInspections, bingCoverageSnapshots, createClient, migrate, projects, runs } from '@ainyc/canonry-db'
-import { bingRoutes } from '../src/bing.js'
+import { bingRoutes, __resetBingCrawlIssuesCacheForTest } from '../src/bing.js'
 import type { BingConnectionRecord, BingConnectionStore } from '../src/bing.js'
 
 function buildApp() {
@@ -77,10 +77,11 @@ describe('Bing routes', () => {
     }).run()
   })
 
-  beforeEach(() => {
+  beforeEach(async () => {
     db.delete(bingUrlInspections).run()
     db.delete(bingCoverageSnapshots).run()
     connections.clear()
+    __resetBingCrawlIssuesCacheForTest()
 
     const now = new Date().toISOString()
     connections.set('example.com', {
@@ -90,6 +91,10 @@ describe('Bing routes', () => {
       createdAt: now,
       updatedAt: now,
     })
+
+    // Default: no crawl issues. Individual tests override with mockResolvedValue.
+    const bingModule = await import('@ainyc/canonry-integration-bing')
+    vi.spyOn(bingModule, 'getCrawlIssues').mockResolvedValue([])
   })
 
   afterEach(() => {
@@ -101,14 +106,13 @@ describe('Bing routes', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true })
   })
 
-  it('maps HttpStatus into httpCode and keeps zero-byte DocumentSize as unknown', async () => {
+  it('maps HttpStatus into httpCode and leaves inIndex null when Bing returns no crawl or discovery signals', async () => {
     const bingModule = await import('@ainyc/canonry-integration-bing')
     vi.spyOn(bingModule, 'getUrlInfo').mockResolvedValue({
       Url: 'https://example.com/page',
       HttpStatus: 200,
       DocumentSize: 0,
       IsPage: true,
-      LastCrawledDate: '2026-03-15T10:00:00Z',
     })
 
     const res = await app.inject({
@@ -144,7 +148,7 @@ describe('Bing routes', () => {
     expect(rows[0]!.syncRunId).toBe(inspectRuns[0]!.id)
   })
 
-  it('derives indexed=true only from positive DocumentSize', async () => {
+  it('derives indexed=true from positive DocumentSize', async () => {
     const bingModule = await import('@ainyc/canonry-integration-bing')
     vi.spyOn(bingModule, 'getUrlInfo').mockResolvedValue({
       Url: 'https://example.com/indexed',
@@ -165,6 +169,171 @@ describe('Bing routes', () => {
     const body = res.json() as { inIndex: boolean | null; httpCode: number | null }
     expect(body.httpCode).toBe(200)
     expect(body.inIndex).toBe(true)
+  })
+
+  it('derives indexed=true from LastCrawledDate when DocumentSize=0 and HttpStatus is missing/zero', async () => {
+    // Regression for issue #342: Bing's modern GetUrlInfo often returns
+    // DocumentSize=0 and an absent or zero HttpStatus for URLs that are clearly
+    // indexed in the Bing UI, as long as LastCrawledDate/DiscoveryDate are set.
+    const lastCrawledMs = new Date('2026-03-12T17:37:29Z').getTime()
+    const discoveryMs = new Date('2026-03-12T07:00:00Z').getTime()
+    const bingModule = await import('@ainyc/canonry-integration-bing')
+    vi.spyOn(bingModule, 'getUrlInfo').mockResolvedValue({
+      Url: 'https://example.com/indexed-zero-size',
+      HttpStatus: 0,
+      DocumentSize: 0,
+      LastCrawledDate: `/Date(${lastCrawledMs})/`,
+      DiscoveryDate: `/Date(${discoveryMs})/`,
+    })
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/projects/test-project/bing/inspect-url',
+      payload: { url: 'https://example.com/indexed-zero-size' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as {
+      inIndex: boolean | null
+      httpCode: number | null
+      lastCrawledDate: string | null
+    }
+    expect(body.httpCode).toBe(0)
+    expect(body.inIndex).toBe(true)
+    expect(body.lastCrawledDate).toBe('2026-03-12T17:37:29.000Z')
+  })
+
+  it('derives indexed=false when a crawled URL returned a 4xx HttpStatus', async () => {
+    const lastCrawledMs = new Date('2026-03-20T10:00:00Z').getTime()
+    const bingModule = await import('@ainyc/canonry-integration-bing')
+    vi.spyOn(bingModule, 'getUrlInfo').mockResolvedValue({
+      Url: 'https://example.com/broken',
+      HttpStatus: 404,
+      DocumentSize: 0,
+      LastCrawledDate: `/Date(${lastCrawledMs})/`,
+    })
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/projects/test-project/bing/inspect-url',
+      payload: { url: 'https://example.com/broken' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as { inIndex: boolean | null; httpCode: number | null }
+    expect(body.httpCode).toBe(404)
+    expect(body.inIndex).toBe(false)
+  })
+
+  it('derives indexed=false when Bing has discovered a URL but not yet crawled it', async () => {
+    const discoveryMs = new Date('2026-03-18T07:00:00Z').getTime()
+    const bingModule = await import('@ainyc/canonry-integration-bing')
+    vi.spyOn(bingModule, 'getUrlInfo').mockResolvedValue({
+      Url: 'https://example.com/discovered-only',
+      HttpStatus: 0,
+      DocumentSize: 0,
+      DiscoveryDate: `/Date(${discoveryMs})/`,
+    })
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/projects/test-project/bing/inspect-url',
+      payload: { url: 'https://example.com/discovered-only' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as { inIndex: boolean | null; lastCrawledDate: string | null; discoveryDate: string | null }
+    expect(body.inIndex).toBe(false)
+    expect(body.lastCrawledDate).toBeNull()
+    expect(body.discoveryDate).toBe('2026-03-18T07:00:00.000Z')
+  })
+
+  it('demotes an indexed URL to not-indexed when GetCrawlIssues flags a blocking issue', async () => {
+    const lastCrawledMs = new Date('2026-03-20T10:00:00Z').getTime()
+    const bingModule = await import('@ainyc/canonry-integration-bing')
+    vi.spyOn(bingModule, 'getUrlInfo').mockResolvedValue({
+      Url: 'https://example.com/blocked',
+      HttpStatus: 200,
+      DocumentSize: 2048,
+      LastCrawledDate: `/Date(${lastCrawledMs})/`,
+    })
+    vi.spyOn(bingModule, 'getCrawlIssues').mockResolvedValue([
+      { Url: 'https://example.com/blocked', HttpCode: 200, Date: '2026-03-20', IssueType: 'Blocked' },
+    ])
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/projects/test-project/bing/inspect-url',
+      payload: { url: 'https://example.com/blocked' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as { inIndex: boolean | null }
+    expect(body.inIndex).toBe(false)
+  })
+
+  it('keeps indexed classification when GetCrawlIssues only flags SEO-only concerns', async () => {
+    const lastCrawledMs = new Date('2026-03-20T10:00:00Z').getTime()
+    const bingModule = await import('@ainyc/canonry-integration-bing')
+    vi.spyOn(bingModule, 'getUrlInfo').mockResolvedValue({
+      Url: 'https://example.com/seo-warn',
+      HttpStatus: 200,
+      DocumentSize: 2048,
+      LastCrawledDate: `/Date(${lastCrawledMs})/`,
+    })
+    vi.spyOn(bingModule, 'getCrawlIssues').mockResolvedValue([
+      { Url: 'https://example.com/seo-warn', HttpCode: 200, Date: '2026-03-20', IssueType: 'SeoIssues' },
+    ])
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/projects/test-project/bing/inspect-url',
+      payload: { url: 'https://example.com/seo-warn' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as { inIndex: boolean | null }
+    expect(body.inIndex).toBe(true)
+  })
+
+  it('keeps indexed classification when GetCrawlIssues lookup fails', async () => {
+    const lastCrawledMs = new Date('2026-03-20T10:00:00Z').getTime()
+    const bingModule = await import('@ainyc/canonry-integration-bing')
+    vi.spyOn(bingModule, 'getUrlInfo').mockResolvedValue({
+      Url: 'https://example.com/ok',
+      HttpStatus: 200,
+      DocumentSize: 2048,
+      LastCrawledDate: `/Date(${lastCrawledMs})/`,
+    })
+    vi.spyOn(bingModule, 'getCrawlIssues').mockRejectedValue(new Error('rate limited'))
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/projects/test-project/bing/inspect-url',
+      payload: { url: 'https://example.com/ok' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as { inIndex: boolean | null }
+    expect(body.inIndex).toBe(true)
+  })
+
+  it('caches GetCrawlIssues across sequential inspections within the TTL', async () => {
+    const lastCrawledMs = new Date('2026-03-20T10:00:00Z').getTime()
+    const bingModule = await import('@ainyc/canonry-integration-bing')
+    vi.spyOn(bingModule, 'getUrlInfo').mockImplementation(async (_apiKey, _siteUrl, url) => ({
+      Url: url,
+      HttpStatus: 200,
+      DocumentSize: 1024,
+      LastCrawledDate: `/Date(${lastCrawledMs})/`,
+    }))
+    const crawlIssuesSpy = vi.spyOn(bingModule, 'getCrawlIssues').mockResolvedValue([])
+
+    await app.inject({ method: 'POST', url: '/projects/test-project/bing/inspect-url', payload: { url: 'https://example.com/a' } })
+    await app.inject({ method: 'POST', url: '/projects/test-project/bing/inspect-url', payload: { url: 'https://example.com/b' } })
+    await app.inject({ method: 'POST', url: '/projects/test-project/bing/inspect-url', payload: { url: 'https://example.com/c' } })
+
+    expect(crawlIssuesSpy).toHaveBeenCalledTimes(1)
   })
 
   it('coverage includes unknown rows in total for percentage calculation', async () => {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -543,6 +543,22 @@ const MIGRATIONS = [
   // to ready, projects with this flag get a backlink-extract run enqueued.
   // Stored as INTEGER (0/1) to match SQLite boolean convention.
   `ALTER TABLE projects ADD COLUMN auto_extract_backlinks INTEGER NOT NULL DEFAULT 0`,
+
+  // v43: Backfill bing_url_inspections.in_index using the new crawl-signal
+  // decision tree. Legacy rows were classified with the retired Bing `InIndex`
+  // flag plus a DocumentSize>0 check, which mis-classifies URLs that modern
+  // Bing returns with DocumentSize=0 but a valid LastCrawledDate. Use a
+  // created_at cutoff so rows written by the new code (which applies a live
+  // GetCrawlIssues demotion that can't be replayed offline) are preserved.
+  `UPDATE bing_url_inspections
+   SET in_index = CASE
+     WHEN document_size IS NOT NULL AND document_size > 0 THEN 1
+     WHEN last_crawled_date IS NOT NULL AND http_code IS NOT NULL AND http_code >= 400 THEN 0
+     WHEN last_crawled_date IS NOT NULL THEN 1
+     WHEN discovery_date IS NOT NULL THEN 0
+     ELSE NULL
+   END
+   WHERE created_at < '2026-04-22T00:00:00Z'`,
 ]
 
 /**

--- a/packages/db/test/index.test.ts
+++ b/packages/db/test/index.test.ts
@@ -144,6 +144,92 @@ test('migrate is idempotent', () => {
   migrate(db)
 })
 
+test('migrate v43 backfills bing_url_inspections.in_index from stored crawl signals', () => {
+  const { db, tmpDir } = createTempDb()
+  onTestFinished(() => cleanup(tmpDir))
+  const now = new Date().toISOString()
+
+  db.insert(projects).values({
+    id: 'proj_1',
+    name: 'test-project',
+    displayName: 'Test Project',
+    canonicalDomain: 'example.com',
+    country: 'US',
+    language: 'en',
+    createdAt: now,
+    updatedAt: now,
+  }).run()
+
+  const legacyCreatedAt = '2026-01-01T00:00:00Z'
+  const futureCreatedAt = '2026-05-01T00:00:00Z'
+
+  db.insert(bingUrlInspections).values([
+    // Legacy row: DocumentSize=0 but a LastCrawledDate — stale in_index=null,
+    // new logic should set in_index=1.
+    {
+      id: 'insp_crawled_zero_size',
+      projectId: 'proj_1',
+      url: 'https://example.com/a',
+      httpCode: 0,
+      inIndex: null,
+      documentSize: 0,
+      lastCrawledDate: '2026-03-12T17:37:29.000Z',
+      discoveryDate: null,
+      inspectedAt: legacyCreatedAt,
+      createdAt: legacyCreatedAt,
+    },
+    // Legacy row: 4xx status on a crawled URL — new logic sets in_index=0.
+    {
+      id: 'insp_broken',
+      projectId: 'proj_1',
+      url: 'https://example.com/broken',
+      httpCode: 404,
+      inIndex: 1,
+      documentSize: 0,
+      lastCrawledDate: '2026-03-20T10:00:00Z',
+      discoveryDate: null,
+      inspectedAt: legacyCreatedAt,
+      createdAt: legacyCreatedAt,
+    },
+    // Legacy row: discovery-only — new logic sets in_index=0.
+    {
+      id: 'insp_discovered',
+      projectId: 'proj_1',
+      url: 'https://example.com/discovered',
+      httpCode: 0,
+      inIndex: null,
+      documentSize: 0,
+      lastCrawledDate: null,
+      discoveryDate: '2026-03-18T07:00:00Z',
+      inspectedAt: legacyCreatedAt,
+      createdAt: legacyCreatedAt,
+    },
+    // Post-cutoff row: written with new code (crawl-issues demotion applied).
+    // Backfill must NOT un-demote this.
+    {
+      id: 'insp_demoted',
+      projectId: 'proj_1',
+      url: 'https://example.com/demoted',
+      httpCode: 200,
+      inIndex: 0,
+      documentSize: 2048,
+      lastCrawledDate: '2026-05-01T10:00:00Z',
+      discoveryDate: null,
+      inspectedAt: futureCreatedAt,
+      createdAt: futureCreatedAt,
+    },
+  ]).run()
+
+  migrate(db)
+
+  const rows = db.select().from(bingUrlInspections).all()
+  const byId = Object.fromEntries(rows.map((row) => [row.id, row]))
+  expect(byId.insp_crawled_zero_size.inIndex).toBe(1)
+  expect(byId.insp_broken.inIndex).toBe(0)
+  expect(byId.insp_discovered.inIndex).toBe(0)
+  expect(byId.insp_demoted.inIndex).toBe(0)
+})
+
 test('migrate adds sync_run_id columns without reintroducing query_snapshots.default_location', () => {
   const { dbPath, tmpDir } = createTempDb()
   onTestFinished(() => cleanup(tmpDir))

--- a/packages/integration-bing/src/types.ts
+++ b/packages/integration-bing/src/types.ts
@@ -16,8 +16,10 @@ export interface BingUrlInfo {
   HttpStatus?: number
   TotalChildUrlCount?: number
   // Legacy/undocumented fields observed in older integrations. Keep as fallbacks.
+  // Note: `InIndex` was retired from the public UrlInfo contract — Microsoft's
+  // current schema (https://learn.microsoft.com/en-us/dotnet/api/microsoft.bing.webmaster.api.interfaces.urlinfo)
+  // lists only the eight crawl-related properties above.
   HttpCode?: number
-  InIndex?: boolean
   InIndexDate?: string
   CacheDate?: string
 }


### PR DESCRIPTION
## Summary
- Microsoft retired `InIndex` from `GetUrlInfo` and routinely returns `DocumentSize=0` for URLs the Bing UI lists as indexed. Derive indexing from `DocumentSize`, `LastCrawledDate` + `HttpStatus` (<400), and `DiscoveryDate` instead.
- Cross-reference `GetCrawlIssues` (60s per-domain in-memory cache) to demote URLs flagged with blocking `IssueType` values (robots, HTTP errors, DNS, malware, noindex), while keeping SEO-only warnings indexed. Crawl-issue lookup failures fail open.
- Drops the retired `InIndex` field from `BingUrlInfo` and bumps version to 2.4.4.

## Test plan
- [x] `pnpm test` — 7 new tests cover LastCrawledDate-based indexing, 4xx demotion, discovery-only, blocking issue demotion, SEO-only pass-through, lookup-failure fail-open, and TTL caching
- [x] `pnpm lint` / `pnpm typecheck`