### PR TITLE
fix(web): tame social referral table overflow with top-N rollup

### DIFF
--- a/apps/web/src/components/project/TrafficSection.tsx
+++ b/apps/web/src/components/project/TrafficSection.tsx
@@ -32,10 +32,21 @@ import {
   disconnectGa,
 } from '../../api.js'
 import type { ApiGaStatus, ApiGaTraffic, ApiGaTrafficAiLandingPage, ApiGaTrafficPage, ApiGaTrafficReferral, ApiGaSocialReferral, GA4AiReferralHistoryEntry, GA4SessionHistoryEntry, GA4SocialReferralHistoryEntry } from '../../api.js'
+import {
+  SOCIAL_OTHER_KEY,
+  SOCIAL_TOTAL_KEY,
+  aggregateSocialChartData,
+  decodeSocialSourceLabel,
+  truncateLabel,
+} from '../../lib/social-chart-helpers.js'
 
 const TRAFFIC_WINDOWS: MetricsWindow[] = ['7d', '30d', '90d', 'all']
 
 const SOURCE_COLORS = CHART_SERIES_COLORS
+
+const SOCIAL_OTHER_COLOR = '#71717a'
+const SOCIAL_TOTAL_COLOR = '#52525b'
+const SOCIAL_TABLE_DEFAULT_LIMIT = 25
 
 type PageSortKey = 'landingPage' | 'sessions' | 'organicSessions' | 'users'
 type ReferralSortKey = 'source' | 'medium' | 'sessions' | 'users'
@@ -79,6 +90,7 @@ export function TrafficSection({ projectName }: { projectName: string }) {
   const [aiHistory, setAiHistory] = useState<GA4AiReferralHistoryEntry[]>([])
   const [sessionHistory, setSessionHistory] = useState<GA4SessionHistoryEntry[]>([])
   const [socialHistory, setSocialHistory] = useState<GA4SocialReferralHistoryEntry[]>([])
+  const [socialTableExpanded, setSocialTableExpanded] = useState(false)
   const [trafficWindow, setTrafficWindow] = useState<MetricsWindow>('30d')
 
   function loadData(cancelled: { current: boolean }) {
@@ -253,25 +265,13 @@ export function TrafficSection({ projectName }: { projectName: string }) {
     })
   }, [traffic?.socialReferrals, socialSortKey, socialSortDir])
 
