### PR TITLE
fix(matching): strip subdomains from competitor brand-token matching

### DIFF
--- a/apps/web/src/components/layout/EvidenceDetailModal.tsx
+++ b/apps/web/src/components/layout/EvidenceDetailModal.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import * as Dialog from '@radix-ui/react-dialog'
 import { X } from 'lucide-react'
-import { brandKeyFromText, effectiveDomains, normalizeProjectDomain } from '@ainyc/canonry-contracts'
+import { brandKeyFromText, brandLabelFromDomain, effectiveDomains, normalizeProjectDomain } from '@ainyc/canonry-contracts'
 
 import { InfoTooltip } from '../shared/InfoTooltip.js'
 import { highlightTermsInText, type HighlightTermGroup } from '../../lib/highlight.js'
@@ -146,11 +146,14 @@ export function EvidenceDetailModal({
     ...display.matchedTerms,
   ].filter(t => t.trim().length > 2)
 
-  // Build competitor highlight terms from overlap domains + recommended competitor names
+  // Build competitor highlight terms from overlap domains + recommended competitor names.
+  // Source the brand from the registrable domain — taking the leftmost label of
+  // a stored subdomain (e.g. `offers.roofle.com` → `offers`) would highlight
+  // arbitrary words like "offers" in the prose. Use `roofle` instead.
   const competitorHighlightTerms = [
     ...display.competitorDomains.flatMap(d => {
-      const brand = d.split('.')[0]
-      return brand && brand.length >= 4 ? [brand] : []
+      const brand = brandLabelFromDomain(d)
+      return brand.length >= 4 ? [brand] : []
     }),
     ...display.recommendedCompetitors,
   ].filter(t => t.trim().length > 2)

--- a/apps/web/src/lib/highlight.ts
+++ b/apps/web/src/lib/highlight.ts
@@ -1,9 +1,25 @@
 import type { ReactNode } from 'react'
 import React from 'react'
+import { brandKeyFromText } from '@ainyc/canonry-contracts'
 
 export interface HighlightTermGroup {
   terms: string[]
   className: string
+}
+
+const SEPARATOR_CHARS = /[\s\-_]+/
+
+/**
+ * Convert a term into a regex source that tolerates separator drift between
+ * the term and the answer text. A stored term `demand-iq` should highlight
+ * "Demand IQ" in prose; "AZ Coatings" should highlight "AZCoatings". Each run
+ * of space/hyphen/underscore in the term becomes `[\s\-_]*` (zero or more
+ * separators) in the regex. Returns `null` if the term reduces to nothing.
+ */
+function termToRegexSource(term: string): string | null {
+  const parts = term.split(SEPARATOR_CHARS).filter(Boolean)
+  if (parts.length === 0) return null
+  return parts.map(p => p.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('[\\s\\-_]*')
 }
 
 /**
@@ -34,17 +50,30 @@ export function highlightTermsInText(text: string, terms: string[] | HighlightTe
     ).filter(Boolean) as ReactNode[]
   }
 
-  // Build a single regex from all terms (longest first to avoid partial matches)
+  // Build a single regex from all terms (longest first to avoid partial matches).
+  // Each term becomes a separator-tolerant alternative so a slug like
+  // `demand-iq` still matches the spaced "Demand IQ" form in answer prose.
   const sorted = [...allTerms].sort((a, b) => b.length - a.length)
-  const escaped = sorted.map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-  const regex = new RegExp(`(${escaped.join('|')})`, 'gi')
+  const sources = sorted
+    .map(termToRegexSource)
+    .filter((s): s is string => Boolean(s))
+  if (sources.length === 0) {
+    return segments.map((seg, i) =>
+      seg.type === 'bold'
+        ? React.createElement('strong', { key: `b-${i}`, className: 'text-zinc-200 font-semibold' }, seg.value)
+        : seg.value,
+    ).filter(Boolean) as ReactNode[]
+  }
+  const regex = new RegExp(`(${sources.join('|')})`, 'gi')
 
-  // Build a lookup: lowercase term → className (first group wins)
+  // Build a lookup keyed by brand-key (alphanumeric-only lowercase) so a
+  // matched span like "Demand IQ" reverse-maps to a term registered as
+  // `demand-iq` (both produce key `demandiq`).
   const termClassMap = new Map<string, string>()
   for (const group of groups) {
     for (const term of group.terms) {
-      const key = term.toLowerCase()
-      if (!termClassMap.has(key)) {
+      const key = brandKeyFromText(term)
+      if (key && !termClassMap.has(key)) {
         termClassMap.set(key, group.className)
       }
     }
@@ -56,7 +85,7 @@ export function highlightTermsInText(text: string, terms: string[] | HighlightTe
       if (!part) return null
       const isMatch = pi % 2 === 1
       if (isMatch) {
-        const cls = termClassMap.get(part.toLowerCase()) ?? 'answer-highlight'
+        const cls = termClassMap.get(brandKeyFromText(part)) ?? 'answer-highlight'
         return seg.type === 'bold'
           ? React.createElement('mark', { key: `hl-${si}-${pi}`, className: cls },
               React.createElement('strong', { className: 'text-zinc-200 font-semibold' }, part))

--- a/apps/web/test/highlight.test.ts
+++ b/apps/web/test/highlight.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import type { ReactElement } from 'react'
+
+import { highlightTermsInText } from '../src/lib/highlight.js'
+
+interface MarkProps {
+  className: string
+  children: unknown
+}
+
+function findMarks(nodes: ReturnType<typeof highlightTermsInText>): MarkProps[] {
+  const marks: MarkProps[] = []
+  for (const node of nodes) {
+    if (node && typeof node === 'object' && 'type' in node) {
+      const el = node as ReactElement<MarkProps>
+      if (el.type === 'mark') marks.push(el.props)
+    }
+  }
+  return marks
+}
+
+describe('highlightTermsInText separator-tolerant matching', () => {
+  it('highlights "Demand IQ" in prose when the term is the slug "demand-iq"', () => {
+    const nodes = highlightTermsInText(
+      'Demand IQ uses AI-driven instant estimates to attract homeowners.',
+      [{ terms: ['demand-iq'], className: 'answer-highlight-brand' }],
+    )
+    const marks = findMarks(nodes)
+    expect(marks).toHaveLength(1)
+    expect(marks[0].children).toBe('Demand IQ')
+    expect(marks[0].className).toBe('answer-highlight-brand')
+  })
+
+  it('highlights "Demand-IQ" hyphen form when the term is the slug', () => {
+    const nodes = highlightTermsInText(
+      'See the Demand-IQ pricing page.',
+      [{ terms: ['demand-iq'], className: 'answer-highlight-brand' }],
+    )
+    const marks = findMarks(nodes)
+    expect(marks).toHaveLength(1)
+    expect(marks[0].children).toBe('Demand-IQ')
+  })
+
+  it('highlights "DemandIQ" concatenated form', () => {
+    const nodes = highlightTermsInText(
+      'Visit DemandIQ for details.',
+      [{ terms: ['demand-iq'], className: 'answer-highlight-brand' }],
+    )
+    const marks = findMarks(nodes)
+    expect(marks).toHaveLength(1)
+    expect(marks[0].children).toBe('DemandIQ')
+  })
+
+  it('highlights every separator variant given a spaced display name', () => {
+    const nodes = highlightTermsInText(
+      'AZ Coatings, AZ-Coatings, and AZCoatings are all the same brand.',
+      [{ terms: ['AZ Coatings'], className: 'answer-highlight-brand' }],
+    )
+    const marks = findMarks(nodes)
+    expect(marks.map(m => m.children)).toEqual(['AZ Coatings', 'AZ-Coatings', 'AZCoatings'])
+  })
+
+  it('still matches a single-word term against itself', () => {
+    const nodes = highlightTermsInText(
+      'Roofle ships install quote engines.',
+      [{ terms: ['Roofle'], className: 'answer-highlight-competitor' }],
+    )
+    const marks = findMarks(nodes)
+    expect(marks).toHaveLength(1)
+    expect(marks[0].children).toBe('Roofle')
+    expect(marks[0].className).toBe('answer-highlight-competitor')
+  })
+
+  it('keeps domain literal matches intact (does not allow separator drift inside dots)', () => {
+    // `acme.com` should match the literal domain in prose; it should NOT
+    // match the phrase "acme com" (separators don't substitute for the dot).
+    const nodes = highlightTermsInText(
+      'Visit acme.com for pricing. Acme com is unrelated.',
+      [{ terms: ['acme.com'], className: 'answer-highlight-brand' }],
+    )
+    const marks = findMarks(nodes)
+    expect(marks).toHaveLength(1)
+    expect(marks[0].children).toBe('acme.com')
+  })
+
+  it('routes the matched span back to the right group via brand-key', () => {
+    const nodes = highlightTermsInText(
+      'Demand IQ partners with Roofle.',
+      [
+        { terms: ['demand-iq'], className: 'answer-highlight-brand' },
+        { terms: ['roofle'], className: 'answer-highlight-competitor' },
+      ],
+    )
+    const marks = findMarks(nodes)
+    const byText = Object.fromEntries(marks.map(m => [m.children, m.className]))
+    expect(byText['Demand IQ']).toBe('answer-highlight-brand')
+    expect(byText['Roofle']).toBe('answer-highlight-competitor')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "3.2.5",
+  "version": "3.2.6",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "3.2.2",
+  "version": "3.2.3",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/apply.ts
+++ b/packages/api-routes/src/apply.ts
@@ -2,7 +2,7 @@ import crypto from 'node:crypto'
 import { eq } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import { projects, keywords, competitors, schedules, notifications, parseJsonColumn } from '@ainyc/canonry-db'
-import { projectConfigSchema, validationError } from '@ainyc/canonry-contracts'
+import { normalizeProjectDomain, projectConfigSchema, registrableDomain, validationError } from '@ainyc/canonry-contracts'
 import { writeAuditLog } from './helpers.js'
 import { resolvePreset, validateCron, isValidTimezone } from './schedule-utils.js'
 import { resolveWebhookTarget } from './webhooks.js'
@@ -173,7 +173,8 @@ export async function applyRoutes(app: FastifyInstance, opts?: ApplyRoutesOption
       })
 
       tx.delete(competitors).where(eq(competitors.projectId, projectId)).run()
-      for (const domain of config.spec.competitors) {
+      const normalizedCompetitors = normalizeCompetitorList(config.spec.competitors)
+      for (const domain of normalizedCompetitors) {
         tx.insert(competitors).values({
           id: crypto.randomUUID(),
           projectId,
@@ -187,7 +188,7 @@ export async function applyRoutes(app: FastifyInstance, opts?: ApplyRoutesOption
         actor: 'api',
         action: 'competitors.replaced',
         entityType: 'competitor',
-        diff: { competitors: config.spec.competitors },
+        diff: { competitors: normalizedCompetitors },
       })
 
       // Handle schedule
@@ -282,4 +283,21 @@ export async function applyRoutes(app: FastifyInstance, opts?: ApplyRoutesOption
       updatedAt: project.updatedAt,
     })
   })
+}
+
+// Reduce competitor domains to their registrable form (eTLD+1) and dedupe.
+// Mirrors the helper in `competitors.ts` so both the YAML apply path and the
+// REST endpoints store competitors uniformly without subdomain noise.
+function normalizeCompetitorList(domains: readonly string[]): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const raw of domains) {
+    const trimmed = raw?.trim()
+    if (!trimmed) continue
+    const normalized = registrableDomain(trimmed) || normalizeProjectDomain(trimmed)
+    if (!normalized || seen.has(normalized)) continue
+    seen.add(normalized)
+    result.push(normalized)
+  }
+  return result
 }

--- a/packages/api-routes/src/competitors.ts
+++ b/packages/api-routes/src/competitors.ts
@@ -2,8 +2,33 @@ import crypto from 'node:crypto'
 import { eq } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import { competitors } from '@ainyc/canonry-db'
-import { competitorBatchRequestSchema, validationError } from '@ainyc/canonry-contracts'
+import { competitorBatchRequestSchema, normalizeProjectDomain, registrableDomain, validationError } from '@ainyc/canonry-contracts'
 import { resolveProject, writeAuditLog } from './helpers.js'
+
+// Reduce a competitor domain to its registrable form (eTLD+1) so that
+// arbitrary subdomain labels like `offers` in `offers.roofle.com` cannot
+// leak into brand-token matching against answer text. Falls back to the
+// normalized hostname when the input has no recognizable TLD (e.g. invalid
+// domains or single-label hostnames) — let downstream matching handle those.
+function normalizeCompetitor(domain: string): string {
+  const reg = registrableDomain(domain)
+  if (reg) return reg
+  return normalizeProjectDomain(domain)
+}
+
+function normalizeCompetitorList(domains: readonly string[]): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const raw of domains) {
+    const trimmed = raw?.trim()
+    if (!trimmed) continue
+    const normalized = normalizeCompetitor(trimmed)
+    if (!normalized || seen.has(normalized)) continue
+    seen.add(normalized)
+    result.push(normalized)
+  }
+  return result
+}
 
 export async function competitorRoutes(app: FastifyInstance) {
   // GET /projects/:name/competitors
@@ -26,12 +51,13 @@ export async function competitorRoutes(app: FastifyInstance) {
     }
 
     const now = new Date().toISOString()
+    const normalizedCompetitors = normalizeCompetitorList(body.competitors)
 
     // Atomic replace: delete + insert in a single transaction
     app.db.transaction((tx) => {
       tx.delete(competitors).where(eq(competitors.projectId, project.id)).run()
 
-      for (const domain of body.competitors) {
+      for (const domain of normalizedCompetitors) {
         tx.insert(competitors).values({
           id: crypto.randomUUID(),
           projectId: project.id,
@@ -45,7 +71,7 @@ export async function competitorRoutes(app: FastifyInstance) {
         actor: 'api',
         action: 'competitors.replaced',
         entityType: 'competitor',
-        diff: { competitors: body.competitors },
+        diff: { competitors: normalizedCompetitors },
       })
     })
 
@@ -62,7 +88,7 @@ export async function competitorRoutes(app: FastifyInstance) {
     const body = parseCompetitorBatch(request.body)
 
     const now = new Date().toISOString()
-    const requested = uniqueStrings(body.competitors)
+    const requested = normalizeCompetitorList(body.competitors)
 
     app.db.transaction((tx) => {
       const existing = tx
@@ -107,7 +133,10 @@ export async function competitorRoutes(app: FastifyInstance) {
     const project = resolveProject(app.db, request.params.name)
     const body = parseCompetitorBatch(request.body)
 
-    const requested = new Set(uniqueStrings(body.competitors))
+    // Normalize delete targets so callers can pass either the original or the
+    // subdomain form (e.g. `offers.roofle.com`) and still hit the stored
+    // registrable form (`roofle.com`).
+    const requested = new Set(normalizeCompetitorList(body.competitors))
 
     app.db.transaction((tx) => {
       const existing = tx
@@ -146,15 +175,4 @@ function parseCompetitorBatch(value: unknown) {
       message: issue.message,
     })),
   })
-}
-
-function uniqueStrings(values: readonly string[]): string[] {
-  const seen = new Set<string>()
-  const result: string[] = []
-  for (const value of values) {
-    if (seen.has(value)) continue
-    seen.add(value)
-    result.push(value)
-  }
-  return result
 }

--- a/packages/api-routes/test/index.test.ts
+++ b/packages/api-routes/test/index.test.ts
@@ -229,21 +229,80 @@ describe('api-routes', () => {
     const first = await app.inject({
       method: 'POST',
       url: '/api/v1/projects/competitor-append/competitors',
-      payload: { competitors: ['rival.example.com', 'rival.example.com'] },
+      payload: { competitors: ['rival.com', 'rival.com'] },
     })
     expect(first.statusCode).toBe(200)
-    expect(JSON.parse(first.payload).map((row: { domain: string }) => row.domain)).toEqual(['rival.example.com'])
+    expect(JSON.parse(first.payload).map((row: { domain: string }) => row.domain)).toEqual(['rival.com'])
 
     const second = await app.inject({
       method: 'POST',
       url: '/api/v1/projects/competitor-append/competitors',
-      payload: { competitors: ['rival.example.com', 'other.example.com'] },
+      payload: { competitors: ['rival.com', 'other-rival.com'] },
     })
     expect(second.statusCode).toBe(200)
     expect(JSON.parse(second.payload).map((row: { domain: string }) => row.domain).sort()).toEqual([
-      'other.example.com',
-      'rival.example.com',
+      'other-rival.com',
+      'rival.com',
     ])
+  })
+
+  it('POST /api/v1/projects/:name/competitors strips subdomains and dedupes', async () => {
+    await app.inject({
+      method: 'PUT',
+      url: '/api/v1/projects/competitor-normalize',
+      payload: {
+        displayName: 'Competitor Normalize',
+        canonicalDomain: 'normalize.example.com',
+        country: 'US',
+        language: 'en',
+      },
+    })
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/competitor-normalize/competitors',
+      payload: {
+        competitors: [
+          'offers.roofle.com',
+          'https://www.Roofle.com/pricing',
+          'app.acme.io',
+        ],
+      },
+    })
+    expect(res.statusCode).toBe(200)
+    expect(JSON.parse(res.payload).map((row: { domain: string }) => row.domain).sort()).toEqual([
+      'acme.io',
+      'roofle.com',
+    ])
+  })
+
+  it('DELETE /api/v1/projects/:name/competitors normalizes the request before matching', async () => {
+    await app.inject({
+      method: 'PUT',
+      url: '/api/v1/projects/competitor-delete-normalized',
+      payload: {
+        displayName: 'Competitor Delete Normalized',
+        canonicalDomain: 'delete-normalized.example.com',
+        country: 'US',
+        language: 'en',
+      },
+    })
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/competitor-delete-normalized/competitors',
+      payload: { competitors: ['offers.roofle.com'] },
+    })
+
+    // Caller passes the original subdomain form; server normalizes and finds
+    // the stored `roofle.com` row.
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/v1/projects/competitor-delete-normalized/competitors',
+      payload: { competitors: ['offers.roofle.com'] },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(JSON.parse(res.payload)).toEqual([])
   })
 
   it('DELETE /api/v1/projects/:name/competitors removes specific competitors', async () => {
@@ -260,17 +319,17 @@ describe('api-routes', () => {
     await app.inject({
       method: 'POST',
       url: '/api/v1/projects/competitor-delete/competitors',
-      payload: { competitors: ['rival.example.com', 'other.example.com'] },
+      payload: { competitors: ['rival.com', 'other-rival.com'] },
     })
 
     const res = await app.inject({
       method: 'DELETE',
       url: '/api/v1/projects/competitor-delete/competitors',
-      payload: { competitors: ['rival.example.com', 'missing.example.com'] },
+      payload: { competitors: ['rival.com', 'missing-rival.com'] },
     })
 
     expect(res.statusCode).toBe(200)
-    expect(JSON.parse(res.payload).map((row: { domain: string }) => row.domain)).toEqual(['other.example.com'])
+    expect(JSON.parse(res.payload).map((row: { domain: string }) => row.domain)).toEqual(['other-rival.com'])
   })
 
   it('POST /api/v1/projects/:name/runs triggers a run', async () => {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/citation-utils.ts
+++ b/packages/canonry/src/citation-utils.ts
@@ -1,5 +1,5 @@
 import type { NormalizedQueryResult } from '@ainyc/canonry-contracts'
-import { brandKeyFromText, normalizeProjectDomain } from '@ainyc/canonry-contracts'
+import { brandKeyFromText, brandLabelFromDomain, normalizeProjectDomain, registrableDomain } from '@ainyc/canonry-contracts'
 
 function domainMatches(domain: string, canonicalDomain: string): boolean {
   const normalized = normalizeProjectDomain(canonicalDomain)
@@ -69,14 +69,22 @@ export function computeCompetitorOverlap(
       if (lowerAnswer.includes(cd.toLowerCase())) {
         overlapSet.add(cd)
       }
-      const brand = cd.split('.')[0]
-      if (brand && brand.length >= 4 && new RegExp(`\\b${brand}\\b`, 'i').test(lowerAnswer)) {
+      // Use the registrable domain's brand label (eTLD+1's leftmost label) so
+      // a stored competitor like `offers.roofle.com` is matched against the
+      // brand `roofle`, not the subdomain `offers` — otherwise the literal
+      // word "offers" in the answer prose would falsely flag the competitor.
+      const brand = brandLabelFromDomain(cd)
+      if (brand.length >= 4 && new RegExp(`\\b${escapeRegExp(brand)}\\b`, 'i').test(lowerAnswer)) {
         overlapSet.add(cd)
       }
     }
   }
 
   return [...overlapSet]
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 /**
@@ -169,18 +177,21 @@ function cleanCandidateName(candidate: string): string {
 }
 
 function collectBrandKeysFromDomain(domain: string): string[] {
-  const hostname = normalizeProjectDomain(domain).split('/')[0] ?? ''
-  const labels = hostname.split('.').filter(Boolean)
-  const keys = new Set<string>()
-
-  const hostnameKey = hostname.replace(/[^a-z0-9]/gi, '').toLowerCase()
-  if (hostnameKey.length >= 4) keys.add(hostnameKey)
-
-  for (const label of labels) {
-    const key = label.replace(/[^a-z0-9]/gi, '').toLowerCase()
-    if (key.length >= 4) keys.add(key)
+  // Source brand keys from the registrable domain only — never from
+  // subdomain labels — so a competitor `offers.roofle.com` does not contribute
+  // `offers` as a brand key (which would let the answer-text word "offers"
+  // false-match in extractRecommendedCompetitors).
+  const reg = registrableDomain(domain)
+  if (!reg) {
+    const hostname = normalizeProjectDomain(domain).split('/')[0] ?? ''
+    const fallback = hostname.replace(/[^a-z0-9]/gi, '').toLowerCase()
+    return fallback.length >= 4 ? [fallback] : []
   }
-
+  const keys = new Set<string>()
+  const fullKey = reg.replace(/[^a-z0-9]/gi, '').toLowerCase()
+  if (fullKey.length >= 4) keys.add(fullKey)
+  const brand = brandLabelFromDomain(reg).replace(/[^a-z0-9]/gi, '').toLowerCase()
+  if (brand.length >= 4) keys.add(brand)
   return [...keys]
 }
 

--- a/packages/canonry/src/cli-commands/backfill.ts
+++ b/packages/canonry/src/cli-commands/backfill.ts
@@ -1,4 +1,4 @@
-import { backfillAiReferralPathsCommand, backfillAnswerVisibilityCommand, backfillInsightsCommand, backfillNormalizedPathsCommand } from '../commands/backfill.js'
+import { backfillAiReferralPathsCommand, backfillAnswerMentionsCommand, backfillAnswerVisibilityCommand, backfillInsightsCommand, backfillNormalizedPathsCommand } from '../commands/backfill.js'
 import type { CliCommandSpec } from '../cli-dispatch.js'
 import { requireProject, getString, stringOption, unknownSubcommand } from '../cli-command-helpers.js'
 
@@ -12,6 +12,20 @@ export const BACKFILL_CLI_COMMANDS: readonly CliCommandSpec[] = [
     allowPositionals: false,
     run: async (input) => {
       await backfillAnswerVisibilityCommand({
+        project: getString(input.values, 'project'),
+        format: input.format,
+      })
+    },
+  },
+  {
+    path: ['backfill', 'answer-mentions'],
+    usage: 'canonry backfill answer-mentions [--project <name>] [--format json]',
+    options: {
+      project: stringOption(),
+    },
+    allowPositionals: false,
+    run: async (input) => {
+      await backfillAnswerMentionsCommand({
         project: getString(input.values, 'project'),
         format: input.format,
       })
@@ -64,12 +78,12 @@ export const BACKFILL_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['backfill'],
-    usage: 'canonry backfill <answer-visibility|insights|normalized-paths|ai-referral-paths> [options]',
+    usage: 'canonry backfill <answer-visibility|answer-mentions|insights|normalized-paths|ai-referral-paths> [options]',
     run: async (input) => {
       unknownSubcommand(input.positionals[0], {
         command: 'backfill',
-        usage: 'canonry backfill <answer-visibility|insights|normalized-paths|ai-referral-paths> [options]',
-        available: ['answer-visibility', 'insights', 'normalized-paths', 'ai-referral-paths'],
+        usage: 'canonry backfill <answer-visibility|answer-mentions|insights|normalized-paths|ai-referral-paths> [options]',
+        available: ['answer-visibility', 'answer-mentions', 'insights', 'normalized-paths', 'ai-referral-paths'],
       })
     },
   },

--- a/packages/canonry/src/commands/backfill.ts
+++ b/packages/canonry/src/commands/backfill.ts
@@ -439,6 +439,189 @@ export async function backfillAiReferralPathsCommand(opts?: {
   console.log(`  Unchanged: ${unchanged}`)
 }
 
+/**
+ * Lighter sibling of `backfillAnswerVisibilityCommand` — recomputes only the
+ * three fields affected by the brand-token matching fix (`answerMentioned`,
+ * `competitorOverlap`, `recommendedCompetitors`) using the snapshot's stored
+ * `answerText` + `citedDomains` and the `groundingSources` already cached in
+ * the `rawResponse` envelope. No provider-specific reparse, so it covers
+ * snapshots from providers without a reparse adapter (cdp, local, ...) and
+ * is fast enough to re-run after any future matching-logic change.
+ *
+ * Does not touch `citationState`, `citedDomains`, or `rawResponse` — those
+ * are computed by domain-to-domain matching, which this PR did not change.
+ */
+export async function backfillAnswerMentionsCommand(opts?: {
+  project?: string
+  format?: CliFormat
+}): Promise<void> {
+  const config = loadConfig()
+  const db = createClient(config.database)
+  migrate(db)
+
+  const projectFilter = opts?.project?.trim()
+
+  const scopedProjects = projectFilter
+    ? db.select().from(projects).where(eq(projects.name, projectFilter)).all()
+    : db.select().from(projects).all()
+
+  let examined = 0
+  let updated = 0
+  let mentioned = 0
+
+  if (scopedProjects.length > 0) {
+    const runRows = projectFilter
+      ? db
+        .select({ id: runs.id, projectId: runs.projectId })
+        .from(runs)
+        .where(and(
+          eq(runs.kind, RunKinds['answer-visibility']),
+          inArray(runs.projectId, scopedProjects.map(project => project.id)),
+        ))
+        .all()
+      : db
+        .select({ id: runs.id, projectId: runs.projectId })
+        .from(runs)
+        .where(eq(runs.kind, RunKinds['answer-visibility']))
+        .all()
+
+    const runIdsByProject = new Map<string, string[]>()
+    for (const run of runRows) {
+      const existing = runIdsByProject.get(run.projectId)
+      if (existing) existing.push(run.id)
+      else runIdsByProject.set(run.projectId, [run.id])
+    }
+
+    for (const project of scopedProjects) {
+      const competitorDomains = db
+        .select({ domain: competitors.domain })
+        .from(competitors)
+        .where(eq(competitors.projectId, project.id))
+        .all()
+        .map(row => row.domain)
+      const runIds = runIdsByProject.get(project.id) ?? []
+      if (runIds.length === 0) continue
+
+      const projectDomains = effectiveDomains({
+        canonicalDomain: project.canonicalDomain,
+        ownedDomains: parseJsonColumn<string[]>(project.ownedDomains, []),
+      })
+
+      for (let offset = 0; offset < runIds.length; offset += SNAPSHOT_BATCH_SIZE) {
+        const batchRunIds = runIds.slice(offset, offset + SNAPSHOT_BATCH_SIZE)
+        const snapshotRows = db.select({
+          id: querySnapshots.id,
+          provider: querySnapshots.provider,
+          answerMentioned: querySnapshots.answerMentioned,
+          answerText: querySnapshots.answerText,
+          citedDomains: querySnapshots.citedDomains,
+          competitorOverlap: querySnapshots.competitorOverlap,
+          recommendedCompetitors: querySnapshots.recommendedCompetitors,
+          rawResponse: querySnapshots.rawResponse,
+        }).from(querySnapshots)
+          .where(inArray(querySnapshots.runId, batchRunIds))
+          .all()
+        const pendingUpdates: Array<{ id: string; patch: Record<string, unknown> }> = []
+
+        for (const snapshot of snapshotRows) {
+          examined++
+
+          const answerText = snapshot.answerText ?? ''
+          const nextAnswerMentioned = determineAnswerMentioned(answerText, project.displayName, projectDomains)
+          if (nextAnswerMentioned) mentioned++
+
+          const citedDomains = parseJsonColumn<string[]>(snapshot.citedDomains, [])
+          const groundingSources = readStoredGroundingSources(snapshot.rawResponse)
+
+          const normalized: NormalizedQueryResult = {
+            provider: snapshot.provider,
+            answerText,
+            citedDomains,
+            groundingSources,
+            searchQueries: [],
+          }
+
+          const nextCompetitorOverlap = JSON.stringify(
+            computeCompetitorOverlap(normalized, competitorDomains),
+          )
+          const nextRecommendedCompetitors = JSON.stringify(
+            extractRecommendedCompetitors(
+              answerText,
+              projectDomains,
+              citedDomains,
+              competitorDomains,
+            ),
+          )
+
+          const nextPatch: Record<string, unknown> = {}
+          if (snapshot.answerMentioned !== nextAnswerMentioned) {
+            nextPatch.answerMentioned = nextAnswerMentioned
+          }
+          if (snapshot.competitorOverlap !== nextCompetitorOverlap) {
+            nextPatch.competitorOverlap = nextCompetitorOverlap
+          }
+          if (snapshot.recommendedCompetitors !== nextRecommendedCompetitors) {
+            nextPatch.recommendedCompetitors = nextRecommendedCompetitors
+          }
+
+          if (Object.keys(nextPatch).length > 0) {
+            pendingUpdates.push({ id: snapshot.id, patch: nextPatch })
+          }
+        }
+
+        if (pendingUpdates.length > 0) {
+          db.transaction((tx) => {
+            for (const update of pendingUpdates) {
+              tx.update(querySnapshots)
+                .set(update.patch)
+                .where(eq(querySnapshots.id, update.id))
+                .run()
+            }
+          })
+          updated += pendingUpdates.length
+        }
+      }
+    }
+  }
+
+  const result = {
+    project: projectFilter ?? null,
+    projects: scopedProjects.length,
+    examined,
+    updated,
+    mentioned,
+  }
+
+  if (opts?.format === 'json') {
+    console.log(JSON.stringify(result, null, 2))
+    return
+  }
+
+  console.log('Answer mentions backfill complete.\n')
+  if (projectFilter) console.log(`  Project:   ${projectFilter}`)
+  console.log(`  Projects:  ${scopedProjects.length}`)
+  console.log(`  Examined:  ${examined}`)
+  console.log(`  Updated:   ${updated}`)
+  console.log(`  Mentioned: ${mentioned}`)
+}
+
+function readStoredGroundingSources(rawResponse: string | null): GroundingSource[] {
+  const envelope = parseJsonColumn<Record<string, unknown>>(rawResponse, {})
+  const sources = envelope.groundingSources
+  if (!Array.isArray(sources)) return []
+  const result: GroundingSource[] = []
+  for (const source of sources) {
+    if (source && typeof source === 'object') {
+      const uri = (source as { uri?: unknown }).uri
+      const title = (source as { title?: unknown }).title
+      if (typeof uri === 'string') {
+        result.push({ uri, title: typeof title === 'string' ? title : '' })
+      }
+    }
+  }
+  return result
+}
+
 export async function backfillInsightsCommand(
   project: string,
   opts?: { fromRun?: string; toRun?: string; format?: CliFormat },

--- a/packages/canonry/test/backfill-answer-mentions.test.ts
+++ b/packages/canonry/test/backfill-answer-mentions.test.ts
@@ -1,0 +1,355 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  competitors,
+  createClient,
+  keywords,
+  migrate,
+  projects,
+  querySnapshots,
+  runs,
+} from '@ainyc/canonry-db'
+import { eq } from 'drizzle-orm'
+import { RunKinds } from '@ainyc/canonry-contracts'
+import { backfillAnswerMentionsCommand } from '../src/commands/backfill.js'
+
+describe('backfill answer-mentions', () => {
+  let tmpDir: string
+  let configDir: string
+  let dbPath: string
+  let db: ReturnType<typeof createClient>
+  let originalConfigDir: string | undefined
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-backfill-mentions-'))
+    configDir = path.join(tmpDir, 'config')
+    fs.mkdirSync(configDir, { recursive: true })
+    dbPath = path.join(tmpDir, 'canonry.db')
+    db = createClient(dbPath)
+    migrate(db)
+
+    originalConfigDir = process.env.CANONRY_CONFIG_DIR
+    process.env.CANONRY_CONFIG_DIR = configDir
+    fs.writeFileSync(
+      path.join(configDir, 'config.yaml'),
+      JSON.stringify({
+        apiUrl: 'http://localhost:4100',
+        database: dbPath,
+        apiKey: 'cnry_test_key',
+        providers: {},
+      }),
+      'utf-8',
+    )
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    if (originalConfigDir === undefined) {
+      delete process.env.CANONRY_CONFIG_DIR
+    } else {
+      process.env.CANONRY_CONFIG_DIR = originalConfigDir
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function seedAnswerVisibilityRun(opts: {
+    projectName: string
+    competitorDomains: string[]
+  }): { projectId: string; runId: string; keywordId: string } {
+    const projectId = crypto.randomUUID()
+    const runId = crypto.randomUUID()
+    const keywordId = crypto.randomUUID()
+    const now = new Date().toISOString()
+
+    db.insert(projects).values({
+      id: projectId,
+      name: opts.projectName,
+      displayName: 'Demand IQ',
+      canonicalDomain: 'demand-iq.com',
+      ownedDomains: '[]',
+      country: 'US',
+      language: 'en',
+      providers: '["openai"]',
+      createdAt: now,
+      updatedAt: now,
+    }).run()
+
+    for (const domain of opts.competitorDomains) {
+      db.insert(competitors).values({
+        id: crypto.randomUUID(),
+        projectId,
+        domain,
+        createdAt: now,
+      }).run()
+    }
+
+    db.insert(runs).values({
+      id: runId,
+      projectId,
+      kind: RunKinds['answer-visibility'],
+      status: 'completed',
+      trigger: 'manual',
+      createdAt: now,
+    }).run()
+
+    db.insert(keywords).values({
+      id: keywordId,
+      projectId,
+      keyword: 'instant roof estimate',
+      createdAt: now,
+    }).run()
+
+    return { projectId, runId, keywordId }
+  }
+
+  it('clears stale competitorOverlap when a stored subdomained competitor caused a brand-token false match', async () => {
+    // Pre-fix data: stored competitor `offers.roofle.com`, the original code
+    // pulled `offers` as the brand label and word-boundary matched it against
+    // the prose word "offers", marking the snapshot as having competitor
+    // overlap when in fact Roofle isn't mentioned at all.
+    const { runId, keywordId } = seedAnswerVisibilityRun({
+      projectName: 'demand-iq',
+      competitorDomains: ['offers.roofle.com'],
+    })
+    const now = new Date().toISOString()
+
+    const snapshotId = crypto.randomUUID()
+    db.insert(querySnapshots).values({
+      id: snapshotId,
+      runId,
+      keywordId,
+      provider: 'openai',
+      model: 'gpt-5',
+      citationState: 'not-cited',
+      answerMentioned: false,
+      answerText: 'Energy Design Systems offers a white-label lead generation tool. Demand IQ uses AI-driven estimates.',
+      citedDomains: '[]',
+      competitorOverlap: '["offers.roofle.com"]',
+      recommendedCompetitors: '[]',
+      rawResponse: JSON.stringify({ groundingSources: [], searchQueries: [] }),
+      createdAt: now,
+    }).run()
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    await backfillAnswerMentionsCommand({ project: 'demand-iq', format: 'json' })
+    const result = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0] ?? '{}'))
+
+    expect(result.examined).toBe(1)
+    expect(result.updated).toBe(1)
+
+    const snapshot = db
+      .select()
+      .from(querySnapshots)
+      .where(eq(querySnapshots.id, snapshotId))
+      .get()
+    expect(JSON.parse(snapshot!.competitorOverlap)).toEqual([])
+    expect(snapshot!.answerMentioned).toBe(true)
+  })
+
+  it('still flags overlap when the answer text mentions the registrable brand', async () => {
+    const { runId, keywordId } = seedAnswerVisibilityRun({
+      projectName: 'demand-iq-positive',
+      competitorDomains: ['offers.roofle.com'],
+    })
+    const now = new Date().toISOString()
+
+    const snapshotId = crypto.randomUUID()
+    db.insert(querySnapshots).values({
+      id: snapshotId,
+      runId,
+      keywordId,
+      provider: 'openai',
+      model: 'gpt-5',
+      citationState: 'not-cited',
+      answerMentioned: false,
+      answerText: 'Brokers turn to Roofle when they need quick install quotes.',
+      citedDomains: '[]',
+      competitorOverlap: '[]',
+      recommendedCompetitors: '[]',
+      rawResponse: JSON.stringify({ groundingSources: [], searchQueries: [] }),
+      createdAt: now,
+    }).run()
+
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    await backfillAnswerMentionsCommand({ project: 'demand-iq-positive', format: 'json' })
+
+    const snapshot = db
+      .select()
+      .from(querySnapshots)
+      .where(eq(querySnapshots.id, snapshotId))
+      .get()
+    expect(JSON.parse(snapshot!.competitorOverlap)).toEqual(['offers.roofle.com'])
+  })
+
+  it('updates snapshots from providers without a reparse adapter (covers the gap left by answer-visibility backfill)', async () => {
+    // CDP/local providers don't have a reparse adapter, so the existing
+    // `backfill answer-visibility` command would skip recomputing
+    // competitorOverlap/recommendedCompetitors for them. This lighter
+    // backfill works off stored data and patches that gap.
+    const { runId, keywordId } = seedAnswerVisibilityRun({
+      projectName: 'cdp-project',
+      competitorDomains: ['offers.roofle.com'],
+    })
+    const now = new Date().toISOString()
+
+    const snapshotId = crypto.randomUUID()
+    db.insert(querySnapshots).values({
+      id: snapshotId,
+      runId,
+      keywordId,
+      provider: 'cdp',
+      model: 'chrome',
+      citationState: 'not-cited',
+      answerMentioned: false,
+      answerText: 'Energy Design Systems offers a white-label lead generation tool.',
+      citedDomains: '[]',
+      competitorOverlap: '["offers.roofle.com"]',
+      recommendedCompetitors: '[]',
+      rawResponse: '{}',
+      createdAt: now,
+    }).run()
+
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    await backfillAnswerMentionsCommand({ project: 'cdp-project', format: 'json' })
+
+    const snapshot = db
+      .select()
+      .from(querySnapshots)
+      .where(eq(querySnapshots.id, snapshotId))
+      .get()
+    expect(JSON.parse(snapshot!.competitorOverlap)).toEqual([])
+    // answerMentioned remains false — the answer doesn't mention Demand IQ.
+    expect(snapshot!.answerMentioned).toBe(false)
+  })
+
+  it('is idempotent — a second run reports zero updates', async () => {
+    const { runId, keywordId } = seedAnswerVisibilityRun({
+      projectName: 'idempotent-project',
+      competitorDomains: ['offers.roofle.com'],
+    })
+    const now = new Date().toISOString()
+
+    db.insert(querySnapshots).values({
+      id: crypto.randomUUID(),
+      runId,
+      keywordId,
+      provider: 'openai',
+      model: 'gpt-5',
+      citationState: 'not-cited',
+      answerMentioned: false,
+      answerText: 'Energy Design Systems offers a white-label lead generation tool. Demand IQ uses AI-driven estimates.',
+      citedDomains: '[]',
+      competitorOverlap: '["offers.roofle.com"]',
+      recommendedCompetitors: '[]',
+      rawResponse: JSON.stringify({ groundingSources: [], searchQueries: [] }),
+      createdAt: now,
+    }).run()
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await backfillAnswerMentionsCommand({ project: 'idempotent-project', format: 'json' })
+    const first = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0] ?? '{}'))
+    expect(first.updated).toBe(1)
+
+    await backfillAnswerMentionsCommand({ project: 'idempotent-project', format: 'json' })
+    const second = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0] ?? '{}'))
+    expect(second.examined).toBe(1)
+    expect(second.updated).toBe(0)
+  })
+
+  it('does not touch citationState, citedDomains, or rawResponse', async () => {
+    // The PR fixed only brand-token matching; the citation path is unchanged.
+    // This backfill must not modify those columns even if it could.
+    const { runId, keywordId } = seedAnswerVisibilityRun({
+      projectName: 'preserves-citation-state',
+      competitorDomains: ['offers.roofle.com'],
+    })
+    const now = new Date().toISOString()
+
+    const snapshotId = crypto.randomUUID()
+    const originalRawResponse = JSON.stringify({
+      groundingSources: [{ uri: 'https://demand-iq.com/docs', title: 'Demand IQ Docs' }],
+      searchQueries: ['instant roof estimate'],
+      apiResponse: { foo: 'bar' },
+    })
+    db.insert(querySnapshots).values({
+      id: snapshotId,
+      runId,
+      keywordId,
+      provider: 'openai',
+      model: 'gpt-5',
+      citationState: 'cited',
+      answerMentioned: false,
+      answerText: 'Energy Design Systems offers a white-label lead generation tool.',
+      citedDomains: '["demand-iq.com"]',
+      competitorOverlap: '["offers.roofle.com"]',
+      recommendedCompetitors: '[]',
+      rawResponse: originalRawResponse,
+      createdAt: now,
+    }).run()
+
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    await backfillAnswerMentionsCommand({ project: 'preserves-citation-state', format: 'json' })
+
+    const snapshot = db
+      .select()
+      .from(querySnapshots)
+      .where(eq(querySnapshots.id, snapshotId))
+      .get()
+    expect(snapshot!.citationState).toBe('cited')
+    expect(snapshot!.citedDomains).toBe('["demand-iq.com"]')
+    expect(snapshot!.rawResponse).toBe(originalRawResponse)
+  })
+
+  it('only processes answer-visibility runs', async () => {
+    const { projectId, keywordId } = seedAnswerVisibilityRun({
+      projectName: 'mixed-runs',
+      competitorDomains: ['offers.roofle.com'],
+    })
+    const now = new Date().toISOString()
+
+    const auditRunId = crypto.randomUUID()
+    db.insert(runs).values({
+      id: auditRunId,
+      projectId,
+      kind: RunKinds['site-audit'],
+      status: 'completed',
+      trigger: 'manual',
+      createdAt: now,
+    }).run()
+
+    const auditSnapshotId = crypto.randomUUID()
+    db.insert(querySnapshots).values({
+      id: auditSnapshotId,
+      runId: auditRunId,
+      keywordId,
+      provider: 'openai',
+      model: 'gpt-5',
+      citationState: 'not-cited',
+      answerMentioned: false,
+      answerText: 'Energy Design Systems offers a white-label lead generation tool.',
+      citedDomains: '[]',
+      competitorOverlap: '["offers.roofle.com"]',
+      recommendedCompetitors: '[]',
+      rawResponse: '{}',
+      createdAt: now,
+    }).run()
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    await backfillAnswerMentionsCommand({ project: 'mixed-runs', format: 'json' })
+    const result = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0] ?? '{}'))
+
+    // The site-audit snapshot was not touched.
+    expect(result.examined).toBe(0)
+
+    const auditSnapshot = db
+      .select()
+      .from(querySnapshots)
+      .where(eq(querySnapshots.id, auditSnapshotId))
+      .get()
+    expect(JSON.parse(auditSnapshot!.competitorOverlap)).toEqual(['offers.roofle.com'])
+  })
+})

