### PR TITLE
fix(web): live sweep status + overview snapshots during in-progress runs

### DIFF
--- a/apps/web/src/build-dashboard.ts
+++ b/apps/web/src/build-dashboard.ts
@@ -916,7 +916,11 @@ export interface ProjectData {
 export function buildProjectCommandCenter(data: ProjectData): ProjectCommandCenterVm {
   const dto = toProjectDto(data.project)
   const evidence = buildEvidenceFromTimeline(dto.name, data.timeline, data.latestRunDetail, data.keywords)
-  const latestVisibilityRunMetrics = data.runs.filter(r => r.kind === RunKinds['answer-visibility']).sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0];
+  // Match latestRunDetail (which is fetched for the most recent completed/partial run)
+  // — using all runs would leave snapshots empty whenever a newer run is queued/running.
+  const latestVisibilityRunMetrics = data.runs
+    .filter(r => r.kind === RunKinds['answer-visibility'] && (r.status === RunStatuses.completed || r.status === RunStatuses.partial))
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0]
   const snapshots = (latestVisibilityRunMetrics && data.latestRunDetail?.id === latestVisibilityRunMetrics.id) ? data.latestRunDetail.snapshots : []
   const kwVis = computeKeywordVisibility(snapshots)
   const gapKeyPhrases = buildGapKeyPhraseSummary(snapshots)
@@ -1058,7 +1062,9 @@ export function buildProjectCommandCenter(data: ProjectData): ProjectCommandCent
 
 export function buildPortfolioProject(data: ProjectData): PortfolioProjectVm {
   const dto = toProjectDto(data.project)
-  const latestVisibilityRun = data.runs.filter(r => r.kind === RunKinds['answer-visibility']).sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0];
+  const latestVisibilityRun = data.runs
+    .filter(r => r.kind === RunKinds['answer-visibility'] && (r.status === RunStatuses.completed || r.status === RunStatuses.partial))
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0]
   const snapshots = (latestVisibilityRun && data.latestRunDetail?.id === latestVisibilityRun.id) ? data.latestRunDetail.snapshots : []
   const kwVis = computeKeywordVisibility(snapshots)
   const pressure = computeCompetitorPressure(snapshots, data.competitors.map(c => c.domain))

