### PR TITLE
feat(ga): four-channel breakdown with disjoint AI cell

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -966,6 +966,8 @@ export interface ApiGaTrafficPage {
   landingPage: string
   sessions: number
   organicSessions: number
+  /** Direct-channel sessions for this landing page (sessions with no source). 0 for legacy rows. */
+  directSessions: number
   users: number
 }
 
@@ -988,13 +990,19 @@ export interface ApiGaSocialReferral {
 export interface ApiGaTraffic {
   totalSessions: number
   totalOrganicSessions: number
+  /** Total Direct-channel sessions across the synced window. */
+  totalDirectSessions: number
   totalUsers: number
   topPages: ApiGaTrafficPage[]
   aiReferrals: ApiGaTrafficReferral[]
-  /** Deduped AI session total (MAX per date+source+medium across attribution dimensions). */
+  /** Deduped AI session total (MAX per date+source+medium across attribution dimensions). Cross-cutting: can overlap with Direct/Organic/Social. */
   aiSessionsDeduped: number
   /** Deduped AI user total. */
   aiUsersDeduped: number
+  /** AI sessions whose CURRENT sessionSource matched an AI engine. Disjoint from Direct/Organic/Social — used by the channel breakdown. */
+  aiSessionsBySession: number
+  /** AI users whose CURRENT sessionSource matched an AI engine. */
+  aiUsersBySession: number
   socialReferrals: ApiGaSocialReferral[]
   /** Total social sessions (session-scoped via sessionDefaultChannelGroup). */
   socialSessions: number
@@ -1002,10 +1010,14 @@ export interface ApiGaTraffic {
   socialUsers: number
   /** Organic sessions as a percentage of total sessions (0–100, rounded). */
   organicSharePct: number
-  /** Deduped AI sessions as a percentage of total sessions (0–100, rounded). */
+  /** Deduped AI sessions as a percentage of total sessions (0–100, rounded). Cross-cutting: can overlap with Direct/Organic/Social. */
   aiSharePct: number
+  /** Session-source-only AI sessions as a percentage of total sessions (0–100, rounded). Disjoint from Direct/Organic/Social. */
+  aiSharePctBySession: number
   /** Social sessions as a percentage of total sessions (0–100, rounded). */
   socialSharePct: number
+  /** Direct sessions as a percentage of total sessions (0–100, rounded). */
+  directSharePct: number
   lastSyncedAt: string | null
   /** Start of the synced date range (YYYY-MM-DD), null if no data. */
   periodStart: string | null

--- a/apps/web/src/components/project/TrafficSection.tsx
+++ b/apps/web/src/components/project/TrafficSection.tsx
@@ -307,10 +307,14 @@ export function TrafficSection({ projectName }: { projectName: string }) {
   }
 
   const organicPct = traffic?.organicSharePct ?? 0
+  const organicSessions = traffic?.totalOrganicSessions ?? 0
   const aiSessions = traffic?.aiSessionsDeduped ?? 0
-  const aiSharePct = traffic?.aiSharePct ?? 0
+  const aiSessionsBySession = traffic?.aiSessionsBySession ?? 0
+  const aiSharePctBySession = traffic?.aiSharePctBySession ?? 0
   const aiSourceCount = traffic ? new Set(traffic.aiReferrals.map((referral) => referral.source.toLowerCase())).size : 0
   const topAiSource = sortedAiReferrals[0] ?? null
+  const directSessions = traffic?.totalDirectSessions ?? 0
+  const directSharePct = traffic?.directSharePct ?? 0
 
   const socialSessions = traffic?.socialSessions ?? 0
   const socialSharePct = traffic?.socialSharePct ?? 0
@@ -528,101 +532,90 @@ export function TrafficSection({ projectName }: { projectName: string }) {
               </Card>
             )}
 
-            <div className="grid gap-4 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.5fr)]">
-              <Card className="surface-card p-5">
-                <div className="mb-4">
-                  <p className="eyebrow eyebrow-soft">Summary</p>
-                  <h3 className="text-sm font-semibold text-zinc-100">Attributable AI visits</h3>
+            <Card className="surface-card p-5 mb-4">
+              <div className="mb-4">
+                <p className="eyebrow eyebrow-soft">Summary</p>
+                <h3 className="text-sm font-semibold text-zinc-100">Channel breakdown</h3>
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                <AttributionStat
+                  label="Organic"
+                  value={`${organicPct}%`}
+                  hint={`${organicSessions.toLocaleString()} sessions`}
+                  tone="positive"
+                  tooltip="Sessions from Google organic search (sessionDefaultChannelGrouping = 'Organic Search')."
+                />
+                <AttributionStat
+                  label="Social"
+                  value={`${socialSharePct}%`}
+                  hint={`${socialSessions.toLocaleString()} sessions`}
+                  tone="neutral"
+                  tooltip="Sessions from social platforms (sessionDefaultChannelGrouping = 'Organic Social' or 'Paid Social')."
+                />
+                <AttributionStat
+                  label="Direct"
+                  value={`${directSharePct}%`}
+                  hint={`${directSessions.toLocaleString()} sessions`}
+                  tone="neutral"
+                  tooltip="Sessions with no source — bookmarks, typed URLs, untagged email, in-app browsers, and AI-driven traffic whose referrer header was stripped."
+                />
+                <AttributionStat
+                  label="Known AI referrers (lower bound)"
+                  value={`${aiSharePctBySession}%`}
+                  hint={`${aiSessionsBySession.toLocaleString()} sessions`}
+                  tone="positive"
+                  tooltip="Sessions whose current sessionSource matched a known AI engine (e.g. chatgpt.com, claude.ai, gemini.google.com). Disjoint from Direct/Organic/Social. This is a strict lower bound: most AI traffic strips the referrer and falls into Direct, so the true AI share is typically higher than what's shown here. The detail table below also surfaces firstUserSource and UTM-tagged AI signals."
+                />
+              </div>
+
+              {topAiSource && (
+                <div className="mt-4 rounded-lg border border-emerald-800/40 bg-emerald-500/6 px-4 py-3 text-sm text-emerald-100">
+                  Top AI referrer: <span className="font-medium">{topAiSource.source}</span> via {topAiSource.medium}, accounting for {topAiSource.sessions.toLocaleString()} sessions.
                 </div>
+              )}
+            </Card>
 
-                {traffic.aiReferrals.length > 0 ? (
-                  <>
-                    <div className="grid gap-3 sm:grid-cols-3">
-                      <AttributionStat
-                        label="AI Sessions"
-                        value={formatCompact(aiSessions)}
-                        hint={`${aiSessions.toLocaleString()} sessions`}
-                        tone="positive"
-                        tooltip="Total sessions attributed to AI referral sources detected via GA4 sessionSource, firstUserSource, and sessionManualSource dimensions."
-                      />
-                      <AttributionStat
-                        label="Share of Traffic"
-                        value={`${aiSharePct}%`}
-                        hint="of total sessions"
-                        tone="neutral"
-                        tooltip="Percentage of your total site sessions that originated from AI answer engines. A higher share indicates stronger AI-driven discovery."
-                      />
-                      <AttributionStat
-                        label="Tracked Sources"
-                        value={String(aiSourceCount)}
-                        hint={`${traffic.aiReferrals.length} source rows`}
-                        tone="neutral"
-                        tooltip="Number of distinct AI referral sources detected. Each unique source/medium combination (e.g. chatgpt.com/referral) counts as one source row."
-                      />
-                    </div>
+            <Card className="surface-card p-5">
+              <div className="mb-4 flex items-end justify-between gap-3">
+                <div>
+                  <p className="eyebrow eyebrow-soft">Detail</p>
+                  <h3 className="text-sm font-semibold text-zinc-100">Known AI referrers — sources detected</h3>
+                </div>
+                <p className="text-xs text-zinc-500">
+                  {traffic.aiReferrals.length > 0 ? `${aiSourceCount} unique sources, ${traffic.aiReferrals.length} rows` : 'No source rows'}
+                </p>
+              </div>
 
-                    {topAiSource && (
-                      <div className="mt-4 rounded-lg border border-emerald-800/40 bg-emerald-500/6 px-4 py-3 text-sm text-emerald-100">
-                        Top AI referrer: <span className="font-medium">{topAiSource.source}</span> via {topAiSource.medium}, accounting for {topAiSource.sessions.toLocaleString()} sessions.
-                      </div>
-                    )}
-                  </>
-                ) : (
-                  <div className="space-y-3">
-                    <div className="grid gap-3 sm:grid-cols-3">
-                      <AttributionStat label="AI Sessions" value="0" hint="0 sessions" tone="neutral" tooltip="Total sessions attributed to AI referral sources detected via GA4 sessionSource, firstUserSource, and sessionManualSource dimensions." />
-                      <AttributionStat label="Share of Traffic" value="0%" hint="of total sessions" tone="neutral" tooltip="Percentage of your total site sessions that originated from AI answer engines." />
-                      <AttributionStat label="Tracked Sources" value="0" hint="known AI sources" tone="neutral" tooltip="Number of distinct AI referral sources detected after matching known AI engine referrers and AI-tagged UTM sources." />
-                    </div>
-                    <div className="rounded-lg border border-zinc-800/60 bg-zinc-900/30 px-4 py-3 text-sm text-zinc-400">
-                      <p className="mb-1.5 text-zinc-300">Monitoring for AI referral traffic from:</p>
-                      <p className="text-xs text-zinc-500">Known AI answer engines and matching UTM-tagged variants. Sessions will appear here once GA4 detects visits from tracked AI sources.</p>
-                    </div>
-                  </div>
-                )}
-              </Card>
-
-              <Card className="surface-card p-5">
-                <div className="mb-4 flex items-end justify-between gap-3">
-                  <div>
-                    <p className="eyebrow eyebrow-soft">Breakdown</p>
-                    <h3 className="text-sm font-semibold text-zinc-100">Source / medium</h3>
-                  </div>
-                  <p className="text-xs text-zinc-500">
-                    {traffic.aiReferrals.length > 0 ? `${traffic.aiReferrals.length} rows` : 'No source rows'}
+              {traffic.aiReferrals.length > 0 ? (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="text-[10px] uppercase tracking-wider text-zinc-500">
+                        <SortHeader label="Source" sortKey="source" current={referralSortKey} dir={referralSortDir} onSort={handleReferralSort} align="left" />
+                        <SortHeader label="Medium" sortKey="medium" current={referralSortKey} dir={referralSortDir} onSort={handleReferralSort} align="left" />
+                        <th className="py-1 font-medium text-left">Attribution</th>
+                        <SortHeader label="Sessions" sortKey="sessions" current={referralSortKey} dir={referralSortDir} onSort={handleReferralSort} align="right" />
+                        <th className="py-1 font-medium text-right">Share</th>
+                        <SortHeader label="Users" sortKey="users" current={referralSortKey} dir={referralSortDir} onSort={handleReferralSort} align="right" />
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {sortedAiReferrals.map((referral) => (
+                        <AiReferralRow key={`${referral.source}:${referral.medium}:${referral.sourceDimension}`} referral={referral} totalSessions={aiSessions} />
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ) : (
+                <div className="flex flex-col items-center justify-center py-8 text-center">
+                  <p className="text-sm text-zinc-400 mb-2">No AI referrer sessions detected yet</p>
+                  <p className="text-xs text-zinc-500 max-w-sm">
+                    AI engines that preserve a referrer (Perplexity, copy/paste from ChatGPT, etc.) will appear here. Most AI traffic strips the referrer — see the Direct cell above for the upper bound.
                   </p>
                 </div>
-
-                {traffic.aiReferrals.length > 0 ? (
-                  <div className="overflow-x-auto">
-                    <table className="w-full text-sm">
-                      <thead>
-                        <tr className="text-[10px] uppercase tracking-wider text-zinc-500">
-                          <SortHeader label="Source" sortKey="source" current={referralSortKey} dir={referralSortDir} onSort={handleReferralSort} align="left" />
-                          <SortHeader label="Medium" sortKey="medium" current={referralSortKey} dir={referralSortDir} onSort={handleReferralSort} align="left" />
-                          <th className="py-1 font-medium text-left">Attribution</th>
-                          <SortHeader label="Sessions" sortKey="sessions" current={referralSortKey} dir={referralSortDir} onSort={handleReferralSort} align="right" />
-                          <th className="py-1 font-medium text-right">Share</th>
-                          <SortHeader label="Users" sortKey="users" current={referralSortKey} dir={referralSortDir} onSort={handleReferralSort} align="right" />
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {sortedAiReferrals.map((referral) => (
-                          <AiReferralRow key={`${referral.source}:${referral.medium}:${referral.sourceDimension}`} referral={referral} totalSessions={aiSessions} />
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-                ) : (
-                  <div className="flex flex-col items-center justify-center py-8 text-center">
-                    <p className="text-sm text-zinc-400 mb-2">No AI referrer sessions detected yet</p>
-                    <p className="text-xs text-zinc-500 max-w-sm">
-                      When visitors arrive from ChatGPT, Claude, Gemini, or other AI platforms, their sessions will be broken down here by source and medium.
-                    </p>
-                  </div>
-                )}
-              </Card>
-            </div>
+              )}
+            </Card>
           </section>
         </>
       )}

--- a/apps/web/test/traffic-section.test.tsx
+++ b/apps/web/test/traffic-section.test.tsx
@@ -1,7 +1,9 @@
 // @vitest-environment jsdom
 import React from 'react'
-import { expect, onTestFinished, test, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { afterEach, expect, onTestFinished, test, vi } from 'vitest'
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+
+afterEach(cleanup)
 
 vi.mock('recharts', () => {
   const passthrough = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>
@@ -51,20 +53,28 @@ test('loads connected GA4 data without changing hook order', async () => {
       return jsonResponse({
         totalSessions: 120,
         totalOrganicSessions: 70,
+        totalDirectSessions: 30,
         totalUsers: 95,
         topPages: [
-          { landingPage: '/pricing', sessions: 80, organicSessions: 50, users: 60 },
+          { landingPage: '/pricing', sessions: 80, organicSessions: 50, directSessions: 20, users: 60 },
         ],
         aiReferrals: [
           { source: 'chatgpt.com', medium: 'referral', sourceDimension: 'session', sessions: 12, users: 9 },
         ],
         aiSessionsDeduped: 12,
         aiUsersDeduped: 9,
+        aiSessionsBySession: 12,
+        aiUsersBySession: 9,
         socialReferrals: [
           { source: 'facebook.com', medium: 'social', channelGroup: 'Organic Social', sessions: 8, users: 6 },
         ],
         socialSessions: 8,
         socialUsers: 6,
+        organicSharePct: 58,
+        aiSharePct: 10,
+        aiSharePctBySession: 10,
+        directSharePct: 25,
+        socialSharePct: 7,
         lastSyncedAt: '2026-03-31T12:00:00.000Z',
       })
     }
@@ -103,4 +113,87 @@ test('loads connected GA4 data without changing hook order', async () => {
       || String(arg).includes('Rendered more hooks than during the previous render'),
     ),
   ).toBe(false)
+})
+
+test('renders four-channel breakdown with Organic, Social, Direct, and Known AI referrers (lower bound)', async () => {
+  const restoreFetch = mockFetch((url) => {
+    const urlPath = url.split('?')[0]!
+    if (urlPath.endsWith('/projects/test-project/ga/status')) {
+      return jsonResponse({
+        connected: true,
+        propertyId: '999888',
+        clientEmail: 'sa@test.iam.gserviceaccount.com',
+        authMethod: 'service-account',
+        lastSyncedAt: '2026-03-31T12:00:00.000Z',
+        createdAt: '2026-03-31T12:00:00.000Z',
+        updatedAt: '2026-03-31T12:00:00.000Z',
+      })
+    }
+    if (urlPath.endsWith('/projects/test-project/ga/traffic')) {
+      return jsonResponse({
+        totalSessions: 120,
+        totalOrganicSessions: 70,
+        totalDirectSessions: 30,
+        totalUsers: 95,
+        topPages: [
+          { landingPage: '/pricing', sessions: 80, organicSessions: 50, directSessions: 20, users: 60 },
+        ],
+        aiReferrals: [
+          { source: 'chatgpt.com', medium: 'referral', sourceDimension: 'session', sessions: 12, users: 9 },
+          { source: 'claude.ai', medium: 'referral', sourceDimension: 'first_user', sessions: 30, users: 24 },
+        ],
+        // Cross-cutting dedup includes firstUserSource → 12 + 30 = 42
+        aiSessionsDeduped: 42,
+        aiUsersDeduped: 33,
+        // Session-source-only count is disjoint from Direct/Organic/Social → 12
+        aiSessionsBySession: 12,
+        aiUsersBySession: 9,
+        socialReferrals: [
+          { source: 'facebook.com', medium: 'social', channelGroup: 'Organic Social', sessions: 8, users: 6 },
+        ],
+        socialSessions: 8,
+        socialUsers: 6,
+        organicSharePct: 58,
+        aiSharePct: 35,
+        aiSharePctBySession: 10,
+        directSharePct: 25,
+        socialSharePct: 7,
+        lastSyncedAt: '2026-03-31T12:00:00.000Z',
+      })
+    }
+    if (urlPath.endsWith('/projects/test-project/ga/ai-referral-history')) return jsonResponse([])
+    if (urlPath.endsWith('/projects/test-project/ga/session-history')) return jsonResponse([])
+    if (urlPath.endsWith('/projects/test-project/ga/social-referral-history')) return jsonResponse([])
+    throw new Error(`Unexpected fetch: ${url}`)
+  })
+  onTestFinished(restoreFetch)
+
+  render(<TrafficSection projectName="test-project" />)
+
+  await waitFor(() => {
+    expect(screen.getByText('Channel breakdown')).toBeTruthy()
+  })
+
+  // Scope queries to the breakdown card so column headers in unrelated tables don't collide.
+  const card = screen.getByText('Channel breakdown').closest('div.surface-card') as HTMLElement
+  expect(card).toBeTruthy()
+  const breakdown = within(card)
+
+  // Four labeled channels appear in the breakdown card
+  expect(breakdown.getByText('Organic')).toBeTruthy()
+  expect(breakdown.getByText('Social')).toBeTruthy()
+  expect(breakdown.getByText('Direct')).toBeTruthy()
+  expect(breakdown.getByText(/Known AI referrers/)).toBeTruthy()
+  expect(breakdown.getByText(/lower bound/i)).toBeTruthy()
+
+  // Direct cell shows the share from API (25%)
+  expect(breakdown.getByText('25%')).toBeTruthy()
+
+  // AI cell uses the session-source-only share (10%, disjoint from Direct/Organic/Social),
+  // NOT the cross-cutting aiSharePct (35%) which would overlap with other channels.
+  expect(breakdown.getByText('10%')).toBeTruthy()
+  expect(breakdown.queryByText('35%')).toBeNull()
+
+  // The misleading old framing is gone: panel title "Attributable AI visits" must not appear
+  expect(screen.queryByText('Attributable AI visits')).toBeNull()
 })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "2.14.2",
+  "version": "2.15.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "2.15.0",
+  "version": "2.15.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/ga.ts
+++ b/packages/api-routes/src/ga.ts
@@ -919,15 +919,18 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       .where(and(eq(gaTrafficSnapshots.projectId, project.id), sql`${gaTrafficSnapshots.date} >= ${from}`, sql`${gaTrafficSnapshots.date} < ${to}`))
       .get()
 
-    // --- AI sessions (deduped: MAX per date+source+medium across dimensions, then SUM) ---
+    // --- AI sessions (sessionSource only, matching the disjoint Channel Breakdown cell). ---
+    // Trend must use the same scope as the displayed AI count, otherwise the row can show
+    // 5 sessions with a trend computed off 12 cross-dimensional sessions.
     const sumAi = (from: string, to: string) => app.db
-      .select({ sessions: sql<number>`COALESCE(SUM(max_sessions), 0)` })
-      .from(sql`(
-        SELECT date, source, medium, MAX(sessions) AS max_sessions
-        FROM ga_ai_referrals
-        WHERE project_id = ${project.id} AND date >= ${from} AND date < ${to}
-        GROUP BY date, source, medium
-      )`)
+      .select({ sessions: sql<number>`COALESCE(SUM(${gaAiReferrals.sessions}), 0)` })
+      .from(gaAiReferrals)
+      .where(and(
+        eq(gaAiReferrals.projectId, project.id),
+        sql`${gaAiReferrals.date} >= ${from}`,
+        sql`${gaAiReferrals.date} < ${to}`,
+        eq(gaAiReferrals.sourceDimension, 'session'),
+      ))
       .get()
 
     // --- Social sessions ---
@@ -947,27 +950,29 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       return { sessions7d: c7, sessionsPrev7d: p7, trend7dPct: pct(c7, p7), sessions30d: c30, sessionsPrev30d: p30, trend30dPct: pct(c30, p30) }
     }
 
-    // --- Biggest movers (AI) ---
+    // --- Biggest movers (AI) — sessionSource-only to match the breakdown cell scope. ---
     const aiSourceCurrent = app.db
-      .select({ source: sql<string>`source`, sessions: sql<number>`COALESCE(SUM(max_sessions), 0)` })
-      .from(sql`(
-        SELECT date, source, medium, MAX(sessions) AS max_sessions
-        FROM ga_ai_referrals
-        WHERE project_id = ${project.id} AND date >= ${daysAgo(7)} AND date < ${todayStr}
-        GROUP BY date, source, medium
-      )`)
-      .groupBy(sql`source`)
+      .select({ source: gaAiReferrals.source, sessions: sql<number>`COALESCE(SUM(${gaAiReferrals.sessions}), 0)` })
+      .from(gaAiReferrals)
+      .where(and(
+        eq(gaAiReferrals.projectId, project.id),
+        sql`${gaAiReferrals.date} >= ${daysAgo(7)}`,
+        sql`${gaAiReferrals.date} < ${todayStr}`,
+        eq(gaAiReferrals.sourceDimension, 'session'),
+      ))
+      .groupBy(gaAiReferrals.source)
       .all()
 
     const aiSourcePrev = app.db
-      .select({ source: sql<string>`source`, sessions: sql<number>`COALESCE(SUM(max_sessions), 0)` })
-      .from(sql`(
-        SELECT date, source, medium, MAX(sessions) AS max_sessions
-        FROM ga_ai_referrals
-        WHERE project_id = ${project.id} AND date >= ${daysAgo(14)} AND date < ${daysAgo(7)}
-        GROUP BY date, source, medium
-      )`)
-      .groupBy(sql`source`)
+      .select({ source: gaAiReferrals.source, sessions: sql<number>`COALESCE(SUM(${gaAiReferrals.sessions}), 0)` })
+      .from(gaAiReferrals)
+      .where(and(
+        eq(gaAiReferrals.projectId, project.id),
+        sql`${gaAiReferrals.date} >= ${daysAgo(14)}`,
+        sql`${gaAiReferrals.date} < ${daysAgo(7)}`,
+        eq(gaAiReferrals.sourceDimension, 'session'),
+      ))
+      .groupBy(gaAiReferrals.source)
       .all()
 
     const findBiggestMover = (

--- a/packages/api-routes/src/ga.ts
+++ b/packages/api-routes/src/ga.ts
@@ -645,6 +645,19 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       )
       .get()
 
+    // Session-source-only AI total: sessions whose CURRENT sessionSource matched
+    // an AI engine. Disjoint from sessionDefaultChannelGrouping = 'Direct' (those
+    // sessions have no source by definition), so it's safe to display alongside
+    // Organic/Social/Direct in a four-channel breakdown without overlap.
+    const aiBySession = app.db
+      .select({
+        sessions: sql<number>`COALESCE(SUM(${gaAiReferrals.sessions}), 0)`,
+        users: sql<number>`COALESCE(SUM(${gaAiReferrals.users}), 0)`,
+      })
+      .from(gaAiReferrals)
+      .where(and(...aiConditions, eq(gaAiReferrals.sourceDimension, 'session')))
+      .get()
+
     const socialReferrals = app.db
       .select({
         source: gaSocialReferrals.source,
@@ -702,6 +715,8 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       })),
       aiSessionsDeduped: aiDeduped?.sessions ?? 0,
       aiUsersDeduped: aiDeduped?.users ?? 0,
+      aiSessionsBySession: aiBySession?.sessions ?? 0,
+      aiUsersBySession: aiBySession?.users ?? 0,
       socialReferrals: socialReferrals.map((r) => ({
         source: r.source,
         medium: r.medium,
@@ -713,6 +728,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       socialUsers: socialTotals?.users ?? 0,
       organicSharePct: total > 0 ? Math.round(((summaryRow?.totalOrganicSessions ?? 0) / total) * 100) : 0,
       aiSharePct: total > 0 ? Math.round(((aiDeduped?.sessions ?? 0) / total) * 100) : 0,
+      aiSharePctBySession: total > 0 ? Math.round(((aiBySession?.sessions ?? 0) / total) * 100) : 0,
       directSharePct: total > 0 ? Math.round((totalDirectSessions / total) * 100) : 0,
       socialSharePct: total > 0 ? Math.round(((socialTotals?.sessions ?? 0) / total) * 100) : 0,
       lastSyncedAt: latestSync?.syncedAt ?? null,
@@ -896,6 +912,13 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       .where(and(eq(gaTrafficSnapshots.projectId, project.id), sql`${gaTrafficSnapshots.date} >= ${from}`, sql`${gaTrafficSnapshots.date} < ${to}`))
       .get()
 
+    // --- Direct sessions (from gaTrafficSnapshots.directSessions) ---
+    const sumDirect = (from: string, to: string) => app.db
+      .select({ sessions: sql<number>`COALESCE(SUM(${gaTrafficSnapshots.directSessions}), 0)` })
+      .from(gaTrafficSnapshots)
+      .where(and(eq(gaTrafficSnapshots.projectId, project.id), sql`${gaTrafficSnapshots.date} >= ${from}`, sql`${gaTrafficSnapshots.date} < ${to}`))
+      .get()
+
     // --- AI sessions (deduped: MAX per date+source+medium across dimensions, then SUM) ---
     const sumAi = (from: string, to: string) => app.db
       .select({ sessions: sql<number>`COALESCE(SUM(max_sessions), 0)` })
@@ -985,6 +1008,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       organic: buildTrend(sumOrganic),
       ai: buildTrend(sumAi),
       social: buildTrend(sumSocial),
+      direct: buildTrend(sumDirect),
       aiBiggestMover: findBiggestMover(aiSourceCurrent, aiSourcePrev),
       socialBiggestMover: findBiggestMover(socialSourceCurrent, socialSourcePrev),
     }

--- a/packages/api-routes/test/ga.test.ts
+++ b/packages/api-routes/test/ga.test.ts
@@ -743,6 +743,104 @@ describe('GA4 routes', () => {
     }
   })
 
+  it('GET /ga/attribution-trend ai channel uses sessionSource only (matches breakdown cell)', async () => {
+    const now = new Date().toISOString()
+    const daysAgo = (n: number): string => {
+      const d = new Date()
+      d.setDate(d.getDate() - n)
+      return d.toISOString().slice(0, 10)
+    }
+    credentials.set('test-project', {
+      projectName: 'test-project',
+      propertyId: '999888',
+      clientEmail: 'sa@test.iam.gserviceaccount.com',
+      privateKey: 'fake-key',
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    // Current 7d window — seed at daysAgo(3).
+    // sessionSource lens: 5 sessions; firstUserSource lens: 12 sessions.
+    // Cross-dim MAX dedup would yield 12; sessionSource-only filter yields 5.
+    const idCurSession = crypto.randomUUID()
+    const idCurFirstUser = crypto.randomUUID()
+    db.insert(gaAiReferrals).values({
+      id: idCurSession,
+      projectId,
+      date: daysAgo(3),
+      source: 'chatgpt.com',
+      medium: 'referral',
+      sourceDimension: 'session',
+      sessions: 5,
+      users: 4,
+      syncedAt: now,
+    }).run()
+    db.insert(gaAiReferrals).values({
+      id: idCurFirstUser,
+      projectId,
+      date: daysAgo(3),
+      source: 'chatgpt.com',
+      medium: 'referral',
+      sourceDimension: 'first_user',
+      sessions: 12,
+      users: 10,
+      syncedAt: now,
+    }).run()
+
+    // Prev 7d window — seed at daysAgo(10).
+    // sessionSource lens: 3 sessions; firstUserSource lens: 8 sessions.
+    const idPrevSession = crypto.randomUUID()
+    const idPrevFirstUser = crypto.randomUUID()
+    db.insert(gaAiReferrals).values({
+      id: idPrevSession,
+      projectId,
+      date: daysAgo(10),
+      source: 'chatgpt.com',
+      medium: 'referral',
+      sourceDimension: 'session',
+      sessions: 3,
+      users: 2,
+      syncedAt: now,
+    }).run()
+    db.insert(gaAiReferrals).values({
+      id: idPrevFirstUser,
+      projectId,
+      date: daysAgo(10),
+      source: 'chatgpt.com',
+      medium: 'referral',
+      sourceDimension: 'first_user',
+      sessions: 8,
+      users: 6,
+      syncedAt: now,
+    }).run()
+
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/v1/projects/test-project/ga/attribution-trend',
+      })
+      expect(res.statusCode).toBe(200)
+      const body = JSON.parse(res.payload)
+      // sessionSource-only counts, NOT cross-dim MAX (which would be 12 / 8).
+      expect(body.ai.sessions7d).toBe(5)
+      expect(body.ai.sessionsPrev7d).toBe(3)
+      // (5 - 3) / 3 = 67% (rounded)
+      expect(body.ai.trend7dPct).toBe(67)
+      // aiBiggestMover should also report sessionSource-only counts.
+      expect(body.aiBiggestMover).toEqual({
+        source: 'chatgpt.com',
+        sessions7d: 5,
+        sessionsPrev7d: 3,
+        changePct: 67,
+      })
+    } finally {
+      db.delete(gaAiReferrals).where(inArray(gaAiReferrals.id, [
+        idCurSession, idCurFirstUser, idPrevSession, idPrevFirstUser,
+      ])).run()
+      credentials.delete('test-project')
+    }
+  })
+
   it('GET /ga/attribution-trend exposes direct channel 7d trend', async () => {
     const now = new Date().toISOString()
     const daysAgo = (n: number): string => {

--- a/packages/api-routes/test/ga.test.ts
+++ b/packages/api-routes/test/ga.test.ts
@@ -500,6 +500,10 @@ describe('GA4 routes', () => {
     ])
     expect(body.aiSessionsDeduped).toBe(17)
     expect(body.aiUsersDeduped).toBe(10)
+    // Only sessionSource-attributed rows seeded, so bySession matches dedup here.
+    expect(body.aiSessionsBySession).toBe(17)
+    expect(body.aiUsersBySession).toBe(10)
+    expect(body.aiSharePctBySession).toBe(5)
     expect(body.socialReferrals).toEqual([])
     expect(body.socialSessions).toBe(0)
     expect(body.socialUsers).toBe(0)
@@ -676,6 +680,126 @@ describe('GA4 routes', () => {
       expect(legacy.directSessions).toBe(0)
     } finally {
       db.delete(gaTrafficSnapshots).where(eq(gaTrafficSnapshots.id, id)).run()
+      credentials.delete('test-project')
+    }
+  })
+
+  it('GET /ga/traffic exposes aiSessionsBySession disjoint from firstUserSource overlap', async () => {
+    const now = new Date().toISOString()
+    credentials.set('test-project', {
+      projectName: 'test-project',
+      propertyId: '999888',
+      clientEmail: 'sa@test.iam.gserviceaccount.com',
+      privateKey: 'fake-key',
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    // Seed two AI referral rows on a unique date for the same source/medium:
+    // - sessionSource lens reports 6 (current-session referrals)
+    // - firstUserSource lens reports 14 (returning users whose lifetime first
+    //   source was AI; 6 of these are also in sessionSource, the other 8 are
+    //   currently arriving via Direct/Organic/Social and would be double-counted)
+    const sessionRowId = crypto.randomUUID()
+    const firstUserRowId = crypto.randomUUID()
+    const distinctDate = '2025-12-31'
+    db.insert(gaAiReferrals).values({
+      id: sessionRowId,
+      projectId,
+      date: distinctDate,
+      source: 'claude.ai',
+      medium: 'referral',
+      sourceDimension: 'session',
+      sessions: 6,
+      users: 5,
+      syncedAt: now,
+    }).run()
+    db.insert(gaAiReferrals).values({
+      id: firstUserRowId,
+      projectId,
+      date: distinctDate,
+      source: 'claude.ai',
+      medium: 'referral',
+      sourceDimension: 'first_user',
+      sessions: 14,
+      users: 12,
+      syncedAt: now,
+    }).run()
+
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/v1/projects/test-project/ga/traffic',
+      })
+      expect(res.statusCode).toBe(200)
+      const body = JSON.parse(res.payload)
+      // Pre-existing chatgpt.com row contributes 17 to both lenses.
+      // claude.ai contributes: dedup MAX(6, 14) = 14, bySession only the 6.
+      expect(body.aiSessionsDeduped).toBe(17 + 14)
+      expect(body.aiSessionsBySession).toBe(17 + 6)
+    } finally {
+      db.delete(gaAiReferrals).where(inArray(gaAiReferrals.id, [sessionRowId, firstUserRowId])).run()
+      credentials.delete('test-project')
+    }
+  })
+
+  it('GET /ga/attribution-trend exposes direct channel 7d trend', async () => {
+    const now = new Date().toISOString()
+    const daysAgo = (n: number): string => {
+      const d = new Date()
+      d.setDate(d.getDate() - n)
+      return d.toISOString().slice(0, 10)
+    }
+    credentials.set('test-project', {
+      projectName: 'test-project',
+      propertyId: '999888',
+      clientEmail: 'sa@test.iam.gserviceaccount.com',
+      privateKey: 'fake-key',
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    // Current 7d window: daysAgo(7) inclusive → today exclusive. Seed at daysAgo(3).
+    // Prev 7d window: daysAgo(14) inclusive → daysAgo(7) exclusive. Seed at daysAgo(10).
+    const idCurrent = crypto.randomUUID()
+    const idPrev = crypto.randomUUID()
+    db.insert(gaTrafficSnapshots).values({
+      id: idCurrent,
+      projectId,
+      date: daysAgo(3),
+      landingPage: '/__direct-trend-current',
+      sessions: 60,
+      organicSessions: 0,
+      directSessions: 50,
+      users: 50,
+      syncedAt: now,
+    }).run()
+    db.insert(gaTrafficSnapshots).values({
+      id: idPrev,
+      projectId,
+      date: daysAgo(10),
+      landingPage: '/__direct-trend-prev',
+      sessions: 30,
+      organicSessions: 0,
+      directSessions: 25,
+      users: 25,
+      syncedAt: now,
+    }).run()
+
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/v1/projects/test-project/ga/attribution-trend',
+      })
+      expect(res.statusCode).toBe(200)
+      const body = JSON.parse(res.payload)
+      expect(body.direct).toBeDefined()
+      expect(body.direct.sessions7d).toBe(50)
+      expect(body.direct.sessionsPrev7d).toBe(25)
+      // (50 - 25) / 25 = 100%
+      expect(body.direct.trend7dPct).toBe(100)
+    } finally {
+      db.delete(gaTrafficSnapshots).where(inArray(gaTrafficSnapshots.id, [idCurrent, idPrev])).run()
       credentials.delete('test-project')
     }
   })

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "2.14.2",
+  "version": "2.15.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/commands/ga.ts
+++ b/packages/canonry/src/commands/ga.ts
@@ -406,11 +406,16 @@ export async function gaAttribution(project: string, opts?: { trend?: boolean; f
         organicSessions: traffic.totalOrganicSessions,
         aiSessions: traffic.aiSessionsDeduped,
         aiUsers: traffic.aiUsersDeduped,
+        aiSessionsBySession: traffic.aiSessionsBySession,
+        aiUsersBySession: traffic.aiUsersBySession,
         socialSessions: traffic.socialSessions,
         socialUsers: traffic.socialUsers,
+        directSessions: traffic.totalDirectSessions,
         aiSharePct: traffic.aiSharePct,
+        aiSharePctBySession: traffic.aiSharePctBySession,
         socialSharePct: traffic.socialSharePct,
         organicSharePct: traffic.organicSharePct,
+        directSharePct: traffic.directSharePct,
         aiReferrals: traffic.aiReferrals,
         socialReferrals: traffic.socialReferrals,
         trend,
@@ -429,9 +434,10 @@ export async function gaAttribution(project: string, opts?: { trend?: boolean; f
     console.log()
     console.log('  CHANNEL BREAKDOWN                  7d trend     30d trend')
     console.log(`    Organic Search: ${String(traffic.totalOrganicSessions).padEnd(6)} (${String(traffic.organicSharePct).padStart(2)}%)    ${fmtTrend(trend.organic.trend7dPct).padEnd(12)} ${fmtTrend(trend.organic.trend30dPct)}`)
-    console.log(`    AI Referrals:   ${String(traffic.aiSessionsDeduped).padEnd(6)} (${String(traffic.aiSharePct).padStart(2)}%)    ${fmtTrend(trend.ai.trend7dPct).padEnd(12)} ${fmtTrend(trend.ai.trend30dPct)}`)
     console.log(`    Social:         ${String(traffic.socialSessions).padEnd(6)} (${String(traffic.socialSharePct).padStart(2)}%)    ${fmtTrend(trend.social.trend7dPct).padEnd(12)} ${fmtTrend(trend.social.trend30dPct)}`)
-    const otherSessions = traffic.totalSessions - traffic.totalOrganicSessions - traffic.aiSessionsDeduped - traffic.socialSessions
+    console.log(`    Direct:         ${String(traffic.totalDirectSessions).padEnd(6)} (${String(traffic.directSharePct).padStart(2)}%)    ${fmtTrend(trend.direct.trend7dPct).padEnd(12)} ${fmtTrend(trend.direct.trend30dPct)}`)
+    console.log(`    AI Referrals:   ${String(traffic.aiSessionsBySession).padEnd(6)} (${String(traffic.aiSharePctBySession).padStart(2)}%)    ${fmtTrend(trend.ai.trend7dPct).padEnd(12)} ${fmtTrend(trend.ai.trend30dPct)}  (lower bound — sessionSource only; referrer-stripped traffic falls under Direct)`)
+    const otherSessions = traffic.totalSessions - traffic.totalOrganicSessions - traffic.aiSessionsBySession - traffic.socialSessions - traffic.totalDirectSessions
     if (otherSessions > 0) {
       const otherPct = traffic.totalSessions > 0 ? Math.round((otherSessions / traffic.totalSessions) * 100) : 0
       console.log(`    Other:          ${String(otherSessions).padEnd(6)} (${String(otherPct).padStart(2)}%)`)
@@ -464,11 +470,16 @@ export async function gaAttribution(project: string, opts?: { trend?: boolean; f
       organicSessions: traffic.totalOrganicSessions,
       aiSessions: traffic.aiSessionsDeduped,
       aiUsers: traffic.aiUsersDeduped,
+      aiSessionsBySession: traffic.aiSessionsBySession,
+      aiUsersBySession: traffic.aiUsersBySession,
       socialSessions: traffic.socialSessions,
       socialUsers: traffic.socialUsers,
+      directSessions: traffic.totalDirectSessions,
       aiSharePct: traffic.aiSharePct,
+      aiSharePctBySession: traffic.aiSharePctBySession,
       socialSharePct: traffic.socialSharePct,
       organicSharePct: traffic.organicSharePct,
+      directSharePct: traffic.directSharePct,
       aiReferrals: traffic.aiReferrals,
       socialReferrals: traffic.socialReferrals,
       periodStart: traffic.periodStart,
@@ -488,9 +499,10 @@ export async function gaAttribution(project: string, opts?: { trend?: boolean; f
   console.log()
   console.log('  CHANNEL BREAKDOWN')
   console.log(`    Organic Search: ${traffic.totalOrganicSessions} sessions (${traffic.organicSharePct}%)`)
-  console.log(`    AI Referrals:   ${traffic.aiSessionsDeduped} sessions (${traffic.aiSharePct}%)`)
   console.log(`    Social:         ${traffic.socialSessions} sessions (${traffic.socialSharePct}%)`)
-  const otherSessions = traffic.totalSessions - traffic.totalOrganicSessions - traffic.aiSessionsDeduped - traffic.socialSessions
+  console.log(`    Direct:         ${traffic.totalDirectSessions} sessions (${traffic.directSharePct}%)`)
+  console.log(`    AI Referrals:   ${traffic.aiSessionsBySession} sessions (${traffic.aiSharePctBySession}%)  (lower bound — sessionSource only; referrer-stripped traffic falls under Direct)`)
+  const otherSessions = traffic.totalSessions - traffic.totalOrganicSessions - traffic.aiSessionsBySession - traffic.socialSessions - traffic.totalDirectSessions
   if (otherSessions > 0) {
     const otherPct = traffic.totalSessions > 0 ? Math.round((otherSessions / traffic.totalSessions) * 100) : 0
     console.log(`    Other:          ${otherSessions} sessions (${otherPct}%)`)

--- a/packages/canonry/src/mcp/tool-registry.ts
+++ b/packages/canonry/src/mcp/tool-registry.ts
@@ -585,7 +585,7 @@ export const canonryMcpTools = [
   defineTool({
     name: 'canonry_ga_attribution_trend',
     title: 'Get GA attribution trend',
-    description: 'Get per-channel attribution trends for organic, AI, social, and total sessions.',
+    description: 'Get per-channel attribution trends for organic, AI, social, direct, and total sessions.',
     access: 'read',
     tier: 'ga',
     inputSchema: projectInputSchema,

--- a/packages/canonry/test/ga-attribution.test.ts
+++ b/packages/canonry/test/ga-attribution.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, beforeEach, afterEach, expect } from 'vitest'
+import os from 'node:os'
+import fs from 'node:fs'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import { createClient, migrate, apiKeys, gaTrafficSnapshots } from '@ainyc/canonry-db'
+import { createServer } from '../src/server.js'
+import { ApiClient } from '../src/client.js'
+
+describe('canonry ga attribution --format json', () => {
+  let tmpDir: string
+  let origConfigDir: string | undefined
+  let client: ApiClient
+  let close: () => Promise<void>
+  let db: ReturnType<typeof createClient>
+
+  beforeEach(async () => {
+    tmpDir = path.join(os.tmpdir(), `canonry-ga-attr-${crypto.randomUUID()}`)
+    fs.mkdirSync(tmpDir, { recursive: true })
+    origConfigDir = process.env.CANONRY_CONFIG_DIR
+    process.env.CANONRY_CONFIG_DIR = tmpDir
+
+    const dbPath = path.join(tmpDir, 'data.db')
+    const configPath = path.join(tmpDir, 'config.yaml')
+
+    db = createClient(dbPath)
+    migrate(db)
+
+    const apiKeyPlain = `cnry_${crypto.randomBytes(16).toString('hex')}`
+    const hashed = crypto.createHash('sha256').update(apiKeyPlain).digest('hex')
+    db.insert(apiKeys).values({
+      id: crypto.randomUUID(),
+      name: 'test',
+      keyHash: hashed,
+      keyPrefix: apiKeyPlain.slice(0, 8),
+      createdAt: new Date().toISOString(),
+    }).run()
+
+    const now = new Date().toISOString()
+    const config = {
+      apiUrl: 'http://localhost:0',
+      database: dbPath,
+      apiKey: apiKeyPlain,
+      providers: { gemini: { apiKey: 'test-key' } },
+      ga4: {
+        connections: [
+          {
+            projectName: 'test-proj',
+            propertyId: '999888',
+            clientEmail: 'sa@test.iam.gserviceaccount.com',
+            privateKey: 'fake-key',
+            createdAt: now,
+            updatedAt: now,
+          },
+        ],
+      },
+    }
+
+    fs.writeFileSync(configPath, JSON.stringify(config), 'utf-8')
+
+    const app = await createServer({ config: config as Parameters<typeof createServer>[0]['config'], db, logger: false })
+    await app.listen({ host: '127.0.0.1', port: 0 })
+
+    const addr = app.server.address()
+    const port = typeof addr === 'object' && addr ? addr.port : 0
+    const serverUrl = `http://127.0.0.1:${port}`
+
+    config.apiUrl = serverUrl
+    fs.writeFileSync(configPath, JSON.stringify(config), 'utf-8')
+
+    close = () => app.close()
+    client = new ApiClient(serverUrl, apiKeyPlain)
+  })
+
+  afterEach(async () => {
+    await close()
+    if (origConfigDir === undefined) {
+      delete process.env.CANONRY_CONFIG_DIR
+    } else {
+      process.env.CANONRY_CONFIG_DIR = origConfigDir
+    }
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('exposes direct as a named channel in trend JSON', async () => {
+    const project = await client.putProject('test-proj', {
+      displayName: 'Test',
+      canonicalDomain: 'example.com',
+      country: 'US',
+      language: 'en',
+    })
+
+    const now = new Date().toISOString()
+    const today = now.slice(0, 10)
+    const daysAgo = (n: number): string => {
+      const d = new Date()
+      d.setDate(d.getDate() - n)
+      return d.toISOString().slice(0, 10)
+    }
+
+    // gaTrafficSummaries row so totalSessions/share calculations work
+    const { gaTrafficSummaries } = await import('@ainyc/canonry-db')
+    db.insert(gaTrafficSummaries).values({
+      id: crypto.randomUUID(),
+      projectId: project.id,
+      periodStart: daysAgo(30),
+      periodEnd: today,
+      totalSessions: 100,
+      totalOrganicSessions: 20,
+      totalUsers: 80,
+      syncedAt: now,
+    }).run()
+
+    // Per-page snapshots: 50 direct sessions in current 7d, 25 in prev 7d
+    db.insert(gaTrafficSnapshots).values({
+      id: crypto.randomUUID(),
+      projectId: project.id,
+      date: daysAgo(3),
+      landingPage: '/__attr-cli-current',
+      sessions: 60,
+      organicSessions: 0,
+      directSessions: 50,
+      users: 50,
+      syncedAt: now,
+    }).run()
+    db.insert(gaTrafficSnapshots).values({
+      id: crypto.randomUUID(),
+      projectId: project.id,
+      date: daysAgo(10),
+      landingPage: '/__attr-cli-prev',
+      sessions: 30,
+      organicSessions: 0,
+      directSessions: 25,
+      users: 25,
+      syncedAt: now,
+    }).run()
+
+    // AI referrals: sessionSource lens (5) + firstUserSource lens (12) for the
+    // same source/medium → dedup MAX = 12, bySession = 5.
+    const { gaAiReferrals } = await import('@ainyc/canonry-db')
+    db.insert(gaAiReferrals).values({
+      id: crypto.randomUUID(),
+      projectId: project.id,
+      date: daysAgo(3),
+      source: 'chatgpt.com',
+      medium: 'referral',
+      sourceDimension: 'session',
+      sessions: 5,
+      users: 4,
+      syncedAt: now,
+    }).run()
+    db.insert(gaAiReferrals).values({
+      id: crypto.randomUUID(),
+      projectId: project.id,
+      date: daysAgo(3),
+      source: 'chatgpt.com',
+      medium: 'referral',
+      sourceDimension: 'first_user',
+      sessions: 12,
+      users: 10,
+      syncedAt: now,
+    }).run()
+
+    const { gaAttribution } = await import('../src/commands/ga.js')
+    const logs: string[] = []
+    const origLog = console.log
+    console.log = (...args: unknown[]) => logs.push(args.join(' '))
+    try {
+      await gaAttribution('test-proj', { trend: true, format: 'json' })
+    } finally {
+      console.log = origLog
+    }
+
+    const parsed = JSON.parse(logs.join('\n')) as Record<string, unknown> & {
+      directSessions: number
+      directSharePct: number
+      aiSessions: number
+      aiSessionsBySession: number
+      aiSharePct: number
+      aiSharePctBySession: number
+      trend: { direct: { sessions7d: number; sessionsPrev7d: number; trend7dPct: number | null } }
+    }
+    expect(parsed.directSessions).toBeGreaterThanOrEqual(75)
+    expect(parsed.directSharePct).toBeGreaterThan(0)
+    // Cross-cutting dedup includes firstUserSource → 12; bySession is the disjoint 5.
+    expect(parsed.aiSessions).toBe(12)
+    expect(parsed.aiSessionsBySession).toBe(5)
+    expect(parsed.aiSharePctBySession).toBeLessThan(parsed.aiSharePct)
+    expect(parsed.trend.direct).toBeDefined()
+    expect(parsed.trend.direct.sessions7d).toBe(50)
+    expect(parsed.trend.direct.sessionsPrev7d).toBe(25)
+    expect(parsed.trend.direct.trend7dPct).toBe(100)
+  })
+})

--- a/packages/contracts/src/ga.ts
+++ b/packages/contracts/src/ga.ts
@@ -136,11 +136,12 @@ export interface GaChannelTrend {
 
 export interface GaAttributionTrendResponse {
   organic: GaChannelTrend
+  /** AI session trend, scoped to sessionSource-only matches so it lines up with the disjoint AI cell in the channel breakdown. */
   ai: GaChannelTrend
   social: GaChannelTrend
   direct: GaChannelTrend
   total: GaChannelTrend
-  /** AI source with largest absolute session change in 7d vs prev 7d */
+  /** AI source with largest absolute session change in 7d vs prev 7d (sessionSource only). */
   aiBiggestMover: { source: string; sessions7d: number; sessionsPrev7d: number; changePct: number } | null
   /** Social source with largest absolute session change in 7d vs prev 7d */
   socialBiggestMover: { source: string; sessions7d: number; sessionsPrev7d: number; changePct: number } | null

--- a/packages/contracts/src/ga.ts
+++ b/packages/contracts/src/ga.ts
@@ -58,10 +58,14 @@ export const ga4TrafficSummaryDtoSchema = z.object({
     users: z.number(),
   })),
   aiReferrals: z.array(ga4AiReferralDtoSchema),
-  /** Deduped AI session total: MAX(sessions) per date+source+medium across attribution dimensions, then summed. */
+  /** Deduped AI session total: MAX(sessions) per date+source+medium across attribution dimensions, then summed. Cross-cutting: can overlap with Direct/Organic/Social via firstUserSource. */
   aiSessionsDeduped: z.number(),
   /** Deduped AI user total: MAX(users) per date+source+medium across attribution dimensions, then summed. */
   aiUsersDeduped: z.number(),
+  /** AI sessions whose CURRENT sessionSource matched an AI engine. Disjoint from Direct/Organic/Social — safe for the channel breakdown. */
+  aiSessionsBySession: z.number(),
+  /** AI users whose CURRENT sessionSource matched an AI engine. Disjoint from Direct/Organic/Social — safe for the channel breakdown. */
+  aiUsersBySession: z.number(),
   socialReferrals: z.array(ga4SocialReferralDtoSchema),
   /** Total social sessions (session-scoped, no cross-dimension dedup needed). */
   socialSessions: z.number(),
@@ -69,8 +73,10 @@ export const ga4TrafficSummaryDtoSchema = z.object({
   socialUsers: z.number(),
   /** Organic sessions as a percentage of total sessions (0–100, rounded). */
   organicSharePct: z.number(),
-  /** Deduped AI sessions as a percentage of total sessions (0–100, rounded). */
+  /** Deduped AI sessions as a percentage of total sessions (0–100, rounded). Cross-cutting: can overlap with Direct/Organic/Social. */
   aiSharePct: z.number(),
+  /** Session-source-only AI sessions as a percentage of total sessions (0–100, rounded). Disjoint from Direct/Organic/Social. */
+  aiSharePctBySession: z.number(),
   /** Direct-channel sessions as a percentage of total sessions (0–100, rounded). */
   directSharePct: z.number(),
   /** Social sessions as a percentage of total sessions (0–100, rounded). */
@@ -132,6 +138,7 @@ export interface GaAttributionTrendResponse {
   organic: GaChannelTrend
   ai: GaChannelTrend
   social: GaChannelTrend
+  direct: GaChannelTrend
   total: GaChannelTrend
   /** AI source with largest absolute session change in 7d vs prev 7d */
   aiBiggestMover: { source: string; sessions7d: number; sessionsPrev7d: number; changePct: number } | null
@@ -147,10 +154,14 @@ export interface GaTrafficResponse {
   totalUsers: number
   topPages: Array<{ landingPage: string; sessions: number; organicSessions: number; directSessions: number; users: number }>
   aiReferrals: Array<{ source: string; medium: string; sessions: number; users: number; sourceDimension: GA4SourceDimension }>
-  /** Deduped AI session total: MAX(sessions) per date+source+medium across attribution dimensions, then summed. */
+  /** Deduped AI session total: MAX(sessions) per date+source+medium across attribution dimensions, then summed. Cross-cutting: can overlap with Direct/Organic/Social via firstUserSource. */
   aiSessionsDeduped: number
   /** Deduped AI user total: MAX(users) per date+source+medium across attribution dimensions, then summed. */
   aiUsersDeduped: number
+  /** AI sessions whose CURRENT sessionSource matched an AI engine. Disjoint from Direct/Organic/Social — safe for the channel breakdown. */
+  aiSessionsBySession: number
+  /** AI users whose CURRENT sessionSource matched an AI engine. Disjoint from Direct/Organic/Social — safe for the channel breakdown. */
+  aiUsersBySession: number
   socialReferrals: Array<{ source: string; medium: string; sessions: number; users: number; channelGroup: string }>
   /** Total social sessions (session-scoped via sessionDefaultChannelGroup). */
   socialSessions: number
@@ -158,8 +169,10 @@ export interface GaTrafficResponse {
   socialUsers: number
   /** Organic sessions as a percentage of total sessions (0–100, rounded). */
   organicSharePct: number
-  /** Deduped AI sessions as a percentage of total sessions (0–100, rounded). */
+  /** Deduped AI sessions as a percentage of total sessions (0–100, rounded). Cross-cutting: can overlap with Direct/Organic/Social. */
   aiSharePct: number
+  /** Session-source-only AI sessions as a percentage of total sessions (0–100, rounded). Disjoint from Direct/Organic/Social. */
+  aiSharePctBySession: number
   /** Direct-channel sessions as a percentage of total sessions (0–100, rounded). */
   directSharePct: number
   /** Social sessions as a percentage of total sessions (0–100, rounded). */


### PR DESCRIPTION
## Summary
- Replaces the AI-only summary with a four-cell channel breakdown (Organic / Social / Direct / Known AI referrers) and pipes a per-page + per-window Direct-channel total through `gaTrafficSnapshots`.
- Adds a sessionSource-only AI count (`aiSessionsBySession` / `aiSharePctBySession`) so the AI cell is disjoint from Direct/Organic/Social and the "lower bound" framing actually holds; the cross-cutting `aiSessionsDeduped` (MAX over session/firstUser/utm) is preserved for the AI detail table and downstream consumers.
- `attribution-trend` gains a `direct` channel; CLI `ga attribution` prints Direct alongside the other channels and uses the disjoint AI count for the `Other` math. Bumps to 2.15.0.

## Test plan
- [ ] `pnpm typecheck && pnpm lint && pnpm test`
- [ ] Open the project Traffic page in the dashboard — confirm the Channel breakdown card shows four cells, the AI cell uses sessionSource-only %, and the detail table still surfaces firstUser/UTM rows.
- [ ] `canonry ga attribution <project>` and `canonry ga attribution <project> --trend --format json` — confirm `Direct` row prints, `aiSessionsBySession` is in JSON, and `Other` math is non-negative.