### PR TITLE
feat(backlinks): auto-discover latest Common Crawl release

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,5 +1,5 @@
-import type { ErrorCode, GroundingSource, ScheduleDto, NotificationDto, GscCoverageSummaryDto, GscCoverageSnapshotDto, IndexingRequestResultDto, BrandMetricsDto, GapAnalysisDto, SourceBreakdownDto, MetricsWindow, GA4AiReferralHistoryEntry, GA4SessionHistoryEntry, GA4SocialReferralHistoryEntry, InsightDto, HealthSnapshotDto, RunKind, RunStatus, RunTrigger, RunErrorDto, CitationState, ComputedTransition, BacklinkSummaryDto, BacklinkDomainDto, BacklinkListResponse, BacklinkHistoryEntry, BacklinksInstallStatusDto, BacklinksInstallResultDto, CcCachedRelease, CcReleaseSyncDto } from '@ainyc/canonry-contracts'
-export type { BacklinkSummaryDto, BacklinkDomainDto, BacklinkListResponse, BacklinkHistoryEntry, BacklinksInstallStatusDto, BacklinksInstallResultDto, CcCachedRelease, CcReleaseSyncDto }
+import type { ErrorCode, GroundingSource, ScheduleDto, NotificationDto, GscCoverageSummaryDto, GscCoverageSnapshotDto, IndexingRequestResultDto, BrandMetricsDto, GapAnalysisDto, SourceBreakdownDto, MetricsWindow, GA4AiReferralHistoryEntry, GA4SessionHistoryEntry, GA4SocialReferralHistoryEntry, InsightDto, HealthSnapshotDto, RunKind, RunStatus, RunTrigger, RunErrorDto, CitationState, ComputedTransition, BacklinkSummaryDto, BacklinkDomainDto, BacklinkListResponse, BacklinkHistoryEntry, BacklinksInstallStatusDto, BacklinksInstallResultDto, CcAvailableRelease, CcCachedRelease, CcReleaseSyncDto } from '@ainyc/canonry-contracts'
+export type { BacklinkSummaryDto, BacklinkDomainDto, BacklinkListResponse, BacklinkHistoryEntry, BacklinksInstallStatusDto, BacklinksInstallResultDto, CcAvailableRelease, CcCachedRelease, CcReleaseSyncDto }
 
 export type { GroundingSource }
 
