### PR TITLE
fix(gsc): surface real sync time and refresh GSC cache after runs

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 import {
   BookOpen,
@@ -49,6 +49,7 @@ import { Toaster } from './components/layout/Toaster.js'
 import { AeroBarHost } from './components/shared/AeroBar.js'
 import { RUNS_STALE_MS } from './queries/query-client.js'
 import { queryKeys } from './queries/query-keys.js'
+import { invalidateQueriesForRunKind } from './queries/run-invalidations.js'
 import type {
   HealthSnapshot,
   ServiceStatus,
@@ -135,6 +136,7 @@ function batchTone(summary: ReturnType<typeof summarizeBatchStatuses>): ToastTon
 }
 
 export function RunNotificationObserver() {
+  const queryClient = useQueryClient()
   const trackedState = useSyncExternalStore(subscribeRunTracker, getRunTrackerState, getRunTrackerState)
   const hasPendingTracking = Object.keys(trackedState.runs).length > 0 || Object.keys(trackedState.batches).length > 0
   const runsQuery = useQuery({
@@ -191,6 +193,11 @@ export function RunNotificationObserver() {
       const previousStatus = prevStatusesRef.current[run.id] ?? trackedRun.lastAnnouncedStatus
       if (previousStatus === run.status) continue
 
+      const project = projects.find((candidate) => candidate.id === run.projectId)
+      if (project) {
+        invalidateQueriesForRunKind(queryClient, run.kind, project.name)
+      }
+
       if (trackedRun.sourceAction === 'run-all') {
         removeTrackedRun(run.id)
         continue
@@ -231,7 +238,7 @@ export function RunNotificationObserver() {
     }
 
     prevStatusesRef.current = nextStatuses
-  }, [projectsQuery.data, runsQuery.data, trackedState])
+  }, [projectsQuery.data, runsQuery.data, trackedState, queryClient])
 
   return null
 }

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -851,7 +851,7 @@ function SearchConsoleSection({
       : googleConfigured
         ? 'Connect Search Console for this domain'
         : 'Add Google OAuth credentials in Settings'
-  const googleUpdatedAt = googleCoverage?.lastInspectedAt ?? googleConnection?.updatedAt ?? null
+  const googleUpdatedAt = googleCoverage?.lastSyncedAt ?? googleCoverage?.lastInspectedAt ?? googleConnection?.updatedAt ?? null
 
   const bingTone = bingConnection?.connected ? 'positive' : bingConfigured ? 'caution' : 'negative'
   const bingStatus = bingConnection?.connected ? 'Connected' : bingConfigured ? 'Ready to connect' : 'Needs setup'

--- a/apps/web/src/queries/mutations.ts
+++ b/apps/web/src/queries/mutations.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query'
+import { RunKinds } from '@ainyc/canonry-contracts'
 import {
   ApiError,
   type ApiRun,
@@ -20,6 +21,7 @@ import {
 import { createTrackedBatch, trackRun, type TrackedRunSourceAction } from '../lib/run-tracker-store.js'
 import { addToast } from '../lib/toast-store.js'
 import { queryKeys } from './query-keys.js'
+import { invalidateQueriesForRunKind } from './run-invalidations.js'
 
 function invalidateProjectAndRunQueries(queryClient: QueryClient) {
   void queryClient.invalidateQueries({ queryKey: queryKeys.runs.all })
@@ -185,7 +187,7 @@ export function useTriggerGscSync() {
       opts?: Parameters<typeof triggerGscSync>[1]
     }) => triggerGscSync(projectName, opts),
     onSuccess: (run, variables) => {
-      invalidateProjectAndRunQueries(queryClient)
+      invalidateQueriesForRunKind(queryClient, RunKinds['gsc-sync'], variables.projectName)
       queueTrackedRunToast(run, {
         projectLabel: variables.projectLabel ?? variables.projectName,
         sourceAction: 'gsc-sync',
@@ -210,7 +212,7 @@ export function useTriggerDiscoverSitemaps() {
       projectLabel?: string
     }) => triggerDiscoverSitemaps(projectName),
     onSuccess: (result, variables) => {
-      invalidateProjectAndRunQueries(queryClient)
+      invalidateQueriesForRunKind(queryClient, result.run.kind, variables.projectName)
       queueTrackedRunToast(result.run, {
         projectLabel: variables.projectLabel ?? variables.projectName,
         sourceAction: 'discover-sitemaps',
@@ -236,7 +238,7 @@ export function useTriggerInspectSitemap() {
       opts?: Parameters<typeof triggerInspectSitemap>[1]
     }) => triggerInspectSitemap(projectName, opts),
     onSuccess: (run, variables) => {
-      invalidateProjectAndRunQueries(queryClient)
+      invalidateQueriesForRunKind(queryClient, RunKinds['inspect-sitemap'], variables.projectName)
       queueTrackedRunToast(run, {
         projectLabel: variables.projectLabel ?? variables.projectName,
         sourceAction: 'inspect-sitemap',

--- a/apps/web/src/queries/run-invalidations.ts
+++ b/apps/web/src/queries/run-invalidations.ts
@@ -1,0 +1,44 @@
+import type { QueryClient } from '@tanstack/react-query'
+
+import { RunKinds, type RunKind } from '@ainyc/canonry-contracts'
+
+import { queryKeys } from './query-keys.js'
+
+/**
+ * Map a run kind to the domain-scoped query keys it invalidates.
+ *
+ * When a run completes (or is queued, depending on the call site), the data
+ * surfaces it touched should be marked stale so the UI re-fetches. Adding a
+ * new `RunKind` variant requires extending this switch — TypeScript will
+ * fail compilation at the `_exhaustive` line if a case is ever missed.
+ */
+export function invalidateQueriesForRunKind(
+  queryClient: QueryClient,
+  kind: RunKind,
+  projectName: string,
+): void {
+  void queryClient.invalidateQueries({ queryKey: queryKeys.runs.all })
+  void queryClient.invalidateQueries({ queryKey: queryKeys.projects.all })
+
+  switch (kind) {
+    case RunKinds['answer-visibility']:
+    case RunKinds['site-audit']:
+    case RunKinds['backlink-extract']:
+      return
+    case RunKinds['gsc-sync']:
+    case RunKinds['inspect-sitemap']:
+      void queryClient.invalidateQueries({ queryKey: queryKeys.gsc.project(projectName) })
+      return
+    case RunKinds['ga-sync']:
+      void queryClient.invalidateQueries({ queryKey: queryKeys.traffic.project(projectName) })
+      return
+    case RunKinds['bing-inspect']:
+    case RunKinds['bing-inspect-sitemap']:
+      void queryClient.invalidateQueries({ queryKey: queryKeys.bing.project(projectName) })
+      return
+    default: {
+      const _exhaustive: never = kind
+      return _exhaustive
+    }
+  }
+}

--- a/apps/web/test/run-invalidations.test.ts
+++ b/apps/web/test/run-invalidations.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+import { QueryClient } from '@tanstack/react-query'
+
+import { RunKinds } from '@ainyc/canonry-contracts'
+
+import { invalidateQueriesForRunKind } from '../src/queries/run-invalidations.js'
+import { queryKeys } from '../src/queries/query-keys.js'
+
+let queryClient: QueryClient
+let invalidateSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity } } })
+  invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+})
+
+afterEach(() => {
+  invalidateSpy.mockRestore()
+  queryClient.clear()
+})
+
+function invalidatedKeys(): unknown[] {
+  return invalidateSpy.mock.calls.map(([arg]) => (arg as { queryKey: unknown }).queryKey)
+}
+
+test('always invalidates the shared runs and projects keys', () => {
+  invalidateQueriesForRunKind(queryClient, RunKinds['answer-visibility'], 'demo')
+  expect(invalidatedKeys()).toContainEqual(queryKeys.runs.all)
+  expect(invalidatedKeys()).toContainEqual(queryKeys.projects.all)
+})
+
+test('invalidates GSC project key for gsc-sync runs', () => {
+  invalidateQueriesForRunKind(queryClient, RunKinds['gsc-sync'], 'demo')
+  expect(invalidatedKeys()).toContainEqual(queryKeys.gsc.project('demo'))
+})
+
+test('invalidates GSC project key for inspect-sitemap runs', () => {
+  invalidateQueriesForRunKind(queryClient, RunKinds['inspect-sitemap'], 'demo')
+  expect(invalidatedKeys()).toContainEqual(queryKeys.gsc.project('demo'))
+})
+
+test('invalidates Bing project key for bing-inspect runs', () => {
+  invalidateQueriesForRunKind(queryClient, RunKinds['bing-inspect'], 'demo')
+  expect(invalidatedKeys()).toContainEqual(queryKeys.bing.project('demo'))
+})
+
+test('invalidates Bing project key for bing-inspect-sitemap runs', () => {
+  invalidateQueriesForRunKind(queryClient, RunKinds['bing-inspect-sitemap'], 'demo')
+  expect(invalidatedKeys()).toContainEqual(queryKeys.bing.project('demo'))
+})
+
+test('invalidates traffic project key for ga-sync runs', () => {
+  invalidateQueriesForRunKind(queryClient, RunKinds['ga-sync'], 'demo')
+  expect(invalidatedKeys()).toContainEqual(queryKeys.traffic.project('demo'))
+})
+
+test('does not invalidate domain-scoped keys for answer-visibility runs', () => {
+  invalidateQueriesForRunKind(queryClient, RunKinds['answer-visibility'], 'demo')
+  const keys = invalidatedKeys()
+  expect(keys).not.toContainEqual(queryKeys.gsc.project('demo'))
+  expect(keys).not.toContainEqual(queryKeys.bing.project('demo'))
+  expect(keys).not.toContainEqual(queryKeys.traffic.project('demo'))
+})

--- a/apps/web/test/run-notifications.test.tsx
+++ b/apps/web/test/run-notifications.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 import React from 'react'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { RouterProvider } from '@tanstack/react-router'
 
@@ -17,7 +17,7 @@ import { createAppRouter } from '../src/router/router.js'
 import { createDashboardFixture } from '../src/mock-data.js'
 import { DashboardProvider } from '../src/contexts/dashboard-context.js'
 import { queryKeys } from '../src/queries/query-keys.js'
-import { useTriggerRun } from '../src/queries/mutations.js'
+import { useTriggerGscSync, useTriggerRun } from '../src/queries/mutations.js'
 import { createQueryClient } from '../src/queries/query-client.js'
 
 function makeProject() {
@@ -70,6 +70,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  cleanup()
   resetToasts()
   resetRunTracker()
   vi.restoreAllMocks()
@@ -195,7 +196,9 @@ test('keeps run notifications active when the app is bootstrapped from dashboard
     expect(fetchMock.mock.calls.some(([input]) => String(input).includes('/api/v1/runs'))).toBe(true)
   })
 
-  expect(getToasts().some((toast) => toast.title === 'Visibility sweep completed')).toBe(true)
+  await waitFor(() => {
+    expect(getToasts().some((toast) => toast.title === 'Visibility sweep completed')).toBe(true)
+  })
 })
 
 test('emits one aggregate batch toast for run-all completions', async () => {
@@ -317,6 +320,121 @@ function TriggerRunButton() {
     </button>
   )
 }
+
+test('invalidates GSC project queries when a tracked gsc-sync run completes', async () => {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.includes('/api/v1/runs')) {
+      return jsonResponse([{ ...makeRun('completed'), kind: 'gsc-sync' }])
+    }
+    if (url.includes('/api/v1/projects')) return jsonResponse([makeProject()])
+    throw new Error(`Unexpected fetch: ${url}`)
+  })
+  vi.stubGlobal('fetch', fetchMock)
+
+  trackRun({
+    id: 'run_1',
+    projectId: 'proj_1',
+    kind: 'gsc-sync',
+    projectLabel: 'Citypoint Dental NYC',
+    sourceAction: 'gsc-sync',
+    lastAnnouncedStatus: 'queued',
+  })
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity } } })
+  queryClient.setQueryData(queryKeys.runs.all, [{ ...makeRun('completed'), kind: 'gsc-sync' }])
+  queryClient.setQueryData(queryKeys.projects.all, [makeProject()])
+  // Pre-populate the GSC coverage cache so invalidation has something to mark stale.
+  queryClient.setQueryData(queryKeys.gsc.coverage('citypoint'), { stale: true })
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RunNotificationObserver />
+    </QueryClientProvider>,
+  )
+
+  await waitFor(() => {
+    const state = queryClient.getQueryState(queryKeys.gsc.coverage('citypoint'))
+    expect(state?.isInvalidated).toBe(true)
+  })
+})
+
+test('does not invalidate GSC project queries for non-GSC runs', async () => {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.includes('/api/v1/runs')) return jsonResponse([makeRun('completed')])
+    if (url.includes('/api/v1/projects')) return jsonResponse([makeProject()])
+    throw new Error(`Unexpected fetch: ${url}`)
+  })
+  vi.stubGlobal('fetch', fetchMock)
+
+  trackRun({
+    id: 'run_1',
+    projectId: 'proj_1',
+    kind: 'answer-visibility',
+    projectLabel: 'Citypoint Dental NYC',
+    sourceAction: 'project-run',
+    lastAnnouncedStatus: 'queued',
+  })
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity } } })
+  queryClient.setQueryData(queryKeys.runs.all, [makeRun('completed')])
+  queryClient.setQueryData(queryKeys.projects.all, [makeProject()])
+  queryClient.setQueryData(queryKeys.gsc.coverage('citypoint'), { stale: true })
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RunNotificationObserver />
+    </QueryClientProvider>,
+  )
+
+  // Wait for the terminal toast to fire so the observer effect has run.
+  await waitFor(() => {
+    expect(getToasts().some((toast) => toast.title === 'Visibility sweep completed')).toBe(true)
+  })
+
+  const state = queryClient.getQueryState(queryKeys.gsc.coverage('citypoint'))
+  expect(state?.isInvalidated).toBe(false)
+})
+
+function TriggerGscSyncButton() {
+  const mutation = useTriggerGscSync()
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        mutation.mutate({ projectName: 'citypoint', projectLabel: 'Citypoint Dental NYC' })
+      }}
+    >
+      Trigger GSC sync
+    </button>
+  )
+}
+
+test('useTriggerGscSync invalidates GSC project queries when the mutation succeeds', async () => {
+  const fetchMock = vi.fn(async () => jsonResponse({
+    ...makeRun('queued'),
+    kind: 'gsc-sync',
+  }))
+  vi.stubGlobal('fetch', fetchMock)
+
+  const queryClient = createQueryClient()
+  // Pre-populate the cache so we can observe invalidation.
+  queryClient.setQueryData(queryKeys.gsc.coverage('citypoint'), { stale: true })
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <TriggerGscSyncButton />
+    </QueryClientProvider>,
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: 'Trigger GSC sync' }))
+
+  await waitFor(() => {
+    const state = queryClient.getQueryState(queryKeys.gsc.coverage('citypoint'))
+    expect(state?.isInvalidated).toBe(true)
+  })
+})
 
 test('maps RUN_IN_PROGRESS errors to one caution toast with an extended timer', async () => {
   const fetchMock = vi.fn(async () => new Response(JSON.stringify({

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "3.4.5",
+  "version": "3.4.6",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/google.ts
+++ b/packages/api-routes/src/google.ts
@@ -643,6 +643,19 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
     const indexed = indexedUrls.length
     const notIndexed = notIndexedUrls.length
 
+    // The most recent coverage snapshot's createdAt records when the sync
+    // last wrote data. This is distinct from lastInspectedAt — a sync that
+    // re-fetched coverage but found no newly-crawled URLs still updates
+    // lastSyncedAt while leaving lastInspectedAt unchanged.
+    const latestSnapshot = app.db
+      .select({ createdAt: gscCoverageSnapshots.createdAt })
+      .from(gscCoverageSnapshots)
+      .where(eq(gscCoverageSnapshots.projectId, project.id))
+      .orderBy(desc(gscCoverageSnapshots.createdAt))
+      .limit(1)
+      .get()
+    const lastSyncedAt = latestSnapshot?.createdAt ?? null
+
     const formatRow = (r: typeof allInspections[number]) => ({
       id: r.id,
       url: r.url,
@@ -686,6 +699,7 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
         percentage: total > 0 ? Math.round((indexed / total) * 1000) / 10 : 0,
       },
       lastInspectedAt,
+      lastSyncedAt,
       indexed: indexedUrls.map(formatRow),
       notIndexed: notIndexedUrls.map(formatRow),
       deindexed: deindexedUrls,

--- a/packages/api-routes/test/google.test.ts
+++ b/packages/api-routes/test/google.test.ts
@@ -772,6 +772,160 @@ describe('googleRoutes: coverage snapshot deduplication', () => {
   })
 })
 
+describe('googleRoutes: GET /projects/:name/google/gsc/coverage', () => {
+  let app: ReturnType<typeof Fastify>
+  let tmpDir: string
+  let db: ReturnType<typeof createClient>
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'google-coverage-summary-'))
+    const dbPath = path.join(tmpDir, 'test.db')
+    db = createClient(dbPath)
+    migrate(db)
+
+    const now = new Date().toISOString()
+    db.insert(projects).values({
+      id: 'p1',
+      name: 'covproj',
+      displayName: 'Coverage Project',
+      canonicalDomain: 'coverage.com',
+      country: 'US',
+      language: 'en',
+      createdAt: now,
+      updatedAt: now,
+    }).run()
+
+    db.insert(runs).values({
+      id: 'r1',
+      projectId: 'p1',
+      kind: 'gsc-sync',
+      status: 'completed',
+      createdAt: now,
+    }).run()
+
+    const fastify = Fastify()
+    fastify.setErrorHandler((error, _request, reply) => {
+      if (error instanceof AppError) {
+        return reply.status(error.statusCode).send(error.toJSON())
+      }
+      throw error
+    })
+    fastify.decorate('db', db)
+    fastify.register(googleRoutes, {
+      getGoogleAuthConfig: () => ({ clientId: undefined, clientSecret: undefined }),
+      googleConnectionStore: {
+        listConnections: () => [],
+        getConnection: () => undefined,
+        upsertConnection: (c) => c,
+        updateConnection: () => undefined,
+        deleteConnection: () => false,
+      },
+      googleStateSecret: 'test-secret-32-bytes-long-enough!',
+    })
+
+    app = fastify
+    await app.ready()
+  })
+
+  afterAll(async () => {
+    await app.close()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns null lastSyncedAt and lastInspectedAt when no data exists', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/projects/covproj/google/gsc/coverage',
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as { lastInspectedAt: string | null; lastSyncedAt: string | null }
+    expect(body.lastInspectedAt).toBeNull()
+    expect(body.lastSyncedAt).toBeNull()
+  })
+
+  it('returns lastSyncedAt from the most recent coverage snapshot, independent of inspection time', async () => {
+    // Inspections from May 1; sync snapshot from May 4 (later) — exercises
+    // the bug fix: a sync that re-fetched coverage but found no new URLs
+    // still updates lastSyncedAt while leaving lastInspectedAt unchanged.
+    const inspectionTime = '2026-05-01T08:00:00.000Z'
+    const syncTime = '2026-05-04T14:36:24.808Z'
+
+    db.insert(gscUrlInspections).values({
+      id: 'i1',
+      projectId: 'p1',
+      syncRunId: 'r1',
+      url: 'https://coverage.com/page-1',
+      indexingState: 'INDEXING_ALLOWED',
+      verdict: 'PASS',
+      coverageState: 'Submitted and indexed',
+      pageFetchState: 'SUCCESSFUL',
+      robotsTxtState: 'ALLOWED',
+      crawlTime: inspectionTime,
+      lastCrawlResult: null,
+      isMobileFriendly: 1,
+      richResults: '[]',
+      referringUrls: '[]',
+      inspectedAt: inspectionTime,
+      createdAt: inspectionTime,
+    }).run()
+
+    db.insert(gscCoverageSnapshots).values({
+      id: 'snap-may4',
+      projectId: 'p1',
+      syncRunId: 'r1',
+      date: '2026-05-04',
+      indexed: 1,
+      notIndexed: 0,
+      reasonBreakdown: '{}',
+      createdAt: syncTime,
+    }).run()
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/projects/covproj/google/gsc/coverage',
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as { lastInspectedAt: string | null; lastSyncedAt: string | null }
+    expect(body.lastInspectedAt).toBe(inspectionTime)
+    expect(body.lastSyncedAt).toBe(syncTime)
+  })
+
+  it('uses the most recent snapshot when several exist for different dates', async () => {
+    const earlierSync = '2026-05-02T12:00:00.000Z'
+    const latestSync = '2026-05-05T09:30:00.000Z'
+
+    db.insert(gscCoverageSnapshots).values({
+      id: 'snap-may2',
+      projectId: 'p1',
+      syncRunId: 'r1',
+      date: '2026-05-02',
+      indexed: 1,
+      notIndexed: 0,
+      reasonBreakdown: '{}',
+      createdAt: earlierSync,
+    }).run()
+
+    db.insert(gscCoverageSnapshots).values({
+      id: 'snap-may5',
+      projectId: 'p1',
+      syncRunId: 'r1',
+      date: '2026-05-05',
+      indexed: 1,
+      notIndexed: 0,
+      reasonBreakdown: '{}',
+      createdAt: latestSync,
+    }).run()
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/projects/covproj/google/gsc/coverage',
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as { lastSyncedAt: string | null }
+    expect(body.lastSyncedAt).toBe(latestSync)
+  })
+})
+
 describe('googleRoutes: POST /projects/:name/google/indexing/request', () => {
   let app: ReturnType<typeof Fastify>
   let tmpDir: string

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "3.4.5",
+  "version": "3.4.6",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/contracts/src/google.ts
+++ b/packages/contracts/src/google.ts
@@ -70,6 +70,7 @@ export const gscCoverageSummaryDtoSchema = z.object({
     percentage: z.number(),
   }),
   lastInspectedAt: z.string().nullable(),
+  lastSyncedAt: z.string().nullable(),
   indexed: z.array(gscUrlInspectionDtoSchema).default([]),
   notIndexed: z.array(gscUrlInspectionDtoSchema).default([]),
   deindexed: z.array(gscDeindexedRowSchema).default([]),


### PR DESCRIPTION
## Summary
- Coverage endpoint now returns `lastSyncedAt` (latest `gsc_coverage_snapshots.created_at`) so the UI shows when the sync ran, not when URLs were last inspected — fixes "Last updated 5/1" lingering after a successful May-4 sync.
- Centralizes per-run-kind cache invalidation in a new `invalidateQueriesForRunKind` helper used by both `useTriggerGscSync`/`useTriggerInspectSitemap`/`useTriggerDiscoverSitemaps` and `RunNotificationObserver`, so GSC queries refresh both at queue-time and on terminal status.
- Exhaustive `RunKind` switch fails compilation if a future run kind forgets its cache mapping; 13 new tests cover the API field, the helper, and observer/mutation invalidation behavior.

## Test plan
- [x] `pnpm typecheck && pnpm lint && pnpm test` (1890 passing, 13 new)
- [x] Trigger GSC sync from the dashboard and confirm "Last synced" updates immediately
- [x] Verify coverage tab refreshes without a manual reload after sync completes