### PR TITLE
fix(contracts): expand normalizer strip-list for CMS and versioning noise

### DIFF
--- a/packages/contracts/src/url-normalize.ts
+++ b/packages/contracts/src/url-normalize.ts
@@ -17,6 +17,7 @@ const STRIP_KEYS: ReadonlySet<string> = new Set([
   'dclid',
   'gbraid',
   'wbraid',
+  'bingid',
   // Mailchimp
   'mc_cid',
   'mc_eid',
@@ -26,6 +27,15 @@ const STRIP_KEYS: ReadonlySet<string> = new Set([
   // Google Tag Manager debug
   'gtm_latency',
   'gtm_debug',
+  // WordPress internal noise
+  'preview',
+  'preview_id',
+  'preview_nonce',
+  '_thumbnail_id',
+  // Common cache-busters/versioning
+  'v',
+  'ver',
+  'version',
 ])
 
 interface QueryPair {

--- a/packages/contracts/test/url-normalize.test.ts
+++ b/packages/contracts/test/url-normalize.test.ts
@@ -77,13 +77,13 @@ describe('normalizeUrlPath', () => {
   })
 
   describe('strip-list policy', () => {
-    it('does NOT strip the v= cache-buster (conservative policy)', () => {
-      // trailing slash collapses regardless of query; v= survives
-      expect(normalizeUrlPath('/michigan/?v=3')).toBe('/michigan?v=3')
+    it('strips the v= cache-buster and versioning noise', () => {
+      // trailing slash collapses regardless of query; v= now stripped
+      expect(normalizeUrlPath('/michigan/?v=3')).toBe('/michigan')
     })
 
-    it('strips the click ID but preserves the v= param', () => {
-      expect(normalizeUrlPath('/michigan/?fbclid=foo&v=3')).toBe('/michigan?v=3')
+    it('strips the click ID and the v= param', () => {
+      expect(normalizeUrlPath('/michigan/?fbclid=foo&v=3')).toBe('/michigan')
     })
 
     it('strips all utm_* keys', () => {
@@ -183,6 +183,12 @@ describe('normalizeUrlPath', () => {
       expect(normalizeUrlPath('/)&nbsp;open')).toBe('/')
       expect(normalizeUrlPath('/path.&nbsp;')).toBe('/path')
       expect(normalizeUrlPath('/path...')).toBe('/path')
+    })
+
+    it('strips CMS and versioning noise (azcoatings examples)', () => {
+      expect(normalizeUrlPath('/polyurea-roofing?preview=true&preview_id=1394&preview_nonce=abc')).toBe('/polyurea-roofing')
+      expect(normalizeUrlPath('/michigan?v=3')).toBe('/michigan')
+      expect(normalizeUrlPath('/path?ver=1.2.3')).toBe('/path')
     })
   })
 })


### PR DESCRIPTION
## Summary
- expand `STRIP_KEYS` to include WordPress internal noise and common cache-buster/versioning parameters
- update test suite to reflect new aggressive cleanup policy
- ensures CMS-specific noise (previews, nonces) and versioning (v, ver) collapse into clean parent paths

## Why
Identified in client dashboards (e.g. azcoatings) where multiple rows were created for the same landing page due to `?v=3` or `?preview=true` parameters, muddying the AEO attribution data.