### PR TITLE
fix(intelligence): filter recurrence lookback by run kind

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "3.4.3",
+  "version": "3.4.4",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "3.4.2",
+  "version": "3.4.3",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/report.ts
+++ b/packages/api-routes/src/report.ts
@@ -36,6 +36,9 @@ import {
   buildContentSourceRows,
   buildContentGapRows,
   categorizeQueryByIntent,
+  groupInsights,
+  isTrendBaseline,
+  MIN_TREND_POINTS,
   mapOpportunitiesToNextSteps,
 } from '@ainyc/canonry-intelligence'
 import { resolveProject } from './helpers.js'
@@ -699,7 +702,7 @@ function buildInsightList(db: DatabaseClient, projectId: string): ReportInsight[
     .all()
 
   const severityRank: Record<string, number> = { critical: 0, high: 1, medium: 2, low: 3 }
-  return rows
+  const flat: Array<ReportInsight & { _sortRank: number }> = rows
     .filter(r => !r.dismissed)
     .map(r => {
       const recommendation = parseJsonColumn<{ action?: string; target?: string; reason?: string } | null>(r.recommendation, null)
@@ -720,9 +723,35 @@ function buildInsightList(db: DatabaseClient, projectId: string): ReportInsight[
         provider: r.provider,
         recommendation: recText,
         createdAt: r.createdAt,
+        instanceCount: 1,
+        _sortRank: severityRank[r.severity] ?? 99,
       }
     })
-    .sort((a, b) => severityRank[a.severity]! - severityRank[b.severity]!)
+
+  // Dedup at the API layer so all consumers — DTO, executive findings, next
+  // steps, renderer — see one row per (keyword, provider, type) tuple.
+  // Without this, a regression that fired in three runs would inflate counts
+  // in `buildExecutiveFindings` (e.g. "3 critical regressions" when there is
+  // really one) and "Resolve 3 critical regressions" in next-steps.
+  const groups = groupInsights(flat)
+  return groups
+    .map((g) => {
+      const rep = g.representative
+      const rest: ReportInsight = {
+        id: rep.id,
+        type: rep.type,
+        severity: rep.severity,
+        title: rep.title,
+        keyword: rep.keyword,
+        provider: rep.provider,
+        recommendation: rep.recommendation,
+        createdAt: rep.createdAt,
+        instanceCount: g.count,
+      }
+      return { ...rest, _sortRank: rep._sortRank }
+    })
+    .sort((a, b) => a._sortRank - b._sortRank)
+    .map(({ _sortRank: _drop, ...rest }) => rest)
 }
 
 function buildRecommendedNextSteps(insightList: ReportInsight[]): RecommendedNextStep[] {
@@ -759,19 +788,26 @@ function buildExecutiveFindings(
   citationRate: number,
   trend: ProjectReportDto['executiveSummary']['trend'],
   trendsPoints: CitationsTrendPoint[],
+  trendBaseline: boolean,
   insightList: ReportInsight[],
   competitorRows: CompetitorRow[],
 ): ProjectReportDto['executiveSummary']['findings'] {
   const findings: ProjectReportDto['executiveSummary']['findings'] = []
 
   if (trendsPoints.length > 0) {
-    const tone = trend === 'up' ? 'positive' : trend === 'down' ? 'negative' : 'neutral'
+    const tone = trendBaseline
+      ? 'neutral'
+      : trend === 'up' ? 'positive' : trend === 'down' ? 'negative' : 'neutral'
     let detail: string
-    switch (trend) {
-      case 'up': detail = 'Up from the previous run.'; break
-      case 'down': detail = 'Down from the previous run.'; break
-      case 'flat': detail = 'Flat compared to the previous run.'; break
-      case 'unknown': detail = 'No prior run to compare against.'; break
+    if (trendBaseline) {
+      detail = `Establishing baseline (${trendsPoints.length} of ${MIN_TREND_POINTS} runs collected).`
+    } else {
+      switch (trend) {
+        case 'up': detail = 'Up from the previous run.'; break
+        case 'down': detail = 'Down from the previous run.'; break
+        case 'flat': detail = 'Flat compared to the previous run.'; break
+        case 'unknown': detail = 'No prior run to compare against.'; break
+      }
     }
     findings.push({
       title: `Citation rate at ${citationRate}%`,
@@ -872,10 +908,15 @@ export async function reportRoutes(app: FastifyInstance) {
       ? Math.round((latestCited / latestConsidered) * 100)
       : 0
 
+    // Suppress trend computation until enough runs exist — a 5%→1% delta on
+    // N=2 reads as a crisis to a non-analyst reader but is pure noise on a
+    // sample of two. Same gate the renderer uses on the line chart so every
+    // surface (CLI, Aero, dashboard) stays consistent.
+    const trendBaseline = isTrendBaseline(citationsTrend)
     const latestPoint = citationsTrend.at(-1)
     const previousPoint = citationsTrend.length >= 2 ? citationsTrend.at(-2) : null
     let trend: ProjectReportDto['executiveSummary']['trend'] = 'unknown'
-    if (latestPoint && previousPoint) {
+    if (!trendBaseline && latestPoint && previousPoint) {
       if (latestPoint.citationRate > previousPoint.citationRate) trend = 'up'
       else if (latestPoint.citationRate < previousPoint.citationRate) trend = 'down'
       else trend = 'flat'
@@ -885,6 +926,7 @@ export async function reportRoutes(app: FastifyInstance) {
       citationRate,
       trend,
       citationsTrend,
+      trendBaseline,
       insightList,
       competitorLandscape.competitors,
     )

--- a/packages/api-routes/test/report.test.ts
+++ b/packages/api-routes/test/report.test.ts
@@ -561,7 +561,49 @@ describe('GET /api/v1/projects/:name/report', () => {
     expect(body.citationsTrend[0]!.citationRate).toBe(0)
     expect(body.citationsTrend[1]!.runId).toBe(r2)
     expect(body.citationsTrend[1]!.citationRate).toBe(100)
+    // Only 2 points — below MIN_TREND_POINTS, so trend is suppressed.
+    expect(body.executiveSummary.trend).toBe('unknown')
+  })
+
+  test('executiveSummary.trend resolves once enough runs are collected', async () => {
+    const projectId = insertProject(ctx.db, 'trend-resolved')
+    const kw = insertKeyword(ctx.db, projectId, 'kw')
+
+    // 4 runs: 0%, 0%, 0%, 100% — last delta is up, sample is large enough.
+    for (let i = 0; i < 4; i++) {
+      const day = String(i + 1).padStart(2, '0')
+      const id = insertRun(ctx.db, projectId, {
+        createdAt: `2026-04-${day}T00:00:00Z`,
+        finishedAt: `2026-04-${day}T00:01:00Z`,
+      })
+      insertSnapshot(ctx.db, id, kw, { citationState: i === 3 ? 'cited' : 'not-cited' })
+    }
+
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/trend-resolved/report' })
+    const body = JSON.parse(res.body) as ProjectReportDto
+
+    expect(body.citationsTrend.length).toBe(4)
     expect(body.executiveSummary.trend).toBe('up')
+  })
+
+  test('findings detail surfaces "Establishing baseline" copy until enough runs exist', async () => {
+    const projectId = insertProject(ctx.db, 'trend-baseline')
+    const kw = insertKeyword(ctx.db, projectId, 'kw')
+
+    const r1 = insertRun(ctx.db, projectId, { createdAt: '2026-04-01T00:00:00Z', finishedAt: '2026-04-01T00:01:00Z' })
+    const r2 = insertRun(ctx.db, projectId, { createdAt: '2026-04-02T00:00:00Z', finishedAt: '2026-04-02T00:01:00Z' })
+    insertSnapshot(ctx.db, r1, kw, { citationState: 'not-cited' })
+    insertSnapshot(ctx.db, r2, kw, { citationState: 'cited' })
+
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/trend-baseline/report' })
+    const body = JSON.parse(res.body) as ProjectReportDto
+
+    const trendFinding = body.executiveSummary.findings.find(f => f.title.startsWith('Citation rate'))
+    expect(trendFinding).toBeDefined()
+    expect(trendFinding!.detail).toMatch(/Establishing baseline/i)
+    expect(trendFinding!.tone).toBe('neutral')
   })
 
   test('partial runs power the scorecard but are excluded from the trend line', async () => {
@@ -650,10 +692,55 @@ describe('GET /api/v1/projects/:name/report', () => {
     expect(body.insights.length).toBe(2)
     expect(body.insights[0]!.severity).toBe('critical')
     expect(body.insights[0]!.recommendation).toContain('review-content')
+    expect(body.insights[0]!.instanceCount).toBe(1)
 
     expect(body.recommendedNextSteps.length).toBeGreaterThan(0)
     const horizons = body.recommendedNextSteps.map(s => s.horizon)
     expect(horizons).toContain('immediate')
+  })
+
+  test('insights are deduped by (keyword, provider, type) with instanceCount surfaced', async () => {
+    // A regression that fires across three runs should collapse to one
+    // ReportInsight with instanceCount=3, not three separate rows. Without
+    // dedup at the API layer, downstream consumers (executive findings,
+    // recommended next steps, CLI list views) overcount.
+    const projectId = insertProject(ctx.db, 'dedup-insights')
+    const r1 = insertRun(ctx.db, projectId, { createdAt: '2026-04-01T00:00:00Z', finishedAt: '2026-04-01T00:01:00Z' })
+    const r2 = insertRun(ctx.db, projectId, { createdAt: '2026-04-02T00:00:00Z', finishedAt: '2026-04-02T00:01:00Z' })
+    const r3 = insertRun(ctx.db, projectId, { createdAt: '2026-04-03T00:00:00Z', finishedAt: '2026-04-03T00:01:00Z' })
+
+    for (const [runId, createdAt, idSuffix] of [
+      [r1, '2026-04-01T00:00:00Z', '1'],
+      [r2, '2026-04-02T00:00:00Z', '2'],
+      [r3, '2026-04-03T00:00:00Z', '3'],
+    ] as const) {
+      ctx.db.insert(insights).values({
+        id: `ins-dup-${idSuffix}`,
+        projectId,
+        runId,
+        type: 'regression',
+        severity: 'critical',
+        title: 'Lost citation on aeo platform',
+        keyword: 'aeo platform',
+        provider: 'gemini',
+        recommendation: null,
+        cause: null,
+        dismissed: false,
+        createdAt,
+      }).run()
+    }
+
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/dedup-insights/report' })
+    const body = JSON.parse(res.body) as ProjectReportDto
+
+    expect(body.insights.length).toBe(1)
+    expect(body.insights[0]!.instanceCount).toBe(3)
+    // Representative is the most-recent firing.
+    expect(body.insights[0]!.id).toBe('ins-dup-3')
+    // Recommended next steps should count one critical regression, not three.
+    const immediate = body.recommendedNextSteps.find(s => s.horizon === 'immediate')
+    expect(immediate?.title).toContain('1 critical regression')
   })
 
   test('report shape is structurally identical across calls (deterministic)', async () => {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/intelligence-service.ts
+++ b/packages/canonry/src/intelligence-service.ts
@@ -84,10 +84,12 @@ export class IntelligenceService {
       insights: result.insights.length,
     })
 
-    // 5. Persist — idempotent via shared persistResult
-    this.persistResult(result, runId, projectId)
+    // 5. Tier severities once, pass tiered insights to persist + return so
+    // RunCoordinator / webhook dispatch see the same severities the DB holds.
+    const tieredResult = this.tierResult(result, runId, projectId)
+    this.persistResult(tieredResult, runId, projectId)
 
-    return result
+    return tieredResult
   }
 
   /**
@@ -117,9 +119,10 @@ export class IntelligenceService {
 
     const result = analyzeRuns(currentRun, previousRun)
 
-    this.persistResult(result, runRecord.id, runRecord.projectId)
+    const tieredResult = this.tierResult(result, runRecord.id, runRecord.projectId)
+    this.persistResult(tieredResult, runRecord.id, runRecord.projectId)
 
-    return result
+    return tieredResult
   }
 
   /**
@@ -205,15 +208,13 @@ export class IntelligenceService {
       }
     }
 
-    const tieredInsights = this.applySeverityTiering(result.insights, runId, projectId)
-
     this.db.transaction((tx) => {
       tx.delete(insights).where(eq(insights.runId, runId)).run()
       tx.delete(healthSnapshots).where(eq(healthSnapshots.runId, runId)).run()
 
       const now = new Date().toISOString()
 
-      for (const insight of tieredInsights) {
+      for (const insight of result.insights) {
         const wasDismissed = previouslyDismissed.has(`${insight.keyword}:${insight.provider}:${insight.type}`)
         tx.insert(insights).values({
           id: insight.id,
@@ -243,7 +244,18 @@ export class IntelligenceService {
       }).run()
     })
 
-    log.info('intelligence.persisted', { runId, insights: tieredInsights.length })
+    log.info('intelligence.persisted', { runId, insights: result.insights.length })
+  }
+
+  /**
+   * Apply severity tiering to the insights of an AnalysisResult and return a
+   * new result. Wraps `applySeverityTiering` so callers (analyzeAndPersist,
+   * analyzeRunWithPrevious) can pass the same tiered shape both into the DB
+   * write and back to the RunCoordinator / webhook dispatcher.
+   */
+  private tierResult(result: AnalysisResult, runId: string, projectId: string): AnalysisResult {
+    if (result.insights.length === 0) return result
+    return { ...result, insights: this.applySeverityTiering(result.insights, runId, projectId) }
   }
 
   /**

--- a/packages/canonry/src/intelligence-service.ts
+++ b/packages/canonry/src/intelligence-service.ts
@@ -3,6 +3,7 @@ import type { DatabaseClient } from '@ainyc/canonry-db'
 import { projects, runs, querySnapshots, keywords, insights, healthSnapshots, gscSearchData, parseJsonColumn } from '@ainyc/canonry-db'
 import { analyzeRuns, classifyRegressionSeverity } from '@ainyc/canonry-intelligence'
 import type { RunData, Snapshot, AnalysisResult, Insight } from '@ainyc/canonry-intelligence'
+import { RunKinds } from '@ainyc/canonry-contracts'
 import crypto from 'node:crypto'
 import { createLogger } from './logger.js'
 
@@ -285,6 +286,7 @@ export class IntelligenceService {
       .where(
         and(
           eq(runs.projectId, projectId),
+          eq(runs.kind, RunKinds['answer-visibility']),
           or(eq(runs.status, 'completed'), eq(runs.status, 'partial')),
         ),
       )

--- a/packages/canonry/src/report-renderer.ts
+++ b/packages/canonry/src/report-renderer.ts
@@ -982,21 +982,24 @@ function renderInsights(report: ProjectReportDto): string {
     )
   }
 
-  const groups = groupInsights(list)
-  const rows = groups.map((g) => {
-    const i = g.representative
-    const tone = severityTone(i.severity)
-    const countChip = g.count > 1
-      ? ` <span class="badge tone-neutral">× ${g.count}</span>`
-      : ''
-    return `<tr>
-      <td><span class="badge tone-${tone}">${escapeHtml(i.severity)}</span></td>
-      <td>${escapeHtml(i.title)}${countChip}</td>
-      <td>${escapeHtml(i.keyword)}</td>
-      <td>${escapeHtml(i.provider)}</td>
-      <td>${i.recommendation ? escapeHtml(i.recommendation) : '<span class="cell-pending">—</span>'}</td>
-    </tr>`
-  }).join('')
+  // The API has already deduped by (keyword, provider, type); use the per-row
+  // `instanceCount` instead of regrouping client-side. Older fixtures without
+  // the field fall back to a defensive group pass.
+  const haveDeduped = list.every((i) => typeof i.instanceCount === 'number')
+  const rows = (haveDeduped ? list.map((i) => ({ rep: i, count: i.instanceCount })) : groupInsights(list).map((g) => ({ rep: g.representative, count: g.count })))
+    .map(({ rep: i, count }) => {
+      const tone = severityTone(i.severity)
+      const countChip = count > 1
+        ? ` <span class="badge tone-neutral">× ${count}</span>`
+        : ''
+      return `<tr>
+        <td><span class="badge tone-${tone}">${escapeHtml(i.severity)}</span></td>
+        <td>${escapeHtml(i.title)}${countChip}</td>
+        <td>${escapeHtml(i.keyword)}</td>
+        <td>${escapeHtml(i.provider)}</td>
+        <td>${i.recommendation ? escapeHtml(i.recommendation) : '<span class="cell-pending">—</span>'}</td>
+      </tr>`
+    }).join('')
 
   return section(
     { id: 'insights', eyebrow: 'Section 11', title: 'Insights & Alerts', intro: 'Priority-ordered findings from the most recent runs.' },

--- a/packages/canonry/test/intelligence-service-severity.test.ts
+++ b/packages/canonry/test/intelligence-service-severity.test.ts
@@ -218,6 +218,28 @@ describe('IntelligenceService — regression severity tiering', () => {
     expect(persistedSeverity(db, currentRunId)).toBe('low')
   })
 
+  it('returns the tiered severity to the caller (so RunCoordinator/webhooks see it)', () => {
+    // RunCoordinator and dispatchInsightWebhooks classify by the AnalysisResult
+    // returned from analyzeAndPersist. If the return value still carried the
+    // legacy 'high' severity, persisted 'critical' regressions would never fire
+    // insight.critical webhooks and 'low' regressions would still announce as
+    // 'high' to Aero.
+    const db = createTempDb('intel-sev-')
+    const { projectId, currentRunId } = seedRegressionScenario(db, {
+      gscImpressions: 500,
+      priorRegressions: 3,
+    })
+
+    const result = new IntelligenceService(db).analyzeAndPersist(currentRunId, projectId)
+
+    expect(result).not.toBeNull()
+    const regression = result!.insights.find(i => i.type === 'regression')
+    expect(regression).toBeDefined()
+    expect(regression!.severity).toBe('critical')
+    // The persisted row carries the same severity.
+    expect(persistedSeverity(db, currentRunId)).toBe('critical')
+  })
+
   it('counts recurrence only across answer-visibility runs (ignores intervening gsc-sync runs)', () => {
     // Without filtering by run kind, intervening sync runs would consume the
     // recurrence-lookback budget and push prior visibility regressions out of

--- a/packages/canonry/test/intelligence-service-severity.test.ts
+++ b/packages/canonry/test/intelligence-service-severity.test.ts
@@ -217,4 +217,35 @@ describe('IntelligenceService — regression severity tiering', () => {
 
     expect(persistedSeverity(db, currentRunId)).toBe('low')
   })
+
+  it('counts recurrence only across answer-visibility runs (ignores intervening gsc-sync runs)', () => {
+    // Without filtering by run kind, intervening sync runs would consume the
+    // recurrence-lookback budget and push prior visibility regressions out of
+    // the window — dropping severity from 'critical' to 'high'.
+    const db = createTempDb('intel-sev-')
+    const { projectId, currentRunId } = seedRegressionScenario(db, {
+      gscImpressions: 500,
+      priorRegressions: 3,
+    })
+    // Insert 4 gsc-sync runs between the previous visibility run (now-24h)
+    // and the first prior regression (now-48h). Without the kind filter the
+    // recurrence query would keep these and discard the 3 visibility regressions.
+    const baseTime = new Date()
+    for (let i = 0; i < 4; i++) {
+      const at = new Date(baseTime.getTime() - (25 + i) * 60 * 60_000).toISOString()
+      db.insert(runs).values({
+        id: crypto.randomUUID(),
+        projectId,
+        kind: 'gsc-sync',
+        status: 'completed',
+        providers: '["gemini"]',
+        createdAt: at,
+        finishedAt: at,
+      }).run()
+    }
+
+    new IntelligenceService(db).analyzeAndPersist(currentRunId, projectId)
+
+    expect(persistedSeverity(db, currentRunId)).toBe('critical')
+  })
 })

--- a/packages/canonry/test/report-renderer.test.ts
+++ b/packages/canonry/test/report-renderer.test.ts
@@ -191,6 +191,7 @@ function richReport(): ProjectReportDto {
         provider: 'gemini',
         recommendation: 'review-content — /landing — rival outranking',
         createdAt: '2026-04-30T00:00:00Z',
+        instanceCount: 1,
       },
     ],
     recommendedNextSteps: [
@@ -443,19 +444,31 @@ describe('renderReportHtml', () => {
     expect(gscBlock).not.toContain('Search queries you should track')
   })
 
-  test('groups duplicate insights into a single row with × N count chip', () => {
+  test('renders × N count chip from the API-supplied instanceCount', () => {
     const report = richReport()
     report.insights = [
-      { id: 'i1', type: 'gain', severity: 'low', title: 'New citation for "kw"', keyword: 'kw', provider: 'gemini', recommendation: null, createdAt: '2026-01-01T00:00:00Z' },
-      { id: 'i2', type: 'gain', severity: 'low', title: 'New citation for "kw"', keyword: 'kw', provider: 'gemini', recommendation: null, createdAt: '2026-01-02T00:00:00Z' },
-      { id: 'i3', type: 'gain', severity: 'low', title: 'New citation for "kw"', keyword: 'kw', provider: 'gemini', recommendation: null, createdAt: '2026-01-03T00:00:00Z' },
+      { id: 'i1', type: 'gain', severity: 'low', title: 'New citation for "kw"', keyword: 'kw', provider: 'gemini', recommendation: null, createdAt: '2026-01-03T00:00:00Z', instanceCount: 3 },
     ]
     const html = renderReportHtml(report)
     const block = html.split('id="insights"')[1]?.split('</section>')[0] ?? ''
     expect(block).toContain('× 3')
-    // The keyword/title should appear exactly once in the rendered table body, not three times
     const occurrences = (block.match(/New citation for &quot;kw&quot;/g) ?? []).length
     expect(occurrences).toBe(1)
+  })
+
+  test('falls back to client-side grouping when instanceCount is missing (legacy fixture)', () => {
+    const report = richReport()
+    // Older payloads that predate the dedup may omit instanceCount. The
+    // renderer must still collapse duplicates so existing reports stay
+    // readable until the consumer upgrades.
+    report.insights = [
+      { id: 'i1', type: 'gain', severity: 'low', title: 'Legacy', keyword: 'kw', provider: 'gemini', recommendation: null, createdAt: '2026-01-01T00:00:00Z' } as ProjectReportDto['insights'][number],
+      { id: 'i2', type: 'gain', severity: 'low', title: 'Legacy', keyword: 'kw', provider: 'gemini', recommendation: null, createdAt: '2026-01-02T00:00:00Z' } as ProjectReportDto['insights'][number],
+    ]
+    const html = renderReportHtml(report)
+    const block = html.split('id="insights"')[1]?.split('</section>')[0] ?? ''
+    expect(block).toContain('× 2')
+    expect((block.match(/Legacy/g) ?? []).length).toBe(1)
   })
 
   test('hides the citations trend chart and shows a baseline note when fewer than 4 points exist', () => {

--- a/packages/contracts/src/report.ts
+++ b/packages/contracts/src/report.ts
@@ -259,6 +259,14 @@ export interface ReportInsight {
   provider: string
   recommendation: string | null
   createdAt: string
+  /**
+   * How many times this insight fired across recent runs for the same
+   * `(keyword, provider, type)` tuple. Always ≥ 1. Insights returned by the
+   * report API are already deduped to one row per tuple, with this counter
+   * surfacing the multiplicity. Use it directly instead of grouping again
+   * client-side — counts derived from raw insight rows will overcount.
+   */
+  instanceCount: number
 }
 
 export interface RecommendedNextStep {


### PR DESCRIPTION
> 📚 **Stacked PR — 5 of 6** · merge order: #405 → #406 → #407 → #408 → **#409** → #410

## Stack (merge top → bottom)
1. #405 — wrap long URLs in landing-page tables
2. #406 — wire content intelligence into the report
3. #407 — SOV %, cited pages, GSC × AEO crossover
4. #408 — severity tiering, grouping, brand classifier, trend gate
5. #409 — fix recurrence-lookback to filter by run kind
6. #410 — wire severity, trend baseline, and insight dedup through to consumers

## Summary
- The recurrence-window query in `applySeverityTiering` selected runs of any kind, but only `answer-visibility` runs produce regression insights. On projects that schedule frequent `gsc-sync` / `inspect-sitemap` / `site-audit` runs alongside weekly visibility sweeps, those runs filled the most-recent slots and consumed the lookback budget without contributing data — so `recurrenceCount` underreported prior regressions and severity stayed at `'high'` instead of escalating to `'critical'`.
- Adds `eq(runs.kind, RunKinds['answer-visibility'])` to the where clause, matching the convention used in `commands/backfill.ts`.
- Bumps `@ainyc/canonry` 3.4.2 → 3.4.3.

## Test plan
- [x] `pnpm --filter @ainyc/canonry test -- --run intelligence-service-severity` — new test interleaves 4 `gsc-sync` runs between the previous visibility run and the first prior regression and asserts the severity still tiers up to `'critical'`. Verified the test fails without the fix.
- [x] `pnpm typecheck && pnpm lint` clean across the workspace.

> Stacked on top of #408. Base is `arberx/report-intelligence`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
