### PR TITLE
refactor(vocab): standardize on mention/cited terminology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,48 @@ high-severity insights after a run — dispatched by `RunCoordinator` after
 - `packages/canonry/` is the only publishable artifact. Internal packages are bundled via tsup.
 - All internal packages use `@ainyc/canonry-*` naming convention.
 
+## Vocabulary (Critical)
+
+Canonry tracks two parallel signals for every (keyword × provider) snapshot. They are independent — a model can do either, both, or neither — and must never be conflated in code, copy, or contract field names.
+
+| Term | Meaning | Source field |
+|------|---------|--------------|
+| **mention / mentioned** | The project's brand or domain appears in the actual LLM answer text response (the prose the model returns). | `query_snapshots.answer_mentioned` (boolean) |
+| **cited** | The project's domain appears in the source links/material the LLM used to get the answer (the structured grounding / citations / search-result list returned alongside the answer). | `query_snapshots.citation_state` = `'cited'` |
+
+### Rules
+
+1. **Use `mention` / `mentioned` for answer-text presence.** Never use `answer`, `visible`, or `visibility` for new code that means the same thing — those exist as legacy terms (DB column `visibility_state`, run kind `answer-visibility`, function `visibilityStateFromAnswerMentioned`) but new APIs, fields, CLI flags, and UI labels must say `mentioned`.
+2. **Use `cited` for source-list presence.** Never use `citation` as an umbrella for both signals — citation refers specifically to the source-attribution side.
+3. **Never compute one signal from the other.** A label that says "cited" must read `citationState` (or a derived `cited: boolean`); a label that says "mentioned" must read `answerMentioned`. If you find a metric named for one signal but computed from the other, that's a bug — fix it, don't paper over it.
+4. **When you need to refer to both at once,** say "citation + mention coverage" or "visibility (cited or mentioned)" — but always disambiguate immediately.
+5. **Public API field names** must use the canonical vocabulary. Renaming a field means a version bump per the API Stability rules, so get it right the first time.
+
+### Anti-patterns
+
+```typescript
+// ❌ Wrong — name says "answer", reader can't tell which signal
+{ answerRate: 0.42 }
+
+// ✅ Correct
+{ mentionRate: 0.42 }
+
+// ❌ Wrong — "visible" is ambiguous (cited? mentioned? both?)
+let visible = 0
+if (mentioned) visible++
+
+// ✅ Correct
+let mentioned = 0
+if (answerMentioned) mentioned++
+
+// ❌ Wrong — "Citation visibility" headline that counts answer-text mentions
+"Cited by 3 of 4 engines" // computed from answerMentioned
+
+// ✅ Correct — distinct headlines for the two signals
+"Cited by 2 of 4 engines"     // citationState
+"Mentioned in 3 of 4 answers" // answerMentioned
+```
+
 ## Enum Constants (Critical)
 
 **Never compare domain values as raw string literals.** Use the enum constant objects exported from `packages/contracts/src/run.ts` (re-exported via `@ainyc/canonry-contracts`).

