### PR TITLE
fix(contracts): match brands across spacing and trailing legal classifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "2.13.1",
+  "version": "2.13.2",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/contracts/src/answer-visibility.ts
+++ b/packages/contracts/src/answer-visibility.ts
@@ -20,6 +20,34 @@ const GENERIC_TOKENS = new Set([
   'tech',
 ])
 
+// Minimum length of the whitespace-stripped brand key required to allow a
+// "loose" match across word boundaries (e.g. registered "azcoatings" matching
+// "AZ Coatings" in answer text). Below this, fall back to the strict
+// space-preserving comparison so short names like "Acme" don't false-match
+// adjacent words.
+const MIN_BRAND_KEY_LENGTH = 6
+
+// Trailing legal/corporate classifiers stripped from a registered brand name
+// before matching, so a project named "AZ Coatings LLC" (or "azcoatingsllc")
+// matches an answer that mentions just "AZ Coatings". Sorted longest-first so
+// "incorporated" is tried before "inc". Stricter than GENERIC_TOKENS — only
+// classifiers that are unambiguous suffixes, never industry words like "tech".
+const BUSINESS_SUFFIXES = [
+  'incorporated',
+  'corporation',
+  'limited',
+  'company',
+  'gmbh',
+  'pllc',
+  'corp',
+  'group',
+  'llp',
+  'plc',
+  'llc',
+  'inc',
+  'ltd',
+]
+
 export interface AnswerMentionResult {
   mentioned: boolean
   matchedTerms: string[]
@@ -43,8 +71,15 @@ export function extractAnswerMentions(
     }
   }
 