--- a/packages/canonry/test/cli-operator-contract.test.ts
+++ b/packages/canonry/test/cli-operator-contract.test.ts
@@ -145,12 +145,12 @@ describe('operator CLI contract', () => {
     })
     expect((await client.listKeywords('test-proj')).map(row => row.keyword).sort()).toEqual(['ai citations', 'answer visibility'])
 
-    await client.appendCompetitors('test-proj', ['rival.example.com', 'other.example.com'])
+    await client.appendCompetitors('test-proj', ['rival.com', 'other-rival.com'])
     const removeResult = await invokeCli([
       'competitor',
       'remove',
       'test-proj',
-      'rival.example.com',
+      'rival.com',
       '--format',
       'json',
     ])
@@ -159,8 +159,8 @@ describe('operator CLI contract', () => {
     expect(removeResult.stderr).toBe('')
     expect(JSON.parse(removeResult.stdout)).toMatchObject({
       project: 'test-proj',
-      domains: ['other.example.com'],
-      removedDomains: ['rival.example.com'],
+      domains: ['other-rival.com'],
+      removedDomains: ['rival.com'],
       removedCount: 1,
     })
   })

--- a/packages/canonry/test/job-runner-competitors.test.ts
+++ b/packages/canonry/test/job-runner-competitors.test.ts
@@ -1,6 +1,18 @@
 import { expect, test } from 'vitest'
