### PR TITLE
fix(ga): always sync traffic foundation so social share stays valid

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1028,15 +1028,15 @@ export interface ApiGaTraffic {
   socialSharePct: number
   /** Direct sessions as a percentage of total sessions (0–100, rounded). */
   directSharePct: number
-  /** Display string for organicSharePct ('10%' or '<1%' when there are sessions but the rounded pct is 0). */
+  /** Display string for organicSharePct: 'X%', '<1%' for non-zero shares that round below 1, or '—' when sessions exist but total is unknown (partial sync). */
   organicSharePctDisplay: string
-  /** Display string for aiSharePct ('5%' or '<1%' when there are sessions but the rounded pct is 0). */
+  /** Display string for aiSharePct: 'X%', '<1%' for non-zero shares that round below 1, or '—' when sessions exist but total is unknown (partial sync). */
   aiSharePctDisplay: string
-  /** Display string for aiSharePctBySession ('5%' or '<1%' when there are sessions but the rounded pct is 0). */
+  /** Display string for aiSharePctBySession: 'X%', '<1%' for non-zero shares that round below 1, or '—' when sessions exist but total is unknown (partial sync). */
   aiSharePctBySessionDisplay: string
-  /** Display string for socialSharePct ('15%' or '<1%' when there are sessions but the rounded pct is 0). */
+  /** Display string for socialSharePct: 'X%', '<1%' for non-zero shares that round below 1, or '—' when sessions exist but total is unknown (partial sync). */
   socialSharePctDisplay: string
-  /** Display string for directSharePct ('20%' or '<1%' when there are sessions but the rounded pct is 0). */
+  /** Display string for directSharePct: 'X%', '<1%' for non-zero shares that round below 1, or '—' when sessions exist but total is unknown (partial sync). */
   directSharePctDisplay: string
   lastSyncedAt: string | null
   /** Start of the synced date range (YYYY-MM-DD), null if no data. */

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "3.2.3",
+  "version": "3.2.4",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "3.2.2",
+  "version": "3.2.3",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/ga.ts
+++ b/packages/api-routes/src/ga.ts
@@ -25,7 +25,14 @@ function gaLog(level: 'info' | 'warn' | 'error', action: string, ctx?: Record<st
 // Format a session-share as a display string. Returns "<1%" for non-zero shares
 // that round below 1%, so 18 AI sessions out of 6000 reads "<1%" instead of
 // "0%" — the display matches the integer pct field exactly otherwise.
+//
+// When the numerator is positive but the total is zero, the share is
+// undefined — typically a partial-sync state where social/AI referral rows
+// exist but the traffic snapshots/summary that drive the denominator have not
+// been synced. We return "—" rather than "0%" so the UI doesn't claim a 0%
+// share for 1.3K social sessions.
 function formatSharePct(numerator: number, total: number): string {
+  if (numerator > 0 && total <= 0) return '—'
   if (total <= 0 || numerator <= 0) return '0%'
   const pct = (numerator / total) * 100
   const rounded = Math.round(pct)
@@ -337,8 +344,15 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
   })
 
   // POST /projects/:name/ga/sync
-  // Supports `only` field to selectively sync a subset of data (e.g. "social").
-  // Valid components: "traffic", "ai", "social". Omit for full sync.
+  // The `only` field opts out of AI or social channel breakdowns. The
+  // traffic snapshots and aggregate summary are always refreshed regardless
+  // — they're the denominator for every share metric in the dashboard, so
+  // letting them go stale would make `socialSharePct` etc. compare social
+  // sessions in the requested window with a total from a different (older)
+  // window. See `share denominator` discussion below.
+  //
+  // Valid `only` values: "traffic" (foundation only), "ai" (foundation + AI),
+  // "social" (foundation + social). Omit for the full set.
   app.post<{
     Params: { name: string }
     Body: { days?: number; only?: string }
@@ -353,11 +367,14 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       throw validationError(`Invalid "only" value "${only}". Must be one of: ${validOnlyValues.join(', ')}`)
     }
 
-    // Determine which components to sync
-    const syncTraffic = !only || only === 'traffic'
+    // Foundation (traffic snapshots + aggregate summary) always syncs — share
+    // metrics depend on a denominator that covers the same window as the
+    // social/AI numerators. The `only` flag controls which channel
+    // breakdowns are also refreshed.
+    const syncTraffic = true
+    const syncSummary = true
     const syncAi = !only || only === 'ai'
     const syncSocial = !only || only === 'social'
-    const syncSummary = !only // always sync summary on full sync
 
     const startedAt = new Date().toISOString()
     const runId = crypto.randomUUID()

--- a/packages/api-routes/src/ga.ts
+++ b/packages/api-routes/src/ga.ts
@@ -522,8 +522,16 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         .where(eq(runs.id, runId))
         .run()
 
+      // List every component that was actually written this run. Foundation
+      // (traffic + summary) always syncs, so it always appears when `only`
+      // is set; the requested channel breakdown is appended.
       const syncedComponents = only
-        ? [only, ...(only !== 'social' && only !== 'ai' && only !== 'traffic' ? [] : [])]
+        ? [
+            ...(syncTraffic ? ['traffic'] : []),
+            ...(syncSummary ? ['summary'] : []),
+            ...(syncAi ? ['ai'] : []),
+            ...(syncSocial ? ['social'] : []),
+          ]
         : undefined
 
       gaLog('info', 'sync.complete', {

--- a/packages/api-routes/test/ga.test.ts
+++ b/packages/api-routes/test/ga.test.ts
@@ -385,6 +385,112 @@ describe('GA4 routes', () => {
       .run()
   })
 
+  it('POST /ga/sync with only=social still refreshes traffic snapshots and summary so share metrics stay valid', async () => {
+    // The traffic foundation (gaTrafficSnapshots + gaTrafficSummaries) is the
+    // denominator for every share metric. Letting it go stale during a
+    // partial sync is what produced the "1.3K social sessions / 0% share"
+    // bug, so `only=social` must still refresh the foundation — only
+    // `gaAiReferrals` is skipped here.
+    const now = new Date().toISOString()
+    const projRes = await app.inject({
+      method: 'PUT',
+      url: '/api/v1/projects/only-social-foundation',
+      payload: {
+        displayName: 'Only Social Foundation',
+        canonicalDomain: 'only-social.example',
+        country: 'US',
+        language: 'en',
+      },
+    })
+    const partialProjectId = JSON.parse(projRes.payload).id
+
+    credentials.set('only-social-foundation', {
+      projectName: 'only-social-foundation',
+      propertyId: '999111',
+      clientEmail: 'sa@test.iam.gserviceaccount.com',
+      privateKey: 'fake-key',
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const gaModule = await import('@ainyc/canonry-integration-google-analytics')
+    const getAccessTokenSpy = vi.spyOn(gaModule, 'getAccessToken').mockResolvedValue('mock-token')
+    const fetchTrafficSpy = vi.spyOn(gaModule, 'fetchTrafficByLandingPage').mockResolvedValue([
+      { date: '2026-04-15', landingPage: '/foundation', sessions: 30000, organicSessions: 12000, directSessions: 5000, users: 22000 },
+    ])
+    const fetchAggregateSpy = vi.spyOn(gaModule, 'fetchAggregateSummary').mockResolvedValue({
+      periodStart: '2026-04-01',
+      periodEnd: '2026-04-30',
+      totalSessions: 30000,
+      totalOrganicSessions: 12000,
+      totalUsers: 22000,
+    })
+    const fetchAiReferralsSpy = vi.spyOn(gaModule, 'fetchAiReferrals').mockResolvedValue([])
+    const fetchSocialReferralsSpy = vi.spyOn(gaModule, 'fetchSocialReferrals').mockResolvedValue([
+      { date: '2026-04-15', source: 'facebook.com', medium: 'referral', sessions: 1273, users: 900, channelGroup: 'Organic Social' },
+    ])
+
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/projects/only-social-foundation/ga/sync',
+        payload: { days: 30, only: 'social' },
+      })
+      expect(res.statusCode).toBe(200)
+
+      // Foundation must be refreshed even though the caller asked for
+      // `only=social` — fetchTrafficByLandingPage + fetchAggregateSummary
+      // were called and rows landed in both tables.
+      expect(fetchTrafficSpy).toHaveBeenCalled()
+      expect(fetchAggregateSpy).toHaveBeenCalled()
+
+      const snapshots = db.select().from(gaTrafficSnapshots)
+        .where(eq(gaTrafficSnapshots.projectId, partialProjectId))
+        .all()
+      expect(snapshots).toHaveLength(1)
+      expect(snapshots[0]!.sessions).toBe(30000)
+
+      const summaries = db.select().from(gaTrafficSummaries)
+        .where(eq(gaTrafficSummaries.projectId, partialProjectId))
+        .all()
+      expect(summaries).toHaveLength(1)
+      expect(summaries[0]!.totalSessions).toBe(30000)
+
+      const socialRefs = db.select().from(gaSocialReferrals)
+        .where(eq(gaSocialReferrals.projectId, partialProjectId))
+        .all()
+      expect(socialRefs).toHaveLength(1)
+      expect(socialRefs[0]!.sessions).toBe(1273)
+
+      // AI was the channel breakdown the caller asked to skip — and it was.
+      expect(fetchAiReferralsSpy).not.toHaveBeenCalled()
+      const aiRefs = db.select().from(gaAiReferrals)
+        .where(eq(gaAiReferrals.projectId, partialProjectId))
+        .all()
+      expect(aiRefs).toHaveLength(0)
+
+      // End-to-end: GET /ga/traffic now returns a real share, not 0% or "—".
+      const trafficRes = await app.inject({
+        method: 'GET',
+        url: '/api/v1/projects/only-social-foundation/ga/traffic?window=30d',
+      })
+      const traffic = JSON.parse(trafficRes.payload)
+      // 1273 / 30000 = 4.24% → 4%
+      expect(traffic.socialSharePct).toBe(4)
+      expect(traffic.socialSharePctDisplay).toBe('4%')
+    } finally {
+      getAccessTokenSpy.mockRestore()
+      fetchTrafficSpy.mockRestore()
+      fetchAggregateSpy.mockRestore()
+      fetchAiReferralsSpy.mockRestore()
+      fetchSocialReferralsSpy.mockRestore()
+      credentials.delete('only-social-foundation')
+      db.delete(gaTrafficSnapshots).where(eq(gaTrafficSnapshots.projectId, partialProjectId)).run()
+      db.delete(gaTrafficSummaries).where(eq(gaTrafficSummaries.projectId, partialProjectId)).run()
+      db.delete(gaSocialReferrals).where(eq(gaSocialReferrals.projectId, partialProjectId)).run()
+    }
+  })
+
   it('POST /ga/sync rejects invalid only parameter', async () => {
     const now = new Date().toISOString()
     credentials.set('test-project', {
@@ -611,6 +717,67 @@ describe('GA4 routes', () => {
       db.delete(gaAiReferrals).where(eq(gaAiReferrals.id, aiId)).run()
       db.delete(gaTrafficSnapshots).where(eq(gaTrafficSnapshots.id, snapshotId)).run()
       credentials.delete('sub-one-pct')
+    }
+  })
+
+  it('GET /ga/traffic returns "—" share display when social rows exist but no traffic snapshots/summary do', async () => {
+    // Defensive case: if any process inserts social rows without the
+    // corresponding traffic foundation (data corruption, manual SQL, a
+    // test/seed flow that bypasses the sync endpoint), the share denominator
+    // is 0 and a literal "0%" would falsely claim social is 0% of traffic.
+    // Surface the data gap honestly with "—" instead. Under the normal sync
+    // flow (which always refreshes traffic+summary) this state shouldn't
+    // arise.
+    const now = new Date().toISOString()
+    const today = now.slice(0, 10)
+    const projRes = await app.inject({
+      method: 'PUT',
+      url: '/api/v1/projects/no-summary',
+      payload: {
+        displayName: 'No Summary',
+        canonicalDomain: 'no-summary.example',
+        country: 'US',
+        language: 'en',
+      },
+    })
+    const noSummaryProjectId = JSON.parse(projRes.payload).id
+
+    credentials.set('no-summary', {
+      projectName: 'no-summary',
+      propertyId: '111444',
+      clientEmail: 'sa@test.iam.gserviceaccount.com',
+      privateKey: 'fake-key',
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const socialId = crypto.randomUUID()
+    db.insert(gaSocialReferrals).values({
+      id: socialId,
+      projectId: noSummaryProjectId,
+      date: today,
+      source: 'facebook.com',
+      medium: 'referral',
+      channelGroup: 'Organic Social',
+      sessions: 1273,
+      users: 900,
+      syncedAt: now,
+    }).run()
+
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/v1/projects/no-summary/ga/traffic?window=30d',
+      })
+      expect(res.statusCode).toBe(200)
+      const body = JSON.parse(res.payload)
+      expect(body.socialSessions).toBe(1273)
+      expect(body.socialSharePct).toBe(0)
+      // No summary, no snapshots — surface the data gap honestly.
+      expect(body.socialSharePctDisplay).toBe('—')
+    } finally {
+      db.delete(gaSocialReferrals).where(eq(gaSocialReferrals.id, socialId)).run()
+      credentials.delete('no-summary')
     }
   })
 

--- a/packages/api-routes/test/ga.test.ts
+++ b/packages/api-routes/test/ga.test.ts
@@ -392,6 +392,7 @@ describe('GA4 routes', () => {
     // bug, so `only=social` must still refresh the foundation — only
     // `gaAiReferrals` is skipped here.
     const now = new Date().toISOString()
+    const today = now.slice(0, 10)
     const projRes = await app.inject({
       method: 'PUT',
       url: '/api/v1/projects/only-social-foundation',
@@ -416,18 +417,18 @@ describe('GA4 routes', () => {
     const gaModule = await import('@ainyc/canonry-integration-google-analytics')
     const getAccessTokenSpy = vi.spyOn(gaModule, 'getAccessToken').mockResolvedValue('mock-token')
     const fetchTrafficSpy = vi.spyOn(gaModule, 'fetchTrafficByLandingPage').mockResolvedValue([
-      { date: '2026-04-15', landingPage: '/foundation', sessions: 30000, organicSessions: 12000, directSessions: 5000, users: 22000 },
+      { date: today, landingPage: '/foundation', sessions: 30000, organicSessions: 12000, directSessions: 5000, users: 22000 },
     ])
     const fetchAggregateSpy = vi.spyOn(gaModule, 'fetchAggregateSummary').mockResolvedValue({
-      periodStart: '2026-04-01',
-      periodEnd: '2026-04-30',
+      periodStart: today,
+      periodEnd: today,
       totalSessions: 30000,
       totalOrganicSessions: 12000,
       totalUsers: 22000,
     })
     const fetchAiReferralsSpy = vi.spyOn(gaModule, 'fetchAiReferrals').mockResolvedValue([])
     const fetchSocialReferralsSpy = vi.spyOn(gaModule, 'fetchSocialReferrals').mockResolvedValue([
-      { date: '2026-04-15', source: 'facebook.com', medium: 'referral', sessions: 1273, users: 900, channelGroup: 'Organic Social' },
+      { date: today, source: 'facebook.com', medium: 'referral', sessions: 1273, users: 900, channelGroup: 'Organic Social' },
     ])
 
     try {
@@ -437,6 +438,12 @@ describe('GA4 routes', () => {
         payload: { days: 30, only: 'social' },
       })
       expect(res.statusCode).toBe(200)
+
+      // The sync response must reflect the foundation write so callers
+      // (CLI `Components:` line, agents reading `syncedComponents`) don't
+      // think only social was refreshed.
+      const syncBody = JSON.parse(res.payload)
+      expect(syncBody.syncedComponents).toEqual(['traffic', 'summary', 'social'])
 
       // Foundation must be refreshed even though the caller asked for
       // `only=social` — fetchTrafficByLandingPage + fetchAggregateSummary

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/contracts/src/ga.ts
+++ b/packages/contracts/src/ga.ts
@@ -92,15 +92,15 @@ export const ga4TrafficSummaryDtoSchema = z.object({
   directSharePct: z.number(),
   /** Social sessions as a percentage of total sessions (0–100, rounded). */
   socialSharePct: z.number(),
-  /** Display string for organicSharePct ('10%' or '<1%' when there are sessions but the rounded pct is 0). */
+  /** Display string for organicSharePct: 'X%', '<1%' for non-zero shares that round below 1, or '—' when sessions exist but total is unknown (partial sync). */
   organicSharePctDisplay: z.string(),
-  /** Display string for aiSharePct ('5%' or '<1%' when there are sessions but the rounded pct is 0). */
+  /** Display string for aiSharePct: 'X%', '<1%' for non-zero shares that round below 1, or '—' when sessions exist but total is unknown (partial sync). */
   aiSharePctDisplay: z.string(),
-  /** Display string for aiSharePctBySession ('5%' or '<1%' when there are sessions but the rounded pct is 0). */
+  /** Display string for aiSharePctBySession: 'X%', '<1%' for non-zero shares that round below 1, or '—' when sessions exist but total is unknown (partial sync). */
   aiSharePctBySessionDisplay: z.string(),
-  /** Display string for directSharePct ('20%' or '<1%' when there are sessions but the rounded pct is 0). */
+  /** Display string for directSharePct: 'X%', '<1%' for non-zero shares that round below 1, or '—' when sessions exist but total is unknown (partial sync). */
   directSharePctDisplay: z.string(),
-  /** Display string for socialSharePct ('15%' or '<1%' when there are sessions but the rounded pct is 0). */
+  /** Display string for socialSharePct: 'X%', '<1%' for non-zero shares that round below 1, or '—' when sessions exist but total is unknown (partial sync). */
   socialSharePctDisplay: z.string(),
   lastSyncedAt: z.string().nullable(),
 })
@@ -200,15 +200,15 @@ export interface GaTrafficResponse {
   directSharePct: number
   /** Social sessions as a percentage of total sessions (0–100, rounded). */
   socialSharePct: number
-  /** Display string for organicSharePct ('10%' or '<1%' when there are sessions but the rounded pct is 0). */
+  /** Display string for organicSharePct: 'X%', '<1%' for non-zero shares that round below 1, or '—' when sessions exist but total is unknown (partial sync). */
   organicSharePctDisplay: string
-  /** Display string for aiSharePct ('5%' or '<1%' when there are sessions but the rounded pct is 0). */
+  /** Display string for aiSharePct: 'X%', '<1%' for non-zero shares that round below 1, or '—' when sessions exist but total is unknown (partial sync). */
   aiSharePctDisplay: string
-  /** Display string for aiSharePctBySession ('5%' or '<1%' when there are sessions but the rounded pct is 0). */
+  /** Display string for aiSharePctBySession: 'X%', '<1%' for non-zero shares that round below 1, or '—' when sessions exist but total is unknown (partial sync). */
   aiSharePctBySessionDisplay: string
-  /** Display string for directSharePct ('20%' or '<1%' when there are sessions but the rounded pct is 0). */
+  /** Display string for directSharePct: 'X%', '<1%' for non-zero shares that round below 1, or '—' when sessions exist but total is unknown (partial sync). */
   directSharePctDisplay: string
-  /** Display string for socialSharePct ('15%' or '<1%' when there are sessions but the rounded pct is 0). */
+  /** Display string for socialSharePct: 'X%', '<1%' for non-zero shares that round below 1, or '—' when sessions exist but total is unknown (partial sync). */
   socialSharePctDisplay: string
   lastSyncedAt: string | null
   /** Start of the synced date range (YYYY-MM-DD), null if no data. */

--- a/packages/contracts/src/ga.ts
+++ b/packages/contracts/src/ga.ts
@@ -132,7 +132,11 @@ export interface GaSyncResponse {
   socialReferralCount: number
   days: number
   syncedAt: string
-  /** Which data components were synced (present when --only is used) */
+  /**
+   * Components that were written this run. Present when `only` is set.
+   * Always includes `traffic` and `summary` (the share denominator) plus
+   * the requested channel breakdown — `ai` and/or `social`.
+   */
   syncedComponents?: string[]
 }
 


### PR DESCRIPTION
## Summary

`--only=social` and `--only=ai` were skipping the per-page traffic fetch and aggregate summary, leaving `gaTrafficSnapshots` / `gaTrafficSummaries` stale while social/AI rows kept refreshing — the dashboard then read a windowed denominator of 0 alongside thousands of social sessions and showed "0% Share of Traffic" for clearly non-zero traffic. Traffic snapshots + summary now always refresh on every sync; `--only` just opts out of the AI or social channel breakdowns, so the share numerator and denominator finally cover the same window. Display falls back to "—" only as a defensive guard for true data corruption (no traffic foundation row at all). Version bumped to 3.2.3.

## Test plan

- [ ] `pnpm typecheck && pnpm lint && pnpm test` (1694 tests pass locally)
- [ ] Run `canonry ga sync <project> --only=social` and confirm `gaTrafficSnapshots` and `gaTrafficSummaries` rows are refreshed alongside `gaSocialReferrals`
- [ ] In the dashboard's Traffic section, confirm "Share of Traffic" shows a real percentage (not 0% or "—") for projects with social sessions