--- a/apps/web/src/components/project/NotificationsSection.tsx
+++ b/apps/web/src/components/project/NotificationsSection.tsx
@@ -22,6 +22,7 @@ export function NotificationsSection({ projectName }: { projectName: string }) {
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [testStates, setTestStates] = useState<Record<string, { state: 'testing' | 'ok' | 'fail'; status?: number }>>({})
+  const [removingIds, setRemovingIds] = useState<Set<string>>(new Set())
 
   useEffect(() => {
     listNotifications(projectName).then(setNotifs).catch(() => setNotifs([]))
@@ -60,6 +61,8 @@ export function NotificationsSection({ projectName }: { projectName: string }) {
   }
 
   const handleRemove = async (id: string) => {
+    if (removingIds.has(id)) return
+    setRemovingIds(prev => new Set(prev).add(id))
     try {
       await removeNotification(projectName, id)
       setNotifs(prev => prev === 'loading' ? prev : prev.filter(n => n.id !== id))
@@ -72,6 +75,12 @@ export function NotificationsSection({ projectName }: { projectName: string }) {
       })
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to remove webhook')
+    } finally {
+      setRemovingIds(prev => {
+        const next = new Set(prev)
+        next.delete(id)
+        return next
+      })
     }
   }
 
@@ -208,8 +217,8 @@ export function NotificationsSection({ projectName }: { projectName: string }) {
                       <Button variant="ghost" size="sm" type="button" disabled={testStates[n.id]?.state === 'testing'} onClick={() => handleTest(n.id)}>
                         Test
                       </Button>
-                      <Button variant="ghost" size="sm" type="button" onClick={() => handleRemove(n.id)}>
-                        Remove
+                      <Button variant="ghost" size="sm" type="button" disabled={removingIds.has(n.id)} onClick={() => handleRemove(n.id)}>
+                        {removingIds.has(n.id) ? 'Removing…' : 'Remove'}
                       </Button>
                     </div>
                   </td>

--- a/apps/web/src/components/project/TrafficSection.tsx
+++ b/apps/web/src/components/project/TrafficSection.tsx
@@ -879,12 +879,12 @@ export function TrafficSection({ projectName }: { projectName: string }) {
                     <div className="overflow-x-auto">
                       <table className="w-full text-sm table-fixed">
                         <colgroup>
-                          <col className="w-[40%]" />
-                          <col className="w-[28%]" />
+                          <col className="w-[32%]" />
+                          <col className="w-[22%]" />
                           <col className="w-[12%]" />
-                          <col className="w-[8%]" />
-                          <col className="w-[6%]" />
-                          <col className="w-[6%]" />
+                          <col className="w-[11%]" />
+                          <col className="w-[11%]" />
+                          <col className="w-[12%]" />
                         </colgroup>
                         <thead>
                           <tr className="text-[10px] uppercase tracking-wider text-zinc-500">

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -3,6 +3,7 @@ import { ChevronRight, Download, Trash2 } from 'lucide-react'
 import { useParams, useNavigate } from '@tanstack/react-router'
 import { Link } from '@tanstack/react-router'
 import { useQueryClient } from '@tanstack/react-query'
+import { RunKinds, RunStatuses } from '@ainyc/canonry-contracts'
 
 import { Button } from '../components/ui/button.js'
 import { Card } from '../components/ui/card.js'
@@ -1090,6 +1091,10 @@ export function ProjectPage({
   const projectLabel = model?.project.displayName || model?.project.name || projectName
   const triggerRunMutation = useTriggerRun()
 
+  const hasActiveVisibilitySweep = (model?.recentRuns ?? []).some(
+    r => r.kind === RunKinds['answer-visibility'] && (r.status === RunStatuses.running || r.status === RunStatuses.queued),
+  )
+
   const locationLabelsInEvidence = useMemo(() => new Set(visibilityEvidence.map(e => e.location ?? '')), [visibilityEvidence])
   const hasNullLocationEvidence = locationLabelsInEvidence.has('')
   const distinctLocationsWithEvidence = useMemo(() => [...locationLabelsInEvidence].filter(Boolean), [locationLabelsInEvidence])
@@ -1387,10 +1392,14 @@ export function ProjectPage({
             </Button>
             <Button
               type="button"
-              disabled={triggerRunMutation.isPending}
+              disabled={triggerRunMutation.isPending || hasActiveVisibilitySweep}
               onClick={handleTriggerRun}
             >
-              {triggerRunMutation.isPending ? 'Starting...' : 'Run now'}
+              {triggerRunMutation.isPending
+                ? 'Starting…'
+                : hasActiveVisibilitySweep
+                  ? 'Sweep running…'
+                  : 'Run now'}
             </Button>
           </div>
         </div>

--- a/apps/web/src/queries/use-dashboard.ts
+++ b/apps/web/src/queries/use-dashboard.ts
@@ -99,12 +99,23 @@ export function useDashboard(initialDashboard?: DashboardVm | null) {
     if (!projectsQuery.data || !runsQuery.data) return null
     if (projects.length > 0 && !allProjectDetailsLoaded) return null
 
+    // Override `runs` with fresh allRuns. The detail query is keyed by the latest
+    // completed run id, so its cached `runs` field misses runs that started after
+    // the last completion (queued/running). Polling refreshes runsQuery every 3s
+    // while a run is active — projecting it through here lets the dashboard
+    // reflect in-progress state without waiting for the detail query to refetch.
     const projectDataList: ProjectData[] = projectDetailQueries
-      .map(q => q.data)
+      .map((q) => {
+        if (!q.data) return null
+        return {
+          ...q.data,
+          runs: allRuns.filter((r) => r.projectId === q.data!.project.id),
+        }
+      })
       .filter((d): d is ProjectData => d != null)
 
     return buildDashboard(projectDataList, settingsQuery.data ?? null)
-  }, [effectiveInitial, projectsQuery.data, runsQuery.data, settingsQuery.data, allProjectDetailsLoaded, projectDetailQueries, projects.length])
+  }, [effectiveInitial, projectsQuery.data, runsQuery.data, settingsQuery.data, allProjectDetailsLoaded, projectDetailQueries, projects.length, allRuns])
 
   const isError = !effectiveInitial && (projectsQuery.isError || runsQuery.isError)
   const isLoading = !effectiveInitial && !dashboard && !isError

--- a/apps/web/test/build-dashboard.test.ts
+++ b/apps/web/test/build-dashboard.test.ts
@@ -900,4 +900,55 @@ describe('provider coverage indicators', () => {
     expect(portfolio.visibilityTone).not.toBe('caution')
     expect(portfolio.providerCoverage).toBeUndefined()
   })
+
+  test('overview keeps last completed snapshots when a newer run is in progress', () => {
+    const data = makeMultiProviderData(['gemini', 'openai'], ['gemini', 'openai'])
+    // A new run was queued after the completed run finished. latestRunDetail still
+    // points at run_1, so the build must fall back to it instead of showing "No data".
+    data.runs = [
+      {
+        id: 'run_2_running',
+        projectId: 'proj_cov',
+        kind: 'answer-visibility',
+        status: 'running',
+        trigger: 'manual',
+        startedAt: '2026-03-16T00:00:00Z',
+        finishedAt: null,
+        error: null,
+        createdAt: '2026-03-16T00:00:00Z',
+      },
+      ...data.runs,
+    ]
+
+    const model = buildProjectCommandCenter(data)
+    expect(model.visibilitySummary.value).not.toBe('No data')
+    expect(model.visibilitySummary.delta).not.toBe('Run a sweep first')
+
+    const portfolio = buildPortfolioProject(data)
+    expect(portfolio.visibilityDelta).not.toBe('No data')
+    expect(portfolio.insight).not.toBe('No runs completed yet.')
+  })
+
+  test('overview shows in-progress status while preserving snapshots', () => {
+    const data = makeMultiProviderData(['gemini', 'openai'], ['gemini', 'openai'])
+    data.runs = [
+      {
+        id: 'run_2_queued',
+        projectId: 'proj_cov',
+        kind: 'answer-visibility',
+        status: 'queued',
+        trigger: 'manual',
+        startedAt: null,
+        finishedAt: null,
+        error: null,
+        createdAt: '2026-03-16T00:00:00Z',
+      },
+      ...data.runs,
+    ]
+
+    const model = buildProjectCommandCenter(data)
+    expect(model.runStatus.value).toBe('Queued')
+    // Snapshots from the previous completed run should still drive the gauges.
+    expect(model.visibilitySummary.value).not.toBe('No data')
+  })
 })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "3.6.2",
+  "version": "3.6.3",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Summary
- Project page reflects queued/running sweeps without a manual refresh: the dashboard memo now projects fresh `allRuns` over each cached project detail so the 3s runs poll propagates new state immediately (the detail query key was stable on the latest *completed* run id, so its cached `runs` never picked up newly queued runs).
- Overview gauges keep the previous completed run's snapshots while a new sweep is in progress instead of blanking to "No data" — `buildProjectCommandCenter` and `buildPortfolioProject` now filter `latestVisibilityRun` to completed/partial, matching what `latestRunDetail` actually contains.
- "Run now" disables and shows "Sweep running…" while a visibility run is queued/running; "Remove" on a notification webhook disables and shows "Removing…" during the delete; the Source/medium social referrals table redistributes column widths so right-aligned "75.0%" no longer overlaps the Sessions cell.

## Test plan
- [x] Open a project and click Run now — the in-progress state appears without refresh and the button stays disabled until the sweep finishes
- [x] During an in-progress sweep, verify overview gauges still show the previous run's data instead of "No data"
- [x] Open Notifications, click Remove on a webhook — button disables to "Removing…"
- [x] Open the Traffic tab — Sessions and Share columns no longer overlap