### PR TITLE
fix(build): validate SPA asset references to prevent white-screen outages

### DIFF
--- a/packages/canonry/build-web.ts
+++ b/packages/canonry/build-web.ts
@@ -50,4 +50,17 @@ if (hadAgentWorkspace) {
   fs.rmSync(agentWorkspaceTmp, { recursive: true })
 }
 
-console.log(`SPA assets copied to ${assetsDir}`)
+// Verify that all asset references in index.html resolve to existing files.
+// Prevents white-screen outages from HTML referencing stale hashed filenames.
+const indexPath = path.join(assetsDir, 'index.html')
+const html = fs.readFileSync(indexPath, 'utf-8')
+const refs = [...html.matchAll(/(?:src|href)="\.\/([^"]+)"/g)].map(m => m[1])
+const missing = refs.filter(ref => !fs.existsSync(path.join(assetsDir, ref)))
+if (missing.length > 0) {
+  console.error('Error: index.html references assets that do not exist:')
+  for (const ref of missing) console.error(`  - ${ref}`)
+  console.error('The web build output and asset copy are out of sync. Rebuild from clean state.')
+  process.exit(1)
+}
+
+console.log(`SPA assets copied to ${assetsDir} (${refs.length} references verified)`) 


### PR DESCRIPTION
## Problem
When web SPA assets get out of sync with `index.html`, Canonry serves a white screen — the browser receives HTML as JS (SPA fallback for missing hashed files) and fails silently.

## Root cause
`packages/canonry/assets/index.html` referenced old hashed filenames that didn't match the actual JS/CSS files on disk. Assets were partially updated without syncing the HTML.

## Fix
Added post-build validation to `build-web.ts` that:
1. Reads `index.html` after the copy step
2. Extracts all `src` and `href` references to local files
3. Verifies each referenced file exists on disk
4. Fails the build with a clear error message if any reference is broken

Build output now shows: `SPA assets copied to ... (N references verified)`

## Prevention
This class of outage can't happen again — the build hard-fails if asset references are mismatched.