### PR TITLE
fix(contracts): handle malformed GA/referral artifacts in normalizer

### DIFF
--- a/packages/contracts/src/url-normalize.ts
+++ b/packages/contracts/src/url-normalize.ts
@@ -67,9 +67,30 @@ function dropTrailingSlash(path: string): string {
 
 export function normalizeUrlPath(input: string | null | undefined): string | null {
   if (input == null) return null
-  const trimmed = input.trim()
+  let trimmed = input.trim()
   if (trimmed === '') return null
+
+  // Pre-normalization artifact cleanup (GA artifacts, Slack/doc copy-paste)
+  trimmed = trimmed
+    .replace(/&nbsp;/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  if (trimmed === '' || trimmed === '/') return '/'
   if (trimmed === '(not set)') return null
+
+  // Strip trailing punctuation that likely isn't part of a slug (e.g. trailing dot or parenthesis)
+  // but only if it's not a root / and it's not preceded by another punctuation (avoid stripping actual file extensions)
+  trimmed = trimmed.replace(/([a-zA-Z0-9])([).]+)$/, '$1')
+
+  // Special case for artifacts like "/) open" -> "/"
+  if (trimmed.startsWith('/)') || trimmed.startsWith('/ ')) {
+    trimmed = '/'
+  }
+  if (trimmed.includes(' ')) {
+    trimmed = trimmed.split(' ')[0]
+  }
+  if (trimmed === '' || trimmed === '/') return '/'
 
   let pathPart: string
   let queryPart: string

--- a/packages/contracts/test/url-normalize.test.ts
+++ b/packages/contracts/test/url-normalize.test.ts
@@ -176,4 +176,13 @@ describe('normalizeUrlPath', () => {
       expect(normalizeUrlPath('/page?fbclid&keep=1')).toBe('/page?keep=1')
     })
   })
+
+  describe('malformed artifacts', () => {
+    it('strips common trailing garbage from GA/referrals', () => {
+      expect(normalizeUrlPath('/aeo-methodology)')).toBe('/aeo-methodology')
+      expect(normalizeUrlPath('/)&nbsp;open')).toBe('/')
+      expect(normalizeUrlPath('/path.&nbsp;')).toBe('/path')
+      expect(normalizeUrlPath('/path...')).toBe('/path')
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- add pre-normalization cleanup for common "dirty" artifacts from GA and manual referral links
- strip trailing punctuation (dots, parentheses) that follow alphanumeric characters
- HTML-decode `&nbsp;` and handle space-fragmented paths
- add regression coverage for identified AINYC malformed rows

## Why
Identified rows in AINYC like `/aeo-methodology)` and `/)&nbsp;open` were surviving normalization because the normalizer was too conservative. This cleanup prevents click-ID-style fragmentation caused by simple parsing/copy-paste errors in the wild.