-  const normalizedDisplayName = normalizeText(displayName)
-  if (normalizedDisplayName && normalizeText(answerText).includes(normalizedDisplayName)) {
+  const answerNormalized = normalizeText(answerText)
+  const answerBrandKey = brandKeyFromText(answerText)
+  const normalizedCandidates = brandNormalizedCandidates(displayName)
+  const brandKeyCandidates = brandKeyCandidatesForMatch(displayName)
+  const matchesNormalized = normalizedCandidates.some(c => answerNormalized.includes(c))
+  const matchesBrandKey = brandKeyCandidates.some(
+    c => c.length >= MIN_BRAND_KEY_LENGTH && answerBrandKey.includes(c),
+  )
+  if (matchesNormalized || matchesBrandKey) {
     matchedTerms.push(displayName)
   }
 
@@ -140,6 +175,39 @@ function isDistinctiveToken(token: string): boolean {
 
 function normalizeText(value: string): string {
   return value.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim()
+}
+
+function brandNormalizedCandidates(displayName: string): string[] {
+  const original = normalizeText(displayName)
+  if (!original) return []
+  const stripped = stripBusinessSuffix(original, ' ')
+  if (!stripped || stripped === original) return [original]
+  // Apply the same MIN_BRAND_KEY_LENGTH guard as the brand-key path: a stripped
+  // candidate like "bob" (from "Bob Inc") would otherwise substring-match inside
+  // unrelated words such as "bobsled".
+  if (brandKeyFromText(stripped).length < MIN_BRAND_KEY_LENGTH) return [original]
+  return [original, stripped]
+}
+
+function brandKeyCandidatesForMatch(displayName: string): string[] {
+  const original = brandKeyFromText(displayName)
+  if (!original) return []
+  const stripped = stripBusinessSuffix(original, '')
+  return stripped && stripped !== original ? [original, stripped] : [original]
+}
+
+// Strip a trailing business classifier (LLC/Inc/Corp/…) from a normalized brand
+// string. `separator` is `' '` for space-separated normalized text and `''` for
+// the whitespace-stripped brand key. Requires ≥3 chars to remain so a name
+// that is only a classifier (e.g. "Inc") is left untouched.
+function stripBusinessSuffix(value: string, separator: string): string {
+  for (const suffix of BUSINESS_SUFFIXES) {
+    const trailing = `${separator}${suffix}`
+    if (value.endsWith(trailing) && value.length - trailing.length >= 3) {
+      return value.slice(0, -trailing.length)
+    }
+  }
+  return value
 }
 
 function escapeRegExp(value: string): string {

--- a/packages/contracts/test/index.test.ts
+++ b/packages/contracts/test/index.test.ts
@@ -617,6 +617,102 @@ describe('extractAnswerMentions', () => {
     expect(result.mentioned).toBe(false)
     expect(result.matchedTerms).toEqual([])
   })
+
+  it('matches when display name has no spaces but the answer spaces it out', () => {
+    // Real-world case: project registered as "azcoatings" with domain
+    // azcoatingsllc.com; answer says "AZ Coatings (Michigan/Detroit Area)".
+    const result = extractAnswerMentions(
+      'Local contractors include AZ Coatings (Michigan/Detroit Area), specializing in polyurea roof restoration.',
+      'azcoatings',
+      ['azcoatingsllc.com'],
+    )
+    expect(result.mentioned).toBe(true)
+    expect(result.matchedTerms).toContain('azcoatings')
+  })
+
+  it('matches when display name has spaces but the answer concatenates it', () => {
+    const result = extractAnswerMentions(
+      'Visit AZCoatings for industrial polyurea systems.',
+      'AZ Coatings',
+      ['azcoatingsllc.com'],
+    )
+    expect(result.mentioned).toBe(true)
+    expect(result.matchedTerms).toContain('AZ Coatings')
+  })
+
+  it('does not loose-match short brand keys across word boundaries', () => {
+    // "acme" (4 chars) is below the brand-key threshold, so the loose match
+    // is gated off. Without that gate, "pa cme" would strip to "pacme" and
+    // falsely contain "acme".
+    const result = extractAnswerMentions(
+      'Find the pa cme report in the archive.',
+      'Acme',
+      ['acme.io'],
+    )
+    expect(result.mentioned).toBe(false)
+    expect(result.matchedTerms).toEqual([])
+  })
+
+  it('does not loose-match short brand+suffix pairings via the stripped normalized candidate', () => {
+    // "Bob Inc" stripped normalized candidate is "bob"; without the
+    // length gate, this would substring-match inside words like "bobsled".
+    // The brand-key path's MIN_BRAND_KEY_LENGTH threshold must apply to the
+    // stripped normalized candidate too.
+    const result = extractAnswerMentions(
+      'Bobsled racing is fun this winter.',
+      'Bob Inc',
+      ['bob.example.com'],
+    )
+    expect(result.mentioned).toBe(false)
+    expect(result.matchedTerms).toEqual([])
+  })
+
+  it('matches when display name carries a trailing LLC/Inc/Corp classifier', () => {
+    // Spaced form: "AZ Coatings LLC" should match an answer that drops the LLC.
+    expect(extractAnswerMentions(
+      'Local contractors include AZ Coatings (Michigan/Detroit Area).',
+      'AZ Coatings LLC',
+      ['azcoatingsllc.com'],
+    ).mentioned).toBe(true)
+
+    // Concatenated form: "azcoatingsllc" should also match without the suffix.
+    expect(extractAnswerMentions(
+      'Local contractors include AZ Coatings (Michigan/Detroit Area).',
+      'azcoatingsllc',
+      ['azcoatingsllc.com'],
+    ).mentioned).toBe(true)
+
+    // "Inc" is stripped likewise.
+    expect(extractAnswerMentions(
+      'According to Sherwin Williams paints are the best.',
+      'Sherwin Williams Inc',
+      ['sherwinwilliams.com'],
+    ).mentioned).toBe(true)
+
+    // "Corporation" (long form) is stripped too.
+    expect(extractAnswerMentions(
+      'Microsoft is launching a new product line.',
+      'Microsoft Corporation',
+      ['microsoft.com'],
+    ).mentioned).toBe(true)
+  })
+
+  it('does not strip a classifier when only the classifier itself remains', () => {
+    // Edge case: display name is just "Inc" (3 chars). Stripping would leave
+    // empty/too-short. The original "inc" stays and is below the brand-key
+    // threshold, so loose matching is gated off.
+    const result = extractAnswerMentions(
+      'The incident report is attached.',
+      'Inc',
+      ['inc.example.com'],
+    )
+    // strict normalized "inc" .includes against "the incident report is attached"
+    // → "inc" appears as substring in "incident", which IS a pre-existing
+    // limitation of the strict path for very short brand names. The classifier
+    // stripping logic must not amplify this — verify "Inc" alone is handled
+    // sanely (no crash, no expanded matching from stripping).
+    expect(result.matchedTerms.filter(t => t === '').length).toBe(0)
+  })
 })
 
 describe('parseProviderName', () => {


### PR DESCRIPTION
## Summary
- Mention detection now also tries a whitespace-stripped brand-key match, so a project registered as `azcoatings` matches answers that say `AZ Coatings` (and vice versa).
- Display names ending in `LLC`, `Inc`, `Corp`, `Ltd`, `GmbH`, `Corporation`, `Incorporated`, etc. are stripped before matching, so `AZ Coatings LLC` matches an answer that drops the suffix.
- Both stripped candidates are gated by a `MIN_BRAND_KEY_LENGTH = 6` threshold so short brand+suffix pairings like `Bob Inc` (→ `bob`) don't substring-match inside unrelated words such as `bobsled`.
- Bumps version 2.13.1 → 2.13.2.

## Test plan
- [x] `pnpm --filter @ainyc/canonry-contracts test` (134 tests passing, including new cases for spaced/concatenated brand variants, classifier stripping, and the short-brand+suffix false-positive guard)
- [x] `pnpm --filter @ainyc/canonry-contracts typecheck`
- [x] `pnpm --filter @ainyc/canonry-contracts lint`