@@ -71,11 +71,12 @@ export function hasExplicitBrowserApiKey(): boolean {
 
 async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
   const key = getApiKey()
+  const hasBody = options?.body != null
   const res = await fetch(`${API_BASE}${path}`, {
     ...options,
     credentials: options?.credentials ?? 'same-origin',
     headers: {
-      'Content-Type': 'application/json',
+      ...(hasBody ? { 'Content-Type': 'application/json' } : {}),
       ...(key ? { Authorization: `Bearer ${key}` } : {}),
       ...options?.headers,
     },
@@ -1152,15 +1153,19 @@ export function fetchReleaseSyncs(): Promise<CcReleaseSyncDto[]> {
   return apiFetch('/backlinks/syncs')
 }
 
-export function triggerReleaseSync(release: string): Promise<CcReleaseSyncDto> {
+export function triggerReleaseSync(release?: string): Promise<CcReleaseSyncDto> {
   return apiFetch('/backlinks/syncs', {
     method: 'POST',
-    body: JSON.stringify({ release }),
+    body: JSON.stringify(release ? { release } : {}),
   })
 }
 
 export function fetchCachedReleases(): Promise<CcCachedRelease[]> {
   return apiFetch('/backlinks/releases')
+}
+
+export function fetchLatestAvailableRelease(): Promise<CcAvailableRelease | null> {
+  return apiFetch('/backlinks/latest-release')
 }
 
 export function pruneCachedRelease(release: string): Promise<{ ok: boolean }> {

--- a/apps/web/src/pages/BacklinksPage.tsx
+++ b/apps/web/src/pages/BacklinksPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useId, useState, type ReactNode } from 'react'
-import { Download, HelpCircle, Play, Trash2, CheckCircle2, AlertCircle, AlertTriangle } from 'lucide-react'
+import { Download, ExternalLink, HelpCircle, Play, Trash2, CheckCircle2, AlertCircle, AlertTriangle } from 'lucide-react'
 import { Button } from '../components/ui/button.js'
 import { Card } from '../components/ui/card.js'
 import { ToneBadge } from '../components/shared/ToneBadge.js'
@@ -48,6 +48,7 @@ function Hint({
 import {
   fetchBacklinksStatus,
   fetchCachedReleases,
+  fetchLatestAvailableRelease,
   fetchLatestReleaseSync,
   fetchReleaseSyncs,
   installBacklinks,
@@ -57,9 +58,12 @@ import {
 } from '../api.js'
 import type {
   BacklinksInstallStatusDto,
+  CcAvailableRelease,
   CcCachedRelease,
   CcReleaseSyncDto,
 } from '../api.js'
+
+const COMMON_CRAWL_RELEASES_URL = 'https://commoncrawl.org/web-graphs'
 
 function formatBytes(n: number | null | undefined): string {
   if (n === null || n === undefined) return '—'
@@ -98,10 +102,12 @@ export function BacklinksPage() {
   const [latest, setLatest] = useState<CcReleaseSyncDto | null>(null)
   const [history, setHistory] = useState<CcReleaseSyncDto[]>([])
   const [cached, setCached] = useState<CcCachedRelease[]>([])
+  const [latestAvailable, setLatestAvailable] = useState<CcAvailableRelease | null>(null)
   const [loading, setLoading] = useState(true)
   const [installing, setInstalling] = useState(false)
   const [syncing, setSyncing] = useState(false)
   const [releaseInput, setReleaseInput] = useState('')
+  const [showOverride, setShowOverride] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
 
@@ -109,16 +115,18 @@ export function BacklinksPage() {
     setLoading(true)
     setError(null)
     try {
-      const [st, lat, hist, cac] = await Promise.all([
+      const [st, lat, hist, cac, avail] = await Promise.all([
         fetchBacklinksStatus(),
         fetchLatestReleaseSync().catch(() => null),
         fetchReleaseSyncs().catch(() => [] as CcReleaseSyncDto[]),
         fetchCachedReleases().catch(() => [] as CcCachedRelease[]),
+        fetchLatestAvailableRelease().catch(() => null),
       ])
       setStatus(st)
       setLatest(lat)
       setHistory(hist)
       setCached(cac)
+      setLatestAvailable(avail)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load backlinks status')
     } finally {
@@ -146,18 +154,19 @@ export function BacklinksPage() {
   }
 
   async function handleSync() {
-    const release = releaseInput.trim()
-    if (!release) {
-      setError('Enter a release id (e.g., cc-main-2026-jan-feb-mar).')
-      return
-    }
+    const release = releaseInput.trim() || undefined
     setSyncing(true)
     setError(null)
     setNotice(null)
     try {
-      await triggerReleaseSync(release)
-      setNotice(`Queued sync for ${release}. Download + query runs in the background.`)
+      const sync = await triggerReleaseSync(release)
+      setNotice(
+        release
+          ? `Queued sync for ${sync.release}. Download + query runs in the background.`
+          : `Queued sync for auto-discovered release ${sync.release}. Download + query runs in the background.`,
+      )
       setReleaseInput('')
+      setShowOverride(false)
       await reload()
     } catch (err) {
       if (err instanceof ApiError && err.code === 'MISSING_DEPENDENCY') {
@@ -401,33 +410,85 @@ export function BacklinksPage() {
               </div>
             </div>
           )}
-          <div className="mt-4 flex flex-wrap items-center gap-2">
-            <input
-              type="text"
-              className="flex-1 min-w-[240px] rounded border border-zinc-700 bg-transparent px-2.5 py-1.5 text-sm text-zinc-200 placeholder-zinc-600 focus:border-zinc-500 focus:outline-none"
-              placeholder="cc-main-2026-jan-feb-mar"
-              value={releaseInput}
-              onChange={(e) => setReleaseInput(e.target.value)}
-              disabled={syncing}
-            />
-            <Button
-              type="button"
-              size="sm"
-              disabled={syncing || !status?.duckdbInstalled}
-              onClick={handleSync}
-            >
-              <Play className="h-4 w-4 mr-1.5" aria-hidden />
-              {syncing ? 'Queuing…' : 'Run sync'}
-            </Button>
-            <Hint label="What does Run sync do?">
-              <span className="block">
-                Downloads the named Common Crawl release (~16 GB) to{' '}
-                <code className="text-zinc-300">~/.canonry/cache/commoncrawl/</code>, then runs a single DuckDB query that extracts referring domains for every project in this workspace.
-              </span>
-              <span className="mt-2 block text-zinc-400">
-                First time for a release: <span className="text-zinc-200">~10–20 min download + ~5 min query</span>. Re-running the same release later: <span className="text-zinc-200">skips download, just re-queries</span> (~5 min).
-              </span>
-            </Hint>
+          <div className="mt-4 rounded border border-zinc-800 bg-zinc-900/40 p-3">
+            <div className="flex items-start justify-between gap-3 mb-3">
+              <div>
+                <p className="text-[10px] uppercase tracking-wide text-zinc-500">
+                  Auto-detected release
+                </p>
+                {latestAvailable ? (
+                  <p className="text-sm text-zinc-200 mt-0.5">
+                    <code className="text-zinc-100">{latestAvailable.release}</code>
+                    <span className="ml-2 text-xs text-zinc-500">
+                      — vertex {formatBytes(latestAvailable.vertexBytes)}, edges {formatBytes(latestAvailable.edgesBytes)}
+                    </span>
+                  </p>
+                ) : (
+                  <p className="text-sm text-zinc-500 mt-0.5">
+                    {loading ? 'Probing Common Crawl…' : 'Could not auto-detect — pass an explicit release below.'}
+                  </p>
+                )}
+                <a
+                  href={COMMON_CRAWL_RELEASES_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-1 inline-flex items-center gap-1 text-xs text-zinc-400 hover:text-zinc-200 focus:text-zinc-200 focus:outline-none focus-visible:ring-1 focus-visible:ring-zinc-500 rounded"
+                >
+                  Browse all Common Crawl web-graph releases
+                  <ExternalLink className="h-3 w-3" aria-hidden />
+                </a>
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                <Button
+                  type="button"
+                  size="sm"
+                  disabled={syncing || !status?.duckdbInstalled || (!latestAvailable && !releaseInput.trim())}
+                  onClick={handleSync}
+                >
+                  <Play className="h-4 w-4 mr-1.5" aria-hidden />
+                  {syncing ? 'Queuing…' : 'Run sync'}
+                </Button>
+                <Hint label="What does Run sync do?">
+                  <span className="block">
+                    Downloads the auto-detected (or chosen) Common Crawl release (~16 GB) to{' '}
+                    <code className="text-zinc-300">~/.canonry/cache/commoncrawl/</code>, then runs a single DuckDB query that extracts referring domains for every project in this workspace.
+                  </span>
+                  <span className="mt-2 block text-zinc-400">
+                    First time for a release: <span className="text-zinc-200">~10–20 min download + ~5 min query</span>. Re-running the same release later: <span className="text-zinc-200">skips download, just re-queries</span> (~5 min).
+                  </span>
+                </Hint>
+              </div>
+            </div>
+            {!showOverride ? (
+              <button
+                type="button"
+                className="text-xs text-zinc-500 hover:text-zinc-300 focus:text-zinc-300 focus:outline-none focus-visible:ring-1 focus-visible:ring-zinc-500 rounded"
+                onClick={() => setShowOverride(true)}
+                disabled={syncing}
+              >
+                Use a different release →
+              </button>
+            ) : (
+              <div className="flex flex-wrap items-center gap-2">
+                <input
+                  type="text"
+                  className="flex-1 min-w-[240px] rounded border border-zinc-700 bg-transparent px-2.5 py-1.5 text-sm text-zinc-200 placeholder-zinc-600 focus:border-zinc-500 focus:outline-none"
+                  placeholder="cc-main-2026-jan-feb-mar"
+                  value={releaseInput}
+                  onChange={(e) => setReleaseInput(e.target.value)}
+                  disabled={syncing}
+                  autoFocus
+                />
+                <button
+                  type="button"
+                  className="text-xs text-zinc-500 hover:text-zinc-300 focus:text-zinc-300 focus:outline-none focus-visible:ring-1 focus-visible:ring-zinc-500 rounded"
+                  onClick={() => { setReleaseInput(''); setShowOverride(false) }}
+                  disabled={syncing}
+                >
+                  Cancel
+                </button>
+              </div>
+            )}
           </div>
           {!status?.duckdbInstalled && (
             <p className="text-xs text-zinc-600 mt-2">Install DuckDB first to enable sync.</p>

--- a/apps/web/test/api-fetch-headers.test.ts
+++ b/apps/web/test/api-fetch-headers.test.ts
@@ -1,0 +1,61 @@
+import { test, expect, onTestFinished, describe } from 'vitest'
+
+import { installBacklinks, triggerGscSync } from '../src/api.js'
+
+function mockFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+  const realFetch = globalThis.fetch
+  globalThis.fetch = handler as typeof fetch
+  return () => {
+    globalThis.fetch = realFetch
+  }
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function headerFromInit(init: RequestInit | undefined, name: string): string | null {
+  const headers = init?.headers
+  if (!headers) return null
+  if (headers instanceof Headers) return headers.get(name)
+  const lowerName = name.toLowerCase()
+  for (const [k, v] of Object.entries(headers as Record<string, string>)) {
+    if (k.toLowerCase() === lowerName) return v
+  }
+  return null
+}
+
+describe('apiFetch Content-Type header', () => {
+  test('omits Content-Type on POST without body (Fastify rejects empty JSON bodies)', async () => {
+    let observed: RequestInit | undefined
+    const restore = mockFetch((_url, init) => {
+      observed = init
+      return jsonResponse({ status: 'ok' })
+    })
+    onTestFinished(restore)
+
+    await installBacklinks()
+
+    expect(observed?.method).toBe('POST')
+    expect(observed?.body).toBeUndefined()
+    expect(headerFromInit(observed, 'Content-Type')).toBeNull()
+  })
+
+  test('sets Content-Type on requests with a body', async () => {
+    let observed: RequestInit | undefined
+    const restore = mockFetch((_url, init) => {
+      observed = init
+      return jsonResponse({ id: 'run-1', status: 'pending' })
+    })
+    onTestFinished(restore)
+
+    await triggerGscSync('demo', { days: 7 })
+
+    expect(observed?.method).toBe('POST')
+    expect(observed?.body).toBeDefined()
+    expect(headerFromInit(observed, 'Content-Type')).toBe('application/json')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "2.13.2",
+  "version": "2.14.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/backlinks.ts
+++ b/packages/api-routes/src/backlinks.ts
@@ -21,6 +21,7 @@ import {
   type BacklinkSummaryDto,
   type BacklinksInstallResultDto,
   type BacklinksInstallStatusDto,
+  type CcAvailableRelease,
   type CcCachedRelease,
   type CcReleaseSyncDto,
   type CcReleaseSyncStatus,
@@ -47,6 +48,12 @@ export interface BacklinksRoutesOptions {
   onBacklinksPruneCache?: (release: string) => void
   /** Reports cached-release metadata from the filesystem. */
   listCachedReleases?: () => CcCachedRelease[]
+  /**
+   * Probes Common Crawl upstream to discover the latest published release.
+   * Implementations should cache the result for a few minutes — this fires on
+   * page loads. Returns `null` when no candidate slug responds 200.
+   */
+  discoverLatestRelease?: () => Promise<CcAvailableRelease | null>
 }
 
 const BACKLINKS_UNSUPPORTED_MESSAGE =
@@ -144,8 +151,22 @@ export async function backlinksRoutes(app: FastifyInstance, opts: BacklinksRoute
   })
 
   app.post<{ Body: { release?: string } }>('/backlinks/syncs', async (request, reply) => {
-    const release = request.body?.release
-    if (!release || !isValidReleaseId(release)) {
+    let release = request.body?.release
+    if (!release) {
+      if (!opts.discoverLatestRelease) {
+        throw validationError(
+          'No `release` provided and auto-discovery is unavailable on this deployment. Pass an explicit release id (e.g., cc-main-2026-jan-feb-mar).',
+        )
+      }
+      const discovered = await opts.discoverLatestRelease()
+      if (!discovered) {
+        throw validationError(
+          'Could not auto-discover the latest Common Crawl release. Pass an explicit `release` body parameter.',
+        )
+      }
+      release = discovered.release
+    }
+    if (!isValidReleaseId(release)) {
       throw validationError('Invalid release id. Expected form: cc-main-YYYY-{jan-feb-mar,apr-may-jun,jul-aug-sep,oct-nov-dec}')
     }
 
@@ -225,6 +246,14 @@ export async function backlinksRoutes(app: FastifyInstance, opts: BacklinksRoute
   app.get('/backlinks/releases', async (_request, reply) => {
     const releases = opts.listCachedReleases?.() ?? []
     return reply.send(releases)
+  })
+
+  app.get('/backlinks/latest-release', async (_request, reply) => {
+    if (!opts.discoverLatestRelease) {
+      throw missingDependency(BACKLINKS_UNSUPPORTED_MESSAGE)
+    }
+    const discovered = await opts.discoverLatestRelease()
+    return reply.send(discovered)
   })
 
   app.delete<{ Params: { release: string } }>('/backlinks/cache/:release', async (request, reply) => {

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -110,6 +110,7 @@ export interface ApiRoutesOptions {
   onBacklinkExtractRequested?: BacklinksRoutesOptions['onBacklinkExtractRequested']
   onBacklinksPruneCache?: BacklinksRoutesOptions['onBacklinksPruneCache']
   listCachedReleases?: BacklinksRoutesOptions['listCachedReleases']
+  discoverLatestRelease?: BacklinksRoutesOptions['discoverLatestRelease']
   /**
    * API route prefix (default: /api/v1).
    * Override when the server is behind a reverse proxy that does NOT strip the
@@ -269,6 +270,7 @@ export async function apiRoutes(app: FastifyInstance, opts: ApiRoutesOptions) {
       onBacklinkExtractRequested: opts.onBacklinkExtractRequested,
       onBacklinksPruneCache: opts.onBacklinksPruneCache,
       listCachedReleases: opts.listCachedReleases,
+      discoverLatestRelease: opts.discoverLatestRelease,
     } satisfies BacklinksRoutesOptions)
     await api.register(doctorRoutes, {
       googleConnectionStore: opts.googleConnectionStore,

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -2429,15 +2429,14 @@ const routeCatalog: OpenApiOperation[] = [
     path: '/api/v1/backlinks/syncs',
     summary: 'Queue a workspace-wide Common Crawl release sync',
     description:
-      'Creates a `cc_release_syncs` row and fires the sync callback. Idempotent: an existing in-flight row for the same release is returned.',
+      'Creates a `cc_release_syncs` row and fires the sync callback. Idempotent: an existing in-flight row for the same release is returned. When `release` is omitted, the server auto-discovers the latest available Common Crawl release.',
     tags: ['backlinks'],
     requestBody: {
-      required: true,
+      required: false,
       content: {
         'application/json': {
           schema: {
             type: 'object',
-            required: ['release'],
             properties: {
               release: stringSchema,
             },
@@ -2478,6 +2477,18 @@ const routeCatalog: OpenApiOperation[] = [
     tags: ['backlinks'],
     responses: {
       200: { description: 'Cached release metadata returned.' },
+    },
+  },
+  {
+    method: 'get',
+    path: '/api/v1/backlinks/latest-release',
+    summary: 'Auto-discover the latest available Common Crawl hyperlinkgraph release',
+    description:
+      'Probes Common Crawl by HEAD-checking quarterly release slugs and returns the newest one published. The local server caches the result for ~5 minutes so repeated calls do not hammer Common Crawl.',
+    tags: ['backlinks'],
+    responses: {
+      200: { description: 'Latest available release, or null when no candidate slug responded.' },
+      422: { description: 'Backlinks feature is not available on this deployment.' },
     },
   },
   {

--- a/packages/api-routes/test/backlinks.test.ts
+++ b/packages/api-routes/test/backlinks.test.ts
@@ -114,6 +114,51 @@ describe('Backlinks routes', () => {
     })
   })
 
+  describe('GET /backlinks/latest-release', () => {
+    it('returns the discovered release from the callback', async () => {
+      const probe = vi.fn(async () => ({
+        release: 'cc-main-2026-jan-feb-mar',
+        vertexUrl: 'https://example.test/v.gz',
+        edgesUrl: 'https://example.test/e.gz',
+        vertexBytes: 4_000_000_000,
+        edgesBytes: 13_000_000_000,
+        lastModified: 'Wed, 15 Apr 2026 12:00:00 GMT',
+      }))
+      const { app: custom } = buildApp({ discoverLatestRelease: probe })
+      await custom.ready()
+
+      const res = await custom.inject({ method: 'GET', url: '/backlinks/latest-release' })
+      expect(res.statusCode).toBe(200)
+      expect(probe).toHaveBeenCalledOnce()
+      const body = res.json() as { release: string; vertexBytes: number }
+      expect(body.release).toBe('cc-main-2026-jan-feb-mar')
+      expect(body.vertexBytes).toBe(4_000_000_000)
+      await custom.close()
+    })
+
+    it('returns null when nothing was discovered', async () => {
+      const { app: custom } = buildApp({ discoverLatestRelease: async () => null })
+      await custom.ready()
+      const res = await custom.inject({ method: 'GET', url: '/backlinks/latest-release' })
+      expect(res.statusCode).toBe(200)
+      expect(res.json()).toBeNull()
+      await custom.close()
+    })
+
+    it('throws MISSING_DEPENDENCY when discoverLatestRelease is not wired (cloud)', async () => {
+      const { app: cloud } = buildApp({
+        getBacklinksStatus: undefined,
+        discoverLatestRelease: undefined,
+      })
+      await cloud.ready()
+      const res = await cloud.inject({ method: 'GET', url: '/backlinks/latest-release' })
+      expect(res.statusCode).toBe(422)
+      const body = res.json() as { error: { code: string } }
+      expect(body.error.code).toBe('MISSING_DEPENDENCY')
+      await cloud.close()
+    })
+  })
+
   describe('POST /backlinks/syncs', () => {
     it('rejects an invalid release id', async () => {
       const res = await app.inject({
@@ -122,6 +167,60 @@ describe('Backlinks routes', () => {
         payload: { release: 'not-a-release' },
       })
       expect(res.statusCode).toBe(400)
+    })
+
+    it('auto-discovers the release when body.release is omitted', async () => {
+      const probe = vi.fn(async () => ({
+        release: 'cc-main-2026-jan-feb-mar',
+        vertexUrl: 'https://example.test/v.gz',
+        edgesUrl: 'https://example.test/e.gz',
+        vertexBytes: null,
+        edgesBytes: null,
+        lastModified: null,
+      }))
+      const sync = vi.fn()
+      const { app: custom } = buildApp({
+        discoverLatestRelease: probe,
+        onReleaseSyncRequested: sync,
+      })
+      await custom.ready()
+
+      const res = await custom.inject({ method: 'POST', url: '/backlinks/syncs', payload: {} })
+      expect(res.statusCode).toBe(201)
+      expect(probe).toHaveBeenCalledOnce()
+      const body = res.json() as { release: string; status: string }
+      expect(body.release).toBe('cc-main-2026-jan-feb-mar')
+      expect(body.status).toBe('queued')
+      expect(sync).toHaveBeenCalledWith(expect.any(String), 'cc-main-2026-jan-feb-mar')
+      await custom.close()
+    })
+
+    it('returns a clear error when auto-discovery fails to find a release', async () => {
+      const { app: custom } = buildApp({
+        discoverLatestRelease: async () => null,
+        onReleaseSyncRequested: vi.fn(),
+      })
+      await custom.ready()
+      const res = await custom.inject({ method: 'POST', url: '/backlinks/syncs', payload: {} })
+      expect(res.statusCode).toBe(400)
+      const body = res.json() as { error: { code: string; message: string } }
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+      expect(body.error.message).toMatch(/auto-discover/i)
+      await custom.close()
+    })
+
+    it('returns a clear error when no release is provided and auto-discovery is unavailable', async () => {
+      const { app: custom } = buildApp({
+        discoverLatestRelease: undefined,
+        onReleaseSyncRequested: vi.fn(),
+      })
+      await custom.ready()
+      const res = await custom.inject({ method: 'POST', url: '/backlinks/syncs', payload: {} })
+      expect(res.statusCode).toBe(400)
+      const body = res.json() as { error: { code: string; message: string } }
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+      expect(body.error.message).toMatch(/auto-discovery is unavailable/i)
+      await custom.close()
     })
 
     it('rejects when DuckDB is not installed', async () => {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "2.13.2",
+  "version": "2.14.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/cli-commands/backlinks.ts
+++ b/packages/canonry/src/cli-commands/backlinks.ts
@@ -3,6 +3,7 @@ import {
   backlinksDoctor,
   backlinksExtract,
   backlinksInstall,
+  backlinksLatestRelease,
   backlinksList,
   backlinksReleases,
   backlinksStatus,
@@ -37,19 +38,14 @@ export const BACKLINKS_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['backlinks', 'sync'],
-    usage: 'canonry backlinks sync --release <id> [--wait] [--format json]',
+    usage: 'canonry backlinks sync [--release <id>] [--wait] [--format json]',
     options: {
       release: stringOption(),
       wait: { type: 'boolean' },
     },
     run: async (input) => {
-      const release = requireStringOption(input, 'release', {
-        message: '--release is required',
-        usage: 'canonry backlinks sync --release <id> [--wait]',
-        command: 'backlinks sync',
-      })
       await backlinksSync({
-        release,
+        release: getString(input.values, 'release'),
         wait: getBoolean(input.values, 'wait'),
         format: input.format,
       })
@@ -92,6 +88,14 @@ export const BACKLINKS_CLI_COMMANDS: readonly CliCommandSpec[] = [
     options: {},
     run: async (input) => {
       await backlinksReleases({ format: input.format })
+    },
+  },
+  {
+    path: ['backlinks', 'releases', 'latest'],
+    usage: 'canonry backlinks releases latest [--format json]',
+    options: {},
+    run: async (input) => {
+      await backlinksLatestRelease({ format: input.format })
     },
   },
   {

--- a/packages/canonry/src/client.ts
+++ b/packages/canonry/src/client.ts
@@ -54,6 +54,7 @@ import type {
   BacklinkSummaryDto,
   BacklinksInstallResultDto,
   BacklinksInstallStatusDto,
+  CcAvailableRelease,
   CcCachedRelease,
   CcReleaseSyncDto,
   AgentMemoryEntryDto,
@@ -1007,8 +1008,12 @@ export class ApiClient {
     return this.request<BacklinksInstallResultDto>('POST', '/backlinks/install')
   }
 
-  async backlinksTriggerSync(release: string): Promise<CcReleaseSyncDto> {
-    return this.request<CcReleaseSyncDto>('POST', '/backlinks/syncs', { release })
+  async backlinksTriggerSync(release?: string): Promise<CcReleaseSyncDto> {
+    return this.request<CcReleaseSyncDto>('POST', '/backlinks/syncs', release ? { release } : undefined)
+  }
+
+  async backlinksLatestRelease(): Promise<CcAvailableRelease | null> {
+    return this.request<CcAvailableRelease | null>('GET', '/backlinks/latest-release')
   }
 
   async backlinksLatestSync(): Promise<CcReleaseSyncDto | null> {

--- a/packages/canonry/src/commands/backlinks.ts
+++ b/packages/canonry/src/commands/backlinks.ts
@@ -3,6 +3,7 @@ import type {
   BacklinkSummaryDto,
   BacklinksInstallResultDto,
   BacklinksInstallStatusDto,
+  CcAvailableRelease,
   CcCachedRelease,
   CcReleaseSyncDto,
   RunDto,
@@ -145,7 +146,7 @@ export async function backlinksDoctor(opts: FormatOptions = {}): Promise<void> {
   console.log(formatInstallStatus(status))
 }
 
-export async function backlinksSync(opts: FormatOptions & { release: string; wait?: boolean }): Promise<void> {
+export async function backlinksSync(opts: FormatOptions & { release?: string; wait?: boolean }): Promise<void> {
   const client = getClient()
   const sync = await client.backlinksTriggerSync(opts.release)
   const final = opts.wait ? await pollSync(sync.id, opts.format) : sync
@@ -154,7 +155,39 @@ export async function backlinksSync(opts: FormatOptions & { release: string; wai
     return
   }
   if (opts.wait) process.stderr.write('\n')
+  if (!opts.release) {
+    process.stderr.write(`Auto-discovered release: ${sync.release}\n`)
+  }
   console.log(formatSync(final))
+}
+
+function formatBytesShort(n: number | null): string {
+  if (n === null) return '—'
+  if (n >= 1e9) return `${(n / 1e9).toFixed(1)} GB`
+  if (n >= 1e6) return `${(n / 1e6).toFixed(1)} MB`
+  if (n >= 1e3) return `${(n / 1e3).toFixed(1)} KB`
+  return `${n} B`
+}
+
+export function formatLatestRelease(result: CcAvailableRelease | null): string {
+  if (!result) return 'No release discovered (Common Crawl probe returned no candidates).'
+  const lines: string[] = []
+  lines.push(`Release: ${result.release}`)
+  lines.push(`Vertex:  ${result.vertexUrl}`)
+  lines.push(`         ${formatBytesShort(result.vertexBytes)}`)
+  lines.push(`Edges:   ${result.edgesUrl}`)
+  lines.push(`         ${formatBytesShort(result.edgesBytes)}`)
+  if (result.lastModified) lines.push(`Last modified: ${result.lastModified}`)
+  return lines.join('\n')
+}
+
+export async function backlinksLatestRelease(opts: FormatOptions = {}): Promise<void> {
+  const result = await getClient().backlinksLatestRelease()
+  if (opts.format === 'json') {
+    printJson(result)
+    return
+  }
+  console.log(formatLatestRelease(result))
 }
 
 export async function backlinksStatus(opts: FormatOptions = {}): Promise<void> {

--- a/packages/canonry/src/mcp/openapi-classification.ts
+++ b/packages/canonry/src/mcp/openapi-classification.ts
@@ -136,6 +136,7 @@ export const MCP_OPENAPI_OPERATION_CLASSIFICATIONS = {
   'GET /api/v1/backlinks/syncs': 'deferred',
   'GET /api/v1/backlinks/syncs/latest': 'deferred',
   'GET /api/v1/backlinks/releases': 'deferred',
+  'GET /api/v1/backlinks/latest-release': 'included',
   'DELETE /api/v1/backlinks/cache/{release}': 'deferred',
   'POST /api/v1/projects/{name}/backlinks/extract': 'deferred',
   'GET /api/v1/projects/{name}/backlinks/summary': 'deferred',

--- a/packages/canonry/src/mcp/tool-registry.ts
+++ b/packages/canonry/src/mcp/tool-registry.ts
@@ -417,6 +417,18 @@ export const canonryMcpTools = [
     handler: (client, input) => client.getSchedule(input.project),
   }),
   defineTool({
+    name: 'canonry_backlinks_latest_release',
+    title: 'Discover latest Common Crawl release',
+    description:
+      'Probes Common Crawl to find the latest published hyperlinkgraph release. Returns the release id and file URLs/sizes ready to feed into a backlinks sync (or null if no candidate slug responded).',
+    access: 'read',
+    tier: 'setup',
+    inputSchema: emptyInputSchema,
+    annotations: readAnnotations(true),
+    openApiOperations: ['GET /api/v1/backlinks/latest-release'],
+    handler: (client) => client.backlinksLatestRelease(),
+  }),
+  defineTool({
     name: 'canonry_settings_get',
     title: 'Get settings',
     description: 'Get Canonry API settings and configured provider status.',

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -54,6 +54,7 @@ import {
   installDuckdb,
   isDuckdbInstalled,
   listCachedReleases as listCachedReleasesFromDisk,
+  probeLatestRelease,
   pruneCachedRelease,
   readInstalledVersion,
 } from '@ainyc/canonry-integration-commoncrawl'
@@ -760,6 +761,31 @@ export async function createServer(opts: {
     return reply.status(204).send()
   })
 
+  const LATEST_RELEASE_TTL_MS = 5 * 60 * 1000
+  let latestReleaseCache: { value: import('@ainyc/canonry-contracts').CcAvailableRelease | null; expiresAt: number } | null = null
+  const discoverLatestRelease = async (): Promise<import('@ainyc/canonry-contracts').CcAvailableRelease | null> => {
+    const now = Date.now()
+    if (latestReleaseCache && latestReleaseCache.expiresAt > now) {
+      return latestReleaseCache.value
+    }
+    const probed = await probeLatestRelease().catch((err: unknown) => {
+      app.log.warn({ err }, 'Common Crawl latest-release probe failed')
+      return null
+    })
+    const value = probed
+      ? {
+          release: probed.release,
+          vertexUrl: probed.vertexUrl,
+          edgesUrl: probed.edgesUrl,
+          vertexBytes: probed.vertexBytes,
+          edgesBytes: probed.edgesBytes,
+          lastModified: probed.lastModified,
+        }
+      : null
+    latestReleaseCache = { value, expiresAt: now + LATEST_RELEASE_TTL_MS }
+    return value
+  }
+
   await app.register(apiRoutes, {
     db: opts.db,
     routePrefix: apiPrefix,
@@ -868,6 +894,7 @@ export async function createServer(opts: {
         }
       })
     },
+    discoverLatestRelease,
     openApiInfo: {
       title: 'Canonry API',
       version: PKG_VERSION,

--- a/packages/canonry/test/mcp-registry.test.ts
+++ b/packages/canonry/test/mcp-registry.test.ts
@@ -36,6 +36,7 @@ const expectedToolNames = [
   'canonry_keywords_list',
   'canonry_competitors_list',
   'canonry_schedule_get',
+  'canonry_backlinks_latest_release',
   'canonry_settings_get',
   'canonry_google_connections_list',
   'canonry_gsc_performance',
@@ -71,10 +72,10 @@ const expectedToolNames = [
 
 describe('MCP tool registry', () => {
   it('ships the curated v1 surface', () => {
-    expect(CANONRY_MCP_TOOL_COUNT).toBe(51)
-    expect(CANONRY_MCP_READ_TOOL_COUNT).toBe(36)
+    expect(CANONRY_MCP_TOOL_COUNT).toBe(52)
+    expect(CANONRY_MCP_READ_TOOL_COUNT).toBe(37)
     expect(canonryMcpTools.map(tool => tool.name)).toEqual(expectedToolNames)
-    expect(getCanonryMcpTools('read-only').map(tool => tool.name)).toEqual(expectedToolNames.slice(0, 36))
+    expect(getCanonryMcpTools('read-only').map(tool => tool.name)).toEqual(expectedToolNames.slice(0, 37))
   })
 
   it('tags every tool with a tier from the published list', () => {
@@ -108,7 +109,7 @@ describe('MCP tool registry', () => {
       counts.set(tool.tier, (counts.get(tool.tier) ?? 0) + 1)
     }
     expect(counts.get('monitoring')).toBe(11)
-    expect(counts.get('setup')).toBe(14)
+    expect(counts.get('setup')).toBe(15)
     expect(counts.get('gsc')).toBe(7)
     expect(counts.get('ga')).toBe(8)
     expect(counts.get('agent')).toBe(1)
@@ -417,6 +418,7 @@ const handlerCases: HandlerCase[] = [
   { tool: 'canonry_keywords_list', input: projectInput, methods: ['listKeywords'] },
   { tool: 'canonry_competitors_list', input: projectInput, methods: ['listCompetitors'] },
   { tool: 'canonry_schedule_get', input: projectInput, methods: ['getSchedule'] },
+  { tool: 'canonry_backlinks_latest_release', input: {}, methods: ['backlinksLatestRelease'] },
   { tool: 'canonry_settings_get', input: {}, methods: ['getSettings'] },
   { tool: 'canonry_google_connections_list', input: projectInput, methods: ['googleConnections'] },
   { tool: 'canonry_gsc_performance', input: { project: 'acme', window: '30d' }, methods: ['gscPerformance'] },

--- a/packages/canonry/test/mcp-stdio.test.ts
+++ b/packages/canonry/test/mcp-stdio.test.ts
@@ -154,11 +154,12 @@ describe('canonry-mcp stdio', () => {
     await client.connect(transport)
 
     const list = await client.listTools()
-    expect(list.tools).toHaveLength(53)
+    expect(list.tools).toHaveLength(54)
     const names = list.tools.map(tool => tool.name)
     expect(names).toContain('canonry_insights_list')
     expect(names).toContain('canonry_project_overview')
     expect(names).toContain('canonry_search')
+    expect(names).toContain('canonry_backlinks_latest_release')
     expect(names).toContain('canonry_help')
   })
 })


### PR DESCRIPTION
## Summary
- Make `--release` optional everywhere (CLI, MCP, API, web): the local server probes Common Crawl by HEAD-checking quarterly slugs (cached ~5 min) via a new `GET /backlinks/latest-release` endpoint.
- Surface the probe as `canonry backlinks releases latest`, the `canonry_backlinks_latest_release` MCP tool, and the Backlinks page (now defaults to auto-detected with a "Use a different release" override).
- Drop `Content-Type: application/json` from body-less POSTs in the web `apiFetch` — Fastify's JSON parser was rejecting empty bodies and breaking `installBacklinks()` from the dashboard.
- Bumps version to 2.14.0 and adds tests for the new route, the auto-discovery fallback, the Content-Type behavior, and the MCP registry shape.

## Test plan
- [ ] `pnpm test` (api-routes backlinks suite, canonry mcp-registry/mcp-stdio, apps/web api-fetch-headers)
- [ ] `pnpm typecheck && pnpm lint`
- [ ] Local: open the Backlinks page, confirm auto-detected release renders, click Run sync without typing anything
- [ ] Local: `canonry backlinks releases latest` and `canonry backlinks sync` (no `--release`) both succeed