### PR TITLE
ci(publish): auto-dispatch homebrew-canonry tap bump on npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,6 +90,35 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+  publish-homebrew:
+    needs: [version, publish-npm]
+    if: github.ref_name == github.event.repository.default_branch && github.event_name == 'push' && needs.version.outputs.version_changed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check Homebrew tap dispatch token
+        id: check-token
+        env:
+          TOKEN: ${{ secrets.HOMEBREW_TAP_DISPATCH_TOKEN }}
+        shell: bash
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "HOMEBREW_TAP_DISPATCH_TOKEN not configured, skipping tap bump"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Notify Homebrew tap
+        if: steps.check-token.outputs.configured == 'true'
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_DISPATCH_TOKEN }}
+          repository: AINYC/homebrew-canonry
+          event-type: canonry-published
+          client-payload: '{"version": "${{ needs.version.outputs.version }}"}'
+
   publish-clawhub:
     needs: version
     if: github.ref_name == github.event.repository.default_branch && github.event_name == 'push'


### PR DESCRIPTION
## Summary

Adds a `publish-homebrew` job to `publish.yml` that fires a `repository_dispatch` event to `AINYC/homebrew-canonry` after every successful npm publish where the canonry version actually changed. The tap repo's bump workflow listens for this event and opens a PR updating `Formula/canonry.rb` with the new url + sha256.

## Why

So the tap doesn't drift from npm. Today the tap formula would be hand-bumped per release; this makes it automatic.

## Activation

The job **gracefully no-ops** when `HOMEBREW_TAP_DISPATCH_TOKEN` is not configured (same pattern as the existing Docker Hub publish step). To turn it on:

1. Create the `AINYC/homebrew-canonry` tap repo (see `.context/homebrew-tap/` in this workspace for scaffolded files).
2. Generate a fine-grained PAT with `contents: write` and `pull-requests: write` on `AINYC/homebrew-canonry`.
3. Add it to `AINYC/canonry` repo secrets as `HOMEBREW_TAP_DISPATCH_TOKEN`.

Until step 3, the job logs `HOMEBREW_TAP_DISPATCH_TOKEN not configured, skipping tap bump` and exits cleanly.

## Test plan

- [ ] Workflow YAML parses (Actions tab "Publish" workflow loads without errors after merge).
- [ ] Without secret set, next merged version-bump PR runs `publish-homebrew` and shows the "skipping" log line.
- [ ] After the secret is provisioned and a version bump merges, a PR appears in `AINYC/homebrew-canonry` with the updated formula.

🤖 Generated with [Claude Code](https://claude.com/claude-code)