--- a/apps/web/src/components/project/AnalyticsSection.tsx
+++ b/apps/web/src/components/project/AnalyticsSection.tsx
@@ -41,13 +41,13 @@ const SOURCE_CATEGORY_COLORS: Record<SourceCategory, string> = {
 }
 
 const METRIC_MODE_LABELS: Record<VisibilityMetricMode, string> = {
-  [VisibilityMetricModes.answer]: 'Answer',
-  [VisibilityMetricModes.citation]: 'Sources',
+  [VisibilityMetricModes.mentioned]: 'Mentioned',
+  [VisibilityMetricModes.cited]: 'Cited',
 }
 
 export function AnalyticsSection({ projectName }: { projectName: string }) {
   const [metricsWindow, setMetricsWindow] = useState<MetricsWindow>('30d')
-  const [metricMode, setMetricMode] = useState<VisibilityMetricMode>(VisibilityMetricModes.answer)
+  const [metricMode, setMetricMode] = useState<VisibilityMetricMode>(VisibilityMetricModes.mentioned)
   const [metrics, setMetrics] = useState<BrandMetricsDto | null>(null)
   const [gaps, setGaps] = useState<GapAnalysisDto | null>(null)
   const [sources, setSources] = useState<SourceBreakdownDto | null>(null)
@@ -80,19 +80,19 @@ export function AnalyticsSection({ projectName }: { projectName: string }) {
     return <p className="text-sm text-zinc-500 py-8 text-center">Loading analytics…</p>
   }
 
-  const isAnswer = metricMode === VisibilityMetricModes.answer
+  const isMention = metricMode === VisibilityMetricModes.mentioned
 
   // Derive mode-aware values from metrics
-  const rate = metrics ? (isAnswer ? metrics.overall.answerRate : metrics.overall.citationRate) : 0
-  const count = metrics ? (isAnswer ? metrics.overall.answerMentionedCount : metrics.overall.cited) : 0
+  const rate = metrics ? (isMention ? metrics.overall.mentionRate : metrics.overall.citationRate) : 0
+  const count = metrics ? (isMention ? metrics.overall.mentionedCount : metrics.overall.cited) : 0
   const total = metrics?.overall.total ?? 0
-  const trend = metrics ? (isAnswer ? metrics.answerTrend : metrics.trend) : 'stable'
+  const trend = metrics ? (isMention ? metrics.mentionTrend : metrics.trend) : 'stable'
   const trendTone: MetricTone = trend === 'improving' ? 'positive' : trend === 'declining' ? 'negative' : 'neutral'
 
   // Gap arrays based on mode
-  const gapCited = gaps ? (isAnswer ? gaps.mentionedKeywords : gaps.cited) : []
-  const gapGap = gaps ? (isAnswer ? gaps.mentionGap : gaps.gap) : []
-  const gapUncited = gaps ? (isAnswer ? gaps.notMentioned : gaps.uncited) : []
+  const gapCited = gaps ? (isMention ? gaps.mentionedKeywords : gaps.cited) : []
+  const gapGap = gaps ? (isMention ? gaps.mentionGap : gaps.gap) : []
+  const gapUncited = gaps ? (isMention ? gaps.notMentioned : gaps.uncited) : []
 
   return (
     <>
@@ -102,18 +102,18 @@ export function AnalyticsSection({ projectName }: { projectName: string }) {
           <div className="flex items-center gap-3">
             <div>
               <p className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 mb-1">
-                {isAnswer ? 'Visibility Metrics' : 'Citation Metrics'}
+                {isMention ? 'Mention Metrics' : 'Citation Metrics'}
               </p>
               <h2 className="text-base font-semibold text-zinc-50 flex items-center gap-1.5">
-                {isAnswer ? 'Answer Visibility Trends' : 'Source Citation Trends'}
-                <InfoTooltip text={isAnswer
-                  ? 'Percentage of queries where your brand is mentioned in the AI-generated answer text. A higher rate means AI engines are actively surfacing your brand when answering user questions.'
+                {isMention ? 'Answer-Mention Trends' : 'Source-Citation Trends'}
+                <InfoTooltip text={isMention
+                  ? 'Percentage of queries where your brand or domain is mentioned in the AI-generated answer text. A higher rate means AI engines are actively naming your brand in their prose when answering user questions.'
                   : 'Percentage of queries where your domain appears in the AI provider\'s source/reference links. This measures whether your pages are used as grounding sources, not whether your brand is named in the answer.'
                 } />
               </h2>
             </div>
             <div className="sidebar-tabs ml-2">
-              {([VisibilityMetricModes.answer, VisibilityMetricModes.citation] as const).map(mode => (
+              {([VisibilityMetricModes.mentioned, VisibilityMetricModes.cited] as const).map(mode => (
                 <button
                   key={mode}
                   type="button"
@@ -149,7 +149,7 @@ export function AnalyticsSection({ projectName }: { projectName: string }) {
             <div className="flex items-center gap-6">
               <ScoreGauge
                 value={`${Math.round(rate * 100)}`}
-                label={isAnswer ? 'Answer Rate' : 'Citation Rate'}
+                label={isMention ? 'Mention Rate' : 'Citation Rate'}
                 delta={`${count} / ${total}`}
                 tone={trendTone}
                 description={`Trend: ${trend}`}
@@ -170,13 +170,13 @@ export function AnalyticsSection({ projectName }: { projectName: string }) {
                       <tr className="text-[10px] uppercase tracking-wider text-zinc-500">
                         <th className="text-left py-1 font-medium">Provider</th>
                         <th className="text-right py-1 font-medium">Rate</th>
-                        <th className="text-right py-1 font-medium">{isAnswer ? 'Mentioned / Total' : 'Cited / Total'}</th>
+                        <th className="text-right py-1 font-medium">{isMention ? 'Mentioned / Total' : 'Cited / Total'}</th>
                       </tr>
                     </thead>
                     <tbody>
                       {Object.entries(metrics.byProvider).map(([provider, m]) => {
-                        const provRate = isAnswer ? m.answerRate : m.citationRate
-                        const provCount = isAnswer ? m.answerMentionedCount : m.cited
+                        const provRate = isMention ? m.mentionRate : m.citationRate
+                        const provCount = isMention ? m.mentionedCount : m.cited
                         return (
                           <tr key={provider} className="border-t border-zinc-800/40">
                             <td className="py-1.5 text-zinc-300">{provider}</td>
@@ -206,7 +206,7 @@ export function AnalyticsSection({ projectName }: { projectName: string }) {
         <div className="flex items-center justify-between mb-4">
           <div>
             <p className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 mb-1">Opportunity Analysis</p>
-            <h2 className="text-base font-semibold text-zinc-50 flex items-center gap-1.5">Brand Gap Analysis <InfoTooltip text={isAnswer
+            <h2 className="text-base font-semibold text-zinc-50 flex items-center gap-1.5">Brand Gap Analysis <InfoTooltip text={isMention
               ? 'Classification based on the most recent completed run. Mentioned: your brand was named in the AI answer text. Gap: a competitor was cited but your brand was not mentioned. Not Mentioned: your brand was not mentioned and no competitors were cited.'
               : 'Classification based on the most recent completed run. Cited: your domain appeared in the AI provider\'s source links. Gap: a competitor was cited but you were not. Not Cited: neither your domain nor competitors appeared in sources. Consistency shows how often each key phrase was cited across all runs in the selected window.'
             } /></h2>
@@ -220,8 +220,8 @@ export function AnalyticsSection({ projectName }: { projectName: string }) {
                 const filterCount = f === 'cited' ? gapCited.length : f === 'gap' ? gapGap.length : gapUncited.length
                 const active = gapFilter === f
                 const label = f === 'gap' ? 'Gap'
-                  : f === 'cited' ? (isAnswer ? 'Mentioned' : 'Cited')
-                  : (isAnswer ? 'Not Mentioned' : 'Not Cited')
+                  : f === 'cited' ? (isMention ? 'Mentioned' : 'Cited')
+                  : (isMention ? 'Not Mentioned' : 'Not Cited')
                 return (
                   <button
                     key={f}
@@ -304,13 +304,13 @@ export function AnalyticsSection({ projectName }: { projectName: string }) {
 }
 
 function AnalyticsTrendChart({ buckets, keywordChanges, metricMode }: { buckets: BrandMetricsDto['buckets']; keywordChanges: KeywordChangeEvent[]; metricMode: VisibilityMetricMode }) {
-  const isAnswer = metricMode === VisibilityMetricModes.answer
-  const dataKey = isAnswer ? 'answerRate' : 'citationRate'
-  const dataLabel = isAnswer ? 'Answer Rate' : 'Citation Rate'
+  const isMention = metricMode === VisibilityMetricModes.mentioned
+  const dataKey = isMention ? 'mentionRate' : 'citationRate'
+  const dataLabel = isMention ? 'Mention Rate' : 'Citation Rate'
 
   const chartData = buckets.map(b => ({
     date: b.startDate,
-    answerRate: Math.round(b.answerRate * 1000) / 10,
+    mentionRate: Math.round(b.mentionRate * 1000) / 10,
     citationRate: Math.round(b.citationRate * 1000) / 10,
     keywordCount: b.keywordCount ?? 0,
   }))
@@ -409,7 +409,7 @@ interface GapAnalysisTableProps {
 }
 
 function GapAnalysisTable({ citedRows, gapRows, uncitedRows, filter, metricMode }: GapAnalysisTableProps) {
-  const isAnswer = metricMode === VisibilityMetricModes.answer
+  const isMention = metricMode === VisibilityMetricModes.mentioned
 
   const rows = useMemo(() => {
     const all = [
@@ -431,7 +431,7 @@ function GapAnalysisTable({ citedRows, gapRows, uncitedRows, filter, metricMode 
         <tr className="text-[10px] uppercase tracking-wider text-zinc-500">
           <th className="text-left py-1 font-medium">Keyword</th>
           <th className="text-left py-1 font-medium">Status</th>
-          <th className="text-left py-1 font-medium">{isAnswer ? 'Providers Mentioning' : 'Providers Citing'}</th>
+          <th className="text-left py-1 font-medium">{isMention ? 'Providers Mentioning' : 'Providers Citing'}</th>
           <th className="text-left py-1 font-medium">Competitors Citing</th>
           <th className="text-right py-1 font-medium">Consistency</th>
         </tr>
@@ -440,9 +440,9 @@ function GapAnalysisTable({ citedRows, gapRows, uncitedRows, filter, metricMode 
         {rows.map(kw => {
           const tone: MetricTone = kw.category === 'cited' ? 'positive' : kw.category === 'gap' ? 'caution' : 'neutral'
           const statusLabel = kw.category === 'gap' ? 'Gap'
-            : kw.category === 'cited' ? (isAnswer ? 'Mentioned' : 'Cited')
-            : (isAnswer ? 'Not Mentioned' : 'Not Cited')
-          const consistencyCount = isAnswer ? kw.consistency.mentionedRuns : kw.consistency.citedRuns
+            : kw.category === 'cited' ? (isMention ? 'Mentioned' : 'Cited')
+            : (isMention ? 'Not Mentioned' : 'Not Cited')
+          const consistencyCount = isMention ? kw.consistency.mentionedRuns : kw.consistency.citedRuns
           return (
             <tr
               key={kw.keywordId}

--- a/apps/web/src/components/project/CitationVisibilitySection.tsx
+++ b/apps/web/src/components/project/CitationVisibilitySection.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
-import { Check, X, Minus } from 'lucide-react'
-import type { CitationVisibilityResponse } from '@ainyc/canonry-contracts'
+import { Minus } from 'lucide-react'
+import type { CitationCoverageProvider, CitationVisibilityResponse } from '@ainyc/canonry-contracts'
 import { fetchCitationVisibility } from '../../api.js'
 import { InfoTooltip } from '../shared/InfoTooltip.js'
 import { ProviderBadge } from '../shared/ProviderBadge.js'
@@ -27,7 +27,7 @@ export function CitationVisibilitySection({ projectName }: { projectName: string
         <div className="section-head section-head-inline">
           <div>
             <p className="eyebrow eyebrow-soft">Citation visibility</p>
-            <h2>Cited by N of M engines</h2>
+            <h2>Citation + answer-mention coverage</h2>
           </div>
         </div>
         <p className="text-sm text-rose-400">{error}</p>
@@ -42,7 +42,7 @@ export function CitationVisibilitySection({ projectName }: { projectName: string
         <div className="section-head section-head-inline">
           <div>
             <p className="eyebrow eyebrow-soft">Citation visibility</p>
-            <h2>Cited by N of M engines</h2>
+            <h2>Citation + answer-mention coverage</h2>
           </div>
         </div>
         <p className="text-sm text-zinc-500">
@@ -54,15 +54,21 @@ export function CitationVisibilitySection({ projectName }: { projectName: string
     )
   }
 
+  const { providersCiting, providersMentioning, providersConfigured } = data.summary
+
   return (
     <section className="page-section-divider">
       <div className="section-head section-head-inline">
-        <div>
+        <div className="space-y-1">
           <p className="eyebrow eyebrow-soft">Citation visibility</p>
-          <h2>
-            Cited by {data.summary.providersCiting} of {data.summary.providersConfigured} engines{' '}
-            <InfoTooltip text="Number of configured AI engines that cite this project for at least one tracked keyword in the latest snapshot per (keyword × provider). Works at any traffic volume." />
+          <h2 className="flex items-center gap-2">
+            Cited by {providersCiting} of {providersConfigured} engines
+            <InfoTooltip text="An engine is &lsquo;citing&rsquo; when our domain appears in its grounding source list (the structured citation/search-result attribution it returns alongside the answer). Counts each configured engine that cites the project on at least one tracked keyword in the latest snapshot per (keyword × provider)." />
           </h2>
+          <p className="text-base text-zinc-300 flex items-center gap-2">
+            Mentioned in {providersMentioning} of {providersConfigured} engine answers
+            <InfoTooltip text="An engine is &lsquo;mentioning&rsquo; when our brand or domain appears inside the prose of the answer text — independent of whether it&rsquo;s in the citation list. Models often name-drop from training without citing a fresh page." />
+          </p>
         </div>
         {data.summary.latestRunAt && (
           <p className="supporting-copy">
@@ -79,40 +85,55 @@ export function CitationVisibilitySection({ projectName }: { projectName: string
 }
 
 function CitationSummaryRow({ data }: { data: CitationVisibilityResponse }) {
+  const {
+    totalKeywords,
+    keywordsCitedAndMentioned,
+    keywordsCitedOnly,
+    keywordsMentionedOnly,
+    keywordsInvisible,
+  } = data.summary
   return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3 mb-4">
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 mb-4">
       <SummaryCell
-        label="Cited keywords"
-        value={`${data.summary.keywordsCited} / ${data.summary.totalKeywords}`}
-        helper="Cited by at least one engine"
-        tone={data.summary.keywordsCited > 0 ? 'positive' : 'neutral'}
+        label="Cited + mentioned"
+        value={`${keywordsCitedAndMentioned} / ${totalKeywords}`}
+        helper="In sources AND named in answer"
+        tone={keywordsCitedAndMentioned > 0 ? 'positive' : 'neutral'}
       />
       <SummaryCell
-        label="Fully covered"
-        value={`${data.summary.keywordsFullyCovered} / ${data.summary.totalKeywords}`}
-        helper="Cited by every configured engine"
-        tone={data.summary.keywordsFullyCovered > 0 ? 'positive' : 'neutral'}
+        label="Cited only"
+        value={`${keywordsCitedOnly} / ${totalKeywords}`}
+        helper="In sources, not named in answer"
+        tone={keywordsCitedOnly > 0 ? 'positive-dim' : 'neutral'}
       />
       <SummaryCell
-        label="Uncovered"
-        value={`${data.summary.keywordsUncovered} / ${data.summary.totalKeywords}`}
-        helper="No engine cites the project"
-        tone={data.summary.keywordsUncovered > 0 ? 'caution' : 'neutral'}
+        label="Mentioned only"
+        value={`${keywordsMentionedOnly} / ${totalKeywords}`}
+        helper="Named in answer, no source link"
+        tone={keywordsMentionedOnly > 0 ? 'caution' : 'neutral'}
+      />
+      <SummaryCell
+        label="Invisible"
+        value={`${keywordsInvisible} / ${totalKeywords}`}
+        helper="No engine cites or mentions"
+        tone={keywordsInvisible > 0 ? 'negative' : 'neutral'}
       />
     </div>
   )
 }
 
-type Tone = 'positive' | 'caution' | 'negative' | 'neutral'
+type Tone = 'positive' | 'positive-dim' | 'caution' | 'negative' | 'neutral'
 
 function SummaryCell({ label, value, helper, tone }: { label: string; value: string; helper: string; tone: Tone }) {
   const valueClass = tone === 'positive'
     ? 'text-emerald-300'
-    : tone === 'caution'
-      ? 'text-amber-300'
-      : tone === 'negative'
-        ? 'text-rose-300'
-        : 'text-zinc-100'
+    : tone === 'positive-dim'
+      ? 'text-emerald-400/70'
+      : tone === 'caution'
+        ? 'text-amber-300'
+        : tone === 'negative'
+          ? 'text-rose-300'
+          : 'text-zinc-100'
   return (
     <div className="rounded-md border border-zinc-800/60 bg-zinc-900/30 px-4 py-3">
       <p className="text-[10px] uppercase tracking-wide text-zinc-500">{label}</p>
@@ -136,56 +157,118 @@ function CoverageTable({ data }: { data: CitationVisibilityResponse }) {
   }
 
   return (
-    <div className="evidence-table-wrap">
-      <table className="evidence-table">
-        <thead>
-          <tr>
-            <th>Keyword</th>
-            {providerColumns.map(p => (
-              <th key={p} className="text-center">
-                <ProviderBadge provider={p} />
-              </th>
-            ))}
-            <th className="text-right">Coverage</th>
-          </tr>
-        </thead>
-        <tbody>
-          {data.byKeyword.map(row => (
-            <tr key={row.keywordId}>
-              <td className="font-medium text-zinc-100">{row.keyword}</td>
-              {providerColumns.map(p => {
-                const provider = row.providers.find(x => x.provider === p)
-                return (
-                  <td key={p} className="text-center">
-                    {provider == null ? (
-                      <Minus className="inline h-3.5 w-3.5 text-zinc-700" aria-label="no data" />
-                    ) : provider.cited ? (
-                      <Check className="inline h-4 w-4 text-emerald-400" aria-label="cited" />
-                    ) : (
-                      <X className="inline h-4 w-4 text-zinc-600" aria-label="not cited" />
-                    )}
-                  </td>
-                )
-              })}
-              <td className="text-right tabular-nums">
-                <span
-                  className={
-                    row.totalProviders > 0 && row.citedCount === row.totalProviders
-                      ? 'text-emerald-300'
-                      : row.citedCount > 0
-                        ? 'text-amber-300'
-                        : 'text-zinc-500'
-                  }
-                >
-                  {row.citedCount}/{row.totalProviders}
-                </span>
-              </td>
+    <div>
+      <CoverageLegend />
+      <div className="evidence-table-wrap">
+        <table className="evidence-table">
+          <thead>
+            <tr>
+              <th>Keyword</th>
+              {providerColumns.map(p => (
+                <th key={p} className="text-center">
+                  <ProviderBadge provider={p} />
+                </th>
+              ))}
+              <th className="text-right">Cite</th>
+              <th className="text-right">Ment</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {data.byKeyword.map(row => (
+              <tr key={row.keywordId}>
+                <td className="font-medium text-zinc-100">{row.keyword}</td>
+                {providerColumns.map(p => {
+                  const provider = row.providers.find(x => x.provider === p)
+                  return (
+                    <td key={p} className="text-center">
+                      {provider == null ? (
+                        <Minus className="inline h-3.5 w-3.5 text-zinc-700" aria-label="no data" />
+                      ) : (
+                        <DualIndicator provider={provider} />
+                      )}
+                    </td>
+                  )
+                })}
+                <td className="text-right tabular-nums">
+                  <span
+                    className={
+                      row.totalProviders > 0 && row.citedCount === row.totalProviders
+                        ? 'text-emerald-300'
+                        : row.citedCount > 0
+                          ? 'text-emerald-400/70'
+                          : 'text-zinc-500'
+                    }
+                  >
+                    {row.citedCount}/{row.totalProviders}
+                  </span>
+                </td>
+                <td className="text-right tabular-nums">
+                  <span
+                    className={
+                      row.totalProviders > 0 && row.mentionedCount === row.totalProviders
+                        ? 'text-sky-300'
+                        : row.mentionedCount > 0
+                          ? 'text-sky-400/70'
+                          : 'text-zinc-500'
+                    }
+                  >
+                    {row.mentionedCount}/{row.totalProviders}
+                  </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   )
+}
+
+function CoverageLegend() {
+  return (
+    <div className="mb-2 flex flex-wrap items-center gap-3 text-[11px] text-zinc-500">
+      <span className="flex items-center gap-1.5">
+        <IndicatorDot active tone="cited" />
+        <span>cited (in sources)</span>
+      </span>
+      <span className="flex items-center gap-1.5">
+        <IndicatorDot active tone="mentioned" />
+        <span>mentioned (in answer)</span>
+      </span>
+      <span className="flex items-center gap-1.5">
+        <IndicatorDot active={false} tone="cited" />
+        <IndicatorDot active={false} tone="mentioned" />
+        <span>neither</span>
+      </span>
+    </div>
+  )
+}
+
+function DualIndicator({ provider }: { provider: CitationCoverageProvider }) {
+  const title = describeIndicator(provider)
+  return (
+    <span className="inline-flex items-center justify-center gap-1" title={title}>
+      <IndicatorDot active={provider.cited} tone="cited" />
+      <IndicatorDot active={provider.mentioned} tone="mentioned" />
+    </span>
+  )
+}
+
+function describeIndicator(provider: CitationCoverageProvider): string {
+  if (provider.cited && provider.mentioned) return 'Cited in sources and mentioned in answer'
+  if (provider.cited) return 'Cited in sources, not mentioned in answer'
+  if (provider.mentioned) return 'Mentioned in answer, not in sources'
+  return 'Not cited and not mentioned'
+}
+
+function IndicatorDot({ active, tone }: { active: boolean; tone: 'cited' | 'mentioned' }) {
+  if (!active) {
+    return <span className="inline-block h-2 w-2 rounded-full border border-zinc-700/80 bg-transparent" aria-hidden="true" />
+  }
+  const className = tone === 'cited'
+    ? 'inline-block h-2 w-2 rounded-full bg-emerald-400 shadow-[0_0_0_1px_rgba(16,185,129,0.25)]'
+    : 'inline-block h-2 w-2 rounded-full bg-sky-400 shadow-[0_0_0_1px_rgba(56,189,248,0.25)]'
+  return <span className={className} aria-hidden="true" />
 }
 
 function CompetitorGapList({ data }: { data: CitationVisibilityResponse }) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.0.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "2.17.0",
+  "version": "3.0.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "2.16.2",
+  "version": "2.17.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/analytics.ts
+++ b/packages/api-routes/src/analytics.ts
@@ -33,10 +33,10 @@ export async function analyticsRoutes(app: FastifyInstance) {
       return reply.send({
         window,
         buckets: [],
-        overall: { citationRate: 0, cited: 0, total: 0, answerRate: 0, answerMentionedCount: 0 },
+        overall: { citationRate: 0, cited: 0, total: 0, mentionRate: 0, mentionedCount: 0 },
         byProvider: {},
         trend: 'stable',
-        answerTrend: 'stable',
+        mentionTrend: 'stable',
         keywordChanges: [],
       } satisfies BrandMetricsDto)
     }
@@ -89,12 +89,12 @@ export async function analyticsRoutes(app: FastifyInstance) {
 
     // Trends
     const trend = computeTrend(buckets, 'citationRate')
-    const answerTrend = computeTrend(buckets, 'answerRate')
+    const mentionTrend = computeTrend(buckets, 'mentionRate')
 
     // Keyword change annotations
     const keywordChanges = computeKeywordChanges(projectKeywords, cutoff)
 
-    return reply.send({ window, buckets, overall, byProvider, trend, answerTrend, keywordChanges } satisfies BrandMetricsDto)
+    return reply.send({ window, buckets, overall, byProvider, trend, mentionTrend, keywordChanges } satisfies BrandMetricsDto)
   })
 
   // GET /projects/:name/analytics/gaps — brand gap analysis
@@ -394,13 +394,13 @@ interface SnapshotLike {
 function computeProviderMetric(snapshots: SnapshotLike[]): ProviderMetric {
   const total = snapshots.length
   const cited = snapshots.filter(s => s.citationState === 'cited').length
-  const answerMentionedCount = snapshots.filter(s => s.resolvedMentioned).length
+  const mentionedCount = snapshots.filter(s => s.resolvedMentioned).length
   return {
     citationRate: total > 0 ? Math.round((cited / total) * 10000) / 10000 : 0,
     cited,
     total,
-    answerRate: total > 0 ? Math.round((answerMentionedCount / total) * 10000) / 10000 : 0,
-    answerMentionedCount,
+    mentionRate: total > 0 ? Math.round((mentionedCount / total) * 10000) / 10000 : 0,
+    mentionedCount,
   }
 }
 
@@ -449,8 +449,8 @@ function computeBuckets(
         cited: metric.cited,
         total: metric.total,
         keywordCount,
-        answerRate: metric.answerRate,
-        answerMentionedCount: metric.answerMentionedCount,
+        mentionRate: metric.mentionRate,
+        mentionedCount: metric.mentionedCount,
       })
     }
 
@@ -484,7 +484,7 @@ function computeKeywordChanges(
   }))
 }
 
-function computeTrend(buckets: TimeBucket[], rateKey: 'citationRate' | 'answerRate'): TrendDirection {
+function computeTrend(buckets: TimeBucket[], rateKey: 'citationRate' | 'mentionRate'): TrendDirection {
   const nonEmpty = buckets.filter(b => b.total > 0)
   if (nonEmpty.length < 2) return 'stable'
 

--- a/packages/api-routes/src/citations.ts
+++ b/packages/api-routes/src/citations.ts
@@ -21,6 +21,7 @@ interface SnapshotRow {
   citationState: string
   citedDomains: string
   competitorOverlap: string
+  answerMentioned: boolean | null
   createdAt: string
   runCreatedAt: string
 }
@@ -66,6 +67,7 @@ export async function citationRoutes(app: FastifyInstance) {
         citationState: querySnapshots.citationState,
         citedDomains: querySnapshots.citedDomains,
         competitorOverlap: querySnapshots.competitorOverlap,
+        answerMentioned: querySnapshots.answerMentioned,
         createdAt: querySnapshots.createdAt,
       })
       .from(querySnapshots)
@@ -136,49 +138,66 @@ export function computeCitationVisibility(input: ComputeInput): CitationVisibili
     ? Array.from(new Set(configuredProviders))
     : Array.from(observedProviders).sort()
 
-  // byKeyword — every project keyword gets a row, even ones with no snapshots
-  // yet. Providers within a row are sorted by the configured order so the UI
-  // can render columns deterministically.
-  const byKeyword: CitationCoverageRow[] = []
   const providersCitingTracker = new Set<string>()
-  let keywordsCited = 0
-  let keywordsFullyCovered = 0
-  let keywordsUncovered = 0
+  const providersMentioningTracker = new Set<string>()
+
+  // Cross-tab buckets at the keyword level. A keyword lands in exactly one
+  // bucket: cited+mentioned > cited-only > mentioned-only > invisible.
+  // Keywords with zero snapshots fall through and are not counted in any
+  // bucket — total - sum(buckets) = "no data yet".
+  let keywordsCitedAndMentioned = 0
+  let keywordsCitedOnly = 0
+  let keywordsMentionedOnly = 0
+  let keywordsInvisible = 0
+
+  const byKeyword: CitationCoverageRow[] = []
 
   for (const kw of kws) {
     const providers: CitationCoverageProvider[] = []
     let citedCount = 0
+    let mentionedCount = 0
 
     for (const provider of providerUniverse) {
       const snap = latestByPair.get(`${kw.id}::${provider}`)
       if (!snap) continue
       const state = snap.citationState as CitationState
       const cited = citationStateToCited(state)
+      // null answer_mentioned (legacy snapshot before the column existed) is
+      // treated as "not mentioned" — we only credit explicit positives.
+      const mentioned = snap.answerMentioned === true
       if (cited) {
         citedCount++
         providersCitingTracker.add(provider)
+      }
+      if (mentioned) {
+        mentionedCount++
+        providersMentioningTracker.add(provider)
       }
       providers.push({
         provider,
         citationState: state,
         cited,
+        mentioned,
         runId: snap.runId,
         runCreatedAt: snap.runCreatedAt,
       })
     }
 
-    if (citedCount > 0) keywordsCited++
-    // Fully covered = cited by every configured provider. A keyword missing
-    // a snapshot for any provider in providerUniverse is not yet fully covered,
-    // even if every observed provider cites it.
-    if (providerUniverse.length > 0 && citedCount === providerUniverse.length) keywordsFullyCovered++
-    if (providers.length > 0 && citedCount === 0) keywordsUncovered++
+    if (providers.length > 0) {
+      const anyCited = citedCount > 0
+      const anyMentioned = mentionedCount > 0
+      if (anyCited && anyMentioned) keywordsCitedAndMentioned++
+      else if (anyCited) keywordsCitedOnly++
+      else if (anyMentioned) keywordsMentionedOnly++
+      else keywordsInvisible++
+    }
 
     byKeyword.push({
       keywordId: kw.id,
       keyword: kw.keyword,
       providers,
       citedCount,
+      mentionedCount,
       totalProviders: providers.length,
     })
   }
@@ -231,10 +250,12 @@ export function computeCitationVisibility(input: ComputeInput): CitationVisibili
   const summary: CitationVisibilitySummary = {
     providersConfigured: providerUniverse.length,
     providersCiting: providersCitingTracker.size,
+    providersMentioning: providersMentioningTracker.size,
     totalKeywords: kws.length,
-    keywordsCited,
-    keywordsFullyCovered,
-    keywordsUncovered,
+    keywordsCitedAndMentioned,
+    keywordsCitedOnly,
+    keywordsMentionedOnly,
+    keywordsInvisible,
     latestRunId,
     latestRunAt,
   }

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -2286,9 +2286,9 @@ const routeCatalog: OpenApiOperation[] = [
   {
     method: 'get',
     path: '/api/v1/projects/{name}/citations/visibility',
-    summary: 'Citation visibility headline (cited by N of M engines)',
+    summary: 'Citation visibility headline (citation + answer-mention, by engine + keyword)',
     description:
-      'Single-call read for the AI citation surface. Returns project headline (`providersConfigured`/`providersCiting`/keyword coverage counts), per-keyword engine coverage rows from the latest snapshot per (keyword × provider), and a competitor-gap list (keywords where the project is not cited but a configured competitor is). Status `no-data` with `reason: "no-runs-yet"` or `"no-keywords"` when the project lacks the inputs.',
+      'Single-call read for the AI citation surface. Returns two parallel headline metrics (`providersCiting` = engines that cite the project in their grounding/source list, `providersMentioning` = engines that name the project in answer prose), per-keyword cross-tab buckets (`keywordsCitedAndMentioned` / `keywordsCitedOnly` / `keywordsMentionedOnly` / `keywordsInvisible` — mutually exclusive over keywords that have at least one snapshot), per-keyword engine coverage rows from the latest snapshot per (keyword × provider) with both `cited` and `mentioned` flags, and a competitor-gap list (keywords where the project is not cited but a configured competitor is). Status `no-data` with `reason: "no-runs-yet"` or `"no-keywords"` when the project lacks the inputs.',
     tags: ['intelligence'],
     parameters: [nameParameter],
     responses: {

--- a/packages/api-routes/test/analytics.test.ts
+++ b/packages/api-routes/test/analytics.test.ts
@@ -193,24 +193,24 @@ describe('analytics routes', () => {
       expect(res.statusCode).toBe(200)
       const body = JSON.parse(res.payload)
 
-      // Answer rate fields exist
-      expect(body.overall.answerRate).toBeGreaterThanOrEqual(0)
-      expect(body.overall.answerRate).toBeLessThanOrEqual(1)
-      expect(body.overall.answerMentionedCount).toBeGreaterThanOrEqual(0)
-      expect(body.answerTrend).toMatch(/^(improving|declining|stable)$/)
+      // Mention rate fields exist
+      expect(body.overall.mentionRate).toBeGreaterThanOrEqual(0)
+      expect(body.overall.mentionRate).toBeLessThanOrEqual(1)
+      expect(body.overall.mentionedCount).toBeGreaterThanOrEqual(0)
+      expect(body.mentionTrend).toMatch(/^(improving|declining|stable)$/)
 
       // kw1/gemini has answerText 'Example.com is great...' and canonicalDomain 'example.com'
       // so it should be resolved as mentioned
-      expect(body.overall.answerMentionedCount).toBeGreaterThan(0)
+      expect(body.overall.mentionedCount).toBeGreaterThan(0)
 
-      // Per-provider answer rate
-      expect(body.byProvider.gemini.answerRate).toBeGreaterThan(0)
-      expect(body.byProvider.gemini.answerMentionedCount).toBeGreaterThan(0)
+      // Per-provider mention rate
+      expect(body.byProvider.gemini.mentionRate).toBeGreaterThan(0)
+      expect(body.byProvider.gemini.mentionedCount).toBeGreaterThan(0)
 
-      // Each bucket has answer fields
+      // Each bucket has mention fields
       for (const bucket of body.buckets) {
-        expect(bucket.answerRate).toBeGreaterThanOrEqual(0)
-        expect(typeof bucket.answerMentionedCount).toBe('number')
+        expect(bucket.mentionRate).toBeGreaterThanOrEqual(0)
+        expect(typeof bucket.mentionedCount).toBe('number')
       }
     })
 
@@ -591,9 +591,9 @@ describe('analytics routes', () => {
     expect(metricsRes.statusCode).toBe(200)
     const metricsBody = JSON.parse(metricsRes.payload)
     expect(metricsBody.overall.total).toBe(0)
-    expect(metricsBody.overall.answerRate).toBe(0)
-    expect(metricsBody.overall.answerMentionedCount).toBe(0)
-    expect(metricsBody.answerTrend).toBe('stable')
+    expect(metricsBody.overall.mentionRate).toBe(0)
+    expect(metricsBody.overall.mentionedCount).toBe(0)
+    expect(metricsBody.mentionTrend).toBe('stable')
 
     const gapsRes = await app.inject({ method: 'GET', url: '/api/v1/projects/empty-project/analytics/gaps' })
     expect(gapsRes.statusCode).toBe(200)

--- a/packages/api-routes/test/citations.test.ts
+++ b/packages/api-routes/test/citations.test.ts
@@ -77,6 +77,7 @@ function insertSnapshot(
     keywordId: string
     provider: string
     citationState: 'cited' | 'not-cited'
+    answerMentioned?: boolean | null
     citedDomains?: string[]
     competitorOverlap?: string[]
     createdAt: string
@@ -88,6 +89,7 @@ function insertSnapshot(
     keywordId: args.keywordId,
     provider: args.provider,
     citationState: args.citationState,
+    answerMentioned: args.answerMentioned ?? null,
     citedDomains: JSON.stringify(args.citedDomains ?? []),
     competitorOverlap: JSON.stringify(args.competitorOverlap ?? []),
     recommendedCompetitors: '[]',
@@ -141,17 +143,17 @@ test('ready response computes coverage from latest snapshot per (keyword × prov
   const oldRun = insertRun(ctx.db, projectId, '2026-04-20T00:00:00Z')
   const newRun = insertRun(ctx.db, projectId, '2026-04-28T00:00:00Z')
 
-  // Old run — both providers, both keywords, all not-cited
-  insertSnapshot(ctx.db, { runId: oldRun, keywordId: kwA, provider: 'gemini', citationState: 'not-cited', createdAt: '2026-04-20T00:00:01Z' })
-  insertSnapshot(ctx.db, { runId: oldRun, keywordId: kwA, provider: 'claude', citationState: 'not-cited', createdAt: '2026-04-20T00:00:01Z' })
-  insertSnapshot(ctx.db, { runId: oldRun, keywordId: kwB, provider: 'gemini', citationState: 'not-cited', createdAt: '2026-04-20T00:00:01Z' })
-  insertSnapshot(ctx.db, { runId: oldRun, keywordId: kwB, provider: 'claude', citationState: 'not-cited', createdAt: '2026-04-20T00:00:01Z' })
+  // Old run — both providers, both keywords, all not-cited and not-mentioned
+  insertSnapshot(ctx.db, { runId: oldRun, keywordId: kwA, provider: 'gemini', citationState: 'not-cited', answerMentioned: false, createdAt: '2026-04-20T00:00:01Z' })
+  insertSnapshot(ctx.db, { runId: oldRun, keywordId: kwA, provider: 'claude', citationState: 'not-cited', answerMentioned: false, createdAt: '2026-04-20T00:00:01Z' })
+  insertSnapshot(ctx.db, { runId: oldRun, keywordId: kwB, provider: 'gemini', citationState: 'not-cited', answerMentioned: false, createdAt: '2026-04-20T00:00:01Z' })
+  insertSnapshot(ctx.db, { runId: oldRun, keywordId: kwB, provider: 'claude', citationState: 'not-cited', answerMentioned: false, createdAt: '2026-04-20T00:00:01Z' })
 
-  // New run — gemini cites kwA only; claude still cites neither
-  insertSnapshot(ctx.db, { runId: newRun, keywordId: kwA, provider: 'gemini', citationState: 'cited', createdAt: '2026-04-28T00:00:01Z' })
-  insertSnapshot(ctx.db, { runId: newRun, keywordId: kwA, provider: 'claude', citationState: 'not-cited', createdAt: '2026-04-28T00:00:01Z' })
-  insertSnapshot(ctx.db, { runId: newRun, keywordId: kwB, provider: 'gemini', citationState: 'not-cited', createdAt: '2026-04-28T00:00:01Z' })
-  insertSnapshot(ctx.db, { runId: newRun, keywordId: kwB, provider: 'claude', citationState: 'not-cited', createdAt: '2026-04-28T00:00:01Z' })
+  // New run — gemini cites kwA only; claude still cites neither but now mentions kwA in prose
+  insertSnapshot(ctx.db, { runId: newRun, keywordId: kwA, provider: 'gemini', citationState: 'cited', answerMentioned: true, createdAt: '2026-04-28T00:00:01Z' })
+  insertSnapshot(ctx.db, { runId: newRun, keywordId: kwA, provider: 'claude', citationState: 'not-cited', answerMentioned: true, createdAt: '2026-04-28T00:00:01Z' })
+  insertSnapshot(ctx.db, { runId: newRun, keywordId: kwB, provider: 'gemini', citationState: 'not-cited', answerMentioned: false, createdAt: '2026-04-28T00:00:01Z' })
+  insertSnapshot(ctx.db, { runId: newRun, keywordId: kwB, provider: 'claude', citationState: 'not-cited', answerMentioned: false, createdAt: '2026-04-28T00:00:01Z' })
 
   await ctx.app.ready()
   const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/live/citations/visibility' })
@@ -161,28 +163,38 @@ test('ready response computes coverage from latest snapshot per (keyword × prov
   expect(body.status).toBe('ready')
   expect(body.summary.providersConfigured).toBe(2)
   expect(body.summary.providersCiting).toBe(1)
+  expect(body.summary.providersMentioning).toBe(2)
   expect(body.summary.totalKeywords).toBe(2)
-  expect(body.summary.keywordsCited).toBe(1)
-  expect(body.summary.keywordsFullyCovered).toBe(0)
-  expect(body.summary.keywordsUncovered).toBe(1)
+  // keyword A: cited (gemini) AND mentioned (gemini + claude) → cited+mentioned bucket
+  // keyword B: nothing → invisible bucket
+  expect(body.summary.keywordsCitedAndMentioned).toBe(1)
+  expect(body.summary.keywordsCitedOnly).toBe(0)
+  expect(body.summary.keywordsMentionedOnly).toBe(0)
+  expect(body.summary.keywordsInvisible).toBe(1)
   expect(body.summary.latestRunId).toBe(newRun)
 
   const rowA = body.byKeyword.find(r => r.keyword === 'keyword A')!
   expect(rowA.citedCount).toBe(1)
+  expect(rowA.mentionedCount).toBe(2)
   expect(rowA.totalProviders).toBe(2)
-  expect(rowA.providers.find(p => p.provider === 'gemini')!.cited).toBe(true)
-  expect(rowA.providers.find(p => p.provider === 'gemini')!.runId).toBe(newRun)
-  expect(rowA.providers.find(p => p.provider === 'claude')!.cited).toBe(false)
+  const rowAGemini = rowA.providers.find(p => p.provider === 'gemini')!
+  expect(rowAGemini.cited).toBe(true)
+  expect(rowAGemini.mentioned).toBe(true)
+  expect(rowAGemini.runId).toBe(newRun)
+  const rowAClaude = rowA.providers.find(p => p.provider === 'claude')!
+  expect(rowAClaude.cited).toBe(false)
+  expect(rowAClaude.mentioned).toBe(true)
 
   const rowB = body.byKeyword.find(r => r.keyword === 'keyword B')!
   expect(rowB.citedCount).toBe(0)
+  expect(rowB.mentionedCount).toBe(0)
 })
 
 test('uses observed providers when project.providers is empty', async () => {
   const projectId = insertProject(ctx.db, 'no-config', [])
   const kw = insertKeyword(ctx.db, projectId, 'keyword X')
   const run = insertRun(ctx.db, projectId, '2026-04-28T00:00:00Z')
-  insertSnapshot(ctx.db, { runId: run, keywordId: kw, provider: 'perplexity', citationState: 'cited', createdAt: '2026-04-28T00:00:01Z' })
+  insertSnapshot(ctx.db, { runId: run, keywordId: kw, provider: 'perplexity', citationState: 'cited', answerMentioned: false, createdAt: '2026-04-28T00:00:01Z' })
 
   await ctx.app.ready()
   const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/no-config/citations/visibility' })
@@ -275,37 +287,76 @@ test('does not surface a gap when project has no configured competitors', async 
   expect(body.competitorGaps).toHaveLength(0)
 })
 
-test('keywordsFullyCovered counts keywords cited by every configured provider', async () => {
-  const projectId = insertProject(ctx.db, 'full', ['gemini', 'claude'])
-  const kw = insertKeyword(ctx.db, projectId, 'keyword Y')
+test('cross-tab buckets are mutually exclusive over keywords with snapshots', async () => {
+  // Four keywords, one per bucket. Single configured provider so the tests
+  // are unambiguous about which bucket each keyword lands in.
+  const projectId = insertProject(ctx.db, 'crosstab', ['gemini'])
+  const kwBoth = insertKeyword(ctx.db, projectId, 'cited and mentioned')
+  const kwCitedOnly = insertKeyword(ctx.db, projectId, 'cited only')
+  const kwMentionedOnly = insertKeyword(ctx.db, projectId, 'mentioned only')
+  const kwInvisible = insertKeyword(ctx.db, projectId, 'invisible')
+  // Fifth keyword has no snapshots — should not count toward any bucket.
+  insertKeyword(ctx.db, projectId, 'no data yet')
+
   const run = insertRun(ctx.db, projectId, '2026-04-28T00:00:00Z')
-  insertSnapshot(ctx.db, { runId: run, keywordId: kw, provider: 'gemini', citationState: 'cited', createdAt: '2026-04-28T00:00:01Z' })
-  insertSnapshot(ctx.db, { runId: run, keywordId: kw, provider: 'claude', citationState: 'cited', createdAt: '2026-04-28T00:00:01Z' })
+  insertSnapshot(ctx.db, { runId: run, keywordId: kwBoth, provider: 'gemini', citationState: 'cited', answerMentioned: true, createdAt: '2026-04-28T00:00:01Z' })
+  insertSnapshot(ctx.db, { runId: run, keywordId: kwCitedOnly, provider: 'gemini', citationState: 'cited', answerMentioned: false, createdAt: '2026-04-28T00:00:01Z' })
+  insertSnapshot(ctx.db, { runId: run, keywordId: kwMentionedOnly, provider: 'gemini', citationState: 'not-cited', answerMentioned: true, createdAt: '2026-04-28T00:00:01Z' })
+  insertSnapshot(ctx.db, { runId: run, keywordId: kwInvisible, provider: 'gemini', citationState: 'not-cited', answerMentioned: false, createdAt: '2026-04-28T00:00:01Z' })
 
   await ctx.app.ready()
-  const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/full/citations/visibility' })
+  const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/crosstab/citations/visibility' })
   const body = JSON.parse(res.body) as CitationVisibilityResponse
-  expect(body.summary.keywordsFullyCovered).toBe(1)
-  expect(body.summary.keywordsCited).toBe(1)
-  expect(body.summary.providersCiting).toBe(2)
+
+  expect(body.summary.totalKeywords).toBe(5)
+  expect(body.summary.keywordsCitedAndMentioned).toBe(1)
+  expect(body.summary.keywordsCitedOnly).toBe(1)
+  expect(body.summary.keywordsMentionedOnly).toBe(1)
+  expect(body.summary.keywordsInvisible).toBe(1)
+  // Sum of buckets = 4, total = 5 — the no-data keyword is excluded
+  const sum =
+    body.summary.keywordsCitedAndMentioned +
+    body.summary.keywordsCitedOnly +
+    body.summary.keywordsMentionedOnly +
+    body.summary.keywordsInvisible
+  expect(sum).toBe(4)
 })
 
-test('keywordsFullyCovered does not count keywords missing snapshots from configured providers', async () => {
-  // Project configures gemini + claude + openai but only gemini + claude have run.
-  // Both observed providers cite, but openai has no snapshot — keyword is NOT
-  // fully covered by the configured set.
-  const projectId = insertProject(ctx.db, 'partial-coverage', ['gemini', 'claude', 'openai'])
-  const kw = insertKeyword(ctx.db, projectId, 'keyword Z')
+test('cited-and-mentioned bucket counts a keyword when different engines provide each signal', async () => {
+  // Gemini cites but does not mention; OpenAI mentions but does not cite.
+  // Keyword should land in cited+mentioned because we count "any engine" per
+  // dimension at the keyword level.
+  const projectId = insertProject(ctx.db, 'split-signals', ['gemini', 'openai'])
+  const kw = insertKeyword(ctx.db, projectId, 'split keyword')
   const run = insertRun(ctx.db, projectId, '2026-04-28T00:00:00Z')
-  insertSnapshot(ctx.db, { runId: run, keywordId: kw, provider: 'gemini', citationState: 'cited', createdAt: '2026-04-28T00:00:01Z' })
-  insertSnapshot(ctx.db, { runId: run, keywordId: kw, provider: 'claude', citationState: 'cited', createdAt: '2026-04-28T00:00:01Z' })
+  insertSnapshot(ctx.db, { runId: run, keywordId: kw, provider: 'gemini', citationState: 'cited', answerMentioned: false, createdAt: '2026-04-28T00:00:01Z' })
+  insertSnapshot(ctx.db, { runId: run, keywordId: kw, provider: 'openai', citationState: 'not-cited', answerMentioned: true, createdAt: '2026-04-28T00:00:01Z' })
 
   await ctx.app.ready()
-  const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/partial-coverage/citations/visibility' })
+  const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/split-signals/citations/visibility' })
   const body = JSON.parse(res.body) as CitationVisibilityResponse
-  expect(body.summary.providersConfigured).toBe(3)
-  expect(body.summary.keywordsCited).toBe(1)
-  expect(body.summary.keywordsFullyCovered).toBe(0)
+
+  expect(body.summary.keywordsCitedAndMentioned).toBe(1)
+  expect(body.summary.keywordsCitedOnly).toBe(0)
+  expect(body.summary.keywordsMentionedOnly).toBe(0)
+  expect(body.summary.providersCiting).toBe(1)
+  expect(body.summary.providersMentioning).toBe(1)
+})
+
+test('legacy snapshots with null answer_mentioned count as not mentioned', async () => {
+  const projectId = insertProject(ctx.db, 'legacy', ['gemini'])
+  const kw = insertKeyword(ctx.db, projectId, 'old keyword')
+  const run = insertRun(ctx.db, projectId, '2026-04-28T00:00:00Z')
+  insertSnapshot(ctx.db, { runId: run, keywordId: kw, provider: 'gemini', citationState: 'cited', answerMentioned: null, createdAt: '2026-04-28T00:00:01Z' })
+
+  await ctx.app.ready()
+  const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/legacy/citations/visibility' })
+  const body = JSON.parse(res.body) as CitationVisibilityResponse
+
+  expect(body.summary.providersMentioning).toBe(0)
+  expect(body.summary.keywordsCitedAndMentioned).toBe(0)
+  expect(body.summary.keywordsCitedOnly).toBe(1)
+  expect(body.byKeyword[0]!.providers[0]!.mentioned).toBe(false)
 })
 
 test('competitor matching normalizes www. and protocol on both sides', async () => {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "2.16.2",
+  "version": "2.17.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "2.17.0",
+  "version": "3.0.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/commands/backfill.ts
+++ b/packages/canonry/src/commands/backfill.ts
@@ -32,7 +32,7 @@ export async function backfillAnswerVisibilityCommand(opts?: {
 
   let examined = 0
   let updated = 0
-  let visible = 0
+  let mentioned = 0
   let reparsed = 0
   let providerErrors = 0
   if (scopedProjects.length > 0) {
@@ -99,7 +99,7 @@ export async function backfillAnswerVisibilityCommand(opts?: {
           const answerText = reparsedResult?.answerText ?? snapshot.answerText ?? ''
           const nextValue = determineAnswerMentioned(answerText, project.displayName, projectDomains)
 
-          if (nextValue) visible++
+          if (nextValue) mentioned++
 
           const nextPatch: Record<string, unknown> = {}
 
@@ -180,7 +180,7 @@ export async function backfillAnswerVisibilityCommand(opts?: {
     projects: scopedProjects.length,
     examined,
     updated,
-    visible,
+    mentioned,
     reparsed,
     providerErrors,
   }
@@ -195,11 +195,11 @@ export async function backfillAnswerVisibilityCommand(opts?: {
     console.log(`  Project:  ${projectFilter}`)
   }
   console.log(`  Projects: ${scopedProjects.length}`)
-  console.log(`  Examined: ${examined}`)
-  console.log(`  Updated:  ${updated}`)
-  console.log(`  Visible:  ${visible}`)
-  console.log(`  Reparsed: ${reparsed}`)
-  console.log(`  Errors:   ${providerErrors}`)
+  console.log(`  Examined:  ${examined}`)
+  console.log(`  Updated:   ${updated}`)
+  console.log(`  Mentioned: ${mentioned}`)
+  console.log(`  Reparsed:  ${reparsed}`)
+  console.log(`  Errors:    ${providerErrors}`)
 }
 
 export interface NormalizedPathsBackfillResult {

--- a/packages/canonry/src/commands/citations.ts
+++ b/packages/canonry/src/commands/citations.ts
@@ -78,7 +78,9 @@ function printCoverage(data: CitationVisibilityResponse): void {
 
   // Each cell is two glyphs: citation state then mention state. Legend printed
   // above the table so the symbols are unambiguous to scripts and humans both.
-  const cellWidth = 6
+  // Width grows with the longest provider name so headers like "perplexity"
+  // stay aligned with the 2-char cells underneath.
+  const cellWidth = Math.max(6, ...providerColumns.map(p => p.length))
   const keywordWidth = Math.max(7, ...data.byKeyword.map(r => r.keyword.length))
   const header = ['Keyword'.padEnd(keywordWidth), ...providerColumns.map(p => p.padEnd(cellWidth)), 'Cite', 'Ment'].join('  ')
   console.log('Per-keyword coverage:  (cell = [citation][mention];  C=cited c=not, M=mentioned m=not, –=no data)')

--- a/packages/canonry/src/commands/citations.ts
+++ b/packages/canonry/src/commands/citations.ts
@@ -32,15 +32,28 @@ export async function showCitationVisibility(
 }
 
 function printSummary(data: CitationVisibilityResponse): void {
-  const { providersCiting, providersConfigured, totalKeywords, keywordsCited, keywordsFullyCovered, keywordsUncovered } = data.summary
-  console.log(`Citation visibility — cited by ${providersCiting}/${providersConfigured} engines`)
+  const {
+    providersCiting,
+    providersMentioning,
+    providersConfigured,
+    totalKeywords,
+    keywordsCitedAndMentioned,
+    keywordsCitedOnly,
+    keywordsMentionedOnly,
+    keywordsInvisible,
+  } = data.summary
+  console.log('Citation visibility')
   if (data.summary.latestRunAt) {
-    console.log(`Latest run:        ${data.summary.latestRunAt}`)
+    console.log(`Latest run:           ${data.summary.latestRunAt}`)
   }
-  console.log(`Keywords:          ${totalKeywords}`)
-  console.log(`  cited (any):     ${keywordsCited}`)
-  console.log(`  fully covered:   ${keywordsFullyCovered}`)
-  console.log(`  uncovered:       ${keywordsUncovered}`)
+  console.log(`Cited in sources:     ${providersCiting}/${providersConfigured} engines`)
+  console.log(`Mentioned in answers: ${providersMentioning}/${providersConfigured} engines`)
+  console.log('')
+  console.log(`Keywords (${totalKeywords} total):`)
+  console.log(`  cited + mentioned:  ${keywordsCitedAndMentioned}`)
+  console.log(`  cited only:         ${keywordsCitedOnly}`)
+  console.log(`  mentioned only:     ${keywordsMentionedOnly}`)
+  console.log(`  invisible:          ${keywordsInvisible}`)
 }
 
 function printCoverage(data: CitationVisibilityResponse): void {
@@ -63,19 +76,25 @@ function printCoverage(data: CitationVisibilityResponse): void {
     return
   }
 
+  // Each cell is two glyphs: citation state then mention state. Legend printed
+  // above the table so the symbols are unambiguous to scripts and humans both.
+  const cellWidth = 6
   const keywordWidth = Math.max(7, ...data.byKeyword.map(r => r.keyword.length))
-  const header = ['Keyword'.padEnd(keywordWidth), ...providerColumns.map(p => p.padEnd(10)), 'Coverage'].join('  ')
-  console.log('Per-keyword coverage:')
+  const header = ['Keyword'.padEnd(keywordWidth), ...providerColumns.map(p => p.padEnd(cellWidth)), 'Cite', 'Ment'].join('  ')
+  console.log('Per-keyword coverage:  (cell = [citation][mention];  C=cited c=not, M=mentioned m=not, –=no data)')
   console.log(header)
   console.log('─'.repeat(header.length))
   for (const row of data.byKeyword) {
     const cells = providerColumns.map(p => {
       const provider = row.providers.find(x => x.provider === p)
-      if (!provider) return '–'.padEnd(10)
-      return (provider.cited ? '✓' : '✗').padEnd(10)
+      if (!provider) return '–'.padEnd(cellWidth)
+      const citationGlyph = provider.cited ? 'C' : 'c'
+      const mentionGlyph = provider.mentioned ? 'M' : 'm'
+      return `${citationGlyph}${mentionGlyph}`.padEnd(cellWidth)
     })
-    const coverage = `${row.citedCount}/${row.totalProviders}`
-    console.log([row.keyword.padEnd(keywordWidth), ...cells, coverage].join('  '))
+    const citeCol = `${row.citedCount}/${row.totalProviders}`
+    const mentCol = `${row.mentionedCount}/${row.totalProviders}`
+    console.log([row.keyword.padEnd(keywordWidth), ...cells, citeCol, mentCol].join('  '))
   }
 }
 

--- a/packages/canonry/test/cli-citations.test.ts
+++ b/packages/canonry/test/cli-citations.test.ts
@@ -159,9 +159,15 @@ describe('citation visibility CLI + parity', () => {
     expect(parsed.competitorGaps).toHaveLength(1)
   })
 
-  it('human output includes the headline + per-keyword table', async () => {
+  it('human output includes both headlines, cross-tab buckets, and the per-keyword table', async () => {
     const out = await captureStdout(() => showCitationVisibility('example', {}))
     expect(out).toContain('Citation visibility')
+    expect(out).toContain('Cited in sources:')
+    expect(out).toContain('Mentioned in answers:')
+    expect(out).toContain('cited + mentioned:')
+    expect(out).toContain('cited only:')
+    expect(out).toContain('mentioned only:')
+    expect(out).toContain('invisible:')
     expect(out).toContain('keyword A')
     expect(out).toContain('keyword B')
     expect(out).toContain('Per-keyword coverage')

--- a/packages/contracts/src/analytics.ts
+++ b/packages/contracts/src/analytics.ts
@@ -5,7 +5,10 @@ export type MetricsWindow = '7d' | '30d' | '90d' | 'all'
 export type TrendDirection = 'improving' | 'declining' | 'stable'
 export type GapCategory = 'cited' | 'gap' | 'uncited'
 
-export const visibilityMetricModeSchema = z.enum(['answer', 'citation'])
+// Mode toggle for analytics views — `mentioned` = brand appears in the answer
+// prose; `cited` = domain appears in the source/grounding list. See AGENTS.md
+// "Vocabulary (Critical)" for the full distinction.
+export const visibilityMetricModeSchema = z.enum(['mentioned', 'cited'])
 export type VisibilityMetricMode = z.infer<typeof visibilityMetricModeSchema>
 export const VisibilityMetricModes = visibilityMetricModeSchema.enum
 
@@ -16,8 +19,8 @@ export interface TimeBucket {
   cited: number
   total: number
   keywordCount: number
-  answerRate: number
-  answerMentionedCount: number
+  mentionRate: number
+  mentionedCount: number
 }
 
 export interface KeywordChangeEvent {
@@ -30,8 +33,8 @@ export interface ProviderMetric {
   citationRate: number
   cited: number
   total: number
-  answerRate: number
-  answerMentionedCount: number
+  mentionRate: number
+  mentionedCount: number
 }
 
 export interface BrandMetricsDto {
@@ -40,7 +43,7 @@ export interface BrandMetricsDto {
   overall: ProviderMetric
   byProvider: Record<string, ProviderMetric>
   trend: TrendDirection
-  answerTrend: TrendDirection
+  mentionTrend: TrendDirection
   keywordChanges: KeywordChangeEvent[]
 }
 

--- a/packages/contracts/src/citations.ts
+++ b/packages/contracts/src/citations.ts
@@ -5,6 +5,7 @@ export const citationCoverageProviderSchema = z.object({
   provider: z.string(),
   citationState: citationStateSchema,
   cited: z.boolean(),
+  mentioned: z.boolean(),
   runId: z.string(),
   runCreatedAt: z.string(),
 })
@@ -15,6 +16,7 @@ export const citationCoverageRowSchema = z.object({
   keyword: z.string(),
   providers: z.array(citationCoverageProviderSchema),
   citedCount: z.number().int().nonnegative(),
+  mentionedCount: z.number().int().nonnegative(),
   totalProviders: z.number().int().nonnegative(),
 })
 export type CitationCoverageRow = z.infer<typeof citationCoverageRowSchema>
@@ -32,10 +34,15 @@ export type CompetitorGapRow = z.infer<typeof competitorGapRowSchema>
 export const citationVisibilitySummarySchema = z.object({
   providersConfigured: z.number().int().nonnegative(),
   providersCiting: z.number().int().nonnegative(),
+  providersMentioning: z.number().int().nonnegative(),
   totalKeywords: z.number().int().nonnegative(),
-  keywordsCited: z.number().int().nonnegative(),
-  keywordsFullyCovered: z.number().int().nonnegative(),
-  keywordsUncovered: z.number().int().nonnegative(),
+  // Cross-tab buckets — each tracked keyword with at least one snapshot lands
+  // in exactly one of these. Keywords with zero snapshots are not counted in
+  // any bucket; (sum of buckets) ≤ totalKeywords.
+  keywordsCitedAndMentioned: z.number().int().nonnegative(),
+  keywordsCitedOnly: z.number().int().nonnegative(),
+  keywordsMentionedOnly: z.number().int().nonnegative(),
+  keywordsInvisible: z.number().int().nonnegative(),
   latestRunId: z.string().nullable(),
   latestRunAt: z.string().nullable(),
 })
@@ -55,10 +62,12 @@ export function emptyCitationVisibility(reason: 'no-runs-yet' | 'no-keywords'): 
     summary: {
       providersConfigured: 0,
       providersCiting: 0,
+      providersMentioning: 0,
       totalKeywords: 0,
-      keywordsCited: 0,
-      keywordsFullyCovered: 0,
-      keywordsUncovered: 0,
+      keywordsCitedAndMentioned: 0,
+      keywordsCitedOnly: 0,
+      keywordsMentionedOnly: 0,
+      keywordsInvisible: 0,
       latestRunId: null,
       latestRunAt: null,
     },

--- a/packages/contracts/test/citations.test.ts
+++ b/packages/contracts/test/citations.test.ts
@@ -8,15 +8,16 @@ import {
 } from '../src/citations.js'
 
 describe('citationCoverageRowSchema', () => {
-  it('accepts a row with mixed citation states', () => {
+  it('accepts a row with mixed citation + mention states', () => {
     const row = {
       keywordId: 'kw-1',
       keyword: 'best CRM',
       providers: [
-        { provider: 'gemini', citationState: 'cited' as const, cited: true, runId: 'run-1', runCreatedAt: '2026-04-29T00:00:00Z' },
-        { provider: 'claude', citationState: 'not-cited' as const, cited: false, runId: 'run-1', runCreatedAt: '2026-04-29T00:00:00Z' },
+        { provider: 'gemini', citationState: 'cited' as const, cited: true, mentioned: true, runId: 'run-1', runCreatedAt: '2026-04-29T00:00:00Z' },
+        { provider: 'claude', citationState: 'not-cited' as const, cited: false, mentioned: true, runId: 'run-1', runCreatedAt: '2026-04-29T00:00:00Z' },
       ],
       citedCount: 1,
+      mentionedCount: 2,
       totalProviders: 2,
     }
     expect(() => citationCoverageRowSchema.parse(row)).not.toThrow()
@@ -26,11 +27,24 @@ describe('citationCoverageRowSchema', () => {
     const bad = {
       keywordId: 'kw-1',
       keyword: 'foo',
-      providers: [{ provider: 'gemini', citationState: 'pending', cited: false, runId: 'r', runCreatedAt: 't' }],
+      providers: [{ provider: 'gemini', citationState: 'pending', cited: false, mentioned: false, runId: 'r', runCreatedAt: 't' }],
       citedCount: 0,
+      mentionedCount: 0,
       totalProviders: 1,
     }
     expect(() => citationCoverageRowSchema.parse(bad)).toThrow()
+  })
+
+  it('requires the mentioned flag on each provider', () => {
+    const missing = {
+      keywordId: 'kw-1',
+      keyword: 'foo',
+      providers: [{ provider: 'gemini', citationState: 'cited', cited: true, runId: 'r', runCreatedAt: 't' }],
+      citedCount: 1,
+      mentionedCount: 0,
+      totalProviders: 1,
+    }
+    expect(() => citationCoverageRowSchema.parse(missing)).toThrow()
   })
 })
 
@@ -49,15 +63,17 @@ describe('competitorGapRowSchema', () => {
 })
 
 describe('citationVisibilityResponseSchema', () => {
-  it('round-trips a ready response', () => {
+  it('round-trips a ready response with cross-tab buckets', () => {
     const response = {
       summary: {
         providersConfigured: 4,
         providersCiting: 1,
+        providersMentioning: 2,
         totalKeywords: 10,
-        keywordsCited: 3,
-        keywordsFullyCovered: 0,
-        keywordsUncovered: 7,
+        keywordsCitedAndMentioned: 1,
+        keywordsCitedOnly: 2,
+        keywordsMentionedOnly: 1,
+        keywordsInvisible: 6,
         latestRunId: 'run-1',
         latestRunAt: '2026-04-29T00:00:00Z',
       },
@@ -67,6 +83,8 @@ describe('citationVisibilityResponseSchema', () => {
     }
     const parsed = citationVisibilityResponseSchema.parse(response)
     expect(parsed.summary.providersCiting).toBe(1)
+    expect(parsed.summary.providersMentioning).toBe(2)
+    expect(parsed.summary.keywordsCitedAndMentioned).toBe(1)
     expect(parsed.status).toBe('ready')
   })
 
@@ -76,6 +94,8 @@ describe('citationVisibilityResponseSchema', () => {
     expect(parsed.status).toBe('no-data')
     expect(parsed.reason).toBe('no-runs-yet')
     expect(parsed.summary.totalKeywords).toBe(0)
+    expect(parsed.summary.providersMentioning).toBe(0)
+    expect(parsed.summary.keywordsInvisible).toBe(0)
   })
 })
 


### PR DESCRIPTION
## Summary

Stacked on #383. After splitting the citation/mention dimensions, the rest of the codebase still used three legacy synonyms for the same two concepts (\`answer\`, \`visible\`, \`citation\` as an umbrella). This PR aligns naming with the canonical vocabulary and adds an AGENTS.md rule so future code stays on convention.

## Vocabulary

- **mention / mentioned** = brand or domain in the LLM answer text response
- **cited** = domain in the source links/material the LLM used to get the answer

## Changes

- **AGENTS.md** — new "Vocabulary (Critical)" section with the two definitions, rules, and anti-patterns.
- **Analytics contract** (\`BrandMetricsDto\`, \`ProviderMetric\`, \`TimeBucket\`) — \`answerRate\` -> \`mentionRate\`, \`answerMentionedCount\` -> \`mentionedCount\`, \`answerTrend\` -> \`mentionTrend\`. \`VisibilityMetricModes.answer/citation\` -> \`.mentioned/.cited\`. **Breaking** — major bump.
- **AnalyticsSection** — toggle now reads "Mentioned / Cited" instead of "Answer / Sources"; all derived labels and tooltips updated.
- **\`canonry backfill answer-visibility\`** — reports renamed \`mentioned\` counter (was \`visible\`) in both human and JSON output.
- Legacy DB columns (\`visibility_state\`) and run kinds (\`answer-visibility\`) are intentionally untouched and called out in the new AGENTS section as historical aliases.

## Test plan

- [x] \`pnpm test\` (1,661 tests pass)
- [x] \`pnpm typecheck\` and \`pnpm lint\` clean across the workspace
- [x] \`apps/web\` production build succeeds
- [ ] After merge, refresh dashboard and confirm Analytics toggle reads "Mentioned / Cited"