### PR TITLE
fix(sitemap): gzip support, child resilience, and visited dedup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "2.5.0",
+  "version": "2.5.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/sitemap-parser.ts
+++ b/packages/canonry/src/sitemap-parser.ts
@@ -1,3 +1,7 @@
+import { createLogger } from './logger.js'
+
+const log = createLogger('SitemapParser')
+
 const LOC_REGEX = /<loc>\s*([^<]+?)\s*<\/loc>/gi
 const SITEMAP_TAG_REGEX = /<sitemap>[\s\S]*?<\/sitemap>/gi
 
@@ -27,23 +31,75 @@ function validateSitemapUrl(url: string): void {
   }
 }
 
+// Read a sitemap response body, transparently decompressing if the payload is
+// gzipped. Detects gzip via the magic header bytes (0x1f 0x8b) rather than
+// trusting the URL extension or Content-Encoding header — Node's fetch already
+// auto-decompresses transport-level gzip, but static `.xml.gz` files served
+// without `Content-Encoding: gzip` reach us as raw deflate bytes.
+async function readSitemapBody(res: Response): Promise<string> {
+  const buf = await res.arrayBuffer()
+  const bytes = new Uint8Array(buf)
+  const isGzipped = bytes.length >= 2 && bytes[0] === 0x1f && bytes[1] === 0x8b
+  if (!isGzipped) {
+    return new TextDecoder().decode(bytes)
+  }
+  const decompressed = new Blob([buf]).stream().pipeThrough(new DecompressionStream('gzip'))
+  return new Response(decompressed).text()
+}
+
 export async function fetchAndParseSitemap(sitemapUrl: string): Promise<string[]> {
   const urls = new Set<string>()
-  await parseSitemapRecursive(sitemapUrl, urls, 0)
+  const visited = new Set<string>()
+  await parseSitemapRecursive(sitemapUrl, urls, visited, 0, /* isChild */ false)
   return [...urls]
 }
 
