### PR TITLE
feat(ga): per-page Direct-channel sessions 

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -76,7 +76,7 @@ erDiagram
 | Table | Purpose |
 |-------|---------|
 | **ga_connections** | GA4 property connection (1:1 with project) |
-| **ga_traffic_snapshots** | Traffic data snapshots |
+| **ga_traffic_snapshots** | Per-page daily traffic snapshots. Includes `sessions`, `organic_sessions`, and `direct_sessions` (nullable; populated by GA4 sync) — supports per-channel landing-page breakdowns. |
 | **ga_traffic_summaries** | Aggregated traffic summaries |
 | **ga_ai_referrals** | AI engine referral tracking. Unique: `(projectId, date, source, medium, sourceDimension)` |
 | **ga_social_referrals** | Social media referral tracking. Unique: `(projectId, date, source, medium, channelGroup)` |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "2.14.1",
+  "version": "2.14.2",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/ga.ts
+++ b/packages/api-routes/src/ga.ts
@@ -405,6 +405,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
               landingPageNormalized: normalizeUrlPath(row.landingPage),
               sessions: row.sessions,
               organicSessions: row.organicSessions,
+              directSessions: row.directSessions,
               users: row.users,
               syncedAt: now,
               syncRunId: runId,
@@ -570,6 +571,18 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
           .where(eq(gaTrafficSummaries.projectId, project.id))
           .get()
 
+    // Direct-channel total. Always sourced from gaTrafficSnapshots since
+    // gaTrafficSummaries doesn't carry a direct_sessions column. Returns
+    // 0 when no rows match (e.g., a project that hasn't synced yet, or
+    // legacy rows with null direct_sessions).
+    const directTotalRow = app.db
+      .select({
+        totalDirectSessions: sql<number>`COALESCE(SUM(${gaTrafficSnapshots.directSessions}), 0)`,
+      })
+      .from(gaTrafficSnapshots)
+      .where(and(...snapshotConditions))
+      .get()
+
     // Always fetch period bounds from the summary table (reflects full synced range).
     const summaryMeta = app.db
       .select({
@@ -588,6 +601,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         landingPage: sql<string>`COALESCE(${gaTrafficSnapshots.landingPageNormalized}, ${gaTrafficSnapshots.landingPage})`,
         sessions: sql<number>`SUM(${gaTrafficSnapshots.sessions})`,
         organicSessions: sql<number>`SUM(${gaTrafficSnapshots.organicSessions})`,
+        directSessions: sql<number>`COALESCE(SUM(${gaTrafficSnapshots.directSessions}), 0)`,
         users: sql<number>`SUM(${gaTrafficSnapshots.users})`,
       })
       .from(gaTrafficSnapshots)
@@ -665,15 +679,18 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       .get()
 
     const total = summaryRow?.totalSessions ?? 0
