### PR TITLE
chore(web): rename sidebar tagline to AEO Operating System

### DIFF
--- a/apps/web/src/components/shared/BrandLockup.tsx
+++ b/apps/web/src/components/shared/BrandLockup.tsx
@@ -10,7 +10,7 @@ export function BrandLockup({ compact = false }: { compact?: boolean }) {
       <img className="brand-icon" src="./favicon.svg" alt="" aria-hidden="true" />
       <span className="brand-copy">
         <span className="brand-mark">Canonry</span>
-        {compact ? null : <span className="brand-subtitle">AEO Monitor</span>}
+        {compact ? null : <span className="brand-subtitle">AEO Operating System</span>}
       </span>
     </Link>
   )

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "2.16.2",
+  "version": "2.16.3",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "2.16.2",
+  "version": "2.16.3",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Summary
- Updates the dashboard sidebar brand subtitle from "AEO Monitor" to "AEO Operating System" to align with the project's agent-first positioning.
- Bumps root and `@ainyc/canonry` package versions to 2.16.3.

## Test plan
- [ ] Sidebar renders "AEO OPERATING SYSTEM" under the Canonry mark and fits within the `w-56` rail.