### PR TITLE
test(mcp): pin SDK pipelining-race error wording

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "2.12.0",
+  "version": "2.12.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/mcp/server.ts
+++ b/packages/canonry/src/mcp/server.ts
@@ -89,7 +89,7 @@ function registerMetaTools(server: McpServer, catalog: DynamicToolCatalog): void
     'canonry_load_toolkit',
     {
       title: 'Load a Canonry MCP toolkit',
-      description: 'Register a toolkit\'s tools for this session and emit one notifications/tools/list_changed. Idempotent. Loaded toolkits remain loaded for the rest of the session. Wait for this call to return before calling any newly enabled tool — pipelining the call with a tools/call on the same connection can race the registration and fail with "Tool ... disabled".',
+      description: 'Register a toolkit\'s tools for this session and emit one notifications/tools/list_changed. Idempotent. Loaded toolkits remain loaded for the rest of the session. Wait for this call to return before calling any newly enabled tool — pipelining the call with a tools/call on the same connection can race the registration and fail with "MCP error -32602: Tool ... disabled".',
       inputSchema: loadToolkitInputSchema.shape,
       annotations: { readOnlyHint: false, idempotentHint: true, destructiveHint: false },
     },

--- a/packages/canonry/test/mcp-stdio.test.ts
+++ b/packages/canonry/test/mcp-stdio.test.ts
@@ -72,6 +72,13 @@ describe('canonry-mcp stdio', () => {
 
     const beforeLoad = await client.callTool({ name: 'canonry_insights_list', arguments: { project: 'acme' } })
     expect(beforeLoad.isError).toBe(true)
+    const beforeLoadText = (beforeLoad.content?.[0] as { text?: string } | undefined)?.text ?? ''
+    // The pipelining caveat documented on canonry_load_toolkit and in docs/mcp.md must match
+    // the error wording the MCP SDK actually emits. If the SDK changes its message, both the
+    // tool description and the docs need to be updated together.
+    expect(beforeLoadText).toMatch(/MCP error -32602: Tool canonry_insights_list disabled/)
+    const loadToolkitTool = list.tools.find(tool => tool.name === 'canonry_load_toolkit')
+    expect(loadToolkitTool?.description ?? '').toContain('Tool ... disabled')
 
     const loaded = await client.callTool({ name: 'canonry_load_toolkit', arguments: { name: 'monitoring' } })
     expect(loaded.isError).not.toBe(true)
@@ -109,6 +116,12 @@ describe('canonry-mcp stdio', () => {
     expect(envelope.error.details?.issues).toBeTruthy()
 
     expect(stderrChunks.join('')).toBe('')
+  })
+
+  it('docs/mcp.md documents the same pipelining error wording the SDK emits', () => {
+    const docsPath = path.resolve(repoRoot, 'docs', 'mcp.md')
+    const docs = fs.readFileSync(docsPath, 'utf8')
+    expect(docs).toContain('MCP error -32602: Tool ... disabled')
   })
 
   it('loads every toolkit at startup when --eager is passed', async () => {


### PR DESCRIPTION
## Summary

While E2E-testing #368, I tracked down a wording mismatch between what `canonry_load_toolkit`'s description claims (`Tool ... disabled`) and what I observed at runtime (`Tool ... not found`). It turned out my E2E observation was hitting a different path (a `--read-only`-filtered, **never-registered** tool, which gives `not found`), while the documented pipelining race hits a **registered-but-disabled** tool, which is the one the SDK reports as `disabled`. So the existing wording was correct — and I wanted to lock that in before someone else burns the same hour.

This PR is purely additive regression coverage:

- New assertions in `mcp-stdio.test.ts` against the **real** SDK error a registered-but-disabled tool emits (`MCP error -32602: Tool canonry_insights_list disabled`), and against the `canonry_load_toolkit` tool description containing the same wording.
- New tiny test that reads `docs/mcp.md` and asserts it contains `MCP error -32602: Tool ... disabled`. Three surfaces (runtime, tool description, docs) now all stay in lockstep — drift in any one breaks the test loudly.
- Tightens the `canonry_load_toolkit` description to include the full `MCP error -32602:` prefix verbatim so it matches `docs/mcp.md` and gives agents the exact substring to grep for.

Version bump: **2.12.0 → 2.12.1**.

## Test plan

- [x] `pnpm --filter @ainyc/canonry exec vitest run test/mcp-stdio.test.ts` — 3 tests pass (initialize/list/call, the new docs-wording check, and `--eager`)
- [x] `pnpm --filter @ainyc/canonry exec vitest run` — full canonry suite, 492/492 pass
- [x] `pnpm run typecheck` (full workspace) — clean
- [x] `pnpm run lint` (full workspace) — clean
- [x] Verified the test fails (red) when the description string or `docs/mcp.md` says anything other than `Tool ... disabled`

🤖 Generated with [Claude Code](https://claude.com/claude-code)