### PR TITLE
feat(ga): display "<1%" for sub-1% channel shares

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1028,6 +1028,16 @@ export interface ApiGaTraffic {
   socialSharePct: number
   /** Direct sessions as a percentage of total sessions (0–100, rounded). */
   directSharePct: number
+  /** Display string for organicSharePct ('10%' or '<1%' when there are sessions but the rounded pct is 0). */
+  organicSharePctDisplay: string
+  /** Display string for aiSharePct ('5%' or '<1%' when there are sessions but the rounded pct is 0). */
+  aiSharePctDisplay: string
+  /** Display string for aiSharePctBySession ('5%' or '<1%' when there are sessions but the rounded pct is 0). */
+  aiSharePctBySessionDisplay: string
+  /** Display string for socialSharePct ('15%' or '<1%' when there are sessions but the rounded pct is 0). */
+  socialSharePctDisplay: string
+  /** Display string for directSharePct ('20%' or '<1%' when there are sessions but the rounded pct is 0). */
+  directSharePctDisplay: string
   lastSyncedAt: string | null
   /** Start of the synced date range (YYYY-MM-DD), null if no data. */
   periodStart: string | null

--- a/apps/web/src/components/project/TrafficSection.tsx
+++ b/apps/web/src/components/project/TrafficSection.tsx
@@ -330,18 +330,18 @@ export function TrafficSection({ projectName }: { projectName: string }) {
     )
   }
 
-  const organicPct = traffic?.organicSharePct ?? 0
+  const organicPctDisplay = traffic?.organicSharePctDisplay ?? '0%'
   const organicSessions = traffic?.totalOrganicSessions ?? 0
   const aiSessions = traffic?.aiSessionsDeduped ?? 0
   const aiSessionsBySession = traffic?.aiSessionsBySession ?? 0
-  const aiSharePctBySession = traffic?.aiSharePctBySession ?? 0
+  const aiSharePctBySessionDisplay = traffic?.aiSharePctBySessionDisplay ?? '0%'
   const aiSourceCount = traffic ? new Set(traffic.aiReferrals.map((referral) => referral.source.toLowerCase())).size : 0
   const topAiSource = sortedAiReferrals[0] ?? null
   const directSessions = traffic?.totalDirectSessions ?? 0
-  const directSharePct = traffic?.directSharePct ?? 0
+  const directSharePctDisplay = traffic?.directSharePctDisplay ?? '0%'
 
   const socialSessions = traffic?.socialSessions ?? 0
-  const socialSharePct = traffic?.socialSharePct ?? 0
+  const socialSharePctDisplay = traffic?.socialSharePctDisplay ?? '0%'
   const socialSourceCount = traffic ? new Set(traffic.socialReferrals.map((r) => r.source.toLowerCase())).size : 0
   const topSocialSource = sortedSocialReferrals[0] ?? null
 
