### PR TITLE
fix(tests): restore @vitest-environment jsdom pragmas for workspace compat

### DIFF
--- a/apps/web/test/router.test.tsx
+++ b/apps/web/test/router.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { test, expect } from 'vitest'
 import React from 'react'
 import { render, waitFor, act } from '@testing-library/react'

--- a/apps/web/test/run-notifications.test.tsx
+++ b/apps/web/test/run-notifications.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 import React from 'react'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'

--- a/apps/web/test/traffic-section.test.tsx
+++ b/apps/web/test/traffic-section.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import React from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, expect, onTestFinished, test, vi } from 'vitest'


### PR DESCRIPTION
## Problem

CI is failing on main with:

- `ReferenceError: window is not defined` — `run-notifications.test.tsx`
- `ReferenceError: document is not defined` — `traffic-section.test.tsx`, `router.test.tsx`

## Root Cause

PR #395 added jsdom as root devDep and set `environment: 'jsdom'` in `apps/web/vitest.config.ts`, but vitest 4.x workspace mode does not reliably propagate the per-project `environment` setting to the worker pool. The jsdom package is resolved, but the env is never activated for some test files.

## Fix

Restore the `// @vitest-environment jsdom` inline pragma at the top of the 3 affected test files. The pragma is explicit per-file and works regardless of workspace configuration. The root devDep and config-level `environment` from #395 are kept as supporting infrastructure.

## Verification

All 165 test files / 1727 tests pass from the root workspace:

```
Test Files  165 passed (165)
     Tests  1727 passed (1727)
```