+import type { NormalizedQueryResult } from '@ainyc/canonry-contracts'
 
-import { extractRecommendedCompetitors } from '../src/citation-utils.js'
+import { computeCompetitorOverlap, extractRecommendedCompetitors } from '../src/citation-utils.js'
+
+function buildResult(answer: string, overrides?: Partial<NormalizedQueryResult>): NormalizedQueryResult {
+  return {
+    provider: 'test',
+    answerText: answer,
+    citedDomains: [],
+    groundingSources: [],
+    searchQueries: [],
+    ...overrides,
+  }
+}
 
 test('extractRecommendedCompetitors excludes headings and the target brand', () => {
   const answer = [
@@ -35,4 +47,50 @@ test('extractRecommendedCompetitors matches spaced company names to compact doma
       [],
     ),
   ).toEqual(['Regional Joint Care', 'Northstar Ortho'])
+})
+
+test('computeCompetitorOverlap does not match a subdomain label as a brand word', () => {
+  // Regression: with stored competitor `offers.roofle.com`, the prior code
+  // pulled `offers` from the leftmost label and word-boundary-matched it
+  // against arbitrary prose. Use the registrable domain's brand label
+  // (`roofle`) instead — the answer below should produce zero overlap.
+  const answer = 'Energy Design Systems offers a white-label lead generation tool. Demand IQ uses AI-driven estimates.'
+  const result = buildResult(answer)
+  expect(computeCompetitorOverlap(result, ['offers.roofle.com'])).toEqual([])
+})
+
+test('computeCompetitorOverlap still flags the registrable brand of a subdomained competitor', () => {
+  // Sanity: the brand label drawn from the eTLD+1 still matches when the
+  // answer mentions the actual brand name.
+  const answer = 'Brokers turn to Roofle for instant install quotes.'
+  const result = buildResult(answer)
+  expect(computeCompetitorOverlap(result, ['offers.roofle.com'])).toEqual(['offers.roofle.com'])
+})
+
+test('computeCompetitorOverlap matches the full registrable domain in the answer', () => {
+  const answer = 'See pricing at roofle.com for details.'
+  const result = buildResult(answer)
+  expect(computeCompetitorOverlap(result, ['roofle.com'])).toEqual(['roofle.com'])
+})
+
+test('extractRecommendedCompetitors does not seed a brand from a subdomain label', () => {
+  // The competitor `offers.roofle.com` should source brand keys from
+  // `roofle.com` (keys: `rooflecom`, `roofle`) — never from `offers`. So
+  // a heading like `### Offers` must not promote "Offers" to a recommended
+  // competitor.
+  const answer = [
+    '### Offers',
+    'Energy Design Systems is a major provider.',
+    '',
+    '1. **Roofle** - install-quote engine',
+  ].join('\n')
+
+  expect(
+    extractRecommendedCompetitors(
+      answer,
+      ['demandiq.com'],
+      [],
+      ['offers.roofle.com'],
+    ),
+  ).toEqual(['Roofle'])
 })

