### PR TITLE
chore(web): replace sidebar tagline with version, links with icons

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,7 +2,9 @@ import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from '
 import { useQuery } from '@tanstack/react-query'
 
 import {
+  BookOpen,
   ChevronRight,
+  FileText,
   Github,
   Globe,
   LayoutDashboard,
@@ -12,6 +14,7 @@ import {
   Rocket,
   Settings,
   X,
+  type LucideIcon,
 } from 'lucide-react'
 
 import { RunKinds, formatRunErrorOneLine, type RunKind } from '@ainyc/canonry-contracts'
@@ -52,9 +55,10 @@ import type {
 
 import { Outlet, Link, useLocation } from '@tanstack/react-router'
 
-const docs = [
-  { label: 'Architecture', href: 'https://github.com/AINYC/canonry/blob/main/docs/architecture.md' },
-  { label: 'Testing Guide', href: 'https://github.com/AINYC/canonry/blob/main/docs/testing.md' },
+const resources: { label: string; href: string; Icon: LucideIcon }[] = [
+  { label: 'GitHub', href: 'https://github.com/AINYC/canonry', Icon: Github },
+  { label: 'Docs', href: 'https://github.com/AINYC/canonry/tree/main/docs', Icon: BookOpen },
+  { label: 'Changelog', href: 'https://github.com/AINYC/canonry/releases', Icon: FileText },
 ]
 
 const checkingStatus = (label: string): ServiceStatus => ({
@@ -323,7 +327,7 @@ export function RootLayout() {
       {/* ── Sidebar (desktop) ── */}
       <aside className="sidebar" aria-label="Primary navigation">
         <div className="sidebar-brand">
-          <BrandLockup />
+          <BrandLockup version={healthSnapshot.apiStatus.version} />
         </div>
 
         <nav className="sidebar-nav">
@@ -419,9 +423,17 @@ export function RootLayout() {
         </nav>
 
         <div className="sidebar-footer">
-          {docs.map((doc) => (
-            <a key={doc.href} className="sidebar-footer-link" href={doc.href} target="_blank" rel="noopener noreferrer">
-              {doc.label}
+          {resources.map(({ label, href, Icon }) => (
+            <a
+              key={href}
+              className="sidebar-footer-icon"
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              title={label}
+              aria-label={label}
+            >
+              <Icon className="size-4" />
             </a>
           ))}
         </div>
@@ -551,14 +563,24 @@ export function RootLayout() {
         </main>
 
         <footer className="footer">
-          <a href="https://github.com/AINYC/canonry" target="_blank" rel="noopener noreferrer" className="footer-brand">
-            <Github className="size-3.5" />
+          <span className="footer-brand">
             <span>Canonry</span>
-          </a>
+            {healthSnapshot.apiStatus.version && healthSnapshot.apiStatus.version !== 'unknown' ? (
+              <span className="footer-version">v{healthSnapshot.apiStatus.version}</span>
+            ) : null}
+          </span>
           <div className="footer-links">
-            {docs.map((doc) => (
-              <a key={doc.href} href={doc.href} target="_blank" rel="noopener noreferrer">
-                {doc.label}
+            {resources.map(({ label, href, Icon }) => (
+              <a
+                key={href}
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                title={label}
+                aria-label={label}
+                className="footer-icon"
+              >
+                <Icon className="size-3.5" />
               </a>
             ))}
           </div>

--- a/apps/web/src/components/shared/BrandLockup.tsx
+++ b/apps/web/src/components/shared/BrandLockup.tsx
@@ -1,6 +1,12 @@
 import { Link } from '@tanstack/react-router'
 
-export function BrandLockup({ compact = false }: { compact?: boolean }) {
+interface BrandLockupProps {
+  compact?: boolean
+  version?: string
+}
+
+export function BrandLockup({ compact = false, version }: BrandLockupProps) {
+  const showVersion = !compact && version && version !== 'unknown'
   return (
     <Link
       to="/"
@@ -10,7 +16,7 @@ export function BrandLockup({ compact = false }: { compact?: boolean }) {
       <img className="brand-icon" src="./favicon.svg" alt="" aria-hidden="true" />
       <span className="brand-copy">
         <span className="brand-mark">Canonry</span>
-        {compact ? null : <span className="brand-subtitle">AEO Operating System</span>}
+        {showVersion ? <span className="brand-version">v{version}</span> : null}
       </span>
     </Link>
   )

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -80,8 +80,8 @@
     @apply text-[14px];
   }
 
-  .brand-subtitle {
-    @apply text-[10px] uppercase tracking-[0.2em] text-zinc-500;
+  .brand-version {
+    @apply mt-0.5 font-mono text-[11px] tracking-tight text-zinc-500;
   }
 
   .sidebar-nav {
@@ -129,11 +129,11 @@
   }
 
   .sidebar-footer {
-    @apply border-t border-zinc-800/60 px-3 py-3;
+    @apply flex items-center gap-1 border-t border-zinc-800/60 px-4 py-3;
   }
 
-  .sidebar-footer-link {
-    @apply block rounded-lg px-2.5 py-1.5 text-[12px] text-zinc-600 transition hover:text-zinc-400;
+  .sidebar-footer-icon {
+    @apply inline-flex size-7 items-center justify-center rounded-md text-zinc-500 transition hover:bg-zinc-800/40 hover:text-zinc-200;
   }
 
   .main-area {
@@ -1023,15 +1023,19 @@
   }
 
   .footer-brand {
-    @apply flex items-center gap-1.5 text-zinc-600 transition hover:text-zinc-300;
+    @apply flex items-center gap-2 text-zinc-500;
+  }
+
+  .footer-version {
+    @apply font-mono text-[11px] tracking-tight text-zinc-600;
   }
 
   .footer-links {
-    @apply flex flex-wrap gap-4;
+    @apply flex flex-wrap items-center gap-1;
   }
 
-  .footer-links a {
-    @apply text-zinc-600 transition hover:text-zinc-300;
+  .footer-icon {
+    @apply inline-flex size-7 items-center justify-center rounded-md text-zinc-500 transition hover:bg-zinc-800/40 hover:text-zinc-200;
   }
 
   /* ── Drawer ── */

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "3.1.0",
+  "version": "3.1.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Summary
- Drops the "AEO Operating System" marketing tagline from the brand lockup; shows the live API version (`v3.1.1`) underneath "Canonry" instead — pulled from `/health`.
- Replaces the text-only "Architecture" / "Testing Guide" links in the sidebar footer and the page footer with a compact icon row (GitHub, Docs, Changelog) that hovers to a brighter zinc.
- Page footer left side now shows `Canonry · v<version>` so mobile users (where the sidebar is hidden) still see the version + same icon row.

## Test plan
- [x] `pnpm --filter @ainyc/canonry-web run typecheck`
- [x] `pnpm --filter @ainyc/canonry-web run lint`
- [x] `pnpm --filter @ainyc/canonry-web run test` (148 tests)
- [ ] Visual check in dev with API running — version pill appears, icon row hover/tooltips render correctly