### PR TITLE
fix(tests): centralize jsdom env in vitest config + root devDep

### DIFF
--- a/apps/web/test/router.test.tsx
+++ b/apps/web/test/router.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { test, expect } from 'vitest'
 import React from 'react'
 import { render, waitFor, act } from '@testing-library/react'

--- a/apps/web/test/run-notifications.test.tsx
+++ b/apps/web/test/run-notifications.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 import React from 'react'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'

--- a/apps/web/test/traffic-section.test.tsx
+++ b/apps/web/test/traffic-section.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import React from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, expect, onTestFinished, test, vi } from 'vitest'

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
+    environment: 'jsdom',
     include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
   },
 })

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "eslint": "^9.0.0",
     "globals": "^17.4.0",
     "husky": "^9.1.7",
+    "jsdom": "^29.0.0",
     "tsx": "^4.20.5",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.43.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      jsdom:
+        specifier: ^29.0.0
+        version: 29.0.0
       tsx:
         specifier: ^4.20.5
         version: 4.21.0


### PR DESCRIPTION
## Problem

vitest worker pool couldn't resolve `jsdom` for `apps/web` React test files. Vitest resolves environment packages from the **workspace root**, not from individual project directories — even when the environment is declared in the project's `vitest.config.ts`. PNPM's strict resolution blocks it without a root declaration.

## Solution

Two changes, zero production impact:

1. **Set `environment: 'jsdom'` in `apps/web/vitest.config.ts`** — one place instead of scattered inline directives
2. **Add `jsdom` to root `devDependencies`** — vitest needs it at root to resolve the jsdom environment (PNPM monorepo constraint)
3. **Remove `// @vitest-environment jsdom`** from 3 `.tsx` test files — no longer needed

`jsdom` is a devDependency, not a runtime dependency. Zero production impact.

## Verification

```
Test Files  15 passed (15)
     Tests  169 passed (169)
```

CI: validate ✓ docker-build ✓