-  const { socialChartData, socialChartSources } = useMemo(() => {
-    const sources = [...new Set(socialHistory.map((r) => r.source))]
-    const byDate = new Map<string, Record<string, number>>()
-
-    for (const row of socialHistory) {
-      let entry = byDate.get(row.date)
-      if (!entry) {
-        entry = { _socialTotal: 0 }
-        byDate.set(row.date, entry)
-      }
-      entry[row.source] = (entry[row.source] ?? 0) + row.sessions
-      entry._socialTotal = (entry._socialTotal ?? 0) + row.sessions
+  const { socialChartData, socialChartSources, socialOtherCount } = useMemo(() => {
+    const agg = aggregateSocialChartData(socialHistory)
+    return {
+      socialChartData: agg.data,
+      socialChartSources: agg.sources,
+      socialOtherCount: agg.otherCount,
     }
-
-    const data = [...byDate.entries()]
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([date, vals]) => ({ date, ...vals }))
-
-    return { socialChartData: data, socialChartSources: sources }
   }, [socialHistory])
 
   // Keep this above the early returns so the hook order stays stable while the
@@ -703,11 +703,16 @@ export function TrafficSection({ projectName }: { projectName: string }) {
 
             {socialChartData.length > 0 && (
               <Card className="surface-card p-5 mb-4">
-                <div className="mb-4 flex items-end justify-between">
+                <div className="mb-4 flex items-end justify-between gap-3">
                   <div>
                     <p className="eyebrow eyebrow-soft">Trend</p>
                     <h3 className="text-sm font-semibold text-zinc-100">Social sessions over time</h3>
                   </div>
+                  {socialOtherCount > 0 && (
+                    <p className="text-xs text-zinc-500">
+                      Showing top {socialChartSources.length - 1} sources · {socialOtherCount} more grouped as Other
+                    </p>
+                  )}
                 </div>
                 <div className="h-64">
                   <ResponsiveContainer width="100%" height="100%">
@@ -732,41 +737,44 @@ export function TrafficSection({ projectName }: { projectName: string }) {
                         formatter={(value, name) => {
                           const formatted = typeof value === 'number' ? value.toLocaleString() : String(value ?? 0)
                           const key = String(name ?? '')
-                          if (key === '_socialTotal') return [formatted, 'Total Social']
-                          return [formatted, key]
-                        }}
-                      />
-                      <Legend
-                        wrapperStyle={{ fontSize: 11, color: '#a1a1aa' }}
-                        formatter={(value: string) => {
-                          if (value === '_socialTotal') return 'Total Social'
-                          return value
+                          if (key === SOCIAL_TOTAL_KEY) return [formatted, 'Total Social']
+                          if (key === SOCIAL_OTHER_KEY) {
+                            const label = `Other (${socialOtherCount} source${socialOtherCount === 1 ? '' : 's'})`
+                            return [formatted, label]
+                          }
+                          return [formatted, decodeSocialSourceLabel(key)]
                         }}
                       />
                       <Area
                         type="monotone"
-                        dataKey="_socialTotal"
-                        stroke="#52525b"
+                        dataKey={SOCIAL_TOTAL_KEY}
+                        stroke={SOCIAL_TOTAL_COLOR}
                         fill="#27272a"
                         fillOpacity={0.4}
                         strokeWidth={1.5}
                         dot={false}
                       />
-                      {socialChartSources.map((source, i) => (
-                        <Area
-                          key={source}
-                          type="monotone"
-                          dataKey={source}
-                          stackId="social"
-                          stroke={SOURCE_COLORS[i % SOURCE_COLORS.length]}
-                          fill={SOURCE_COLORS[i % SOURCE_COLORS.length]}
-                          fillOpacity={0.4}
-                          strokeWidth={1.5}
-                        />
-                      ))}
+                      {socialChartSources.map((source, i) => {
+                        const isOther = source === SOCIAL_OTHER_KEY
+                        const color = isOther ? SOCIAL_OTHER_COLOR : SOURCE_COLORS[i % SOURCE_COLORS.length]
+                        return (
+                          <Area
+                            key={source}
+                            type="monotone"
+                            dataKey={source}
+                            stackId="social"
+                            stroke={color}
+                            fill={color}
+                            fillOpacity={0.4}
+                            strokeWidth={1.5}
+                          />
+                        )
+                      })}
                     </ComposedChart>
                   </ResponsiveContainer>
                 </div>
+
+                <SocialChartLegend sources={socialChartSources} otherCount={socialOtherCount} />
               </Card>
             )}
 
@@ -805,7 +813,16 @@ export function TrafficSection({ projectName }: { projectName: string }) {
 
                     {topSocialSource && (
                       <div className="mt-4 rounded-lg border border-sky-800/40 bg-sky-500/6 px-4 py-3 text-sm text-sky-100">
-                        Top social source: <span className="font-medium">{topSocialSource.source}</span> via {topSocialSource.medium}, accounting for {topSocialSource.sessions.toLocaleString()} sessions.
+                        <p className="text-xs uppercase tracking-wider text-sky-300/70 mb-1">Top social source</p>
+                        <p
+                          className="font-medium truncate"
+                          title={`${topSocialSource.source} via ${topSocialSource.medium}`}
+                        >
+                          {truncateLabel(decodeSocialSourceLabel(topSocialSource.source), 64)}
+                        </p>
+                        <p className="text-xs text-sky-200/70 mt-0.5 truncate" title={topSocialSource.medium}>
+                          via {decodeSocialSourceLabel(topSocialSource.medium)} · {topSocialSource.sessions.toLocaleString()} sessions
+                        </p>
                       </div>
                     )}
                   </>
@@ -831,30 +848,61 @@ export function TrafficSection({ projectName }: { projectName: string }) {
                     <h3 className="text-sm font-semibold text-zinc-100">Source / medium</h3>
                   </div>
                   <p className="text-xs text-zinc-500">
-                    {traffic.socialReferrals.length > 0 ? `${traffic.socialReferrals.length} rows` : 'No source rows'}
+                    {traffic.socialReferrals.length > 0
+                      ? sortedSocialReferrals.length > SOCIAL_TABLE_DEFAULT_LIMIT && !socialTableExpanded
+                        ? `Top ${SOCIAL_TABLE_DEFAULT_LIMIT} of ${sortedSocialReferrals.length}`
+                        : `${sortedSocialReferrals.length} rows`
+                      : 'No source rows'}
                   </p>
                 </div>
 
                 {traffic.socialReferrals.length > 0 ? (
-                  <div className="overflow-x-auto">
-                    <table className="w-full text-sm">
-                      <thead>
-                        <tr className="text-[10px] uppercase tracking-wider text-zinc-500">
-                          <SortHeader label="Source" sortKey="source" current={socialSortKey} dir={socialSortDir} onSort={handleSocialSort} align="left" />
-                          <SortHeader label="Medium" sortKey="medium" current={socialSortKey} dir={socialSortDir} onSort={handleSocialSort} align="left" />
-                          <th className="py-1 font-medium text-left">Channel</th>
-                          <SortHeader label="Sessions" sortKey="sessions" current={socialSortKey} dir={socialSortDir} onSort={handleSocialSort} align="right" />
-                          <th className="py-1 font-medium text-right">Share</th>
-                          <SortHeader label="Users" sortKey="users" current={socialSortKey} dir={socialSortDir} onSort={handleSocialSort} align="right" />
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {sortedSocialReferrals.map((referral) => (
-                          <SocialReferralRow key={`${referral.source}:${referral.medium}:${referral.channelGroup}`} referral={referral} totalSessions={socialSessions} />
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
+                  <>
+                    <div className="overflow-x-auto">
+                      <table className="w-full text-sm table-fixed">
+                        <colgroup>
+                          <col className="w-[40%]" />
+                          <col className="w-[28%]" />
+                          <col className="w-[12%]" />
+                          <col className="w-[8%]" />
+                          <col className="w-[6%]" />
+                          <col className="w-[6%]" />
+                        </colgroup>
+                        <thead>
+                          <tr className="text-[10px] uppercase tracking-wider text-zinc-500">
+                            <SortHeader label="Source" sortKey="source" current={socialSortKey} dir={socialSortDir} onSort={handleSocialSort} align="left" />
+                            <SortHeader label="Medium" sortKey="medium" current={socialSortKey} dir={socialSortDir} onSort={handleSocialSort} align="left" />
+                            <th className="py-1 font-medium text-left">Channel</th>
+                            <SortHeader label="Sessions" sortKey="sessions" current={socialSortKey} dir={socialSortDir} onSort={handleSocialSort} align="right" />
+                            <th className="py-1 font-medium text-right">Share</th>
+                            <SortHeader label="Users" sortKey="users" current={socialSortKey} dir={socialSortDir} onSort={handleSocialSort} align="right" />
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {(socialTableExpanded
+                            ? sortedSocialReferrals
+                            : sortedSocialReferrals.slice(0, SOCIAL_TABLE_DEFAULT_LIMIT)
+                          ).map((referral) => (
+                            <SocialReferralRow key={`${referral.source}:${referral.medium}:${referral.channelGroup}`} referral={referral} totalSessions={socialSessions} />
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+
+                    {sortedSocialReferrals.length > SOCIAL_TABLE_DEFAULT_LIMIT && (
+                      <div className="mt-3 flex justify-center">
+                        <button
+                          type="button"
+                          onClick={() => setSocialTableExpanded((v) => !v)}
+                          className="text-xs text-zinc-400 hover:text-zinc-200 px-3 py-1 rounded-full border border-zinc-800 hover:border-zinc-700 transition-colors"
+                        >
+                          {socialTableExpanded
+                            ? `Show top ${SOCIAL_TABLE_DEFAULT_LIMIT}`
+                            : `Show all ${sortedSocialReferrals.length} sources`}
+                        </button>
+                      </div>
+                    )}
+                  </>
                 ) : (
                   <div className="flex flex-col items-center justify-center py-8 text-center">
                     <p className="text-sm text-zinc-400 mb-2">No social media sessions detected yet</p>
@@ -1251,16 +1299,18 @@ function SocialReferralRow({
 }) {
   const share = totalSessions > 0 ? ((referral.sessions / totalSessions) * 100).toFixed(1) : '0.0'
   const channelLabel = referral.channelGroup === 'Paid Social' ? 'Paid' : 'Organic'
+  const sourceDisplay = decodeSocialSourceLabel(referral.source)
+  const mediumDisplay = decodeSocialSourceLabel(referral.medium)
 
   return (
     <tr className="border-t border-zinc-800/40">
-      <td className="py-1.5 text-zinc-200 max-w-[220px] truncate" title={referral.source}>
-        {referral.source}
+      <td className="py-1.5 pr-3 text-zinc-200 truncate" title={referral.source}>
+        {sourceDisplay}
       </td>
-      <td className="py-1.5 text-zinc-500 max-w-[180px] truncate" title={referral.medium}>
-        {referral.medium}
+      <td className="py-1.5 pr-3 text-zinc-500 truncate" title={referral.medium}>
+        {mediumDisplay}
       </td>
-      <td className="py-1.5">
+      <td className="py-1.5 pr-3">
         <span
           className="inline-block text-[10px] px-1.5 py-0.5 rounded-full border border-zinc-700 text-zinc-400"
           title={`GA4 channel group: ${referral.channelGroup}`}
@@ -1278,5 +1328,61 @@ function SocialReferralRow({
         {referral.users.toLocaleString()}
       </td>
     </tr>
+  )
+}
+
+function SocialChartLegend({
+  sources,
+  otherCount,
+}: {
+  sources: string[]
+  otherCount: number
+}) {
+  const items: Array<{ key: string; color: string; label: string; tooltip: string }> = [
+    {
+      key: SOCIAL_TOTAL_KEY,
+      color: SOCIAL_TOTAL_COLOR,
+      label: 'Total',
+      tooltip: 'All social sessions across every source.',
+    },
+  ]
+
+  for (let i = 0; i < sources.length; i++) {
+    const source = sources[i]!
+    if (source === SOCIAL_OTHER_KEY) {
+      items.push({
+        key: SOCIAL_OTHER_KEY,
+        color: SOCIAL_OTHER_COLOR,
+        label: `Other (${otherCount})`,
+        tooltip: `${otherCount} smaller source${otherCount === 1 ? '' : 's'} grouped together`,
+      })
+    } else {
+      const decoded = decodeSocialSourceLabel(source)
+      items.push({
+        key: source,
+        color: SOURCE_COLORS[i % SOURCE_COLORS.length] ?? SOCIAL_OTHER_COLOR,
+        label: truncateLabel(decoded, 32),
+        tooltip: decoded,
+      })
+    }
+  }
+
+  return (
+    <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1.5 text-[11px] text-zinc-400">
+      {items.map((item) => (
+        <div
+          key={item.key}
+          className="flex items-center gap-1.5 min-w-0 max-w-[260px]"
+          title={item.tooltip}
+        >
+          <span
+            className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
+            style={{ backgroundColor: item.color }}
+            aria-hidden="true"
+          />
+          <span className="truncate">{item.label}</span>
+        </div>
+      ))}
+    </div>
   )
 }

--- a/apps/web/src/lib/social-chart-helpers.ts
+++ b/apps/web/src/lib/social-chart-helpers.ts
@@ -1,0 +1,60 @@
+import type { GA4SocialReferralHistoryEntry } from '../api.js'
+
+export const SOCIAL_CHART_TOP_N = 6
+export const SOCIAL_OTHER_KEY = '__other__'
+export const SOCIAL_TOTAL_KEY = '_socialTotal'
+
+export interface SocialChartAggregation {
+  data: Array<Record<string, string | number>>
+  sources: string[]
+  otherCount: number
+}
+
+export function aggregateSocialChartData(
+  history: GA4SocialReferralHistoryEntry[],
+  topN: number = SOCIAL_CHART_TOP_N,
+): SocialChartAggregation {
+  const totals = new Map<string, number>()
+  for (const row of history) {
+    totals.set(row.source, (totals.get(row.source) ?? 0) + row.sessions)
+  }
+
+  const ranked = [...totals.entries()].sort((a, b) => {
+    if (b[1] !== a[1]) return b[1] - a[1]
+    return a[0].localeCompare(b[0])
+  })
+  const topEntries = ranked.slice(0, topN)
+  const topSources = new Set(topEntries.map(([source]) => source))
+  const otherCount = Math.max(0, ranked.length - topN)
+
+  const byDate = new Map<string, Record<string, string | number>>()
+  for (const row of history) {
+    let entry = byDate.get(row.date)
+    if (!entry) {
+      entry = { date: row.date, [SOCIAL_TOTAL_KEY]: 0 }
+      byDate.set(row.date, entry)
+    }
+    const key = topSources.has(row.source) ? row.source : SOCIAL_OTHER_KEY
+    entry[key] = ((entry[key] as number) ?? 0) + row.sessions
+    entry[SOCIAL_TOTAL_KEY] = ((entry[SOCIAL_TOTAL_KEY] as number) ?? 0) + row.sessions
+  }
+
+  const data = [...byDate.values()].sort((a, b) =>
+    String(a.date).localeCompare(String(b.date)),
+  )
+
+  const sources = topEntries.map(([source]) => source)
+  if (otherCount > 0) sources.push(SOCIAL_OTHER_KEY)
+
+  return { data, sources, otherCount }
+}
+
+/** UTM-tagged sources often use `+` for spaces. Decode for display while keeping the raw value for tooltips/sorting. */
+export function decodeSocialSourceLabel(source: string): string {
+  return source.replace(/\+/g, ' ')
+}
+
+export function truncateLabel(label: string, max = 30): string {
+  if (label.length <= max) return label
+  return label.slice(0, Math.max(1, max - 1)) + '…'
+}

--- a/apps/web/test/social-chart-helpers.test.ts
+++ b/apps/web/test/social-chart-helpers.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from 'vitest'
+import {
+  SOCIAL_OTHER_KEY,
+  SOCIAL_TOTAL_KEY,
+  aggregateSocialChartData,
+  decodeSocialSourceLabel,
+  truncateLabel,
+} from '../src/lib/social-chart-helpers.js'
+import type { GA4SocialReferralHistoryEntry } from '../src/api.js'
+
+function makeRow(
+  date: string,
+  source: string,
+  sessions: number,
+  medium = 'social',
+  channelGroup = 'Organic Social',
+  users = sessions,
+): GA4SocialReferralHistoryEntry {
+  return { date, source, medium, channelGroup, sessions, users }
+}
+
+describe('aggregateSocialChartData', () => {
+  test('returns empty result for empty history', () => {
+    const agg = aggregateSocialChartData([])
+    expect(agg.data).toEqual([])
+    expect(agg.sources).toEqual([])
+    expect(agg.otherCount).toBe(0)
+  })
+
+  test('keeps all sources when count is within topN', () => {
+    const history = [
+      makeRow('2026-04-01', 'facebook.com', 10),
+      makeRow('2026-04-01', 'x.com', 4),
+      makeRow('2026-04-02', 'facebook.com', 6),
+    ]
+    const agg = aggregateSocialChartData(history, 6)
+    expect(agg.sources).toEqual(['facebook.com', 'x.com'])
+    expect(agg.otherCount).toBe(0)
+    expect(agg.data).toEqual([
+      { date: '2026-04-01', [SOCIAL_TOTAL_KEY]: 14, 'facebook.com': 10, 'x.com': 4 },
+      { date: '2026-04-02', [SOCIAL_TOTAL_KEY]: 6, 'facebook.com': 6 },
+    ])
+  })
+
+  test('sorts dates chronologically regardless of input order', () => {
+    const history = [
+      makeRow('2026-04-03', 'facebook.com', 1),
+      makeRow('2026-04-01', 'facebook.com', 1),
+      makeRow('2026-04-02', 'facebook.com', 1),
+    ]
+    const agg = aggregateSocialChartData(history)
+    expect(agg.data.map((d) => d.date)).toEqual(['2026-04-01', '2026-04-02', '2026-04-03'])
+  })
+
+  test('folds smaller sources into Other when count exceeds topN', () => {
+    const history = [
+      makeRow('2026-04-01', 'top1', 100),
+      makeRow('2026-04-01', 'top2', 90),
+      makeRow('2026-04-01', 'top3', 80),
+      makeRow('2026-04-01', 'small1', 10),
+      makeRow('2026-04-01', 'small2', 5),
+      makeRow('2026-04-01', 'small3', 1),
+    ]
+    const agg = aggregateSocialChartData(history, 3)
+    expect(agg.sources).toEqual(['top1', 'top2', 'top3', SOCIAL_OTHER_KEY])
+    expect(agg.otherCount).toBe(3)
+    const row = agg.data[0]!
+    expect(row['top1']).toBe(100)
+    expect(row['top2']).toBe(90)
+    expect(row['top3']).toBe(80)
+    expect(row[SOCIAL_OTHER_KEY]).toBe(16)
+    expect(row[SOCIAL_TOTAL_KEY]).toBe(286)
+    expect(row['small1']).toBeUndefined()
+  })
+
+  test('ranks by total sessions across the window, not per-day max', () => {
+    // x has higher single-day spike but lower total than y.
+    const history = [
+      makeRow('2026-04-01', 'x', 50),
+      makeRow('2026-04-02', 'y', 30),
+      makeRow('2026-04-03', 'y', 30),
+      makeRow('2026-04-04', 'y', 30),
+    ]
+    const agg = aggregateSocialChartData(history, 1)
+    expect(agg.sources).toEqual(['y', SOCIAL_OTHER_KEY])
+    expect(agg.otherCount).toBe(1)
+  })
+
+  test('break ties on equal totals by source name (deterministic)', () => {
+    const history = [
+      makeRow('2026-04-01', 'beta', 5),
+      makeRow('2026-04-01', 'alpha', 5),
+    ]
+    const agg = aggregateSocialChartData(history, 1)
+    expect(agg.sources).toEqual(['alpha', SOCIAL_OTHER_KEY])
+  })
+
+  test('Other count is zero when topN exactly equals source count', () => {
+    const history = [
+      makeRow('2026-04-01', 'a', 1),
+      makeRow('2026-04-01', 'b', 1),
+    ]
+    const agg = aggregateSocialChartData(history, 2)
+    expect(agg.sources).toEqual(['a', 'b'])
+    expect(agg.otherCount).toBe(0)
+    expect(agg.data[0]![SOCIAL_OTHER_KEY]).toBeUndefined()
+  })
+
+  test('Total equals sum of top sources plus Other for every date', () => {
+    const history = [
+      makeRow('2026-04-01', 'top', 100),
+      makeRow('2026-04-01', 'mid', 50),
+      makeRow('2026-04-01', 'low', 10),
+      makeRow('2026-04-02', 'top', 80),
+      makeRow('2026-04-02', 'low', 5),
+    ]
+    const agg = aggregateSocialChartData(history, 1)
+    for (const row of agg.data) {
+      const top = (row['top'] as number) ?? 0
+      const other = (row[SOCIAL_OTHER_KEY] as number) ?? 0
+      expect(top + other).toBe(row[SOCIAL_TOTAL_KEY])
+    }
+  })
+})
+
+describe('decodeSocialSourceLabel', () => {
+  test('replaces + with space (UTM-encoded campaigns)', () => {
+    expect(decodeSocialSourceLabel('HVAC+Facebook+Groups+Q1+2026')).toBe('HVAC Facebook Groups Q1 2026')
+  })
+
+  test('leaves non-+ characters intact', () => {
+    expect(decodeSocialSourceLabel('m.facebook.com')).toBe('m.facebook.com')
+    expect(decodeSocialSourceLabel('news|category')).toBe('news|category')
+  })
+})
+
+describe('truncateLabel', () => {
+  test('returns label unchanged when shorter than max', () => {
+    expect(truncateLabel('short', 10)).toBe('short')
+  })
+
+  test('appends ellipsis when too long', () => {
+    expect(truncateLabel('this is a long label', 10)).toBe('this is a…')
+  })
+
+  test('handles edge cases', () => {
+    expect(truncateLabel('', 10)).toBe('')
+    expect(truncateLabel('abc', 3)).toBe('abc')
+    expect(truncateLabel('abcd', 3)).toBe('ab…')
+  })
+})

--- a/apps/web/test/traffic-section.test.tsx
+++ b/apps/web/test/traffic-section.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import React from 'react'
 import { afterEach, expect, onTestFinished, test, vi } from 'vitest'
-import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 
 afterEach(cleanup)
 
@@ -211,4 +211,105 @@ test('renders four-channel breakdown with Organic, Social, Direct, and Known AI 
   expect(row).toBeTruthy()
   expect(within(row).getByText('chatgpt.com')).toBeTruthy()
   expect(within(row).getByText('12')).toBeTruthy()
+})
+
+test('social table collapses to top 25 with show-all toggle and surfaces Other-source rollup', async () => {
+  // 30 sources keeps the table over the 25-row default cap and forces top-N + Other in the chart
+  const longCampaignName = (i: number) =>
+    `HVAC+Facebook+Groups+Q1+2026+|+Closed+|+US+CAN+|+1k+sources+(${i.toString().padStart(2, '0')})`
+  const referrals = Array.from({ length: 30 }, (_, i) => ({
+    source: longCampaignName(i),
+    medium: 'paid_facebook_Mobile_Feed',
+    channelGroup: 'Paid Social' as const,
+    sessions: 100 - i,
+    users: 90 - i,
+  }))
+  const history = referrals.flatMap((r) => [
+    { date: '2026-04-01', source: r.source, medium: r.medium, channelGroup: r.channelGroup, sessions: r.sessions, users: r.users },
+    { date: '2026-04-02', source: r.source, medium: r.medium, channelGroup: r.channelGroup, sessions: Math.max(1, r.sessions - 5), users: Math.max(1, r.users - 5) },
+  ])
+
+  const restoreFetch = mockFetch((url) => {
+    const urlPath = url.split('?')[0]!
+    if (urlPath.endsWith('/projects/test-project/ga/status')) {
+      return jsonResponse({
+        connected: true,
+        propertyId: '999888',
+        clientEmail: 'sa@test.iam.gserviceaccount.com',
+        authMethod: 'service-account',
+        lastSyncedAt: '2026-04-02T12:00:00.000Z',
+        createdAt: '2026-04-02T12:00:00.000Z',
+        updatedAt: '2026-04-02T12:00:00.000Z',
+      })
+    }
+    if (urlPath.endsWith('/projects/test-project/ga/traffic')) {
+      const totalSessions = referrals.reduce((acc, r) => acc + r.sessions, 0)
+      return jsonResponse({
+        totalSessions,
+        totalOrganicSessions: 0,
+        totalDirectSessions: 0,
+        totalUsers: referrals.reduce((acc, r) => acc + r.users, 0),
+        topPages: [],
+        aiReferrals: [],
+        aiReferralLandingPages: [],
+        aiSessionsDeduped: 0,
+        aiUsersDeduped: 0,
+        aiSessionsBySession: 0,
+        aiUsersBySession: 0,
+        socialReferrals: referrals,
+        socialSessions: totalSessions,
+        socialUsers: referrals.reduce((acc, r) => acc + r.users, 0),
+        organicSharePct: 0,
+        aiSharePct: 0,
+        aiSharePctBySession: 0,
+        directSharePct: 0,
+        socialSharePct: 100,
+        lastSyncedAt: '2026-04-02T12:00:00.000Z',
+      })
+    }
+    if (urlPath.endsWith('/projects/test-project/ga/ai-referral-history')) return jsonResponse([])
+    if (urlPath.endsWith('/projects/test-project/ga/session-history')) return jsonResponse([])
+    if (urlPath.endsWith('/projects/test-project/ga/social-referral-history')) return jsonResponse(history)
+    throw new Error(`Unexpected fetch: ${url}`)
+  })
+  onTestFinished(restoreFetch)
+
+  render(<TrafficSection projectName="test-project" />)
+
+  await waitFor(() => {
+    expect(screen.getByText('Source / medium')).toBeTruthy()
+  })
+
+  // Top-N + Other notice: 30 sources, top 6 plotted, 24 collapsed into Other
+  expect(screen.getByText(/Showing top 6 sources · 24 more grouped as Other/)).toBeTruthy()
+
+  // Source / medium table starts collapsed at the default limit of 25
+  const breakdownCard = screen.getByText('Source / medium').closest('div.surface-card') as HTMLElement
+  expect(breakdownCard).toBeTruthy()
+  const breakdown = within(breakdownCard)
+  expect(breakdown.getByText('Top 25 of 30')).toBeTruthy()
+  expect(breakdown.queryAllByRole('row').length - 1 /* header */).toBe(25)
+
+  // Long source names render decoded — `+` becomes space — but the title attribute keeps the raw value
+  const decodedCell = breakdown.getAllByText(/HVAC Facebook Groups Q1 2026/)[0]!
+  expect(decodedCell).toBeTruthy()
+  expect(decodedCell.getAttribute('title')).toMatch(/HVAC\+Facebook\+Groups\+Q1\+2026/)
+
+  // Toggling the Show-all button expands to all 30 rows; toggling back returns to the cap
+  const showAllButton = breakdown.getByRole('button', { name: /Show all 30 sources/ })
+  act(() => {
+    fireEvent.click(showAllButton)
+  })
+  await waitFor(() => {
+    expect(breakdown.queryAllByRole('row').length - 1).toBe(30)
+  })
+  expect(breakdown.getByText('30 rows')).toBeTruthy()
+
+  const collapseButton = breakdown.getByRole('button', { name: /Show top 25/ })
+  act(() => {
+    fireEvent.click(collapseButton)
+  })
+  await waitFor(() => {
+    expect(breakdown.queryAllByRole('row').length - 1).toBe(25)
+  })
 })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "3.2.0",
+  "version": "3.2.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Summary
- Caps the social Source/medium table at 25 rows with a show-all/show-top toggle so long-tail campaigns no longer blow out the layout.
- Folds the trend chart to the top 6 sources plus an `Other` rollup, with a custom legend that mirrors the chart's colors.
- Decodes UTM `+` characters in source/medium labels for display while keeping the raw value in `title` tooltips and sort keys.
- Switches the breakdown table to fixed-width columns and extracts the aggregation/decoding logic into pure helpers covered by unit + integration tests.

## Test plan
- [x] `pnpm test --run social-chart-helpers` (13 cases)
- [x] `pnpm test --run traffic-section` (3 cases)
- [x] `pnpm typecheck`
- [x] `pnpm lint`