-async function parseSitemapRecursive(url: string, urls: Set<string>, depth: number): Promise<void> {
+async function parseSitemapRecursive(
+  url: string,
+  urls: Set<string>,
+  visited: Set<string>,
+  depth: number,
+  isChild: boolean,
+): Promise<void> {
   if (depth > 3) return // Prevent infinite recursion
+  if (visited.has(url)) return // Skip sitemaps we've already fetched in this run
+  visited.add(url)
 
   validateSitemapUrl(url)
 
-  const res = await fetch(url)
-  if (!res.ok) {
-    throw new Error(`Failed to fetch sitemap at ${url}: ${res.status} ${res.statusText}`)
+  let res: Response
+  try {
+    res = await fetch(url)
+  } catch (err) {
+    // Top-level failures bubble up so the caller's run is marked failed; child
+    // failures only warn so one bad nested sitemap doesn't doom the whole index.
+    if (!isChild) throw err
+    log.warn('child-sitemap.fetch-failed', {
+      url,
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return
   }
 
-  const xml = await res.text()
+  if (!res.ok) {
+    if (!isChild) {
+      throw new Error(`Failed to fetch sitemap at ${url}: ${res.status} ${res.statusText}`)
+    }
+    log.warn('child-sitemap.http-error', { url, status: res.status, statusText: res.statusText })
+    return
+  }
+
+  let xml: string
+  try {
+    xml = await readSitemapBody(res)
+  } catch (err) {
+    if (!isChild) throw err
+    log.warn('child-sitemap.parse-failed', {
+      url,
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return
+  }
 
   // Check if this is a sitemap index (contains <sitemap> tags)
   const sitemapEntries = xml.match(SITEMAP_TAG_REGEX)
@@ -52,7 +108,7 @@ async function parseSitemapRecursive(url: string, urls: Set<string>, depth: numb
       const locMatch = LOC_REGEX.exec(entry)
       LOC_REGEX.lastIndex = 0
       if (locMatch?.[1]) {
-        await parseSitemapRecursive(locMatch[1], urls, depth + 1)
+        await parseSitemapRecursive(locMatch[1], urls, visited, depth + 1, /* isChild */ true)
       }
     }
     return

--- a/packages/canonry/test/sitemap-parser.test.ts
+++ b/packages/canonry/test/sitemap-parser.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, afterEach, expect } from 'vitest'
 import http from 'node:http'
+import { gzipSync } from 'node:zlib'
 import { fetchAndParseSitemap } from '../src/sitemap-parser.js'
 
 function createServer(routes: Record<string, string>): Promise<{ server: http.Server; baseUrl: string }> {
@@ -123,5 +124,117 @@ describe('fetchAndParseSitemap', () => {
 
     const urls = await fetchAndParseSitemap(`${s.baseUrl}/sitemap.xml`)
     expect(urls.length).toBe(0)
+  })
+
+  it('decompresses gzipped sitemap bodies', async () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/page1</loc></url>
+  <url><loc>https://example.com/page2</loc></url>
+</urlset>`
+    const gz = gzipSync(xml)
+
+    const srv = http.createServer((req, res) => {
+      if (req.url === '/sitemap.xml.gz') {
+        // Static .gz file at rest — no Content-Encoding header.
+        res.writeHead(200, { 'Content-Type': 'application/octet-stream' })
+        res.end(gz)
+      } else {
+        res.writeHead(404)
+        res.end()
+      }
+    })
+    const s = await new Promise<{ server: http.Server; baseUrl: string }>((resolve) => {
+      srv.listen(0, () => {
+        const addr = srv.address()
+        const port = typeof addr === 'object' && addr ? addr.port : 0
+        resolve({ server: srv, baseUrl: `http://localhost:${port}` })
+      })
+    })
+    server = s.server
+
+    const urls = await fetchAndParseSitemap(`${s.baseUrl}/sitemap.xml.gz`)
+    expect(urls.length).toBe(2)
+    expect(urls.includes('https://example.com/page1')).toBeTruthy()
+    expect(urls.includes('https://example.com/page2')).toBeTruthy()
+  })
+
+  it('skips child sitemaps that 404 instead of failing the whole index', async () => {
+    const childOk = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/page-from-good-child</loc></url>
+</urlset>`
+
+    const s = await new Promise<{ server: http.Server; baseUrl: string }>((resolve) => {
+      const srv = http.createServer((req, res) => {
+        if (req.url === '/child-good.xml') {
+          res.writeHead(200, { 'Content-Type': 'application/xml' })
+          res.end(childOk)
+        } else if (req.url === '/sitemap.xml') {
+          const addr = srv.address()
+          const port = typeof addr === 'object' && addr ? addr.port : 0
+          const indexXml = `<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>http://localhost:${port}/child-good.xml</loc></sitemap>
+  <sitemap><loc>http://localhost:${port}/child-missing.xml</loc></sitemap>
+</sitemapindex>`
+          res.writeHead(200, { 'Content-Type': 'application/xml' })
+          res.end(indexXml)
+        } else {
+          res.writeHead(404)
+          res.end('Not found')
+        }
+      })
+      srv.listen(0, () => {
+        const addr = srv.address()
+        const port = typeof addr === 'object' && addr ? addr.port : 0
+        resolve({ server: srv, baseUrl: `http://localhost:${port}` })
+      })
+    })
+    server = s.server
+
+    const urls = await fetchAndParseSitemap(`${s.baseUrl}/sitemap.xml`)
+    expect(urls).toEqual(['https://example.com/page-from-good-child'])
+  })
+
+  it('does not refetch a child sitemap referenced more than once', async () => {
+    const childCalls: string[] = []
+    const childXml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/dedup-page</loc></url>
+</urlset>`
+
+    const s = await new Promise<{ server: http.Server; baseUrl: string }>((resolve) => {
+      const srv = http.createServer((req, res) => {
+        if (req.url === '/child.xml') {
+          childCalls.push(req.url)
+          res.writeHead(200, { 'Content-Type': 'application/xml' })
+          res.end(childXml)
+        } else if (req.url === '/sitemap.xml') {
+          const addr = srv.address()
+          const port = typeof addr === 'object' && addr ? addr.port : 0
+          const indexXml = `<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>http://localhost:${port}/child.xml</loc></sitemap>
+  <sitemap><loc>http://localhost:${port}/child.xml</loc></sitemap>
+</sitemapindex>`
+          res.writeHead(200, { 'Content-Type': 'application/xml' })
+          res.end(indexXml)
+        } else {
+          res.writeHead(404)
+          res.end()
+        }
+      })
+      srv.listen(0, () => {
+        const addr = srv.address()
+        const port = typeof addr === 'object' && addr ? addr.port : 0
+        resolve({ server: srv, baseUrl: `http://localhost:${port}` })
+      })
+    })
+    server = s.server
+
+    const urls = await fetchAndParseSitemap(`${s.baseUrl}/sitemap.xml`)
+    expect(urls).toEqual(['https://example.com/dedup-page'])
+    expect(childCalls.length).toBe(1)
   })
 })


### PR DESCRIPTION
## Summary

- Transparently decompresses gzipped sitemap bodies, detected via the gzip magic header bytes (`0x1f 0x8b`) so static `.xml.gz` files served without `Content-Encoding: gzip` are still parsed.
- Treats child sitemap fetch/HTTP/parse failures as warnings instead of fatal errors so one bad nested sitemap doesn't doom an entire index walk.
- Tracks visited sitemap URLs within a run to avoid refetching duplicates referenced more than once in an index.

## Test plan

- [ ] `pnpm -C packages/canonry test` (covers new gzip, child-404, and dedup cases)
- [ ] `canonry google inspect-sitemap` against a real domain whose index references gzipped or partially-broken child sitemaps