### PR TITLE
feat: add GA AI referral landing pages

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -979,6 +979,15 @@ export interface ApiGaTrafficReferral {
   users: number
 }
 
+export interface ApiGaTrafficAiLandingPage {
+  source: string
+  medium: string
+  sourceDimension: 'session' | 'first_user' | 'manual_utm'
+  landingPage: string
+  sessions: number
+  users: number
+}
+
 export interface ApiGaSocialReferral {
   source: string
   medium: string
@@ -995,6 +1004,7 @@ export interface ApiGaTraffic {
   totalUsers: number
   topPages: ApiGaTrafficPage[]
   aiReferrals: ApiGaTrafficReferral[]
+  aiReferralLandingPages: ApiGaTrafficAiLandingPage[]
   /** Deduped AI session total (MAX per date+source+medium across attribution dimensions). Cross-cutting: can overlap with Direct/Organic/Social. */
   aiSessionsDeduped: number
   /** Deduped AI user total. */

--- a/apps/web/src/components/project/TrafficSection.tsx
+++ b/apps/web/src/components/project/TrafficSection.tsx
@@ -40,6 +40,7 @@ const SOURCE_COLORS = CHART_SERIES_COLORS
 type PageSortKey = 'landingPage' | 'sessions' | 'organicSessions' | 'users'
 type ReferralSortKey = 'source' | 'medium' | 'sessions' | 'users'
 type SocialSortKey = 'source' | 'medium' | 'sessions' | 'users'
+type AiLandingPageSortKey = 'landingPage' | 'source' | 'sessions' | 'users'
 type SortDir = 'asc' | 'desc'
 
 function formatCompact(n: number): string {
@@ -73,6 +74,8 @@ export function TrafficSection({ projectName }: { projectName: string }) {
   const [referralSortDir, setReferralSortDir] = useState<SortDir>('desc')
   const [socialSortKey, setSocialSortKey] = useState<SocialSortKey>('sessions')
   const [socialSortDir, setSocialSortDir] = useState<SortDir>('desc')
+  const [aiLandingSortKey, setAiLandingSortKey] = useState<AiLandingPageSortKey>('sessions')
+  const [aiLandingSortDir, setAiLandingSortDir] = useState<SortDir>('desc')
   const [aiHistory, setAiHistory] = useState<GA4AiReferralHistoryEntry[]>([])
   const [sessionHistory, setSessionHistory] = useState<GA4SessionHistoryEntry[]>([])
   const [socialHistory, setSocialHistory] = useState<GA4SocialReferralHistoryEntry[]>([])
@@ -193,6 +196,15 @@ export function TrafficSection({ projectName }: { projectName: string }) {
     }
   }
 
+  function handleAiLandingSort(key: AiLandingPageSortKey) {
+    if (aiLandingSortKey === key) {
+      setAiLandingSortDir((d) => (d === 'desc' ? 'asc' : 'desc'))
+    } else {
+      setAiLandingSortKey(key)
+      setAiLandingSortDir('desc')
+    }
+  }
+
   const sortedPages = useMemo(() => {
     if (!traffic?.topPages) return []
     return [...traffic.topPages].sort((a, b) => {
@@ -219,8 +231,15 @@ export function TrafficSection({ projectName }: { projectName: string }) {
 
   const sortedAiLandingPages = useMemo(() => {
     if (!traffic?.aiReferralLandingPages) return []
-    return [...traffic.aiReferralLandingPages].sort((a, b) => b.sessions - a.sessions)
-  }, [traffic?.aiReferralLandingPages])
+    return [...traffic.aiReferralLandingPages].sort((a, b) => {
+      const av = a[aiLandingSortKey]
+      const bv = b[aiLandingSortKey]
+      if (typeof av === 'string' && typeof bv === 'string') {
+        return aiLandingSortDir === 'asc' ? av.localeCompare(bv) : bv.localeCompare(av)
+      }
+      return aiLandingSortDir === 'asc' ? (av as number) - (bv as number) : (bv as number) - (av as number)
+    })
+  }, [traffic?.aiReferralLandingPages, aiLandingSortKey, aiLandingSortDir])
 
   const sortedSocialReferrals = useMemo(() => {
     if (!traffic?.socialReferrals) return []
@@ -638,11 +657,11 @@ export function TrafficSection({ projectName }: { projectName: string }) {
                   <table className="w-full text-sm">
                     <thead>
                       <tr className="text-[10px] uppercase tracking-wider text-zinc-500">
-                        <th className="py-1 font-medium text-left">Landing Page</th>
-                        <th className="py-1 font-medium text-left">Source</th>
+                        <SortHeader label="Landing Page" sortKey="landingPage" current={aiLandingSortKey} dir={aiLandingSortDir} onSort={handleAiLandingSort} align="left" />
+                        <SortHeader label="Source" sortKey="source" current={aiLandingSortKey} dir={aiLandingSortDir} onSort={handleAiLandingSort} align="left" />
                         <th className="py-1 font-medium text-left">Attribution</th>
-                        <th className="py-1 font-medium text-right">Sessions</th>
-                        <th className="py-1 font-medium text-right">Users</th>
+                        <SortHeader label="Sessions" sortKey="sessions" current={aiLandingSortKey} dir={aiLandingSortDir} onSort={handleAiLandingSort} align="right" />
+                        <SortHeader label="Users" sortKey="users" current={aiLandingSortKey} dir={aiLandingSortDir} onSort={handleAiLandingSort} align="right" />
                       </tr>
                     </thead>
                     <tbody>

--- a/apps/web/src/components/project/TrafficSection.tsx
+++ b/apps/web/src/components/project/TrafficSection.tsx
@@ -31,7 +31,7 @@ import {
   triggerGaSync,
   disconnectGa,
 } from '../../api.js'
-import type { ApiGaStatus, ApiGaTraffic, ApiGaTrafficPage, ApiGaTrafficReferral, ApiGaSocialReferral, GA4AiReferralHistoryEntry, GA4SessionHistoryEntry, GA4SocialReferralHistoryEntry } from '../../api.js'
+import type { ApiGaStatus, ApiGaTraffic, ApiGaTrafficAiLandingPage, ApiGaTrafficPage, ApiGaTrafficReferral, ApiGaSocialReferral, GA4AiReferralHistoryEntry, GA4SessionHistoryEntry, GA4SocialReferralHistoryEntry } from '../../api.js'
 
 const TRAFFIC_WINDOWS: MetricsWindow[] = ['7d', '30d', '90d', 'all']
 
@@ -216,6 +216,11 @@ export function TrafficSection({ projectName }: { projectName: string }) {
       return referralSortDir === 'asc' ? (av as number) - (bv as number) : (bv as number) - (av as number)
     })
   }, [traffic?.aiReferrals, referralSortKey, referralSortDir])
+
+  const sortedAiLandingPages = useMemo(() => {
+    if (!traffic?.aiReferralLandingPages) return []
+    return [...traffic.aiReferralLandingPages].sort((a, b) => b.sessions - a.sessions)
+  }, [traffic?.aiReferralLandingPages])
 
   const sortedSocialReferrals = useMemo(() => {
     if (!traffic?.socialReferrals) return []
@@ -576,7 +581,7 @@ export function TrafficSection({ projectName }: { projectName: string }) {
               )}
             </Card>
 
-            <Card className="surface-card p-5">
+            <Card className="surface-card p-5 mb-4">
               <div className="mb-4 flex items-end justify-between gap-3">
                 <div>
                   <p className="eyebrow eyebrow-soft">Detail</p>
@@ -612,6 +617,49 @@ export function TrafficSection({ projectName }: { projectName: string }) {
                   <p className="text-sm text-zinc-400 mb-2">No AI referrer sessions detected yet</p>
                   <p className="text-xs text-zinc-500 max-w-sm">
                     AI engines that preserve a referrer (Perplexity, copy/paste from ChatGPT, etc.) will appear here. Most AI traffic strips the referrer — see the Direct cell above for the upper bound.
+                  </p>
+                </div>
+              )}
+            </Card>
+
+            <Card className="surface-card p-5">
+              <div className="mb-4 flex items-end justify-between gap-3">
+                <div>
+                  <p className="eyebrow eyebrow-soft">Detail</p>
+                  <h3 className="text-sm font-semibold text-zinc-100">Known AI referrers — landing pages</h3>
+                </div>
+                <p className="text-xs text-zinc-500">
+                  {sortedAiLandingPages.length > 0 ? `${sortedAiLandingPages.length} rows` : 'No landing-page rows'}
+                </p>
+              </div>
+
+              {sortedAiLandingPages.length > 0 ? (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="text-[10px] uppercase tracking-wider text-zinc-500">
+                        <th className="py-1 font-medium text-left">Landing Page</th>
+                        <th className="py-1 font-medium text-left">Source</th>
+                        <th className="py-1 font-medium text-left">Attribution</th>
+                        <th className="py-1 font-medium text-right">Sessions</th>
+                        <th className="py-1 font-medium text-right">Users</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {sortedAiLandingPages.map((row) => (
+                        <AiReferralLandingPageRow
+                          key={`${row.landingPage}:${row.source}:${row.medium}:${row.sourceDimension}`}
+                          row={row}
+                        />
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ) : (
+                <div className="flex flex-col items-center justify-center py-8 text-center">
+                  <p className="text-sm text-zinc-400 mb-2">No AI landing pages detected yet</p>
+                  <p className="text-xs text-zinc-500 max-w-sm">
+                    Known-AI landing pages appear after a GA4 sync records visits from AI referrers.
                   </p>
                 </div>
               )}
@@ -1140,6 +1188,36 @@ function AiReferralRow({
       </td>
       <td className="py-1.5 text-right text-zinc-200 tabular-nums">
         {referral.users.toLocaleString()}
+      </td>
+    </tr>
+  )
+}
+
+function AiReferralLandingPageRow({ row }: { row: ApiGaTrafficAiLandingPage }) {
+  const dimLabel = DIMENSION_LABELS[row.sourceDimension] ?? row.sourceDimension
+  const dimTooltip = DIMENSION_TOOLTIPS[row.sourceDimension] ?? ''
+
+  return (
+    <tr className="border-t border-zinc-800/40">
+      <td className="py-1.5 text-zinc-300 max-w-[360px] truncate" title={row.landingPage}>
+        {row.landingPage}
+      </td>
+      <td className="py-1.5 text-zinc-200 max-w-[220px] truncate" title={row.source}>
+        {row.source}
+      </td>
+      <td className="py-1.5">
+        <span
+          className="inline-block text-[10px] px-1.5 py-0.5 rounded-full border border-zinc-700 text-zinc-400"
+          title={dimTooltip}
+        >
+          {dimLabel}
+        </span>
+      </td>
+      <td className="py-1.5 text-right text-emerald-400 tabular-nums">
+        {row.sessions.toLocaleString()}
+      </td>
+      <td className="py-1.5 text-right text-zinc-200 tabular-nums">
+        {row.users.toLocaleString()}
       </td>
     </tr>
   )

--- a/apps/web/test/traffic-section.test.tsx
+++ b/apps/web/test/traffic-section.test.tsx
@@ -61,6 +61,9 @@ test('loads connected GA4 data without changing hook order', async () => {
         aiReferrals: [
           { source: 'chatgpt.com', medium: 'referral', sourceDimension: 'session', sessions: 12, users: 9 },
         ],
+        aiReferralLandingPages: [
+          { source: 'chatgpt.com', medium: 'referral', sourceDimension: 'session', landingPage: '/pricing', sessions: 12, users: 9 },
+        ],
         aiSessionsDeduped: 12,
         aiUsersDeduped: 9,
         aiSessionsBySession: 12,
@@ -142,6 +145,10 @@ test('renders four-channel breakdown with Organic, Social, Direct, and Known AI 
           { source: 'chatgpt.com', medium: 'referral', sourceDimension: 'session', sessions: 12, users: 9 },
           { source: 'claude.ai', medium: 'referral', sourceDimension: 'first_user', sessions: 30, users: 24 },
         ],
+        aiReferralLandingPages: [
+          { source: 'chatgpt.com', medium: 'referral', sourceDimension: 'session', landingPage: '/pricing', sessions: 12, users: 9 },
+          { source: 'claude.ai', medium: 'referral', sourceDimension: 'first_user', landingPage: '/guide', sessions: 30, users: 24 },
+        ],
         // Cross-cutting dedup includes firstUserSource → 12 + 30 = 42
         aiSessionsDeduped: 42,
         aiUsersDeduped: 33,
@@ -196,4 +203,12 @@ test('renders four-channel breakdown with Organic, Social, Direct, and Known AI 
 
   // The misleading old framing is gone: panel title "Attributable AI visits" must not appear
   expect(screen.queryByText('Attributable AI visits')).toBeNull()
+
+  expect(screen.getByText('Known AI referrers — landing pages')).toBeTruthy()
+  const row = screen.getAllByText('/pricing')
+    .map((cell) => cell.closest('tr') as HTMLElement | null)
+    .find((candidate): candidate is HTMLElement => Boolean(candidate && within(candidate).queryByText('chatgpt.com')))
+  expect(row).toBeTruthy()
+  expect(within(row).getByText('chatgpt.com')).toBeTruthy()
+  expect(within(row).getByText('12')).toBeTruthy()
 })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "3.1.1",
+  "version": "3.2.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/ga.ts
+++ b/packages/api-routes/src/ga.ts
@@ -645,7 +645,6 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         sql`COALESCE(${gaAiReferrals.landingPageNormalized}, ${gaAiReferrals.landingPage})`,
       )
       .orderBy(sql`SUM(${gaAiReferrals.sessions}) DESC`)
-      .limit(limit)
       .all()
 
     // Deduplicated AI totals: sessionSource, firstUserSource, and manualSource are

--- a/packages/api-routes/src/ga.ts
+++ b/packages/api-routes/src/ga.ts
@@ -432,6 +432,8 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
               source: row.source,
               medium: row.medium,
               sourceDimension: row.sourceDimension,
+              landingPage: row.landingPage,
+              landingPageNormalized: normalizeUrlPath(row.landingPage),
               sessions: row.sessions,
               users: row.users,
               syncedAt: now,
@@ -625,21 +627,49 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       .orderBy(sql`SUM(${gaAiReferrals.sessions}) DESC`)
       .all()
 
+    const aiReferralLandingPages = app.db
+      .select({
+        source: gaAiReferrals.source,
+        medium: gaAiReferrals.medium,
+        sourceDimension: gaAiReferrals.sourceDimension,
+        landingPage: sql<string>`COALESCE(${gaAiReferrals.landingPageNormalized}, ${gaAiReferrals.landingPage})`,
+        sessions: sql<number>`SUM(${gaAiReferrals.sessions})`,
+        users: sql<number>`SUM(${gaAiReferrals.users})`,
+      })
+      .from(gaAiReferrals)
+      .where(and(...aiConditions))
+      .groupBy(
+        gaAiReferrals.source,
+        gaAiReferrals.medium,
+        gaAiReferrals.sourceDimension,
+        sql`COALESCE(${gaAiReferrals.landingPageNormalized}, ${gaAiReferrals.landingPage})`,
+      )
+      .orderBy(sql`SUM(${gaAiReferrals.sessions}) DESC`)
+      .limit(limit)
+      .all()
+
     // Deduplicated AI totals: sessionSource, firstUserSource, and manualSource are
     // overlapping attribution lenses, not disjoint visits. To avoid double-counting,
-    // take MAX(sessions) per date+source+medium across dimensions, then sum.
+    // first sum landing pages within each dimension, then take MAX(sessions) per
+    // date+source+medium across dimensions, then sum.
     const aiDeduped = app.db
       .select({
-        sessions: sql<number>`SUM(max_sessions)`,
-        users: sql<number>`SUM(max_users)`,
+        sessions: sql<number>`COALESCE(SUM(max_sessions), 0)`,
+        users: sql<number>`COALESCE(SUM(max_users), 0)`,
       })
       .from(
         sql`(
           SELECT date, source, medium,
-                 MAX(sessions) AS max_sessions,
-                 MAX(users) AS max_users
-          FROM ga_ai_referrals
-          WHERE project_id = ${project.id}${cutoffDate ? sql` AND date >= ${cutoffDate}` : sql``}
+                 MAX(dimension_sessions) AS max_sessions,
+                 MAX(dimension_users) AS max_users
+          FROM (
+            SELECT date, source, medium, source_dimension,
+                   SUM(sessions) AS dimension_sessions,
+                   SUM(users) AS dimension_users
+            FROM ga_ai_referrals
+            WHERE project_id = ${project.id}${cutoffDate ? sql` AND date >= ${cutoffDate}` : sql``}
+            GROUP BY date, source, medium, source_dimension
+          )
           GROUP BY date, source, medium
         )`
       )
@@ -713,6 +743,14 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         sessions: r.sessions ?? 0,
         users: r.users ?? 0,
       })),
+      aiReferralLandingPages: aiReferralLandingPages.map((r) => ({
+        source: r.source,
+        medium: r.medium,
+        sourceDimension: r.sourceDimension,
+        landingPage: r.landingPage,
+        sessions: r.sessions ?? 0,
+        users: r.users ?? 0,
+      })),
       aiSessionsDeduped: aiDeduped?.sessions ?? 0,
       aiUsersDeduped: aiDeduped?.users ?? 0,
       aiSessionsBySession: aiBySession?.sessions ?? 0,
@@ -760,12 +798,20 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         date: gaAiReferrals.date,
         source: gaAiReferrals.source,
         medium: gaAiReferrals.medium,
+        landingPage: sql<string>`COALESCE(${gaAiReferrals.landingPageNormalized}, ${gaAiReferrals.landingPage})`,
         sourceDimension: gaAiReferrals.sourceDimension,
-        sessions: gaAiReferrals.sessions,
-        users: gaAiReferrals.users,
+        sessions: sql<number>`SUM(${gaAiReferrals.sessions})`,
+        users: sql<number>`SUM(${gaAiReferrals.users})`,
       })
       .from(gaAiReferrals)
       .where(and(...conditions))
+      .groupBy(
+        gaAiReferrals.date,
+        gaAiReferrals.source,
+        gaAiReferrals.medium,
+        gaAiReferrals.sourceDimension,
+        sql`COALESCE(${gaAiReferrals.landingPageNormalized}, ${gaAiReferrals.landingPage})`,
+      )
       .orderBy(gaAiReferrals.date)
       .all()
 

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -2130,7 +2130,7 @@ const routeCatalog: OpenApiOperation[] = [
   {
     method: 'get',
     path: '/api/v1/projects/{name}/ga/traffic',
-    summary: 'Get GA4 landing page traffic and AI referral sources',
+    summary: 'Get GA4 landing page traffic, channel breakdown, and AI referral landing pages',
     tags: ['ga4'],
     parameters: [nameParameter, limitQueryParameter, analyticsWindowParameter],
     responses: {
@@ -2142,7 +2142,7 @@ const routeCatalog: OpenApiOperation[] = [
   {
     method: 'get',
     path: '/api/v1/projects/{name}/ga/ai-referral-history',
-    summary: 'Get AI referral sessions per day grouped by source',
+    summary: 'Get AI referral sessions per day grouped by source and landing page',
     tags: ['ga4'],
     parameters: [nameParameter, analyticsWindowParameter],
     responses: {

--- a/packages/api-routes/test/ga.test.ts
+++ b/packages/api-routes/test/ga.test.ts
@@ -239,7 +239,7 @@ describe('GA4 routes', () => {
       totalUsers: 55,
     })
     const fetchAiReferralsSpy = vi.spyOn(gaModule, 'fetchAiReferrals').mockResolvedValue([
-      { date: '2026-03-20', source: 'chatgpt.com', medium: 'referral', sessions: 12, users: 9, sourceDimension: 'session' },
+      { date: '2026-03-20', source: 'chatgpt.com', medium: 'referral', landingPage: '/pricing?utm_source=chatgpt.com', sessions: 12, users: 9, sourceDimension: 'session' },
     ])
     const fetchSocialReferralsSpy = vi.spyOn(gaModule, 'fetchSocialReferrals').mockResolvedValue([
       { date: '2026-03-20', source: 'facebook.com', medium: 'social', sessions: 8, users: 6, channelGroup: 'Organic Social' },
@@ -284,6 +284,8 @@ describe('GA4 routes', () => {
       .all()
     expect(aiReferrals).toHaveLength(1)
     expect(aiReferrals[0]!.source).toBe('chatgpt.com')
+    expect(aiReferrals[0]!.landingPage).toBe('/pricing?utm_source=chatgpt.com')
+    expect(aiReferrals[0]!.landingPageNormalized).toBe('/pricing')
 
     const socialRefs = db.select().from(gaSocialReferrals)
       .where(eq(gaSocialReferrals.projectId, projectId))
@@ -476,6 +478,8 @@ describe('GA4 routes', () => {
       date: '2026-03-20',
       source: 'chatgpt.com',
       medium: 'referral',
+      landingPage: '/page-a?utm_source=chatgpt.com',
+      landingPageNormalized: '/page-a',
       sessions: 17,
       users: 10,
       syncedAt: now,
@@ -497,6 +501,9 @@ describe('GA4 routes', () => {
     expect(body.topPages[1].landingPage).toBe('/page-b')
     expect(body.aiReferrals).toEqual([
       { source: 'chatgpt.com', medium: 'referral', sourceDimension: 'session', sessions: 17, users: 10 },
+    ])
+    expect(body.aiReferralLandingPages).toEqual([
+      { source: 'chatgpt.com', medium: 'referral', sourceDimension: 'session', landingPage: '/page-a', sessions: 17, users: 10 },
     ])
     expect(body.aiSessionsDeduped).toBe(17)
     expect(body.aiUsersDeduped).toBe(10)
@@ -1044,6 +1051,8 @@ describe('GA4 routes', () => {
       date: '2026-03-17',
       source: 'chatgpt.com',
       medium: 'referral',
+      landingPage: '/pricing?utm_source=chatgpt.com',
+      landingPageNormalized: '/pricing',
       sessions: 3,
       users: 2,
       syncedAt: now,
@@ -1054,6 +1063,8 @@ describe('GA4 routes', () => {
       date: '2026-03-18',
       source: 'perplexity.ai',
       medium: 'referral',
+      landingPage: '/guide?utm_source=perplexity.ai',
+      landingPageNormalized: '/guide',
       sessions: 7,
       users: 6,
       syncedAt: now,
@@ -1064,11 +1075,25 @@ describe('GA4 routes', () => {
       url: '/api/v1/projects/test-project/ga/ai-referral-history',
     })
     expect(res.statusCode).toBe(200)
-    const body = JSON.parse(res.payload) as Array<{ date: string; source: string; medium: string; sessions: number; users: number }>
+    const body = JSON.parse(res.payload) as Array<{ date: string; source: string; medium: string; landingPage: string; sessions: number; users: number }>
     expect(body.length).toBeGreaterThanOrEqual(2)
     // Should be ordered by date
     const dates = body.map((r) => r.date)
     expect(dates).toEqual([...dates].sort())
+    expect(body).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        date: '2026-03-17',
+        source: 'chatgpt.com',
+        landingPage: '/pricing',
+        sessions: 3,
+      }),
+      expect.objectContaining({
+        date: '2026-03-18',
+        source: 'perplexity.ai',
+        landingPage: '/guide',
+        sessions: 7,
+      }),
+    ]))
     // Should include both sources
     const sources = body.map((r) => r.source)
     expect(sources).toContain('chatgpt.com')

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/cli-commands/backfill.ts
+++ b/packages/canonry/src/cli-commands/backfill.ts
@@ -1,4 +1,4 @@
-import { backfillAnswerVisibilityCommand, backfillInsightsCommand, backfillNormalizedPathsCommand } from '../commands/backfill.js'
+import { backfillAiReferralPathsCommand, backfillAnswerVisibilityCommand, backfillInsightsCommand, backfillNormalizedPathsCommand } from '../commands/backfill.js'
 import type { CliCommandSpec } from '../cli-dispatch.js'
 import { requireProject, getString, stringOption, unknownSubcommand } from '../cli-command-helpers.js'
 
@@ -49,13 +49,27 @@ export const BACKFILL_CLI_COMMANDS: readonly CliCommandSpec[] = [
     },
   },
   {
+    path: ['backfill', 'ai-referral-paths'],
+    usage: 'canonry backfill ai-referral-paths [--project <name>] [--format json]',
+    options: {
+      project: stringOption(),
+    },
+    allowPositionals: false,
+    run: async (input) => {
+      await backfillAiReferralPathsCommand({
+        project: getString(input.values, 'project'),
+        format: input.format,
+      })
+    },
+  },
+  {
     path: ['backfill'],
-    usage: 'canonry backfill <answer-visibility|insights|normalized-paths> [options]',
+    usage: 'canonry backfill <answer-visibility|insights|normalized-paths|ai-referral-paths> [options]',
     run: async (input) => {
       unknownSubcommand(input.positionals[0], {
         command: 'backfill',
-        usage: 'canonry backfill <answer-visibility|insights|normalized-paths> [options]',
-        available: ['answer-visibility', 'insights', 'normalized-paths'],
+        usage: 'canonry backfill <answer-visibility|insights|normalized-paths|ai-referral-paths> [options]',
+        available: ['answer-visibility', 'insights', 'normalized-paths', 'ai-referral-paths'],
       })
     },
   },

--- a/packages/canonry/src/commands/backfill.ts
+++ b/packages/canonry/src/commands/backfill.ts
@@ -1,6 +1,6 @@
 import { and, eq, inArray } from 'drizzle-orm'
 import type { GroundingSource, NormalizedQueryResult } from '@ainyc/canonry-contracts'
-import { createClient, gaTrafficSnapshots, migrate, parseJsonColumn, competitors, projects, querySnapshots, runs } from '@ainyc/canonry-db'
+import { createClient, gaAiReferrals, gaTrafficSnapshots, migrate, parseJsonColumn, competitors, projects, querySnapshots, runs } from '@ainyc/canonry-db'
 import { determineAnswerMentioned, effectiveDomains, normalizeUrlPath, ProviderNames, RunKinds } from '@ainyc/canonry-contracts'
 import { reparseStoredResult as reparseOpenAIStoredResult } from '@ainyc/canonry-provider-openai'
 import { reparseStoredResult as reparseClaudeStoredResult } from '@ainyc/canonry-provider-claude'
@@ -324,6 +324,115 @@ export async function backfillNormalizedPathsCommand(opts?: {
   }
 
   console.log('Normalized-path backfill complete.\n')
+  if (projectFilter) console.log(`  Project:   ${projectFilter}`)
+  console.log(`  Examined:  ${examined}`)
+  console.log(`  Updated:   ${updated}`)
+  console.log(`  Unchanged: ${unchanged}`)
+}
+
+/**
+ * Pure helper: backfill `ga_ai_referrals.landing_page_normalized` for rows
+ * where it is currently null. Mirrors `backfillNormalizedPaths` but for the
+ * AI referral table, which gained landing-page columns in v46. Idempotent.
+ *
+ * Used by both the CLI command (`canonry backfill ai-referral-paths`) and
+ * the server startup path (`canonry serve` runs it post-migrate so legacy
+ * rows surface in the dashboard's landing-page panel without a re-sync).
+ */
+export function backfillAiReferralPaths(
+  db: ReturnType<typeof createClient>,
+  opts?: { projectId?: string },
+): NormalizedPathsBackfillResult {
+  const baseConditions = []
+  if (opts?.projectId) {
+    baseConditions.push(eq(gaAiReferrals.projectId, opts.projectId))
+  }
+
+  const rows = db
+    .select({
+      id: gaAiReferrals.id,
+      landingPage: gaAiReferrals.landingPage,
+      landingPageNormalized: gaAiReferrals.landingPageNormalized,
+    })
+    .from(gaAiReferrals)
+    .where(baseConditions.length > 0 ? and(...baseConditions) : undefined)
+    .all()
+
+  let updated = 0
+  let unchanged = 0
+
+  if (rows.length > 0) {
+    db.transaction((tx) => {
+      for (const row of rows) {
+        const next = normalizeUrlPath(row.landingPage)
+        if (next === null) {
+          unchanged++
+          continue
+        }
+        if (row.landingPageNormalized === next) {
+          unchanged++
+          continue
+        }
+        tx.update(gaAiReferrals)
+          .set({ landingPageNormalized: next })
+          .where(eq(gaAiReferrals.id, row.id))
+          .run()
+        updated++
+      }
+    })
+  }
+
+  return { examined: rows.length, updated, unchanged }
+}
+
+export async function backfillAiReferralPathsCommand(opts?: {
+  project?: string
+  format?: CliFormat
+}): Promise<void> {
+  const config = loadConfig()
+  const db = createClient(config.database)
+  migrate(db)
+
+  const projectFilter = opts?.project?.trim()
+  let projectId: string | undefined
+  if (projectFilter) {
+    const project = db
+      .select({ id: projects.id })
+      .from(projects)
+      .where(eq(projects.name, projectFilter))
+      .get()
+    if (!project) {
+      const result = {
+        project: projectFilter,
+        examined: 0,
+        updated: 0,
+        unchanged: 0,
+      }
+      if (opts?.format === 'json') {
+        console.log(JSON.stringify(result, null, 2))
+        return
+      }
+      console.log(`Backfill ai-referral-paths: project "${projectFilter}" not found.`)
+      return
+    }
+    projectId = project.id
+  }
+
+  const { examined, updated, unchanged } = backfillAiReferralPaths(db, { projectId })
+
+  const result = {
+    project: projectFilter ?? null,
+    examined,
+    updated,
+    unchanged,
+  }
+
+  if (opts?.format === 'json') {
+    console.log(JSON.stringify(result, null, 2))
+    return
+  }
+
+  console.log('AI referral landing-page backfill complete.\n')
   if (projectFilter) console.log(`  Project:   ${projectFilter}`)
   console.log(`  Examined:  ${examined}`)
   console.log(`  Updated:   ${updated}`)

--- a/packages/canonry/src/commands/ga.ts
+++ b/packages/canonry/src/commands/ga.ts
@@ -143,7 +143,7 @@ export async function gaTraffic(project: string, opts?: { limit?: number; window
     return
   }
 
-  if (result.topPages.length === 0 && result.aiReferrals.length === 0 && result.socialReferrals.length === 0) {
+  if (result.topPages.length === 0 && result.aiReferrals.length === 0 && result.aiReferralLandingPages.length === 0 && result.socialReferrals.length === 0) {
     if (!result.lastSyncedAt) {
       console.log('No GA4 traffic data. Run "canonry ga sync <project>" first.')
     } else {
@@ -172,6 +172,21 @@ export async function gaTraffic(project: string, opts?: { limit?: number; window
       const dimLabel = ref.sourceDimension === 'first_user' ? 'first-visit' : ref.sourceDimension === 'manual_utm' ? 'utm' : 'session'
       console.log(
         `  ${ref.source.padEnd(25)}  ${ref.medium.padEnd(15)}  ${dimLabel.padEnd(attrWidth)}  ${String(ref.sessions).padEnd(10)}${String(ref.users).padEnd(8)}`,
+      )
+    }
+    console.log()
+  }
+
+  if (result.aiReferralLandingPages.length > 0) {
+    const attrWidth = 12
+    console.log('  AI REFERRAL LANDING PAGES')
+    console.log(`  ${'LANDING PAGE'.padEnd(30)}  ${'SOURCE'.padEnd(25)}  ${'ATTRIBUTION'.padEnd(attrWidth)}  ${'SESSIONS'.padEnd(10)}${'USERS'.padEnd(8)}`)
+    console.log(`  ${'─'.repeat(30)}  ${'─'.repeat(25)}  ${'─'.repeat(attrWidth)}  ${'─'.repeat(10)}${'─'.repeat(8)}`)
+
+    for (const row of result.aiReferralLandingPages) {
+      const dimLabel = row.sourceDimension === 'first_user' ? 'first-visit' : row.sourceDimension === 'manual_utm' ? 'utm' : 'session'
+      console.log(
+        `  ${row.landingPage.padEnd(30)}  ${row.source.padEnd(25)}  ${dimLabel.padEnd(attrWidth)}  ${String(row.sessions).padEnd(10)}${String(row.users).padEnd(8)}`,
       )
     }
     console.log()
@@ -417,6 +432,7 @@ export async function gaAttribution(project: string, opts?: { trend?: boolean; f
         organicSharePct: traffic.organicSharePct,
         directSharePct: traffic.directSharePct,
         aiReferrals: traffic.aiReferrals,
+        aiReferralLandingPages: traffic.aiReferralLandingPages,
         socialReferrals: traffic.socialReferrals,
         trend,
       }, null, 2))
@@ -481,6 +497,7 @@ export async function gaAttribution(project: string, opts?: { trend?: boolean; f
       organicSharePct: traffic.organicSharePct,
       directSharePct: traffic.directSharePct,
       aiReferrals: traffic.aiReferrals,
+      aiReferralLandingPages: traffic.aiReferralLandingPages,
       socialReferrals: traffic.socialReferrals,
       periodStart: traffic.periodStart,
       periodEnd: traffic.periodEnd,
@@ -514,6 +531,15 @@ export async function gaAttribution(project: string, opts?: { trend?: boolean; f
     for (const ref of traffic.aiReferrals.slice(0, 10)) {
       const dimLabel = ref.sourceDimension === 'first_user' ? 'first-visit' : ref.sourceDimension === 'manual_utm' ? 'utm' : 'session'
       console.log(`    ${ref.source.padEnd(25)} ${String(ref.sessions).padEnd(8)} sessions  (${dimLabel})`)
+    }
+  }
+
+  if (traffic.aiReferralLandingPages.length > 0) {
+    console.log()
+    console.log('  AI LANDING PAGES')
+    for (const row of traffic.aiReferralLandingPages.slice(0, 10)) {
+      const dimLabel = row.sourceDimension === 'first_user' ? 'first-visit' : row.sourceDimension === 'manual_utm' ? 'utm' : 'session'
+      console.log(`    ${row.landingPage.padEnd(30)} ${row.source.padEnd(22)} ${String(row.sessions).padEnd(8)} sessions  (${dimLabel})`)
     }
   }
 

--- a/packages/canonry/src/commands/ga.ts
+++ b/packages/canonry/src/commands/ga.ts
@@ -185,8 +185,10 @@ export async function gaTraffic(project: string, opts?: { limit?: number; window
 
     for (const row of result.aiReferralLandingPages) {
       const dimLabel = row.sourceDimension === 'first_user' ? 'first-visit' : row.sourceDimension === 'manual_utm' ? 'utm' : 'session'
+      const page = row.landingPage.length > 30 ? row.landingPage.slice(0, 27) + '...' : row.landingPage
+      const source = row.source.length > 25 ? row.source.slice(0, 22) + '...' : row.source
       console.log(
-        `  ${row.landingPage.padEnd(30)}  ${row.source.padEnd(25)}  ${dimLabel.padEnd(attrWidth)}  ${String(row.sessions).padEnd(10)}${String(row.users).padEnd(8)}`,
+        `  ${page.padEnd(30)}  ${source.padEnd(25)}  ${dimLabel.padEnd(attrWidth)}  ${String(row.sessions).padEnd(10)}${String(row.users).padEnd(8)}`,
       )
     }
     console.log()
@@ -539,7 +541,9 @@ export async function gaAttribution(project: string, opts?: { trend?: boolean; f
     console.log('  AI LANDING PAGES')
     for (const row of traffic.aiReferralLandingPages.slice(0, 10)) {
       const dimLabel = row.sourceDimension === 'first_user' ? 'first-visit' : row.sourceDimension === 'manual_utm' ? 'utm' : 'session'
-      console.log(`    ${row.landingPage.padEnd(30)} ${row.source.padEnd(22)} ${String(row.sessions).padEnd(8)} sessions  (${dimLabel})`)
+      const page = row.landingPage.length > 30 ? row.landingPage.slice(0, 27) + '...' : row.landingPage
+      const source = row.source.length > 22 ? row.source.slice(0, 19) + '...' : row.source
+      console.log(`    ${page.padEnd(30)} ${source.padEnd(22)} ${String(row.sessions).padEnd(8)} sessions  (${dimLabel})`)
     }
   }
 

--- a/packages/canonry/src/commands/serve.ts
+++ b/packages/canonry/src/commands/serve.ts
@@ -3,7 +3,7 @@ import { createClient, migrate } from '@ainyc/canonry-db'
 import { createServer } from '../server.js'
 import { trackEvent } from '../telemetry.js'
 import { CliError, type CliFormat } from '../cli-error.js'
-import { backfillNormalizedPaths } from './backfill.js'
+import { backfillAiReferralPaths, backfillNormalizedPaths } from './backfill.js'
 
 /**
  * Precedence: `CANONRY_PORT` env var (also set by `--port`) > config.yaml `port:` > 4100.
@@ -44,6 +44,22 @@ export async function serveCommand(format: CliFormat = 'text'): Promise<void> {
     // via COALESCE for non-fragmented legacy rows.
     const msg = err instanceof Error ? err.message : String(err)
     process.stderr.write(`warning: normalized-path backfill skipped: ${msg}\n`)
+  }
+
+  // Same idea for ga_ai_referrals — landing_page_normalized was added in
+  // v46. Without this, the dashboard's "Known AI referrers — landing pages"
+  // panel surfaces legacy rows as a synthetic '(not set)' bucket until the
+  // user re-syncs.
+  try {
+    const result = backfillAiReferralPaths(db)
+    if (result.updated > 0 && format === 'text') {
+      console.log(
+        `Migrated ${result.updated} GA AI referral row${result.updated === 1 ? '' : 's'} to canonical form.`,
+      )
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    process.stderr.write(`warning: ai-referral-paths backfill skipped: ${msg}\n`)
   }
 
   // Create and start server

--- a/packages/canonry/test/backfill-ai-referral-paths.test.ts
+++ b/packages/canonry/test/backfill-ai-referral-paths.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  createClient,
+  gaAiReferrals,
+  migrate,
+  projects,
+} from '@ainyc/canonry-db'
+import { eq } from 'drizzle-orm'
+import { backfillAiReferralPaths } from '../src/commands/backfill.js'
+
+describe('backfillAiReferralPaths', () => {
+  let tmpDir: string
+  let dbPath: string
+  let db: ReturnType<typeof createClient>
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-backfill-ai-paths-'))
+    dbPath = path.join(tmpDir, 'canonry.db')
+    db = createClient(dbPath)
+    migrate(db)
+
+    const now = new Date().toISOString()
+    db.insert(projects).values({
+      id: 'proj_1',
+      name: 'test-project',
+      displayName: 'Test',
+      canonicalDomain: 'example.com',
+      country: 'US',
+      language: 'en',
+      createdAt: now,
+      updatedAt: now,
+    }).run()
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function insertReferral(opts: {
+    id: string
+    projectId?: string
+    source?: string
+    medium?: string
+    sourceDimension?: 'session' | 'first_user' | 'manual_utm'
+    landingPage: string
+    landingPageNormalized?: string | null
+  }) {
+    const now = new Date().toISOString()
+    db.insert(gaAiReferrals).values({
+      id: opts.id,
+      projectId: opts.projectId ?? 'proj_1',
+      date: '2026-04-29',
+      source: opts.source ?? 'chatgpt.com',
+      medium: opts.medium ?? 'referral',
+      sourceDimension: opts.sourceDimension ?? 'session',
+      landingPage: opts.landingPage,
+      landingPageNormalized:
+        opts.landingPageNormalized === undefined ? null : opts.landingPageNormalized,
+      sessions: 1,
+      users: 1,
+      syncedAt: now,
+    }).run()
+  }
+
+  function readNormalized(id: string): string | null | undefined {
+    const [row] = db
+      .select({ landingPageNormalized: gaAiReferrals.landingPageNormalized })
+      .from(gaAiReferrals)
+      .where(eq(gaAiReferrals.id, id))
+      .all()
+    return row?.landingPageNormalized
+  }
+
+  it('populates landing_page_normalized for rows where it is null', () => {
+    insertReferral({ id: 'r1', source: 'chatgpt.com', landingPage: '/pricing?utm_source=chatgpt.com' })
+    insertReferral({ id: 'r2', source: 'claude.ai', landingPage: '/about/' })
+    insertReferral({ id: 'r3', source: 'perplexity.ai', landingPage: '/' })
+    insertReferral({ id: 'r4', source: 'gemini.google.com', landingPage: '(not set)' })
+
+    const result = backfillAiReferralPaths(db)
+    expect(result.examined).toBe(4)
+    expect(result.updated).toBe(3)
+    expect(result.unchanged).toBe(1)
+
+    expect(readNormalized('r1')).toBe('/pricing')
+    expect(readNormalized('r2')).toBe('/about')
+    expect(readNormalized('r3')).toBe('/')
+    expect(readNormalized('r4')).toBeNull()
+  })
+
+  it('repairs stale normalized values', () => {
+    insertReferral({
+      id: 'r_stale',
+      source: 'chatgpt.com',
+      landingPage: '/about/',
+      landingPageNormalized: '/sentinel',
+    })
+    insertReferral({ id: 'r_null', source: 'claude.ai', landingPage: '/about/' })
+
+    backfillAiReferralPaths(db)
+
+    expect(readNormalized('r_stale')).toBe('/about')
+    expect(readNormalized('r_null')).toBe('/about')
+  })
+
+  it('handles multiple landing pages under the same source × dimension', () => {
+    insertReferral({ id: 'p1', source: 'chatgpt.com', sourceDimension: 'session', landingPage: '/pricing' })
+    insertReferral({ id: 'p2', source: 'chatgpt.com', sourceDimension: 'first_user', landingPage: '/guide/' })
+    insertReferral({ id: 'p3', source: 'claude.ai', sourceDimension: 'session', landingPage: '/comparison/' })
+
+    const result = backfillAiReferralPaths(db)
+    expect(result.examined).toBe(3)
+    expect(result.updated).toBe(3)
+    expect(readNormalized('p1')).toBe('/pricing')
+    expect(readNormalized('p2')).toBe('/guide')
+    expect(readNormalized('p3')).toBe('/comparison')
+  })
+
+  it('is idempotent — second run touches nothing', () => {
+    insertReferral({ id: 'r1', source: 'chatgpt.com', landingPage: '/about/' })
+    const first = backfillAiReferralPaths(db)
+    expect(first.updated).toBe(1)
+
+    const second = backfillAiReferralPaths(db)
+    expect(second.updated).toBe(0)
+    expect(second.examined).toBe(1)
+    expect(second.unchanged).toBe(1)
+  })
+
+  it('scopes to a project when projectId is provided', () => {
+    const now = new Date().toISOString()
+    db.insert(projects).values({
+      id: 'proj_2',
+      name: 'other-project',
+      displayName: 'Other',
+      canonicalDomain: 'other.com',
+      country: 'US',
+      language: 'en',
+      createdAt: now,
+      updatedAt: now,
+    }).run()
+    insertReferral({ id: 'r_other', projectId: 'proj_2', source: 'chatgpt.com', landingPage: '/?fbclid=skip' })
+    insertReferral({ id: 'r_in_scope', source: 'claude.ai', landingPage: '/?fbclid=touch' })
+
+    backfillAiReferralPaths(db, { projectId: 'proj_1' })
+
+    expect(readNormalized('r_in_scope')).toBe('/')
+    expect(readNormalized('r_other')).toBeNull()
+  })
+})

--- a/packages/canonry/test/ga-attribution.test.ts
+++ b/packages/canonry/test/ga-attribution.test.ts
@@ -145,6 +145,8 @@ describe('canonry ga attribution --format json', () => {
       source: 'chatgpt.com',
       medium: 'referral',
       sourceDimension: 'session',
+      landingPage: '/pricing?utm_source=chatgpt.com',
+      landingPageNormalized: '/pricing',
       sessions: 5,
       users: 4,
       syncedAt: now,
@@ -156,6 +158,8 @@ describe('canonry ga attribution --format json', () => {
       source: 'chatgpt.com',
       medium: 'referral',
       sourceDimension: 'first_user',
+      landingPage: '/pricing?utm_source=chatgpt.com',
+      landingPageNormalized: '/pricing',
       sessions: 12,
       users: 10,
       syncedAt: now,
@@ -178,6 +182,7 @@ describe('canonry ga attribution --format json', () => {
       aiSessionsBySession: number
       aiSharePct: number
       aiSharePctBySession: number
+      aiReferralLandingPages: Array<{ landingPage: string; source: string; sessions: number }>
       trend: { direct: { sessions7d: number; sessionsPrev7d: number; trend7dPct: number | null } }
     }
     expect(parsed.directSessions).toBeGreaterThanOrEqual(75)
@@ -186,6 +191,9 @@ describe('canonry ga attribution --format json', () => {
     expect(parsed.aiSessions).toBe(12)
     expect(parsed.aiSessionsBySession).toBe(5)
     expect(parsed.aiSharePctBySession).toBeLessThan(parsed.aiSharePct)
+    expect(parsed.aiReferralLandingPages).toEqual(expect.arrayContaining([
+      expect.objectContaining({ landingPage: '/pricing', source: 'chatgpt.com', sessions: 12 }),
+    ]))
     expect(parsed.trend.direct).toBeDefined()
     expect(parsed.trend.direct.sessions7d).toBe(50)
     expect(parsed.trend.direct.sessionsPrev7d).toBe(25)

--- a/packages/contracts/src/ga.ts
+++ b/packages/contracts/src/ga.ts
@@ -33,6 +33,16 @@ export const ga4AiReferralDtoSchema = z.object({
 })
 export type GA4AiReferralDto = z.infer<typeof ga4AiReferralDtoSchema>
 
+export const ga4AiReferralLandingPageDtoSchema = z.object({
+  source: z.string(),
+  medium: z.string(),
+  sourceDimension: ga4SourceDimensionSchema,
+  landingPage: z.string(),
+  sessions: z.number(),
+  users: z.number(),
+})
+export type GA4AiReferralLandingPageDto = z.infer<typeof ga4AiReferralLandingPageDtoSchema>
+
 export const ga4SocialReferralDtoSchema = z.object({
   source: z.string(),
   medium: z.string(),
@@ -58,6 +68,7 @@ export const ga4TrafficSummaryDtoSchema = z.object({
     users: z.number(),
   })),
   aiReferrals: z.array(ga4AiReferralDtoSchema),
+  aiReferralLandingPages: z.array(ga4AiReferralLandingPageDtoSchema),
   /** Deduped AI session total: MAX(sessions) per date+source+medium across attribution dimensions, then summed. Cross-cutting: can overlap with Direct/Organic/Social via firstUserSource. */
   aiSessionsDeduped: z.number(),
   /** Deduped AI user total: MAX(users) per date+source+medium across attribution dimensions, then summed. */
@@ -155,6 +166,7 @@ export interface GaTrafficResponse {
   totalUsers: number
   topPages: Array<{ landingPage: string; sessions: number; organicSessions: number; directSessions: number; users: number }>
   aiReferrals: Array<{ source: string; medium: string; sessions: number; users: number; sourceDimension: GA4SourceDimension }>
+  aiReferralLandingPages: Array<{ source: string; medium: string; sourceDimension: GA4SourceDimension; landingPage: string; sessions: number; users: number }>
   /** Deduped AI session total: MAX(sessions) per date+source+medium across attribution dimensions, then summed. Cross-cutting: can overlap with Direct/Organic/Social via firstUserSource. */
   aiSessionsDeduped: number
   /** Deduped AI user total: MAX(users) per date+source+medium across attribution dimensions, then summed. */
@@ -193,6 +205,7 @@ export const ga4AiReferralHistoryEntrySchema = z.object({
   date: z.string(),
   source: z.string(),
   medium: z.string(),
+  landingPage: z.string(),
   sessions: z.number(),
   users: z.number(),
   /** Which GA4 dimension this row came from: session (sessionSource), first_user (firstUserSource), or manual_utm (utm_source parameter) */

--- a/packages/contracts/test/ga.test.ts
+++ b/packages/contracts/test/ga.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ga4AiReferralHistoryEntrySchema,
+  ga4TrafficSummaryDtoSchema,
+} from '../src/ga.js'
+
+describe('GA contracts', () => {
+  it('includes known-AI referral landing-page rows in the traffic summary contract', () => {
+    const parsed = ga4TrafficSummaryDtoSchema.parse({
+      totalSessions: 100,
+      totalOrganicSessions: 30,
+      totalDirectSessions: 20,
+      totalUsers: 80,
+      topPages: [],
+      aiReferrals: [],
+      aiReferralLandingPages: [
+        {
+          source: 'chatgpt.com',
+          medium: 'referral',
+          sourceDimension: 'session',
+          landingPage: '/pricing',
+          sessions: 12,
+          users: 9,
+        },
+      ],
+      aiSessionsDeduped: 12,
+      aiUsersDeduped: 9,
+      aiSessionsBySession: 12,
+      aiUsersBySession: 9,
+      socialReferrals: [],
+      socialSessions: 0,
+      socialUsers: 0,
+      organicSharePct: 30,
+      aiSharePct: 12,
+      aiSharePctBySession: 12,
+      directSharePct: 20,
+      socialSharePct: 0,
+      lastSyncedAt: null,
+    })
+
+    expect(parsed.aiReferralLandingPages[0]!.landingPage).toBe('/pricing')
+  })
+
+  it('includes landingPage in AI referral history entries', () => {
+    const parsed = ga4AiReferralHistoryEntrySchema.parse({
+      date: '2026-03-20',
+      source: 'perplexity.ai',
+      medium: 'referral',
+      sourceDimension: 'session',
+      landingPage: '/guide',
+      sessions: 7,
+      users: 6,
+    })
+
+    expect(parsed.landingPage).toBe('/guide')
+  })
+})

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -577,6 +577,17 @@ const MIGRATIONS = [
   // dashboard (organic / social / direct / known-AI) — see
   // plans/ai-attribution-research.md scope A.
   `ALTER TABLE ga_traffic_snapshots ADD COLUMN direct_sessions INTEGER`,
+
+  // v46: Landing-page breakdown for GA4 known-AI referral rows. The raw
+  // landing_page participates in the unique key so distinct query strings can
+  // be ingested without collision; API reads group by landing_page_normalized.
+  `ALTER TABLE ga_ai_referrals ADD COLUMN landing_page TEXT NOT NULL DEFAULT '(unknown)'`,
+  `ALTER TABLE ga_ai_referrals ADD COLUMN landing_page_normalized TEXT`,
+  `DROP INDEX IF EXISTS idx_ga_ai_ref_unique_v2`,
+  `CREATE INDEX IF NOT EXISTS idx_ga_ai_ref_landing_page
+     ON ga_ai_referrals(project_id, date, landing_page_normalized)`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS idx_ga_ai_ref_unique_v3
+     ON ga_ai_referrals(project_id, date, source, medium, source_dimension, landing_page)`,
 ]
 
 /**

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -581,7 +581,10 @@ const MIGRATIONS = [
   // v46: Landing-page breakdown for GA4 known-AI referral rows. The raw
   // landing_page participates in the unique key so distinct query strings can
   // be ingested without collision; API reads group by landing_page_normalized.
-  `ALTER TABLE ga_ai_referrals ADD COLUMN landing_page TEXT NOT NULL DEFAULT '(unknown)'`,
+  // Default '(not set)' matches GA4's own sentinel for missing dimension
+  // values, so legacy rows surface as the same bucket new ingestion uses
+  // when GA4 returns nothing.
+  `ALTER TABLE ga_ai_referrals ADD COLUMN landing_page TEXT NOT NULL DEFAULT '(not set)'`,
   `ALTER TABLE ga_ai_referrals ADD COLUMN landing_page_normalized TEXT`,
   `DROP INDEX IF EXISTS idx_ga_ai_ref_unique_v2`,
   `CREATE INDEX IF NOT EXISTS idx_ga_ai_ref_landing_page

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -317,6 +317,8 @@ export const gaAiReferrals = sqliteTable('ga_ai_referrals', {
   medium: text('medium').notNull(),
   /** Which GA4 dimension produced this row: 'session' | 'first_user' | 'manual_utm' */
   sourceDimension: text('source_dimension').notNull().default('session'),
+  landingPage: text('landing_page').notNull().default('(unknown)'),
+  landingPageNormalized: text('landing_page_normalized'),
   sessions: integer('sessions').notNull().default(0),
   users: integer('users').notNull().default(0),
   syncedAt: text('synced_at').notNull(),
@@ -324,7 +326,8 @@ export const gaAiReferrals = sqliteTable('ga_ai_referrals', {
 }, (table) => [
   index('idx_ga_ai_ref_project_date').on(table.projectId, table.date),
   index('idx_ga_ai_ref_source').on(table.source),
-  uniqueIndex('idx_ga_ai_ref_unique_v2').on(table.projectId, table.date, table.source, table.medium, table.sourceDimension),
+  index('idx_ga_ai_ref_landing_page').on(table.projectId, table.date, table.landingPageNormalized),
+  uniqueIndex('idx_ga_ai_ref_unique_v3').on(table.projectId, table.date, table.source, table.medium, table.sourceDimension, table.landingPage),
   index('idx_ga_ai_ref_run').on(table.syncRunId),
 ])
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -317,7 +317,7 @@ export const gaAiReferrals = sqliteTable('ga_ai_referrals', {
   medium: text('medium').notNull(),
   /** Which GA4 dimension produced this row: 'session' | 'first_user' | 'manual_utm' */
   sourceDimension: text('source_dimension').notNull().default('session'),
-  landingPage: text('landing_page').notNull().default('(unknown)'),
+  landingPage: text('landing_page').notNull().default('(not set)'),
   landingPageNormalized: text('landing_page_normalized'),
   sessions: integer('sessions').notNull().default(0),
   users: integer('users').notNull().default(0),

--- a/packages/integration-google-analytics/src/ga4-client.ts
+++ b/packages/integration-google-analytics/src/ga4-client.ts
@@ -580,6 +580,7 @@ export async function fetchAiReferrals(
           { name: 'date' },
           { name: sourceDim },
           { name: mediumDim },
+          { name: 'landingPagePlusQueryString' },
         ],
         metrics: [
           { name: 'sessions' },
@@ -606,6 +607,7 @@ export async function fetchAiReferrals(
         date: row.dimensionValues[0]!.value,
         source: row.dimensionValues[1]!.value,
         medium: row.dimensionValues[2]!.value,
+        landingPage: row.dimensionValues[3]?.value ?? '(not set)',
         sessions: parseInt(row.metricValues[0]!.value, 10) || 0,
         users: parseInt(row.metricValues[1]!.value, 10) || 0,
         sourceDimension: dimLabel,
@@ -619,11 +621,11 @@ export async function fetchAiReferrals(
     }
   }
 
-  // Deduplicate within each dimension: if the same date+source+medium+dimension
+  // Deduplicate within each dimension: if the same date+source+medium+page+dimension
   // appears multiple times (shouldn't happen, but defensive), keep the higher count.
   const deduped = new Map<string, GA4AiReferralRow>()
   for (const row of rows) {
-    const key = `${row.date}::${row.source}::${row.medium}::${row.sourceDimension}`
+    const key = `${row.date}::${row.source}::${row.medium}::${row.sourceDimension}::${row.landingPage}`
     const existing = deduped.get(key)
     if (!existing) {
       deduped.set(key, row)

--- a/packages/integration-google-analytics/src/types.ts
+++ b/packages/integration-google-analytics/src/types.ts
@@ -64,6 +64,7 @@ export interface GA4AiReferralRow {
   date: string
   source: string
   medium: string
+  landingPage: string
   sessions: number
   users: number
   sourceDimension: GA4SourceDimension

--- a/packages/integration-google-analytics/test/ga4-client.test.ts
+++ b/packages/integration-google-analytics/test/ga4-client.test.ts
@@ -231,7 +231,7 @@ describe('fetchAiReferrals', () => {
       return mockFetchResponse({
         rows: [
           {
-            dimensionValues: [{ value: '20260320' }, { value: 'chatgpt.com' }, { value: 'referral' }],
+            dimensionValues: [{ value: '20260320' }, { value: 'chatgpt.com' }, { value: 'referral' }, { value: '/pricing?utm_source=chatgpt.com' }],
             metricValues: [{ value: '12' }, { value: '10' }],
           },
         ],
@@ -244,9 +244,9 @@ describe('fetchAiReferrals', () => {
     // Returns one row per dimension (session, first_user, manual_utm) since
     // the mock returns the same data for all three queries
     expect(rows).toEqual([
-      { date: '2026-03-20', source: 'chatgpt.com', medium: 'referral', sessions: 12, users: 10, sourceDimension: 'session' },
-      { date: '2026-03-20', source: 'chatgpt.com', medium: 'referral', sessions: 12, users: 10, sourceDimension: 'first_user' },
-      { date: '2026-03-20', source: 'chatgpt.com', medium: 'referral', sessions: 12, users: 10, sourceDimension: 'manual_utm' },
+      { date: '2026-03-20', source: 'chatgpt.com', medium: 'referral', landingPage: '/pricing?utm_source=chatgpt.com', sessions: 12, users: 10, sourceDimension: 'session' },
+      { date: '2026-03-20', source: 'chatgpt.com', medium: 'referral', landingPage: '/pricing?utm_source=chatgpt.com', sessions: 12, users: 10, sourceDimension: 'first_user' },
+      { date: '2026-03-20', source: 'chatgpt.com', medium: 'referral', landingPage: '/pricing?utm_source=chatgpt.com', sessions: 12, users: 10, sourceDimension: 'manual_utm' },
     ])
 
     // Verify all three dimension pairs were queried
@@ -274,6 +274,12 @@ describe('fetchAiReferrals', () => {
       return dimensions[2]?.name
     })
     expect(mediumDims).toEqual(['sessionMedium', 'firstUserMedium', 'sessionManualMedium'])
+
+    const landingDims = requestBodies.map((b) => {
+      const dimensions = b.dimensions as Array<{ name: string }>
+      return dimensions[3]?.name
+    })
+    expect(landingDims).toEqual(['landingPagePlusQueryString', 'landingPagePlusQueryString', 'landingPagePlusQueryString'])
   })
 })
 

--- a/plans/server-side-ai-traffic-ingestion.md
+++ b/plans/server-side-ai-traffic-ingestion.md
@@ -1,0 +1,317 @@
+# Server-Side AI Traffic & Crawler Ingestion Plan
+
+Status: design plan for implementation after GA known-AI landing page work
+Last updated: 2026-04-30
+
+## Context
+
+Canonry already has two AI discovery signals:
+
+- Answer visibility sweeps show whether AI answer engines cite or mention a project domain.
+- GA4 attribution shows explicit known-AI human referrals when GA exposes a matching source, medium, or UTM signal.
+
+GA4 cannot recover crawler activity or referrer-stripped AI clicks. GA4 also automatically excludes known bot traffic before reporting and does not expose how much was excluded. Server-side ingestion is therefore a separate product layer: it captures request evidence before browser JavaScript, GA attribution, or GA bot filtering shape the data.
+
+## Goals
+
+1. Show AI crawler activity by bot, verification confidence, path, status, and time window.
+2. Show server-observed human AI referrals when request evidence exists (`Referer`, UTM, or similar explicit marker).
+3. Correlate crawler activity, answer-engine citations, GA known-AI referrals, GA Direct traffic, and server-observed referrals without overstating causality.
+4. Keep Canonry local-first and pull-based. No Canonry-hosted endpoint may sit in the hot data path.
+5. Make the first adapters useful for both non-technical WordPress users and developer-hosted Cloud Run users.
+
+## Non-Goals
+
+- No JavaScript pixel for crawler detection. Crawlers do not execute it, and GA already covers the browser-tag lower-bound click signal.
+- No Canonry SaaS relay.
+- No crawler blocking, paywalling, or robots policy enforcement.
+- No deterministic claim that a referrer-stripped Direct session came from an AI surface.
+- No Vercel adapter until the user-owned log destination story is resolved; Vercel drains are push-oriented.
+
+## Canonry Boundaries
+
+The implementation must preserve the platform rules in `AGENTS.md`:
+
+- API and CLI first.
+- Dashboard consumes API data only.
+- MCP tools are adapters over public API client methods.
+- Aero receives tools through the MCP-to-agent adapter once the MCP registry is updated.
+- Credentials and adapter secrets live in `~/.canonry/config.yaml`, not the project database.
+- Any new DB table or column in `schema.ts` has a matching migration in `migrate.ts`.
+
+## Data Model
+
+Store rollups as the durable reporting source and keep raw samples only for inspection and classifier debugging.
+
+### `traffic_sources`
+
+Connection/status metadata for each pull source.
+
+Fields:
+
+- `id`
+- `project_id`
+- `source_type`: `wordpress` | `cloud-run`
+- `display_name`
+- `status`: `connected` | `error` | `paused`
+- `last_synced_at`
+- `last_cursor`
+- `last_error`
+- `created_at`
+- `updated_at`
+
+No credentials in this table.
+
+### `crawler_events_hourly`
+
+Hourly rollups for server-observed crawler requests.
+
+Fields:
+
+- `project_id`
+- `source_id`
+- `ts_hour`
+- `bot_id`
+- `operator`
+- `verification_status`: `verified` | `claimed_unverified` | `unknown_ai_like`
+- `path_normalized`
+- `status`
+- `hits`
+- `sampled_user_agent`
+- `created_at`
+- `updated_at`
+
+Suggested unique key:
+
+`project_id, source_id, ts_hour, bot_id, verification_status, path_normalized, status`
+
+### `ai_referral_events_hourly`
+
+Hourly rollups for server-observed human visits with explicit AI-origin evidence.
+
+Fields:
+
+- `project_id`
+- `source_id`
+- `ts_hour`
+- `product`
+- `operator`
+- `source_domain`
+- `evidence_type`: `referer` | `utm` | `other`
+- `landing_path_normalized`
+- `sessions_or_hits`
+- `users_estimated` nullable
+- `created_at`
+- `updated_at`
+
+This is not a GA replacement. It is raw request-level evidence that can be compared with GA known-AI rows and GA Direct buckets.
+
+### `raw_event_samples`
+
+Short-retention samples for debugging.
+
+Fields:
+
+- `project_id`
+- `source_id`
+- `ts`
+- `event_type`: `crawler` | `ai_referral` | `unknown`
+- `ip_hash` or truncated IP, not full IP by default
+- `user_agent`
+- `path_normalized`
+- `status`
+- `referer_host`
+- `classifier_details_json`
+- `created_at`
+
+Retention target: 30 days by default.
+
+## Classifier
+
+Use a bundled manifest with optional refresh from a public repository.
+
+Classifier tiers:
+
+1. User-agent pattern match creates a candidate bot.
+2. IP/rDNS verification promotes the event to `verified` where the provider publishes usable ranges or host suffixes.
+3. UA-only or unverifiable matches remain `claimed_unverified`.
+4. Behavioral heuristics can flag `unknown_ai_like`, but these must be clearly labeled as heuristic.
+
+Manifest fields:
+
+- `id`
+- `operator`
+- `product`
+- `purpose`
+- `user_agent_patterns`
+- `ip_sources`
+- `rdns_suffixes`
+- `verification_methods`
+- `docs_url`
+- `last_reviewed`
+
+The manifest must not assume every crawler has authoritative IP ranges. Some providers support verification; some only expose UA guidance.
+
+## Pull Adapters
+
+### Phase 1 Adapter: WordPress
+
+Purpose: support Hostinger/shared WordPress and other users without server config access.
+
+Components:
+
+- A small WordPress plugin.
+- A Canonry puller that reads the plugin endpoint.
+- Config stored under `~/.canonry/config.yaml`.
+
+Plugin behavior:
+
+- Runs server-side in the WordPress request lifecycle.
+- Records candidate AI crawler hits and explicit AI referral hits.
+- Avoids front-end JavaScript injection.
+- Stores events or pre-rollups in plugin-owned tables.
+- Exposes a cursor-paginated REST endpoint under `/wp-json/canonry/v1/events` or `/rollups`.
+- Uses `Authorization` header or signed request auth, not query-string tokens.
+- Has bounded retention and cleanup via WP-Cron.
+- Hashes or truncates IPs by default.
+
+Canonry CLI/API:
+
+- `canonry traffic connect wordpress <project> --url <url> --token-env <env>`
+- `canonry traffic sync <project> --source wordpress`
+- `canonry traffic status <project>`
+
+Security review requirements:
+
+- Token validation.
+- Rate limiting or cheap cursor reads.
+- No public unauthenticated event dump.
+- No collection of cookies or request bodies.
+- Explicit retention behavior.
+
+### Phase 1 Adapter: Cloud Run / Cloud Logging
+
+Purpose: support developer-hosted apps with no app code changes.
+
+Inputs:
+
+- Cloud project id.
+- Log resource filters.
+- Service name or labels where available.
+- Time cursor.
+
+Pulled fields:
+
+- timestamp
+- request URL/path
+- status
+- user agent
+- remote IP
+- referer
+- request method
+- resource labels
+
+Canonry CLI/API:
+
+- `canonry traffic connect cloud-run <project> --gcp-project <id> --service <service>`
+- `canonry traffic sync <project> --source cloud-run`
+- `canonry traffic status <project>`
+
+Operational requirements:
+
+- Support dry-run filter preview.
+- Store cursors so repeated syncs are incremental.
+- Prefer narrow Cloud Logging filters when possible, but allow full request pulls for verification/testing.
+- Keep IAM instructions explicit in docs.
+
+## Public Surfaces
+
+### API
+
+- `GET /api/v1/projects/:name/traffic/status`
+- `POST /api/v1/projects/:name/traffic/sync`
+- `GET /api/v1/projects/:name/traffic/crawlers?window=7d`
+- `GET /api/v1/projects/:name/traffic/referrals?window=7d`
+- `GET /api/v1/projects/:name/traffic/timeline?window=30d`
+- `GET /api/v1/projects/:name/traffic/sources`
+
+### CLI
+
+- `canonry traffic status <project> --format json`
+- `canonry traffic sync <project> --source wordpress|cloud-run --format json`
+- `canonry traffic crawlers <project> --window 7d --format json`
+- `canonry traffic referrals <project> --window 7d --format json`
+- `canonry traffic timeline <project> --window 30d --format json`
+- `canonry traffic sources <project> --format json`
+
+### MCP and Aero
+
+Add read tools to the MCP registry after the API and CLI exist. The current Aero implementation adapts MCP registry tools automatically, so no second Aero-specific registration should be needed unless a tool belongs in the Aero exclusion set.
+
+### Dashboard
+
+Add an AI Traffic section that consumes only API data:
+
+- Crawler activity table.
+- Verified vs claimed-unverified split.
+- Top crawled paths.
+- Server-observed AI referrals.
+- Timeline comparing crawls, citation visibility, GA known-AI referrals, and Direct traffic.
+
+## Insight Rules
+
+The intelligence layer should use evidence-weighted phrasing:
+
+- "GPTBot crawled `/pricing` 34 times before the next observed citation gain."
+- "`/guide` is cited but has no detectable AI referral clicks."
+- "`/blog/foo` has crawler activity but no current citation visibility."
+- "Direct traffic rose on a cited page; source is unknown because no referrer or UTM survived."
+
+Avoid deterministic attribution unless the request evidence is explicit.
+
+## Testing Strategy
+
+Unit tests:
+
+- Manifest parser.
+- UA matching.
+- IP/rDNS verification status.
+- Path normalization.
+- Rollup aggregation.
+
+API tests:
+
+- Sync cursor behavior.
+- Idempotent repeated sync.
+- Window filtering.
+- Verified vs unverified crawler breakdown.
+- No credentials in response payloads.
+
+CLI tests:
+
+- `--format json` for every command.
+- User-error exit semantics for missing connections and invalid source names.
+
+Adapter tests:
+
+- WordPress fixture endpoint with pagination and auth failures.
+- Cloud Logging fixture responses with timestamp cursors and duplicate event prevention.
+
+UI tests:
+
+- Empty state.
+- Verified/unverified labeling.
+- Timeline with no overclaiming language.
+
+## Rollout Order
+
+1. Traffic contracts and DB schema.
+2. Manifest parser and classifier.
+3. API/CLI read surfaces over seeded data.
+4. WordPress plugin and puller.
+5. Cloud Run / Cloud Logging puller.
+6. MCP registry entries.
+7. Dashboard section.
+8. Intelligence correlations.
+
+The key product line: GA remains the lower-bound click signal; server-side ingestion adds crawler visibility and raw request-level AI referral evidence.


### PR DESCRIPTION
## Summary

- Add `landingPagePlusQueryString` to GA4 known-AI referral ingestion.
- Persist raw and normalized AI referral landing pages with a DB migration.
- Expose landing-page breakdowns through contracts, API, CLI JSON, and the dashboard.
- Add a detailed Plan B document for server-side AI traffic and crawler ingestion, starting with WordPress and Cloud Run.

## Validation

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm -r --no-bail run test`
- Targeted GA client, contracts, API, CLI, DB, and web tests

Note: root `pnpm run test` still discovers `.claude/worktrees/*` and fails on missing dependencies in those detached worktrees; the actual pnpm workspace package test run passes.