### PR TITLE
fix(backfill): repair stale normalized GA paths

### DIFF
--- a/packages/canonry/src/commands/backfill.ts
+++ b/packages/canonry/src/commands/backfill.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNull } from 'drizzle-orm'
+import { and, eq, inArray } from 'drizzle-orm'
 import type { GroundingSource, NormalizedQueryResult } from '@ainyc/canonry-contracts'
 import { createClient, gaTrafficSnapshots, migrate, parseJsonColumn, competitors, projects, querySnapshots, runs } from '@ainyc/canonry-db'
 import { determineAnswerMentioned, effectiveDomains, normalizeUrlPath, ProviderNames, RunKinds } from '@ainyc/canonry-contracts'
@@ -226,7 +226,7 @@ export function backfillNormalizedPaths(
   db: ReturnType<typeof createClient>,
   opts?: { projectId?: string },
 ): NormalizedPathsBackfillResult {
-  const baseConditions = [isNull(gaTrafficSnapshots.landingPageNormalized)]
+  const baseConditions = []
   if (opts?.projectId) {
     baseConditions.push(eq(gaTrafficSnapshots.projectId, opts.projectId))
   }
@@ -235,9 +235,10 @@ export function backfillNormalizedPaths(
     .select({
       id: gaTrafficSnapshots.id,
       landingPage: gaTrafficSnapshots.landingPage,
+      landingPageNormalized: gaTrafficSnapshots.landingPageNormalized,
     })
     .from(gaTrafficSnapshots)
-    .where(and(...baseConditions))
+    .where(baseConditions.length > 0 ? and(...baseConditions) : undefined)
     .all()
 
   let updated = 0
@@ -247,12 +248,15 @@ export function backfillNormalizedPaths(
     db.transaction((tx) => {
       for (const row of rows) {
         const next = normalizeUrlPath(row.landingPage)
-        // Even if `next` is null (e.g., row.landingPage was "(not set)"),
-        // we still skip the write — leaving the column null is fine. The
-        // tradeoff: those rows stay candidates for future backfill runs,
-        // but the work is bounded (a row only stays null after we've seen
-        // it once if it can't be canonicalized, which is rare).
+        // If normalization still can't produce a canonical path, leave the
+        // row as-is. Otherwise, rewrite whenever the stored normalized value
+        // is missing or stale, so improved normalization logic can repair
+        // older rows after upgrades.
         if (next === null) {
+          unchanged++
+          continue
+        }
+        if (row.landingPageNormalized === next) {
           unchanged++
           continue
         }

--- a/packages/canonry/test/backfill-normalized-paths.test.ts
+++ b/packages/canonry/test/backfill-normalized-paths.test.ts
@@ -107,15 +107,15 @@ describe('backfill normalized-paths', () => {
     expect(readNormalized('s4')).toBeNull() // (not set) normalizes to null
   })
 
-  it('does not touch rows where landing_page_normalized is already populated', async () => {
-    insertSnapshot({ id: 's_already', landingPage: '/old', landingPageNormalized: '/sentinel' })
+  it('repairs stale normalized values and fills missing ones', async () => {
+    insertSnapshot({ id: 's_stale', landingPage: '/about/', landingPageNormalized: '/sentinel' })
     insertSnapshot({ id: 's_null', landingPage: '/about/' })
 
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
     await backfillNormalizedPathsCommand({ format: 'json' })
     logSpy.mockRestore()
 
-    expect(readNormalized('s_already')).toBe('/sentinel')
+    expect(readNormalized('s_stale')).toBe('/about')
     expect(readNormalized('s_null')).toBe('/about')
   })
 
@@ -133,7 +133,7 @@ describe('backfill normalized-paths', () => {
     const secondCall = logSpy.mock.calls.at(-1)?.[0] as string
     const secondResult = JSON.parse(secondCall)
     expect(secondResult.updated).toBe(0)
-    expect(secondResult.examined).toBe(0)
+    expect(secondResult.examined).toBe(1)
 
     logSpy.mockRestore()
   })


### PR DESCRIPTION
## Summary
- update normalized-paths backfill to repair stale stored values, not just null ones
- keep the backfill idempotent while allowing upgraded normalization logic to fix old rows
- add regression coverage for stale normalized values

## Why
The previous backfill only touched rows where `landing_page_normalized` was null. That left older rows with non-null but stale normalized values permanently skipped, so malformed GA landing paths could survive even after the feature shipped.

## Testing
- pnpm --filter @ainyc/canonry test -- --run packages/canonry/test/backfill-normalized-paths.test.ts
- full vitest suite passed locally (59 files, 501 tests)