### PR TITLE
chore: add root build script delegating to @ainyc/canonry

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {
+    "build": "pnpm --filter @ainyc/canonry run build",
     "typecheck": "pnpm -r --no-bail run typecheck",
     "test": "vitest run",
     "lint": "pnpm -r run lint",


### PR DESCRIPTION
## Summary
- Root `package.json` had no `build` script, so `pnpm run build` at the repo root failed with `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL` and broke a deploy that assumed the standard convention. This adds a one-line alias that delegates to `pnpm --filter @ainyc/canonry run build` — the only publishable package — so the deploy path works without any workaround.

## Test plan
- [ ] `pnpm run build` at repo root completes successfully (equivalent to `pnpm --filter @ainyc/canonry run build`)