### PR TITLE
fix(tests): migrate vitest workspace to test.projects for Vitest 4

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    projects: ['packages/*/vitest.config.ts', 'apps/*/vitest.config.ts'],
+  },
+})

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,6 +1,0 @@
-import { defineWorkspace } from 'vitest/config'
-
-export default defineWorkspace([
-  'packages/*/vitest.config.ts',
-  'apps/*/vitest.config.ts',
-])


### PR DESCRIPTION
## Summary

- Vitest 4 dropped `vitest.workspace.ts` support — the file was silently ignored, so per-package configs (including `apps/web/vitest.config.ts`'s `environment: 'jsdom'`) never applied. CI broke at #395 with `ReferenceError: document is not defined` in the .tsx tests.
- Replaced with a root `vitest.config.ts` using `test.projects` pointing at the same per-package configs.
- Verified locally: `apps/web/test/router.test.tsx` 14/14 pass (was 14/14 fail), full suite 165 files / 1,727 tests pass.

## Test plan

- [ ] CI passes