### PR TITLE
fix(report): wrap long URLs and summarise tracking params in landing-page tables

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "3.3.8",
+  "version": "3.3.9",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "3.3.8",
+  "version": "3.3.9",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/report-renderer.ts
+++ b/packages/canonry/src/report-renderer.ts
@@ -43,6 +43,51 @@ function formatNumber(value: number): string {
   return value.toLocaleString('en-US')
 }
 
+function summarizeQueryParams(params: URLSearchParams): string {
+  const keys = Array.from(params.keys())
+  const total = keys.length
+  if (total === 0) return ''
+  const noun = total === 1 ? 'param' : 'params'
+  const tag = inferAdSource(params)
+  return tag ? `${tag} · ${total} ${noun}` : `${total} tracking ${noun}`
+}
+
+function inferAdSource(params: URLSearchParams): string | null {
+  if (params.has('fbclid')) return 'Facebook Ad'
+  if (params.has('gclid') || params.has('gbraid') || params.has('wbraid')) return 'Google Ad'
+  if (params.has('msclkid')) return 'Microsoft Ad'
+  if (params.has('ttclid')) return 'TikTok Ad'
+  if (params.has('li_fat_id')) return 'LinkedIn Ad'
+  if (params.has('twclid')) return 'X / Twitter Ad'
+  if (params.has('epik')) return 'Pinterest Ad'
+  for (const k of params.keys()) {
+    if (k.startsWith('hsa_')) return 'Search Ad'
+  }
+  const src = params.get('utm_source')
+  const med = params.get('utm_medium')
+  if (src && med) return `${src} / ${med}`
+  if (src) return `Source: ${src}`
+  if (med) return `Medium: ${med}`
+  return null
+}
+
+export function formatLandingPageHtml(raw: string): string {
+  const value = raw ?? ''
+  const queryIdx = value.indexOf('?')
+  const path = queryIdx === -1 ? value : value.slice(0, queryIdx)
+  const query = queryIdx === -1 ? '' : value.slice(queryIdx + 1)
+  const pathHtml = `<span class="page-path">${escapeHtml(path || '/')}</span>`
+  if (!query) return pathHtml
+  let summary = ''
+  try {
+    summary = summarizeQueryParams(new URLSearchParams(query))
+  } catch {
+    summary = 'tracking params'
+  }
+  if (!summary) return pathHtml
+  return `${pathHtml}<span class="page-query" title="${escapeHtml(value)}">${escapeHtml(summary)}</span>`
+}
+
 function formatDate(iso: string): string {
   if (!iso) return '—'
   try {
@@ -180,6 +225,9 @@ table.report-table th, table.report-table td {
   text-align: left;
   padding: 10px 12px;
   border-bottom: 1px solid ${COLORS.border};
+  vertical-align: top;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 table.report-table th {
   font-weight: 600;
@@ -188,7 +236,25 @@ table.report-table th {
   letter-spacing: 0.06em;
   font-size: 10px;
 }
-table.report-table td.numeric { text-align: right; font-variant-numeric: tabular-nums; }
+table.report-table td.numeric { text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
+table.report-table td.page-cell { max-width: 0; }
+table.report-table td.page-cell .page-path {
+  display: block;
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 12px;
+  color: ${COLORS.text};
+}
+table.report-table td.page-cell .page-query {
+  display: inline-block;
+  margin-top: 4px;
+  padding: 1px 8px;
+  font-size: 11px;
+  color: ${COLORS.textMuted};
+  background: ${COLORS.surface};
+  border: 1px solid ${COLORS.border};
+  border-radius: 999px;
+  cursor: help;
+}
 table.report-table td .badge {
   display: inline-block;
   padding: 2px 8px;
@@ -661,7 +727,7 @@ function renderGa(report: ProjectReportDto): string {
 
   const pageRows = ga.topLandingPages.map(p => `
     <tr>
-      <td>${escapeHtml(p.page)}</td>
+      <td class="page-cell">${formatLandingPageHtml(p.page)}</td>
       <td class="numeric">${formatNumber(p.sessions)}</td>
       <td class="numeric">${formatNumber(p.users)}</td>
       <td class="numeric">${formatNumber(p.organicSessions)}</td>
@@ -760,7 +826,7 @@ function renderAiReferrals(report: ProjectReportDto): string {
 
   const pageRows = ai.topLandingPages.map(p => `
     <tr>
-      <td>${escapeHtml(p.page)}</td>
+      <td class="page-cell">${formatLandingPageHtml(p.page)}</td>
       <td class="numeric">${formatNumber(p.sessions)}</td>
       <td class="numeric">${formatNumber(p.users)}</td>
     </tr>`).join('')

--- a/packages/canonry/test/report-renderer.test.ts
+++ b/packages/canonry/test/report-renderer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import type { ProjectReportDto } from '@ainyc/canonry-contracts'
-import { renderReportHtml } from '../src/report-renderer.js'
+import { formatLandingPageHtml, renderReportHtml } from '../src/report-renderer.js'
 
 function emptyReport(): ProjectReportDto {
   return {
@@ -268,5 +268,93 @@ describe('renderReportHtml', () => {
     // and provider names
     expect(html).toContain('gemini')
     expect(html).toContain('openai')
+  })
+
+  test('inline CSS allows long table cells to wrap', () => {
+    const html = renderReportHtml(emptyReport())
+    expect(html).toContain('overflow-wrap: anywhere')
+    expect(html).toContain('word-break: break-word')
+  })
+
+  test('renders landing page URLs with full URL accessible via title', () => {
+    const report = richReport()
+    report.ga!.topLandingPages = [
+      {
+        page: '/solar?fbclid=120242511631000253&h_ad_id=120242512056450253',
+        sessions: 100, users: 80, organicSessions: 0,
+      },
+    ]
+    const html = renderReportHtml(report)
+    expect(html).toContain('class="page-cell"')
+    expect(html).toContain('class="page-path"')
+    expect(html).toContain('Facebook Ad')
+    expect(html).toContain('title="/solar?fbclid=120242511631000253&amp;h_ad_id=120242512056450253"')
+    // The raw query string should not appear as visible cell text
+    expect(html).not.toMatch(/<span class="page-path">[^<]*fbclid/)
+  })
+})
+
+describe('formatLandingPageHtml', () => {
+  test('returns just the path span when there is no query string', () => {
+    expect(formatLandingPageHtml('/blog/foo')).toBe('<span class="page-path">/blog/foo</span>')
+  })
+
+  test('falls back to / when input is empty', () => {
+    expect(formatLandingPageHtml('')).toBe('<span class="page-path">/</span>')
+  })
+
+  test('preserves GA placeholders like (not set)', () => {
+    expect(formatLandingPageHtml('(not set)')).toBe('<span class="page-path">(not set)</span>')
+  })
+
+  test('escapes HTML in the path', () => {
+    const html = formatLandingPageHtml('/<script>alert(1)</script>')
+    expect(html).toContain('&lt;script&gt;')
+    expect(html).not.toContain('<script>')
+  })
+
+  test('labels Facebook Ads via fbclid', () => {
+    const html = formatLandingPageHtml('/solar?fbclid=abc&h_ad_id=123')
+    expect(html).toContain('Facebook Ad · 2 params')
+    expect(html).toContain('title="/solar?fbclid=abc&amp;h_ad_id=123"')
+  })
+
+  test('labels Google Ads via gclid', () => {
+    expect(formatLandingPageHtml('/x?gclid=abc')).toContain('Google Ad · 1 param')
+  })
+
+  test('labels Search Ads via hsa_* params', () => {
+    const url = '/roofing?adgroupid=1&hsa_acc=2&hsa_cam=3&hsa_grp=4&hsa_ad=5&hsa_kw=roof&hsa_mt=e&hsa_net=adwords&hsa_ver=3'
+    const html = formatLandingPageHtml(url)
+    expect(html).toContain('Search Ad · 9 params')
+    expect(html).toContain('<span class="page-path">/roofing</span>')
+  })
+
+  test('labels Microsoft Ads via msclkid', () => {
+    expect(formatLandingPageHtml('/x?msclkid=abc')).toContain('Microsoft Ad')
+  })
+
+  test('labels TikTok Ads via ttclid', () => {
+    expect(formatLandingPageHtml('/x?ttclid=abc')).toContain('TikTok Ad')
+  })
+
+  test('labels LinkedIn Ads via li_fat_id', () => {
+    expect(formatLandingPageHtml('/x?li_fat_id=abc')).toContain('LinkedIn Ad')
+  })
+
+  test('reports utm source / medium when no ad-click id', () => {
+    const html = formatLandingPageHtml('/x?utm_source=newsletter&utm_medium=email&utm_campaign=may')
+    expect(html).toContain('newsletter / email · 3 params')
+  })
+
+  test('falls back to "tracking params" count when no recognised tag', () => {
+    const html = formatLandingPageHtml('/x?foo=1&bar=2')
+    expect(html).toContain('2 tracking params')
+  })
+
+  test('singular noun for one tracking param', () => {
+    const html = formatLandingPageHtml('/x?foo=1')
+    expect(html).toContain('1 tracking param')
+    expect(html).not.toContain('1 tracking params')
   })
 })


### PR DESCRIPTION
> 📚 **Stacked PR — 1 of 6** · merge order: **#405** → #406 → #407 → #408 → #409 → #410

## Stack (merge top → bottom)
1. #405 — wrap long URLs in landing-page tables
2. #406 — wire content intelligence into the report
3. #407 — SOV %, cited pages, GSC × AEO crossover
4. #408 — severity tiering, grouping, brand classifier, trend gate
5. #409 — fix recurrence-lookback to filter by run kind
6. #410 — wire severity, trend baseline, and insight dedup through to consumers

## Summary
- Long URLs in `Top landing pages` and `AI referrals` sections were overflowing the table — added `overflow-wrap: anywhere` / `word-break: break-word` and a dedicated `.page-cell` style.
- New `formatLandingPageHtml` helper splits the path from the query string, summarises tracking params as a chip (`Facebook Ad · 4 params`, `Google Ad · 1 param`, `utm_source / utm_medium`, generic `N tracking params`), and tucks the full URL into the `title` attribute.

## Test plan
- [x] `pnpm --filter @ainyc/canonry test -- --run report-renderer`
- [x] Visual: regenerated reports for projects with `fbclid`/`gclid`/`hsa_*`/`utm_*` URLs render with chips and don't overflow.

> First commit in the report-polish stack — base is `main`. Following PRs build on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
