### PR TITLE
fix(ga): stop overcounting Total Users when a window filter is active

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "3.5.0",
+  "version": "3.5.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/ga.ts
+++ b/packages/api-routes/src/ga.ts
@@ -1,13 +1,14 @@
 import crypto from 'node:crypto'
 import { eq, desc, and, sql } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
-import { gaTrafficSnapshots, gaTrafficSummaries, gaAiReferrals, gaSocialReferrals, runs } from '@ainyc/canonry-db'
+import { gaTrafficSnapshots, gaTrafficSummaries, gaTrafficWindowSummaries, gaAiReferrals, gaSocialReferrals, runs } from '@ainyc/canonry-db'
 import { validationError, notFound, RunKinds, RunStatuses, RunTriggers, parseWindow, windowCutoff, normalizeUrlPath } from '@ainyc/canonry-contracts'
 import { resolveProject, writeAuditLog } from './helpers.js'
 import {
   getAccessToken,
   fetchTrafficByLandingPage,
   fetchAggregateSummary,
+  fetchWindowSummary,
   fetchAiReferrals,
   fetchSocialReferrals,
   verifyConnection,
@@ -395,15 +396,22 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       let aiReferrals: Awaited<ReturnType<typeof fetchAiReferrals>> = []
       let socialReferrals: Awaited<ReturnType<typeof fetchSocialReferrals>> = []
 
-      // Always need summary for date range (periodStart/periodEnd), even for partial sync
-      const fetches: Promise<unknown>[] = [fetchAggregateSummary(accessToken, propertyId, days)]
+      // Always need summary for date range (periodStart/periodEnd), even for partial sync.
+      // Windowed summaries (7d/30d/90d) are fetched alongside so the dashboard can show
+      // deduplicated totalUsers per window without summing per-page snapshots (overcounts).
+      const WINDOW_KEYS = ['7d', '30d', '90d'] as const
+      const fetches: Promise<unknown>[] = [
+        fetchAggregateSummary(accessToken, propertyId, days),
+        ...WINDOW_KEYS.map((w) => fetchWindowSummary(accessToken, propertyId, w)),
+      ]
       if (syncTraffic) fetches.push(fetchTrafficByLandingPage(accessToken, propertyId, days))
       if (syncAi) fetches.push(fetchAiReferrals(accessToken, propertyId, days))
       if (syncSocial) fetches.push(fetchSocialReferrals(accessToken, propertyId, days))
 
       const results = await Promise.all(fetches)
       const summary: Awaited<ReturnType<typeof fetchAggregateSummary>> = results[0] as Awaited<ReturnType<typeof fetchAggregateSummary>>
-      let idx = 1
+      const windowSummaries = results.slice(1, 1 + WINDOW_KEYS.length) as Array<Awaited<ReturnType<typeof fetchWindowSummary>>>
+      let idx = 1 + WINDOW_KEYS.length
       if (syncTraffic) { rows = results[idx++] as typeof rows }
       if (syncAi) { aiReferrals = results[idx++] as typeof aiReferrals }
       if (syncSocial) { socialReferrals = results[idx++] as typeof socialReferrals }
@@ -514,6 +522,28 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
             syncedAt: now,
             syncRunId: runId,
           }).run()
+
+          // Replace windowed summaries — one row per (project, windowKey).
+          // Drives the deduplicated totalUsers headline when a window filter
+          // is active in /ga/traffic.
+          tx.delete(gaTrafficWindowSummaries)
+            .where(eq(gaTrafficWindowSummaries.projectId, project.id))
+            .run()
+          for (const ws of windowSummaries) {
+            tx.insert(gaTrafficWindowSummaries).values({
+              id: crypto.randomUUID(),
+              projectId: project.id,
+              windowKey: ws.windowKey,
+              periodStart: ws.periodStart,
+              periodEnd: ws.periodEnd,
+              totalSessions: ws.totalSessions,
+              totalOrganicSessions: ws.totalOrganicSessions,
+              totalDirectSessions: ws.totalDirectSessions,
+              totalUsers: ws.totalUsers,
+              syncedAt: now,
+              syncRunId: runId,
+            }).run()
+          }
         }
       })
 
