### PR TITLE
docs: positioning — agent-first AEO operating platform

### DIFF
--- a/.claude/skills/canonry-setup/SKILL.md
+++ b/.claude/skills/canonry-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: canonry
-description: "AEO (Answer Engine Optimization) monitoring and analysis using canonry CLI and aeo-audit tool. Use when: (1) running citation sweeps across AI providers (Gemini, ChatGPT, Claude, Perplexity); (2) auditing technical SEO with structured data validation; (3) implementing schema markup, sitemaps, llms.txt; (4) diagnosing indexing issues via Google Search Console and Bing Webmaster Tools; (5) optimizing content for AI readability and entity consistency. NOT for: general web development, content writing, PPC campaigns, or social media management."
+description: "Agent-first AEO (Answer Engine Optimization) operating platform using canonry CLI and aeo-audit tool. Use when: (1) running citation sweeps across AI providers (Gemini, ChatGPT, Claude, Perplexity); (2) auditing technical SEO with structured data validation; (3) implementing schema markup, sitemaps, llms.txt; (4) diagnosing indexing issues via Google Search Console and Bing Webmaster Tools; (5) optimizing content for AI readability and entity consistency. NOT for: general web development, content writing, PPC campaigns, or social media management."
 metadata:
   {
     "agent":
@@ -32,7 +32,7 @@ metadata:
 
 # Canonry
 
-Monitor and optimize site visibility across AI answer engines (Gemini, ChatGPT, Claude, Perplexity) and traditional search engines using the `canonry` CLI for AEO monitoring and `aeo-audit` for technical SEO analysis.
+Agent-first AEO operating platform — track and act on site visibility across AI answer engines (Gemini, ChatGPT, Claude, Perplexity) and traditional search engines using the `canonry` CLI and `aeo-audit` for technical SEO analysis.
 
 ## When to Use
 
@@ -67,7 +67,7 @@ Monitor and optimize site visibility across AI answer engines (Gemini, ChatGPT, 
 
 ## Toolchain
 
-### canonry (AEO Monitoring)
+### canonry (AEO Operating Platform)
 ```bash
 # List projects
 canonry project list

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-`canonry` is an open-source **agent-first** AEO monitoring platform that tracks how AI answer engines cite a domain for tracked keywords. Published as `@ainyc/canonry` on npm. The CLI and API are the primary interfaces — the web dashboard is supplementary.
+`canonry` is an **agent-first** open-source AEO operating platform that tracks how AI answer engines cite a domain for tracked keywords and acts on the signal through the content engine and integrations. Published as `@ainyc/canonry` on npm. The CLI and API are the primary interfaces — the web dashboard is supplementary.
 
 ## Workspace Map
 
@@ -254,7 +254,7 @@ The CLI and API **are** the agent interface. No MCP layer, no virtual filesystem
 - Keep provider logic in `packages/provider-*/`.
 - Keep API route plugins in `packages/api-routes` (no app-level concerns).
 - Keep API handlers thin.
-- Keep the monitoring app independent from the audit package repo except for the published npm dependency.
+- Keep the canonry app independent from the audit package repo except for the published npm dependency.
 - Raw observation snapshots only (`cited`/`not-cited`); transitions computed at query time.
 
 ## Error Handling in API Routes (Critical)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/@ainyc/canonry)](https://www.npmjs.com/package/@ainyc/canonry) [![License: FSL-1.1-ALv2](https://img.shields.io/badge/License-FSL--1.1--ALv2-blue.svg)](https://fsl.software/) [![Node.js >= 22.14](https://img.shields.io/badge/node-%3E%3D22.14-brightgreen)](https://nodejs.org)
 
-Canonry is an agent-first AEO platform. It ships a built-in AI agent — **Aero** — that reads project state, analyzes regressions, acts through a typed tool surface, and wakes up unprompted when runs complete. Users who prefer their own agent (Claude Code, Codex, custom) consume Canonry through the same CLI/API surface or subscribe via webhook. It tracks how ChatGPT, Gemini, Claude, and Perplexity cite your site, detects regressions, diagnoses causes, coordinates fixes, and reports results.
+Canonry is an agent-first AEO operating platform. It ships a built-in AI agent — **Aero** — that reads project state, analyzes regressions, acts through a typed tool surface, and wakes up unprompted when runs complete. Users who prefer their own agent (Claude Code, Codex, custom) consume Canonry through the same CLI/API surface or subscribe via webhook. It tracks how ChatGPT, Gemini, Claude, and Perplexity cite your site, detects regressions, diagnoses causes, coordinates fixes, and reports results.
 
 AEO (Answer Engine Optimization) is about making sure your content shows up accurately in AI-generated answers. As search shifts from links to synthesized responses, you need something that can monitor, analyze, and act across these engines continuously.
 

--- a/docs/adr/0001-root-package-workspace.md
+++ b/docs/adr/0001-root-package-workspace.md
@@ -2,13 +2,13 @@
 
 ## Decision
 
-The monitoring application must consume the published `@ainyc/aeo-audit` npm package instead of sharing a repository with the audit package source.
+The canonry application must consume the published `@ainyc/aeo-audit` npm package instead of sharing a repository with the audit package source.
 
 ## Why
 
 - keeps repository responsibilities clear
-- allows the audit package and monitoring app to release independently
-- ensures the monitoring app uses the same public contract as external consumers
+- allows the audit package and canonry app to release independently
+- ensures the canonry app uses the same public contract as external consumers
 
 ## Consequences
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Canonry is a self-hosted AEO monitoring application. It tracks how AI answer engines (Gemini, OpenAI, Claude, Perplexity, and local LLMs) cite or omit a domain for tracked keywords.
+Canonry is a self-hosted agent-first AEO operating platform. It tracks how AI answer engines (Gemini, OpenAI, Claude, Perplexity, and local LLMs) cite or omit a domain for tracked keywords, and acts on that signal through the content engine and integrations.
 
 Locations are modeled as project-scoped run context. A project can define named locations and an optional default location, while keywords remain project-wide.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -157,7 +157,7 @@ Create `/etc/systemd/system/canonry.service`:
 
 ```ini
 [Unit]
-Description=Canonry AEO monitoring server
+Description=Canonry — agent-first AEO operating platform
 After=network.target
 
 [Service]

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 ## Current State
 
-Canonry is a fully functional open-source AEO monitoring tool with the following capabilities:
+Canonry is a fully functional agent-first open-source AEO operating platform with the following capabilities:
 
 - **Multi-provider visibility runs**: Gemini, OpenAI, Claude, and local LLM (OpenAI-compatible API)
 - **CLI / API / UI surface parity**: Every feature accessible through all three surfaces

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -2,7 +2,7 @@
   "name": "@ainyc/canonry",
   "version": "2.4.6",
   "type": "module",
-  "description": "The ultimate open-source AEO monitoring tool - track how answer engines cite your domain",
+  "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",
   "homepage": "https://ainyc.ai",
   "repository": {

--- a/plans/openclaw-agent-layer.md
+++ b/plans/openclaw-agent-layer.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Canonry (v1.39.0) is an open-source agent-first AEO monitoring platform. The team wants to add an AI agent layer (persona: "Aero") on top of canonry, following the **DenchClaw distribution model** (forked OpenClaw for CRM) and the **Obsidian monetization model** (free local tool, paid sync for teams).
+Canonry (v1.39.0) is an agent-first open-source AEO operating platform. The team wants to add an AI agent layer (persona: "Aero") on top of canonry, following the **DenchClaw distribution model** (forked OpenClaw for CRM) and the **Obsidian monetization model** (free local tool, paid sync for teams).
 
 The team decided: **build everything inside canonry**, not a separate repo. One `npx canonry`, one release cycle.
 

--- a/skills/canonry-setup/SKILL.md
+++ b/skills/canonry-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: canonry
-description: "Agent-first AEO monitoring and operating platform."
+description: "Agent-first AEO operating platform."
 metadata:
   {
     "agent":
@@ -32,7 +32,7 @@ metadata:
 
 # Canonry
 
-Open-source AEO (Answer Engine Optimization) monitoring platform. Track how AI answer engines cite your domain across Gemini, ChatGPT, Claude, and Perplexity.
+Agent-first open-source AEO (Answer Engine Optimization) operating platform. Track how AI answer engines cite your domain across Gemini, ChatGPT, Claude, and Perplexity, then act on the signal through the content engine and integrations.
 
 **Website:** [ainyc.ai](https://ainyc.ai) | **Docs:** [github.com/AINYC/canonry](https://github.com/AINYC/canonry)
 
@@ -54,7 +54,7 @@ Open-source AEO (Answer Engine Optimization) monitoring platform. Track how AI a
 
 ## Toolchain
 
-### canonry (AEO Monitoring)
+### canonry (AEO Operating Platform)
 ```bash
 # List projects
 canonry project list


### PR DESCRIPTION
## Summary

Replace "AEO monitoring tool/platform/application" with **"agent-first AEO operating platform"** across all surfaces describing canonry's positioning. The monitoring framing under-sells the product — canonry observes citations *and* acts on them through the content engine, integrations, and built-in agent.

## Touched

- `README.md` — intro paragraph
- `AGENTS.md` — project overview + maintenance guidance bullet
- `packages/canonry/package.json` — npm description
- `docs/architecture.md` — overview opener
- `docs/roadmap.md` — Current State
- `docs/deployment.md` — systemd `Description=`
- `docs/adr/0001-root-package-workspace.md` — historical references
- `skills/canonry-setup/SKILL.md` — frontmatter, body, "AEO Monitoring" subheading
- `.claude/skills/canonry-setup/SKILL.md` — installed copy
- `plans/openclaw-agent-layer.md` — context paragraph

## Deliberately untouched

- **Verb usage** ("monitor visibility sweeps", "monitor for regressions") — accurate description of one capability.
- **Feature labels** ("Crawl Health Monitoring", "Scheduled monitoring") — they are monitoring features.
- **Competitor descriptions** ("Profound, Otterly, Semrush AEO are monitoring tools") — true descriptor, and the contrast strengthens canonry's positioning.

## Test plan

- [x] CI lint green (already passes locally on commit hook).
- [x] `git grep -i 'monitoring \(tool\|platform\|application\)' -- ':!docs/adr/0005*' ':!docs/roadmap.md' ':!plans/'` returns no canonry-self-descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)