### PR TITLE
fix(gsc): accept numeric GSC property IDs in site URL validation

### DIFF
--- a/docs/google-search-console-setup.md
+++ b/docs/google-search-console-setup.md
@@ -153,7 +153,7 @@ canonry google properties <project>
 canonry google set-property <project> https://example.com/
 ```
 
-> Properties in GSC are typically `https://example.com/` (URL prefix) or `sc-domain:example.com` (domain property). Use whichever matches your verified property.
+> Properties in GSC are typically `https://example.com/` (URL prefix) or `sc-domain:example.com` (domain property). Some accounts also surface a numeric property ID (e.g. `364127269`); canonry passes any of these formats straight through to the GSC API. Use whichever matches your verified property.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "3.4.6",
+  "version": "3.4.7",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/integration-google/src/gsc-client.ts
+++ b/packages/integration-google/src/gsc-client.ts
@@ -20,7 +20,13 @@ function validateSiteUrl(siteUrl: string): void {
   if (!siteUrl || typeof siteUrl !== 'string' || siteUrl.trim().length === 0) {
     throw new GoogleApiError('Site URL is required and must be a non-empty string', 400)
   }
-  // Accept both https://example.com and sc-domain:example.com patterns
+  // Accept three formats GSC's API uses for the {siteUrl} path segment:
+  //   - sc-domain:example.com   (domain property)
+  //   - https://example.com/    (URL-prefix property)
+  //   - 364127269               (numeric property ID returned by some GSC accounts)
+  if (/^\d+$/.test(siteUrl)) {
+    return
+  }
   if (siteUrl.startsWith('sc-domain:')) {
     const domain = siteUrl.slice('sc-domain:'.length)
     if (!domain) {

--- a/packages/integration-google/test/gsc-client.test.ts
+++ b/packages/integration-google/test/gsc-client.test.ts
@@ -100,6 +100,17 @@ describe('listSitemaps', () => {
     expect(capturedUrl).toContain(encodeURIComponent('sc-domain:example.com'))
   })
 
+  it('accepts a numeric property ID and uses it in the request path', async () => {
+    let capturedUrl = ''
+    globalThis.fetch = async (url: string | URL | Request) => {
+      capturedUrl = String(url)
+      return new Response(JSON.stringify({ sitemap: [] }), { status: 200 })
+    }
+
+    await listSitemaps('test-token', '364127269')
+    expect(capturedUrl).toBe(`${GSC_API_BASE}/sites/364127269/sitemaps`)
+  })
+
   it('throws GoogleApiError on 401', async () => {
     globalThis.fetch = async () => new Response('Unauthorized', { status: 401 })
     await expect(() => listSitemaps('bad-token', 'https://example.com/')).rejects.toMatchObject({ name: 'GoogleApiError' })
@@ -177,6 +188,17 @@ describe('fetchSearchAnalytics', () => {
       () => fetchSearchAnalytics('token', 'https://example.com', { startDate: '2024-01-01', endDate: '2024-01-31' }),
     ).rejects.toThrow(/rate limit/)
   })
+
+  it('accepts a numeric property ID and uses it in the request path', async () => {
+    let capturedUrl = ''
+    globalThis.fetch = async (url: string | URL | Request) => {
+      capturedUrl = String(url)
+      return new Response(JSON.stringify({ rows: [] }), { status: 200 })
+    }
+
+    await fetchSearchAnalytics('token', '364127269', { startDate: '2024-01-01', endDate: '2024-01-31' })
+    expect(capturedUrl).toBe(`${GSC_API_BASE}/sites/364127269/searchAnalytics/query`)
+  })
 })
 
 describe('inspectUrl', () => {
@@ -229,6 +251,21 @@ describe('inspectUrl', () => {
     expect(result.inspectionResult.indexStatusResult?.verdict).toBe('PASS')
     expect(result.inspectionResult.indexStatusResult?.indexingState).toBe('INDEXING_ALLOWED')
     expect(result.inspectionResult.richResultsResult?.detectedItems?.[0]?.richResultType).toBe('FAQ')
+  })
+
+  it('accepts a numeric property ID for siteUrl', async () => {
+    let capturedBody: unknown
+    globalThis.fetch = async (_url: string | URL | Request, init?: RequestInit) => {
+      capturedBody = JSON.parse(String(init?.body ?? '{}'))
+      return new Response(
+        JSON.stringify({ inspectionResult: { indexStatusResult: { verdict: 'PASS' } } }),
+        { status: 200 },
+      )
+    }
+
+    await inspectUrl('token', 'https://example.com/page', '364127269')
+    const body = capturedBody as { inspectionUrl: string; siteUrl: string }
+    expect(body.siteUrl).toBe('364127269')
   })
 })
 


### PR DESCRIPTION
## Summary
- `validateSiteUrl()` in `packages/integration-google/src/gsc-client.ts` now accepts all-digit property IDs (e.g. `364127269`) alongside `sc-domain:` and `https://` formats. Some GSC accounts surface numeric IDs that Google's API accepts directly in the path (`/sites/{siteUrl}/...`), but the validator was rejecting them as "Site URL must be a valid URL", which broke every GSC sync (search analytics, URL inspection, sitemap listing) for affected projects such as demand-iq.com.
- Added tests covering the numeric path through `listSitemaps`, `fetchSearchAnalytics`, and `inspectUrl`. Updated `docs/google-search-console-setup.md` to mention the numeric format. Bumped 3.4.6 → 3.4.7.

## Test plan
- [x] `pnpm --filter @ainyc/canonry-integration-google test` (26/26 pass, 3 new)
- [x] `pnpm --filter @ainyc/canonry-integration-google typecheck`
- [x] `pnpm --filter @ainyc/canonry-integration-google lint`
- [ ] Trigger GSC sync on a project whose `propertyId` is numeric and confirm it no longer errors with "Site URL must be a valid URL"