@@ -587,9 +617,31 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
     const socialConditions = [eq(gaSocialReferrals.projectId, project.id)]
     if (cutoffDate) socialConditions.push(sql`${gaSocialReferrals.date} >= ${cutoffDate}`)
 
-    // When filtering by window, compute totals from snapshots instead of the
-    // pre-aggregated summary (which covers the full synced range).
-    const summaryRow = cutoffDate
+    // When filtering by window, prefer the per-window summary row populated by
+    // /ga/sync — it carries deduplicated totalUsers (no landing-page dimension).
+    // Summing gaTrafficSnapshots.users here would double-count users who land
+    // on multiple pages (one row per landing page). Falls back to the
+    // snapshot SUM for backwards compatibility (projects that haven't synced
+    // since the windowed-summary table was introduced).
+    const windowSummaryRow = cutoffDate
+      ? app.db
+          .select({
+            totalSessions: gaTrafficWindowSummaries.totalSessions,
+            totalOrganicSessions: gaTrafficWindowSummaries.totalOrganicSessions,
+            totalDirectSessions: gaTrafficWindowSummaries.totalDirectSessions,
+            totalUsers: gaTrafficWindowSummaries.totalUsers,
+          })
+          .from(gaTrafficWindowSummaries)
+          .where(
+            and(
+              eq(gaTrafficWindowSummaries.projectId, project.id),
+              eq(gaTrafficWindowSummaries.windowKey, window),
+            ),
+          )
+          .get()
+      : null
+
+    const snapshotTotalsRow = cutoffDate && !windowSummaryRow
       ? app.db
           .select({
             totalSessions: sql<number>`COALESCE(SUM(${gaTrafficSnapshots.sessions}), 0)`,
@@ -599,6 +651,10 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
           .from(gaTrafficSnapshots)
           .where(and(...snapshotConditions))
           .get()
+      : null
+
+    const summaryRow = cutoffDate
+      ? windowSummaryRow ?? snapshotTotalsRow
       : app.db
           .select({
             totalSessions: gaTrafficSummaries.totalSessions,
@@ -609,17 +665,19 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
           .where(eq(gaTrafficSummaries.projectId, project.id))
           .get()
 
-    // Direct-channel total. Always sourced from gaTrafficSnapshots since
-    // gaTrafficSummaries doesn't carry a direct_sessions column. Returns
-    // 0 when no rows match (e.g., a project that hasn't synced yet, or
-    // legacy rows with null direct_sessions).
-    const directTotalRow = app.db
-      .select({
-        totalDirectSessions: sql<number>`COALESCE(SUM(${gaTrafficSnapshots.directSessions}), 0)`,
-      })
-      .from(gaTrafficSnapshots)
-      .where(and(...snapshotConditions))
-      .get()
+    // Direct-channel total. With a window filter, prefer the deduplicated value
+    // from gaTrafficWindowSummaries; otherwise fall back to summing snapshots
+    // (sessions are dimensioned by landing page but each session has a single
+    // landing page, so SUM doesn't overcount sessions — only users).
+    const directTotalRow = windowSummaryRow
+      ? { totalDirectSessions: windowSummaryRow.totalDirectSessions }
+      : app.db
+          .select({
+            totalDirectSessions: sql<number>`COALESCE(SUM(${gaTrafficSnapshots.directSessions}), 0)`,
+          })
+          .from(gaTrafficSnapshots)
+          .where(and(...snapshotConditions))
+          .get()
 
     // Always fetch period bounds from the summary table (reflects full synced range).
     const summaryMeta = app.db

--- a/packages/api-routes/test/ga.test.ts
+++ b/packages/api-routes/test/ga.test.ts
@@ -6,7 +6,7 @@ import crypto from 'node:crypto'
 import Fastify from 'fastify'
 import { eq, inArray } from 'drizzle-orm'
 import { RunKinds, RunStatuses, RunTriggers } from '@ainyc/canonry-contracts'
-import { createClient, migrate, gaAiReferrals, gaSocialReferrals, gaTrafficSnapshots, gaTrafficSummaries, runs } from '@ainyc/canonry-db'
+import { createClient, migrate, gaAiReferrals, gaSocialReferrals, gaTrafficSnapshots, gaTrafficSummaries, gaTrafficWindowSummaries, runs } from '@ainyc/canonry-db'
 import { apiRoutes } from '../src/index.js'
 import type { Ga4CredentialStore, Ga4CredentialRecord } from '../src/ga.js'
 
@@ -238,6 +238,15 @@ describe('GA4 routes', () => {
       totalOrganicSessions: 30,
       totalUsers: 55,
     })
+    const fetchWindowSummarySpy = vi.spyOn(gaModule, 'fetchWindowSummary').mockImplementation(async (_token, _propId, windowKey) => ({
+      windowKey,
+      periodStart: '2026-02-19',
+      periodEnd: '2026-03-20',
+      totalSessions: windowKey === '7d' ? 20 : windowKey === '30d' ? 80 : 200,
+      totalOrganicSessions: windowKey === '7d' ? 8 : windowKey === '30d' ? 30 : 75,
+      totalDirectSessions: windowKey === '7d' ? 4 : windowKey === '30d' ? 16 : 40,
+      totalUsers: windowKey === '7d' ? 15 : windowKey === '30d' ? 55 : 140,
+    }))
     const fetchAiReferralsSpy = vi.spyOn(gaModule, 'fetchAiReferrals').mockResolvedValue([
       { date: '2026-03-20', source: 'chatgpt.com', medium: 'referral', landingPage: '/pricing?utm_source=chatgpt.com', sessions: 12, users: 9, sourceDimension: 'session' },
     ])
@@ -279,6 +288,22 @@ describe('GA4 routes', () => {
     expect(summaries[0]!.totalSessions).toBe(80)
     expect(summaries[0]!.totalOrganicSessions).toBe(30)
 
+    // Verify per-window summaries were written (one row per 7d/30d/90d).
+    // Drives the deduplicated totalUsers headline when a window filter is
+    // active in /ga/traffic — summing snapshots overcounts users who land
+    // on multiple pages.
+    const windowSummaries = db.select().from(gaTrafficWindowSummaries)
+      .where(eq(gaTrafficWindowSummaries.projectId, projectId))
+      .all()
+      .sort((a, b) => a.windowKey.localeCompare(b.windowKey))
+    expect(windowSummaries.map((r) => r.windowKey)).toEqual(['30d', '7d', '90d'])
+    const byKey = Object.fromEntries(windowSummaries.map((r) => [r.windowKey, r]))
+    expect(byKey['7d']!.totalUsers).toBe(15)
+    expect(byKey['30d']!.totalUsers).toBe(55)
+    expect(byKey['90d']!.totalUsers).toBe(140)
+    expect(byKey['30d']!.totalDirectSessions).toBe(16)
+    expect(windowSummaries.every((r) => r.syncRunId === gaRuns[0]!.id)).toBe(true)
+
     const aiReferrals = db.select().from(gaAiReferrals)
       .where(eq(gaAiReferrals.projectId, projectId))
       .all()
@@ -301,6 +326,7 @@ describe('GA4 routes', () => {
     getAccessTokenSpy.mockRestore()
     fetchTrafficSpy.mockRestore()
     fetchAggregateSpy.mockRestore()
+    fetchWindowSummarySpy.mockRestore()
     fetchAiReferralsSpy.mockRestore()
     fetchSocialReferralsSpy.mockRestore()
     credentials.delete('test-project')
@@ -361,6 +387,15 @@ describe('GA4 routes', () => {
       totalOrganicSessions: 0,
       totalUsers: 0,
     })
+    const fetchWindowSummarySpy = vi.spyOn(gaModule, 'fetchWindowSummary').mockImplementation(async (_t, _p, windowKey) => ({
+      windowKey,
+      periodStart: '2026-03-01',
+      periodEnd: '2026-03-31',
+      totalSessions: 0,
+      totalOrganicSessions: 0,
+      totalDirectSessions: 0,
+      totalUsers: 0,
+    }))
     const fetchAiReferralsSpy = vi.spyOn(gaModule, 'fetchAiReferrals').mockResolvedValue([])
     const fetchSocialReferralsSpy = vi.spyOn(gaModule, 'fetchSocialReferrals').mockResolvedValue([])
 
@@ -377,11 +412,15 @@ describe('GA4 routes', () => {
     getAccessTokenSpy.mockRestore()
     fetchTrafficSpy.mockRestore()
     fetchAggregateSpy.mockRestore()
+    fetchWindowSummarySpy.mockRestore()
     fetchAiReferralsSpy.mockRestore()
     fetchSocialReferralsSpy.mockRestore()
     credentials.delete('test-project')
     db.delete(gaTrafficSummaries)
       .where(eq(gaTrafficSummaries.projectId, projectId))
+      .run()
+    db.delete(gaTrafficWindowSummaries)
+      .where(eq(gaTrafficWindowSummaries.projectId, projectId))
       .run()
   })
 
@@ -426,6 +465,15 @@ describe('GA4 routes', () => {
       totalOrganicSessions: 12000,
       totalUsers: 22000,
     })
+    const fetchWindowSummarySpy = vi.spyOn(gaModule, 'fetchWindowSummary').mockImplementation(async (_t, _p, windowKey) => ({
+      windowKey,
+      periodStart: today,
+      periodEnd: today,
+      totalSessions: 30000,
+      totalOrganicSessions: 12000,
+      totalDirectSessions: 5000,
+      totalUsers: 22000,
+    }))
     const fetchAiReferralsSpy = vi.spyOn(gaModule, 'fetchAiReferrals').mockResolvedValue([])
     const fetchSocialReferralsSpy = vi.spyOn(gaModule, 'fetchSocialReferrals').mockResolvedValue([
       { date: today, source: 'facebook.com', medium: 'referral', sessions: 1273, users: 900, channelGroup: 'Organic Social' },
@@ -489,11 +537,13 @@ describe('GA4 routes', () => {
       getAccessTokenSpy.mockRestore()
       fetchTrafficSpy.mockRestore()
       fetchAggregateSpy.mockRestore()
+      fetchWindowSummarySpy.mockRestore()
       fetchAiReferralsSpy.mockRestore()
       fetchSocialReferralsSpy.mockRestore()
       credentials.delete('only-social-foundation')
       db.delete(gaTrafficSnapshots).where(eq(gaTrafficSnapshots.projectId, partialProjectId)).run()
       db.delete(gaTrafficSummaries).where(eq(gaTrafficSummaries.projectId, partialProjectId)).run()
+      db.delete(gaTrafficWindowSummaries).where(eq(gaTrafficWindowSummaries.projectId, partialProjectId)).run()
       db.delete(gaSocialReferrals).where(eq(gaSocialReferrals.projectId, partialProjectId)).run()
     }
   })
@@ -845,6 +895,152 @@ describe('GA4 routes', () => {
     expect(body.periodStart).toBe('2026-02-19')
 
     credentials.delete('test-project')
+  })
+
+  it('GET /ga/traffic uses windowed summary for totalUsers (no per-page SUM overcount)', async () => {
+    // Regression for the SUM-across-landing-pages overcount: when a window
+    // filter is active, summing gaTrafficSnapshots.users double-counts users
+    // who land on more than one page. The fix is to read totalUsers from the
+    // per-window summary (no landing-page dimension at sync time).
+    const now = new Date().toISOString()
+    const today = now.slice(0, 10)
+    const projRes = await app.inject({
+      method: 'PUT',
+      url: '/api/v1/projects/window-users',
+      payload: {
+        displayName: 'Window Users',
+        canonicalDomain: 'window-users.example',
+        country: 'US',
+        language: 'en',
+      },
+    })
+    const winProjectId = JSON.parse(projRes.payload).id
+
+    credentials.set('window-users', {
+      projectName: 'window-users',
+      propertyId: '111222',
+      clientEmail: 'sa@test.iam.gserviceaccount.com',
+      privateKey: 'fake-key',
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    // Seed five snapshot rows for the same window — summing users across them
+    // gives 5,625, the overcounted figure the bug produced.
+    const snapshotIds: string[] = []
+    for (const [page, users, sessions] of [
+      ['/p1', 1500, 1500],
+      ['/p2', 1200, 1200],
+      ['/p3', 1100, 1100],
+      ['/p4', 950, 950],
+      ['/p5', 875, 875],
+    ] as Array<[string, number, number]>) {
+      const id = crypto.randomUUID()
+      snapshotIds.push(id)
+      db.insert(gaTrafficSnapshots).values({
+        id,
+        projectId: winProjectId,
+        date: today,
+        landingPage: page,
+        sessions,
+        organicSessions: 0,
+        directSessions: 0,
+        users,
+        syncedAt: now,
+      }).run()
+    }
+
+    // Seed the windowed summary with the deduplicated GA4 totalUsers — this
+    // is what the API should return, not the snapshot SUM.
+    db.insert(gaTrafficWindowSummaries).values({
+      id: crypto.randomUUID(),
+      projectId: winProjectId,
+      windowKey: '30d',
+      periodStart: today,
+      periodEnd: today,
+      totalSessions: 5625,
+      totalOrganicSessions: 0,
+      totalDirectSessions: 0,
+      totalUsers: 4905,
+      syncedAt: now,
+    }).run()
+
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/v1/projects/window-users/ga/traffic?window=30d',
+      })
+      expect(res.statusCode).toBe(200)
+      const body = JSON.parse(res.payload)
+      // The fix: totalUsers comes from the windowed summary (4905), NOT the
+      // snapshot SUM (5625). If this assertion ever flips back to 5625, the
+      // overcount bug is back.
+      expect(body.totalUsers).toBe(4905)
+      expect(body.totalUsers).not.toBe(5625)
+      expect(body.totalSessions).toBe(5625)
+    } finally {
+      db.delete(gaTrafficSnapshots).where(inArray(gaTrafficSnapshots.id, snapshotIds)).run()
+      db.delete(gaTrafficWindowSummaries).where(eq(gaTrafficWindowSummaries.projectId, winProjectId)).run()
+      credentials.delete('window-users')
+    }
+  })
+
+  it('GET /ga/traffic falls back to snapshot SUM when no windowed summary exists yet', async () => {
+    // Backwards-compatibility path: projects that haven't synced since the
+    // windowed-summary table was introduced still get a totals number — just
+    // the legacy (overcounted) one. New syncs replace it with the deduplicated
+    // value above.
+    const now = new Date().toISOString()
+    const today = now.slice(0, 10)
+    const projRes = await app.inject({
+      method: 'PUT',
+      url: '/api/v1/projects/window-fallback',
+      payload: {
+        displayName: 'Window Fallback',
+        canonicalDomain: 'window-fallback.example',
+        country: 'US',
+        language: 'en',
+      },
+    })
+    const fbProjectId = JSON.parse(projRes.payload).id
+
+    credentials.set('window-fallback', {
+      projectName: 'window-fallback',
+      propertyId: '222333',
+      clientEmail: 'sa@test.iam.gserviceaccount.com',
+      privateKey: 'fake-key',
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const snapshotId = crypto.randomUUID()
+    db.insert(gaTrafficSnapshots).values({
+      id: snapshotId,
+      projectId: fbProjectId,
+      date: today,
+      landingPage: '/legacy',
+      sessions: 80,
+      organicSessions: 30,
+      directSessions: 10,
+      users: 60,
+      syncedAt: now,
+    }).run()
+
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/v1/projects/window-fallback/ga/traffic?window=30d',
+      })
+      expect(res.statusCode).toBe(200)
+      const body = JSON.parse(res.payload)
+      // No windowed summary row → fall back to SUM (single page here so no
+      // overcount risk).
+      expect(body.totalUsers).toBe(60)
+      expect(body.totalSessions).toBe(80)
+    } finally {
+      db.delete(gaTrafficSnapshots).where(eq(gaTrafficSnapshots.id, snapshotId)).run()
+      credentials.delete('window-fallback')
+    }
   })
 
   it('GET /ga/traffic exposes per-page directSessions and totalDirectSessions', async () => {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -804,6 +804,29 @@ export const MIGRATION_VERSIONS: ReadonlyArray<MigrationVersion> = [
          ON ga_ai_referrals(project_id, date, source, medium, source_dimension, landing_page)`,
     ],
   },
+  {
+    version: 47,
+    name: 'ga-traffic-window-summaries',
+    statements: [
+      `CREATE TABLE IF NOT EXISTS ga_traffic_window_summaries (
+        id                       TEXT PRIMARY KEY,
+        project_id               TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+        window_key               TEXT NOT NULL,
+        period_start             TEXT NOT NULL,
+        period_end               TEXT NOT NULL,
+        total_sessions           INTEGER NOT NULL DEFAULT 0,
+        total_organic_sessions   INTEGER NOT NULL DEFAULT 0,
+        total_direct_sessions    INTEGER NOT NULL DEFAULT 0,
+        total_users              INTEGER NOT NULL DEFAULT 0,
+        synced_at                TEXT NOT NULL,
+        sync_run_id              TEXT REFERENCES runs(id) ON DELETE CASCADE
+      )`,
+      `CREATE UNIQUE INDEX IF NOT EXISTS idx_ga_window_summary_unique
+         ON ga_traffic_window_summaries(project_id, window_key)`,
+      `CREATE INDEX IF NOT EXISTS idx_ga_window_summary_run
+         ON ga_traffic_window_summaries(sync_run_id)`,
+    ],
+  },
 ]
 
 /**

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -369,6 +369,28 @@ export const gaTrafficSummaries = sqliteTable('ga_traffic_summaries', {
   index('idx_ga_summary_run').on(table.syncRunId),
 ])
 
+// Per-window aggregate totals (7d / 30d / 90d). Sourced from GA4 with no
+// landing-page dimension, so totalUsers is the true deduplicated count.
+// Summing gaTrafficSnapshots.users by window double-counts users who land
+// on multiple pages — this table avoids that bug.
+export const gaTrafficWindowSummaries = sqliteTable('ga_traffic_window_summaries', {
+  id: text('id').primaryKey(),
+  projectId: text('project_id').notNull().references(() => projects.id, { onDelete: 'cascade' }),
+  /** '7d' | '30d' | '90d' */
+  windowKey: text('window_key').notNull(),
+  periodStart: text('period_start').notNull(),
+  periodEnd: text('period_end').notNull(),
+  totalSessions: integer('total_sessions').notNull().default(0),
+  totalOrganicSessions: integer('total_organic_sessions').notNull().default(0),
+  totalDirectSessions: integer('total_direct_sessions').notNull().default(0),
+  totalUsers: integer('total_users').notNull().default(0),
+  syncedAt: text('synced_at').notNull(),
+  syncRunId: text('sync_run_id').references(() => runs.id, { onDelete: 'cascade' }),
+}, (table) => [
+  uniqueIndex('idx_ga_window_summary_unique').on(table.projectId, table.windowKey),
+  index('idx_ga_window_summary_run').on(table.syncRunId),
+])
+
 export const usageCounters = sqliteTable('usage_counters', {
   id: text('id').primaryKey(),
   scope: text('scope').notNull(),

--- a/packages/integration-google-analytics/src/ga4-client.ts
+++ b/packages/integration-google-analytics/src/ga4-client.ts
@@ -517,6 +517,98 @@ export async function fetchAggregateSummary(
   return summary
 }
 
+export interface GA4WindowSummary {
+  windowKey: string
+  periodStart: string
+  periodEnd: string
+  totalSessions: number
+  totalOrganicSessions: number
+  totalDirectSessions: number
+  totalUsers: number
+}
+
+const WINDOW_DAYS: Record<string, number> = { '7d': 7, '30d': 30, '90d': 90 }
+
+/**
+ * Fetch deduplicated totals for a fixed window (no landing-page dimension).
+ * Used to back the windowed `totalUsers` headline on the dashboard — summing
+ * `gaTrafficSnapshots.users` overcounts users who land on multiple pages.
+ *
+ * Returns sessions/organic/direct totals as well so the windowed view is
+ * consistent across all four channel buckets without re-aggregating snapshots.
+ */
+export async function fetchWindowSummary(
+  accessToken: string,
+  propertyId: string,
+  windowKey: '7d' | '30d' | '90d',
+): Promise<GA4WindowSummary> {
+  validateAccessToken(accessToken)
+  validatePropertyId(propertyId)
+
+  const days = WINDOW_DAYS[windowKey]
+  if (!days) {
+    throw new GA4ApiError(`Unsupported windowKey "${windowKey}" — must be 7d, 30d, or 90d`, 400)
+  }
+
+  const endDate = new Date()
+  const startDate = new Date()
+  startDate.setDate(startDate.getDate() - days)
+  const dateRange = { startDate: formatDate(startDate), endDate: formatDate(endDate) }
+
+  ga4Log('info', 'fetch-window-summary.start', { propertyId, windowKey, days })
+
+  // Three reports in one batch — total + organic + direct, no landing-page dim.
+  const batchRes = await batchRunReports(accessToken, propertyId, [
+    {
+      dateRanges: [dateRange],
+      dimensions: [],
+      metrics: [{ name: 'sessions' }, { name: 'totalUsers' }],
+      limit: 1,
+    },
+    {
+      dateRanges: [dateRange],
+      dimensions: [],
+      metrics: [{ name: 'sessions' }],
+      dimensionFilter: {
+        filter: {
+          fieldName: 'sessionDefaultChannelGrouping',
+          stringFilter: { matchType: 'EXACT', value: 'Organic Search' },
+        },
+      },
+      limit: 1,
+    },
+    {
+      dateRanges: [dateRange],
+      dimensions: [],
+      metrics: [{ name: 'sessions' }],
+      dimensionFilter: {
+        filter: {
+          fieldName: 'sessionDefaultChannelGrouping',
+          stringFilter: { matchType: 'EXACT', value: 'Direct' },
+        },
+      },
+      limit: 1,
+    },
+  ])
+
+  const totalRow = batchRes[0]?.rows?.[0]
+  const organicRow = batchRes[1]?.rows?.[0]
+  const directRow = batchRes[2]?.rows?.[0]
+
+  const summary: GA4WindowSummary = {
+    windowKey,
+    periodStart: formatDate(startDate),
+    periodEnd: formatDate(endDate),
+    totalSessions: parseInt(totalRow?.metricValues[0]?.value ?? '0', 10) || 0,
+    totalUsers: parseInt(totalRow?.metricValues[1]?.value ?? '0', 10) || 0,
+    totalOrganicSessions: parseInt(organicRow?.metricValues[0]?.value ?? '0', 10) || 0,
+    totalDirectSessions: parseInt(directRow?.metricValues[0]?.value ?? '0', 10) || 0,
+  }
+
+  ga4Log('info', 'fetch-window-summary.done', { propertyId, ...summary })
+  return summary
+}
+
 /**
  * Fetch traffic specifically from AI referral sources.
  */

--- a/packages/integration-google-analytics/src/index.ts
+++ b/packages/integration-google-analytics/src/index.ts
@@ -3,11 +3,12 @@ export {
   getAccessToken,
   fetchTrafficByLandingPage,
   fetchAggregateSummary,
+  fetchWindowSummary,
   fetchAiReferrals,
   fetchSocialReferrals,
   verifyConnection,
   verifyConnectionWithToken,
 } from './ga4-client.js'
-export type { GA4AggregateSummary } from './ga4-client.js'
+export type { GA4AggregateSummary, GA4WindowSummary } from './ga4-client.js'
 export * from './constants.js'
 export * from './types.js'

--- a/packages/integration-google-analytics/test/ga4-client.test.ts
+++ b/packages/integration-google-analytics/test/ga4-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
-import { createServiceAccountJwt, fetchAiReferrals, fetchTrafficByLandingPage, getAccessToken, verifyConnectionWithToken, fetchAggregateSummary } from '../src/ga4-client.js'
+import { createServiceAccountJwt, fetchAiReferrals, fetchTrafficByLandingPage, getAccessToken, verifyConnectionWithToken, fetchAggregateSummary, fetchWindowSummary } from '../src/ga4-client.js'
 import crypto from 'node:crypto'
 
 describe('createServiceAccountJwt', () => {
@@ -422,5 +422,53 @@ describe('fetchAggregateSummary', () => {
     expect(summary.totalSessions).toBe(0)
     expect(summary.totalUsers).toBe(0)
     expect(summary.totalOrganicSessions).toBe(0)
+  })
+})
+
+describe('fetchWindowSummary', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  function mockFetchResponse(body: object, status = 200) {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  it('returns deduplicated totals across all four channels for a window', async () => {
+    // Three reports per window: total/users, organic-only, direct-only — all
+    // with no landing-page dimension so totalUsers reflects unique visitors.
+    fetchSpy.mockImplementation(async (_input: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? '{}')) as { requests: unknown[] }
+      expect(body.requests).toHaveLength(3)
+      return mockFetchResponse({
+        reports: [
+          { rows: [{ dimensionValues: [], metricValues: [{ value: '5625' }, { value: '4905' }] }] },
+          { rows: [{ dimensionValues: [], metricValues: [{ value: '2200' }] }] },
+          { rows: [{ dimensionValues: [], metricValues: [{ value: '1100' }] }] },
+        ],
+      })
+    })
+
+    const summary = await fetchWindowSummary('fake-token', '123456', '30d')
+    expect(summary.windowKey).toBe('30d')
+    expect(summary.totalSessions).toBe(5625)
+    expect(summary.totalUsers).toBe(4905)
+    expect(summary.totalOrganicSessions).toBe(2200)
+    expect(summary.totalDirectSessions).toBe(1100)
+  })
+
+  it('rejects unsupported windowKey values', async () => {
+    await expect(
+      fetchWindowSummary('fake-token', '123456', 'all' as unknown as '7d'),
+    ).rejects.toThrow(/Unsupported windowKey/)
   })
 })


### PR DESCRIPTION
## Summary
- `GET /ga/traffic` was summing `gaTrafficSnapshots.users` across landing-page rows when a 7d/30d/90d window was active, double-counting any user who landed on multiple pages (e.g. 5,625 vs the correct 4,905).
- Adds a per-window summary table (`ga_traffic_window_summaries`) populated at sync time from a no-landing-page-dimension GA4 query — stores totalSessions, totalOrganicSessions, totalDirectSessions, and the deduplicated totalUsers per (project, window).
- `/ga/traffic` reads from the windowed row when a window is set; falls back to the snapshot SUM only for projects that haven't synced since the table was introduced.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` — 1,899 / 1,899 passing
- [x] New regression test: 5-page seed that would SUM to 5,625 returns 4,905 from the windowed summary
- [x] New fallback test: projects with no windowed row still get a (legacy) totals number
- [x] Sync test verifies 3 windowed rows written per project (7d/30d/90d) with correct windowKey + run id