### PR TITLE
feat(bing): add inspect-sitemap to discover and inspect every sitemap URL

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -75,6 +75,7 @@ function formatTrackedRunKind(kind: RunKind): string {
     case RunKinds['inspect-sitemap']: return 'Sitemap inspection'
     case RunKinds['ga-sync']: return 'GA sync'
     case RunKinds['bing-inspect']: return 'Bing URL inspection'
+    case RunKinds['bing-inspect-sitemap']: return 'Bing sitemap inspection'
     case RunKinds['site-audit']: return 'Site audit'
     case RunKinds['backlink-extract']: return 'Backlink extract'
   }

--- a/apps/web/src/build-dashboard.ts
+++ b/apps/web/src/build-dashboard.ts
@@ -79,6 +79,7 @@ function kindLabel(kind: RunKind): string {
     case RunKinds['inspect-sitemap']: return 'Sitemap inspection'
     case RunKinds['ga-sync']: return 'GA sync'
     case RunKinds['bing-inspect']: return 'Bing URL inspection'
+    case RunKinds['bing-inspect-sitemap']: return 'Bing sitemap inspection'
     case RunKinds['site-audit']: return 'Site audit'
     case RunKinds['backlink-extract']: return 'Backlink extract'
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "2.4.6",
+  "version": "2.5.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/bing.ts
+++ b/packages/api-routes/src/bing.ts
@@ -97,6 +97,11 @@ export interface BingConnectionStore {
 
 export interface BingRoutesOptions {
   bingConnectionStore?: BingConnectionStore
+  onInspectSitemapRequested?: (
+    runId: string,
+    projectId: string,
+    opts?: { sitemapUrl?: string },
+  ) => void
 }
 
 export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) {
@@ -536,6 +541,42 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
         .run()
       throw e
     }
+  })
+
+  // POST /projects/:name/bing/inspect-sitemap
+  app.post<{
+    Params: { name: string }
+    Body: { sitemapUrl?: string }
+  }>('/projects/:name/bing/inspect-sitemap', async (request) => {
+    const store = requireConnectionStore()
+
+    const project = resolveProject(app.db, request.params.name)
+    const conn = requireConnection(store, project.canonicalDomain)
+
+    if (!conn.siteUrl) {
+      throw validationError('No Bing site configured. Run "canonry bing set-site <project> <url>" first.')
+    }
+
+    const now = new Date().toISOString()
+    const runId = crypto.randomUUID()
+    app.db.insert(runs).values({
+      id: runId,
+      projectId: project.id,
+      kind: RunKinds['bing-inspect-sitemap'],
+      status: RunStatuses.queued,
+      trigger: RunTriggers.manual,
+      createdAt: now,
+    }).run()
+
+    const { sitemapUrl } = request.body ?? {}
+    if (opts.onInspectSitemapRequested) {
+      opts.onInspectSitemapRequested(runId, project.id, { sitemapUrl: sitemapUrl ?? undefined })
+    } else {
+      bingLog('warn', 'inspect-sitemap.no-callback', { domain: project.canonicalDomain, runId })
+    }
+
+    const run = app.db.select().from(runs).where(eq(runs.id, runId)).get()
+    return run
   })
 
   // POST /projects/:name/bing/request-indexing

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -91,6 +91,7 @@ export interface ApiRoutesOptions {
   /** Bing settings summary for settings endpoint */
   bingSettingsSummary?: SettingsRoutesOptions['bing']
   onBingSettingsUpdate?: SettingsRoutesOptions['onBingUpdate']
+  onBingInspectSitemapRequested?: BingRoutesOptions['onInspectSitemapRequested']
   /** WordPress connection store */
   wordpressConnectionStore?: WordpressRoutesOptions['wordpressConnectionStore']
   /** CDP browser provider callbacks */
@@ -225,6 +226,7 @@ export async function apiRoutes(app: FastifyInstance, opts: ApiRoutesOptions) {
     } satisfies TelemetryRoutesOptions)
     await api.register(bingRoutes, {
       bingConnectionStore: opts.bingConnectionStore,
+      onInspectSitemapRequested: opts.onBingInspectSitemapRequested,
     } satisfies BingRoutesOptions)
     await api.register(googleRoutes, {
       getGoogleAuthConfig: opts.getGoogleAuthConfig,

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -1532,6 +1532,31 @@ const routeCatalog: OpenApiOperation[] = [
   },
   {
     method: 'post',
+    path: '/api/v1/projects/{name}/bing/inspect-sitemap',
+    summary: 'Inspect every URL in a sitemap through Bing Webmaster Tools',
+    tags: ['bing'],
+    parameters: [nameParameter],
+    requestBody: {
+      required: false,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              sitemapUrl: stringSchema,
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: { description: 'Sitemap inspection run queued.' },
+      400: { description: 'Bing is not configured for this project.' },
+      404: { description: 'Project not found.' },
+    },
+  },
+  {
+    method: 'post',
     path: '/api/v1/projects/{name}/bing/request-indexing',
     summary: 'Submit URLs to Bing for indexing',
     tags: ['bing'],

--- a/packages/api-routes/test/bing.test.ts
+++ b/packages/api-routes/test/bing.test.ts
@@ -561,6 +561,89 @@ describe('Bing routes', () => {
     expect(body[2]!.indexed).toBe(5)
   })
 
+  it('inspect-sitemap creates a queued run and invokes the callback with the sitemap URL', async () => {
+    const callback = vi.fn()
+
+    const inspectApp = Fastify()
+    inspectApp.decorate('db', db)
+    inspectApp.register(bingRoutes, {
+      bingConnectionStore: {
+        getConnection: () => connections.get('example.com'),
+        upsertConnection: (c) => { connections.set(c.domain, c); return c },
+        updateConnection: (d, p) => {
+          const e = connections.get(d); if (!e) return undefined
+          const n = { ...e, ...p }; connections.set(d, n); return n
+        },
+        deleteConnection: (d) => connections.delete(d),
+      },
+      onInspectSitemapRequested: callback,
+    })
+    await inspectApp.ready()
+
+    try {
+      const res = await inspectApp.inject({
+        method: 'POST',
+        url: '/projects/test-project/bing/inspect-sitemap',
+        payload: { sitemapUrl: 'https://example.com/custom-sitemap.xml' },
+      })
+
+      expect(res.statusCode).toBe(200)
+      const body = res.json() as { id: string; kind: string; status: string }
+      expect(body.kind).toBe(RunKinds['bing-inspect-sitemap'])
+      expect(body.status).toBe(RunStatuses.queued)
+
+      expect(callback).toHaveBeenCalledTimes(1)
+      const [runIdArg, projectIdArg, optsArg] = callback.mock.calls[0]!
+      expect(runIdArg).toBe(body.id)
+      expect(projectIdArg).toBe(projectId)
+      expect(optsArg).toEqual({ sitemapUrl: 'https://example.com/custom-sitemap.xml' })
+
+      const stored = db.select().from(runs).where(eq(runs.id, body.id)).get()
+      expect(stored?.kind).toBe(RunKinds['bing-inspect-sitemap'])
+      expect(stored?.status).toBe(RunStatuses.queued)
+      expect(stored?.trigger).toBe(RunTriggers.manual)
+    } finally {
+      await inspectApp.close()
+    }
+  })
+
+  it('inspect-sitemap rejects with 400 when no Bing site is configured', async () => {
+    connections.set('example.com', {
+      domain: 'example.com',
+      apiKey: 'test-key',
+      siteUrl: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    })
+
+    const inspectApp = Fastify()
+    inspectApp.decorate('db', db)
+    inspectApp.register(bingRoutes, {
+      bingConnectionStore: {
+        getConnection: () => connections.get('example.com'),
+        upsertConnection: (c) => { connections.set(c.domain, c); return c },
+        updateConnection: (d, p) => {
+          const e = connections.get(d); if (!e) return undefined
+          const n = { ...e, ...p }; connections.set(d, n); return n
+        },
+        deleteConnection: (d) => connections.delete(d),
+      },
+      onInspectSitemapRequested: vi.fn(),
+    })
+    await inspectApp.ready()
+
+    try {
+      const res = await inspectApp.inject({
+        method: 'POST',
+        url: '/projects/test-project/bing/inspect-sitemap',
+        payload: {},
+      })
+      expect(res.statusCode).toBe(400)
+    } finally {
+      await inspectApp.close()
+    }
+  })
+
   it('coverage-history respects limit parameter', async () => {
     const now = new Date().toISOString()
     db.insert(bingCoverageSnapshots).values([

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "2.4.6",
+  "version": "2.5.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/bing-inspect-sitemap.ts
+++ b/packages/canonry/src/bing-inspect-sitemap.ts
@@ -1,0 +1,259 @@
+import crypto from 'node:crypto'
+import { eq, desc } from 'drizzle-orm'
+import type { DatabaseClient } from '@ainyc/canonry-db'
+import { runs, projects, bingUrlInspections, bingCoverageSnapshots } from '@ainyc/canonry-db'
+import { RunStatuses } from '@ainyc/canonry-contracts'
+import { getUrlInfo, getCrawlIssues } from '@ainyc/canonry-integration-bing'
+import type { CanonryConfig } from './config.js'
+import { fetchAndParseSitemap } from './sitemap-parser.js'
+import { createLogger } from './logger.js'
+
+const log = createLogger('BingInspectSitemap')
+
+interface BingInspectSitemapOptions {
+  sitemapUrl?: string
+  config: CanonryConfig
+}
+
+function parseBingDate(value: string | undefined | null): string | null {
+  if (!value) return null
+  const match = /\/Date\((-?\d+)[^)]*\)\//.exec(value)
+  if (!match) return null
+  const ms = parseInt(match[1]!, 10)
+  if (ms <= 0) return null
+  return new Date(ms).toISOString()
+}
+
+function isBlockingIssueType(issueType: string | null | undefined): boolean {
+  if (!issueType) return true
+  const trimmed = issueType.trim()
+  if (!trimmed) return true
+  return trimmed.split(/\s+/).some((flag) => !/^(None|Seo(Issues|Concerns))$/i.test(flag))
+}
+
+export async function executeBingInspectSitemap(
+  db: DatabaseClient,
+  runId: string,
+  projectId: string,
+  opts: BingInspectSitemapOptions,
+): Promise<void> {
+  const startedAt = new Date().toISOString()
+  db.update(runs).set({ status: RunStatuses.running, startedAt }).where(eq(runs.id, runId)).run()
+
+  try {
+    const project = db.select().from(projects).where(eq(projects.id, projectId)).get()
+    if (!project) {
+      throw new Error(`Project not found: ${projectId}`)
+    }
+
+    const conn = opts.config.bing?.connections?.find((c) => c.domain === project.canonicalDomain)
+    if (!conn) {
+      throw new Error('No Bing connection found for this project. Run "canonry bing connect <project>" first.')
+    }
+    if (!conn.siteUrl) {
+      throw new Error('No Bing site configured. Run "canonry bing set-site <project> <url>" first.')
+    }
+
+    const sitemapUrl = opts.sitemapUrl ?? `https://${project.canonicalDomain}/sitemap.xml`
+    log.info('sitemap.fetch', { runId, projectId, sitemapUrl })
+
+    const sitemapUrls = await fetchAndParseSitemap(sitemapUrl)
+    log.info('sitemap.parsed', { runId, projectId, urlCount: sitemapUrls.length, sitemapUrl })
+
+    if (sitemapUrls.length === 0) {
+      throw new Error('No URLs found in sitemap')
+    }
+
+    // Diff vs already-tracked URLs so the log clearly distinguishes new
+    // discoveries from re-inspections of the existing tracked set.
+    const trackedRows = db
+      .select({ url: bingUrlInspections.url })
+      .from(bingUrlInspections)
+      .where(eq(bingUrlInspections.projectId, projectId))
+      .all()
+    const trackedUrls = new Set(trackedRows.map((r) => r.url))
+    const discovered = sitemapUrls.filter((u) => !trackedUrls.has(u))
+    log.info('sitemap.diff', {
+      runId,
+      projectId,
+      sitemapTotal: sitemapUrls.length,
+      alreadyTracked: sitemapUrls.length - discovered.length,
+      newlyDiscovered: discovered.length,
+    })
+
+    // Fetch the blocking-crawl-issues set once so each URL's derivation can
+    // honor it without N extra HTTP calls. Failure here must not block the
+    // whole inspection — fall back to "no blocked URLs".
+    let blockedUrls = new Set<string>()
+    try {
+      const issues = await getCrawlIssues(conn.apiKey, conn.siteUrl)
+      for (const issue of issues) {
+        if (issue.Url && isBlockingIssueType(issue.IssueType ?? null)) {
+          blockedUrls.add(issue.Url)
+        }
+      }
+      log.info('crawl-issues.loaded', { runId, projectId, blockedCount: blockedUrls.size })
+    } catch (err) {
+      log.warn('crawl-issues.lookup-failed', {
+        runId,
+        projectId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+      blockedUrls = new Set()
+    }
+
+    let inspected = 0
+    let errors = 0
+
+    for (const pageUrl of sitemapUrls) {
+      try {
+        const result = await getUrlInfo(conn.apiKey, conn.siteUrl, pageUrl)
+        const inspectedAt = new Date().toISOString()
+        const httpCode = result.HttpStatus ?? result.HttpCode ?? null
+        const lastCrawledDate = parseBingDate(result.LastCrawledDate)
+        const inIndexDate = parseBingDate(result.InIndexDate)
+        const discoveryDate = parseBingDate(result.DiscoveryDate)
+
+        // Mirrors the derivation in packages/api-routes/src/bing.ts inspect-url:
+        // GetUrlInfo no longer ships an InIndex flag, so DocumentSize and a
+        // recent successful crawl are the positive signals.
+        let derivedInIndex: boolean | null = null
+        if (result.DocumentSize != null && result.DocumentSize > 0) {
+          derivedInIndex = true
+        } else if (lastCrawledDate != null) {
+          derivedInIndex = httpCode != null && httpCode >= 400 ? false : true
+        } else if (discoveryDate != null) {
+          derivedInIndex = false
+        }
+        if (derivedInIndex === true && blockedUrls.has(pageUrl)) {
+          derivedInIndex = false
+        }
+
+        db.insert(bingUrlInspections).values({
+          id: crypto.randomUUID(),
+          projectId,
+          url: pageUrl,
+          httpCode,
+          inIndex: derivedInIndex === true ? 1 : derivedInIndex === false ? 0 : null,
+          lastCrawledDate,
+          inIndexDate,
+          inspectedAt,
+          syncRunId: runId,
+          createdAt: inspectedAt,
+          documentSize: result.DocumentSize ?? null,
+          anchorCount: result.AnchorCount ?? null,
+          discoveryDate,
+        }).run()
+
+        inspected++
+        log.info('inspect.url-done', {
+          runId,
+          projectId,
+          url: pageUrl,
+          progress: `${inspected}/${sitemapUrls.length}`,
+        })
+      } catch (err) {
+        errors++
+        log.error('inspect.url-failed', {
+          runId,
+          projectId,
+          url: pageUrl,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+
+      // Rate limit: keep below Bing's per-key throughput so a large sitemap
+      // doesn't trip the 429 ceiling on GetUrlInfo.
+      if (inspected + errors < sitemapUrls.length) {
+        await new Promise((r) => setTimeout(r, 1000))
+      }
+    }
+
+    // Coverage snapshot — pick the latest definitive (non-null) inspection per
+    // URL across all history, mirroring the GET /bing/coverage logic so the
+    // snapshot row matches what users see in the dashboard.
+    const allInspections = db
+      .select()
+      .from(bingUrlInspections)
+      .where(eq(bingUrlInspections.projectId, projectId))
+      .orderBy(desc(bingUrlInspections.inspectedAt))
+      .all()
+
+    const latestByUrl = new Map<string, typeof allInspections[number]>()
+    const definitiveByUrl = new Map<string, typeof allInspections[number]>()
+    for (const row of allInspections) {
+      if (!latestByUrl.has(row.url)) latestByUrl.set(row.url, row)
+      if (!definitiveByUrl.has(row.url) && row.inIndex != null) definitiveByUrl.set(row.url, row)
+    }
+    for (const [url, latest] of latestByUrl) {
+      if (latest.inIndex == null) {
+        const def = definitiveByUrl.get(url)
+        if (def) latestByUrl.set(url, def)
+      }
+    }
+
+    let snapIndexed = 0
+    let snapNotIndexed = 0
+    let snapUnknown = 0
+    for (const [, row] of latestByUrl) {
+      if (row.inIndex === 1) snapIndexed++
+      else if (row.inIndex === 0) snapNotIndexed++
+      else snapUnknown++
+    }
+
+    const snapshotDate = new Date().toISOString().split('T')[0]!
+    const snapNow = new Date().toISOString()
+    db.insert(bingCoverageSnapshots).values({
+      id: crypto.randomUUID(),
+      projectId,
+      syncRunId: runId,
+      date: snapshotDate,
+      indexed: snapIndexed,
+      notIndexed: snapNotIndexed,
+      unknown: snapUnknown,
+      createdAt: snapNow,
+    }).onConflictDoUpdate({
+      target: [bingCoverageSnapshots.projectId, bingCoverageSnapshots.date],
+      set: {
+        indexed: snapIndexed,
+        notIndexed: snapNotIndexed,
+        unknown: snapUnknown,
+        createdAt: snapNow,
+        syncRunId: runId,
+      },
+    }).run()
+
+    const status: typeof RunStatuses[keyof typeof RunStatuses] =
+      errors === sitemapUrls.length
+        ? RunStatuses.failed
+        : errors > 0
+          ? RunStatuses.partial
+          : RunStatuses.completed
+
+    db.update(runs)
+      .set({ status, finishedAt: new Date().toISOString() })
+      .where(eq(runs.id, runId))
+      .run()
+
+    log.info('inspect.completed', {
+      runId,
+      projectId,
+      inspected,
+      errors,
+      total: sitemapUrls.length,
+      newlyDiscovered: discovered.length,
+      indexed: snapIndexed,
+      notIndexed: snapNotIndexed,
+      unknown: snapUnknown,
+    })
+  } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : String(err)
+    db.update(runs)
+      .set({ status: RunStatuses.failed, error: errorMsg, finishedAt: new Date().toISOString() })
+      .where(eq(runs.id, runId))
+      .run()
+
+    log.error('inspect.failed', { runId, projectId, error: errorMsg })
+    throw err
+  }
+}

--- a/packages/canonry/src/cli-commands/bing.ts
+++ b/packages/canonry/src/cli-commands/bing.ts
@@ -4,6 +4,7 @@ import {
   bingCoverageHistory,
   bingDisconnect,
   bingInspect,
+  bingInspectSitemap,
   bingInspections,
   bingPerformance,
   bingRefresh,
@@ -120,6 +121,22 @@ export const BING_CLI_COMMANDS: readonly CliCommandSpec[] = [
     },
   },
   {
+    path: ['bing', 'inspect-sitemap'],
+    usage: 'canonry bing inspect-sitemap <project> [--sitemap-url <url>] [--wait] [--format json]',
+    options: {
+      'sitemap-url': stringOption(),
+      wait: { type: 'boolean', default: false },
+    },
+    run: async (input) => {
+      const project = requireProject(input, 'bing.inspect-sitemap', 'canonry bing inspect-sitemap <project> [--sitemap-url <url>] [--wait] [--format json]')
+      await bingInspectSitemap(project, {
+        sitemapUrl: getString(input.values, 'sitemap-url'),
+        wait: getBoolean(input.values, 'wait'),
+        format: input.format,
+      })
+    },
+  },
+  {
     path: ['bing', 'request-indexing'],
     usage: 'canonry bing request-indexing <project> [url] [--all-unindexed] [--format json]',
     options: {
@@ -163,12 +180,12 @@ export const BING_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['bing'],
-    usage: 'canonry bing <connect|disconnect|status|sites|set-site|coverage|coverage-history|inspect|inspections|request-indexing|performance|refresh> <project> [args]',
+    usage: 'canonry bing <connect|disconnect|status|sites|set-site|coverage|coverage-history|inspect|inspect-sitemap|inspections|request-indexing|performance|refresh> <project> [args]',
     run: async (input) => {
       unknownSubcommand(input.positionals[0], {
         command: 'bing',
-        usage: 'canonry bing <connect|disconnect|status|sites|set-site|coverage|coverage-history|inspect|inspections|request-indexing|performance|refresh> <project> [args]',
-        available: ['connect', 'disconnect', 'status', 'sites', 'set-site', 'coverage', 'coverage-history', 'inspect', 'inspections', 'request-indexing', 'performance', 'refresh'],
+        usage: 'canonry bing <connect|disconnect|status|sites|set-site|coverage|coverage-history|inspect|inspect-sitemap|inspections|request-indexing|performance|refresh> <project> [args]',
+        available: ['connect', 'disconnect', 'status', 'sites', 'set-site', 'coverage', 'coverage-history', 'inspect', 'inspect-sitemap', 'inspections', 'request-indexing', 'performance', 'refresh'],
       })
     },
   },

--- a/packages/canonry/src/client.ts
+++ b/packages/canonry/src/client.ts
@@ -653,6 +653,10 @@ export class ApiClient {
     return this.request<object>('POST', `/projects/${encodeURIComponent(project)}/bing/inspect-url`, { url })
   }
 
+  async bingInspectSitemap(project: string, body?: { sitemapUrl?: string }): Promise<object> {
+    return this.request<object>('POST', `/projects/${encodeURIComponent(project)}/bing/inspect-sitemap`, body ?? {})
+  }
+
   async bingRequestIndexing(project: string, body: { urls?: string[]; allUnindexed?: boolean }): Promise<object> {
     return this.request<object>('POST', `/projects/${encodeURIComponent(project)}/bing/request-indexing`, body)
   }

--- a/packages/canonry/src/commands/bing.ts
+++ b/packages/canonry/src/commands/bing.ts
@@ -1,8 +1,58 @@
-import { createApiClient } from '../client.js'
+import type { RunDetailDto } from '@ainyc/canonry-contracts'
+import { type ApiClient, createApiClient } from '../client.js'
 import { CliError } from '../cli-error.js'
 
 function getClient() {
   return createApiClient()
+}
+
+async function waitForRunStatus(
+  client: ApiClient,
+  runId: string,
+  config: {
+    timeoutMs: number
+    intervalMs: number
+    progressLabel: string
+    successStatuses: string[]
+    failureStatuses: string[]
+    timeoutCode: string
+    failureCode: string
+    timeoutMessage: string
+    failureMessage: string
+    details?: Record<string, unknown>
+  },
+): Promise<RunDetailDto> {
+  const start = Date.now()
+  process.stderr.write(config.progressLabel)
+
+  while (Date.now() - start < config.timeoutMs) {
+    await new Promise((resolve) => setTimeout(resolve, config.intervalMs))
+    const current = await client.getRun(runId)
+    process.stderr.write('.')
+
+    if (config.successStatuses.includes(current.status)) {
+      process.stderr.write('\n')
+      return current
+    }
+
+    if (config.failureStatuses.includes(current.status)) {
+      process.stderr.write('\n')
+      throw new CliError({
+        code: config.failureCode,
+        message: config.failureMessage,
+        displayMessage: config.failureMessage,
+        details: { runId, status: current.status, ...(config.details ?? {}) },
+      })
+    }
+  }
+
+  process.stderr.write('\n')
+  throw new CliError({
+    code: config.timeoutCode,
+    message: config.timeoutMessage,
+    displayMessage: config.timeoutMessage,
+    details: { runId, ...(config.details ?? {}) },
+  })
 }
 
 export async function bingConnect(project: string, opts?: { apiKey?: string; format?: string }): Promise<void> {
@@ -372,6 +422,53 @@ export async function bingRequestIndexing(project: string, opts: {
 
   if (result.results.length > 1) {
     console.log(`Summary: ${result.summary.succeeded} succeeded, ${result.summary.failed} failed (${result.summary.total} total)`)
+  }
+}
+
+export async function bingInspectSitemap(project: string, opts: {
+  sitemapUrl?: string
+  wait?: boolean
+  format?: string
+}): Promise<void> {
+  const client = getClient()
+  const run = await client.bingInspectSitemap(project, {
+    sitemapUrl: opts.sitemapUrl,
+  }) as { id: string; status: string; kind: string }
+
+  if (!opts.wait && opts.format === 'json') {
+    console.log(JSON.stringify(run, null, 2))
+    return
+  }
+
+  if (opts.format !== 'json') {
+    console.log(`Bing sitemap inspection started (run ${run.id})`)
+  }
+
+  if (opts.wait) {
+    const current = await waitForRunStatus(client, run.id, {
+      timeoutMs: 30 * 60 * 1000,
+      intervalMs: 3000,
+      progressLabel: 'Waiting for Bing sitemap inspection to complete',
+      successStatuses: ['completed', 'partial'],
+      failureStatuses: ['failed'],
+      timeoutCode: 'BING_INSPECT_SITEMAP_TIMEOUT',
+      failureCode: 'BING_INSPECT_SITEMAP_FAILED',
+      timeoutMessage: 'Timed out waiting for Bing sitemap inspection to complete.',
+      failureMessage: 'Bing sitemap inspection failed.',
+      details: { project },
+    })
+
+    if (opts.format === 'json') {
+      console.log(JSON.stringify(current, null, 2))
+      return
+    }
+
+    if (current.status === 'partial') {
+      console.log('Bing sitemap inspection completed with some errors.')
+      return
+    }
+
+    console.log('Bing sitemap inspection completed successfully.')
   }
 }
 

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -45,6 +45,7 @@ import { isTelemetryEnabled, getOrCreateAnonymousId } from './telemetry.js'
 import { JobRunner } from './job-runner.js'
 import { executeGscSync } from './gsc-sync.js'
 import { executeInspectSitemap } from './gsc-inspect-sitemap.js'
+import { executeBingInspectSitemap } from './bing-inspect-sitemap.js'
 import { executeReleaseSync } from './commoncrawl-sync.js'
 import { executeBacklinkExtract } from './backlink-extract.js'
 import {
@@ -883,6 +884,14 @@ export async function createServer(opts: {
     googleSettingsSummary,
     bingSettingsSummary,
     bingConnectionStore,
+    onBingInspectSitemapRequested: (runId: string, projectId: string, inspectOpts?: { sitemapUrl?: string }) => {
+      executeBingInspectSitemap(opts.db, runId, projectId, {
+        ...inspectOpts,
+        config: opts.config,
+      }).catch((err: unknown) => {
+        app.log.error({ runId, err }, 'Bing inspect sitemap failed')
+      })
+    },
     wordpressConnectionStore,
     ga4CredentialStore,
     onRunCreated: (runId: string, projectId: string, providers?: string[], location?: import('@ainyc/canonry-contracts').LocationContext | null) => {

--- a/packages/canonry/test/bing-inspect-sitemap.test.ts
+++ b/packages/canonry/test/bing-inspect-sitemap.test.ts
@@ -1,0 +1,307 @@
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import http from 'node:http'
+import os from 'node:os'
+import path from 'node:path'
+import { eq } from 'drizzle-orm'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RunKinds, RunStatuses, RunTriggers } from '@ainyc/canonry-contracts'
+import { bingCoverageSnapshots, bingUrlInspections, createClient, migrate, projects, runs } from '@ainyc/canonry-db'
+import { executeBingInspectSitemap } from '../src/bing-inspect-sitemap.js'
+import type { CanonryConfig } from '../src/config.js'
+
+function startSitemapServer(routes: Record<string, string | undefined>): Promise<{ server: http.Server; baseUrl: string }> {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      const body = routes[req.url ?? '/']
+      if (body == null) {
+        res.writeHead(404)
+        res.end('Not found')
+        return
+      }
+      res.writeHead(200, { 'Content-Type': 'application/xml' })
+      res.end(body)
+    })
+    server.listen(0, () => {
+      const addr = server.address()
+      const port = typeof addr === 'object' && addr ? addr.port : 0
+      resolve({ server, baseUrl: `http://localhost:${port}` })
+    })
+  })
+}
+
+function buildConfig(domain: string): CanonryConfig {
+  return {
+    apiUrl: 'http://localhost:4100',
+    database: '/tmp/test.db',
+    apiKey: 'cnry_test',
+    bing: {
+      connections: [
+        {
+          domain,
+          apiKey: 'bing-test-key',
+          siteUrl: `https://${domain}/`,
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      ],
+    },
+  }
+}
+
+describe('executeBingInspectSitemap', () => {
+  let tmpDir: string
+  let db: ReturnType<typeof createClient>
+  let projectId: string
+  let server: http.Server | null = null
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bing-inspect-sitemap-test-'))
+    db = createClient(path.join(tmpDir, 'test.db'))
+    migrate(db)
+
+    projectId = crypto.randomUUID()
+    const now = new Date().toISOString()
+    db.insert(projects).values({
+      id: projectId,
+      name: 'azcoatings',
+      displayName: 'AZ Coatings',
+      canonicalDomain: 'azcoatingsllc.com',
+      ownedDomains: '[]',
+      country: 'US',
+      language: 'en',
+      tags: '[]',
+      labels: '{}',
+      providers: '[]',
+      locations: '[]',
+      defaultLocation: null,
+      configSource: 'cli',
+      configRevision: 1,
+      createdAt: now,
+      updatedAt: now,
+    }).run()
+  })
+
+  afterAll(async () => {
+    vi.restoreAllMocks()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  beforeEach(async () => {
+    db.delete(bingUrlInspections).run()
+    db.delete(bingCoverageSnapshots).run()
+    db.delete(runs).run()
+
+    const bingModule = await import('@ainyc/canonry-integration-bing')
+    vi.spyOn(bingModule, 'getCrawlIssues').mockResolvedValue([])
+  })
+
+  afterEach(() => {
+    if (server) {
+      server.close()
+      server = null
+    }
+    vi.restoreAllMocks()
+  })
+
+  async function queueRun(): Promise<string> {
+    const runId = crypto.randomUUID()
+    const now = new Date().toISOString()
+    db.insert(runs).values({
+      id: runId,
+      projectId,
+      kind: RunKinds['bing-inspect-sitemap'],
+      status: RunStatuses.queued,
+      trigger: RunTriggers.manual,
+      createdAt: now,
+    }).run()
+    return runId
+  }
+
+  it('discovers sitemap URLs missing from the tracked set, inspects each, and writes a coverage snapshot', async () => {
+    // Seed: only 2 of the 4 sitemap URLs are tracked (issue #352 scenario —
+    // newer sitemap URLs were silently absent from Bing tracking).
+    const seededAt = '2026-04-20T10:00:00Z'
+    db.insert(bingUrlInspections).values([
+      {
+        id: crypto.randomUUID(), projectId,
+        url: 'https://azcoatingsllc.com/',
+        httpCode: 200, inIndex: 1,
+        lastCrawledDate: '2026-04-19T10:00:00Z', inIndexDate: null,
+        inspectedAt: seededAt, syncRunId: null, createdAt: seededAt,
+        documentSize: 5000, anchorCount: null, discoveryDate: null,
+      },
+      {
+        id: crypto.randomUUID(), projectId,
+        url: 'https://azcoatingsllc.com/about/',
+        httpCode: 200, inIndex: 1,
+        lastCrawledDate: '2026-04-19T10:00:00Z', inIndexDate: null,
+        inspectedAt: seededAt, syncRunId: null, createdAt: seededAt,
+        documentSize: 3000, anchorCount: null, discoveryDate: null,
+      },
+    ]).run()
+
+    const sitemapXml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://azcoatingsllc.com/</loc></url>
+  <url><loc>https://azcoatingsllc.com/about/</loc></url>
+  <url><loc>https://azcoatingsllc.com/michigan/</loc></url>
+  <url><loc>https://azcoatingsllc.com/southeast-florida/</loc></url>
+</urlset>`
+    const s = await startSitemapServer({ '/sitemap.xml': sitemapXml })
+    server = s.server
+
+    const bingModule = await import('@ainyc/canonry-integration-bing')
+    const lastCrawledMs = new Date('2026-04-25T10:00:00Z').getTime()
+    vi.spyOn(bingModule, 'getUrlInfo').mockImplementation(async (_apiKey, _site, url) => ({
+      Url: url,
+      HttpStatus: 200,
+      DocumentSize: 4096,
+      LastCrawledDate: `/Date(${lastCrawledMs})/`,
+    }))
+
+    const runId = await queueRun()
+    await executeBingInspectSitemap(db, runId, projectId, {
+      sitemapUrl: `${s.baseUrl}/sitemap.xml`,
+      config: buildConfig('azcoatingsllc.com'),
+    })
+
+    const run = db.select().from(runs).where(eq(runs.id, runId)).get()
+    expect(run?.status).toBe(RunStatuses.completed)
+    expect(run?.startedAt).toBeTruthy()
+    expect(run?.finishedAt).toBeTruthy()
+
+    // 4 fresh inspections from this run on top of the 2 seed rows
+    const newInspections = db.select().from(bingUrlInspections)
+      .where(eq(bingUrlInspections.syncRunId, runId)).all()
+    expect(newInspections).toHaveLength(4)
+    const newUrls = newInspections.map((r) => r.url).sort()
+    expect(newUrls).toEqual([
+      'https://azcoatingsllc.com/',
+      'https://azcoatingsllc.com/about/',
+      'https://azcoatingsllc.com/michigan/',
+      'https://azcoatingsllc.com/southeast-florida/',
+    ])
+    // Newly discovered URLs are now tracked + indexed
+    for (const row of newInspections) {
+      expect(row.inIndex).toBe(1)
+    }
+
+    // Coverage snapshot covers the full discovered set, not just the originally
+    // tracked subset — this is the bug fix.
+    const snapshots = db.select().from(bingCoverageSnapshots)
+      .where(eq(bingCoverageSnapshots.projectId, projectId)).all()
+    expect(snapshots).toHaveLength(1)
+    expect(snapshots[0]!.indexed).toBe(4)
+    expect(snapshots[0]!.notIndexed).toBe(0)
+    expect(snapshots[0]!.unknown).toBe(0)
+    expect(snapshots[0]!.syncRunId).toBe(runId)
+  })
+
+  it('marks the run partial when some URLs fail to inspect', async () => {
+    const sitemapXml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset>
+  <url><loc>https://azcoatingsllc.com/ok</loc></url>
+  <url><loc>https://azcoatingsllc.com/fail</loc></url>
+</urlset>`
+    const s = await startSitemapServer({ '/sitemap.xml': sitemapXml })
+    server = s.server
+
+    const bingModule = await import('@ainyc/canonry-integration-bing')
+    vi.spyOn(bingModule, 'getUrlInfo').mockImplementation(async (_apiKey, _site, url) => {
+      if (url.endsWith('/fail')) throw new Error('Bing API error')
+      return { Url: url, HttpStatus: 200, DocumentSize: 1000 }
+    })
+
+    const runId = await queueRun()
+    await executeBingInspectSitemap(db, runId, projectId, {
+      sitemapUrl: `${s.baseUrl}/sitemap.xml`,
+      config: buildConfig('azcoatingsllc.com'),
+    })
+
+    const run = db.select().from(runs).where(eq(runs.id, runId)).get()
+    expect(run?.status).toBe(RunStatuses.partial)
+
+    const inspections = db.select().from(bingUrlInspections)
+      .where(eq(bingUrlInspections.syncRunId, runId)).all()
+    expect(inspections).toHaveLength(1)
+    expect(inspections[0]!.url).toBe('https://azcoatingsllc.com/ok')
+  })
+
+  it('marks the run failed when sitemap is empty', async () => {
+    const sitemapXml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>`
+    const s = await startSitemapServer({ '/sitemap.xml': sitemapXml })
+    server = s.server
+
+    const runId = await queueRun()
+    await expect(() => executeBingInspectSitemap(db, runId, projectId, {
+      sitemapUrl: `${s.baseUrl}/sitemap.xml`,
+      config: buildConfig('azcoatingsllc.com'),
+    })).rejects.toThrow('No URLs found in sitemap')
+
+    const run = db.select().from(runs).where(eq(runs.id, runId)).get()
+    expect(run?.status).toBe(RunStatuses.failed)
+    expect(run?.error).toContain('No URLs found in sitemap')
+  })
+
+  it('marks the run failed when no Bing connection exists for the project', async () => {
+    const runId = await queueRun()
+    await expect(() => executeBingInspectSitemap(db, runId, projectId, {
+      sitemapUrl: 'https://azcoatingsllc.com/sitemap.xml',
+      config: { apiUrl: 'http://localhost:4100', database: '/tmp/x', apiKey: 'cnry_test' },
+    })).rejects.toThrow('No Bing connection')
+
+    const run = db.select().from(runs).where(eq(runs.id, runId)).get()
+    expect(run?.status).toBe(RunStatuses.failed)
+  })
+
+  it('marks the run failed when the Bing connection has no siteUrl', async () => {
+    const runId = await queueRun()
+    const noSite: CanonryConfig = {
+      apiUrl: 'http://localhost:4100', database: '/tmp/x', apiKey: 'cnry_test',
+      bing: { connections: [{
+        domain: 'azcoatingsllc.com', apiKey: 'k', siteUrl: null,
+        createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z',
+      }] },
+    }
+    await expect(() => executeBingInspectSitemap(db, runId, projectId, {
+      sitemapUrl: 'https://azcoatingsllc.com/sitemap.xml',
+      config: noSite,
+    })).rejects.toThrow('No Bing site configured')
+
+    const run = db.select().from(runs).where(eq(runs.id, runId)).get()
+    expect(run?.status).toBe(RunStatuses.failed)
+  })
+
+  it('downgrades indexed URLs that GetCrawlIssues flags with a blocking issue', async () => {
+    const sitemapXml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset>
+  <url><loc>https://azcoatingsllc.com/blocked</loc></url>
+  <url><loc>https://azcoatingsllc.com/ok</loc></url>
+</urlset>`
+    const s = await startSitemapServer({ '/sitemap.xml': sitemapXml })
+    server = s.server
+
+    const bingModule = await import('@ainyc/canonry-integration-bing')
+    vi.spyOn(bingModule, 'getUrlInfo').mockImplementation(async (_apiKey, _site, url) => ({
+      Url: url, HttpStatus: 200, DocumentSize: 1234,
+    }))
+    vi.spyOn(bingModule, 'getCrawlIssues').mockResolvedValue([
+      { Url: 'https://azcoatingsllc.com/blocked', HttpCode: 403, Date: '2026-04-25', IssueType: 'BlockedByRobotsTxt' },
+    ])
+
+    const runId = await queueRun()
+    await executeBingInspectSitemap(db, runId, projectId, {
+      sitemapUrl: `${s.baseUrl}/sitemap.xml`,
+      config: buildConfig('azcoatingsllc.com'),
+    })
+
+    const inspections = db.select().from(bingUrlInspections)
+      .where(eq(bingUrlInspections.syncRunId, runId)).all()
+    const blocked = inspections.find((r) => r.url.endsWith('/blocked'))
+    const ok = inspections.find((r) => r.url.endsWith('/ok'))
+    expect(blocked?.inIndex).toBe(0)
+    expect(ok?.inIndex).toBe(1)
+  })
+})

--- a/packages/contracts/src/run.ts
+++ b/packages/contracts/src/run.ts
@@ -12,6 +12,7 @@ export const runKindSchema = z.enum([
   'inspect-sitemap',
   'ga-sync',
   'bing-inspect',
+  'bing-inspect-sitemap',
   'backlink-extract',
 ])
 export type RunKind = z.infer<typeof runKindSchema>

--- a/skills/canonry-setup/references/canonry-cli.md
+++ b/skills/canonry-setup/references/canonry-cli.md
@@ -216,6 +216,8 @@ canonry bing set-site <project> <url>            # set active site URL
 canonry bing coverage <project>                  # URL coverage data
 canonry bing refresh <project>                  # force-fetch fresh Bing coverage data
 canonry bing inspect <project> <url>             # inspect specific URL
+canonry bing inspect-sitemap <project>           # discover sitemap URLs and inspect each via Bing
+canonry bing inspect-sitemap <project> --sitemap-url <url> --wait  # explicit sitemap, wait for run
 canonry bing inspections <project>               # inspection history
 canonry bing request-indexing <project> <url>    # submit URL for indexing
 canonry bing request-indexing <project> --all-unindexed  # submit all unindexed

--- a/skills/canonry-setup/references/indexing.md
+++ b/skills/canonry-setup/references/indexing.md
@@ -90,6 +90,14 @@ canonry bing inspect <project> <url>
 canonry bing inspections <project>
 ```
 
+### Inspect every URL in your sitemap
+```bash
+canonry bing inspect-sitemap <project>                       # default https://<domain>/sitemap.xml
+canonry bing inspect-sitemap <project> --sitemap-url <url>   # explicit sitemap or sitemap index
+canonry bing inspect-sitemap <project> --wait                # block until the run finishes
+```
+Bing has no native sitemap inspection API — this command fetches the sitemap, diffs against the tracked URL set, then calls `GetUrlInfo` for each discovered URL so coverage reflects the full sitemap rather than only previously inspected pages.
+
 ### Submit URLs for indexing
 ```bash
 canonry bing request-indexing <project> <url>


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/projects/:name/bing/inspect-sitemap` and `canonry bing inspect-sitemap` (with `--sitemap-url`, `--wait`, `--format json`) to fetch the project's sitemap, diff against tracked URLs, and call `GetUrlInfo` for each so Bing coverage reflects the full sitemap rather than only previously inspected pages.
- Cross-references `GetCrawlIssues` once per run to downgrade URLs Bing flagged with blocking issues (robots/HTTP/DNS/malware/noindex), mirroring the derivation in the existing `inspect-url` route.
- Writes a coverage snapshot per run using the same "latest definitive inspection per URL" rollup as `GET /bing/coverage`, upserting on `(projectId, date)`.
- New `bing-inspect-sitemap` `RunKind` plumbed through contracts, API, CLI, server callback, dashboard run-kind labels, OpenAPI, and skill docs; bumps to `2.5.0`.

## Test plan

- [ ] `pnpm typecheck && pnpm test && pnpm lint`
- [ ] `canonry bing inspect-sitemap <project> --wait` against a real Bing-connected project
- [ ] Verify coverage snapshot count matches the sitemap on a project that previously had only a subset tracked (issue #352 scenario)
- [ ] Verify a URL flagged by `GetCrawlIssues` lands as `inIndex=0`