### PR TITLE
fix(google): confirm indexing via verdict=PASS, not indexingState

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "2.4.5",
+  "version": "2.4.6",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "type": "module",
   "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/commands/google.ts
+++ b/packages/canonry/src/commands/google.ts
@@ -1,6 +1,11 @@
-import type { IndexingRequestResultDto } from '@ainyc/canonry-contracts'
+import type { GscUrlInspectionDto, IndexingRequestResultDto } from '@ainyc/canonry-contracts'
 import { type ApiClient, createApiClient } from '../client.js'
 import { CliError } from '../cli-error.js'
+
+const INDEXING_API_SCOPE_NOTICE =
+  "Note: Google's Indexing API officially supports only pages with JobPosting or BroadcastEvent (livestream VideoObject) structured data. " +
+  'For other URL types, submissions are accepted (HTTP 200) but not guaranteed to be prioritized for crawling. ' +
+  'For general pages, submit a sitemap and use URL Inspection to monitor status.'
 
 function getClient() {
   return createApiClient()
@@ -604,6 +609,10 @@ export async function googleRequestIndexing(project: string, opts: {
   allUnindexed?: boolean
   wait?: boolean
   format?: string
+  /** @internal timing overrides for tests; not exposed to the CLI. */
+  waitTimeoutMs?: number
+  /** @internal timing overrides for tests; not exposed to the CLI. */
+  waitPollIntervalMs?: number
 }): Promise<void> {
   const client = getClient()
 
@@ -621,35 +630,39 @@ export async function googleRequestIndexing(project: string, opts: {
     })
   }
 
+  if (opts.format !== 'json') {
+    console.error(INDEXING_API_SCOPE_NOTICE)
+    console.error()
+  }
+
   const result = await client.googleRequestIndexing(project, body) as {
     summary: { total: number; succeeded: number; failed: number }
     results: IndexingRequestResultDto[]
   }
 
   let indexingConfirmed = false
+  const lastInspection = new Map<string, GscUrlInspectionDto>()
   if (opts.wait && result.results.some((r) => r.status === 'success')) {
     const successUrls = result.results.filter((r) => r.status === 'success').map((r) => r.url)
-    const timeout = 10 * 60 * 1000
+    const timeout = opts.waitTimeoutMs ?? 10 * 60 * 1000
+    const pollInterval = opts.waitPollIntervalMs ?? 10_000
     const start = Date.now()
-    process.stderr.write('Waiting for indexing confirmation')
+    process.stderr.write('Polling URL Inspection for indexed verdict')
 
     while (Date.now() - start < timeout) {
-      await new Promise((r) => setTimeout(r, 10000))
+      await new Promise((r) => setTimeout(r, pollInterval))
       process.stderr.write('.')
 
       let allIndexed = true
       for (const url of successUrls) {
         try {
-          const inspection = await client.gscInspect(project, url) as {
-            indexingState?: string
-          }
-          if (inspection.indexingState !== 'INDEXING_ALLOWED') {
+          const inspection = await client.gscInspect(project, url)
+          lastInspection.set(url, inspection)
+          if (inspection.verdict !== 'PASS') {
             allIndexed = false
-            break
           }
         } catch {
           allIndexed = false
-          break
         }
       }
 
@@ -662,13 +675,25 @@ export async function googleRequestIndexing(project: string, opts: {
 
     if (!indexingConfirmed) {
       process.stderr.write('\n')
+      const observed = successUrls.map((url) => {
+        const i = lastInspection.get(url)
+        return {
+          url,
+          verdict: i?.verdict ?? null,
+          coverageState: i?.coverageState ?? null,
+          indexingState: i?.indexingState ?? null,
+        }
+      })
       throw new CliError({
         code: 'GOOGLE_INDEXING_CONFIRMATION_TIMEOUT',
-        message: 'Timed out waiting for indexing confirmation. URLs may still be processing.',
-        displayMessage: 'Timed out waiting for indexing confirmation. URLs may still be processing.',
+        message:
+          "Timed out waiting for Google to report verdict=PASS. Google typically takes hours to days to index new URLs, so this is expected and does not mean the submission failed. Re-check later with `canonry google gsc inspect <url>`.",
+        displayMessage:
+          "Timed out waiting for Google to report verdict=PASS. Google typically takes hours to days to index new URLs — this is not a failure. Re-check later with `canonry google gsc inspect <url>`.",
         details: {
           project,
           urls: successUrls,
+          lastObserved: observed,
         },
       })
     }
@@ -697,7 +722,7 @@ export async function googleRequestIndexing(project: string, opts: {
   }
 
   if (indexingConfirmed) {
-    console.log('All requested URLs are now indexed.')
+    console.log('URL Inspection now reports verdict=PASS for the requested URLs (indexed in Google Search).')
   }
 }
 

--- a/packages/canonry/test/google-commands.test.ts
+++ b/packages/canonry/test/google-commands.test.ts
@@ -393,4 +393,158 @@ describe('google CLI commands', () => {
     const { googleRequestIndexing } = await import('../src/commands/google.js')
     await expect(() => googleRequestIndexing('test-proj', {})).rejects.toThrow('provide a URL or use --all-unindexed')
   })
+
+  it('googleRequestIndexing prints the Indexing-API scope notice to stderr', async () => {
+    await client.putProject('test-proj', {
+      displayName: 'Test',
+      canonicalDomain: 'example.com',
+      country: 'US',
+      language: 'en',
+    })
+
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('indexing.googleapis.com')) {
+        return new Response(JSON.stringify({
+          urlNotificationMetadata: {
+            url: 'https://example.com/page',
+            latestUpdate: {
+              url: 'https://example.com/page',
+              type: 'URL_UPDATED',
+              notifyTime: '2026-03-17T12:00:00Z',
+            },
+          },
+        }), { status: 200 })
+      }
+      return originalFetch(input, init)
+    }
+
+    const { googleRequestIndexing } = await import('../src/commands/google.js')
+    const errors: string[] = []
+    const origErr = console.error
+    console.error = (...args: unknown[]) => errors.push(args.join(' '))
+    try {
+      await googleRequestIndexing('test-proj', { url: 'https://example.com/page' })
+    } finally {
+      console.error = origErr
+      globalThis.fetch = originalFetch
+    }
+
+    expect(errors.join('\n')).toMatch(/JobPosting or BroadcastEvent/)
+  })
+
+  it('googleRequestIndexing --wait confirms indexing when URL Inspection returns verdict=PASS', async () => {
+    await client.putProject('test-proj', {
+      displayName: 'Test',
+      canonicalDomain: 'example.com',
+      country: 'US',
+      language: 'en',
+    })
+
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('indexing.googleapis.com')) {
+        return new Response(JSON.stringify({
+          urlNotificationMetadata: {
+            url: 'https://example.com/page',
+            latestUpdate: {
+              url: 'https://example.com/page',
+              type: 'URL_UPDATED',
+              notifyTime: '2026-03-17T12:00:00Z',
+            },
+          },
+        }), { status: 200 })
+      }
+      if (url.includes('searchconsole.googleapis.com') && url.includes('urlInspection')) {
+        return new Response(JSON.stringify({
+          inspectionResult: {
+            indexStatusResult: {
+              verdict: 'PASS',
+              coverageState: 'Submitted and indexed',
+              indexingState: 'INDEXING_ALLOWED',
+              googleCanonical: 'https://example.com/page',
+            },
+          },
+        }), { status: 200 })
+      }
+      return originalFetch(input, init)
+    }
+
+    const { googleRequestIndexing } = await import('../src/commands/google.js')
+    const logs: string[] = []
+    const origLog = console.log
+    console.log = (...args: unknown[]) => logs.push(args.join(' '))
+    try {
+      await googleRequestIndexing('test-proj', {
+        url: 'https://example.com/page',
+        wait: true,
+        waitTimeoutMs: 3_000,
+        waitPollIntervalMs: 50,
+      })
+    } finally {
+      console.log = origLog
+      globalThis.fetch = originalFetch
+    }
+
+    const output = logs.join('\n')
+    expect(output).toMatch(/verdict=PASS/)
+    expect(output).toMatch(/indexed in Google Search/)
+  })
+
+  it('googleRequestIndexing --wait does NOT confirm when only indexingState=INDEXING_ALLOWED (verdict missing)', async () => {
+    await client.putProject('test-proj', {
+      displayName: 'Test',
+      canonicalDomain: 'example.com',
+      country: 'US',
+      language: 'en',
+    })
+
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      if (url.includes('indexing.googleapis.com')) {
+        return new Response(JSON.stringify({
+          urlNotificationMetadata: {
+            url: 'https://example.com/page',
+            latestUpdate: {
+              url: 'https://example.com/page',
+              type: 'URL_UPDATED',
+              notifyTime: '2026-03-17T12:00:00Z',
+            },
+          },
+        }), { status: 200 })
+      }
+      if (url.includes('searchconsole.googleapis.com') && url.includes('urlInspection')) {
+        // Regression guard: returning INDEXING_ALLOWED alone (no PASS verdict)
+        // previously made canonry declare "indexed" — it must now keep waiting
+        // and eventually time out.
+        return new Response(JSON.stringify({
+          inspectionResult: {
+            indexStatusResult: {
+              indexingState: 'INDEXING_ALLOWED',
+              verdict: 'NEUTRAL',
+              coverageState: 'Crawled - currently not indexed',
+            },
+          },
+        }), { status: 200 })
+      }
+      return originalFetch(input, init)
+    }
+
+    const { googleRequestIndexing } = await import('../src/commands/google.js')
+    try {
+      await expect(() =>
+        googleRequestIndexing('test-proj', {
+          url: 'https://example.com/page',
+          wait: true,
+          waitTimeoutMs: 500,
+          waitPollIntervalMs: 50,
+        }),
+      ).rejects.toThrow(/Timed out waiting for Google to report verdict=PASS/)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
 })


### PR DESCRIPTION
## Summary

- `canonry google request-indexing --wait` previously reported "indexed" when URL Inspection returned `indexingState=INDEXING_ALLOWED` — that value only means indexing is *permitted* (no `noindex`), not that the URL is in Google's index. Switched the poll check to `verdict=PASS`, which is the real indexed signal.
- The poll loop now collects per-URL inspection state, so the `GOOGLE_INDEXING_CONFIRMATION_TIMEOUT` error surfaces `lastObserved` (`verdict`, `coverageState`, `indexingState`) per URL and the message clarifies that Google indexing takes hours to days.
- Added a stderr scope notice that Google's Indexing API officially supports only JobPosting/BroadcastEvent pages, dropped an unsafe `as { indexingState?: string }` cast in favor of the typed `GscUrlInspectionDto`, and bumped to 2.4.6.

## Test plan

- [x] New vitest cases: scope notice stderr assertion, happy-path confirm on `verdict=PASS`, and regression guard that `INDEXING_ALLOWED` alone does not confirm.
- [x] `pnpm lint` (ran via precommit hook).