### PR TITLE
feat(web): mentions/citations toggle + tighter brand mention chips

### DIFF
--- a/apps/web/src/components/project/EvidenceTable.tsx
+++ b/apps/web/src/components/project/EvidenceTable.tsx
@@ -6,7 +6,73 @@ import { CitationBadge } from '../shared/CitationBadge.js'
 import { ProviderBadge } from '../shared/ProviderBadge.js'
 import { CitationTimeline, mergeProviderHistories } from './CitationTimeline.js'
 import { useDrawer } from '../../hooks/use-drawer.js'
-import type { CitationInsightVm, CitationState } from '../../view-models.js'
+import type { CitationInsightVm, CitationState, RunHistoryPoint } from '../../view-models.js'
+
+type CoverageMode = 'citations' | 'mentions'
+
+/** Map a snapshot to the state value driving the column for the active mode.
+ *  In citations mode we read `citationState` directly. In mentions mode we
+ *  collapse to `cited`/`not-cited`/`pending` based on `answerMentioned` (with
+ *  `visibilityState` as a fallback) so the visualization can reuse the same
+ *  dot palette and badge component. */
+function deriveStateForMode(
+  input: { citationState: string; answerMentioned?: boolean; visibilityState?: string },
+  mode: CoverageMode,
+): CitationState {
+  if (mode === 'citations') return input.citationState as CitationState
+  if (input.visibilityState === 'pending') return 'pending'
+  if (input.answerMentioned == null && input.visibilityState == null) return 'pending'
+  const mentioned = input.visibilityState === 'visible' || input.answerMentioned === true
+  return mentioned ? 'cited' : 'not-cited'
+}
+
+function statusLabelForMode(state: CitationState, mode: CoverageMode): string {
+  if (mode === 'mentions') {
+    switch (state) {
+      case 'cited': return 'Mentioned'
+      case 'not-cited': return 'Not Mentioned'
+      case 'pending': return 'Pending'
+      // 'emerging' / 'lost' are collapsed by deriveStateForMode in mentions mode,
+      // but fall through here defensively if a caller passes them anyway.
+      case 'emerging': return 'Newly Mentioned'
+      case 'lost': return 'No Longer Mentioned'
+    }
+  }
+  switch (state) {
+    case 'cited': return 'Cited'
+    case 'not-cited': return 'Not Cited'
+    case 'lost': return 'Lost'
+    case 'emerging': return 'Emerging'
+    case 'pending': return 'Pending'
+  }
+}
+
+function describeChange(history: RunHistoryPoint[], mode: CoverageMode): string {
+  const verb = mode === 'mentions' ? 'mentioned' : 'cited'
+  const verbCap = mode === 'mentions' ? 'Mentioned' : 'Cited'
+  if (history.length === 0) return 'Awaiting first run'
+  if (history.length === 1) return 'First observation'
+  const latest = history[history.length - 1]!.citationState
+  const prev = history[history.length - 2]!.citationState
+  if (prev !== 'cited' && latest === 'cited') return `Newly ${verb}`
+  if (prev === 'cited' && latest !== 'cited') return 'Lost since last run'
+  let streak = 0
+  for (let i = history.length - 1; i >= 0; i--) {
+    if (history[i]!.citationState === latest) streak++
+    else break
+  }
+  if (latest === 'cited') return streak <= 1 ? `${verbCap} in latest run` : `${verbCap} for ${streak} runs`
+  return streak <= 1 ? `Not ${verb} in latest run` : `Not ${verb} across ${streak} runs`
+}
+
+function projectItemsForMode(items: CitationInsightVm[], mode: CoverageMode): CitationInsightVm[] {
+  if (mode === 'citations') return items
+  return items.map(item => ({
+    ...item,
+    citationState: deriveStateForMode(item, mode),
+    runHistory: item.runHistory.map(h => ({ ...h, citationState: deriveStateForMode(h, mode) })),
+  }))
+}
 
 export function EvidenceTable({
   evidence,
@@ -15,15 +81,17 @@ export function EvidenceTable({
 }) {
   const { openEvidence } = useDrawer()
   const [expandedPhrases, setExpandedPhrases] = useState<Set<string>>(new Set())
+  const [mode, setMode] = useState<CoverageMode>('citations')
 
   const groups = useMemo(() => {
+    const projected = projectItemsForMode(evidence, mode)
     const map = new Map<string, CitationInsightVm[]>()
-    for (const item of evidence) {
+    for (const item of projected) {
       const existing = map.get(item.keyword) ?? []
       map.set(item.keyword, [...existing, item])
     }
     return [...map.entries()].map(([phrase, items]) => ({ phrase, items }))
-  }, [evidence])
+  }, [evidence, mode])
 
   const togglePhrase = (phrase: string) => {
     setExpandedPhrases(prev => {
@@ -34,115 +102,159 @@ export function EvidenceTable({
     })
   }
 
+  const presenceVerb = mode === 'mentions' ? 'mentioned' : 'cited'
+  const historyHeader = mode === 'mentions' ? 'Mention History' : 'Citation History'
+  const countNoun = mode === 'mentions' ? 'mentioned' : 'cited'
+
   return (
-    <div className="evidence-table-wrap">
-      <table className="evidence-table">
-        <thead>
-          <tr>
-            <th style={{ width: '2rem' }} />
-            <th>Key Phrase</th>
-            <th>Status</th>
-            <th>Citation History</th>
-            <th>Change</th>
-            <th />
-          </tr>
-        </thead>
-        <tbody>
-          {groups.map(({ phrase, items }) => {
-            const isExpanded = expandedPhrases.has(phrase)
-            const states = items.map(i => i.citationState)
-            const aggState: CitationState =
-              states.includes('cited') ? 'cited' :
-              states.includes('emerging') ? 'emerging' :
-              states.includes('lost') ? 'lost' :
-              states.every(s => s === 'pending') ? 'pending' : 'not-cited'
+    <div>
+      <div className="mb-3 flex flex-wrap items-center gap-2">
+        <span className="text-[10px] uppercase tracking-wide text-zinc-500">View by</span>
+        <div
+          className="inline-flex gap-0.5 p-0.5 rounded-md bg-zinc-900/60 border border-zinc-800/40"
+          role="tablist"
+          aria-label="Citation tracking view"
+        >
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'citations'}
+            className={`px-2.5 py-1 text-xs font-medium rounded transition-colors ${
+              mode === 'citations'
+                ? 'bg-zinc-800 text-zinc-100'
+                : 'text-zinc-400 hover:text-zinc-200'
+            }`}
+            onClick={() => setMode('citations')}
+          >
+            Citations
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'mentions'}
+            className={`px-2.5 py-1 text-xs font-medium rounded transition-colors ${
+              mode === 'mentions'
+                ? 'bg-zinc-800 text-zinc-100'
+                : 'text-zinc-400 hover:text-zinc-200'
+            }`}
+            onClick={() => setMode('mentions')}
+          >
+            Mentions
+          </button>
+        </div>
+        <span className="text-[11px] text-zinc-500">
+          {mode === 'mentions'
+            ? 'Brand or domain in answer text'
+            : 'Brand or domain in source links'}
+        </span>
+      </div>
+      <div className="evidence-table-wrap">
+        <table className="evidence-table">
+          <thead>
+            <tr>
+              <th style={{ width: '2rem' }} />
+              <th>Key Phrase</th>
+              <th>Status</th>
+              <th>{historyHeader}</th>
+              <th>Change</th>
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {groups.map(({ phrase, items }) => {
+              const isExpanded = expandedPhrases.has(phrase)
+              const states = items.map(i => i.citationState)
+              const aggState: CitationState =
+                states.includes('cited') ? 'cited' :
+                states.includes('emerging') ? 'emerging' :
+                states.includes('lost') ? 'lost' :
+                states.every(s => s === 'pending') ? 'pending' : 'not-cited'
 
-            const mergedHistory = mergeProviderHistories(items)
-            const citedCount = items.filter(i => i.citationState === 'cited' || i.citationState === 'emerging').length
+              const mergedHistory = mergeProviderHistories(items)
+              const presentCount = items.filter(i => i.citationState === 'cited' || i.citationState === 'emerging').length
+              const aggChangeLabel = describeChange(mergedHistory, mode)
 
-            // Compute phrase-level change label from merged history
-            const aggChangeLabel = (() => {
-              if (mergedHistory.length === 0) return 'Awaiting first run'
-              if (mergedHistory.length === 1) return 'First observation'
-              const latest = mergedHistory[mergedHistory.length - 1]!.citationState
-              const prev = mergedHistory[mergedHistory.length - 2]!.citationState
-              if (prev !== 'cited' && latest === 'cited') return 'Newly cited'
-              if (prev === 'cited' && latest !== 'cited') return 'Lost since last run'
-              // Count streak
-              let streak = 0
-              for (let i = mergedHistory.length - 1; i >= 0; i--) {
-                if (mergedHistory[i]!.citationState === latest) streak++
-                else break
-              }
-              if (latest === 'cited') return streak <= 1 ? 'Cited in latest run' : `Cited for ${streak} runs`
-              return streak <= 1 ? 'Not cited in latest run' : `Not cited across ${streak} runs`
-            })()
-
-            return (
-              <Fragment key={phrase}>
-                <tr
-                  className="evidence-phrase-row cursor-pointer hover:bg-zinc-800/40"
-                  onClick={() => togglePhrase(phrase)}
-                  aria-expanded={isExpanded}
-                >
-                  <td>
-                    <ChevronRight
-                      size={14}
-                      className={`transition-transform duration-150 text-zinc-500 ${isExpanded ? 'rotate-90' : ''}`}
-                    />
-                  </td>
-                  <td className="evidence-keyword-cell">
-                    <div>
-                      <span className="font-medium text-zinc-100">{phrase}</span>
-                      <div className="flex flex-wrap gap-1 mt-1">
-                        {items.map(item => (
-                          <ProviderBadge key={item.id} provider={item.provider} />
-                        ))}
+              return (
+                <Fragment key={phrase}>
+                  <tr
+                    className="evidence-phrase-row cursor-pointer hover:bg-zinc-800/40"
+                    onClick={() => togglePhrase(phrase)}
+                    aria-expanded={isExpanded}
+                  >
+                    <td>
+                      <ChevronRight
+                        size={14}
+                        className={`transition-transform duration-150 text-zinc-500 ${isExpanded ? 'rotate-90' : ''}`}
+                      />
+                    </td>
+                    <td className="evidence-keyword-cell">
+                      <div>
+                        <span className="font-medium text-zinc-100">{phrase}</span>
+                        <div className="flex flex-wrap gap-1 mt-1">
+                          {items.map(item => (
+                            <ProviderBadge key={item.id} provider={item.provider} />
+                          ))}
+                        </div>
                       </div>
-                    </div>
-                  </td>
-                  <td>
-                    <div className="flex items-center gap-2">
-                      <CitationBadge state={aggState} />
-                      <span className="text-[11px] text-zinc-500">{citedCount}/{items.length}</span>
-                    </div>
-                  </td>
-                  <td>
-                    <CitationTimeline history={mergedHistory} />
-                  </td>
-                  <td className="evidence-change-cell">
-                    {aggChangeLabel}
-                  </td>
-                  <td />
-                </tr>
-                {isExpanded && items.map(item => (
-                  <tr key={item.id} className="bg-zinc-900/30">
+                    </td>
+                    <td>
+                      <div className="flex items-center gap-2">
+                        <CitationBadge state={aggState} label={statusLabelForMode(aggState, mode)} />
+                        <span
+                          className="text-[11px] text-zinc-500"
+                          title={`${presentCount} of ${items.length} engines ${countNoun}`}
+                        >
+                          {presentCount}/{items.length}
+                        </span>
+                      </div>
+                    </td>
+                    <td>
+                      <CitationTimeline history={mergedHistory} />
+                    </td>
+                    <td className="evidence-change-cell">
+                      {aggChangeLabel}
+                    </td>
                     <td />
-                    <td className="evidence-keyword-cell pl-5">
-                      <ProviderBadge provider={item.provider} />
-                    </td>
-                    <td><CitationBadge state={item.citationState} /></td>
-                    <td>
-                      <CitationTimeline history={item.runHistory} />
-                    </td>
-                    <td className="evidence-change-cell">{item.changeLabel}</td>
-                    <td>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        type="button"
-                        onClick={(e) => { e.stopPropagation(); openEvidence(item.id) }}
-                      >
-                        View
-                      </Button>
-                    </td>
                   </tr>
-                ))}
-              </Fragment>
-            )
-          })}
-        </tbody>
-      </table>
+                  {isExpanded && items.map(item => (
+                    <tr key={item.id} className="bg-zinc-900/30">
+                      <td />
+                      <td className="evidence-keyword-cell pl-5">
+                        <ProviderBadge provider={item.provider} />
+                      </td>
+                      <td>
+                        <CitationBadge
+                          state={item.citationState}
+                          label={statusLabelForMode(item.citationState, mode)}
+                        />
+                      </td>
+                      <td>
+                        <CitationTimeline history={item.runHistory} />
+                      </td>
+                      <td className="evidence-change-cell">
+                        {describeChange(item.runHistory, mode)}
+                      </td>
+                      <td>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          type="button"
+                          onClick={(e) => { e.stopPropagation(); openEvidence(item.id) }}
+                        >
+                          View
+                        </Button>
+                      </td>
+                    </tr>
+                  ))}
+                </Fragment>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+      <p className="sr-only" aria-live="polite">
+        Showing {presenceVerb === 'cited' ? 'citations (sources)' : 'mentions (answer text)'}.
+      </p>
     </div>
   )
 }

--- a/apps/web/src/components/shared/CitationBadge.tsx
+++ b/apps/web/src/components/shared/CitationBadge.tsx
@@ -3,6 +3,14 @@ import { toneFromCitationState } from '../../lib/tone-helpers.js'
 import { toTitleCase } from '../../lib/format-helpers.js'
 import { ToneBadge } from './ToneBadge.js'
 
-export function CitationBadge({ state }: { state: CitationInsightVm['citationState'] }) {
-  return <ToneBadge tone={toneFromCitationState(state)}>{toTitleCase(state)}</ToneBadge>
+export function CitationBadge({
+  state,
+  label,
+}: {
+  state: CitationInsightVm['citationState']
+  /** Optional override for the rendered text — lets callers swap "Cited" for
+   *  "Mentioned" while keeping the same tone color. */
+  label?: string
+}) {
+  return <ToneBadge tone={toneFromCitationState(state)}>{label ?? toTitleCase(state)}</ToneBadge>
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1197,6 +1197,11 @@
 
   .answer-snippet-block {
     @apply rounded-lg border border-zinc-800/60 bg-zinc-900/50 p-3 text-sm leading-relaxed text-zinc-400;
+    /* Long markdown citation URLs in answer text have no natural break
+       points; force them to wrap so they can't push the column wider than
+       the modal viewport. */
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
 
   .answer-highlight,
@@ -1330,7 +1335,7 @@
   }
 
   .evidence-modal-main {
-    @apply grid gap-4 content-start;
+    @apply grid gap-4 content-start min-w-0;
   }
 
   .evidence-modal-sidebar {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "3.6.3",
+  "version": "3.6.4",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "3.6.3",
+  "version": "3.6.4",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/contracts/src/answer-visibility.ts
+++ b/packages/contracts/src/answer-visibility.ts
@@ -89,23 +89,33 @@ export function extractAnswerMentions(
     matchedTerms.push(displayName)
   }
 
-  const tokens = collectDistinctiveTokens(displayName, domains)
+  // Token-based matching: count every distinctive token toward the
+  // threshold (so detection accuracy stays the same — a multi-word brand
+  // still requires ≥2 matches before it fires), but only surface the
+  // *primary* tokens as matchedTerms. Secondary tokens are trailing
+  // descriptors like "Roofing"/"Plumbing"/"Construction" that are too
+  // generic to be useful as standalone evidence. Surfacing them as chips
+  // (or as highlight terms in the answer body) misleads the reader into
+  // thinking every "roofing" mention is a hit on the brand "Cenco Roofing".
+  const brandTokens = collectBrandTokens(displayName, domains)
+  const allTokens = [...brandTokens.primary, ...brandTokens.secondary]
+  const secondarySet = new Set(brandTokens.secondary)
   let tokenMatches = 0
-  const matchedTokens: string[] = []
-  for (const token of tokens) {
+  const matchedPrimary: string[] = []
+  for (const token of allTokens) {
     if (new RegExp(`\\b${escapeRegExp(token)}\\b`).test(lowerAnswer)) {
       tokenMatches++
-      matchedTokens.push(token)
+      if (!secondarySet.has(token)) matchedPrimary.push(token)
     }
   }
 
-  const tokenThresholdMet = tokens.length > 0 && (
-    (tokens.length === 1 && tokenMatches >= 1)
-    || tokenMatches >= Math.min(2, tokens.length)
+  const tokenThresholdMet = allTokens.length > 0 && (
+    (allTokens.length === 1 && tokenMatches >= 1)
+    || tokenMatches >= Math.min(2, allTokens.length)
   )
 
   if (tokenThresholdMet) {
-    matchedTerms.push(...matchedTokens)
+    matchedTerms.push(...matchedPrimary)
   }
 
   // Deduplicate and remove tokens already subsumed by a domain match
@@ -150,11 +160,34 @@ function domainMentioned(lowerAnswer: string, normalizedDomain: string): boolean
   return patterns.some(pattern => pattern.test(lowerAnswer))
 }
 
-function collectDistinctiveTokens(displayName: string, domains: string[]): string[] {
-  const tokens = new Set<string>()
+interface BrandTokens {
+  /**
+   * Tokens that may match standalone in answer text — the brand prefix
+   * (first distinctive word of the display name) and the registrable
+   * domain's concatenated brand label. These are unique enough that a
+   * single word-boundary hit signals a real mention.
+   */
+  primary: string[]
+  /**
+   * Distinctive but trailing descriptor words from the display name
+   * (e.g. "Roofing" in "Cenco Roofing"). These flow through full-phrase
+   * and brand-key matching, but are NEVER matched standalone in prose,
+   * because generic industry nouns are too common to be a reliable
+   * signal of brand presence on their own.
+   */
+  secondary: string[]
+}
 
-  for (const token of extractDistinctiveTokens(displayName)) {
-    tokens.add(token)
+function collectBrandTokens(displayName: string, domains: string[]): BrandTokens {
+  const primary = new Set<string>()
+  const secondary = new Set<string>()
+
+  const distinctiveWords = extractDistinctiveTokens(displayName)
+  if (distinctiveWords.length > 0) {
+    primary.add(distinctiveWords[0]!)
+    for (let i = 1; i < distinctiveWords.length; i++) {
+      secondary.add(distinctiveWords[i]!)
+    }
   }
 
   for (const domain of domains) {
@@ -168,10 +201,13 @@ function collectDistinctiveTokens(displayName: string, domains: string[]): strin
       ? brandLabelFromDomain(reg)
       : (normalizeProjectDomain(domain).split('/')[0]?.split('.')[0] ?? '')
     const token = brand.replace(/[^a-z0-9]/gi, '').toLowerCase()
-    if (isDistinctiveToken(token)) tokens.add(token)
+    if (isDistinctiveToken(token)) primary.add(token)
   }
 
-  return [...tokens]
+  // A token must not appear in both buckets — primary wins.
+  for (const t of primary) secondary.delete(t)
+
+  return { primary: [...primary], secondary: [...secondary] }
 }
 
 function extractDistinctiveTokens(value: string): string[] {

--- a/packages/contracts/test/index.test.ts
+++ b/packages/contracts/test/index.test.ts
@@ -881,6 +881,39 @@ describe('extractAnswerMentions', () => {
       ['ainyc.ai'],
     ).mentioned).toBe(false)
   })
+
+  it('does not flag a multi-word brand on the trailing descriptor word alone', () => {
+    // Regression: a project "Cenco Roofing" must not be considered mentioned
+    // when the answer only contains the generic word "roofing" — even when
+    // it appears many times. Standalone descriptor words like "Roofing",
+    // "Plumbing", "Construction" are too common in industry prose to be a
+    // reliable signal of brand presence on their own.
+    const result = extractAnswerMentions(
+      'Roofing repair work requires permits and trained inspectors. Most homeowners pay $300 for a basic roofing inspection.',
+      'Cenco Roofing',
+      ['cencoroofing.com'],
+    )
+    expect(result.mentioned).toBe(false)
+    expect(result.matchedTerms).toEqual([])
+  })
+
+  it('does not surface trailing descriptor words as matched terms when the full phrase is present', () => {
+    // The brand IS mentioned (full phrase appears + many "roofing" mentions
+    // in surrounding prose). The match itself is correct, but matchedTerms
+    // must NOT surface "roofing" — otherwise it gets shown as a chip in the
+    // UI and highlighted everywhere the generic word appears, which is
+    // misleading. Only the distinctive prefix ("cenco") and the displayName
+    // should be exposed as evidence.
+    const result = extractAnswerMentions(
+      'Denver-area picks: Precision Exteriors (commercial roofing), ESS Roofing & Exteriors (storm damage), and Cenco Roofing for residential work. Budget around $11,000 for a full roofing replacement.',
+      'Cenco Roofing',
+      ['cencoroofing.com'],
+    )
+    expect(result.mentioned).toBe(true)
+    expect(result.matchedTerms).toContain('Cenco Roofing')
+    expect(result.matchedTerms).toContain('cenco')
+    expect(result.matchedTerms).not.toContain('roofing')
+  })
 })
 
 describe('parseProviderName', () => {


### PR DESCRIPTION
## Summary
- Adds a Mentions/Citations toggle to the "Key phrase citation tracking" table so the same row can be read against either the source-link signal (`citationState`) or the answer-text signal (`answerMentioned`); status, history dots, change column and ratios all swap.
- Stops trailing descriptor tokens (e.g. "roofing" in "Cenco Roofing") from being added to `matchedTerms`. Detection threshold is unchanged, but chips and answer-body highlights no longer flag every generic "roofing" mention as the user's brand.
- Forces long markdown citation URLs in the evidence answer modal to wrap so the OpenAI panel no longer scrolls horizontally.

## Test plan
- [x] `pnpm test` (1917/1917 pass, includes 2 new regression tests for the chip filtering)
- [x] `pnpm typecheck` and `pnpm lint` clean
- [x] Open a project with a multi-word brand (e.g. Cenco Roofing) — confirm the toggle switches signals, the OpenAI answer modal no longer scrolls horizontally, and "roofing" is no longer chipped/highlighted as the user's brand.