### PR TITLE
chore: polish MCP agent ops docs

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -74,6 +74,8 @@ args = []
 
 v1 is curated for client usability: 48 tools total, 33 read tools in read-only mode. It covers projects, config apply, runs, snapshots, insights, health, keyword generation and replacement, competitor add/remove, schedules, settings, GSC reads, GA reads, run trigger/cancel, schedule updates, insight dismiss, and agent webhook attach/detach.
 
+`canonry_apply_config` accepts one config-as-code project document per call. For multi-document YAML or multiple project files, agents should call the tool once per project document. `canonry_keywords_generate` returns suggestions only; persist accepted suggestions with `canonry_keywords_add` or replace the tracked set with `canonry_keywords_replace`.
+
 Deferred from v1: Aero ask SSE, OAuth callbacks, raw screenshots, project delete, snapshot generation, broad admin/provider writes, Google/Bing/GA connect/sync/inspect/indexing writes, WordPress writes, CDP screenshot, generic notifications, backlinks, raw OpenAPI, and raw HTTP escape hatches.
 
 Some write tools compose existing API calls rather than using a native atomic endpoint. The agent webhook attach/detach tools are best-effort under concurrent calls until the public API grows narrower attach/detach operations for that domain.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "2.8.1",
+  "version": "2.8.2",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/commands/competitor.ts
+++ b/packages/canonry/src/commands/competitor.ts
@@ -9,13 +9,15 @@ export async function addCompetitors(project: string, domains: string[], format?
   const existing = await client.listCompetitors(project)
   const existingDomains = existing.map(c => c.domain)
   const existingSet = new Set(existingDomains)
-  const addedDomains = [...new Set(domains.filter(domain => !existingSet.has(domain)))]
+  const requested = new Set(uniqueStrings(domains))
   const current = await client.appendCompetitors(project, domains)
+  const currentDomains = current.map(c => c.domain)
+  const addedDomains = currentDomains.filter(domain => requested.has(domain) && !existingSet.has(domain))
 
   if (format === 'json') {
     console.log(JSON.stringify({
       project,
-      domains: current.map(c => c.domain),
+      domains: currentDomains,
       addedDomains,
       addedCount: addedDomains.length,
     }, null, 2))
@@ -32,9 +34,11 @@ export async function addCompetitors(project: string, domains: string[], format?
 export async function removeCompetitors(project: string, domains: string[], format?: string): Promise<void> {
   const client = getClient()
   const existing = await client.listCompetitors(project)
-  const existingSet = new Set(existing.map(c => c.domain))
-  const removedDomains = [...new Set(domains.filter(domain => existingSet.has(domain)))]
+  const existingDomains = existing.map(c => c.domain)
+  const requested = new Set(uniqueStrings(domains))
   const current = await client.deleteCompetitors(project, domains)
+  const currentSet = new Set(current.map(c => c.domain))
+  const removedDomains = existingDomains.filter(domain => requested.has(domain) && !currentSet.has(domain))
 
   if (format === 'json') {
     console.log(JSON.stringify({
@@ -47,6 +51,17 @@ export async function removeCompetitors(project: string, domains: string[], form
   }
 
   console.log(`Removed ${removedDomains.length} competitor(s) from "${project}".`)
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const value of values) {
+    if (seen.has(value)) continue
+    seen.add(value)
+    result.push(value)
+  }
+  return result
 }
 
 export async function listCompetitors(project: string, format?: string): Promise<void> {

--- a/packages/canonry/src/mcp/tool-registry.ts
+++ b/packages/canonry/src/mcp/tool-registry.ts
@@ -527,9 +527,10 @@ export const canonryMcpTools = [
   defineTool({
     name: 'canonry_apply_config',
     title: 'Apply project config',
-    description: 'Apply one Canonry config-as-code project document. Replaces the project to match the config — fields omitted from the spec are reset to defaults. Loop and call once per project to apply multi-doc configs.',
+    description: 'Apply one Canonry config-as-code project document. Replaces the project to match the config — fields omitted from the spec are reset to defaults. For multi-document YAML, call this tool once per project document.',
     access: 'write',
     inputSchema: applyConfigInputSchema,
+    // Declarative apply is safe to repeat, but it replaces configured child state.
     annotations: writeAnnotations({ idempotentHint: true, destructiveHint: true }),
     openApiOperations: ['POST /api/v1/apply'],
     handler: (client, input) => client.apply(input.config),
@@ -537,7 +538,7 @@ export const canonryMcpTools = [
   defineTool({
     name: 'canonry_keywords_generate',
     title: 'Generate keyword suggestions',
-    description: 'Generate candidate key phrases for a Canonry project using a configured provider.',
+    description: 'Generate candidate key phrases using a configured provider. Returns suggestions only; use canonry_keywords_add to persist them.',
     access: 'write',
     inputSchema: keywordGenerateInputSchema,
     annotations: writeAnnotations({ idempotentHint: false, openWorldHint: true }),


### PR DESCRIPTION
## Summary

Stacked on #361. Polishes a few review follow-ups without expanding scope.

- clarifies that `canonry_apply_config` accepts one project document per call
- clarifies that `canonry_keywords_generate` returns suggestions only and does not persist them
- derives competitor add/remove CLI counts from observed pre/post API state
- adds a registry note for `apply` being both idempotent and destructive
- bumps `@ainyc/canonry` patch version to 2.7.1

## Validation

- `pnpm --filter @ainyc/canonry run test -- mcp-registry cli-operator-contract`
- `pnpm --filter @ainyc/canonry run typecheck`
- `pnpm --filter @ainyc/canonry run lint`
- `git diff --check`
- commit hook: `pnpm run lint`