### PR TITLE
feat(report): mentions landscape, section copy pass, absolutize Our page links

### DIFF
--- a/apps/web/src/pages/ReportPage.tsx
+++ b/apps/web/src/pages/ReportPage.tsx
@@ -12,6 +12,7 @@ import type {
   RecommendedNextStep,
   ReportInsight,
 } from '@ainyc/canonry-contracts'
+import { absolutizeProjectUrl } from '@ainyc/canonry-contracts'
 
 import {
   Bar,
@@ -226,7 +227,7 @@ function ExecutiveSummarySection({ report }: { report: ProjectReportDto }) {
   const competitorSuffix = `${exec.competitorCount} competitor${exec.competitorCount === 1 ? '' : 's'} tracked`
   return (
     <section className="page-section-divider">
-      <SectionHeading eyebrow="Section 1" title="Executive summary" />
+      <SectionHeading eyebrow="Section 1" title="Executive summary" subtitle="Top-line citation rate with trend versus the prior run, plus the most actionable findings from the latest visibility sweep." />
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
         <Metric label="Citation rate" value={formatPercent(exec.citationRate, 0)} tone={trendTone(exec.trend)} subtitle={providerSuffix} />
         <Metric label="Keywords tracked" value={formatNumber(exec.keywordCount)} subtitle={competitorSuffix} />
@@ -290,14 +291,14 @@ function CitationScorecardSection({ report }: { report: ProjectReportDto }) {
   if (sc.providers.length === 0 || sc.keywords.length === 0) {
     return (
       <section className="page-section-divider">
-        <SectionHeading eyebrow="Section 2" title="Citation scorecard" />
+        <SectionHeading eyebrow="Section 2" title="Citation scorecard" subtitle="Whether your domain appeared in each AI engine's source list for every tracked keyword in the latest sweep — green = cited, red = not cited, gray = no snapshot." />
         <EmptyHint message="No completed answer-visibility runs yet." />
       </section>
     )
   }
   return (
     <section className="page-section-divider">
-      <SectionHeading eyebrow="Section 2" title="Citation scorecard" />
+      <SectionHeading eyebrow="Section 2" title="Citation scorecard" subtitle="Whether your domain appeared in each AI engine's source list for every tracked keyword in the latest sweep — green = cited, red = not cited, gray = no snapshot." />
       <div className="mb-4">
         <p className="eyebrow mb-2">Provider citation rate</p>
         <div className="h-48 rounded-xl border border-zinc-800/60 bg-zinc-900/30 p-3">
@@ -363,84 +364,123 @@ function CitationScorecardSection({ report }: { report: ProjectReportDto }) {
 
 function CompetitorLandscapeSection({ report }: { report: ProjectReportDto }) {
   const cl = report.competitorLandscape
+  const ml = report.mentionLandscape
   const canonical = report.meta.project.canonicalDomain
-  if (cl.competitors.length === 0 && cl.projectCitationCount === 0) {
+  const noCitationData = cl.competitors.length === 0 && cl.projectCitationCount === 0
+  const noMentionData = ml.competitors.length === 0 && ml.projectMentionCount === 0
+  if (noCitationData && noMentionData) {
     return (
       <section className="page-section-divider">
-        <SectionHeading eyebrow="Section 3" title="Competitor landscape" />
+        <SectionHeading eyebrow="Section 3" title="Competitor landscape" subtitle="Where tracked competitors appear in AI answers compared to your domain — both in source citations and in the answer text itself." />
         <EmptyHint message="No competitor data yet. Add competitors and run a visibility sweep." />
       </section>
     )
   }
-  const barData = [
+  const citationBarData = [
     { label: canonical, count: cl.projectCitationCount, isProject: true },
     ...cl.competitors.map(c => ({ label: c.domain, count: c.citationCount, isProject: false })),
   ]
-  const showBars = barData.length > 1
+  const mentionBarData = [
+    { label: canonical, count: ml.projectMentionCount, isProject: true },
+    ...ml.competitors.map(c => ({ label: c.domain, count: c.mentionCount, isProject: false })),
+  ]
+  const showCitationBars = citationBarData.length > 1
+  const showMentionBars = mentionBarData.length > 1
+  const mentionByDomain = new Map(ml.competitors.map(m => [m.domain, m]))
   return (
     <section className="page-section-divider">
-      <SectionHeading eyebrow="Section 3" title="Competitor landscape" />
-      {showBars && (
-        <div className="mb-4">
-          <p className="eyebrow mb-2">Citations per domain</p>
-          <div className="rounded-xl border border-zinc-800/60 bg-zinc-900/30 p-3" style={{ height: barData.length * 32 + 32 }}>
-            <ResponsiveContainer width="100%" height="100%">
-              <BarChart data={barData} layout="vertical" margin={{ left: 20, right: 32, top: 8, bottom: 8 }}>
-                <CartesianGrid stroke={CHART_GRID_STROKE} horizontal={false} />
-                <XAxis type="number" tick={CHART_AXIS_TICK} stroke={CHART_AXIS_STROKE} />
-                <YAxis type="category" dataKey="label" tick={CHART_AXIS_TICK} stroke={CHART_AXIS_STROKE} width={140} />
-                <RechartsTooltip {...CHART_TOOLTIP_STYLE} />
-                <Bar dataKey="count" radius={[0, 4, 4, 0]}>
-                  {barData.map((d, i) => (
-                    <Cell key={i} fill={d.isProject ? '#3b82f6' : CHART_SERIES_COLORS[(i + 1) % CHART_SERIES_COLORS.length]} />
-                  ))}
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
+      <SectionHeading eyebrow="Section 3" title="Competitor landscape" subtitle="Where tracked competitors appear in AI answers compared to your domain — both in source citations and in the answer text itself." />
+      <div className="grid gap-4 lg:grid-cols-2">
+        {showCitationBars && (
+          <div>
+            <p className="eyebrow mb-2">Citations per domain</p>
+            <div className="rounded-xl border border-zinc-800/60 bg-zinc-900/30 p-3" style={{ height: citationBarData.length * 32 + 32 }}>
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={citationBarData} layout="vertical" margin={{ left: 20, right: 32, top: 8, bottom: 8 }}>
+                  <CartesianGrid stroke={CHART_GRID_STROKE} horizontal={false} />
+                  <XAxis type="number" tick={CHART_AXIS_TICK} stroke={CHART_AXIS_STROKE} />
+                  <YAxis type="category" dataKey="label" tick={CHART_AXIS_TICK} stroke={CHART_AXIS_STROKE} width={140} />
+                  <RechartsTooltip {...CHART_TOOLTIP_STYLE} />
+                  <Bar dataKey="count" radius={[0, 4, 4, 0]}>
+                    {citationBarData.map((d, i) => (
+                      <Cell key={i} fill={d.isProject ? '#3b82f6' : CHART_SERIES_COLORS[(i + 1) % CHART_SERIES_COLORS.length]} />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
           </div>
-        </div>
-      )}
+        )}
+        {showMentionBars && (
+          <div>
+            <p className="eyebrow mb-2">Mentions per domain</p>
+            <div className="rounded-xl border border-zinc-800/60 bg-zinc-900/30 p-3" style={{ height: mentionBarData.length * 32 + 32 }}>
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={mentionBarData} layout="vertical" margin={{ left: 20, right: 32, top: 8, bottom: 8 }}>
+                  <CartesianGrid stroke={CHART_GRID_STROKE} horizontal={false} />
+                  <XAxis type="number" tick={CHART_AXIS_TICK} stroke={CHART_AXIS_STROKE} />
+                  <YAxis type="category" dataKey="label" tick={CHART_AXIS_TICK} stroke={CHART_AXIS_STROKE} width={140} />
+                  <RechartsTooltip {...CHART_TOOLTIP_STYLE} />
+                  <Bar dataKey="count" radius={[0, 4, 4, 0]}>
+                    {mentionBarData.map((d, i) => (
+                      <Cell key={i} fill={d.isProject ? '#3b82f6' : CHART_SERIES_COLORS[(i + 1) % CHART_SERIES_COLORS.length]} />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+        )}
+      </div>
+      <p className="mt-2 text-[11px] text-zinc-500">Citations = domain in source list · Mentions = brand or domain in answer text — independent signals.</p>
       {cl.competitors.length === 0 ? (
         <EmptyHint message="No competitors configured." />
       ) : (
-        <div className="competitor-table-wrap">
+        <div className="competitor-table-wrap mt-4">
           <table className="competitor-table">
             <thead>
               <tr>
                 <th>Domain</th>
                 <th>Pressure</th>
                 <th>Citations</th>
+                <th>Mentions</th>
                 <th>SOV</th>
                 <th>Cited keywords</th>
               </tr>
             </thead>
             <tbody>
-              {cl.competitors.map(c => (
-                <tr key={c.domain}>
-                  <td className="evidence-keyword-cell">{c.domain}</td>
-                  <td><ToneBadge tone={pressureTone(c.pressureLabel)}>{c.pressureLabel}</ToneBadge></td>
-                  <td>{c.citationCount} / {c.totalCount}</td>
-                  <td>{c.sharePct}%</td>
-                  <td className="text-xs text-zinc-400">
-                    {c.citedKeywords.slice(0, 5).join(', ')}{c.citedKeywords.length > 5 ? '…' : ''}
-                    {c.theirCitedPages.length > 0 && (
-                      <details className="mt-1">
-                        <summary className="cursor-pointer text-zinc-500 hover:text-zinc-300">
-                          {c.theirCitedPages.length} cited URL{c.theirCitedPages.length > 1 ? 's' : ''}
-                        </summary>
-                        <ul className="mt-1 space-y-1 pl-3">
-                          {c.theirCitedPages.map((p, i) => (
-                            <li key={i}>
-                              <a href={p.url} className="break-all text-blue-400 hover:underline" target="_blank" rel="noreferrer">{p.url}</a>
-                              <span className="ml-2 text-zinc-500">{p.citedFor.join(', ')}</span>
-                            </li>
-                          ))}
-                        </ul>
-                      </details>
-                    )}
-                  </td>
-                </tr>
-              ))}
+              {cl.competitors.map(c => {
+                const mention = mentionByDomain.get(c.domain)
+                const mentionCount = mention?.mentionCount ?? 0
+                const mentionTotal = mention?.totalCount ?? ml.totalAnswerSnapshots
+                return (
+                  <tr key={c.domain}>
+                    <td className="evidence-keyword-cell">{c.domain}</td>
+                    <td><ToneBadge tone={pressureTone(c.pressureLabel)}>{c.pressureLabel}</ToneBadge></td>
+                    <td>{c.citationCount} / {c.totalCount}</td>
+                    <td>{mentionCount} / {mentionTotal}</td>
+                    <td>{c.sharePct}%</td>
+                    <td className="text-xs text-zinc-400">
+                      {c.citedKeywords.slice(0, 5).join(', ')}{c.citedKeywords.length > 5 ? '…' : ''}
+                      {c.theirCitedPages.length > 0 && (
+                        <details className="mt-1">
+                          <summary className="cursor-pointer text-zinc-500 hover:text-zinc-300">
+                            {c.theirCitedPages.length} cited URL{c.theirCitedPages.length > 1 ? 's' : ''}
+                          </summary>
+                          <ul className="mt-1 space-y-1 pl-3">
+                            {c.theirCitedPages.map((p, i) => (
+                              <li key={i}>
+                                <a href={p.url} className="break-all text-blue-400 hover:underline" target="_blank" rel="noreferrer">{p.url}</a>
+                                <span className="ml-2 text-zinc-500">{p.citedFor.join(', ')}</span>
+                              </li>
+                            ))}
+                          </ul>
+                        </details>
+                      )}
+                    </td>
+                  </tr>
+                )
+              })}
             </tbody>
           </table>
         </div>
@@ -449,14 +489,14 @@ function CompetitorLandscapeSection({ report }: { report: ProjectReportDto }) {
   )
 }
 
-// ─── Section: AI source origin ─────────────────────────────────────────────
+// ─── Section: AI citation sources ──────────────────────────────────────────
 
 function AiSourceOriginSection({ report }: { report: ProjectReportDto }) {
   const so = report.aiSourceOrigin
   if (so.categories.length === 0 && so.topDomains.length === 0) {
     return (
       <section className="page-section-divider">
-        <SectionHeading eyebrow="Section 4" title="AI source origin" />
+        <SectionHeading eyebrow="Section 4" title="AI citation sources" subtitle="Every external website AI engines cited as a source for your tracked keywords in the latest sweep — categorized by site type on the left and ranked by frequency on the right. Your own domains are excluded; tracked competitors are flagged." />
         <EmptyHint message="No source data yet. Run a visibility sweep first." />
       </section>
     )
@@ -464,7 +504,7 @@ function AiSourceOriginSection({ report }: { report: ProjectReportDto }) {
   const pieData = so.categories.filter(c => c.count > 0).map(c => ({ name: c.label, value: c.count }))
   return (
     <section className="page-section-divider">
-      <SectionHeading eyebrow="Section 4" title="AI source origin" />
+      <SectionHeading eyebrow="Section 4" title="AI citation sources" subtitle="Every external website AI engines cited as a source for your tracked keywords in the latest sweep — categorized by site type on the left and ranked by frequency on the right. Your own domains are excluded; tracked competitors are flagged." />
       <div className="grid gap-4 lg:grid-cols-2">
         <div>
           <p className="eyebrow mb-2">AI source categories</p>
@@ -529,14 +569,14 @@ function GscPerformanceSection({ report }: { report: ProjectReportDto }) {
   if (!gsc) {
     return (
       <section className="page-section-divider">
-        <SectionHeading eyebrow="Section 5" title="GSC performance" />
+        <SectionHeading eyebrow="Section 5" title="GSC performance" subtitle="Your site's performance in Google's regular (non-AI) search results — top queries, intent breakdown, and the click trend, sourced from Google Search Console for the most recent sync window." />
         <EmptyHint message="Google Search Console is not connected for this project." />
       </section>
     )
   }
   return (
     <section className="page-section-divider">
-      <SectionHeading eyebrow="Section 5" title="GSC performance" />
+      <SectionHeading eyebrow="Section 5" title="GSC performance" subtitle="Your site's performance in Google's regular (non-AI) search results — top queries, intent breakdown, and the click trend, sourced from Google Search Console for the most recent sync window." />
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
         <Metric label="Clicks" value={formatNumber(gsc.totalClicks)} />
         <Metric label="Impressions" value={formatNumber(gsc.totalImpressions)} />
@@ -644,15 +684,14 @@ function GaTrafficSection({ report }: { report: ProjectReportDto }) {
   if (!ga) {
     return (
       <section className="page-section-divider">
-        <SectionHeading eyebrow="Section 6" title="GA4 traffic" />
+        <SectionHeading eyebrow="Section 6" title="GA4 traffic" subtitle="Total sessions and users on your site, with top landing pages and channel breakdown — sourced from Google Analytics 4." />
         <EmptyHint message="Google Analytics 4 is not connected for this project." />
       </section>
     )
   }
   return (
     <section className="page-section-divider">
-      <SectionHeading eyebrow="Section 6" title="GA4 traffic" />
-      <p className="page-subtitle">{formatDate(ga.periodStart)} → {formatDate(ga.periodEnd)}</p>
+      <SectionHeading eyebrow="Section 6" title="GA4 traffic" subtitle={`Total sessions and users on your site between ${formatDate(ga.periodStart)} and ${formatDate(ga.periodEnd)}, with top landing pages and channel breakdown — sourced from Google Analytics 4.`} />
       <div className="mt-3 grid gap-3 sm:grid-cols-3">
         <Metric label="Sessions" value={formatNumber(ga.totalSessions)} />
         <Metric label="Users" value={formatNumber(ga.totalUsers)} />
@@ -710,14 +749,14 @@ function SocialReferralsSection({ report }: { report: ProjectReportDto }) {
   if (!sr) {
     return (
       <section className="page-section-divider">
-        <SectionHeading eyebrow="Section 7" title="Social referrals" />
+        <SectionHeading eyebrow="Section 7" title="Social referrals" subtitle="Sessions on your site sent by social platforms (LinkedIn, Facebook, X, etc.) — paid versus organic split with the top driving campaigns. Sourced from Google Analytics 4." />
         <EmptyHint message="No social referral data." />
       </section>
     )
   }
   return (
     <section className="page-section-divider">
-      <SectionHeading eyebrow="Section 7" title="Social referrals" />
+      <SectionHeading eyebrow="Section 7" title="Social referrals" subtitle="Sessions on your site sent by social platforms (LinkedIn, Facebook, X, etc.) — paid versus organic split with the top driving campaigns. Sourced from Google Analytics 4." />
       <div className="grid gap-3 sm:grid-cols-3">
         <Metric label="Total sessions" value={formatNumber(sr.totalSessions)} />
         <Metric label="Organic" value={formatNumber(sr.organicSessions)} />
@@ -773,14 +812,14 @@ function AiReferralsSection({ report }: { report: ProjectReportDto }) {
   if (!ai) {
     return (
       <section className="page-section-divider">
-        <SectionHeading eyebrow="Section 8" title="AI referral traffic" />
+        <SectionHeading eyebrow="Section 8" title="AI referral traffic" subtitle="Sessions on your site referred by AI answer engines (ChatGPT, Perplexity, Claude, Copilot, Gemini, etc.) — broken down by referrer with a daily trend and the top landing pages. Sourced from Google Analytics 4." />
         <EmptyHint message="No AI referral data." />
       </section>
     )
   }
   return (
     <section className="page-section-divider">
-      <SectionHeading eyebrow="Section 8" title="AI referral traffic" />
+      <SectionHeading eyebrow="Section 8" title="AI referral traffic" subtitle="Sessions on your site referred by AI answer engines (ChatGPT, Perplexity, Claude, Copilot, Gemini, etc.) — broken down by referrer with a daily trend and the top landing pages. Sourced from Google Analytics 4." />
       <div className="grid gap-3 sm:grid-cols-2">
         <Metric label="Sessions" value={formatNumber(ai.totalSessions)} />
         <Metric label="Users" value={formatNumber(ai.totalUsers)} />
@@ -845,15 +884,16 @@ function IndexingHealthSectionView({ report }: { report: ProjectReportDto }) {
   if (!ih || !ih.provider) {
     return (
       <section className="page-section-divider">
-        <SectionHeading eyebrow="Section 9" title="Indexing health" />
+        <SectionHeading eyebrow="Section 9" title="Indexing health" subtitle="What share of your tracked URLs are currently indexed in Google or Bing — connect Google Search Console or Bing Webmaster Tools to populate this section." />
         <EmptyHint message="No indexing data — connect Google Search Console or Bing Webmaster Tools." />
       </section>
     )
   }
   const tone: MetricTone = ih.indexedPct >= 90 ? 'positive' : ih.indexedPct >= 70 ? 'caution' : 'negative'
+  const indexingSubtitle = `What share of your tracked URLs are currently indexed in ${ih.provider === 'google' ? 'Google' : 'Bing'} — sourced from ${ih.provider === 'google' ? 'Google Search Console URL Inspection' : 'Bing Webmaster Tools URL Inspection'}. Pages absent from the index can't be retrieved by AI engines either.`
   return (
     <section className="page-section-divider">
-      <SectionHeading eyebrow="Section 9" title={`Indexing health — ${ih.provider}`} />
+      <SectionHeading eyebrow="Section 9" title={`Indexing health — ${ih.provider}`} subtitle={indexingSubtitle} />
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
         <Metric label="Indexed" value={formatPercent(ih.indexedPct, 0)} tone={tone} />
         <Metric label="Total pages" value={formatNumber(ih.total)} />
@@ -877,7 +917,7 @@ function CitationsTrendSection({ report }: { report: ProjectReportDto }) {
   if (trend.length === 0) {
     return (
       <section className="page-section-divider">
-        <SectionHeading eyebrow="Section 10" title="Citations over time" />
+        <SectionHeading eyebrow="Section 10" title="Citations over time" subtitle="Citation rate across every visibility sweep — the share of (keyword × provider) pairs in each run where your domain appeared in the source list, with a per-provider breakdown beneath." />
         <EmptyHint message="Run multiple visibility sweeps to see a trend." />
       </section>
     )
@@ -885,14 +925,14 @@ function CitationsTrendSection({ report }: { report: ProjectReportDto }) {
   if (isTrendBaseline(trend)) {
     return (
       <section className="page-section-divider">
-        <SectionHeading eyebrow="Section 10" title="Citations over time" />
+        <SectionHeading eyebrow="Section 10" title="Citations over time" subtitle="Citation rate across every visibility sweep — the share of (keyword × provider) pairs in each run where your domain appeared in the source list, with a per-provider breakdown beneath." />
         <EmptyHint message={`Establishing baseline (${trend.length} of ${MIN_TREND_POINTS} runs collected). Trend will appear once more sweeps are recorded.`} />
       </section>
     )
   }
   return (
     <section className="page-section-divider">
-      <SectionHeading eyebrow="Section 10" title="Citations over time" />
+      <SectionHeading eyebrow="Section 10" title="Citations over time" subtitle="Citation rate across every visibility sweep — the share of (keyword × provider) pairs in each run where your domain appeared in the source list, with a per-provider breakdown beneath." />
       <div className="h-64 rounded-xl border border-zinc-800/60 bg-zinc-900/30 p-3">
         <ResponsiveContainer width="100%" height="100%">
           <LineChart data={trend} margin={{ left: 8, right: 12, top: 8, bottom: 8 }}>
@@ -950,14 +990,14 @@ function InsightsSection({ report }: { report: ProjectReportDto }) {
   if (report.insights.length === 0) {
     return (
       <section className="page-section-divider">
-        <SectionHeading eyebrow="Section 11" title="Insights &amp; alerts" />
+        <SectionHeading eyebrow="Section 11" title="Insights &amp; alerts" subtitle="Regressions (citations lost), gains (citations won), and opportunities surfaced by the intelligence engine across the most recent sweeps — ordered by severity and recurrence." />
         <EmptyHint message="No active insights — everything looks stable." />
       </section>
     )
   }
   return (
     <section className="page-section-divider">
-      <SectionHeading eyebrow="Section 11" title="Insights &amp; alerts" />
+      <SectionHeading eyebrow="Section 11" title="Insights &amp; alerts" subtitle="Regressions (citations lost), gains (citations won), and opportunities surfaced by the intelligence engine across the most recent sweeps — ordered by severity and recurrence." />
       <div className="evidence-table-wrap">
         <table className="evidence-table">
           <thead>
@@ -997,10 +1037,10 @@ function ContentOpportunitiesSection({ report }: { report: ProjectReportDto }) {
   if (report.contentOpportunities.length === 0) {
     return null
   }
+  const canonical = report.meta.project.canonicalDomain
   return (
     <section className="page-section-divider">
-      <SectionHeading eyebrow="Section 12" title="Content opportunities" />
-      <p className="page-subtitle mb-3">Ranked, action-typed targets from the content recommendation engine. Top 10 shown.</p>
+      <SectionHeading eyebrow="Section 12" title="Content opportunities" subtitle="Queries where you have search demand or competitor citation pressure but aren't winning AI citations. Each row carries a suggested action (create / refresh / expand / add-schema). Top 10 shown." />
       <div className="evidence-table-wrap">
         <table className="evidence-table">
           <thead>
@@ -1022,7 +1062,7 @@ function ContentOpportunitiesSection({ report }: { report: ProjectReportDto }) {
                 <td>{Math.round(o.score)}</td>
                 <td className="text-xs">
                   {o.ourBestPage
-                    ? <a href={o.ourBestPage.url} target="_blank" rel="noreferrer" className="text-blue-400 hover:underline break-all">{o.ourBestPage.url}</a>
+                    ? <a href={absolutizeProjectUrl(o.ourBestPage.url, canonical)} target="_blank" rel="noreferrer" className="text-blue-400 hover:underline break-all">{o.ourBestPage.url}</a>
                     : <span className="text-zinc-600">—</span>}
                 </td>
                 <td className="text-xs">
@@ -1047,14 +1087,14 @@ function NextStepsSection({ report }: { report: ProjectReportDto }) {
   if (report.recommendedNextSteps.length === 0) {
     return (
       <section className="page-section-divider">
-        <SectionHeading eyebrow="Section 13" title="Recommended next steps" />
+        <SectionHeading eyebrow="Section 13" title="Recommended next steps" subtitle="Action items bucketed by horizon (immediate, short-term, medium-term), drawn from open insights and the highest-ranked content opportunities." />
         <EmptyHint message="No prioritized actions yet." />
       </section>
     )
   }
   return (
     <section className="page-section-divider">
-      <SectionHeading eyebrow="Section 13" title="Recommended next steps" />
+      <SectionHeading eyebrow="Section 13" title="Recommended next steps" subtitle="Action items bucketed by horizon (immediate, short-term, medium-term), drawn from open insights and the highest-ranked content opportunities." />
       <div className="grid gap-3 lg:grid-cols-3">
         {(['immediate', 'short-term', 'medium-term'] as const).map(h => {
           const steps = report.recommendedNextSteps.filter(s => s.horizon === h)
@@ -1081,11 +1121,12 @@ function NextStepsSection({ report }: { report: ProjectReportDto }) {
 
 // ─── Shared helpers ────────────────────────────────────────────────────────
 
-function SectionHeading({ eyebrow, title }: { eyebrow: string; title: string }) {
+function SectionHeading({ eyebrow, title, subtitle }: { eyebrow: string; title: string; subtitle?: string }) {
   return (
     <div className="mb-3">
       <p className="eyebrow-soft">{eyebrow}</p>
       <h2 className="page-title">{title}</h2>
+      {subtitle && <p className="page-subtitle mt-1">{subtitle}</p>}
     </div>
   )
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "3.5.0",
+  "version": "3.6.2",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -2262,7 +2262,7 @@ const routeCatalog: OpenApiOperation[] = [
     summary: 'Aggregated client-facing AEO report',
     tags: ['report'],
     description:
-      'Bundles every section the canonry-report HTML output needs (executive summary, citation scorecard, competitor landscape, AI source origin, GSC, GA4, social/AI referrals, indexing health, citations trend, insights, and recommended next steps) into a single JSON payload. Backs `canonry report <project>`.',
+      'Bundles every section the canonry-report HTML output needs (executive summary, citation scorecard, competitor landscape — citation + mention landscapes, AI citation sources, GSC, GA4, social/AI referrals, indexing health, citations trend, insights, and recommended next steps) into a single JSON payload. Backs `canonry report <project>`.',
     parameters: [nameParameter],
     responses: {
       200: { description: 'Report returned.' },

--- a/packages/api-routes/src/report-renderer.ts
+++ b/packages/api-routes/src/report-renderer.ts
@@ -6,6 +6,7 @@ import type {
   ProjectReportDto,
   ReportInsight,
 } from '@ainyc/canonry-contracts'
+import { absolutizeProjectUrl } from '@ainyc/canonry-contracts'
 import {
   groupInsights,
   isTrendBaseline,
@@ -424,7 +425,12 @@ function renderExecutiveSummary(report: ProjectReportDto): string {
     : ''
 
   return section(
-    { id: 'executive-summary', eyebrow: 'Section 1', title: 'Executive Summary' },
+    {
+      id: 'executive-summary',
+      eyebrow: 'Section 1',
+      title: 'Executive Summary',
+      intro: 'Top-line citation rate with trend versus the prior run, plus the most actionable findings from the latest visibility sweep.',
+    },
     metricsHtml + findingsHtml,
   )
 }
@@ -489,16 +495,18 @@ function renderCitationScorecard(report: ProjectReportDto): string {
     ${renderCitationMatrix(report.citationScorecard)}
   `
   return section(
-    { id: 'citation-scorecard', eyebrow: 'Section 2', title: 'Citation Scorecard', intro: 'Per-keyword × per-provider citation matrix from the latest visibility sweep.' },
+    { id: 'citation-scorecard', eyebrow: 'Section 2', title: 'Citation Scorecard', intro: 'Whether your domain appeared in each AI engine’s source list for every tracked keyword in the latest sweep — a cell turns green when your domain was cited, red when it was not, and gray when no snapshot exists for that pair.' },
     body,
   )
 }
 
-function renderCompetitorBars(landscape: ProjectReportDto['competitorLandscape'], canonical: string): string {
-  const data = [
-    { label: canonical, count: landscape.projectCitationCount, isProject: true },
-    ...landscape.competitors.map(c => ({ label: c.domain, count: c.citationCount, isProject: false })),
-  ]
+interface LandscapeBar {
+  label: string
+  count: number
+  isProject: boolean
+}
+
+function renderLandscapeBars(data: LandscapeBar[], heading: string, ariaLabel: string): string {
   if (data.length <= 1) return ''
   const max = Math.max(...data.map(d => d.count), 1)
   const width = 600
@@ -517,24 +525,47 @@ function renderCompetitorBars(landscape: ProjectReportDto['competitorLandscape']
   }).join('')
 
   return `<div class="chart-card">
-    <h3>Citations per domain</h3>
-    <svg viewBox="0 0 ${width} ${height}" width="100%" preserveAspectRatio="xMinYMin meet" role="img" aria-label="Citations per domain bar chart">
+    <h3>${escapeHtml(heading)}</h3>
+    <svg viewBox="0 0 ${width} ${height}" width="100%" preserveAspectRatio="xMinYMin meet" role="img" aria-label="${escapeHtml(ariaLabel)}">
       ${bars}
     </svg>
   </div>`
 }
 
+function renderCompetitorBars(landscape: ProjectReportDto['competitorLandscape'], canonical: string): string {
+  const data: LandscapeBar[] = [
+    { label: canonical, count: landscape.projectCitationCount, isProject: true },
+    ...landscape.competitors.map(c => ({ label: c.domain, count: c.citationCount, isProject: false })),
+  ]
+  return renderLandscapeBars(data, 'Citations per domain', 'Citations per domain bar chart')
+}
+
+function renderMentionBars(landscape: ProjectReportDto['mentionLandscape'], canonical: string): string {
+  const data: LandscapeBar[] = [
+    { label: canonical, count: landscape.projectMentionCount, isProject: true },
+    ...landscape.competitors.map(c => ({ label: c.domain, count: c.mentionCount, isProject: false })),
+  ]
+  return renderLandscapeBars(data, 'Mentions per domain', 'Mentions per domain bar chart')
+}
+
 function renderCompetitorLandscape(report: ProjectReportDto): string {
   const competitors = report.competitorLandscape.competitors
-  if (competitors.length === 0 && report.competitorLandscape.projectCitationCount === 0) {
+  const mentionLandscape = report.mentionLandscape
+  const noCitationData = competitors.length === 0 && report.competitorLandscape.projectCitationCount === 0
+  const noMentionData = mentionLandscape.competitors.length === 0 && mentionLandscape.projectMentionCount === 0
+  if (noCitationData && noMentionData) {
     return section(
       { id: 'competitor-landscape', eyebrow: 'Section 3', title: 'Competitor Landscape' },
       renderEmpty('No competitor data yet. Add competitors and run a visibility sweep.'),
     )
   }
 
+  const mentionByDomain = new Map(mentionLandscape.competitors.map(m => [m.domain, m]))
   const rows = competitors.map(c => {
     const tone = pressureTone(c.pressureLabel)
+    const mention = mentionByDomain.get(c.domain)
+    const mentionCount = mention?.mentionCount ?? 0
+    const mentionTotal = mention?.totalCount ?? mentionLandscape.totalAnswerSnapshots
     const pagesDisclosure = c.theirCitedPages.length > 0
       ? `<details class="cited-pages"><summary>${c.theirCitedPages.length} cited URL${c.theirCitedPages.length > 1 ? 's' : ''}</summary>
           <ul>${c.theirCitedPages.map(p => `<li><a href="${escapeHtml(p.url)}">${escapeHtml(p.url)}</a> <span class="cited-for">${escapeHtml(p.citedFor.join(', '))}</span></li>`).join('')}</ul>
@@ -544,6 +575,7 @@ function renderCompetitorLandscape(report: ProjectReportDto): string {
       <td>${escapeHtml(c.domain)}</td>
       <td><span class="badge tone-${tone}">${escapeHtml(c.pressureLabel)}</span></td>
       <td class="numeric">${c.citationCount} / ${c.totalCount}</td>
+      <td class="numeric">${mentionCount} / ${mentionTotal}</td>
       <td class="numeric">${c.sharePct}%</td>
       <td>${escapeHtml(c.citedKeywords.slice(0, 5).join(', '))}${c.citedKeywords.length > 5 ? '…' : ''}${pagesDisclosure}</td>
     </tr>`
@@ -551,14 +583,25 @@ function renderCompetitorLandscape(report: ProjectReportDto): string {
 
   const table = competitors.length > 0
     ? `<table class="report-table">
-        <thead><tr><th>Domain</th><th>Pressure</th><th>Citations</th><th class="numeric">SOV</th><th>Cited keywords</th></tr></thead>
+        <thead><tr><th>Domain</th><th>Pressure</th><th>Citations</th><th class="numeric">Mentions</th><th class="numeric">SOV</th><th>Cited keywords</th></tr></thead>
         <tbody>${rows}</tbody>
       </table>`
     : renderEmpty('No competitors configured.')
 
+  const citationBars = renderCompetitorBars(report.competitorLandscape, report.meta.project.canonicalDomain)
+  const mentionBars = renderMentionBars(mentionLandscape, report.meta.project.canonicalDomain)
+  const charts = citationBars && mentionBars
+    ? `<div class="chart-grid">${citationBars}${mentionBars}</div>`
+    : `${citationBars}${mentionBars}`
+
   return section(
-    { id: 'competitor-landscape', eyebrow: 'Section 3', title: 'Competitor Landscape', intro: 'Where tracked competitors appear in AI answers compared to your domain.' },
-    `${renderCompetitorBars(report.competitorLandscape, report.meta.project.canonicalDomain)}${table}`,
+    {
+      id: 'competitor-landscape',
+      eyebrow: 'Section 3',
+      title: 'Competitor Landscape',
+      intro: 'Where tracked competitors appear in AI answers compared to your domain — both in source citations and in the answer text itself.',
+    },
+    `${charts}${table}`,
   )
 }
 
@@ -609,7 +652,7 @@ function renderAiSourceOrigin(report: ProjectReportDto): string {
   const origin = report.aiSourceOrigin
   if (origin.categories.length === 0 && origin.topDomains.length === 0) {
     return section(
-      { id: 'ai-source-origin', eyebrow: 'Section 4', title: 'AI Source Origin' },
+      { id: 'ai-source-origin', eyebrow: 'Section 4', title: 'AI Citation Sources' },
       renderEmpty('No source data yet. Run a visibility sweep first.'),
     )
   }
@@ -629,7 +672,12 @@ function renderAiSourceOrigin(report: ProjectReportDto): string {
     : ''
 
   return section(
-    { id: 'ai-source-origin', eyebrow: 'Section 4', title: 'AI Source Origin', intro: 'Where AI answers pull from, aggregated across the latest sweep.' },
+    {
+      id: 'ai-source-origin',
+      eyebrow: 'Section 4',
+      title: 'AI Citation Sources',
+      intro: 'Every external website AI engines cited as a source for your tracked keywords in the latest sweep — categorized by site type (Reddit, YouTube, news, etc.) on the left and ranked by citation count on the right. Your own domains are excluded; tracked competitors are flagged.',
+    },
     `${renderDonut(origin.categories)}${table}`,
   )
 }
@@ -718,7 +766,7 @@ function renderGsc(report: ProjectReportDto): string {
   }
 
   return section(
-    { id: 'gsc', eyebrow: 'Section 5', title: 'GSC Performance', intro: 'Top queries, category breakdown, and traffic trend from Google Search Console.' },
+    { id: 'gsc', eyebrow: 'Section 5', title: 'GSC Performance', intro: 'Your site’s performance in Google’s regular (non-AI) search results — top queries that drove impressions, intent breakdown, and the click trend, sourced from Google Search Console for the most recent sync window.' },
     `<div class="metric-grid">
       <div class="metric"><div class="label">Total clicks</div><div class="value">${formatNumber(gsc.totalClicks)}</div></div>
       <div class="metric"><div class="label">Total impressions</div><div class="value">${formatNumber(gsc.totalImpressions)}</div></div>
@@ -767,7 +815,7 @@ function renderGa(report: ProjectReportDto): string {
     </tr>`).join('')
 
   return section(
-    { id: 'ga', eyebrow: 'Section 6', title: 'GA4 Traffic', intro: `Sessions and users for ${formatDate(ga.periodStart)} → ${formatDate(ga.periodEnd)}.` },
+    { id: 'ga', eyebrow: 'Section 6', title: 'GA4 Traffic', intro: `Total sessions and users on your site between ${formatDate(ga.periodStart)} and ${formatDate(ga.periodEnd)}, with the top landing pages and channel breakdown — sourced from Google Analytics 4.` },
     `<div class="metric-grid">
       <div class="metric"><div class="label">Total sessions</div><div class="value">${formatNumber(ga.totalSessions)}</div></div>
       <div class="metric"><div class="label">Total users</div><div class="value">${formatNumber(ga.totalUsers)}</div></div>
@@ -812,7 +860,7 @@ function renderSocial(report: ProjectReportDto): string {
     </tr>`).join('')
 
   return section(
-    { id: 'social-referrals', eyebrow: 'Section 7', title: 'Social Referrals', intro: 'Paid vs organic split with top campaigns.' },
+    { id: 'social-referrals', eyebrow: 'Section 7', title: 'Social Referrals', intro: 'Sessions on your site sent by social platforms (LinkedIn, Facebook, X, etc.) — paid versus organic split and the top campaigns that drove them. Sourced from Google Analytics 4.' },
     `<div class="metric-grid">
       <div class="metric"><div class="label">Total sessions</div><div class="value">${formatNumber(social.totalSessions)}</div></div>
       <div class="metric"><div class="label">Organic social</div><div class="value">${formatNumber(social.organicSessions)}</div></div>
@@ -864,7 +912,7 @@ function renderAiReferrals(report: ProjectReportDto): string {
   )
 
   return section(
-    { id: 'ai-referrals', eyebrow: 'Section 8', title: 'AI Referral Traffic', intro: 'Sessions sent from AI answer engines.' },
+    { id: 'ai-referrals', eyebrow: 'Section 8', title: 'AI Referral Traffic', intro: 'Sessions on your site referred by AI answer engines (ChatGPT, Perplexity, Claude, Copilot, Gemini, etc.) — broken down by referrer with a daily trend and the top landing pages. Sourced from Google Analytics 4.' },
     `<div class="metric-grid">
       <div class="metric"><div class="label">Total sessions</div><div class="value">${formatNumber(ai.totalSessions)}</div></div>
       <div class="metric"><div class="label">Total users</div><div class="value">${formatNumber(ai.totalUsers)}</div></div>
@@ -916,7 +964,7 @@ function renderIndexingHealth(report: ProjectReportDto): string {
   const legend = segments.map(s => `<span><span class="legend-swatch" style="background:${s.color}"></span>${escapeHtml(s.label)}: ${s.count}</span>`).join('')
 
   return section(
-    { id: 'indexing-health', eyebrow: 'Section 9', title: 'Indexing Health', intro: `Source: ${ih.provider === 'google' ? 'Google Search Console' : 'Bing Webmaster Tools'}.` },
+    { id: 'indexing-health', eyebrow: 'Section 9', title: 'Indexing Health', intro: `What share of your tracked URLs are currently indexed in ${ih.provider === 'google' ? 'Google' : 'Bing'} — sourced from ${ih.provider === 'google' ? 'Google Search Console URL Inspection' : 'Bing Webmaster Tools URL Inspection'}. Pages absent from the index can’t be retrieved by AI engines either.` },
     `<div class="metric-grid">
       <div class="metric"><div class="label">Indexed</div><div class="value tone-positive">${formatNumber(ih.indexed)}</div></div>
       <div class="metric"><div class="label">Total inspected</div><div class="value">${formatNumber(ih.total)}</div></div>
@@ -961,7 +1009,7 @@ function renderCitationsTrend(report: ProjectReportDto): string {
     </tr>`).join('')
 
   return section(
-    { id: 'citations-trend', eyebrow: 'Section 10', title: 'Citations Over Time', intro: 'Per-run citation rate across the project history.' },
+    { id: 'citations-trend', eyebrow: 'Section 10', title: 'Citations Over Time', intro: 'Citation rate across every visibility sweep — the share of (keyword × provider) pairs in each run where your domain appeared in the source list, with a per-provider breakdown beneath.' },
     `${chart}
     <div class="chart-card"><h3>Run-by-run breakdown</h3>
       <table class="report-table">
@@ -1001,7 +1049,7 @@ function renderInsights(report: ProjectReportDto): string {
     }).join('')
 
   return section(
-    { id: 'insights', eyebrow: 'Section 11', title: 'Insights & Alerts', intro: 'Priority-ordered findings from the most recent runs.' },
+    { id: 'insights', eyebrow: 'Section 11', title: 'Insights & Alerts', intro: 'Regressions (citations lost), gains (citations won), and opportunities surfaced by the intelligence engine across the most recent sweeps — ordered by severity and recurrence.' },
     `<table class="report-table">
       <thead><tr><th>Severity</th><th>Title</th><th>Keyword</th><th>Provider</th><th>Recommendation</th></tr></thead>
       <tbody>${rows}</tbody>
@@ -1013,9 +1061,10 @@ function renderOpportunities(report: ProjectReportDto): string {
   const opps = report.contentOpportunities
   if (opps.length === 0) return ''
 
+  const canonical = report.meta.project.canonicalDomain
   const rows = opps.slice(0, 10).map((o) => {
     const ourPage = o.ourBestPage
-      ? `<a href="${escapeHtml(o.ourBestPage.url)}">${escapeHtml(o.ourBestPage.url)}</a>`
+      ? `<a href="${escapeHtml(absolutizeProjectUrl(o.ourBestPage.url, canonical))}">${escapeHtml(o.ourBestPage.url)}</a>`
       : '<span class="cell-not-cited">—</span>'
     const winning = o.winningCompetitor
       ? `<a href="${escapeHtml(o.winningCompetitor.url)}">${escapeHtml(o.winningCompetitor.domain)}</a>`
@@ -1036,7 +1085,7 @@ function renderOpportunities(report: ProjectReportDto): string {
       id: 'content-opportunities',
       eyebrow: 'Section 12',
       title: 'Content Opportunities',
-      intro: 'Ranked, action-typed targets from the content recommendation engine. Top 10 shown.',
+      intro: 'Queries where you have search demand or competitor citation pressure but aren’t winning AI citations. Each row carries a suggested action (create / refresh / expand / add-schema). Top 10 shown.',
     },
     `<table class="report-table">
       <thead><tr><th>Query</th><th>Action</th><th class="numeric">Score</th><th>Our page</th><th>Winning competitor</th><th>Demand</th><th>Confidence</th></tr></thead>
@@ -1052,7 +1101,7 @@ function renderRecommendedNextSteps(report: ProjectReportDto): string {
   const steps = report.recommendedNextSteps
   if (steps.length === 0) {
     return section(
-      { id: 'recommended-next-steps', eyebrow: 'Section 13', title: 'Recommended Next Steps' },
+      { id: 'recommended-next-steps', eyebrow: 'Section 13', title: 'Recommended Next Steps', intro: 'Action items bucketed by horizon (immediate, short-term, medium-term), drawn from open insights and the highest-ranked content opportunities.' },
       renderEmpty('No outstanding actions.'),
     )
   }
@@ -1065,7 +1114,7 @@ function renderRecommendedNextSteps(report: ProjectReportDto): string {
     </div>`).join('')
 
   return section(
-    { id: 'recommended-next-steps', eyebrow: 'Section 13', title: 'Recommended Next Steps' },
+    { id: 'recommended-next-steps', eyebrow: 'Section 13', title: 'Recommended Next Steps', intro: 'Action items bucketed by horizon (immediate, short-term, medium-term), drawn from open insights and the highest-ranked content opportunities.' },
     `<div class="steps">${items}</div>`,
   )
 }

--- a/packages/api-routes/src/report.ts
+++ b/packages/api-routes/src/report.ts
@@ -16,7 +16,9 @@ import {
   runs,
 } from '@ainyc/canonry-db'
 import {
+  brandLabelFromDomain,
   categorizeSource,
+  determineAnswerMentioned,
   normalizeProjectDomain,
   RunKinds,
   RunStatuses,
@@ -25,6 +27,7 @@ import {
   type CitationsTrendPoint,
   type CompetitorRow,
   type GscQueryRow,
+  type MentionRow,
   type ProjectReportDto,
   type RecommendedNextStep,
   type ReportInsight,
@@ -271,6 +274,82 @@ function buildCompetitorLandscape(
   competitorRows.sort((a, b) => b.citationCount - a.citationCount)
 
   return { projectCitationCount, competitors: competitorRows }
+}
+
+// Mirrors buildCompetitorLandscape but operates on the answer-text
+// signal — `answerMentioned` for the project, and per-competitor brand
+// detection via extractAnswerMentions on the snapshot's answerText.
+// Snapshots with no answerText are excluded from the denominator since
+// we can't compute mention either way for them.
+function buildMentionLandscape(
+  snapshots: SnapshotRow[],
+  competitorDomains: string[],
+  projectDisplayName: string,
+  projectDomains: string[],
+  keywordLookup: KeywordLookup,
+): ProjectReportDto['mentionLandscape'] {
+  let projectMentionCount = 0
+  let totalAnswerSnapshots = 0
+  const competitorMap = new Map<string, { count: number; keywords: Set<string> }>()
+  for (const c of competitorDomains) {
+    competitorMap.set(c, { count: 0, keywords: new Set() })
+  }
+
+  for (const snap of snapshots) {
+    const text = snap.answerText
+    if (!text) continue
+    totalAnswerSnapshots++
+
+    const kw = keywordLookup.byId.get(snap.keywordId)
+    // Project mention: prefer the stored snapshot.answerMentioned (computed at
+    // run time against the project's own brand + domains). Fall back to a
+    // recompute when the column is null (legacy rows) so this stays consistent
+    // with the citation builder, which uses snapshot fields directly.
+    const projectMentioned = snap.answerMentioned ?? determineAnswerMentioned(
+      text,
+      projectDisplayName,
+      projectDomains,
+    )
+    if (projectMentioned) projectMentionCount++
+
+    for (const competitor of competitorDomains) {
+      const brand = brandLabelFromDomain(competitor)
+      const mentioned = determineAnswerMentioned(text, brand, [competitor])
+      if (mentioned) {
+        const entry = competitorMap.get(competitor)!
+        entry.count++
+        if (kw) entry.keywords.add(kw)
+      }
+    }
+  }
+
+  const totalMentionedSlots = projectMentionCount
+    + [...competitorMap.values()].reduce((sum, v) => sum + v.count, 0)
+
+  const competitorRows: MentionRow[] = [...competitorMap.entries()].map(([domain, data]) => {
+    const ratio = totalAnswerSnapshots > 0 ? data.count / totalAnswerSnapshots : 0
+    let pressureLabel: MentionRow['pressureLabel'] = 'None'
+    if (data.count > 0) {
+      if (ratio >= 0.5) pressureLabel = 'High'
+      else if (ratio >= 0.2) pressureLabel = 'Moderate'
+      else pressureLabel = 'Low'
+    }
+    const sharePct = totalMentionedSlots > 0
+      ? Math.round((data.count / totalMentionedSlots) * 100)
+      : 0
+    return {
+      domain,
+      mentionCount: data.count,
+      totalCount: totalAnswerSnapshots,
+      pressureLabel,
+      mentionedKeywords: [...data.keywords].sort(),
+      sharePct,
+    }
+  })
+
+  competitorRows.sort((a, b) => b.mentionCount - a.mentionCount)
+
+  return { projectMentionCount, totalAnswerSnapshots, competitors: competitorRows }
 }
 
 function buildAiSourceOrigin(
@@ -901,6 +980,13 @@ function buildProjectReport(db: DatabaseClient, projectName: string): ProjectRep
     projectDomains,
     keywordLookup,
   )
+  const mentionLandscape = buildMentionLandscape(
+    latestSnapshots,
+    competitorDomains,
+    project.displayName,
+    projectDomains,
+    keywordLookup,
+  )
   const aiSourceOrigin = buildAiSourceOrigin(latestSnapshots, projectDomains, competitorDomains)
   const trackedKeywords = [...keywordLookup.byId.values()]
   const gscSection = buildGscSection(
@@ -1016,6 +1102,7 @@ function buildProjectReport(db: DatabaseClient, projectName: string): ProjectRep
     },
     citationScorecard,
     competitorLandscape,
+    mentionLandscape,
     aiSourceOrigin,
     gsc: gscSection,
     ga: gaSection,

--- a/packages/api-routes/test/report-aggregations.test.ts
+++ b/packages/api-routes/test/report-aggregations.test.ts
@@ -93,6 +93,8 @@ function insertSnapshot(
     competitorOverlap?: string[]
     citationState?: 'cited' | 'not-cited'
     rawResponse?: { groundingSources: { uri: string; title?: string }[] }
+    answerText?: string | null
+    answerMentioned?: boolean | null
   } = {},
 ) {
   db.insert(querySnapshots).values({
@@ -101,7 +103,8 @@ function insertSnapshot(
     keywordId,
     provider: 'gemini',
     citationState: opts.citationState ?? 'cited',
-    answerMentioned: false,
+    answerMentioned: opts.answerMentioned ?? false,
+    answerText: opts.answerText ?? null,
     citedDomains: JSON.stringify(opts.citedDomains ?? []),
     competitorOverlap: JSON.stringify(opts.competitorOverlap ?? []),
     rawResponse: opts.rawResponse ? JSON.stringify(opts.rawResponse) : null,
@@ -248,6 +251,86 @@ describe('CompetitorRow.theirCitedPages', () => {
 
     const rival = body.competitorLandscape.competitors.find(c => c.domain === 'rival.com')!
     expect(rival.theirCitedPages.map(p => p.url)).toEqual(['https://rival.com/keep'])
+  })
+})
+
+describe('mentionLandscape', () => {
+  test('counts per-competitor mentions from snapshot answer text', async () => {
+    const projectId = insertProject(ctx.db, 'mentions', 'mentions.example.com')
+    insertCompetitor(ctx.db, projectId, 'rival-a.com')
+    insertCompetitor(ctx.db, projectId, 'rival-b.com')
+    const k1 = insertKeyword(ctx.db, projectId, 'k1')
+    const k2 = insertKeyword(ctx.db, projectId, 'k2')
+    const k3 = insertKeyword(ctx.db, projectId, 'k3')
+    const runId = insertRun(ctx.db, projectId)
+
+    // Snap 1: project + rival-a mentioned
+    insertSnapshot(ctx.db, runId, k1, {
+      answerText: 'Top picks include mentions.example.com and rival-a.com for this category.',
+      answerMentioned: true,
+    })
+    // Snap 2: rival-a + rival-b mentioned, project not
+    insertSnapshot(ctx.db, runId, k2, {
+      answerText: 'Consider rival-a.com or rival-b.com depending on workflow.',
+      answerMentioned: false,
+    })
+    // Snap 3: rival-a only
+    insertSnapshot(ctx.db, runId, k3, {
+      answerText: 'rival-a.com leads the category for this segment.',
+      answerMentioned: false,
+    })
+
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/mentions/report' })
+    const body = JSON.parse(res.body) as ProjectReportDto
+
+    expect(body.mentionLandscape.totalAnswerSnapshots).toBe(3)
+    expect(body.mentionLandscape.projectMentionCount).toBe(1)
+    const byDomain = Object.fromEntries(body.mentionLandscape.competitors.map(c => [c.domain, c]))
+    expect(byDomain['rival-a.com']!.mentionCount).toBe(3)
+    expect(byDomain['rival-b.com']!.mentionCount).toBe(1)
+    expect(byDomain['rival-a.com']!.mentionedKeywords).toEqual(expect.arrayContaining(['k1', 'k2', 'k3']))
+    expect(byDomain['rival-a.com']!.pressureLabel).toBe('High')
+    // SOV denominator = projectMentions(1) + rivalA(3) + rivalB(1) = 5
+    expect(byDomain['rival-a.com']!.sharePct).toBe(60)
+    expect(byDomain['rival-b.com']!.sharePct).toBe(20)
+  })
+
+  test('skips snapshots with no answer text from the totalCount denominator', async () => {
+    const projectId = insertProject(ctx.db, 'no-text', 'no-text.example.com')
+    insertCompetitor(ctx.db, projectId, 'rival.com')
+    const k1 = insertKeyword(ctx.db, projectId, 'k1')
+    const k2 = insertKeyword(ctx.db, projectId, 'k2')
+    const runId = insertRun(ctx.db, projectId)
+
+    insertSnapshot(ctx.db, runId, k1, { answerText: 'rival.com is mentioned here.' })
+    insertSnapshot(ctx.db, runId, k2, { answerText: null }) // ignored
+
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/no-text/report' })
+    const body = JSON.parse(res.body) as ProjectReportDto
+
+    expect(body.mentionLandscape.totalAnswerSnapshots).toBe(1)
+    const rival = body.mentionLandscape.competitors.find(c => c.domain === 'rival.com')!
+    expect(rival.mentionCount).toBe(1)
+    expect(rival.totalCount).toBe(1)
+  })
+
+  test('returns zero mentions when no snapshot text references competitors or project', async () => {
+    const projectId = insertProject(ctx.db, 'empty-mentions', 'empty.example.com')
+    insertCompetitor(ctx.db, projectId, 'rival.com')
+    const k = insertKeyword(ctx.db, projectId, 'k')
+    const runId = insertRun(ctx.db, projectId)
+    insertSnapshot(ctx.db, runId, k, { answerText: 'Generic advice with no brand references.' })
+
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/empty-mentions/report' })
+    const body = JSON.parse(res.body) as ProjectReportDto
+
+    expect(body.mentionLandscape.projectMentionCount).toBe(0)
+    expect(body.mentionLandscape.competitors[0]!.mentionCount).toBe(0)
+    expect(body.mentionLandscape.competitors[0]!.sharePct).toBe(0)
+    expect(body.mentionLandscape.competitors[0]!.pressureLabel).toBe('None')
   })
 })
 

--- a/packages/api-routes/test/report-renderer.test.ts
+++ b/packages/api-routes/test/report-renderer.test.ts
@@ -29,6 +29,7 @@ function emptyReport(): ProjectReportDto {
     },
     citationScorecard: { keywords: [], providers: [], matrix: [], providerRates: [] },
     competitorLandscape: { projectCitationCount: 0, competitors: [] },
+    mentionLandscape: { projectMentionCount: 0, totalAnswerSnapshots: 0, competitors: [] },
     aiSourceOrigin: { categories: [], topDomains: [] },
     gsc: null,
     ga: null,
@@ -95,6 +96,14 @@ function richReport(): ProjectReportDto {
       competitors: [
         { domain: 'rival.com', citationCount: 3, totalCount: 4, pressureLabel: 'High', citedKeywords: ['aeo platform'], sharePct: 0, theirCitedPages: [] },
         { domain: 'other.com', citationCount: 1, totalCount: 4, pressureLabel: 'Low', citedKeywords: ['answer engine'], sharePct: 0, theirCitedPages: [] },
+      ],
+    },
+    mentionLandscape: {
+      projectMentionCount: 3,
+      totalAnswerSnapshots: 4,
+      competitors: [
+        { domain: 'rival.com', mentionCount: 2, totalCount: 4, pressureLabel: 'Moderate', mentionedKeywords: ['aeo platform'], sharePct: 33 },
+        { domain: 'other.com', mentionCount: 1, totalCount: 4, pressureLabel: 'Low', mentionedKeywords: ['answer engine'], sharePct: 17 },
       ],
     },
     aiSourceOrigin: {
@@ -376,6 +385,16 @@ describe('renderReportHtml', () => {
     expect(html).not.toContain('id="content-opportunities"')
   })
 
+  test('absolutizes path-only Our page links to the project canonical domain', () => {
+    // richReport's second opportunity has ourBestPage.url = '/blog/answer-engine-optimization'
+    // and the project canonical domain is rich.example.com.
+    const html = renderReportHtml(richReport())
+    const opps = html.split('id="content-opportunities"')[1]?.split('</section>')[0] ?? ''
+    expect(opps).toContain('href="https://rich.example.com/blog/answer-engine-optimization"')
+    // Display text stays as the path so reviewers still see the slug
+    expect(opps).toContain('>/blog/answer-engine-optimization<')
+  })
+
   test('renders the API-supplied recommendedNextSteps verbatim', () => {
     // The API merges insight-derived and opportunity-derived steps via
     // mapOpportunitiesToNextSteps and ships the merged list. The renderer
@@ -425,6 +444,17 @@ describe('renderReportHtml', () => {
     const html = renderReportHtml(report)
     const landscape = html.split('id="competitor-landscape"')[1]?.split('</section>')[0] ?? ''
     expect(landscape).not.toContain('<details')
+  })
+
+  test('renders the Mentions per domain bar chart and Mentions column alongside Citations', () => {
+    const html = renderReportHtml(richReport())
+    const landscape = html.split('id="competitor-landscape"')[1]?.split('</section>')[0] ?? ''
+    expect(landscape).toContain('Citations per domain')
+    expect(landscape).toContain('Mentions per domain')
+    expect(landscape).toContain('<th class="numeric">Mentions</th>')
+    // rival.com has citationCount=3 / totalCount=4 (citations) and mentionCount=2 / totalCount=4 (mentions)
+    expect(landscape).toContain('3 / 4')
+    expect(landscape).toContain('2 / 4')
   })
 
   test('renders GSC × AEO crossover companion blocks when non-empty', () => {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "3.5.0",
+  "version": "3.6.2",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/mcp/tool-registry.ts
+++ b/packages/canonry/src/mcp/tool-registry.ts
@@ -249,7 +249,7 @@ export const canonryMcpTools = [
     name: 'canonry_report',
     title: 'Get aggregated AEO report',
     description:
-      'Returns the full client-facing AEO report bundle for a project — executive summary, per-keyword × per-provider citation matrix, competitor landscape, AI source origin, GSC/GA4 performance, social and AI referrals, indexing health, citations trend, prioritized insights, and recommended next steps. Same payload `canonry report <project>` consumes to render the self-contained HTML.',
+      'Returns the full client-facing AEO report bundle for a project — executive summary, per-keyword × per-provider citation matrix, competitor landscape, AI citation sources, GSC/GA4 performance, social and AI referrals, indexing health, citations trend, prioritized insights, and recommended next steps. Same payload `canonry report <project>` consumes to render the self-contained HTML.',
     access: 'read',
     tier: 'monitoring',
     inputSchema: projectInputSchema,

--- a/packages/canonry/test/report-command.test.ts
+++ b/packages/canonry/test/report-command.test.ts
@@ -31,6 +31,7 @@ function makeReport(): ProjectReportDto {
     },
     citationScorecard: { keywords: [], providers: [], matrix: [], providerRates: [] },
     competitorLandscape: { projectCitationCount: 0, competitors: [] },
+    mentionLandscape: { projectMentionCount: 0, totalAnswerSnapshots: 0, competitors: [] },
     aiSourceOrigin: { categories: [], topDomains: [] },
     gsc: null,
     ga: null,

--- a/packages/contracts/src/report.ts
+++ b/packages/contracts/src/report.ts
@@ -116,6 +116,33 @@ export interface CompetitorLandscape {
   competitors: CompetitorRow[]
 }
 
+export interface MentionRow {
+  domain: string
+  /** Number of (keyword × provider) pairs whose answer text mentioned this competitor's brand or domain. */
+  mentionCount: number
+  /** Out-of count for the same denominator (snapshots that had answer text). */
+  totalCount: number
+  /** 'High' | 'Moderate' | 'Low' | 'None' — mention frequency tier (mirrors CompetitorRow.pressureLabel). */
+  pressureLabel: 'High' | 'Moderate' | 'Low' | 'None'
+  /** Distinct keywords on which this competitor was mentioned. */
+  mentionedKeywords: string[]
+  /**
+   * Share of voice 0..100. Numerator = this competitor's `mentionCount`.
+   * Denominator = sum of `mentionCount` across all competitors plus the
+   * project's own `projectMentionCount`. Equals 0 when no snapshot had any
+   * mention.
+   */
+  sharePct: number
+}
+
+export interface MentionLandscape {
+  /** Project's own mention count (for the bar chart comparing project vs competitors). */
+  projectMentionCount: number
+  /** Snapshots considered — those with non-empty answerText. Drives the totalCount denominator. */
+  totalAnswerSnapshots: number
+  competitors: MentionRow[]
+}
+
 export interface AiSourceCategoryBucket {
   /** Category slug from packages/contracts/src/source-categories. */
   category: string
@@ -281,6 +308,7 @@ export interface ProjectReportDto {
   executiveSummary: ReportExecutiveSummary
   citationScorecard: CitationScorecard
   competitorLandscape: CompetitorLandscape
+  mentionLandscape: MentionLandscape
   aiSourceOrigin: AiSourceOrigin
   gsc: GscSection | null
   ga: GaTrafficSection | null

--- a/packages/contracts/src/url-normalize.ts
+++ b/packages/contracts/src/url-normalize.ts
@@ -75,6 +75,33 @@ function dropTrailingSlash(path: string): string {
   return path
 }
 
+/**
+ * Build an absolute URL for a path stored against a project domain. GSC
+ * returns most landing pages as path-only strings (`/blog/foo`), and storing
+ * them that way is correct — but rendering them as `<a href="/blog/foo">` in
+ * a report HTML file makes the browser resolve the path against whatever host
+ * the file is served from (often the canonry dashboard host or `file://`).
+ * This helper prepends `https://<canonicalDomain>` so the link resolves to
+ * the project's actual site instead. Already-absolute URLs (http/https) and
+ * protocol-relative URLs (`//host/...`) are returned unchanged. Returns the
+ * input as-is when it can't be confidently absolutized.
+ */
+export function absolutizeProjectUrl(
+  url: string | null | undefined,
+  canonicalDomain: string,
+): string {
+  if (!url) return ''
+  const trimmed = url.trim()
+  if (!trimmed) return ''
+  if (/^https?:\/\//i.test(trimmed)) return trimmed
+  if (trimmed.startsWith('//')) return `https:${trimmed}`
+  const host = canonicalDomain.trim().replace(/^https?:\/\//i, '').replace(/\/+$/, '')
+  if (!host) return trimmed
+  if (trimmed.startsWith('/')) return `https://${host}${trimmed}`
+  // Bare paths or domain-prefixed strings are ambiguous — treat as paths.
+  return `https://${host}/${trimmed}`
+}
+
 export function normalizeUrlPath(input: string | null | undefined): string | null {
   if (input == null) return null
   let trimmed = input.trim()

--- a/packages/contracts/test/url-normalize.test.ts
+++ b/packages/contracts/test/url-normalize.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { normalizeUrlPath } from '../src/url-normalize.js'
+import { absolutizeProjectUrl, normalizeUrlPath } from '../src/url-normalize.js'
 
 describe('normalizeUrlPath', () => {
   describe('null and empty inputs', () => {
@@ -190,5 +190,46 @@ describe('normalizeUrlPath', () => {
       expect(normalizeUrlPath('/michigan?v=3')).toBe('/michigan')
       expect(normalizeUrlPath('/path?ver=1.2.3')).toBe('/path')
     })
+  })
+})
+
+describe('absolutizeProjectUrl', () => {
+  it('prefixes path-only URLs with https://<canonicalDomain>', () => {
+    expect(absolutizeProjectUrl('/blog/foo', 'example.com')).toBe('https://example.com/blog/foo')
+  })
+
+  it('preserves the query string when prefixing a path', () => {
+    expect(absolutizeProjectUrl('/p?q=1', 'example.com')).toBe('https://example.com/p?q=1')
+  })
+
+  it('returns absolute https URLs unchanged', () => {
+    expect(absolutizeProjectUrl('https://other.com/x', 'example.com')).toBe('https://other.com/x')
+  })
+
+  it('returns absolute http URLs unchanged', () => {
+    expect(absolutizeProjectUrl('http://other.com/x', 'example.com')).toBe('http://other.com/x')
+  })
+
+  it('upgrades protocol-relative URLs to https', () => {
+    expect(absolutizeProjectUrl('//cdn.example.com/x', 'example.com')).toBe('https://cdn.example.com/x')
+  })
+
+  it('strips an http(s) prefix and trailing slash from the canonical domain', () => {
+    expect(absolutizeProjectUrl('/x', 'https://example.com/')).toBe('https://example.com/x')
+    expect(absolutizeProjectUrl('/x', 'http://example.com')).toBe('https://example.com/x')
+  })
+
+  it('returns empty string for null, undefined, or whitespace input', () => {
+    expect(absolutizeProjectUrl(null, 'example.com')).toBe('')
+    expect(absolutizeProjectUrl(undefined, 'example.com')).toBe('')
+    expect(absolutizeProjectUrl('   ', 'example.com')).toBe('')
+  })
+
+  it('treats bare slugs (no leading slash) as paths under the canonical host', () => {
+    expect(absolutizeProjectUrl('blog/foo', 'example.com')).toBe('https://example.com/blog/foo')
+  })
+
+  it('returns the original input when canonicalDomain is empty', () => {
+    expect(absolutizeProjectUrl('/blog/foo', '')).toBe('/blog/foo')
   })
 })

--- a/skills/aero/references/reporting.md
+++ b/skills/aero/references/reporting.md
@@ -15,7 +15,7 @@ canonry report <project> --output dist/aeo.html   # custom path
 canonry report <project> --format json            # raw payload, useful for narrating in chat
 ```
 
-The HTML is self-contained (inline CSS + SVG charts, no network dependencies) and covers: executive summary, per-keyword × per-provider citation matrix, competitor landscape, AI source origin, GSC + GA4 performance, social and AI referrals, indexing health, citations trend, prioritized insights, and recommended next steps. Same payload is available via `GET /api/v1/projects/<name>/report` and the `canonry_report` MCP tool — use `--format json` when you want to summarize specific numbers in a thread instead of attaching the file.
+The HTML is self-contained (inline CSS + SVG charts, no network dependencies) and covers: executive summary, per-keyword × per-provider citation matrix, competitor landscape, AI citation sources, GSC + GA4 performance, social and AI referrals, indexing health, citations trend, prioritized insights, and recommended next steps. Same payload is available via `GET /api/v1/projects/<name>/report` and the `canonry_report` MCP tool — use `--format json` when you want to summarize specific numbers in a thread instead of attaching the file.
 
 Behaviors worth knowing before narrating numbers from the report:
 - `executiveSummary.citationRate` is always sourced from the latest visibility run (completed **or** partial), so it tracks the scorecard table even when the latest sweep had a flaky provider.

--- a/skills/canonry-setup/references/canonry-cli.md
+++ b/skills/canonry-setup/references/canonry-cli.md
@@ -92,7 +92,7 @@ canonry report <project> --output dist/aeo.html   # custom path
 canonry report <project> --format json            # raw report payload to stdout
 ```
 
-One-command client-facing AEO report. Bundles the latest visibility sweep, competitor landscape, AI source origin, GSC + GA4 performance, social and AI referrals, indexing health, citations trend, prioritized insights, and recommended next steps into a self-contained HTML file (inline CSS + SVG charts, no network dependencies). Backed by `GET /api/v1/projects/<name>/report` and the `canonry_report` MCP tool.
+One-command client-facing AEO report. Bundles the latest visibility sweep, competitor landscape, AI citation sources, GSC + GA4 performance, social and AI referrals, indexing health, citations trend, prioritized insights, and recommended next steps into a self-contained HTML file (inline CSS + SVG charts, no network dependencies). Backed by `GET /api/v1/projects/<name>/report` and the `canonry_report` MCP tool.
 
 Behavior to know when narrating numbers from the report:
 - `executiveSummary.citationRate` is sourced from the latest visibility run (completed **or** partial), so it always matches the scorecard table.


### PR DESCRIPTION
## Summary

- **Section 3 — Mentions landscape**: adds a parallel "Mentions per domain" bar chart (and a Mentions column in the competitor table) alongside the existing "Citations per domain" chart, surfacing the answer-text signal next to the source-citation signal that already existed.
- **Section 4 rename + section copy pass**: "AI Source Origin" → "AI Citation Sources" (anchor unchanged so deep links still resolve), plus a one-sentence subtitle on every section that names the data source, says what each chart/table answers, and calls out the major exclusion. `SectionHeading` in the dashboard now takes a `subtitle` prop so the standalone HTML and the dashboard show identical copy.
- **Section 12 — absolutize Our page links**: GSC stores landing pages as path-only strings (`/blog/foo`); rendering them as `<a href="/blog/foo">` made them resolve against the report's host (canonry dashboard or `file://`). New `absolutizeProjectUrl()` helper in `@ainyc/canonry-contracts` prefixes the project's canonical domain while keeping the path as visible link text.

Bumped to `3.6.2`. UI/CLI parity holds — every change applies to both the standalone HTML report and the dashboard `ReportPage`.

## Test plan

- [x] `pnpm run typecheck` — passes
- [x] `pnpm run lint` — passes
- [x] `pnpm run test` — 1909 / 1909 pass (added 9 helper tests + 1 renderer test for absolutize, 4 mention-landscape aggregation tests, 1 renderer test for the new chart/column)
- [ ] Open the rendered HTML report and confirm Section 3 shows both charts side-by-side, Section 4 reads "AI Citation Sources" with the new subtitle, and Section 12 "Our page" links open the project's domain in a new tab