### PR TITLE
docs: blog content engine GTM plan + ADR 0009

### DIFF
--- a/docs/adr/0009-content-action-outcome-ledger-and-publish-boundary.md
+++ b/docs/adr/0009-content-action-outcome-ledger-and-publish-boundary.md
@@ -1,0 +1,174 @@
+# ADR 0009: Content Action Outcome Ledger + Publish Transformer/Adapter Boundary
+
+## Status
+
+Proposed. This ADR captures three intertwined product contracts surfaced during the Wave-0 content engine design (`docs/gtm.md` §3a). Adoption is gated on the GTM doc landing.
+
+## Context
+
+Canonry has been observational since v1: it tracks AI citations across providers and surfaces "you're cited" / "competitor X is cited instead." The `integration-wordpress/` package is the one exception, modelling a "manual-assist" pattern (generate payload, leave the final mutation to the operator/agent — see `docs/wordpress-setup.md:44-54`).
+
+The Wave-0 GTM plan introduces a **citation-driven content opportunity engine** as the lead investment for the v1 launch. Three design decisions in that work define product contracts that will shape canonry's surface for years:
+
+1. **What canonry generates and what it deliberately doesn't.** Briefs vs drafts, evidence ledgers vs body retrieval, payloads vs mutations.
+2. **How recommended actions are executed across diverse CMS targets** without canonry becoming a multi-CMS API client.
+3. **How recommended actions are tracked across their full lifecycle** so outcome data accumulates and future ranker iterations can learn from observed per-domain results.
+
+These warrant ADR-level memorialization because they cross both API stability and conceptual product framing — they are not just implementation choices.
+
+## Problem
+
+### A. Generation boundary
+
+Without explicit boundaries, "content recommendations" naturally drifts toward "content generator" and from there toward "content scraper" (reading competitor bodies for source material, fetching user pages for verification, etc.). That drift would:
+
+- Violate AGENTS.md's agent-first thesis ("canonry surfaces, agent acts").
+- Expose canonry to ToS / scraping concerns at scale.
+- Make the recommendations indistinguishable from generic AI writing tools.
+- Enable hallucination — the LLM filling in gaps with invented facts (competitor word counts, H2 structures, etc.) presented as if grounded.
+
+### B. Publish execution
+
+Canonry could implement live API clients for every CMS (WordPress, Ghost, Webflow, Sanity, Contentful, ...) but each adds:
+
+- Credential storage + keychain integration per provider.
+- Auth refresh logic (OAuth, app passwords, token rotation).
+- Rate-limit + retry handling.
+- API drift maintenance forever.
+- Error handling per provider's quirks.
+
+External agents (Claude Code, Codex, etc.) already have HTTP + credential capabilities. Duplicating this in canonry is out-of-thesis maintenance burden.
+
+### C. Recommendation lifecycle
+
+Without persistence beyond the brief artifact, every recommendation is forgotten the moment the brief is generated. Canonry can never answer "did `add-schema` work better than `expand` for this site?" — the foundational question for any future ranker improvement. Building this ledger AFTER actions are already shipping means losing the most valuable training data: early-adopter outcomes.
+
+## Proposed Decision
+
+### Decision 1 — Generation boundary (the ladder)
+
+```
+1. content targets         → ranked actions (no prose)
+2. content sources         → evidence map (URLs/titles/counts)
+3. content brief json      → canonical structured brief w/ evidence ledger
+4. content brief md        → renderer of the JSON
+5. (drafting)              → OUT OF SCOPE — external agent only
+6. content publish-payload → CMS-shaped payload (no mutation)
+7. wordpress create-draft  → EXPLICIT MUTATION (WP only, audit-logged)
+```
+
+- **Drafting is never a canonry surface.** External agents fetch the brief's cited URLs (their own WebFetch / browser tool / rate-limit obligations) and produce the draft.
+- **The brief carries explicit `unknownFields[]`** listing facts the LLM was instructed not to invent (e.g., `competitor_h2_structure`, `competitor_word_count`). This is the load-bearing anti-hallucination guarantee — testable per-field, not aspirational.
+- **Canonry never reads competitor *or* user page bodies.** Body retrieval is the agent's job. The boundary is uniform.
+
+### Decision 2 — Publish via pure transformers; one full adapter
+
+- **Transformers are pure functions** (`(brief, draft, targetMeta) → ContentPublishPayloadDto`) with no HTTP, no auth, no runtime deps. New `packages/publish-transformers/` package ships `wordpress`, `ghost`, `next-mdx`, `generic` transformers at v1 launch.
+- **WordPress is the one full adapter** because (a) `integration-wordpress/` already exists, (b) the target audience (solo AEO analysts, SEO consultants, in-house SEO) has heavy WP overlap, (c) the marginal cost to keep it is near zero. `canonry wordpress create-draft` is the only mutation in the content surface.
+- **All other CMSes** receive the payload with credential placeholders (e.g., `${GHOST_ADMIN_KEY}`); the agent substitutes credentials from its env and executes the HTTP call. Canonry never sees non-WP secrets.
+- Webflow, Hugo, Sanity, Contentful added on user request only — never speculatively.
+
+### Decision 3 — Content Action Outcome Ledger
+
+Every recommended action becomes a **tracked experiment** persisted in a new `content_actions` table:
+
+- **Identity:** `actionId`, `query`, `action ∈ {create|expand|refresh|add-schema}`, `targetPage?`, `state`
+- **Promotion context (frozen at creation):** `scoreAtPromotion`, `driversAtPromotion[]`, `sourceRunId`
+- **Baseline (frozen at creation):** `baselineCitedRate`, `baselineProviderBreakdown`, `baselineGscStats { impressions, position, ctr }`, `baselineCompetitorOverlap[]`, `baselineObservationSet { providers[], models[], locations[] }`
+- **Lifecycle artifacts:** `briefId?`, `payloadGeneratedAt?`, `wpDraftId?`, `wpDraftUrl?`, `draftCreatedAt?`, `publishedUrl?`, `publishedAt?`, `dismissedAt?`, `dismissedReason?`
+- **Outcome (computed lazily, refined as runs accumulate):** `firstMeasurement` (after first eligible post-publish run) + `result ∈ {improved|unchanged|regressed|inconclusive}` + `citationGained[]`, `citationLost[]`, `providersImproved[]`, `competitorDisplacement`, `timeToFirstCitation`, `newEvidence[]` (post-baseline observation expansions, surfaced separately)
+
+State machine:
+
+```
+proposed → briefed → payload-generated → draft-created (WP only) → published → validated
+                                              ↓
+                                          published (non-WP path: mark-published or agent)
+                                              ↓
+                                      dismissed (terminal, any state)
+```
+
+`draft-created` is a WP-only intermediate state — a WordPress draft is not published content, just a draft sitting in WP admin awaiting user review. WP poll watches for `status: publish` before transitioning the action to `published`. Non-WP paths skip `draft-created` entirely.
+
+**Validation threshold:** `published → validated` only fires after ≥3 eligible post-publish runs OR ≥14 days, whichever first. Until threshold, `result = 'inconclusive'` with `firstMeasurement` populated. AI citation results are noisy; a single post-publish snapshot is not enough evidence to call an action validated — and the ledger is training data, so false positives would corrupt future per-domain ranking. Eligible runs = those whose observation set has non-empty intersection with `baselineObservationSet`.
+
+**Like-for-like outcome comparison:** outcome computation only considers post-publish runs whose observation set (providers × models × locations) intersects the frozen `baselineObservationSet`. New providers/locations/models added after publish are surfaced separately as `newEvidence[]`, never folded into the result (would be a category error).
+
+**Idempotency contract:** at most one in-progress action per `(projectId, query, action, targetPage)` triple. `content brief --target-ref` reuses an existing in-progress action if one exists. `content targets` hides in-progress actions by default; `--include-in-progress` shows them annotated with `existingAction: { actionId, state, lastUpdated }`.
+
+**Mutation boundary — two layers:**
+- **External mutation** (writes outside canonry): only `wordpress create-draft`. WP-only, audit-logged.
+- **Local ledger mutation** (writes to canonry's own DB): `content brief`, `content publish-payload`, `content mark-published`, `content dismiss`. These are durable lifecycle tracking, not boundary violations.
+
+The boundary canonry preserves is "no silent external mutation." Internal ledger writes are how the system stays accountable to the user.
+
+**Publish-state confirmation:**
+
+| Path | Determinism |
+|---|---|
+| `wordpress create-draft` → `draft-created`, then WP poll detects `status: publish` → `published` | **Deterministic** (canonry knows the WP post ID) |
+| Agent calls `content mark-published` as last workflow step | **Deterministic** (agent-mediated; non-WP path skips `draft-created`) |
+| `content mark-published --url` (user-initiated) | **Deterministic** (manual fallback) |
+| Sitemap-inspection diff finds matching slug | **Heuristic** — surfaces dashboard candidate "is this you?", never auto-transitions state |
+
+## Why
+
+### Generation boundary
+- Aligns 1:1 with AGENTS.md ("canonry surfaces, agent acts").
+- `unknownFields[]` makes the anti-hallucination guarantee testable per-field, not just aspirational copy.
+- Body-reading prohibition is uniform (competitor + user pages alike), avoiding a confusing "we read sometimes" rule that would be easy to violate.
+- Drafting being external preserves the open ecosystem: any agent that can generate prose can complete the loop, not just Aero.
+
+### Transformer/adapter boundary
+- Avoids becoming a multi-CMS HTTP client — out-of-thesis maintenance burden on the order of multiple integration-wordpress-equivalents.
+- Pure transformers are 100% unit-testable with golden fixtures (no live API mocking, no auth setup).
+- WP earns the adapter exception because the integration already exists and the audience overlap is high; other CMSes don't earn it speculatively.
+- No off-the-shelf library covers this space (Micropub coverage too narrow for our targets — no Ghost/Webflow/core-WP; headless-CMS libraries like Contentlayer face inward, not outward). Composing `remark`/`rehype` + per-target transformers (~100-150 LOC each) is the right build (researched).
+
+### Outcome ledger
+- Without it, every recommendation is forgotten and no learning data accumulates.
+- Building the ledger AFTER actions are already shipping means losing the most valuable training data (early-adopter validated outcomes).
+- The state machine makes the closed loop visible to the user (lifecycle timeline in the dashboard) and to future ranker iterations (per-action-type outcome rates per domain).
+- No ML in v1 — just deterministic before/after computation. ML becomes an option once enough rows accumulate per-domain.
+- "Watching for publish" is honestly framed as deterministic-where-possible, suggest-with-confirmation otherwise — no false claims of automatic content-alignment verification.
+
+## Tradeoffs / Costs
+
+| Cost | Mitigation |
+|---|---|
+| Two new DB tables (`contentBriefs`, `content_actions`) + migrations | Standard Drizzle pattern; covered by AGENTS.md schema rules |
+| New `packages/publish-transformers/` package | Sibling to `integration-wordpress/`; ~500 LOC total for 4 transformers at launch |
+| Outcome computation needs post-publish snapshot data | Computed lazily on read; no eager pipeline overhead |
+| Heuristic publish detection (sitemap diff) is suggest-only, not auto-confirm | Documented constraint; user confirms with one tap, or runs `mark-published` for full determinism |
+| No drafting in canonry might disappoint users expecting AI-generated content | Doc emphasizes the brief is the artifact; demo loop showcases brief → external agent draft → measured outcome |
+| WP exceptionalism (one full adapter) creates an asymmetry | Doc explicitly frames WP as "first publishing integration"; other CMSes never speculatively built |
+| `unknownFields[]` discipline requires careful prompt engineering | Ship criteria force schema-first, prompt-second; tests assert no inferred values leak into `knownFields` |
+| Ledger introduces lifecycle complexity (state machine + transitions) | State machine is small (5 states + dismissed); transitions are well-defined and testable |
+
+## Explicitly Not Decided
+
+- Future ML-based ranker that weights action types by observed per-domain outcome — opt-in, requires sufficient validated rows per domain.
+- Whether `content publish-payload` should support batch (multiple briefs → one payload).
+- Eager vs lazy outcome computation. Default lazy unless dashboard latency forces a change.
+- Whether `add-schema` extends beyond WP audit data via a generic `inspect-schema` HTTP fetch + JSON-LD parse on the user's own pages (~50 LOC, universal). Likely yes as a follow-up; v1 is WP-only schema audit.
+- Whether competitor-schema comparison ever ships. Would require body retrieval, which the boundary forbids — would need a separate ADR to revisit.
+
+## Open Questions
+
+1. Should the heuristic publish-candidate UX (sitemap diff suggesting "did you publish this?") fire only when site inventory is enabled, or is it a v1.5 follow-up?
+2. Does `content publish-payload` need a `--dry-run` mode? (`payload-generated` is already non-mutating, so possibly redundant.)
+3. Should outcome computation include sentiment changes (per Phase 2.5 sentiment work) once that ships, or stay citation-only in v1?
+4. For non-WP users with no agent integration and no sitemap, what's the friendliest reminder pattern to mark-publish? In-dashboard nag, email, or nothing?
+5. Where do `mark-published` and `dismiss` live — separate API endpoints, or query params on a generic `PATCH /content/actions/:actionId`?
+
+## Next Step
+
+Discuss, revise, then accept or reject in tandem with the GTM plan landing. Nothing implements until this ADR and `docs/gtm.md` are both Accepted.
+
+## See Also
+
+- `docs/gtm.md` §3a — full product spec with command surface, DTOs, state transitions, and detection-vs-verification framing
+- `docs/roadmap.md` — "Citation-Driven Content Opportunities + Action Outcome Ledger" entry (the lead Wave-0 investment)
+- `AGENTS.md` (root) — agent-first contract, UI/CLI parity, error handling, JSON parsing, schema-migration rules
+- `docs/wordpress-setup.md` — the existing WP integration patterns this work builds on
+- `ADR 0008` — package split (the new `packages/publish-transformers/` slots into the same monorepo seam)

--- a/docs/gtm.md
+++ b/docs/gtm.md
@@ -45,7 +45,7 @@ Build on `SetupPage.tsx`, don't replace it.
 
 #### Path B — CLI/agent setup (power users, agent-driven)
 
-Same capabilities exposed for users who say "Claude, install canonry and set me up for stripe.com."
+Same capabilities exposed for users who say "Claude, install canonry and set me up for example.com."
 
 - **`canonry skill install [--for claude-code|codex|cursor|generic]`** — drops the canonry-setup skill into the right location (`~/.claude/skills/`, Codex config, Cursor rules, or prints markdown for a generic README).
 - **`canonry init` handoff step:** after setup, detect installed agent tooling and print the one-line install. "Claude Code detected — run `canonry skill install --for claude-code` to give it full context."
@@ -94,11 +94,11 @@ Same capabilities exposed for users who say "Claude, install canonry and set me 
 
 Plus the `competitors` table (`packages/db/src/schema.ts:32`), `competitorOverlap` / `recommendedCompetitors` on health snapshots (lines 68-69), and the intelligence package (`packages/intelligence/src/regressions.ts`, `gains.ts`, `causes.ts`) which already computes *why* citations move.
 
-This is **URL-level competitive intel, not just domain-level.** Canonry knows not only "stripe.com is cited for payment processing," but "the LLM pulled from `stripe.com/guides/payment-processing` with title X, and also searched for these related queries." **What's missing is turning that signal into "here's what to write next."**
+This is **URL-level competitive intel, not just domain-level.** Canonry knows not only "competitor-a.com is cited for [topic]," but "the LLM pulled from `competitor-a.com/guides/[topic]` with title X, and also searched for these related queries." **What's missing is turning that signal into "here's what to write next."**
 
 This is the highest-leverage feature on the list, for two reasons:
 1. AEO buyers ultimately want **outcomes** (more citations), not observation. Content is the lever that moves the metric.
-2. It's the perfect agent-driven loop: canonry says what to write → agent (Claude Code / Codex / Aero) drafts it → user publishes → next sweep measures the impact. Closes the observation-to-action loop that Profound and Semrush AEO leave open.
+2. It's the perfect agent-driven loop: canonry says what to write → agent (Claude Code / Codex / Aero) drafts it → user publishes → next sweep measures the impact. Closes the observation-to-action loop that incumbent paid AEO observability tools leave open.
 
 **Product framing:** Canonry identifies **citation-driven content *opportunities*** and packages them as actionable briefs. The unit of value is a **recommended action on a specific page or query**, not a topic. Drafting is deliberately not the product — briefs are.
 
@@ -288,7 +288,7 @@ The boundary canonry preserves is "no silent external mutation." Internal ledger
 **Demo synergy:** `canonry demo` and the hosted sandbox should highlight this loop. "Watch canonry tell you exactly what blog post to write next based on what your competitors are getting cited for" is a much stronger demo moment than a static dashboard tour. Bake this into the Wave 1 demo script.
 
 **Why this is a GTM differentiator:**
-- Profound and Semrush AEO observe; they don't generate. This closes the loop.
+- Incumbent paid AEO tools observe; they don't generate. This closes the loop.
 - URL-level grounding-source intel is a signal most AEO tools don't expose — "here's the exact page your competitor wrote that earned the citation" beats "your competitor is cited more than you."
 - Aligns 1:1 with the agent-first thesis: agents are excellent at writing; canonry is excellent at signal. Don't blur the lines.
 - Has SEO value beyond AEO — the same gap analysis helps with traditional Google search.
@@ -302,7 +302,7 @@ The boundary canonry preserves is "no silent external mutation." Internal ledger
 
 Today users must bring Gemini/OpenAI/Claude keys *before* seeing anything. Huge funnel drop.
 
-- **`canonry demo`** — installs a sample project (e.g. "stripe.com / payment processing") with pre-recorded snapshots, fake citations, populated insights. Users see the dashboard before paying any provider cost.
+- **`canonry demo`** — installs a sample project (e.g. a generic SaaS company tracking a payment-processing topic) with pre-recorded snapshots, fake citations, populated insights. Users see the dashboard before paying any provider cost.
 - **Hosted sandbox** at a public URL — read-only public dashboard so prospects click around without installing. Same data as `canonry demo`.
 - **`packages/provider-mock/`** — deterministic replayable provider for CI, demos, and offline dev. Half-implied by `provider-local`; formalize it.
 
@@ -348,7 +348,7 @@ Shipped agent guidance is stale enough that an agent following it hits dead ends
 
 Only a GitHub README today. `ainyc.ai` is referenced but there's no landing, no docs site. **GTM marketing site lives at `canonry.ai`** (separate from `ainyc.ai` which remains the telemetry/backend domain).
 
-- Landing page at `canonry.ai`: positioning, one-line install, comparison table vs Profound / Semrush AEO / Ahrefs Brand Radar.
+- Landing page at `canonry.ai`: positioning, one-line install, categorical comparison vs incumbent paid AEO observability tools and SEO-suite AEO add-ons (no per-vendor name-and-shame).
 - **"How to use canonry with Claude Code, Codex, Hermes, OpenClaw"** — dedicated pages per agent. This is the distribution story.
 - "Compete vs X" SEO pages — eat branded search.
 - 90-second Loom showing agent-driven workflow end-to-end, leading with the content-loop demo (#3a).
@@ -536,7 +536,7 @@ Track against a funnel dashboard powered by `packages/canonry/src/telemetry.ts`:
 ### OpenClaw
 
 - **Install:** `canonry skill install --for openclaw` writes OpenClaw skill bundle.
-- **Example prompt:** "Set up canonry for stripe.com and run the first sweep."
+- **Example prompt:** "Set up canonry for example.com and run the first sweep."
 - **Expected workflow:** OpenClaw drives `canonry init` → `canonry project create` → `canonry keyword add` → `canonry run` → `canonry insights list` end-to-end.
 
 ### Generic fallback

--- a/docs/gtm.md
+++ b/docs/gtm.md
@@ -8,7 +8,7 @@ Canonry is **CLI/API-first, any-agent**. AGENTS.md is explicit: "No MCP layer, n
 
 That reframes the GTM feature set: the question isn't "what can Aero do?" It's **"how fast can any agent become productive with canonry?"** Everything below is oriented around that.
 
-**Lead investment:** the content engine (`canonry content gaps|sources|suggest|brief|draft` + WordPress publish). It is the launch headliner, the demo moment, and the feature that closes the loop from observation to outcome.
+**Lead investment:** the citation-driven content opportunity engine — `canonry content targets → content brief (JSON) → external agent draft → content publish-payload → optional wordpress create-draft`. It is the launch headliner, the demo moment, and the feature that closes the loop from observation to outcome. **Drafting itself is out of scope for canonry** (external agent only); the rest of the ladder is.
 
 ## Target Users & Agents
 
@@ -100,16 +100,190 @@ This is the highest-leverage feature on the list, for two reasons:
 1. AEO buyers ultimately want **outcomes** (more citations), not observation. Content is the lever that moves the metric.
 2. It's the perfect agent-driven loop: canonry says what to write → agent (Claude Code / Codex / Aero) drafts it → user publishes → next sweep measures the impact. Closes the observation-to-action loop that Profound and Semrush AEO leave open.
 
+**Product framing:** Canonry identifies **citation-driven content *opportunities*** and packages them as actionable briefs. The unit of value is a **recommended action on a specific page or query**, not a topic. Drafting is deliberately not the product — briefs are.
+
 **New CLI commands (extend the manual-assist pattern from #2):**
-- `canonry content gaps <project> --format json` — queries where competitors are cited but you're not, ranked by frequency and competitor count. Reuses `competitor_overlap` data; pure DB query, no LLM.
-- `canonry content sources <project> [--query "..."] [--competitor <domain>] --format json` — the grounding URLs the LLM used, grouped by query and cited domain. "For this query, the LLM pulled from these 4 URLs with these titles" — a reference map the agent (or user) can read to understand what earns a citation. Pure DB query, no LLM, no third-party fetch (canonry surfaces URLs; the agent decides whether to read them).
-- `canonry content suggest <project> [--limit N]` — prioritized topic recommendations with reasoning ("3 competitors cited for 'best CRM for SaaS', you're missing — grounding sources suggest long-form comparison posts earn citations here"). Enriched by `searchQueries` (shows the LLM's internal related angles) and `groundingSources` (shows competitive depth).
-- `canonry content brief <project> "<topic>" --format md` — full content brief: target query, **top grounding URLs cited for this query** (so the agent knows what to match/exceed), the LLM's internal `searchQueries` as related-angle coverage, competitor citation patterns, suggested H2s/entities, schema to include, target length, supporting stats. Single LLM call using the grounding signal as context.
-- `canonry content draft <project> "<topic>" --provider <name> --format md` — full draft using the project's configured provider. Outputs markdown the user/agent commits to their repo, or pipes into the WordPress integration for a draft post. The agent is expected to fetch the grounding URLs itself (via its own WebFetch / browser tool) for source material — canonry surfaces the URLs but never scrapes them (respects ToS, keeps canonry on the "signal, not execution" side).
+- `canonry content gaps <project> [--provider <p>] --format json` — queries where competitors are cited but you're not. Pure DB query, no LLM.
+- `canonry content sources <project> [--query "..."] [--competitor <domain>] --format json` — the grounding URLs the LLM used, grouped by query and cited domain. URL-level competitive map. Pure DB query, no LLM, no third-party fetch (canonry surfaces URLs; the agent decides whether to read them).
+- `canonry content targets <project> [--sort score] [--limit N] [--include-in-progress] --format json` — **the ranked action-typed opportunity list.** Each row: `{query, action ∈ create|expand|refresh|add-schema, ourBestPage?, winningCompetitor, score, scoreBreakdown, drivers[], demandSource, actionConfidence, existingAction?}`. Deterministic scorer, additive two-branch (GSC demand + competitor evidence) so zero-GSC `create` opportunities still rank. No reasoning prose — auditable score breakdowns only.
 
-**New Aero tools:** `get_content_gaps`, `get_grounding_sources`, `suggest_content_topics`, `generate_content_brief`. Same scope rules as existing tools (gaps/sources always-on since they're DB reads; draft generation only via explicit user invocation since it spends provider tokens).
+  **Existing-action awareness:** if a target already has an in-flight action (`briefed`, `payload-generated`, `draft-created`, or `published-not-yet-validated`) for the same `(query, action, targetPage)` triple, the row carries `existingAction: { actionId, state, lastUpdated }`. **By default the CLI/UI hides these rows** (so users don't keep seeing work they already started); `--include-in-progress` includes them annotated. `dismissed` and `validated` actions never reappear by default; pass `--include-validated` for retrospection.
 
-**WordPress synergy:** `canonry wordpress publish-draft <project> --content-file <md>` extends the existing manual-assist pattern (`docs/wordpress-setup.md:44-54`) — generates the WP draft post, stops short of publishing. Same "advise + payload, never silently mutate" principle.
+  **Classifier is AEO-first**, not SEO-first: AI citation status is checked before SEO rank. A page ranking #25 in Google but cited by an LLM is a *win* (`add-schema` to lock it in), not an `expand` candidate. SEO rank acts only as triage when AEO is failing.
+
+  | Page state | Action |
+  |---|---|
+  | No page (or page ranks > 30) | `create` |
+  | Cited by LLM, no schema | `add-schema` (lock in the win) |
+  | Cited by LLM, has schema | skip (already winning) |
+  | Not cited, ranks ≤ 10 in GSC | `refresh` (SEO works, AEO doesn't — restructure for LLM consumption) |
+  | Not cited, ranks 11–30 in GSC | `expand` (thin/stale on both fronts) |
+
+  `add-schema` fires only on first-party schema audit evidence (WordPress audit today; a generic `inspect-schema` HTTP fetch + JSON-LD parse can extend this universally later, ~50 LOC). Competitor-schema comparison is deferred until a retrieval layer exists.
+- `canonry content brief <project> --target-ref <id> [--format json|md]` (preferred) **or** `--topic "<q>"` (exploratory, degraded) — **JSON canonical, structured brief with explicit known/unknown fields and an evidence ledger.** Markdown is a renderer of the JSON, never the source of truth (don't edit md and re-import). Single LLM call. Persisted to `contentBriefs` and assigned a stable `briefId`.
+
+  **Two modes:**
+  - **`--target-ref <id>` (evidence-grounded, default path):** the brief inherits the full scored context, evidence ledger, and confidence rating from `content targets`. `briefMode = 'evidence-grounded'`.
+  - **`--topic "<q>"` (exploratory, degraded):** for queries the user has in mind that haven't yet ranked or been classified. The command first attempts to resolve the topic to an existing target — if a match exists, behaves identically to `--target-ref`. Otherwise emits an `briefMode = 'exploratory'` brief with `actionConfidence: 'low'`, an enlarged `unknownFields[]`, and an empty `evidenceLedger.gscEvidence`. The brief explicitly warns that it lacks ranking/citation grounding. **This is the only path to brief generation without an evidence-backed target — and it's marked as such.**
+
+  **Action ledger integration:** generating a brief creates (or reuses) a tracked action in `content_actions` and returns its `actionId` alongside the `briefId`. The action is the durable unit; the brief is its first artifact. See "Content Action Outcome Ledger" below.
+
+  `ContentBriefDto` shape:
+  - **Lifecycle:** `briefId` (stable handle), `actionId` (the parent action — durable across the whole experiment), `targetRef` (nullable in exploratory mode), `sourceRunId` (the `runs.id` whose data backed this brief), `generatedAt` (ISO timestamp), `briefMode ∈ { 'evidence-grounded' | 'exploratory' }`
+  - **Content:** `primaryQuery`, `secondaryQueries[]`, `pageType`, `searchIntent`, `recommendedAction`, `schemaRecommendation`
+  - **`evidenceLedger`:** `{ winningCompetitorUrls[], gscEvidence, citationHistory }` — provenance for every claim; URLs/titles preserved byte-identical from `content sources`
+  - **`knownFields`:** values derived from canonry's own data (counts, URLs, GSC stats, citation rates)
+  - **`unknownFields[]`:** fields the LLM was instructed *not* to invent (e.g., `competitor_h2_structure`, `competitor_word_count`) — `null` with a `whyUnknown` reason rather than guessed. **Load-bearing anti-hallucination guarantee.**
+  - **`acceptanceCriteria[]`:** measurable bars ("covers entities X, Y, Z", "includes FAQPage schema", "≥ 1500 words")
+  - **`requiredSections[]`:** `[{ heading, mustCoverEntities[] }]`
+  - **`risks[]`:** short labels ("competitor page is 5,000 words — depth match is significant", "highly contested SERP")
+  - **`successMetric`:** `{ target, baseline, measuredBy }`
+
+  **No drafting in canonry, ever.** Brief generation is the ceiling of canonry's content surface. See "Generation boundary" below.
+- `canonry content publish-payload <project> --action-id <id> --content-file draft.md --target wordpress|ghost|next-mdx|generic [--format json]` — emits a `ContentPublishPayloadDto` keyed to a specific tracked action. The payload is tied to the action's brief, evidence ledger, sourceRunId, and recommendedAction; a payload generated against action v1 cannot be confused with one against action v2 even if the target query is unchanged. **Pure payload generation, no mutation.** Updates action state to `payload-generated`. Returns `{ actionId, briefId, target, execution: { method, url, headers, body }, metadata: { evidenceLedger, sourceRunId, generatedAt }, credentialHints, nextSteps, successValidation }`. See "Content Action Outcome Ledger" + "Generation boundary" + "Publish boundary" below.
+
+**Composite API contract (up-front):** routes live in `packages/api-routes/src/content.ts`; scorer lives in `packages/intelligence/src/content-targets.ts`. CLI/UI/Aero all consume the same DTOs byte-for-byte.
+
+| Route | DTO |
+|---|---|
+| `GET /projects/:name/content/gaps` | `ContentGapsResponseDto` |
+| `GET /projects/:name/content/sources` | `ContentSourcesResponseDto` |
+| `GET /projects/:name/content/targets` | `ContentTargetsResponseDto` (with `ContentTargetRowDto[]`) |
+| `POST /projects/:name/content/briefs` | `ContentBriefDto` (creates/reuses action; returns `briefId` + `actionId`; idempotent by `(query, action, targetPage)`) |
+| `POST /projects/:name/content/publish-payload` | `ContentPublishPayloadDto` (no mutation; updates action state to `payload-generated`) |
+| `GET  /projects/:name/content/actions` | `ContentActionsResponseDto` — list tracked actions, filterable by state/action |
+| `GET  /projects/:name/content/actions/:actionId` | `ContentActionDto` — single action + computed outcome |
+| `POST /projects/:name/content/actions/:actionId/mark-published` | mutation: records `publishedUrl` + `publishedAt`; transitions to `published` |
+| `POST /projects/:name/content/actions/:actionId/dismiss` | mutation: terminal state |
+| `POST /projects/:name/wordpress/create-draft` | mutation: returns `WordpressDraftCreatedDto`; transitions action state to `published`. The only WP-touching mutation in the surface. |
+
+**New Aero tools:**
+- **Read-only, always-on** (DB reads): `get_content_gaps`, `get_grounding_sources`, `get_content_targets`, `list_content_actions` (filter by state/action), `get_content_action` (single action + outcome)
+- **Write, explicit invocation:** `generate_content_brief` (spends LLM tokens; auto-creates the action), `dismiss_content_action` (terminal state change)
+
+Drafting is deliberately *not* an Aero tool. `mark_published` is also intentionally CLI/API-only — agents typically don't know the user's published URL; that's a user-side fact.
+
+**How competitor data drives recommendations:** competitor signal is the primary lever distinguishing canonry's content engine from generic SEO content tools. We use it four ways:
+
+1. **Demand inference** — the `competitor_score` branch fires when GSC has zero impressions, so `create` opportunities still rank for queries Google doesn't yet recognize as demand. This is what unblocks the recommendation engine for early-stage / niche / emerging-topic queries.
+2. **Page-type and intent inference** — competitor URL patterns and titles (`/compare/`, `/best-`, `/vs/`, `/guides/`, `/glossary/`) populate `pageType` and `searchIntent` in the brief without an LLM call.
+3. **The evidence map (`winningCompetitorUrls[]`)** — every brief carries the exact competitor URLs + titles + citation counts the agent needs to read, beat, or differentiate against. Canonry surfaces; the agent fetches via its own WebFetch.
+4. **Trend signals** — newly-appearing competitor citations (`recommendedCompetitors`, recent-run deltas) feed `recent_miss_rate` and surface as `drivers[]` (e.g., "competitor X gained citation in last 30 days"). Catches rising threats before they consolidate.
+
+**What canonry never reads:** competitor *page bodies*. Only URLs, titles, citation patterns, and per-provider citation history. Body content is the agent's job (its WebFetch tool, its bandwidth, its rate-limit obligations). Keeps canonry firmly on the signal side.
+
+**Content Action Outcome Ledger (V1):** every recommended action becomes a **tracked experiment** with a durable lifecycle and computed outcome. This is what turns canonry from "recommendation generator" into "recommendation system that learns from its own past advice." It is the foundation for future per-domain action ranking — *no ML required in v1*, just the data that would eventually feed it.
+
+**The lifecycle states** (persisted in `content_actions` table):
+
+```
+proposed → briefed → payload-generated → draft-created → published → validated
+                                                ↓             ↓
+                                              published      (skip draft-
+                                              (non-WP path:   created — was
+                                              mark-published  always going
+                                              or agent)       direct)
+                                                ↓
+                                          dismissed (terminal, any state)
+```
+
+`proposed` is optional (a user "claiming" a target before generating a brief); the common path begins at `briefed`. **`draft-created` is a WP-only intermediate state** — a WordPress draft is *not* published content; it's a draft sitting in WP admin awaiting user review. Non-WP paths skip it entirely (going directly `payload-generated → published` via `mark-published` or agent confirmation).
+
+**Each action record carries:**
+- **Identity:** `actionId` (stable handle), `projectId`, `query`, `action ∈ {create|expand|refresh|add-schema}`, `targetPage?` (nullable for `create` actions), `state`, `createdAt`, `updatedAt`
+- **Promotion context:** `scoreAtPromotion`, `driversAtPromotion[]`, `sourceRunId` (the run whose data justified this action) — frozen at creation
+- **Baseline (frozen at creation):** `baselineCitedRate`, `baselineProviderBreakdown`, `baselineGscStats { impressions, position, ctr }`, `baselineCompetitorOverlap[]`, **`baselineObservationSet { providers[], models[], locations[] }`** — the "before" snapshot, plus the exact observation surface that produced it
+- **Lifecycle artifacts:** `briefId?`, `payloadGeneratedAt?`, **`wpDraftId?`, `wpDraftUrl?`, `draftCreatedAt?`** (WP only), `publishedUrl?`, `publishedAt?`, `dismissedAt?`, `dismissedReason?`
+- **Outcome (computed lazily after publish, refined as more runs accumulate):** `outcomeResult ∈ {improved|unchanged|regressed|inconclusive}` + `firstMeasurement` (computed on first post-publish run) + full computed payload — see below
+
+**Outcome computation** (pure given action + post-publish snapshots; lives in `intelligence/`):
+
+```
+// Comparison happens only over the intersection of baseline observation set
+// AND post-publish observation set — like-for-like, never cross-category.
+observationSet         = intersect(baselineObservationSet, postPublishObservationSet)
+
+citationRateBefore     = baselineCitedRate over observationSet
+citationRateAfter      = latest-run cited rate over observationSet
+citationGained[]       = (provider, model) pairs where we became cited post-publish (within observationSet only)
+citationLost[]         = (provider, model) pairs where we lost (within observationSet only)
+providersImproved[]    = providers in observationSet with cited-rate increase
+competitorDisplacement = competitors that lost share for this query post-publish
+timeToFirstCitation    = days from publishedAt to first cited snapshot in observationSet
+newEvidence[]          = providers/models/locations added AFTER publish — surfaced separately,
+                          NOT folded into result (would be a category error)
+result                 = 'improved' | 'unchanged' | 'regressed' | 'inconclusive'
+```
+
+**Validation threshold** (when `published → validated` fires): the transition only happens when ≥ **3 eligible post-publish runs** OR ≥ **14 days** have elapsed since `publishedAt` (whichever comes first). Until then, the action stays in `published` with `firstMeasurement` populated and `result = 'inconclusive'`. AI citation results are noisy; a single post-publish snapshot is not enough evidence to call an action validated — and the ledger is training data, so false positives would corrupt future per-domain ranking. Eligible runs are those whose observation set has non-empty intersection with `baselineObservationSet`.
+
+**Idempotency contract:** at most one *in-progress* (non-`dismissed`, non-`validated`) action per `(projectId, query, action, targetPage)` triple. `content brief --target-ref <id>` creates a new action OR reuses an existing in-progress one for the same triple. Re-running `content targets` does not duplicate actions.
+
+**New CLI commands for the ledger:**
+- `canonry content actions <project> [--state ...] [--action ...] [--limit N] --format json` — list tracked actions; filter by lifecycle state and/or action type
+- `canonry content action <project> <action-id> --format json` — single action, includes computed outcome if `published`
+- `canonry content mark-published <project> --action-id <id> --url <published-url> [--published-at <iso-date>]` — explicit publish confirmation; transitions to `published`. Records URL + timestamp; does not mutate baseline or evidence.
+- `canonry content dismiss <project> --action-id <id> [--reason <text>]` — terminal dismissal; excludes from future `content targets` ranking by default
+
+**State transitions and the surrounding commands:**
+
+| Command / signal | State transition | External mutation? | Determinism | Notes |
+|---|---|---|---|---|
+| `content brief --target-ref <id>` | `(none)` → `briefed` (creates action) **OR** reuses existing in-progress action | No (local ledger only) | Deterministic | Idempotent per `(query, action, targetPage)` |
+| `content publish-payload --action-id <id>` | `briefed` → `payload-generated` | No (local ledger only) | Deterministic | Records `payloadGeneratedAt` |
+| `wordpress create-draft --action-id <id>` | `payload-generated` → `draft-created` (WP only) | **Yes** (creates WP draft post) | Deterministic | Records `wpDraftId`, `wpDraftUrl`, `draftCreatedAt`. **Does not transition to `published`** — a WP draft is not published content, just a draft awaiting user review. Audit-logged. |
+| WP poll detects `wpDraftId` status changed to `publish` | `draft-created` → `published` | No (canonry observing WP) | Deterministic | Only fires when WP API confirms the draft is now `status: publish`. Records `publishedUrl` + `publishedAt` from WP response. |
+| Agent calls `content mark-published` as last workflow step | `payload-generated` → `published` | No (local ledger only) | Deterministic | Agent-mediated zero-friction path (Claude Code, Codex). Skips `draft-created` — non-WP path doesn't have a draft state. |
+| `content mark-published --action-id <id>` (user-initiated) | `payload-generated` or `draft-created` → `published` | No (local ledger only) | Deterministic | Explicit fallback. From `draft-created`: confirms the WP draft was promoted to publish without waiting for poll. |
+| Sitemap-inspection diff finds a new URL whose slug overlaps with the action's `primaryQuery` | (no state change — surfaces a candidate prompt) | No | **Heuristic — surfaces in dashboard for user confirmation, never auto-transitions** | Slug match alone cannot prove the new URL is the post we briefed. Dashboard shows "looks like you published X — confirm?" with one-tap yes/no. |
+| `content dismiss --action-id <id>` | any → `dismissed` | No (local ledger only) | Deterministic | Terminal; excluded from default `content targets` ranking |
+| (post-publish runs accumulate) | `published` → `validated` | No (local ledger only) | Deterministic (outcome) | **Threshold:** ≥3 eligible post-publish runs OR ≥14 days since `publishedAt`, whichever first. Eligible run = its observation set intersects `baselineObservationSet`. Until threshold, stays in `published` with `result = 'inconclusive'` and `firstMeasurement` populated. **Not a publish-detection signal** — outcome only fires once `publishedAt` is already set. |
+
+**Detection vs verification (load-bearing distinction):** canonry does **not** verify that a published post matches the brief. We don't read user page bodies any more than we read competitor page bodies — the body-reading boundary holds for both. What canonry does:
+
+- **Deterministic detection** (WP poll, agent-mediated, manual): records the URL with confidence
+- **Heuristic candidate suggestion** (sitemap diff): surfaces "is this you?" in the dashboard, requires user confirmation
+- **Outcome measurement** (citation appearance, displacement, time-to-first-citation): computed deterministically from snapshot history *after* publish is confirmed
+
+What canonry does *not* do:
+- ❌ Fetch the user's published URL and check entities
+- ❌ Auto-mark `published` on slug match alone
+- ❌ Treat citation appearance as evidence the user *published* (it's evidence of *outcome*, two different states)
+
+The honest UX: WP and agent flows are zero-effort end-to-end; pure-manual users either tap a confirmation in the dashboard when canonry surfaces a candidate, or run `mark-published` explicitly. No persona is asked to "remember to come back to canonry."
+
+**Why this matters (and why it's V1, not deferred):** without this ledger, canonry can generate good briefs but cannot answer "did `add-schema` work better than `expand` for this site?" With it, the next iteration of the ranker can weight action types by observed per-domain outcome — the foundation for learning, without ML in v1. Building the ledger AFTER actions are already shipping means losing the training data we'd most want.
+
+**Generation boundary (the ladder):** every layer below has a single canonical artifact. Higher layers consume lower-layer output verbatim; canonry never invents to fill gaps. Each step is also a state transition in the action ledger above.
+
+| # | Surface | Produces | Mutation? |
+|---|---|---|---|
+| 1 | `content targets` | Ranked actions (no prose) | none |
+| 2 | `content sources` | Evidence map (URLs/titles/counts only) | none |
+| 3 | `content brief --format json` | Canonical structured brief w/ evidence ledger | none |
+| 4 | `content brief --format md` | Human-readable render of the JSON | none |
+| 5 | (drafting) | **Out of scope. External agent only.** | n/a |
+| 6 | `content publish-payload` | CMS-shaped payload, credential placeholders | none |
+| 7 | `wordpress create-draft` | **Explicit external mutation** — creates WP draft post (`payload-generated → draft-created`); does **not** mark as published | yes (WP only) |
+| 8 | WP poll OR `mark-published` | Records `publishedUrl` + `publishedAt`, transitions to `published` | no (canonry observes / records) |
+
+**Drafting is explicitly not a canonry surface.** External agents fetch the brief's cited URLs (their own WebFetch / browser tool / rate-limit obligations), produce the draft, and either commit it to the user's repo or hand it back to canonry's payload/mutation layers. This boundary is what prevents canonry from hallucinating source material it never fetched. The brief's `unknownFields[]` makes this contract enforceable per-field.
+
+**Mutation gate — two layers, not one:**
+
+- **External mutation** (writes to systems outside canonry): `wordpress create-draft` is the **only** command in the content surface that touches external state. Renamed from `publish-draft` to make this explicit. WP-only, gated, audit-logged via existing audit-log infrastructure.
+- **Local ledger mutation** (writes to canonry's own DB): `content brief`, `content publish-payload`, `content mark-published`, `content dismiss` all create or transition rows in the `content_actions` and `contentBriefs` tables. These are not external mutations — they're durable lifecycle tracking inside canonry.
+
+The boundary canonry preserves is "no silent external mutation." Internal ledger writes are how the system stays accountable to the user, not a violation of the boundary. Conflating the two would either let canonry silently mutate external systems (bad) or stop tracking the recommendation lifecycle entirely (also bad).
+
+**Publish boundary — transformers, not adapters:** the agent takes a brief + draft and publishes. Canonry's role ends at **preparing a CMS-shaped payload**; the agent calls the CMS's API with its own credentials.
+
+- **Transformers are pure functions** in a new `packages/publish-transformers/`: `(brief, draft, targetMeta) → ContentPublishPayloadDto`. No HTTP, no auth, no runtime deps. 100% unit-testable. Ship `wordpress`, `ghost`, `next-mdx`, `generic` at launch; add Webflow/Hugo/Sanity/Contentful on user demand.
+- **WordPress stays as the one full adapter.** `integration-wordpress/` already owns auth + live execution + audit. `canonry wordpress create-draft` (the mutation gate, see "Generation boundary" above) is a thin wrapper: run the WP transformer → call the existing `createPage({status: 'draft'})`. Earns its keep because the target audience (solo AEO analysts, SEO consultants, in-house SEO) has heavy WP overlap. **Gutenberg quirk:** WP's block editor auto-converts pasted markdown, so the WP transformer can emit minimal block JSON + a `core/html` fallback and let Gutenberg do the rest — dramatically shrinks the transformer's surface.
+- **Other CMSes: transformer only.** Agent substitutes credentials from its env (placeholders like `${GHOST_ADMIN_KEY}` in the payload) and executes the HTTP call itself. Canonry never sees non-WP secrets.
+- **No adapter maintenance treadmill.** The agent already has HTTP + credential resolution; canonry adding a live client per CMS duplicates that work and exposes us to auth/rate-limit/API-drift churn.
+
+**Why this is the right boundary:** aligns 1:1 with AGENTS.md ("canonry surfaces, agent acts"). Keeps canonry's unique value concentrated on what only it can do — producing CMS-shaped payloads from the brief schema, page type, and metadata. Research confirmed no off-the-shelf library covers this space (Micropub has limited CMS coverage — no Ghost/Webflow/core-WP; headless-CMS libraries like Contentlayer face inward to the user's own site); composing `remark`/`rehype` + per-target transformers (~100–150 LOC each) is the right build.
 
 **Demo synergy:** `canonry demo` and the hosted sandbox should highlight this loop. "Watch canonry tell you exactly what blog post to write next based on what your competitors are getting cited for" is a much stronger demo moment than a static dashboard tour. Bake this into the Wave 1 demo script.
 
@@ -205,14 +379,27 @@ Would embarrass, not block:
 Content is the lead investment. It's the differentiator, the demo headliner, and the feature that closes the loop from observation to outcome. Everything else in Wave 0 is supporting hardening that runs in parallel.
 
 **Lead — content engine (#3a, full scope):**
-- **`canonry content gaps`** — DB-only query: which queries do competitors win that you don't?
-- **`canonry content sources`** — DB-only query: the grounding URLs the LLM used per query/competitor (URL-level competitive map).
-- **`canonry content suggest`** — prioritized topic recommendations enriched by `searchQueries` and `groundingSources`.
-- **`canonry content brief`** — full content brief: target query + top grounding URLs + LLM internal queries + suggested H2s/entities/schema. Single LLM call.
-- **`canonry content draft`** — full draft via the project's configured provider; emits markdown the user/agent commits to their repo.
-- **`canonry wordpress publish-draft`** — closes the WordPress loop; generates draft post via existing manual-assist pattern.
-- **Aero tools:** `get_content_gaps`, `get_grounding_sources`, `suggest_content_topics`, `generate_content_brief` (draft generation gated to explicit user invocation).
-- **Demo fixtures highlight the content loop** — sample project's `canonry demo` data shows a clear "your competitor is cited via this URL → here's the brief → here's the draft" walkthrough.
+
+*PR 1 — deterministic read layer (no LLM, no persistence):*
+- **`canonry content gaps / sources / targets`** — DB-only reads; `targets` is the ranked action-typed opportunity list (additive two-branch scorer so `create` opportunities with zero GSC still rank).
+- **Contracts:** `ContentTargetRowDto` + response DTOs in `packages/contracts/src/content.ts` (canonical for CLI + API + UI).
+- **API routes:** `/projects/:name/content/{gaps,sources,targets}` — composite reads so agents never client-side-join.
+- **Scorer + action classifier:** `packages/intelligence/src/content-targets.ts` — pure function, unit-tested with fixture snapshots.
+- **Aero read tools:** `get_content_gaps`, `get_grounding_sources`, `get_content_targets`.
+
+*PR 3 — brief + transformers + publish loop:*
+- **`canonry content brief --target-ref <id>`** — structured JSON (canonical) with markdown renderer. Single LLM call. `POST /content/briefs` idempotent by `(query, action, targetPage)`. **Auto-creates / reuses a tracked action** (see ledger below); returns `{ briefId, actionId, ... }`.
+- **`canonry content publish-payload --action-id <id>`** — emits `ContentPublishPayloadDto`; ships `wordpress`, `ghost`, `next-mdx`, `generic` transformers at launch. **Pure payload generation, no mutation.** Transitions action state to `payload-generated`.
+- **`canonry wordpress create-draft --action-id <id>`** — **explicit external mutation**: runs the WP transformer + calls existing `createPage({status:'draft'})`. Records `wpDraftId`, `wpDraftUrl`, `draftCreatedAt` on the action; transitions state to **`draft-created`** (NOT `published` — a WP draft is awaiting user review, not yet live). Audit-logged. WP poll then watches the draft for status change to `publish`, transitioning to `published` only at that point.
+- **`canonry content actions / action / mark-published / dismiss`** — action ledger CLI surface (see "Content Action Outcome Ledger" in §3a).
+- **Content Action Outcome Ledger** — new `content_actions` table + state machine + outcome computation (lazy, post-publish). The durable lifecycle is the unit of value, not just the brief.
+- **Aero write tool:** `generate_content_brief`, `dismiss_content_action`. Plus read tools: `list_content_actions`, `get_content_action`.
+- **New package:** `packages/publish-transformers/` — pure per-target transformers (`remark`/`rehype`-backed), no runtime deps.
+- **Persistence:** `contentBriefs` table (artifacts) + `content_actions` table (durable lifecycle) + outcome computation in `packages/intelligence/src/content-outcomes.ts`.
+
+*PR 2 — UI surfacing (moves to Wave 1 under content surfacing below).*
+
+*Demo fixtures highlight the content loop* — sample project's `canonry demo` data shows "competitor wins query X via URL Y → here's the action-typed target → here's the brief → agent publishes via transformer payload" end-to-end.
 
 **Parallel — launch hardening:**
 - **Credential encryption — full secret scope** (#5): provider keys, Vertex creds, Google OAuth + tokens, Bing keys, GA4 private keys, WordPress app passwords, local API key.
@@ -226,7 +413,7 @@ Content is the lead investment. It's the differentiator, the demo headliner, and
 
 - **Extend the existing `/setup` wizard** (#1, Path A): inline provider step before system check, integrations step (GSC/GA4/Bing/WordPress), final "Connect your AI editor" step.
 - **Persistent setup checklist** independent of the one-shot wizard (since `routes.tsx:108-113` redirects users away once a project exists) (#1, Path A).
-- **Content surfacing in the dashboard** — gaps/sources/suggest results visible in the project page, not only in the CLI. Same UI/CLI parity rule as the rest of the dashboard.
+- **Content surfacing in the dashboard** (content engine PR 2) — gaps/sources/targets results visible in the project page, consuming the same DTOs as the CLI. Action-type filters (`create|expand|refresh|add-schema`) and score-driver chips. Same UI/CLI parity rule as the rest of the dashboard.
 - **Empty-state polish** sweep across remaining dashboard views (#1, Path A).
 - `canonry skill install --for <agent>` + agent-guide doc surface (#1, Path B) — backs the UI panel and the CLI path.
 - `canonry init` detects + recommends agent integration (#1, Path B).
@@ -261,8 +448,25 @@ Track against a funnel dashboard powered by `packages/canonry/src/telemetry.ts`:
 - `init_completed` rate (vs `init_started`).
 - `first_run_completed` rate (vs `init_completed`).
 - `skill_installed` rate (which agent breakdown).
-- `content_brief_generated` rate (Wave 0 lead-feature adoption).
-- `content_draft_published` rate (closed-loop validation).
+- `content_action_promoted` rate — first time a target is brought into the ledger (when brief is generated).
+- `content_brief_generated` rate (per-action; one event per brief artifact).
+- `content_publish_payload_generated` rate (agent-driven publish flows).
+- `wp_draft_created` rate (WP-specific mutation; transitions to `draft-created`).
+- `wp_draft_published` rate (WP poll detects draft → publish; transitions to `published`).
+- `content_published_marked` rate — explicit user confirmation via `mark-published`.
+- `content_action_first_measured` rate — first post-publish run with eligible snapshot data; `firstMeasurement` populated, `result` still `inconclusive`.
+- `content_action_validated` rate — outcome reached the validation threshold (≥3 eligible runs OR ≥14 days); `result` resolved.
+- `content_action_dismissed` rate.
+- `external_publish_confirmed` rate — derived from transitions into `published` state. **Confirmation paths, ordered by determinism:**
+  - **Deterministic auto (two-step for WP):** `wordpress create-draft` transitions action to `draft-created` (not `published`). WP poll watches the draft's `wpDraftId` for `status: publish`. When it flips, action transitions to `published`. Two distinct events: `wp_draft_created` and `wp_draft_published`.
+  - **Deterministic agent-mediated** — agent (Claude Code, Codex) calls `canonry content mark-published` as the last step of its workflow. Skips the WP draft state for non-WP flows.
+  - **Deterministic manual** — user runs `canonry content mark-published --url <u>` (or clicks the equivalent in the dashboard).
+  - **Heuristic candidate (NOT auto-confirm)** — sitemap-inspection diff finds a new URL with slug overlap to the action's `primaryQuery`. Surfaces in the dashboard as "looks like you published X — confirm?" Requires one-tap user confirmation; never transitions state on its own. Slug match alone cannot prove the URL is the post we briefed.
+
+  **Outcome confirmation is a separate signal** — citation appearance in `groundingSources` is OUTCOME evidence (`published → validated`), not publish evidence. It only fires once `publishedAt` is already set via one of the paths above.
+
+  v1 ships the WP-auto, agent-mediated, and manual paths. The heuristic candidate UI lands once site-inventory diffing is wired up (PR 1 inventory layer feeds this). Outcome computation lands in PR 3.
+- **Per-action-type outcome rates** — `improved | unchanged | regressed | inconclusive` rates broken down by `action ∈ {create|expand|refresh|add-schema}`. The training data for future per-domain ranker improvements.
 - 7-day retention on dashboard.
 - Demo → install conversion (hosted sandbox to local install).
 
@@ -270,6 +474,21 @@ Track against a funnel dashboard powered by `packages/canonry/src/telemetry.ts`:
 
 ### Wave 0 ship gate
 - [ ] All `canonry content` subcommands ship with `--format json` parity and tests.
+- [ ] **`ContentBriefDto` JSON schema exists in `packages/contracts/` before any prompt-template work begins** (schema-first, prompt-second).
+- [ ] **Every generated brief includes a populated `evidenceLedger` with provenance for each grounded field.**
+- [ ] **`unknownFields[]` is non-empty whenever any LLM-inferable field could not be grounded; tests assert no inferred values leak into `knownFields`.**
+- [ ] **Tests assert grounding URLs + titles survive byte-identical from `content sources` → `content brief.evidenceLedger` → `content publish-payload.metadata.evidenceLedger`.** Body content may be transformed (markdown links, HTML encoding); the structured-metadata ledger is the preservation contract.
+- [ ] **`wordpress create-draft` is the only command that mutates *external* systems (WP API write); test via a network-call interceptor that no other content command opens an outbound HTTP socket to a CMS.** All other lifecycle commands (`brief`, `publish-payload`, `mark-published`, `dismiss`) mutate only canonry's local ledger (DB rows in `content_actions` / `contentBriefs`).
+- [ ] **`content_actions` table exists with all required columns**: identity, baseline (frozen at creation), promotion context, lifecycle artifacts, outcome (lazy).
+- [ ] **Idempotency test passes:** generating a brief twice for the same `(query, action, targetPage)` reuses the existing in-progress action; re-running `content targets` does not duplicate in-progress actions.
+- [ ] **`mark-published` records URL + timestamp without modifying baseline, evidenceLedger, scoreAtPromotion, or driversAtPromotion** (test via diff of action record before/after).
+- [ ] **State machine precision:** `wordpress create-draft` transitions to `draft-created`, never directly to `published`. WP poll detecting `status: publish` (or `mark-published`) is the only path from `draft-created` to `published`. Test asserts these transitions in isolation.
+- [ ] **Validation threshold enforced:** `published → validated` only fires after ≥3 eligible post-publish runs OR ≥14 days. Test fixture verifies that 1 post-publish run leaves the action in `published` with `result='inconclusive'` + `firstMeasurement` populated; 3 runs (or 14d) transitions it to `validated` with full result.
+- [ ] **Observation-set scoping:** baseline records `baselineObservationSet { providers, models, locations }`. Outcome compares like-for-like only; providers/models/locations added after publish are surfaced in `newEvidence[]` separately, not folded into the result. Test fixture covers both cases.
+- [ ] **Outcome computation test:** given an action in `published` state and a fixture run dated after `publishedAt` with snapshot data, `firstMeasurement` and `outcomeResult` are populated correctly. After threshold, action transitions to `validated`.
+- [ ] **`content targets` hides in-progress actions by default:** test asserts a query with an existing `briefed` action does not appear in the default `content targets` response, but appears with `existingAction: { state: 'briefed', ... }` when `--include-in-progress` is passed.
+- [ ] **Dismissed actions are excluded from `content targets` default ranking** (assertable in fixture test).
+- [ ] Telemetry distinguishes the full action-lifecycle events: `content_action_promoted`, `brief_generated`, `publish_payload_generated`, `wp_draft_created`, `content_published_marked`, `content_action_validated`, `content_action_dismissed`, `external_publish_confirmed` — distinct events, not collapsed.
 - [ ] All seven secret types in `config.ts` migrated to keychain. Zero plaintext secrets in fresh `~/.canonry/config.yaml`.
 - [ ] CI lint asserts every doc-referenced `canonry <verb>` invocation is registered. `canonry timeline` ships or all references removed.
 - [ ] `canonry demo` boots a working sample project with content-loop data on a clean machine in under 60 seconds.
@@ -278,7 +497,7 @@ Track against a funnel dashboard powered by `packages/canonry/src/telemetry.ts`:
 ### Wave 1 ship gate
 - [ ] `/setup` wizard covers provider, integrations, agent-connect.
 - [ ] Persistent setup checklist surfaces post-redirect.
-- [ ] Content gaps/sources/suggest visible in dashboard with API/CLI parity.
+- [ ] Content gaps/sources/targets visible in dashboard with API/CLI parity.
 - [ ] `canonry skill install` works for Claude Code, Codex, Hermes, OpenClaw.
 - [ ] Hosted sandbox live at canonry.ai subdomain with demo fixtures.
 - [ ] Landing page at canonry.ai with content-loop demo video.
@@ -296,7 +515,11 @@ Track against a funnel dashboard powered by `packages/canonry/src/telemetry.ts`:
 
 - **Install:** `canonry skill install --for claude-code` drops skill into `~/.claude/skills/`.
 - **Example prompt:** "Use canonry to find queries where my competitors are cited but I'm not, then write a brief for the highest-priority topic."
-- **Expected workflow:** `canonry content gaps --format json` → pick top result → `canonry content brief "<topic>" --format md` → Claude Code writes draft and commits to user repo → `canonry run` next sweep validates impact.
+- **Expected workflow:** `canonry content targets --sort score --limit 5 --format json` (defaults hide already-in-progress actions) → pick a `targetRef` → `canonry content brief --target-ref <id> --format json` (returns `briefId` + `actionId`; action now `briefed`) → Claude Code fetches the brief's `evidenceLedger.winningCompetitorUrls` via WebFetch, drafts the post in the user's repo → `canonry content publish-payload --action-id <id> --content-file draft.md --target wordpress|next-mdx|...` (action now `payload-generated`) → agent applies the payload, then either:
+  - **WP users:** `canonry wordpress create-draft --action-id <id>` → action `draft-created` (WP draft sits in admin awaiting user review). User publishes in WP. Canonry polls and auto-transitions to `published`. **Or** the agent calls `canonry content mark-published` to skip the polling delay.
+  - **Other:** `canonry content mark-published --action-id <id> --url <published-url>` → action `published`.
+
+  After publish: each subsequent `canonry run` accumulates evidence. After ≥3 eligible runs OR ≥14 days, action auto-transitions `published → validated` with computed outcome (`improved | unchanged | regressed | inconclusive`). Until then, `firstMeasurement` populated and `result = 'inconclusive'`.
 
 ### Codex
 
@@ -308,7 +531,7 @@ Track against a funnel dashboard powered by `packages/canonry/src/telemetry.ts`:
 
 - **Install:** `canonry skill install --for hermes` writes Hermes-format guidance.
 - **Example prompt:** "Plan a content roadmap based on canonry's competitive intel for this domain."
-- **Expected workflow:** `canonry content suggest --limit 10 --format json` → Hermes synthesizes editorial calendar → user approves → Hermes drives `canonry content draft` for each topic.
+- **Expected workflow:** `canonry content targets --sort score --limit 10 --format json` → Hermes synthesizes editorial calendar → user approves → Hermes drives `canonry content brief --target-ref <id>` per target and drafts into the user's repo.
 
 ### OpenClaw
 
@@ -328,9 +551,8 @@ Track against a funnel dashboard powered by `packages/canonry/src/telemetry.ts`:
 
 | Wave | Area | Files |
 |------|------|-------|
-| 0 (lead) | Content gaps + sources + suggest | new `packages/canonry/src/commands/content.ts` (gaps, sources, suggest subcommands); reads `groundingSources` + `searchQueries` + `competitorOverlap` fields on `QuerySnapshotDto` (`packages/contracts/src/run.ts:57-77`); reuses `competitors` table + health-snapshot fields (`packages/db/src/schema.ts:32,68`); reuses `packages/intelligence/src/causes.ts` |
-| 0 (lead) | Content brief + draft | extend `packages/canonry/src/commands/content.ts`, new `packages/intelligence/src/content-prompts.ts` for brief + draft prompt templates, new Aero tools in `packages/canonry/src/agent/tools.ts` |
-| 0 (lead) | WordPress draft publish | extend `packages/integration-wordpress/src/wordpress-client.ts` (draft post creation), new CLI subcommand in `packages/canonry/src/cli-commands/wordpress.ts` |
+| 0 (lead, PR 1) | Content targets + gaps + sources (read layer) | new `packages/contracts/src/content.ts` (`ContentTargetRowDto`, `ContentTargetsResponseDto`, `ContentGapsResponseDto`, `ContentSourcesResponseDto`); new `packages/intelligence/src/content-targets.ts` (scorer + action classifier, pure); new `packages/api-routes/src/content.ts` (composite `/content/{gaps,sources,targets}` routes); new `packages/canonry/src/commands/content.ts` + `cli-commands/content.ts`; new Aero read tools in `packages/canonry/src/agent/tools.ts`; reads `groundingSources` + `competitorOverlap` via `rawResponse`, `gscSearchData`, `gaTrafficSnapshots` (per-page organic only — no per-page AI, see note), project-level `gaAiReferrals` |
+| 0 (lead, PR 3) | Content brief + publish transformers + **action ledger** | extend `packages/canonry/src/commands/content.ts` (brief, publish-payload, actions, action, mark-published, dismiss subcommands); new `packages/intelligence/src/content-prompts.ts` (must include `unknownFields` discipline); new `packages/intelligence/src/content-outcomes.ts` (pure outcome computation); **new `packages/publish-transformers/` package** with `wordpress`, `ghost`, `next-mdx`, `generic` transformers; **new `contentBriefs` + `content_actions` tables + migrations** (see DB rules in `AGENTS.md`); extend `packages/canonry/src/agent/tools.ts` with `generate_content_brief`, `list_content_actions`, `get_content_action`, `dismiss_content_action`; new `canonry wordpress create-draft` mutation command (renamed from `publish-draft`) wraps the WP transformer + existing `createPage()` in `packages/integration-wordpress/src/wordpress-client.ts`, audit-logged, transitions action state |
 | 0 | Credential encryption | `packages/canonry/src/config.ts` (all secret fields lines 10, 19, 33-34, 43, 49, 56, 64, 80, 101), `packages/canonry/src/commands/init.ts`, new `packages/canonry/src/keychain.ts`, migration in `packages/canonry/src/config-migrate.ts` |
 | 0 | Agent-docs accuracy | `packages/canonry/assets/agent-workspace/AGENTS.md`, `skills/aero/references/memory-patterns.md`, `skills/canonry-setup/`, new CI lint comparing doc invocations to `packages/canonry/src/cli-commands.ts` |
 | 0 | `canonry timeline` CLI wrapper | new `packages/canonry/src/commands/timeline.ts` wrapping the existing `/timeline` API route, register in `packages/canonry/src/cli-commands/run.ts` (or new `cli-commands/timeline.ts`) |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -92,10 +92,16 @@ These build on existing infrastructure with minimal schema/architecture changes.
 **Implementation**: Use an LLM call to cluster keywords into topic groups (e.g., "pricing", "comparison", "how-to"). Store topic assignments in a new `keywordTopics` table. Aggregate SOV and sentiment by topic on the dashboard.
 **Impact**: Analysts think by topic, not keyword-by-keyword. This is how Profound justifies $499/mo.
 
-### Content Optimization Recommendations
-**Gap**: Profound's "AEO Content Score" is their most differentiated feature. No open-source tool offers this.
-**Implementation**: For keywords where the domain is `not-cited`, analyze the AI answer to extract: (a) what sources *were* cited and why, (b) what content format the answer favors, (c) structured data the cited pages use. Generate actionable recommendations. Store in a `recommendations` table linked to snapshots.
-**Impact**: Moves Canonry from "monitoring" to "optimization."
+### Citation-Driven Content Opportunities + Action Outcome Ledger (LEAD WAVE-0 INVESTMENT)
+**Gap**: Profound's "AEO Content Score" is their most differentiated feature. No open-source tool offers an action-typed, deterministic recommendation engine paired with closed-loop outcome tracking.
+**Implementation**: See `docs/gtm.md` §3a for the full product spec and `docs/adr/0009-content-action-outcome-ledger-and-publish-boundary.md` for the architectural contract. Canonical artifacts:
+- `canonry content targets` — ranked, action-typed (`create | expand | refresh | add-schema`) opportunity list with deterministic AEO-first classifier and additive two-branch scorer (`demand_score + competitor_score`) so zero-GSC `create` opportunities still rank.
+- `canonry content brief` — JSON-canonical structured brief with explicit `evidenceLedger`, `knownFields`, `unknownFields[]` (the load-bearing anti-hallucination guarantee).
+- `canonry content publish-payload` — pure CMS-shaped payload generation (no mutation); pluggable transformers for WordPress, Ghost, Next.js MDX, generic. Other CMSes via transformer payload + agent-executed HTTP.
+- `canonry wordpress create-draft` — the one full CMS mutation (WP only, audit-logged). All other publishing executed by agent with its own credentials.
+- **`content_actions` ledger** — every recommended action becomes a tracked experiment with baseline + lifecycle states (`briefed → payload-generated → published → validated`, plus `dismissed`) + computed outcome (`improved | unchanged | regressed | inconclusive`). Foundation for future per-domain ranker learning.
+- **Drafting deliberately out of scope** for canonry — external agents (Claude Code, Codex, Aero) write the prose from brief + their own URL retrieval.
+**Impact**: Closes the loop from observation → action → measurement. Generates the training data for "did `add-schema` work better than `expand` for this site?" — the foundation for outcome-weighted ranking, no ML required in v1. Most differentiated content surface in the open-source AEO category.
 
 ### Claude Code Skill
 **Gap**: AI agents need a way to interact with Canonry data.
@@ -188,7 +194,7 @@ Project grouping ("workspaces" or "organizations"), cross-project dashboards, te
 | Persona-framed queries | Medium | Very High | **P1** |
 | Site audit / tech readiness | Low-Medium (uses `@ainyc/aeo-audit`) | High | **P2** |
 | Prompt-to-topic clustering | Medium | High | **P2** |
-| Content optimization recs | Medium | Very High | **P2** |
+| **Citation-driven content opportunities + action ledger (lead Wave 0)** | Medium-Large | Very High | **P0** |
 | Anomaly detection alerts | Medium | Medium | **P2** |
 | Claude Code skill | Low-Medium | High | **P2** |
 | Crawl health monitoring | Low (uses `@ainyc/aeo-audit`) | Medium | **P2** |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -23,19 +23,17 @@ Published as `@ainyc/canonry` on npm.
 
 ---
 
-## Competitive Landscape
+## Market Position
 
-Canonry competes with paid AEO monitoring tools:
+Canonry sits in the AEO observability and optimization category. The market today is split across three shapes:
 
-| Tool | Price | Key Differentiator |
-|------|-------|--------------------|
-| Profound | $499+/mo | AEO Content Score, prompt volumes, enterprise SOV |
-| Otterly | $29-989/mo | Daily snapshots, GEO Audit SWOT, per-prompt pricing |
-| Peec | ~99-530+/mo | Looker Studio integration, per-platform add-ons |
-| Scrunch | $250+/mo | Shadow sites for AI optimization, enterprise RBAC |
-| HubSpot AEO Grader | Free | Brand positioning only, no deep tracking |
+| Category | Typical pricing | Typical strengths | Typical limits |
+|---|---|---|---|
+| Hosted paid AEO observability tools | $250–$1000+/mo | AEO content scoring, prompt volumes, enterprise SOV, daily snapshots | Closed source, per-prompt or per-seat pricing, no data ownership, single-perspective queries from cloud DCs |
+| AEO add-ons inside large SEO suites | bundled in SEO seats | BI-tool integration, per-platform add-ons, established UX | Tied to suite pricing/lock-in; AEO is a secondary feature |
+| Free brand-positioning graders | $0 | Awareness / lead-gen entry point | Brand positioning only; no deep tracking |
 
-**Canonry's structural advantages**: open-source, local-first, API-first, config-as-code, no vendor lock-in, no per-prompt pricing, full data ownership.
+**Canonry's structural advantages**: open-source, local-first, API-first, config-as-code, no vendor lock-in, no per-prompt pricing, full data ownership. Where incumbents observe from one cloud perspective, canonry's local-first architecture enables a distributed sensing network capturing localized, audience-specific perspectives (see [ADR 0005](adr/0005-distributed-node-hub-architecture.md)).
 
 ---
 
@@ -44,17 +42,17 @@ Canonry competes with paid AEO monitoring tools:
 These build on existing infrastructure with minimal schema/architecture changes.
 
 ### Citation Position & Prominence Tracking
-**Gap**: Canonry records binary `cited`/`not-cited`. Profound tracks "prominence" (where in the answer your brand appears). Otterly tracks citation ordering.
+**Gap**: Canonry records binary `cited`/`not-cited`. Hosted incumbents track "prominence" (where in the answer your brand appears) and citation ordering.
 **Implementation**: When normalizing provider results, record the *index* of your domain in `groundingSources[]` and whether the domain appears in the first paragraph of `answerText`. Add `citationPosition` (int, nullable) and `prominenceScore` (float 0-1) to `querySnapshots`.
 **Impact**: Transforms flat binary tracking into ranked visibility — "you're cited, but dropping from position 1 to position 4."
 
 ### Share of Voice (SOV) Metrics
-**Gap**: Every competitor (Profound, Otterly, Peec) offers SOV. Canonry doesn't compute it.
+**Gap**: Every paid AEO incumbent offers SOV. Canonry doesn't compute it.
 **Implementation**: SOV = (runs where cited / total runs) as a percentage, computed per keyword and aggregated per project. Pure query-time computation over existing `querySnapshots` data — no schema changes needed. Add `GET /api/v1/projects/:name/sov` endpoint. Show on dashboard as a primary metric gauge.
 **Impact**: The single most-requested AEO metric. Makes Canonry dashboards immediately comparable to paid tools.
 
 ### Sentiment Classification of Mentions
-**Gap**: Profound and Otterly classify mentions as positive/neutral/negative. Canonry stores `answerText` but doesn't analyze tone.
+**Gap**: Hosted incumbents classify mentions as positive/neutral/negative. Canonry stores `answerText` but doesn't analyze tone.
 **Implementation**: Use a cheap model (Haiku/GPT-4o-mini) to classify sentiment of how the domain is mentioned. Add `sentimentTone` ('positive'|'neutral'|'negative') and `sentimentSnippet` (the relevant excerpt) to `querySnapshots`. Run as a post-processing step after the main query.
 **Impact**: Distinguishes "Brand X is the industry leader" from "Brand X has been criticized for..."
 
@@ -64,7 +62,7 @@ These build on existing infrastructure with minimal schema/architecture changes.
 **Impact**: Answers "who's winning the AI answer war for this keyword?"
 
 ### Results CSV/JSON Export
-**Gap**: Otterly highlights CSV export. Canonry's `canonry export` exports config YAML, not results data.
+**Gap**: Some paid incumbents highlight CSV export as a key feature. Canonry's `canonry export` exports config YAML, not results data.
 **Implementation**: Add `canonry export <project> --format csv --include-results` that exports snapshot data as CSV. Add corresponding `GET /api/v1/projects/:name/export?format=csv&include=results` endpoint.
 **Impact**: Enables BI tool integration (Excel, Looker Studio, Tableau) without API coding.
 
@@ -78,22 +76,22 @@ These build on existing infrastructure with minimal schema/architecture changes.
 **Impact**: Completes the "monitor + optimize" loop. Two score families give Canonry a unique dual-lens view.
 
 ### Perplexity Provider
-**Gap**: Profound tracks 5+ engines. Perplexity is the #2 most-requested engine after ChatGPT.
+**Gap**: Paid incumbents track 5+ engines. Perplexity is the #2 most-requested engine after ChatGPT.
 **Implementation**: New `packages/provider-perplexity/` adapter using Perplexity's OpenAI-compatible API with `web_search` focus. Minimal work given existing OpenAI adapter as template.
 **Impact**: Engine coverage from 3 to 4+ puts Canonry ahead of most mid-market tools.
 
 ### Answer Snapshots & Diff Viewer
 **Gap**: No tool shows exactly *how* AI answers changed over time for the same query.
 **Implementation**: Canonry already stores `answerText`. Build a side-by-side diff view in the UI comparing answer text across runs for the same keyword. Highlight added/removed citations and text changes.
-**Impact**: Unique feature — even Profound doesn't show full answer diffs.
+**Impact**: Unique feature — paid incumbents don't show full answer diffs.
 
 ### Prompt-to-Topic Clustering
-**Gap**: Profound offers "prompt-level analytics" grouping queries by topic.
+**Gap**: Hosted incumbents offer "prompt-level analytics" grouping queries by topic.
 **Implementation**: Use an LLM call to cluster keywords into topic groups (e.g., "pricing", "comparison", "how-to"). Store topic assignments in a new `keywordTopics` table. Aggregate SOV and sentiment by topic on the dashboard.
-**Impact**: Analysts think by topic, not keyword-by-keyword. This is how Profound justifies $499/mo.
+**Impact**: Analysts think by topic, not keyword-by-keyword. This is how hosted incumbents justify their high SaaS pricing tiers.
 
 ### Citation-Driven Content Opportunities + Action Outcome Ledger (LEAD WAVE-0 INVESTMENT)
-**Gap**: Profound's "AEO Content Score" is their most differentiated feature. No open-source tool offers an action-typed, deterministic recommendation engine paired with closed-loop outcome tracking.
+**Gap**: An "AEO Content Score" is the most differentiated feature offered by hosted incumbents. No open-source tool offers an action-typed, deterministic recommendation engine paired with closed-loop outcome tracking.
 **Implementation**: See `docs/gtm.md` §3a for the full product spec and `docs/adr/0009-content-action-outcome-ledger-and-publish-boundary.md` for the architectural contract. Canonical artifacts:
 - `canonry content targets` — ranked, action-typed (`create | expand | refresh | add-schema`) opportunity list with deterministic AEO-first classifier and additive two-branch scorer (`demand_score + competitor_score`) so zero-GSC `create` opportunities still rank.
 - `canonry content brief` — JSON-canonical structured brief with explicit `evidenceLedger`, `knownFields`, `unknownFields[]` (the load-bearing anti-hallucination guarantee).
@@ -109,13 +107,13 @@ These build on existing infrastructure with minimal schema/architecture changes.
 **Impact**: AI agents get natural-language access to Canonry through existing surfaces.
 
 ### Crawl Health Monitoring
-**Gap**: Profound tracks AI crawler frequency. Sites that block AI crawlers get worse citations.
+**Gap**: Hosted incumbents track AI crawler frequency. Sites that block AI crawlers get worse citations.
 **Existing asset**: `@ainyc/aeo-audit` already checks per-bot `robots.txt` rules for GPTBot, ClaudeBot, PerplexityBot as its "AI Crawler Access" factor.
 **Implementation**: Run a single-factor audit (`runAeoAudit(url, { factors: ['ai-crawler-access'] })`) or add a dedicated `GET /api/v1/projects/:name/crawl-health` endpoint.
 **Impact**: Answers "can AI engines even access my content?" Near-zero new code thanks to `aeo-audit`.
 
 ### Anomaly Detection & Smart Alerts
-**Gap**: Profound offers "anomaly detection." Current Canonry webhooks fire on every citation change.
+**Gap**: Hosted incumbents offer "anomaly detection." Current Canonry webhooks fire on every citation change.
 **Implementation**: Track rolling SOV averages. Alert only when SOV drops/spikes beyond a configurable threshold. Add alert rules: `citation.anomaly`, `sov.drop`, `sov.spike`.
 **Impact**: Reduces alert noise. Analysts get signal, not every fluctuation.
 


### PR DESCRIPTION
## Summary

Define the **citation-driven blog content opportunity engine** as the lead Wave 0 investment. Design-only — no code changes.

- **`docs/gtm.md` §3a**: full product spec for the engine
  - Action-typed recommendations: `create | expand | refresh | add-schema`
  - **AEO-first** deterministic classifier (citation status checked before SEO rank)
  - **Additive two-branch scorer** (`demand_score + competitor_score`) so zero-GSC `create` opportunities still rank
  - **JSON-canonical brief** with `evidenceLedger`, `knownFields`, `unknownFields[]` (load-bearing anti-hallucination guarantee)
  - **Transformer/adapter publish boundary**: WordPress as one full adapter; Ghost / Next-MDX / generic via pure transformers + agent-executed HTTP
  - **Content Action Outcome Ledger (V1)**: every recommendation becomes a tracked experiment with baseline → state machine → computed outcome. Foundation for future per-domain ranker learning, no ML required in v1.
  - State machine with explicit `draft-created` (WP-only intermediate, distinct from `published`); validation threshold (≥3 eligible runs OR ≥14 days); like-for-like outcome comparison via frozen `baselineObservationSet`
  - Detection vs verification: deterministic confirmation (WP poll, agent-mediated, manual) vs heuristic candidate suggestion (sitemap diff with user confirm); canonry never reads user *or* competitor page bodies
- **`docs/roadmap.md`**: lead Wave-0 entry promoted to **P0**, points at gtm.md and ADR 0009
- **`docs/adr/0009-content-action-outcome-ledger-and-publish-boundary.md`**: durable architectural record covering the three intertwined contracts (generation boundary, transformer/adapter publish boundary, action ledger lifecycle)

## Why

Closes the loop from observation → action → measurement. Most differentiated content surface in the open-source AEO category. Generates the training data for future "did `add-schema` work better than `expand` for this site?" ranking — without ML in v1.

## Process

Result of 5 rounds of reviewer feedback. Each round tightened the contract:

1. JSON-canonical brief, no drafting in canonry, action-not-topic
2. `--target-ref` primary, lifecycle IDs, byte-identical evidence preservation
3. Action Outcome Ledger added (every recommendation tracked end-to-end)
4. Detection-vs-verification distinction (canonry watches; doesn't verify content alignment)
5. State machine precision (`draft-created` ≠ `published`; validation threshold; observation-set scoping; mutation-layer clarification; in-progress action awareness in `targets`)

## Test plan

- [ ] Read `docs/gtm.md` §3a in full — focus on the state-transitions table and Detection-vs-verification subsection
- [ ] Walk the classifier truth table against 5–10 real blog scenarios from your own work
- [ ] Confirm the state machine separates `draft-created` (WP intermediate) from `published` (live to audience)
- [ ] Confirm the validation threshold (≥3 runs OR ≥14 days) is conservative enough for your use of the ledger as training data
- [ ] Confirm the publish boundary feels right for non-WP users (transformer payload + agent-executed HTTP)
- [ ] Skim `docs/adr/0009-...md` — verify the three architectural contracts are captured durably
- [ ] Skim `docs/roadmap.md` — confirm the lead Wave-0 entry aligns with the gtm.md spec

## Follow-up

Implementation will land in a stacked PR on top of this one. PR 1 of the implementation = deterministic read layer (contracts + scorer + 3 routes + 3 CLI commands + 3 Aero read tools, no LLM, no persistence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)