@@ -430,7 +430,7 @@ export function TrafficSection({ projectName }: { projectName: string }) {
             <TrafficMetric
               value={formatCompact(traffic.totalOrganicSessions)}
               label="Organic Sessions"
-              subtitle={`${organicPct}% of total`}
+              subtitle={`${organicPctDisplay} of total`}
               tone="positive"
             />
             <TrafficMetric
@@ -565,28 +565,28 @@ export function TrafficSection({ projectName }: { projectName: string }) {
               <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
                 <AttributionStat
                   label="Organic"
-                  value={`${organicPct}%`}
+                  value={organicPctDisplay}
                   hint={`${organicSessions.toLocaleString()} sessions`}
                   tone="positive"
                   tooltip="Sessions from Google organic search (sessionDefaultChannelGrouping = 'Organic Search')."
                 />
                 <AttributionStat
                   label="Social"
-                  value={`${socialSharePct}%`}
+                  value={socialSharePctDisplay}
                   hint={`${socialSessions.toLocaleString()} sessions`}
                   tone="neutral"
                   tooltip="Sessions from social platforms (sessionDefaultChannelGrouping = 'Organic Social' or 'Paid Social')."
                 />
                 <AttributionStat
                   label="Direct"
-                  value={`${directSharePct}%`}
+                  value={directSharePctDisplay}
                   hint={`${directSessions.toLocaleString()} sessions`}
                   tone="neutral"
                   tooltip="Sessions with no source — bookmarks, typed URLs, untagged email, in-app browsers, and AI-driven traffic whose referrer header was stripped."
                 />
                 <AttributionStat
                   label="Known AI referrers (lower bound)"
-                  value={`${aiSharePctBySession}%`}
+                  value={aiSharePctBySessionDisplay}
                   hint={`${aiSessionsBySession.toLocaleString()} sessions`}
                   tone="positive"
                   tooltip="Sessions whose current sessionSource matched a known AI engine (e.g. chatgpt.com, claude.ai, gemini.google.com). Disjoint from Direct/Organic/Social. This is a strict lower bound: most AI traffic strips the referrer and falls into Direct, so the true AI share is typically higher than what's shown here. The detail table below also surfaces firstUserSource and UTM-tagged AI signals."
@@ -789,7 +789,7 @@ export function TrafficSection({ projectName }: { projectName: string }) {
                       />
                       <AttributionStat
                         label="Share of Traffic"
-                        value={`${socialSharePct}%`}
+                        value={socialSharePctDisplay}
                         hint="of total sessions"
                         tone="neutral"
                         tooltip="Percentage of your total site sessions that originated from social media platforms."

--- a/apps/web/test/traffic-section.test.tsx
+++ b/apps/web/test/traffic-section.test.tsx
@@ -165,6 +165,11 @@ test('renders four-channel breakdown with Organic, Social, Direct, and Known AI 
         aiSharePctBySession: 10,
         directSharePct: 25,
         socialSharePct: 7,
+        organicSharePctDisplay: '58%',
+        aiSharePctDisplay: '35%',
+        aiSharePctBySessionDisplay: '10%',
+        directSharePctDisplay: '25%',
+        socialSharePctDisplay: '7%',
         lastSyncedAt: '2026-03-31T12:00:00.000Z',
       })
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "3.2.0",
+  "version": "3.2.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/ga.ts
+++ b/packages/api-routes/src/ga.ts
@@ -22,6 +22,17 @@ function gaLog(level: 'info' | 'warn' | 'error', action: string, ctx?: Record<st
   stream.write(JSON.stringify(entry) + '\n')
 }
 
+// Format a session-share as a display string. Returns "<1%" for non-zero shares
+// that round below 1%, so 18 AI sessions out of 6000 reads "<1%" instead of
+// "0%" — the display matches the integer pct field exactly otherwise.
+function formatSharePct(numerator: number, total: number): string {
+  if (total <= 0 || numerator <= 0) return '0%'
+  const pct = (numerator / total) * 100
+  const rounded = Math.round(pct)
+  if (rounded === 0) return '<1%'
+  return `${rounded}%`
+}
+
 export interface Ga4CredentialRecord {
   projectName: string
   propertyId: string
@@ -768,6 +779,11 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       aiSharePctBySession: total > 0 ? Math.round(((aiBySession?.sessions ?? 0) / total) * 100) : 0,
       directSharePct: total > 0 ? Math.round((totalDirectSessions / total) * 100) : 0,
       socialSharePct: total > 0 ? Math.round(((socialTotals?.sessions ?? 0) / total) * 100) : 0,
+      organicSharePctDisplay: formatSharePct(summaryRow?.totalOrganicSessions ?? 0, total),
+      aiSharePctDisplay: formatSharePct(aiDeduped?.sessions ?? 0, total),
+      aiSharePctBySessionDisplay: formatSharePct(aiBySession?.sessions ?? 0, total),
+      directSharePctDisplay: formatSharePct(totalDirectSessions, total),
+      socialSharePctDisplay: formatSharePct(socialTotals?.sessions ?? 0, total),
       lastSyncedAt: latestSync?.syncedAt ?? null,
       periodStart: (() => {
         const start = cutoffDate ?? summaryMeta?.periodStart ?? null

--- a/packages/api-routes/test/ga.test.ts
+++ b/packages/api-routes/test/ga.test.ts
@@ -517,11 +517,101 @@ describe('GA4 routes', () => {
     expect(body.organicSharePct).toBe(50)
     expect(body.aiSharePct).toBe(5)
     expect(body.socialSharePct).toBe(0)
+    expect(body.organicSharePctDisplay).toBe('50%')
+    expect(body.aiSharePctDisplay).toBe('5%')
+    expect(body.aiSharePctBySessionDisplay).toBe('5%')
+    expect(body.socialSharePctDisplay).toBe('0%')
+    expect(body.directSharePctDisplay).toBe('0%')
     expect(body.lastSyncedAt).toBe(now)
     expect(body.periodStart).toBe('2026-02-19')
     expect(body.periodEnd).toBe('2026-03-20')
 
     credentials.delete('test-project')
+  })
+
+  it('GET /ga/traffic returns "<1%" display when AI sessions are present but rounded pct is 0', async () => {
+    // Seed a fresh project so we don't pollute the shared row counts.
+    const now = new Date().toISOString()
+    const today = now.slice(0, 10)
+    const projRes = await app.inject({
+      method: 'PUT',
+      url: '/api/v1/projects/sub-one-pct',
+      payload: {
+        displayName: 'Sub One Pct',
+        canonicalDomain: 'sub-one.example',
+        country: 'US',
+        language: 'en',
+      },
+    })
+    const subProjectId = JSON.parse(projRes.payload).id
+
+    credentials.set('sub-one-pct', {
+      projectName: 'sub-one-pct',
+      propertyId: '111222',
+      clientEmail: 'sa@test.iam.gserviceaccount.com',
+      privateKey: 'fake-key',
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    // 6,000 total sessions, 18 AI referrals → 0.3%, which Math.round flattens to 0%.
+    const snapshotId = crypto.randomUUID()
+    db.insert(gaTrafficSnapshots).values({
+      id: snapshotId,
+      projectId: subProjectId,
+      date: today,
+      landingPage: '/sub-one-page',
+      sessions: 6000,
+      organicSessions: 600,
+      directSessions: 1000,
+      users: 4500,
+      syncedAt: now,
+    }).run()
+    db.insert(gaTrafficSummaries).values({
+      id: crypto.randomUUID(),
+      projectId: subProjectId,
+      periodStart: today,
+      periodEnd: today,
+      totalSessions: 6000,
+      totalOrganicSessions: 600,
+      totalUsers: 4500,
+      syncedAt: now,
+    }).run()
+    const aiId = crypto.randomUUID()
+    db.insert(gaAiReferrals).values({
+      id: aiId,
+      projectId: subProjectId,
+      date: today,
+      source: 'chatgpt.com',
+      medium: 'referral',
+      landingPage: '/sub-one-page',
+      sessions: 18,
+      users: 13,
+      syncedAt: now,
+    }).run()
+
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/v1/projects/sub-one-pct/ga/traffic',
+      })
+      expect(res.statusCode).toBe(200)
+      const body = JSON.parse(res.payload)
+      expect(body.aiSessionsBySession).toBe(18)
+      // The integer pct still rounds to 0, preserved for back-compat...
+      expect(body.aiSharePctBySession).toBe(0)
+      // ...but the display string surfaces the non-zero share as "<1%".
+      expect(body.aiSharePctBySessionDisplay).toBe('<1%')
+      expect(body.aiSharePctDisplay).toBe('<1%')
+      // Channels with truly zero sessions still render "0%" (no false "<1%").
+      expect(body.socialSharePctDisplay).toBe('0%')
+      // 600 / 6000 = 10%
+      expect(body.organicSharePctDisplay).toBe('10%')
+    } finally {
+      db.delete(gaAiReferrals).where(eq(gaAiReferrals.id, aiId)).run()
+      db.delete(gaTrafficSnapshots).where(eq(gaTrafficSnapshots.id, snapshotId)).run()
+      credentials.delete('sub-one-pct')
+    }
   })
 
   it('GET /ga/traffic respects limit parameter and computes totals across all pages', async () => {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/commands/ga.ts
+++ b/packages/canonry/src/commands/ga.ts
@@ -433,6 +433,11 @@ export async function gaAttribution(project: string, opts?: { trend?: boolean; f
         socialSharePct: traffic.socialSharePct,
         organicSharePct: traffic.organicSharePct,
         directSharePct: traffic.directSharePct,
+        organicSharePctDisplay: traffic.organicSharePctDisplay,
+        aiSharePctDisplay: traffic.aiSharePctDisplay,
+        aiSharePctBySessionDisplay: traffic.aiSharePctBySessionDisplay,
+        socialSharePctDisplay: traffic.socialSharePctDisplay,
+        directSharePctDisplay: traffic.directSharePctDisplay,
         aiReferrals: traffic.aiReferrals,
         aiReferralLandingPages: traffic.aiReferralLandingPages,
         socialReferrals: traffic.socialReferrals,
@@ -451,10 +456,10 @@ export async function gaAttribution(project: string, opts?: { trend?: boolean; f
     console.log(`  Total Users:      ${traffic.totalUsers}`)
     console.log()
     console.log('  CHANNEL BREAKDOWN                  7d trend     30d trend')
-    console.log(`    Organic Search: ${String(traffic.totalOrganicSessions).padEnd(6)} (${String(traffic.organicSharePct).padStart(2)}%)    ${fmtTrend(trend.organic.trend7dPct).padEnd(12)} ${fmtTrend(trend.organic.trend30dPct)}`)
-    console.log(`    Social:         ${String(traffic.socialSessions).padEnd(6)} (${String(traffic.socialSharePct).padStart(2)}%)    ${fmtTrend(trend.social.trend7dPct).padEnd(12)} ${fmtTrend(trend.social.trend30dPct)}`)
-    console.log(`    Direct:         ${String(traffic.totalDirectSessions).padEnd(6)} (${String(traffic.directSharePct).padStart(2)}%)    ${fmtTrend(trend.direct.trend7dPct).padEnd(12)} ${fmtTrend(trend.direct.trend30dPct)}`)
-    console.log(`    AI Referrals:   ${String(traffic.aiSessionsBySession).padEnd(6)} (${String(traffic.aiSharePctBySession).padStart(2)}%)    ${fmtTrend(trend.ai.trend7dPct).padEnd(12)} ${fmtTrend(trend.ai.trend30dPct)}  (lower bound — sessionSource only; referrer-stripped traffic falls under Direct)`)
+    console.log(`    Organic Search: ${String(traffic.totalOrganicSessions).padEnd(6)} (${traffic.organicSharePctDisplay.padStart(4)})    ${fmtTrend(trend.organic.trend7dPct).padEnd(12)} ${fmtTrend(trend.organic.trend30dPct)}`)
+    console.log(`    Social:         ${String(traffic.socialSessions).padEnd(6)} (${traffic.socialSharePctDisplay.padStart(4)})    ${fmtTrend(trend.social.trend7dPct).padEnd(12)} ${fmtTrend(trend.social.trend30dPct)}`)
+    console.log(`    Direct:         ${String(traffic.totalDirectSessions).padEnd(6)} (${traffic.directSharePctDisplay.padStart(4)})    ${fmtTrend(trend.direct.trend7dPct).padEnd(12)} ${fmtTrend(trend.direct.trend30dPct)}`)
+    console.log(`    AI Referrals:   ${String(traffic.aiSessionsBySession).padEnd(6)} (${traffic.aiSharePctBySessionDisplay.padStart(4)})    ${fmtTrend(trend.ai.trend7dPct).padEnd(12)} ${fmtTrend(trend.ai.trend30dPct)}  (lower bound — sessionSource only; referrer-stripped traffic falls under Direct)`)
     const otherSessions = traffic.totalSessions - traffic.totalOrganicSessions - traffic.aiSessionsBySession - traffic.socialSessions - traffic.totalDirectSessions
     if (otherSessions > 0) {
       const otherPct = traffic.totalSessions > 0 ? Math.round((otherSessions / traffic.totalSessions) * 100) : 0
@@ -498,6 +503,11 @@ export async function gaAttribution(project: string, opts?: { trend?: boolean; f
       socialSharePct: traffic.socialSharePct,
       organicSharePct: traffic.organicSharePct,
       directSharePct: traffic.directSharePct,
+      organicSharePctDisplay: traffic.organicSharePctDisplay,
+      aiSharePctDisplay: traffic.aiSharePctDisplay,
+      aiSharePctBySessionDisplay: traffic.aiSharePctBySessionDisplay,
+      socialSharePctDisplay: traffic.socialSharePctDisplay,
+      directSharePctDisplay: traffic.directSharePctDisplay,
       aiReferrals: traffic.aiReferrals,
       aiReferralLandingPages: traffic.aiReferralLandingPages,
       socialReferrals: traffic.socialReferrals,
@@ -517,10 +527,10 @@ export async function gaAttribution(project: string, opts?: { trend?: boolean; f
   console.log(`  Total Users:      ${traffic.totalUsers}`)
   console.log()
   console.log('  CHANNEL BREAKDOWN')
-  console.log(`    Organic Search: ${traffic.totalOrganicSessions} sessions (${traffic.organicSharePct}%)`)
-  console.log(`    Social:         ${traffic.socialSessions} sessions (${traffic.socialSharePct}%)`)
-  console.log(`    Direct:         ${traffic.totalDirectSessions} sessions (${traffic.directSharePct}%)`)
-  console.log(`    AI Referrals:   ${traffic.aiSessionsBySession} sessions (${traffic.aiSharePctBySession}%)  (lower bound — sessionSource only; referrer-stripped traffic falls under Direct)`)
+  console.log(`    Organic Search: ${traffic.totalOrganicSessions} sessions (${traffic.organicSharePctDisplay})`)
+  console.log(`    Social:         ${traffic.socialSessions} sessions (${traffic.socialSharePctDisplay})`)
+  console.log(`    Direct:         ${traffic.totalDirectSessions} sessions (${traffic.directSharePctDisplay})`)
+  console.log(`    AI Referrals:   ${traffic.aiSessionsBySession} sessions (${traffic.aiSharePctBySessionDisplay})  (lower bound — sessionSource only; referrer-stripped traffic falls under Direct)`)
   const otherSessions = traffic.totalSessions - traffic.totalOrganicSessions - traffic.aiSessionsBySession - traffic.socialSessions - traffic.totalDirectSessions
   if (otherSessions > 0) {
     const otherPct = traffic.totalSessions > 0 ? Math.round((otherSessions / traffic.totalSessions) * 100) : 0

--- a/packages/contracts/src/ga.ts
+++ b/packages/contracts/src/ga.ts
@@ -92,6 +92,16 @@ export const ga4TrafficSummaryDtoSchema = z.object({
   directSharePct: z.number(),
   /** Social sessions as a percentage of total sessions (0–100, rounded). */
   socialSharePct: z.number(),
+  /** Display string for organicSharePct ('10%' or '<1%' when there are sessions but the rounded pct is 0). */
+  organicSharePctDisplay: z.string(),
+  /** Display string for aiSharePct ('5%' or '<1%' when there are sessions but the rounded pct is 0). */
+  aiSharePctDisplay: z.string(),
+  /** Display string for aiSharePctBySession ('5%' or '<1%' when there are sessions but the rounded pct is 0). */
+  aiSharePctBySessionDisplay: z.string(),
+  /** Display string for directSharePct ('20%' or '<1%' when there are sessions but the rounded pct is 0). */
+  directSharePctDisplay: z.string(),
+  /** Display string for socialSharePct ('15%' or '<1%' when there are sessions but the rounded pct is 0). */
+  socialSharePctDisplay: z.string(),
   lastSyncedAt: z.string().nullable(),
 })
 export type GA4TrafficSummaryDto = z.infer<typeof ga4TrafficSummaryDtoSchema>
@@ -190,6 +200,16 @@ export interface GaTrafficResponse {
   directSharePct: number
   /** Social sessions as a percentage of total sessions (0–100, rounded). */
   socialSharePct: number
+  /** Display string for organicSharePct ('10%' or '<1%' when there are sessions but the rounded pct is 0). */
+  organicSharePctDisplay: string
+  /** Display string for aiSharePct ('5%' or '<1%' when there are sessions but the rounded pct is 0). */
+  aiSharePctDisplay: string
+  /** Display string for aiSharePctBySession ('5%' or '<1%' when there are sessions but the rounded pct is 0). */
+  aiSharePctBySessionDisplay: string
+  /** Display string for directSharePct ('20%' or '<1%' when there are sessions but the rounded pct is 0). */
+  directSharePctDisplay: string
+  /** Display string for socialSharePct ('15%' or '<1%' when there are sessions but the rounded pct is 0). */
+  socialSharePctDisplay: string
   lastSyncedAt: string | null
   /** Start of the synced date range (YYYY-MM-DD), null if no data. */
   periodStart: string | null

--- a/packages/contracts/test/ga.test.ts
+++ b/packages/contracts/test/ga.test.ts
@@ -35,6 +35,11 @@ describe('GA contracts', () => {
       aiSharePctBySession: 12,
       directSharePct: 20,
       socialSharePct: 0,
+      organicSharePctDisplay: '30%',
+      aiSharePctDisplay: '12%',
+      aiSharePctBySessionDisplay: '12%',
+      directSharePctDisplay: '20%',
+      socialSharePctDisplay: '0%',
       lastSyncedAt: null,
     })
 


### PR DESCRIPTION
## Summary
- Adds `*SharePctDisplay` string fields alongside the existing integer `*SharePct` fields on the GA traffic response so non-zero sub-1% channel shares (e.g. 18 AI sessions out of 6000) render as `<1%` instead of `0%`.
- Integer pct fields are unchanged — existing API consumers and the OpenAPI surface stay back-compat. The dashboard `TrafficSection` and CLI `canonry ga attribution` (human + JSON output) now consume the display strings; CLI column padding is widened to 4 chars to keep the trend column aligned.
- Tests cover both normal values and the `<1%` path in `packages/api-routes`, `packages/contracts`, and `apps/web`.

## Test plan
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm lint`
- [ ] Verify dashboard Attribution panel shows `<1%` for a project with sub-1% AI traffic