--- a/packages/contracts/src/answer-visibility.ts
+++ b/packages/contracts/src/answer-visibility.ts
@@ -1,4 +1,4 @@
-import { normalizeProjectDomain } from './project.js'
+import { brandLabelFromDomain, normalizeProjectDomain, registrableDomain } from './project.js'
 import type { VisibilityState } from './run.js'
 
 const GENERIC_TOKENS = new Set([
@@ -152,11 +152,17 @@ function collectDistinctiveTokens(displayName: string, domains: string[]): strin
   }
 
   for (const domain of domains) {
-    const hostname = normalizeProjectDomain(domain).split('/')[0] ?? ''
-    for (const label of hostname.split('.').filter(Boolean)) {
-      const token = label.replace(/[^a-z0-9]/gi, '').toLowerCase()
-      if (isDistinctiveToken(token)) tokens.add(token)
-    }
+    // Use only the registrable domain's brand label as a token — never the
+    // subdomain. Otherwise an owned domain like `app.example.com` would
+    // contribute `app` as a word-boundary token and false-match every "app"
+    // in the answer text. Falls back to the hostname's leftmost label when
+    // the input has no recognizable TLD (e.g. `localhost`).
+    const reg = registrableDomain(domain)
+    const brand = reg
+      ? brandLabelFromDomain(reg)
+      : (normalizeProjectDomain(domain).split('/')[0]?.split('.')[0] ?? '')
+    const token = brand.replace(/[^a-z0-9]/gi, '').toLowerCase()
+    if (isDistinctiveToken(token)) tokens.add(token)
   }
 
   return [...tokens]

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -113,6 +113,89 @@ export function normalizeProjectDomain(input: string): string {
   return domain.replace(/^www\./, '')
 }
 
+// Two-label public suffixes where the eTLD+1 needs three labels
+// (e.g. example.co.uk → example.co.uk, not co.uk). Not exhaustive — a real
+// PSL has thousands of entries — but covers the common ccTLDs Canonry users
+// hit. Keep alphabetized.
+const MULTI_LABEL_PUBLIC_SUFFIXES = new Set([
+  'ac.uk',
+  'co.id',
+  'co.il',
+  'co.in',
+  'co.jp',
+  'co.kr',
+  'co.nz',
+  'co.th',
+  'co.uk',
+  'co.za',
+  'com.au',
+  'com.br',
+  'com.cn',
+  'com.mx',
+  'com.ph',
+  'com.sg',
+  'com.tr',
+  'edu.au',
+  'edu.sg',
+  'gov.au',
+  'gov.uk',
+  'me.uk',
+  'ne.jp',
+  'net.au',
+  'net.br',
+  'net.cn',
+  'net.in',
+  'net.tr',
+  'or.jp',
+  'or.kr',
+  'org.au',
+  'org.br',
+  'org.in',
+  'org.nz',
+  'org.tr',
+  'org.uk',
+  'org.za',
+])
+
+/**
+ * Reduce a domain to its registrable form (eTLD+1).
+ *
+ * `offers.roofle.com` → `roofle.com`
+ * `acme.com` → `acme.com`
+ * `bbc.co.uk` → `bbc.co.uk`
+ * `news.bbc.co.uk` → `bbc.co.uk`
+ *
+ * Strips subdomains so an arbitrary subdomain label (`offers`, `blog`, `app`)
+ * cannot leak into brand-token matching against answer text. Returns `''` for
+ * empty or single-label input. Idempotent.
+ */
+export function registrableDomain(input: string): string {
+  const normalized = normalizeProjectDomain(input)
+  if (!normalized) return ''
+  const hostname = normalized.split('/')[0]?.split(':')[0] ?? ''
+  if (!hostname) return ''
+  const labels = hostname.split('.').filter(Boolean)
+  if (labels.length < 2) return ''
+  if (labels.length === 2) return labels.join('.')
+  const lastTwo = labels.slice(-2).join('.')
+  if (MULTI_LABEL_PUBLIC_SUFFIXES.has(lastTwo)) {
+    return labels.length >= 3 ? labels.slice(-3).join('.') : ''
+  }
+  return labels.slice(-2).join('.')
+}
+
+/**
+ * The leftmost label of the registrable domain — the "brand" segment used for
+ * word-boundary matching against answer text. `offers.roofle.com` → `roofle`,
+ * `acme.com` → `acme`, `bbc.co.uk` → `bbc`. Returns `''` if there is no
+ * extractable brand label.
+ */
+export function brandLabelFromDomain(input: string): string {
+  const reg = registrableDomain(input)
+  if (!reg) return ''
+  return reg.split('.')[0] ?? ''
+}
+
 /** Returns deduplicated list of all domains owned by the project. */
 export function effectiveDomains(project: { canonicalDomain: string; ownedDomains?: string[] }): string[] {
   const all = [project.canonicalDomain, ...(project.ownedDomains ?? [])]

--- a/packages/contracts/test/index.test.ts
+++ b/packages/contracts/test/index.test.ts
@@ -25,6 +25,8 @@ import {
   notificationEventSchema,
   effectiveDomains,
   normalizeProjectDomain,
+  registrableDomain,
+  brandLabelFromDomain,
   locationContextSchema,
 } from '../src/index.js'
 
@@ -47,6 +49,60 @@ test('projectDtoSchema applies defaults for tags, labels, configSource, configRe
 test('normalizeProjectDomain strips scheme and www prefix', () => {
   expect(normalizeProjectDomain('https://www.Docs.Example.com/path')).toBe('docs.example.com')
   expect(normalizeProjectDomain('WWW.example.com')).toBe('example.com')
+})
+
+describe('registrableDomain', () => {
+  it('returns the eTLD+1 for a subdomained host', () => {
+    expect(registrableDomain('offers.roofle.com')).toBe('roofle.com')
+    expect(registrableDomain('app.example.io')).toBe('example.io')
+    expect(registrableDomain('blog.news.example.org')).toBe('example.org')
+  })
+
+  it('returns the input unchanged when there is no subdomain', () => {
+    expect(registrableDomain('roofle.com')).toBe('roofle.com')
+    expect(registrableDomain('example.ai')).toBe('example.ai')
+  })
+
+  it('strips scheme, port, path, and www prefix before parsing', () => {
+    expect(registrableDomain('https://www.offers.Roofle.com/foo?x=1')).toBe('roofle.com')
+    expect(registrableDomain('http://api.example.com:8080/v1')).toBe('example.com')
+  })
+
+  it('keeps the third label for known multi-label public suffixes', () => {
+    expect(registrableDomain('bbc.co.uk')).toBe('bbc.co.uk')
+    expect(registrableDomain('news.bbc.co.uk')).toBe('bbc.co.uk')
+    expect(registrableDomain('shop.example.com.au')).toBe('example.com.au')
+    expect(registrableDomain('foo.bar.example.co.jp')).toBe('example.co.jp')
+  })
+
+  it('returns empty string for empty or single-label input', () => {
+    expect(registrableDomain('')).toBe('')
+    expect(registrableDomain('localhost')).toBe('')
+    expect(registrableDomain('   ')).toBe('')
+  })
+
+  it('is idempotent', () => {
+    expect(registrableDomain(registrableDomain('offers.roofle.com'))).toBe('roofle.com')
+    expect(registrableDomain(registrableDomain('news.bbc.co.uk'))).toBe('bbc.co.uk')
+  })
+})
+
+describe('brandLabelFromDomain', () => {
+  it('returns the leftmost label of the registrable domain', () => {
+    expect(brandLabelFromDomain('offers.roofle.com')).toBe('roofle')
+    expect(brandLabelFromDomain('roofle.com')).toBe('roofle')
+    expect(brandLabelFromDomain('app.acme.io')).toBe('acme')
+  })
+
+  it('handles multi-label public suffixes', () => {
+    expect(brandLabelFromDomain('news.bbc.co.uk')).toBe('bbc')
+    expect(brandLabelFromDomain('bbc.co.uk')).toBe('bbc')
+  })
+
+  it('returns empty string when there is no registrable domain', () => {
+    expect(brandLabelFromDomain('')).toBe('')
+    expect(brandLabelFromDomain('localhost')).toBe('')
+  })
 })
 
 test('effectiveDomains deduplicates canonical and owned domain variants', () => {
@@ -695,6 +751,28 @@ describe('extractAnswerMentions', () => {
       'Microsoft Corporation',
       ['microsoft.com'],
     ).mentioned).toBe(true)
+  })
+
+  it('does not match the leftmost subdomain label as a brand token', () => {
+    // Regression: a project with own domain `offers.example.com` must not
+    // word-boundary match the literal word "offers" in the answer prose. Only
+    // the registrable domain's brand label (`example`) is a valid token.
+    const result = extractAnswerMentions(
+      'Energy Design Systems offers a white-label lead generation tool.',
+      'Demand IQ',
+      ['offers.example.com'],
+    )
+    expect(result.mentioned).toBe(false)
+    expect(result.matchedTerms).toEqual([])
+  })
+
+  it('still matches the registrable brand of a subdomained own domain', () => {
+    const result = extractAnswerMentions(
+      'Brokers turn to Roofle when they need quick install quotes.',
+      'Roofle',
+      ['offers.roofle.com'],
+    )
+    expect(result.mentioned).toBe(true)
   })
 
   it('does not strip a classifier when only the classifier itself remains', () => {


### PR DESCRIPTION
## Summary

- Stored competitor `offers.roofle.com` was word-boundary-matching the literal English word "offers" in answer prose because three matchers (`computeCompetitorOverlap`, `extractRecommendedCompetitors`, `collectDistinctiveTokens`) sourced the brand from the leftmost label of a domain. Fixed by introducing `registrableDomain()` (eTLD+1, with a small built-in multi-label-public-suffix list) and `brandLabelFromDomain()`, sourcing the brand from the registrable form, and normalizing competitor inputs to registrable form on ingest (POST/PUT/DELETE + YAML apply).
- Answer-text highlighter (`highlightTermsInText`) now tolerates separator drift so a slug-form term like `demand-iq` highlights `Demand IQ`/`Demand-IQ`/`DemandIQ` in prose, with brand-key reverse-mapping so each match still routes to the right group color. Dot literals in domain terms stay strict.
- 25 new specs across contracts, api-routes, canonry, and web; version 3.2.2 → 3.2.3.

## Test plan

- [ ] `pnpm typecheck && pnpm lint && pnpm test` (1716 specs pass locally)
- [ ] Run a real sweep against a project with a subdomained competitor and confirm the literal subdomain word is no longer flagged
- [ ] Open the evidence drawer for a project whose displayName is a slug and confirm the spaced form in prose is highlighted
- [ ] Re-add a subdomained competitor via CLI and confirm it stores as the registrable domain