+    const totalDirectSessions = directTotalRow?.totalDirectSessions ?? 0
 
     return {
       totalSessions: total,
       totalOrganicSessions: summaryRow?.totalOrganicSessions ?? 0,
+      totalDirectSessions,
       totalUsers: summaryRow?.totalUsers ?? 0,
       topPages: rows.map((r) => ({
         landingPage: r.landingPage,
         sessions: r.sessions ?? 0,
         organicSessions: r.organicSessions ?? 0,
+        directSessions: r.directSessions ?? 0,
         users: r.users ?? 0,
       })),
       aiReferrals: aiReferrals.map((r) => ({
@@ -696,6 +713,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       socialUsers: socialTotals?.users ?? 0,
       organicSharePct: total > 0 ? Math.round(((summaryRow?.totalOrganicSessions ?? 0) / total) * 100) : 0,
       aiSharePct: total > 0 ? Math.round(((aiDeduped?.sessions ?? 0) / total) * 100) : 0,
+      directSharePct: total > 0 ? Math.round((totalDirectSessions / total) * 100) : 0,
       socialSharePct: total > 0 ? Math.round(((socialTotals?.sessions ?? 0) / total) * 100) : 0,
       lastSyncedAt: latestSync?.syncedAt ?? null,
       periodStart: (() => {

--- a/packages/api-routes/test/ga.test.ts
+++ b/packages/api-routes/test/ga.test.ts
@@ -572,6 +572,114 @@ describe('GA4 routes', () => {
     credentials.delete('test-project')
   })
 
+  it('GET /ga/traffic exposes per-page directSessions and totalDirectSessions', async () => {
+    const now = new Date().toISOString()
+    const today = now.slice(0, 10)
+    credentials.set('test-project', {
+      projectName: 'test-project',
+      propertyId: '999888',
+      clientEmail: 'sa@test.iam.gserviceaccount.com',
+      privateKey: 'fake-key',
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    // Seed two pages with explicit Direct counts at today's date so they
+    // fall inside any window filter. Use unique landingPage paths so the
+    // shared-DB coverage test downstream isn't polluted.
+    const idA = crypto.randomUUID()
+    const idB = crypto.randomUUID()
+    db.insert(gaTrafficSnapshots).values({
+      id: idA,
+      projectId,
+      date: today,
+      landingPage: '/__direct-test-pricing',
+      sessions: 60,
+      organicSessions: 10,
+      directSessions: 40,
+      users: 50,
+      syncedAt: now,
+    }).run()
+    db.insert(gaTrafficSnapshots).values({
+      id: idB,
+      projectId,
+      date: today,
+      landingPage: '/__direct-test-about',
+      sessions: 10,
+      organicSessions: 8,
+      directSessions: 1,
+      users: 9,
+      syncedAt: now,
+    }).run()
+
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/v1/projects/test-project/ga/traffic?window=7d',
+      })
+      expect(res.statusCode).toBe(200)
+      const body = JSON.parse(res.payload)
+      expect(body.totalDirectSessions).toBe(41)
+      const pricing = body.topPages.find(
+        (p: { landingPage: string }) => p.landingPage === '/__direct-test-pricing',
+      )
+      expect(pricing.directSessions).toBe(40)
+      const about = body.topPages.find(
+        (p: { landingPage: string }) => p.landingPage === '/__direct-test-about',
+      )
+      expect(about.directSessions).toBe(1)
+      // 41 / 70 ≈ 59% ; total here is 60 + 10 = 70
+      expect(body.directSharePct).toBe(59)
+    } finally {
+      db.delete(gaTrafficSnapshots).where(inArray(gaTrafficSnapshots.id, [idA, idB])).run()
+      credentials.delete('test-project')
+    }
+  })
+
+  it('GET /ga/traffic returns directSessions=0 for legacy rows with null direct_sessions', async () => {
+    const now = new Date().toISOString()
+    const today = now.slice(0, 10)
+    credentials.set('test-project', {
+      projectName: 'test-project',
+      propertyId: '999888',
+      clientEmail: 'sa@test.iam.gserviceaccount.com',
+      privateKey: 'fake-key',
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const id = crypto.randomUUID()
+    db.insert(gaTrafficSnapshots).values({
+      id,
+      projectId,
+      date: today,
+      landingPage: '/__direct-test-legacy',
+      sessions: 10,
+      organicSessions: 0,
+      // direct_sessions intentionally omitted (legacy row)
+      users: 8,
+      syncedAt: now,
+    }).run()
+
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/v1/projects/test-project/ga/traffic?window=7d',
+      })
+      expect(res.statusCode).toBe(200)
+      const body = JSON.parse(res.payload)
+      expect(body.totalDirectSessions).toBe(0)
+      expect(body.directSharePct).toBe(0)
+      const legacy = body.topPages.find(
+        (p: { landingPage: string }) => p.landingPage === '/__direct-test-legacy',
+      )
+      expect(legacy.directSessions).toBe(0)
+    } finally {
+      db.delete(gaTrafficSnapshots).where(eq(gaTrafficSnapshots.id, id)).run()
+      credentials.delete('test-project')
+    }
+  })
+
   it('GET /ga/coverage returns all pages', async () => {
     const now = new Date().toISOString()
     credentials.set('test-project', {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/contracts/src/ga.ts
+++ b/packages/contracts/src/ga.ts
@@ -46,11 +46,15 @@ export type GA4SocialReferralDto = z.infer<typeof ga4SocialReferralDtoSchema>
 export const ga4TrafficSummaryDtoSchema = z.object({
   totalSessions: z.number(),
   totalOrganicSessions: z.number(),
+  /** Direct-channel sessions (sessions with no source — bookmarks, typed URLs, AI-driven traffic with stripped referrer). 0 for legacy rows from before the column was added. */
+  totalDirectSessions: z.number(),
   totalUsers: z.number(),
   topPages: z.array(z.object({
     landingPage: z.string(),
     sessions: z.number(),
     organicSessions: z.number(),
+    /** Per-page Direct-channel sessions. 0 for legacy rows. */
+    directSessions: z.number(),
     users: z.number(),
   })),
   aiReferrals: z.array(ga4AiReferralDtoSchema),
@@ -67,6 +71,8 @@ export const ga4TrafficSummaryDtoSchema = z.object({
   organicSharePct: z.number(),
   /** Deduped AI sessions as a percentage of total sessions (0–100, rounded). */
   aiSharePct: z.number(),
+  /** Direct-channel sessions as a percentage of total sessions (0–100, rounded). */
+  directSharePct: z.number(),
   /** Social sessions as a percentage of total sessions (0–100, rounded). */
   socialSharePct: z.number(),
   lastSyncedAt: z.string().nullable(),
@@ -136,8 +142,10 @@ export interface GaAttributionTrendResponse {
 export interface GaTrafficResponse {
   totalSessions: number
   totalOrganicSessions: number
+  /** Direct-channel sessions (sessions with no source — bookmarks, typed URLs, AI-driven traffic with stripped referrer). 0 for legacy rows from before the column was added. */
+  totalDirectSessions: number
   totalUsers: number
-  topPages: Array<{ landingPage: string; sessions: number; organicSessions: number; users: number }>
+  topPages: Array<{ landingPage: string; sessions: number; organicSessions: number; directSessions: number; users: number }>
   aiReferrals: Array<{ source: string; medium: string; sessions: number; users: number; sourceDimension: GA4SourceDimension }>
   /** Deduped AI session total: MAX(sessions) per date+source+medium across attribution dimensions, then summed. */
   aiSessionsDeduped: number
@@ -152,6 +160,8 @@ export interface GaTrafficResponse {
   organicSharePct: number
   /** Deduped AI sessions as a percentage of total sessions (0–100, rounded). */
   aiSharePct: number
+  /** Direct-channel sessions as a percentage of total sessions (0–100, rounded). */
+  directSharePct: number
   /** Social sessions as a percentage of total sessions (0–100, rounded). */
   socialSharePct: number
   lastSyncedAt: string | null

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -570,6 +570,13 @@ const MIGRATIONS = [
   `ALTER TABLE ga_traffic_snapshots ADD COLUMN landing_page_normalized TEXT`,
   `CREATE INDEX IF NOT EXISTS idx_ga_traffic_page_normalized
      ON ga_traffic_snapshots(project_id, date, landing_page_normalized)`,
+
+  // v45: Per-page Direct channel sessions on ga_traffic_snapshots. Nullable
+  // so existing rows survive; populated by the GA4 sync writer in a
+  // separate commit. Unblocks an honest channel breakdown for the project
+  // dashboard (organic / social / direct / known-AI) — see
+  // plans/ai-attribution-research.md scope A.
+  `ALTER TABLE ga_traffic_snapshots ADD COLUMN direct_sessions INTEGER`,
 ]
 
 /**

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -292,6 +292,13 @@ export const gaTrafficSnapshots = sqliteTable('ga_traffic_snapshots', {
   landingPageNormalized: text('landing_page_normalized'),
   sessions: integer('sessions').notNull().default(0),
   organicSessions: integer('organic_sessions').notNull().default(0),
+  /**
+   * Per-page Direct channel sessions. Nullable so existing rows survive
+   * the migration; new GA4 sync writes populate it. Distinct from
+   * `sessions - organicSessions` because that residual lumps Direct
+   * together with social, referral, paid, and email.
+   */
+  directSessions: integer('direct_sessions'),
   users: integer('users').notNull().default(0),
   syncedAt: text('synced_at').notNull(),
   syncRunId: text('sync_run_id').references(() => runs.id, { onDelete: 'cascade' }),

--- a/packages/db/test/ga-traffic-direct-sessions.test.ts
+++ b/packages/db/test/ga-traffic-direct-sessions.test.ts
@@ -1,0 +1,125 @@
+import { test, expect, onTestFinished } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { eq } from 'drizzle-orm'
+import {
+  createClient,
+  migrate,
+  projects,
+  gaTrafficSnapshots,
+} from '../src/index.js'
+
+function createTempDb() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-test-'))
+  const dbPath = path.join(tmpDir, 'test.db')
+  const db = createClient(dbPath)
+  migrate(db)
+  return { db, dbPath, tmpDir }
+}
+
+function cleanup(tmpDir: string) {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+}
+
+function seedProject(db: ReturnType<typeof createTempDb>['db']) {
+  const now = new Date().toISOString()
+  db.insert(projects).values({
+    id: 'proj_1',
+    name: 'test-project',
+    displayName: 'Test Project',
+    canonicalDomain: 'example.com',
+    country: 'US',
+    language: 'en',
+    createdAt: now,
+    updatedAt: now,
+  }).run()
+}
+
+test('ga_traffic_snapshots round-trips direct_sessions when set', () => {
+  const { db, tmpDir } = createTempDb()
+  onTestFinished(() => cleanup(tmpDir))
+
+  seedProject(db)
+
+  const now = new Date().toISOString()
+  db.insert(gaTrafficSnapshots).values({
+    id: 'snap_1',
+    projectId: 'proj_1',
+    date: '2026-04-29',
+    landingPage: '/pricing',
+    sessions: 25,
+    organicSessions: 4,
+    directSessions: 7,
+    users: 18,
+    syncedAt: now,
+  }).run()
+
+  const [row] = db
+    .select()
+    .from(gaTrafficSnapshots)
+    .where(eq(gaTrafficSnapshots.id, 'snap_1'))
+    .all()
+
+  expect(row).toBeDefined()
+  expect(row.directSessions).toBe(7)
+  expect(row.sessions).toBe(25)
+  expect(row.organicSessions).toBe(4)
+})
+
+test('ga_traffic_snapshots accepts a row without direct_sessions (nullable)', () => {
+  const { db, tmpDir } = createTempDb()
+  onTestFinished(() => cleanup(tmpDir))
+
+  seedProject(db)
+
+  const now = new Date().toISOString()
+  db.insert(gaTrafficSnapshots).values({
+    id: 'snap_2',
+    projectId: 'proj_1',
+    date: '2026-04-29',
+    landingPage: '/about',
+    sessions: 10,
+    organicSessions: 2,
+    users: 8,
+    syncedAt: now,
+  }).run()
+
+  const [row] = db
+    .select()
+    .from(gaTrafficSnapshots)
+    .where(eq(gaTrafficSnapshots.id, 'snap_2'))
+    .all()
+
+  expect(row).toBeDefined()
+  expect(row.directSessions).toBeNull()
+})
+
+test('ga_traffic_snapshots can store directSessions = 0 distinctly from null', () => {
+  const { db, tmpDir } = createTempDb()
+  onTestFinished(() => cleanup(tmpDir))
+
+  seedProject(db)
+
+  const now = new Date().toISOString()
+  db.insert(gaTrafficSnapshots).values({
+    id: 'snap_zero',
+    projectId: 'proj_1',
+    date: '2026-04-29',
+    landingPage: '/contact',
+    sessions: 5,
+    organicSessions: 5,
+    directSessions: 0,
+    users: 4,
+    syncedAt: now,
+  }).run()
+
+  const [row] = db
+    .select()
+    .from(gaTrafficSnapshots)
+    .where(eq(gaTrafficSnapshots.id, 'snap_zero'))
+    .all()
+
+  expect(row.directSessions).toBe(0)
+  expect(row.directSessions).not.toBeNull()
+})

--- a/packages/integration-google-analytics/src/ga4-client.ts
+++ b/packages/integration-google-analytics/src/ga4-client.ts
@@ -314,6 +314,7 @@ export async function fetchTrafficByLandingPage(
       landingPage: row.dimensionValues[1]!.value,
       sessions: parseInt(row.metricValues[0]!.value, 10) || 0,
       organicSessions: 0, // populated by organic-only pass below
+      directSessions: 0, // populated by direct-only pass below
       users: parseInt(row.metricValues[1]!.value, 10) || 0,
     }))
 
@@ -358,10 +359,45 @@ export async function fetchTrafficByLandingPage(
     if ((organicResponse.rows ?? []).length < 10000 || organicOffset >= total) break
   }
 
-  // Merge organic session counts back into the rows
+  // Third pass: direct-only report filtered to "Direct" channel.
+  // GA4's Direct channel is everything with no source — bookmarks,
+  // typed URLs, untagged email, in-app browsers, and (the reason this
+  // pass exists) AI-driven traffic that lost its referrer header.
+  const directMap = new Map<string, number>()
+  let directOffset = 0
+  let directPageCount = 0
+  while (directPageCount < GA4_MAX_PAGES) {
+    directPageCount++
+    const directRequest: GA4RunReportRequest = {
+      dateRanges: [{ startDate: formatDate(startDate), endDate: formatDate(endDate) }],
+      dimensions: [{ name: 'date' }, { name: 'landingPagePlusQueryString' }],
+      metrics: [{ name: 'sessions' }],
+      dimensionFilter: {
+        filter: {
+          fieldName: 'sessionDefaultChannelGrouping',
+          stringFilter: { matchType: 'EXACT', value: 'Direct' },
+        },
+      },
+      limit: 10000,
+      offset: directOffset,
+    }
+    const directResponse = await runReport(accessToken, propertyId, directRequest)
+    if (!directResponse) break
+
+    for (const row of directResponse.rows ?? []) {
+      const key = `${row.dimensionValues[0]!.value}::${row.dimensionValues[1]!.value}`
+      directMap.set(key, parseInt(row.metricValues[0]!.value, 10) || 0)
+    }
+    const total = directResponse.rowCount ?? 0
+    directOffset += (directResponse.rows ?? []).length
+    if ((directResponse.rows ?? []).length < 10000 || directOffset >= total) break
+  }
+
+  // Merge organic and direct session counts back into the rows
   for (const row of rows) {
     const key = `${row.date}::${row.landingPage}`
     row.organicSessions = organicMap.get(key) ?? 0
+    row.directSessions = directMap.get(key) ?? 0
   }
 
   // Convert YYYYMMDD to YYYY-MM-DD

--- a/packages/integration-google-analytics/src/types.ts
+++ b/packages/integration-google-analytics/src/types.ts
@@ -45,6 +45,15 @@ export interface GA4TrafficRow {
   landingPage: string
   sessions: number
   organicSessions: number
+  /**
+   * Sessions whose `sessionDefaultChannelGrouping` is `Direct` — i.e., GA4
+   * couldn't attribute a source. The dark-traffic bucket lives here on
+   * deep pages with no UTM, which is also where AI-driven traffic
+   * (referrer-stripped) lands. Captured via a separate filtered Reports
+   * API pass; defaults to 0 for landing pages absent from the Direct
+   * channel response.
+   */
+  directSessions: number
   users: number
 }
 

--- a/packages/integration-google-analytics/test/ga4-client.test.ts
+++ b/packages/integration-google-analytics/test/ga4-client.test.ts
@@ -143,6 +143,66 @@ describe('fetchTrafficByLandingPage', () => {
     expect(rows[0]!.sessions).toBe(100)
     expect(mainCallCount).toBe(1)
   })
+
+  it('populates directSessions per page from a Direct-channel pass', async () => {
+    // Main pass: two pages with sessions; organic pass returns one page;
+    // direct pass returns a different page with a session count.
+    const mainResponse = {
+      rows: [
+        { dimensionValues: [{ value: '20260320' }, { value: '/' }], metricValues: [{ value: '100' }, { value: '60' }] },
+        { dimensionValues: [{ value: '20260320' }, { value: '/about' }], metricValues: [{ value: '20' }, { value: '15' }] },
+      ],
+      rowCount: 2,
+    }
+    const organicResponse = {
+      rows: [
+        { dimensionValues: [{ value: '20260320' }, { value: '/' }], metricValues: [{ value: '12' }] },
+      ],
+      rowCount: 1,
+    }
+    const directResponse = {
+      rows: [
+        { dimensionValues: [{ value: '20260320' }, { value: '/' }], metricValues: [{ value: '70' }] },
+        { dimensionValues: [{ value: '20260320' }, { value: '/about' }], metricValues: [{ value: '5' }] },
+      ],
+      rowCount: 2,
+    }
+
+    fetchSpy.mockImplementation(async (_input: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(init?.body as string ?? '{}')
+      const filterValue = body?.dimensionFilter?.filter?.stringFilter?.value
+      if (filterValue === 'Organic Search') return mockFetchResponse(organicResponse)
+      if (filterValue === 'Direct') return mockFetchResponse(directResponse)
+      return mockFetchResponse(mainResponse)
+    })
+
+    const rows = await fetchTrafficByLandingPage('fake-token', '123456', 1)
+    const byPage = new Map(rows.map((r) => [r.landingPage, r]))
+
+    expect(byPage.get('/')?.sessions).toBe(100)
+    expect(byPage.get('/')?.organicSessions).toBe(12)
+    expect(byPage.get('/')?.directSessions).toBe(70)
+    expect(byPage.get('/about')?.sessions).toBe(20)
+    expect(byPage.get('/about')?.organicSessions).toBe(0)
+    expect(byPage.get('/about')?.directSessions).toBe(5)
+  })
+
+  it('directSessions is 0 when the Direct pass has no rows for that page', async () => {
+    const mainResponse = {
+      rows: [
+        { dimensionValues: [{ value: '20260320' }, { value: '/lonely' }], metricValues: [{ value: '5' }, { value: '4' }] },
+      ],
+      rowCount: 1,
+    }
+    fetchSpy.mockImplementation(async (_input: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(init?.body as string ?? '{}')
+      if (body?.dimensionFilter) return mockFetchResponse({ rows: [], rowCount: 0 })
+      return mockFetchResponse(mainResponse)
+    })
+
+    const rows = await fetchTrafficByLandingPage('fake-token', '123456', 1)
+    expect(rows[0]!.directSessions).toBe(0)
+  })
 })
 
 describe('fetchAiReferrals', () => {


### PR DESCRIPTION
## Summary

**Stacked on top of [#373](https://github.com/AINYC/canonry/pull/373) (path normalization). Review and merge that one first; this PR's diff is only the Direct-sessions delta.**

- Adds a nullable `direct_sessions` column to `ga_traffic_snapshots` (migration v45) — per-page Direct-channel session counts.
- Extends `fetchTrafficByLandingPage()` with a third filtered Reports API pass (`sessionDefaultChannelGrouping = 'Direct'`) that mirrors the existing organic-only pass.
- GA sync writer persists the new metric on every insert; the `/api/v1/projects/:name/ga/traffic` endpoint returns it as `topPages[].directSessions`, `totalDirectSessions`, and `directSharePct`.

This is **Step 2a** of the two-step plan in [`plans/ai-attribution-research.md`](https://github.com/AINYC/canonry/blob/arberx/path-normalize/plans/ai-attribution-research.md). Step 1 (path normalization, [#373](https://github.com/AINYC/canonry/pull/373)) is the base of this branch; the UI rework that consumes these new fields ships separately.

## Why now

The current "Attributable AI visits" panel shows `0 / 0% / 0` on real production data (and any project where GA4 didn't recognize an AI source string in the referrer). That zero is read as a measurement when it's really a structural blind spot — GA4 attributes only sessions where the referrer header survived. AI traffic that lands as Direct (referrer stripped, in-app browsers, copy-pasted URLs) is invisible.

This PR captures the signal we need to replace that surface with an honest channel breakdown:

```
TRAFFIC SOURCES (last 30d)        sessions   share
  Organic search                       14    11.2%
  Facebook (referral)                  16    12.8%
  Direct                               88    70.4%   ← NEW
  Known AI referrers                    0     0.0%
```

The `direct_sessions` value is the *total* Direct bucket, not the dark-traffic bucket — separating "Direct to homepage" from "Direct to deep pages" requires the path normalization in [#373](https://github.com/AINYC/canonry/pull/373) (this PR's base) and is layered on top in the follow-up UI commit.

## API additions (additive, no breaking changes)

```
GET /api/v1/projects/:name/ga/traffic

  // existing fields unchanged
  totalSessions, totalOrganicSessions, totalUsers,
  topPages: [{ landingPage, sessions, organicSessions, users, ... }],
  aiReferrals, aiSessionsDeduped, aiUsersDeduped,
  socialReferrals, socialSessions, socialUsers,
  organicSharePct, aiSharePct, socialSharePct,

  // NEW
  totalDirectSessions: number,
  topPages[].directSessions: number,
  directSharePct: number,
```

All new fields default to 0 for legacy rows from before the migration. No version-bump-blocking schema break.

## Migration ordering

Both commits in the stack land their own migration:

- v44 (from [#373](https://github.com/AINYC/canonry/pull/373)): `landing_page_normalized` column
- v45 (this PR): `direct_sessions` column

Independent ALTER TABLE statements on the same table; no conflict.

## Test plan

- [x] 3 new TDD tests on `gaTrafficSnapshots` for the `direct_sessions` round-trip (set, null, zero distinct from null) — schema/migration commit
- [x] 2 new TDD tests for `fetchTrafficByLandingPage()` covering the Direct pass + zero-fallback for absent pages
- [x] 2 new TDD tests for `/ga/traffic` exposing `directSessions`, `totalDirectSessions`, `directSharePct` (with a separate assertion for the legacy-null path)
- [x] `pnpm typecheck` clean across the workspace
- [x] `pnpm lint` clean across the workspace
- [x] Full `pnpm test` — 1646 tests pass (includes [#373](https://github.com/AINYC/canonry/pull/373)'s 1639 plus the 7 new in this PR)
- [ ] Manual verification on production: re-sync the affected project, confirm the response now carries `directSessions` per page

## What this branch leaves for follow-ups

Documented in the research plan; calling out the immediate next slices:

1. Web UI rework in `apps/web/src/components/project/TrafficSection.tsx` — replace the binary "AI sessions / known referrers" panel with the four-source breakdown above. Will use the new fields plus the `directSharePct` derived metric.
2. Equivalent CLI surface (`canonry analytics ... --feature sources` extension) per the AGENTS.md UI/CLI parity rule.
3. Eventual integration with the path normalization from [#373](https://github.com/AINYC/canonry/pull/373) to compute the dark-traffic predicate (Direct + deep path + no UTM) — that's the "estimated AI traffic" surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)