### PR TITLE
feat(report): add client and agency report modes

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,4 +1,4 @@
-import type { ErrorCode, GroundingSource, ProjectOverviewDto, ScheduleDto, NotificationDto, GscCoverageSummaryDto, GscCoverageSnapshotDto, IndexingRequestResultDto, MetricsWindow, GA4AiReferralHistoryEntry, GA4SessionHistoryEntry, GA4SocialReferralHistoryEntry, InsightDto, HealthSnapshotDto, ProjectReportDto, RunKind, RunStatus, RunTrigger, RunErrorDto, CitationState, CitationVisibilityResponse, ComputedTransition, BacklinkSummaryDto, BacklinkDomainDto, BacklinkListResponse, BacklinkHistoryEntry, BacklinksInstallStatusDto, BacklinksInstallResultDto, CcAvailableRelease, CcCachedRelease, CcReleaseSyncDto } from '@ainyc/canonry-contracts'
+import type { ErrorCode, GroundingSource, ProjectOverviewDto, ScheduleDto, NotificationDto, GscCoverageSummaryDto, GscCoverageSnapshotDto, IndexingRequestResultDto, MetricsWindow, GA4AiReferralHistoryEntry, GA4SessionHistoryEntry, GA4SocialReferralHistoryEntry, InsightDto, HealthSnapshotDto, ProjectReportDto, ReportAudience, RunKind, RunStatus, RunTrigger, RunErrorDto, CitationState, CitationVisibilityResponse, ComputedTransition, BacklinkSummaryDto, BacklinkDomainDto, BacklinkListResponse, BacklinkHistoryEntry, BacklinksInstallStatusDto, BacklinksInstallResultDto, CcAvailableRelease, CcCachedRelease, CcReleaseSyncDto } from '@ainyc/canonry-contracts'
 export type { ProjectOverviewDto }
 export type { BacklinkSummaryDto, BacklinkDomainDto, BacklinkListResponse, BacklinkHistoryEntry, BacklinksInstallStatusDto, BacklinksInstallResultDto, CcAvailableRelease, CcCachedRelease, CcReleaseSyncDto }
 
@@ -958,9 +958,10 @@ function parseFilenameFromContentDisposition(header: string | null): string | nu
   return match?.[1] ?? null
 }
 
-export async function downloadReportHtml(project: string): Promise<void> {
+export async function downloadReportHtml(project: string, audience: ReportAudience = 'agency'): Promise<void> {
   const key = getApiKey()
-  const res = await fetch(`${API_BASE}/projects/${encodeURIComponent(project)}/report.html`, {
+  const params = new URLSearchParams({ audience })
+  const res = await fetch(`${API_BASE}/projects/${encodeURIComponent(project)}/report.html?${params.toString()}`, {
     credentials: 'same-origin',
     headers: key ? { Authorization: `Bearer ${key}` } : {},
   })

--- a/apps/web/src/pages/ReportPage.tsx
+++ b/apps/web/src/pages/ReportPage.tsx
@@ -9,6 +9,8 @@ import type {
   GscQueryRow,
   IndexingHealthSection,
   ProjectReportDto,
+  ReportActionPlanItem,
+  ReportAudience,
   RecommendedNextStep,
   ReportInsight,
 } from '@ainyc/canonry-contracts'
@@ -181,6 +183,7 @@ function pressureTone(label: CompetitorRow['pressureLabel']): MetricTone {
 export function ReportPage({ projectName }: { projectName: string }) {
   const [downloading, setDownloading] = useState(false)
   const [downloadError, setDownloadError] = useState<string | null>(null)
+  const [audience, setAudience] = useState<ReportAudience>('agency')
 
   const reportQuery = useQuery({
     queryKey: queryKeys.report(projectName),
@@ -191,7 +194,7 @@ export function ReportPage({ projectName }: { projectName: string }) {
     setDownloading(true)
     setDownloadError(null)
     try {
-      await downloadReportHtml(projectName)
+      await downloadReportHtml(projectName, audience)
     } catch (err) {
       const message = err instanceof ApiError ? err.message : err instanceof Error ? err.message : 'Download failed'
       setDownloadError(message)
@@ -230,6 +233,24 @@ export function ReportPage({ projectName }: { projectName: string }) {
           {downloadError && <p className="mt-2 text-xs text-rose-400">{downloadError}</p>}
         </div>
         <div className="page-header-right">
+          <div className="inline-flex rounded-lg border border-zinc-800/70 bg-zinc-950/60 p-1" role="tablist" aria-label="Report audience">
+            {(['agency', 'client'] as const).map(mode => (
+              <button
+                key={mode}
+                type="button"
+                role="tab"
+                aria-selected={audience === mode}
+                onClick={() => setAudience(mode)}
+                className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${
+                  audience === mode
+                    ? 'bg-zinc-100 text-zinc-950'
+                    : 'text-zinc-400 hover:text-zinc-100'
+                }`}
+              >
+                {mode === 'agency' ? 'Agency' : 'Client'}
+              </button>
+            ))}
+          </div>
           <Button
             variant="secondary"
             size="sm"
@@ -242,21 +263,224 @@ export function ReportPage({ projectName }: { projectName: string }) {
         </div>
       </div>
 
-      <ExecutiveSummarySection report={report} />
-      <CitationScorecardSection report={report} />
-      <CompetitorLandscapeSection report={report} />
-      <AiSourceOriginSection report={report} />
-      <GscPerformanceSection report={report} />
-      <GaTrafficSection report={report} />
-      <SocialReferralsSection report={report} />
-      <AiReferralsSection report={report} />
-      <IndexingHealthSectionView report={report} />
-      <CitationsTrendSection report={report} />
-      <InsightsSection report={report} />
-      <ContentOpportunitiesSection report={report} />
-      <ContentGapsSection report={report} />
-      <NextStepsSection report={report} />
+      {audience === 'client' ? (
+        <>
+          <ClientSummarySection report={report} />
+          <ActionPlanSection report={report} audience="client" />
+          <ClientEvidenceSection report={report} />
+        </>
+      ) : (
+        <>
+          <ExecutiveSummarySection report={report} />
+          <ActionPlanSection report={report} audience="agency" />
+          <AgencyDiagnosticsSection report={report} />
+          <CitationScorecardSection report={report} />
+          <CompetitorLandscapeSection report={report} />
+          <AiSourceOriginSection report={report} />
+          <GscPerformanceSection report={report} />
+          <GaTrafficSection report={report} />
+          <SocialReferralsSection report={report} />
+          <AiReferralsSection report={report} />
+          <IndexingHealthSectionView report={report} />
+          <CitationsTrendSection report={report} />
+          <InsightsSection report={report} />
+          <ContentOpportunitiesSection report={report} />
+          <ContentGapsSection report={report} />
+          <NextStepsSection report={report} />
+        </>
+      )}
     </div>
+  )
+}
+
+function actionAudienceMatches(action: ReportActionPlanItem, audience: ReportAudience): boolean {
+  return action.audience === 'both' || action.audience === audience
+}
+
+function actionTone(action: ReportActionPlanItem): MetricTone {
+  if (action.horizon === 'immediate') return 'negative'
+  if (action.confidence === 'high') return 'caution'
+  return 'neutral'
+}
+
+function ClientSummarySection({ report }: { report: ProjectReportDto }) {
+  const exec = report.executiveSummary
+  return (
+    <section className="page-section-divider">
+      <SectionHeading eyebrow="Client summary" title="How you're appearing" subtitle={report.clientSummary.overview} />
+      <div className="rounded-xl border border-zinc-800/60 bg-zinc-900/30 p-4">
+        <p className="text-sm font-medium text-zinc-100">{report.clientSummary.headline}</p>
+        <p className="mt-1 text-sm text-zinc-400">{report.clientSummary.overview}</p>
+      </div>
+      <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <Metric label="Citation coverage" value={formatPercent(exec.citationRate, 0)} tone={trendTone(exec.trend)} subtitle={`${exec.citedQueryCount}/${exec.totalQueryCount} tracked queries cited`} />
+        <Metric label="Mention coverage" value={formatPercent(exec.mentionRate, 0)} subtitle={`${exec.mentionedQueryCount}/${exec.totalQueryCount} tracked queries mentioned`} />
+        <Metric label="Providers checked" value={formatNumber(exec.providerCount)} subtitle={`${formatNumber(exec.queryCount)} tracked queries`} />
+        {exec.gsc && <Metric label="Search impressions" value={formatNumber(exec.gsc.impressions)} subtitle={`${formatNumber(exec.gsc.clicks)} clicks`} />}
+      </div>
+      {report.clientSummary.confidenceNotes.length > 0 && (
+        <div className="mt-4 grid gap-2">
+          {report.clientSummary.confidenceNotes.map((note, i) => (
+            <div key={i} className="rounded-lg border border-zinc-800/60 bg-zinc-900/30 px-3 py-2 text-xs text-zinc-400">{note}</div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function ActionPlanSection({ report, audience }: { report: ProjectReportDto; audience: ReportAudience }) {
+  const actions = audience === 'client'
+    ? report.clientSummary.actionItems
+    : report.agencyDiagnostics.priorities.length > 0
+      ? report.agencyDiagnostics.priorities
+      : report.actionPlan.filter(a => actionAudienceMatches(a, audience))
+  return (
+    <section className="page-section-divider">
+      <SectionHeading
+        eyebrow={audience === 'client' ? 'Client actions' : 'Agency actions'}
+        title={audience === 'client' ? 'What we recommend next' : 'Agency action plan'}
+        subtitle={audience === 'client' ? 'Polished next steps backed by concise evidence.' : 'Technical priorities from the canonical action plan.'}
+      />
+      {actions.length === 0 ? (
+        <EmptyHint message="No prioritized actions yet." />
+      ) : (
+        <div className="grid gap-3 lg:grid-cols-2">
+          {actions.map(action => (
+            <div key={`${action.priority}-${action.title}`} className="rounded-xl border border-zinc-800/60 bg-zinc-900/30 p-4">
+              <div className="mb-3 flex flex-wrap gap-2">
+                <ToneBadge tone={actionTone(action)}>{horizonLabel(action.horizon)}</ToneBadge>
+                <ToneBadge tone="neutral">{action.category}</ToneBadge>
+                <ToneBadge tone="neutral">{action.confidence} confidence</ToneBadge>
+              </div>
+              <p className="text-sm font-medium text-zinc-100">{action.title}</p>
+              <p className="mt-1 text-sm text-zinc-400">{action.action}</p>
+              {action.why.length > 0 && (
+                <div className="mt-3">
+                  <p className="eyebrow-soft mb-1">Why</p>
+                  <ul className="list-disc space-y-1 pl-4 text-xs text-zinc-400">
+                    {action.why.map((item, i) => <li key={i}>{item}</li>)}
+                  </ul>
+                </div>
+              )}
+              {action.evidence.length > 0 && (
+                <div className="mt-3">
+                  <p className="eyebrow-soft mb-1">Evidence</p>
+                  <ul className="list-disc space-y-1 pl-4 text-xs text-zinc-400">
+                    {action.evidence.map((item, i) => <li key={i}>{item}</li>)}
+                  </ul>
+                </div>
+              )}
+              <p className="mt-3 border-t border-zinc-800/60 pt-3 text-xs text-zinc-300">
+                <span className="font-medium">Success metric:</span> {action.successMetric}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function AgencyDiagnosticsSection({ report }: { report: ProjectReportDto }) {
+  const diagnostics = report.agencyDiagnostics.diagnostics
+  if (diagnostics.length === 0) return null
+  return (
+    <section className="page-section-divider">
+      <SectionHeading eyebrow="Agency diagnostics" title="Technical diagnostics" subtitle="Operator-facing evidence for provider, source-domain, search-demand, indexing, content, and location follow-up." />
+      <div className="grid gap-3 lg:grid-cols-2">
+        {diagnostics.map(d => (
+          <div key={d.title} className="rounded-xl border border-zinc-800/60 bg-zinc-900/30 p-4">
+            <div className="mb-2 flex items-center gap-2">
+              <ToneBadge tone={d.severity}>{d.severity}</ToneBadge>
+              <p className="text-sm font-medium text-zinc-100">{d.title}</p>
+            </div>
+            <p className="text-sm text-zinc-400">{d.detail}</p>
+            {d.evidence.length > 0 && (
+              <ul className="mt-3 list-disc space-y-1 pl-4 text-xs text-zinc-500">
+                {d.evidence.map((item, i) => <li key={i}>{item}</li>)}
+              </ul>
+            )}
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function ClientEvidenceSection({ report }: { report: ProjectReportDto }) {
+  const cards: Array<{
+    key: string
+    tone: MetricTone
+    title: string
+    detail: string
+    items: string[]
+  }> = []
+
+  if (report.aiSourceOrigin.topDomains.length > 0) {
+    cards.push({
+      key: 'source-domains',
+      tone: 'neutral',
+      title: 'Sources AI engines trust',
+      detail: 'These domains appeared most often as cited sources outside your owned domain.',
+      items: report.aiSourceOrigin.topDomains.slice(0, 5).map(d => `${d.domain}: ${formatNumber(d.count)} citation${d.count === 1 ? '' : 's'}`),
+    })
+  }
+  if (report.gsc) {
+    cards.push({
+      key: 'search-demand',
+      tone: 'neutral',
+      title: 'Search demand',
+      detail: `Search Console shows ${formatNumber(report.gsc.totalImpressions)} impressions and ${formatNumber(report.gsc.totalClicks)} clicks in the report window.`,
+      items: report.gsc.topQueries.slice(0, 5).map(q => `${q.query}: ${formatNumber(q.impressions)} impressions`),
+    })
+  }
+  if (report.indexingHealth) {
+    cards.push({
+      key: 'indexing',
+      tone: report.indexingHealth.indexedPct >= 90 ? 'positive' : report.indexingHealth.indexedPct >= 70 ? 'caution' : 'negative',
+      title: 'Indexing readiness',
+      detail: `${report.indexingHealth.indexedPct}% of inspected URLs are indexed.`,
+      items: [
+        `${formatNumber(report.indexingHealth.indexed)} indexed`,
+        `${formatNumber(report.indexingHealth.notIndexed)} not indexed`,
+      ],
+    })
+  }
+  if (report.contentOpportunities.length > 0) {
+    cards.push({
+      key: 'content',
+      tone: 'caution',
+      title: 'Content opportunities',
+      detail: 'Canonry found topics where better content could improve AI citations.',
+      items: report.contentOpportunities.slice(0, 5).map(o => `${o.query}: ${actionLabel(o.action)} (${Math.round(o.score)})`),
+    })
+  }
+
+  return (
+    <section className="page-section-divider">
+      <SectionHeading eyebrow="Evidence" title="Why this is the plan" subtitle="Concise support for the client summary. Switch to Agency for the detailed tables and matrices." />
+      {cards.length === 0 ? (
+        <EmptyHint message="No supporting evidence sections are populated yet." />
+      ) : (
+        <div className="grid gap-3 lg:grid-cols-2">
+          {cards.map(card => (
+            <div key={card.key} className="rounded-xl border border-zinc-800/60 bg-zinc-900/30 p-4">
+              <div className="mb-2 flex items-center gap-2">
+                <ToneBadge tone={card.tone}>{card.tone}</ToneBadge>
+                <p className="text-sm font-medium text-zinc-100">{card.title}</p>
+              </div>
+              <p className="text-sm text-zinc-400">{card.detail}</p>
+              {card.items.length > 0 && (
+                <ul className="mt-3 list-disc space-y-1 pl-4 text-xs text-zinc-500">
+                  {card.items.map((item, i) => <li key={i}>{item}</li>)}
+                </ul>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
   )
 }
 

--- a/apps/web/src/pages/ReportPage.tsx
+++ b/apps/web/src/pages/ReportPage.tsx
@@ -14,7 +14,7 @@ import type {
   RecommendedNextStep,
   ReportInsight,
 } from '@ainyc/canonry-contracts'
-import { absolutizeProjectUrl, CitationStates } from '@ainyc/canonry-contracts'
+import { absolutizeProjectUrl, CitationStates, reportActionTone } from '@ainyc/canonry-contracts'
 
 import {
   Bar,
@@ -297,12 +297,6 @@ function actionAudienceMatches(action: ReportActionPlanItem, audience: ReportAud
   return action.audience === 'both' || action.audience === audience
 }
 
-function actionTone(action: ReportActionPlanItem): MetricTone {
-  if (action.horizon === 'immediate') return 'negative'
-  if (action.confidence === 'high') return 'caution'
-  return 'neutral'
-}
-
 function ClientSummarySection({ report }: { report: ProjectReportDto }) {
   const exec = report.executiveSummary
   return (
@@ -349,7 +343,7 @@ function ActionPlanSection({ report, audience }: { report: ProjectReportDto; aud
           {actions.map(action => (
             <div key={`${action.priority}-${action.title}`} className="rounded-xl border border-zinc-800/60 bg-zinc-900/30 p-4">
               <div className="mb-3 flex flex-wrap gap-2">
-                <ToneBadge tone={actionTone(action)}>{horizonLabel(action.horizon)}</ToneBadge>
+                <ToneBadge tone={reportActionTone(action)}>{horizonLabel(action.horizon)}</ToneBadge>
                 <ToneBadge tone="neutral">{action.category}</ToneBadge>
                 <ToneBadge tone="neutral">{action.confidence} confidence</ToneBadge>
               </div>

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -144,6 +144,13 @@ const locationQueryParameter: OpenApiParameter = {
   schema: stringSchema,
 }
 
+const reportAudienceQueryParameter: OpenApiParameter = {
+  name: 'audience',
+  in: 'query',
+  description: 'HTML report audience mode. Defaults to agency.',
+  schema: { type: 'string', enum: ['agency', 'client'] },
+}
+
 const analyticsWindowParameter: OpenApiParameter = {
   name: 'window',
   in: 'query',
@@ -2368,10 +2375,10 @@ const routeCatalog: OpenApiOperation[] = [
   {
     method: 'get',
     path: '/api/v1/projects/{name}/report',
-    summary: 'Aggregated client-facing AEO report',
+    summary: 'Aggregated canonical AEO report',
     tags: ['report'],
     description:
-      'Bundles every section the canonry-report HTML output needs (executive summary, citation scorecard, competitor landscape — citation + mention landscapes, AI citation sources, GSC, GA4, social/AI referrals, indexing health, citations trend, insights, and recommended next steps) into a single JSON payload. Backs `canonry report <project>`.',
+      'Bundles every section the canonry-report HTML output needs (executive summary, client summary, agency diagnostics, action plan, citation scorecard, competitor landscape — citation + mention landscapes, AI citation sources, GSC, GA4, social/AI referrals, indexing health, citations trend, insights, and recommended next steps) into a single canonical JSON payload. Backs `canonry report <project>` and MCP report reads.',
     parameters: [nameParameter],
     responses: {
       200: { description: 'Report returned.' },
@@ -2384,8 +2391,8 @@ const routeCatalog: OpenApiOperation[] = [
     summary: 'Standalone HTML AEO report',
     tags: ['report'],
     description:
-      'Server-rendered self-contained HTML version of the project report. Same data as `/projects/{name}/report` (JSON), rendered through the canonry HTML report renderer. Returns `text/html` with `Content-Disposition: attachment` so browsers download it as `canonry-report-<project>-YYYY-MM-DD.html`. Open in a browser and Print → Save as PDF for a PDF copy.',
-    parameters: [nameParameter],
+      'Server-rendered self-contained HTML version of the project report. Same data as `/projects/{name}/report` (JSON), rendered through the canonry HTML report renderer in agency or client mode. Returns `text/html` with `Content-Disposition: attachment` so browsers download it as `canonry-report-<project>-<audience>-YYYY-MM-DD.html`. Open in a browser and Print → Save as PDF for a PDF copy.',
+    parameters: [nameParameter, reportAudienceQueryParameter],
     responses: {
       200: { description: 'HTML report returned.' },
       404: { description: 'Project not found.' },

--- a/packages/api-routes/src/report-renderer.ts
+++ b/packages/api-routes/src/report-renderer.ts
@@ -8,7 +8,7 @@ import type {
   ReportAudience,
   ReportInsight,
 } from '@ainyc/canonry-contracts'
-import { absolutizeProjectUrl, CitationStates } from '@ainyc/canonry-contracts'
+import { absolutizeProjectUrl, CitationStates, reportActionTone } from '@ainyc/canonry-contracts'
 import {
   groupInsights,
   isTrendBaseline,
@@ -350,88 +350,88 @@ table.report-table td .badge {
   display: grid;
   gap: 4px;
 }
-	.step .horizon {
-	  text-transform: uppercase;
-	  font-size: 10px;
-	  letter-spacing: 0.08em;
-	  color: ${COLORS.textFaint};
-	  font-weight: 600;
-	}
-	.step .title { font-weight: 600; }
-	.step .rationale { color: ${COLORS.textMuted}; font-size: 13px; }
-	.action-card-grid {
-	  display: grid;
-	  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-	  gap: 16px;
-	}
-	.action-card {
-	  background: ${COLORS.surface};
-	  border: 1px solid ${COLORS.border};
-	  border-radius: 8px;
-	  padding: 18px 20px;
-	}
-	.action-card .action-meta {
-	  display: flex;
-	  flex-wrap: wrap;
-	  gap: 8px;
-	  margin-bottom: 10px;
-	}
-	.action-card h3 {
-	  font-size: 16px;
-	  margin: 0 0 8px;
-	}
-	.action-card p {
-	  margin: 0 0 12px;
-	  color: ${COLORS.textMuted};
-	}
-	.action-card ul {
-	  margin: 0 0 12px;
-	  padding-left: 18px;
-	  color: ${COLORS.textMuted};
-	  font-size: 13px;
-	}
-	.action-card li { margin: 4px 0; }
-	.action-card .success-metric {
-	  color: ${COLORS.text};
-	  font-size: 13px;
-	  border-top: 1px solid ${COLORS.border};
-	  padding-top: 10px;
-	  margin-top: 12px;
-	}
-	.client-notes {
-	  margin-top: 18px;
-	  display: grid;
-	  gap: 8px;
-	}
-	.client-note {
-	  color: ${COLORS.textMuted};
-	  font-size: 13px;
-	  background: ${COLORS.surface};
-	  border: 1px solid ${COLORS.border};
-	  border-radius: 8px;
-	  padding: 10px 12px;
-	}
-	.diagnostics-grid {
-	  display: grid;
-	  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-	  gap: 12px;
-	}
-	.diagnostic-card {
-	  background: ${COLORS.surface};
-	  border: 1px solid ${COLORS.border};
-	  border-left-width: 3px;
-	  border-radius: 8px;
-	  padding: 14px 16px;
-	}
-	.diagnostic-card h3 { font-size: 14px; margin: 0 0 6px; }
-	.diagnostic-card p { margin: 0 0 8px; color: ${COLORS.textMuted}; font-size: 13px; }
-	.diagnostic-card ul { margin: 0; padding-left: 16px; color: ${COLORS.textMuted}; font-size: 12px; }
-	.diagnostic-card.tone-positive { border-left-color: ${COLORS.positive}; }
-	.diagnostic-card.tone-caution { border-left-color: ${COLORS.caution}; }
-	.diagnostic-card.tone-negative { border-left-color: ${COLORS.negative}; }
-	.diagnostic-card.tone-neutral { border-left-color: ${COLORS.neutral}; }
-	.footer {
-	  margin-top: 96px;
+.step .horizon {
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  color: ${COLORS.textFaint};
+  font-weight: 600;
+}
+.step .title { font-weight: 600; }
+.step .rationale { color: ${COLORS.textMuted}; font-size: 13px; }
+.action-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+}
+.action-card {
+  background: ${COLORS.surface};
+  border: 1px solid ${COLORS.border};
+  border-radius: 8px;
+  padding: 18px 20px;
+}
+.action-card .action-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.action-card h3 {
+  font-size: 16px;
+  margin: 0 0 8px;
+}
+.action-card p {
+  margin: 0 0 12px;
+  color: ${COLORS.textMuted};
+}
+.action-card ul {
+  margin: 0 0 12px;
+  padding-left: 18px;
+  color: ${COLORS.textMuted};
+  font-size: 13px;
+}
+.action-card li { margin: 4px 0; }
+.action-card .success-metric {
+  color: ${COLORS.text};
+  font-size: 13px;
+  border-top: 1px solid ${COLORS.border};
+  padding-top: 10px;
+  margin-top: 12px;
+}
+.client-notes {
+  margin-top: 18px;
+  display: grid;
+  gap: 8px;
+}
+.client-note {
+  color: ${COLORS.textMuted};
+  font-size: 13px;
+  background: ${COLORS.surface};
+  border: 1px solid ${COLORS.border};
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+.diagnostics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 12px;
+}
+.diagnostic-card {
+  background: ${COLORS.surface};
+  border: 1px solid ${COLORS.border};
+  border-left-width: 3px;
+  border-radius: 8px;
+  padding: 14px 16px;
+}
+.diagnostic-card h3 { font-size: 14px; margin: 0 0 6px; }
+.diagnostic-card p { margin: 0 0 8px; color: ${COLORS.textMuted}; font-size: 13px; }
+.diagnostic-card ul { margin: 0; padding-left: 16px; color: ${COLORS.textMuted}; font-size: 12px; }
+.diagnostic-card.tone-positive { border-left-color: ${COLORS.positive}; }
+.diagnostic-card.tone-caution { border-left-color: ${COLORS.caution}; }
+.diagnostic-card.tone-negative { border-left-color: ${COLORS.negative}; }
+.diagnostic-card.tone-neutral { border-left-color: ${COLORS.neutral}; }
+.footer {
+  margin-top: 96px;
   padding-top: 24px;
   border-top: 1px solid ${COLORS.border};
   text-align: center;
@@ -1335,18 +1335,11 @@ function actionAudienceMatches(action: ReportActionPlanItem, audience: ReportAud
   return action.audience === 'both' || action.audience === audience
 }
 
-function actionTone(action: ReportActionPlanItem): 'positive' | 'caution' | 'negative' | 'neutral' {
-  if (action.horizon === 'immediate') return 'negative'
-  if (action.confidence === 'high') return 'caution'
-  if (action.confidence === 'low') return 'neutral'
-  return 'caution'
-}
-
 function renderActionCards(actions: readonly ReportActionPlanItem[]): string {
   if (actions.length === 0) return renderEmpty('No prioritized actions yet.')
   return `<div class="action-card-grid">
     ${actions.map(action => {
-      const tone = actionTone(action)
+      const tone = reportActionTone(action)
       const why = action.why.length > 0
         ? `<ul>${action.why.map(item => `<li>${escapeHtml(item)}</li>`).join('')}</ul>`
         : ''
@@ -1536,9 +1529,9 @@ export function renderReportHtml(report: ProjectReportDto, opts: RenderReportHtm
 </head>
 <body>
 <div class="container">
-	  <header class="header">
-	    <div class="eyebrow">${audience === 'client' ? 'AEO Client Summary' : 'AEO Agency Report'}</div>
-	    <h1>${escapeHtml(report.meta.project.displayName)}</h1>
+  <header class="header">
+    <div class="eyebrow">${audience === 'client' ? 'AEO Client Summary' : 'AEO Agency Report'}</div>
+    <h1>${escapeHtml(report.meta.project.displayName)}</h1>
     <div class="subtitle">${escapeHtml(report.meta.project.canonicalDomain)} · ${escapeHtml(report.meta.project.country)} / ${escapeHtml(report.meta.project.language.toUpperCase())}${renderHeaderLocationFragment(report.meta.location)} · Generated ${formatDate(report.meta.generatedAt)}</div>
   </header>
   ${sections}

--- a/packages/api-routes/src/report-renderer.ts
+++ b/packages/api-routes/src/report-renderer.ts
@@ -4,6 +4,8 @@ import type {
   CompetitorRow,
   GscQueryRow,
   ProjectReportDto,
+  ReportActionPlanItem,
+  ReportAudience,
   ReportInsight,
 } from '@ainyc/canonry-contracts'
 import { absolutizeProjectUrl, CitationStates } from '@ainyc/canonry-contracts'
@@ -348,17 +350,88 @@ table.report-table td .badge {
   display: grid;
   gap: 4px;
 }
-.step .horizon {
-  text-transform: uppercase;
-  font-size: 10px;
-  letter-spacing: 0.08em;
-  color: ${COLORS.textFaint};
-  font-weight: 600;
-}
-.step .title { font-weight: 600; }
-.step .rationale { color: ${COLORS.textMuted}; font-size: 13px; }
-.footer {
-  margin-top: 96px;
+	.step .horizon {
+	  text-transform: uppercase;
+	  font-size: 10px;
+	  letter-spacing: 0.08em;
+	  color: ${COLORS.textFaint};
+	  font-weight: 600;
+	}
+	.step .title { font-weight: 600; }
+	.step .rationale { color: ${COLORS.textMuted}; font-size: 13px; }
+	.action-card-grid {
+	  display: grid;
+	  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+	  gap: 16px;
+	}
+	.action-card {
+	  background: ${COLORS.surface};
+	  border: 1px solid ${COLORS.border};
+	  border-radius: 8px;
+	  padding: 18px 20px;
+	}
+	.action-card .action-meta {
+	  display: flex;
+	  flex-wrap: wrap;
+	  gap: 8px;
+	  margin-bottom: 10px;
+	}
+	.action-card h3 {
+	  font-size: 16px;
+	  margin: 0 0 8px;
+	}
+	.action-card p {
+	  margin: 0 0 12px;
+	  color: ${COLORS.textMuted};
+	}
+	.action-card ul {
+	  margin: 0 0 12px;
+	  padding-left: 18px;
+	  color: ${COLORS.textMuted};
+	  font-size: 13px;
+	}
+	.action-card li { margin: 4px 0; }
+	.action-card .success-metric {
+	  color: ${COLORS.text};
+	  font-size: 13px;
+	  border-top: 1px solid ${COLORS.border};
+	  padding-top: 10px;
+	  margin-top: 12px;
+	}
+	.client-notes {
+	  margin-top: 18px;
+	  display: grid;
+	  gap: 8px;
+	}
+	.client-note {
+	  color: ${COLORS.textMuted};
+	  font-size: 13px;
+	  background: ${COLORS.surface};
+	  border: 1px solid ${COLORS.border};
+	  border-radius: 8px;
+	  padding: 10px 12px;
+	}
+	.diagnostics-grid {
+	  display: grid;
+	  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+	  gap: 12px;
+	}
+	.diagnostic-card {
+	  background: ${COLORS.surface};
+	  border: 1px solid ${COLORS.border};
+	  border-left-width: 3px;
+	  border-radius: 8px;
+	  padding: 14px 16px;
+	}
+	.diagnostic-card h3 { font-size: 14px; margin: 0 0 6px; }
+	.diagnostic-card p { margin: 0 0 8px; color: ${COLORS.textMuted}; font-size: 13px; }
+	.diagnostic-card ul { margin: 0; padding-left: 16px; color: ${COLORS.textMuted}; font-size: 12px; }
+	.diagnostic-card.tone-positive { border-left-color: ${COLORS.positive}; }
+	.diagnostic-card.tone-caution { border-left-color: ${COLORS.caution}; }
+	.diagnostic-card.tone-negative { border-left-color: ${COLORS.negative}; }
+	.diagnostic-card.tone-neutral { border-left-color: ${COLORS.neutral}; }
+	.footer {
+	  margin-top: 96px;
   padding-top: 24px;
   border-top: 1px solid ${COLORS.border};
   text-align: center;
@@ -1258,6 +1331,153 @@ function renderRecommendedNextSteps(report: ProjectReportDto): string {
   )
 }
 
+function actionAudienceMatches(action: ReportActionPlanItem, audience: ReportAudience): boolean {
+  return action.audience === 'both' || action.audience === audience
+}
+
+function actionTone(action: ReportActionPlanItem): 'positive' | 'caution' | 'negative' | 'neutral' {
+  if (action.horizon === 'immediate') return 'negative'
+  if (action.confidence === 'high') return 'caution'
+  if (action.confidence === 'low') return 'neutral'
+  return 'caution'
+}
+
+function renderActionCards(actions: readonly ReportActionPlanItem[]): string {
+  if (actions.length === 0) return renderEmpty('No prioritized actions yet.')
+  return `<div class="action-card-grid">
+    ${actions.map(action => {
+      const tone = actionTone(action)
+      const why = action.why.length > 0
+        ? `<ul>${action.why.map(item => `<li>${escapeHtml(item)}</li>`).join('')}</ul>`
+        : ''
+      const evidence = action.evidence.length > 0
+        ? `<ul>${action.evidence.map(item => `<li>${escapeHtml(item)}</li>`).join('')}</ul>`
+        : ''
+      return `<article class="action-card">
+        <div class="action-meta">
+          <span class="badge tone-${tone}">${escapeHtml(action.horizon)}</span>
+          <span class="badge tone-neutral">${escapeHtml(action.category)}</span>
+          <span class="badge tone-neutral">${escapeHtml(action.confidence)} confidence</span>
+        </div>
+        <h3>${escapeHtml(action.title)}</h3>
+        <p>${escapeHtml(action.action)}</p>
+        ${why ? `<div><strong>Why</strong>${why}</div>` : ''}
+        ${evidence ? `<div><strong>Evidence</strong>${evidence}</div>` : ''}
+        <div class="success-metric"><strong>Success metric:</strong> ${escapeHtml(action.successMetric)}</div>
+      </article>`
+    }).join('')}
+  </div>`
+}
+
+function renderAudienceActionPlan(report: ProjectReportDto, audience: ReportAudience): string {
+  const actions = audience === 'client'
+    ? report.clientSummary.actionItems
+    : report.agencyDiagnostics.priorities.length > 0
+      ? report.agencyDiagnostics.priorities
+      : report.actionPlan.filter(a => actionAudienceMatches(a, audience))
+  return section(
+    {
+      id: audience === 'client' ? 'client-action-plan' : 'agency-action-plan',
+      eyebrow: audience === 'client' ? 'Client actions' : 'Agency actions',
+      title: audience === 'client' ? 'What We Recommend Next' : 'Agency Action Plan',
+      intro: audience === 'client'
+        ? 'Polished next steps the client can understand, backed by concise evidence from the report.'
+        : 'Technical priorities pulled from the canonical action plan, sorted by urgency and evidence strength.',
+    },
+    renderActionCards(actions),
+  )
+}
+
+function renderClientSummary(report: ProjectReportDto): string {
+  const s = report.executiveSummary
+  const metrics = `<div class="metric-grid">
+    <div class="metric"><div class="label">Citation coverage</div><div class="value">${s.citationRate}%</div><div class="delta">${s.citedQueryCount}/${s.totalQueryCount} tracked queries cited</div></div>
+    <div class="metric"><div class="label">Mention coverage</div><div class="value">${s.mentionRate}%</div><div class="delta">${s.mentionedQueryCount}/${s.totalQueryCount} tracked queries mentioned</div></div>
+    <div class="metric"><div class="label">Providers checked</div><div class="value">${formatNumber(s.providerCount)}</div><div class="delta">${formatNumber(s.queryCount)} tracked queries</div></div>
+  </div>`
+  const notes = report.clientSummary.confidenceNotes.length > 0
+    ? `<div class="client-notes">${report.clientSummary.confidenceNotes.map(note => `<div class="client-note">${escapeHtml(note)}</div>`).join('')}</div>`
+    : ''
+  return section(
+    {
+      id: 'client-summary',
+      eyebrow: 'Client summary',
+      title: "How You're Appearing",
+      intro: report.clientSummary.overview,
+    },
+    `<div class="chart-card">
+      <h3>${escapeHtml(report.clientSummary.headline)}</h3>
+      <p class="source-origin-headline">${escapeHtml(report.clientSummary.overview)}</p>
+    </div>
+    ${metrics}
+    ${notes}`,
+  )
+}
+
+function renderClientEvidenceSummary(report: ProjectReportDto): string {
+  const evidenceCards: string[] = []
+  if (report.aiSourceOrigin.topDomains.length > 0) {
+    evidenceCards.push(`<div class="diagnostic-card tone-neutral">
+      <h3>Sources AI engines trust</h3>
+      <p>These domains appeared most often as cited sources outside your owned domain.</p>
+      <ul>${report.aiSourceOrigin.topDomains.slice(0, 5).map(d => `<li>${escapeHtml(d.domain)}: ${formatNumber(d.count)} citation${d.count === 1 ? '' : 's'}</li>`).join('')}</ul>
+    </div>`)
+  }
+  if (report.gsc) {
+    evidenceCards.push(`<div class="diagnostic-card tone-neutral">
+      <h3>Search demand</h3>
+      <p>Search Console shows ${formatNumber(report.gsc.totalImpressions)} impressions and ${formatNumber(report.gsc.totalClicks)} clicks in the report window.</p>
+      <ul>${report.gsc.topQueries.slice(0, 5).map(q => `<li>${escapeHtml(q.query)}: ${formatNumber(q.impressions)} impressions</li>`).join('')}</ul>
+    </div>`)
+  }
+  if (report.indexingHealth) {
+    const tone = report.indexingHealth.indexedPct >= 90 ? 'positive' : report.indexingHealth.indexedPct >= 70 ? 'caution' : 'negative'
+    evidenceCards.push(`<div class="diagnostic-card tone-${tone}">
+      <h3>Indexing readiness</h3>
+      <p>${report.indexingHealth.indexedPct}% of inspected URLs are indexed.</p>
+      <ul><li>${formatNumber(report.indexingHealth.indexed)} indexed</li><li>${formatNumber(report.indexingHealth.notIndexed)} not indexed</li></ul>
+    </div>`)
+  }
+  if (report.contentOpportunities.length > 0) {
+    evidenceCards.push(`<div class="diagnostic-card tone-caution">
+      <h3>Content opportunities</h3>
+      <p>Canonry found topics where better content could improve AI citations.</p>
+      <ul>${report.contentOpportunities.slice(0, 5).map(o => `<li>${escapeHtml(o.query)}: ${escapeHtml(o.action)} (${Math.round(o.score)})</li>`).join('')}</ul>
+    </div>`)
+  }
+  return section(
+    {
+      id: 'client-evidence-summary',
+      eyebrow: 'Evidence',
+      title: 'Why This Is The Plan',
+      intro: 'A concise evidence view for the client summary. The agency report keeps the full matrices and detailed tables.',
+    },
+    evidenceCards.length > 0 ? `<div class="diagnostics-grid">${evidenceCards.join('')}</div>` : renderEmpty('No supporting evidence sections are populated yet.'),
+  )
+}
+
+function renderAgencyDiagnostics(report: ProjectReportDto): string {
+  const diagnostics = report.agencyDiagnostics.diagnostics
+  const body = diagnostics.length > 0
+    ? `<div class="diagnostics-grid">
+        ${diagnostics.map(d => `<div class="diagnostic-card tone-${d.severity}">
+          <h3>${escapeHtml(d.title)}</h3>
+          <p>${escapeHtml(d.detail)}</p>
+          ${d.evidence.length > 0 ? `<ul>${d.evidence.map(e => `<li>${escapeHtml(e)}</li>`).join('')}</ul>` : ''}
+        </div>`).join('')}
+      </div>`
+    : renderEmpty('No agency diagnostics available yet.')
+  return section(
+    {
+      id: 'agency-diagnostics',
+      eyebrow: 'Agency diagnostics',
+      title: 'Technical Diagnostics',
+      intro: 'Operator-facing diagnostics for content, provider, source-domain, search-demand, indexing, and location follow-up.',
+    },
+    body,
+  )
+}
+
 function escapeJsonForScript(json: string): string {
   // Avoid breaking out of the </script> tag — both JSON literally as `</`
   // and unicode escapes need handling.
@@ -1272,26 +1492,37 @@ function escapeJsonForScript(json: string): string {
 export interface RenderReportHtmlOptions {
   /** Override <title>. Default: `Canonry report — <project displayName>`. */
   title?: string
+  /** Audience render mode. JSON payload stays canonical either way. Default: agency. */
+  audience?: ReportAudience
 }
 
 export function renderReportHtml(report: ProjectReportDto, opts: RenderReportHtmlOptions = {}): string {
-  const title = opts.title ?? `Canonry report — ${report.meta.project.displayName}`
-  const sections = [
-    renderExecutiveSummary(report),
-    renderCitationScorecard(report),
-    renderCompetitorLandscape(report),
-    renderAiSourceOrigin(report),
-    renderGsc(report),
-    renderGa(report),
-    renderSocial(report),
-    renderAiReferrals(report),
-    renderIndexingHealth(report),
-    renderCitationsTrend(report),
-    renderInsights(report),
-    renderOpportunities(report),
-    renderContentGaps(report),
-    renderRecommendedNextSteps(report),
-  ].join('\n')
+  const audience = opts.audience ?? 'agency'
+  const title = opts.title ?? `Canonry ${audience} report — ${report.meta.project.displayName}`
+  const sections = audience === 'client'
+    ? [
+        renderClientSummary(report),
+        renderAudienceActionPlan(report, 'client'),
+        renderClientEvidenceSummary(report),
+      ].join('\n')
+    : [
+        renderExecutiveSummary(report),
+        renderAudienceActionPlan(report, 'agency'),
+        renderAgencyDiagnostics(report),
+        renderCitationScorecard(report),
+        renderCompetitorLandscape(report),
+        renderAiSourceOrigin(report),
+        renderGsc(report),
+        renderGa(report),
+        renderSocial(report),
+        renderAiReferrals(report),
+        renderIndexingHealth(report),
+        renderCitationsTrend(report),
+        renderInsights(report),
+        renderOpportunities(report),
+        renderContentGaps(report),
+        renderRecommendedNextSteps(report),
+      ].join('\n')
 
   const json = escapeJsonForScript(JSON.stringify(report))
 
@@ -1305,9 +1536,9 @@ export function renderReportHtml(report: ProjectReportDto, opts: RenderReportHtm
 </head>
 <body>
 <div class="container">
-  <header class="header">
-    <div class="eyebrow">AEO Report</div>
-    <h1>${escapeHtml(report.meta.project.displayName)}</h1>
+	  <header class="header">
+	    <div class="eyebrow">${audience === 'client' ? 'AEO Client Summary' : 'AEO Agency Report'}</div>
+	    <h1>${escapeHtml(report.meta.project.displayName)}</h1>
     <div class="subtitle">${escapeHtml(report.meta.project.canonicalDomain)} · ${escapeHtml(report.meta.project.country)} / ${escapeHtml(report.meta.project.language.toUpperCase())}${renderHeaderLocationFragment(report.meta.location)} · Generated ${formatDate(report.meta.generatedAt)}</div>
   </header>
   ${sections}

--- a/packages/api-routes/src/report.ts
+++ b/packages/api-routes/src/report.ts
@@ -20,12 +20,15 @@ import {
   RunKinds,
   RunStatuses,
   getProviderLocationHandling,
+  validationError,
   type CitationsTrendPoint,
   type CompetitorRow,
   type GscQueryRow,
   type LocationContext,
   type ProjectReportDto,
   type RecommendedNextStep,
+  type ReportActionPlanItem,
+  type ReportAudience,
   type ReportInsight,
   type ReportProviderLocationHandling,
   type SocialReferralSection,
@@ -757,6 +760,375 @@ function buildProviderLocationHandling(
   })
 }
 
+function compactList(items: readonly string[], limit = 3): string {
+  const visible = items.slice(0, limit)
+  const extra = items.length - visible.length
+  return extra > 0 ? `${visible.join(', ')}, +${extra} more` : visible.join(', ')
+}
+
+function contentActionVerb(action: ProjectReportDto['contentOpportunities'][number]['action']): string {
+  switch (action) {
+    case 'create': return 'Create'
+    case 'expand': return 'Expand'
+    case 'refresh': return 'Refresh'
+    case 'add-schema': return 'Add schema to'
+  }
+}
+
+function confidenceFromEvidence(count: number): ReportActionPlanItem['confidence'] {
+  if (count >= 3) return 'high'
+  if (count >= 1) return 'medium'
+  return 'low'
+}
+
+function actionAudienceMatches(action: ReportActionPlanItem, audience: ReportAudience): boolean {
+  return action.audience === 'both' || action.audience === audience
+}
+
+interface ReportActionPlanInput {
+  canonicalDomain: string
+  competitorDomains: string[]
+  citationScorecard: ProjectReportDto['citationScorecard']
+  aiSourceOrigin: ProjectReportDto['aiSourceOrigin']
+  gsc: ProjectReportDto['gsc']
+  indexingHealth: ProjectReportDto['indexingHealth']
+  contentOpportunities: ProjectReportDto['contentOpportunities']
+  contentGaps: ProjectReportDto['contentGaps']
+  reportLocation: ProjectReportDto['meta']['location']
+  providerLocationHandling: ProjectReportDto['meta']['providerLocationHandling']
+}
+
+function buildReportActionPlan(input: ReportActionPlanInput): ReportActionPlanItem[] {
+  const actions: ReportActionPlanItem[] = []
+
+  if (input.competitorDomains.length === 0 && input.aiSourceOrigin.topDomains.length > 0) {
+    const topDomains = input.aiSourceOrigin.topDomains.slice(0, 5)
+    actions.push({
+      audience: 'both',
+      priority: 10,
+      horizon: 'immediate',
+      category: 'competitors',
+      title: 'Define the competitor set Canonry should benchmark against',
+      action: 'Review the recurring external source domains and add the true competitors before the next sweep.',
+      why: [
+        'The report can identify repeated external sources, but it cannot separate competitors from publishers until competitors are configured.',
+        'A clean competitor set makes future share-of-voice and content-gap reporting easier to explain to clients.',
+      ],
+      evidence: topDomains.map(d => `${d.domain} appeared in ${d.count} cited source${d.count === 1 ? '' : 's'}`),
+      successMetric: 'Next report separates tracked competitors from independent source domains in the competitor landscape.',
+      confidence: confidenceFromEvidence(topDomains.length),
+    })
+  }
+
+  for (const [index, opportunity] of input.contentOpportunities.slice(0, 2).entries()) {
+    const verb = contentActionVerb(opportunity.action)
+    const target = opportunity.ourBestPage?.url ?? `a new page for "${opportunity.query}"`
+    const evidence = [
+      `Opportunity score ${Math.round(opportunity.score)} with ${opportunity.actionConfidence} confidence`,
+      `Demand source: ${opportunity.demandSource}`,
+    ]
+    if (opportunity.winningCompetitor) {
+      evidence.push(`${opportunity.winningCompetitor.domain} is the current winning cited source`)
+    }
+    if (opportunity.ourBestPage) {
+      evidence.push(`Best matching owned page: ${opportunity.ourBestPage.url}`)
+    } else {
+      evidence.push('No matching owned page was found')
+    }
+
+    actions.push({
+      audience: 'both',
+      priority: 20 + index,
+      horizon: opportunity.actionConfidence === 'high' ? 'short-term' : 'medium-term',
+      category: 'content',
+      title: `${verb} content for "${opportunity.query}"`,
+      action: opportunity.ourBestPage
+        ? `${verb} ${target} so it directly answers the tracked query and cites the strongest supporting evidence.`
+        : `${verb} ${target} that directly answers the query and earns citations from AI answer engines.`,
+      why: opportunity.drivers.length > 0
+        ? opportunity.drivers
+        : ['Canonry ranked this as a content opportunity from search-demand and citation evidence.'],
+      evidence,
+      successMetric: `A future sweep cites ${input.canonicalDomain} for "${opportunity.query}" and the matching GSC query/page improves.`,
+      confidence: opportunity.actionConfidence,
+    })
+  }
+
+  if (input.indexingHealth && input.indexingHealth.total > 0 && input.indexingHealth.indexedPct < 70) {
+    const ih = input.indexingHealth
+    const evidence = [
+      `${ih.indexedPct}% indexed (${ih.indexed}/${ih.total})`,
+      `${ih.notIndexed} not indexed${ih.deindexed > 0 ? `, ${ih.deindexed} deindexed` : ''}`,
+    ]
+    actions.push({
+      audience: 'both',
+      priority: 30,
+      horizon: 'immediate',
+      category: 'indexing',
+      title: 'Fix indexing coverage before expanding the content plan',
+      action: 'Audit the not-indexed tracked URLs, resolve crawl/index blockers, and resubmit priority pages.',
+      why: [
+        'Pages missing from the search index are less likely to be retrieved or cited by AI answer engines.',
+        'Indexing issues can hide otherwise strong content from both search and AI systems.',
+      ],
+      evidence,
+      successMetric: 'Indexed share moves above 80% for tracked URLs and priority pages are eligible for retrieval.',
+      confidence: ih.total >= 5 ? 'high' : 'medium',
+    })
+  }
+
+  const zeroCitationProviders = input.citationScorecard.providerRates
+    .filter(p => p.totalCount > 0 && p.citedCount === 0)
+  if (zeroCitationProviders.length > 0) {
+    actions.push({
+      audience: 'agency',
+      priority: 40,
+      horizon: 'short-term',
+      category: 'provider',
+      title: 'Diagnose providers with zero citations',
+      action: 'Inspect zero-citation provider answers and compare their cited domains against the pages currently available on the client site.',
+      why: [
+        'Provider-level misses show where one model family is not retrieving the client even when others might.',
+        'This points the agency toward provider-specific evidence gaps instead of a generic content recommendation.',
+      ],
+      evidence: zeroCitationProviders.map(p => `${p.provider}: 0/${p.totalCount} cited query-provider pairs`),
+      successMetric: 'At least one zero-citation provider cites the client on a priority query in a later sweep.',
+      confidence: 'high',
+    })
+  }
+
+  if (input.gsc && (input.gsc.trackedButNoGsc.length > 0 || input.gsc.gscButNotTracked.length > 0)) {
+    const evidence: string[] = []
+    if (input.gsc.trackedButNoGsc.length > 0) {
+      evidence.push(`Tracked with no GSC demand: ${compactList(input.gsc.trackedButNoGsc)}`)
+    }
+    if (input.gsc.gscButNotTracked.length > 0) {
+      evidence.push(`Search demand not tracked in AEO: ${compactList(input.gsc.gscButNotTracked)}`)
+    }
+    actions.push({
+      audience: 'agency',
+      priority: 50,
+      horizon: 'short-term',
+      category: 'search-demand',
+      title: 'Align tracked AEO queries with search demand',
+      action: 'Prune or relabel tracked queries with no search demand and add high-impression non-brand GSC queries to the AEO tracking set.',
+      why: [
+        'The strongest report actions come from overlap between real search demand and AI citation gaps.',
+        'Mismatch here can make the client report feel interesting but hard to act on.',
+      ],
+      evidence,
+      successMetric: 'Next report has fewer no-demand tracked queries and includes the highest-impression non-brand GSC candidates.',
+      confidence: evidence.length > 1 ? 'high' : 'medium',
+    })
+  }
+
+  if (input.contentGaps.length > 0) {
+    const topGap = input.contentGaps[0]!
+    actions.push({
+      audience: 'agency',
+      priority: 60,
+      horizon: 'medium-term',
+      category: 'content',
+      title: 'Close competitor-cited content gaps',
+      action: 'Map the top missing queries to owned pages or new briefs, starting with the gaps where multiple competitors are already cited.',
+      why: [
+        'These are explicit places where AI engines found competitor sources but not the client.',
+        'They are stronger evidence than a generic topic list because the model is already retrieving competing content.',
+      ],
+      evidence: [
+        `"${topGap.query}" missed at ${Math.round(topGap.missRate * 100)}% with ${topGap.competitorCount} competitor${topGap.competitorCount === 1 ? '' : 's'} cited`,
+        `Cited competitors: ${compactList(topGap.competitorDomains)}`,
+      ],
+      successMetric: 'The top content-gap query moves from missed to cited or mentioned after the recommended content work ships.',
+      confidence: topGap.competitorCount >= 2 ? 'high' : 'medium',
+    })
+  }
+
+  if (input.reportLocation && input.reportLocation.otherConfiguredLabels.length > 0) {
+    const ignoredProviders = input.providerLocationHandling
+      .filter(p => p.treatment === 'ignored' || p.treatment === 'browser-geo')
+      .map(p => p.provider)
+    const evidence = [
+      `Current report location: ${input.reportLocation.label}`,
+      `Other configured locations: ${compactList(input.reportLocation.otherConfiguredLabels)}`,
+    ]
+    if (ignoredProviders.length > 0) {
+      evidence.push(`Providers with weak/indirect location handling: ${compactList(ignoredProviders)}`)
+    }
+    actions.push({
+      audience: 'agency',
+      priority: 70,
+      horizon: 'medium-term',
+      category: 'location',
+      title: 'Keep location-scoped reporting separate by market',
+      action: 'Run and compare separate sweeps for each configured location before making market-level recommendations.',
+      why: [
+        'A multi-location client can appear differently by market.',
+        'Keeping each report location-scoped avoids mixing Florida and Michigan evidence in the same client story.',
+      ],
+      evidence,
+      successMetric: 'Each configured market has its own current sweep and trend before cross-market decisions are made.',
+      confidence: 'high',
+    })
+  }
+
+  if (actions.length === 0) {
+    actions.push({
+      audience: 'both',
+      priority: 90,
+      horizon: 'short-term',
+      category: 'monitoring',
+      title: 'Keep monitoring citation and mention coverage',
+      action: 'Run the next scheduled visibility sweep and watch for citation gains, losses, and provider-specific misses.',
+      why: [
+        'No urgent corrective action surfaced from the current evidence.',
+        'AEO performance is directional; repeated sweeps are needed before overreacting to a single sample.',
+      ],
+      evidence: ['No critical insights, content gaps, indexing blockers, or provider-zero issues were detected in this report.'],
+      successMetric: 'Coverage stays stable or improves across the next trend window.',
+      confidence: 'medium',
+    })
+  }
+
+  return actions.sort((a, b) => a.priority - b.priority).slice(0, 10)
+}
+
+function trendSentence(trend: ProjectReportDto['executiveSummary']['trend']): string {
+  switch (trend) {
+    case 'up': return 'Citation coverage improved versus the prior comparable sweep.'
+    case 'down': return 'Citation coverage declined versus the prior comparable sweep.'
+    case 'flat': return 'Citation coverage is flat versus the prior comparable sweep.'
+    case 'unknown': return 'There is not enough comparable run history yet to call a trend.'
+  }
+}
+
+function buildClientSummary(
+  reportLike: {
+    canonicalDomain: string
+    reportLocation: ProjectReportDto['meta']['location']
+    executiveSummary: ProjectReportDto['executiveSummary']
+    citationsTrend: ProjectReportDto['citationsTrend']
+    gsc: ProjectReportDto['gsc']
+    actionPlan: ProjectReportDto['actionPlan']
+  },
+): ProjectReportDto['clientSummary'] {
+  const s = reportLike.executiveSummary
+  const queryNoun = s.totalQueryCount === 1 ? 'query' : 'queries'
+  const headline = s.totalQueryCount > 0
+    ? `${s.citedQueryCount} of ${s.totalQueryCount} tracked ${queryNoun} are cited by AI engines`
+    : 'No tracked queries have completed a visibility sweep yet'
+  const overview = s.totalQueryCount > 0
+    ? `${reportLike.canonicalDomain} is cited on ${s.citationRate}% of tracked queries and mentioned on ${s.mentionRate}% of tracked queries. ${trendSentence(s.trend)}`
+    : 'Canonry needs at least one completed visibility sweep before it can summarize how the brand appears in AI answers.'
+
+  const confidenceNotes: string[] = []
+  if (s.totalQueryCount === 0) {
+    confidenceNotes.push('Confidence is low until the first tracked query sweep completes.')
+  } else if (s.totalQueryCount < 5) {
+    confidenceNotes.push('Directional read: the tracked query set is still small, so each query has outsized impact on the percentage.')
+  }
+  if (isTrendBaseline(reportLike.citationsTrend)) {
+    confidenceNotes.push(`Trend confidence is still developing; ${MIN_TREND_POINTS} comparable sweeps are needed for a stable trend.`)
+  }
+  if (!reportLike.gsc) {
+    confidenceNotes.push('Search Console is not connected, so content recommendations lean more heavily on citation and competitor evidence.')
+  }
+  if (reportLike.reportLocation) {
+    confidenceNotes.push(`This summary is scoped to the ${reportLike.reportLocation.label} run location.`)
+  }
+
+  return {
+    headline,
+    overview,
+    actionItems: reportLike.actionPlan.filter(a => actionAudienceMatches(a, 'client')).slice(0, 3),
+    confidenceNotes,
+  }
+}
+
+function buildAgencyDiagnostics(input: ReportActionPlanInput & {
+  actionPlan: ProjectReportDto['actionPlan']
+}): ProjectReportDto['agencyDiagnostics'] {
+  const diagnostics: ProjectReportDto['agencyDiagnostics']['diagnostics'] = []
+
+  const zeroCitationProviders = input.citationScorecard.providerRates
+    .filter(p => p.totalCount > 0 && p.citedCount === 0)
+  diagnostics.push({
+    title: 'Provider citation coverage',
+    detail: zeroCitationProviders.length > 0
+      ? `${zeroCitationProviders.length} provider${zeroCitationProviders.length === 1 ? '' : 's'} returned zero client citations in the latest sweep.`
+      : 'Every provider with completed snapshots produced at least one client citation or no provider data is available yet.',
+    severity: zeroCitationProviders.length > 0 ? 'negative' : 'positive',
+    evidence: zeroCitationProviders.length > 0
+      ? zeroCitationProviders.map(p => `${p.provider}: 0/${p.totalCount}`)
+      : input.citationScorecard.providerRates.map(p => `${p.provider}: ${p.citedCount}/${p.totalCount}`),
+  })
+
+  diagnostics.push({
+    title: 'AI source domains',
+    detail: input.aiSourceOrigin.topDomains.length > 0
+      ? 'Repeated external source domains show what AI engines are currently trusting for this topic set.'
+      : 'No external source-domain evidence is available from the latest sweep yet.',
+    severity: input.aiSourceOrigin.topDomains.length > 0 ? 'neutral' : 'caution',
+    evidence: input.aiSourceOrigin.topDomains.slice(0, 5).map(d => `${d.domain}: ${d.count}`),
+  })
+
+  if (input.gsc) {
+    diagnostics.push({
+      title: 'GSC query mismatch',
+      detail: input.gsc.trackedButNoGsc.length > 0 || input.gsc.gscButNotTracked.length > 0
+        ? 'The tracked AEO query set and real search demand are not fully aligned.'
+        : 'Tracked AEO queries and high-impression non-brand GSC queries are aligned for the current window.',
+      severity: input.gsc.trackedButNoGsc.length > 0 || input.gsc.gscButNotTracked.length > 0 ? 'caution' : 'positive',
+      evidence: [
+        ...(input.gsc.trackedButNoGsc.length > 0 ? [`Tracked with no GSC demand: ${compactList(input.gsc.trackedButNoGsc)}`] : []),
+        ...(input.gsc.gscButNotTracked.length > 0 ? [`GSC queries not tracked in AEO: ${compactList(input.gsc.gscButNotTracked)}`] : []),
+      ],
+    })
+  }
+
+  if (input.indexingHealth) {
+    diagnostics.push({
+      title: 'Indexing health',
+      detail: `${input.indexingHealth.indexedPct}% of inspected URLs are indexed in ${input.indexingHealth.provider ?? 'the connected provider'}.`,
+      severity: input.indexingHealth.indexedPct >= 90 ? 'positive' : input.indexingHealth.indexedPct >= 70 ? 'caution' : 'negative',
+      evidence: [
+        `${input.indexingHealth.indexed}/${input.indexingHealth.total} indexed`,
+        `${input.indexingHealth.notIndexed} not indexed`,
+      ],
+    })
+  }
+
+  diagnostics.push({
+    title: 'Content opportunity pipeline',
+    detail: input.contentOpportunities.length > 0
+      ? `${input.contentOpportunities.length} ranked content opportunit${input.contentOpportunities.length === 1 ? 'y' : 'ies'} and ${input.contentGaps.length} content gap${input.contentGaps.length === 1 ? '' : 's'} are available.`
+      : 'No ranked content opportunities are available from the current evidence.',
+    severity: input.contentOpportunities.length > 0 ? 'caution' : 'neutral',
+    evidence: input.contentOpportunities.slice(0, 3).map(o => `${o.query}: ${o.action} (${Math.round(o.score)})`),
+  })
+
+  if (input.reportLocation) {
+    diagnostics.push({
+      title: 'Location caveat',
+      detail: input.reportLocation.otherConfiguredLabels.length > 0
+        ? 'This report is scoped to the latest run location; other configured locations need separate interpretation.'
+        : 'This report is scoped to one configured location.',
+      severity: input.reportLocation.otherConfiguredLabels.length > 0 ? 'caution' : 'neutral',
+      evidence: [
+        `Current location: ${input.reportLocation.label}`,
+        ...(input.reportLocation.otherConfiguredLabels.length > 0
+          ? [`Other configured locations: ${compactList(input.reportLocation.otherConfiguredLabels)}`]
+          : []),
+      ],
+    })
+  }
+
+  return {
+    priorities: input.actionPlan.filter(a => actionAudienceMatches(a, 'agency')).slice(0, 6),
+    diagnostics,
+  }
+}
+
 function buildProjectReport(db: DatabaseClient, projectName: string): ProjectReportDto {
   const project = resolveProject(db, projectName)
   const queryLookup = loadQueryLookup(db, project.id)
@@ -903,6 +1275,69 @@ function buildProjectReport(db: DatabaseClient, projectName: string): ProjectRep
     ? buildProviderLocationHandling(citationScorecard.providers)
     : []
 
+  const executiveSummary: ProjectReportDto['executiveSummary'] = {
+    citationRate,
+    citedQueryCount,
+    totalQueryCount,
+    mentionRate,
+    mentionedQueryCount,
+    trend,
+    queryCount: queryLookup.byId.size,
+    competitorCount: competitorDomains.length,
+    providerCount: citationScorecard.providers.length,
+    gsc: gscSection
+      ? {
+          clicks: gscSection.totalClicks,
+          impressions: gscSection.totalImpressions,
+          ctr: gscSection.ctr,
+          avgPosition: gscSection.avgPosition,
+        }
+      : null,
+    ga: gaSection
+      ? {
+          sessions: gaSection.totalSessions,
+          users: gaSection.totalUsers,
+          periodStart: gaSection.periodStart,
+          periodEnd: gaSection.periodEnd,
+        }
+      : null,
+    findings,
+  }
+
+  const actionPlan = buildReportActionPlan({
+    canonicalDomain: project.canonicalDomain,
+    competitorDomains,
+    citationScorecard,
+    aiSourceOrigin,
+    gsc: gscSection,
+    indexingHealth: indexingHealthSection,
+    contentOpportunities,
+    contentGaps,
+    reportLocation,
+    providerLocationHandling,
+  })
+  const clientSummary = buildClientSummary({
+    canonicalDomain: project.canonicalDomain,
+    reportLocation,
+    executiveSummary,
+    citationsTrend,
+    gsc: gscSection,
+    actionPlan,
+  })
+  const agencyDiagnostics = buildAgencyDiagnostics({
+    canonicalDomain: project.canonicalDomain,
+    competitorDomains,
+    citationScorecard,
+    aiSourceOrigin,
+    gsc: gscSection,
+    indexingHealth: indexingHealthSection,
+    contentOpportunities,
+    contentGaps,
+    reportLocation,
+    providerLocationHandling,
+    actionPlan,
+  })
+
   return {
     meta: {
       generatedAt: new Date().toISOString(),
@@ -919,34 +1354,7 @@ function buildProjectReport(db: DatabaseClient, projectName: string): ProjectRep
       periodStart,
       periodEnd,
     },
-    executiveSummary: {
-      citationRate,
-      citedQueryCount,
-      totalQueryCount,
-      mentionRate,
-      mentionedQueryCount,
-      trend,
-      queryCount: queryLookup.byId.size,
-      competitorCount: competitorDomains.length,
-      providerCount: citationScorecard.providers.length,
-      gsc: gscSection
-        ? {
-            clicks: gscSection.totalClicks,
-            impressions: gscSection.totalImpressions,
-            ctr: gscSection.ctr,
-            avgPosition: gscSection.avgPosition,
-          }
-        : null,
-      ga: gaSection
-        ? {
-            sessions: gaSection.totalSessions,
-            users: gaSection.totalUsers,
-            periodStart: gaSection.periodStart,
-            periodEnd: gaSection.periodEnd,
-          }
-        : null,
-      findings,
-    },
+    executiveSummary,
     citationScorecard,
     competitorLandscape,
     mentionLandscape,
@@ -959,15 +1367,28 @@ function buildProjectReport(db: DatabaseClient, projectName: string): ProjectRep
     citationsTrend,
     insights: insightList,
     recommendedNextSteps,
+    actionPlan,
+    clientSummary,
+    agencyDiagnostics,
     contentOpportunities,
     contentGaps,
     groundingSources,
   }
 }
 
-function reportFilenameFor(project: ProjectReportDto['meta']['project'], generatedAt: string): string {
+function parseReportAudience(value: string | undefined): ReportAudience {
+  if (value === undefined || value === 'agency') return 'agency'
+  if (value === 'client') return 'client'
+  throw validationError('"audience" must be "agency" or "client"')
+}
+
+function reportFilenameFor(
+  project: ProjectReportDto['meta']['project'],
+  generatedAt: string,
+  audience: ReportAudience,
+): string {
   const date = generatedAt.slice(0, 10)
-  return `canonry-report-${project.name}-${date}.html`
+  return `canonry-report-${project.name}-${audience}-${date}.html`
 }
 
 export async function reportRoutes(app: FastifyInstance) {
@@ -976,10 +1397,11 @@ export async function reportRoutes(app: FastifyInstance) {
     return reply.send(dto)
   })
 
-  app.get<{ Params: { name: string } }>('/projects/:name/report.html', async (request, reply) => {
+  app.get<{ Params: { name: string }; Querystring: { audience?: string } }>('/projects/:name/report.html', async (request, reply) => {
+    const audience = parseReportAudience(request.query.audience)
     const dto = buildProjectReport(app.db, request.params.name)
-    const html = renderReportHtml(dto)
-    const filename = reportFilenameFor(dto.meta.project, dto.meta.generatedAt)
+    const html = renderReportHtml(dto, { audience })
+    const filename = reportFilenameFor(dto.meta.project, dto.meta.generatedAt, audience)
     reply.header('Content-Type', 'text/html; charset=utf-8')
     reply.header('Content-Disposition', `attachment; filename="${filename}"`)
     return reply.send(html)

--- a/packages/api-routes/test/report-renderer.test.ts
+++ b/packages/api-routes/test/report-renderer.test.ts
@@ -45,6 +45,17 @@ function emptyReport(): ProjectReportDto {
     citationsTrend: [],
     insights: [],
     recommendedNextSteps: [],
+    actionPlan: [],
+    clientSummary: {
+      headline: 'No tracked queries have completed a visibility sweep yet',
+      overview: 'No visibility data yet.',
+      actionItems: [],
+      confidenceNotes: [],
+    },
+    agencyDiagnostics: {
+      priorities: [],
+      diagnostics: [],
+    },
     contentOpportunities: [],
     contentGaps: [],
     groundingSources: [],
@@ -52,6 +63,30 @@ function emptyReport(): ProjectReportDto {
 }
 
 function richReport(): ProjectReportDto {
+  const clientAction: ProjectReportDto['actionPlan'][number] = {
+    audience: 'both',
+    priority: 10,
+    horizon: 'short-term',
+    category: 'content',
+    title: 'Create content for "best aeo platform"',
+    action: 'Publish a client-safe guide that directly answers the priority query.',
+    why: ['AI engines already cite competitors for this query.'],
+    evidence: ['rival.com is the current winning cited source'],
+    successMetric: 'The client is cited for "best aeo platform" in a future sweep.',
+    confidence: 'high',
+  }
+  const agencyAction: ProjectReportDto['actionPlan'][number] = {
+    audience: 'agency',
+    priority: 20,
+    horizon: 'short-term',
+    category: 'provider',
+    title: 'Diagnose zero-citation providers',
+    action: 'Inspect provider answers and source lists for model-specific gaps.',
+    why: ['Provider-level misses isolate where retrieval differs by model family.'],
+    evidence: ['openai: 0/2 cited query-provider pairs'],
+    successMetric: 'OpenAI cites the client on at least one tracked query.',
+    confidence: 'high',
+  }
   return {
     meta: {
       generatedAt: '2026-05-02T12:00:00.000Z',
@@ -227,6 +262,24 @@ function richReport(): ProjectReportDto {
     recommendedNextSteps: [
       { horizon: 'immediate', title: 'Resolve 1 critical regression', rationale: 'Lost citation on aeo platform.' },
     ],
+    actionPlan: [clientAction, agencyAction],
+    clientSummary: {
+      headline: '3 of 5 tracked queries are cited by AI engines',
+      overview: 'Rich Project is cited on 65% of tracked queries and mentioned on 40%. Citation coverage improved versus the prior comparable sweep.',
+      actionItems: [clientAction],
+      confidenceNotes: ['This summary is scoped to the michigan run location.'],
+    },
+    agencyDiagnostics: {
+      priorities: [clientAction, agencyAction],
+      diagnostics: [
+        {
+          title: 'Provider citation coverage',
+          detail: 'One provider returned zero client citations.',
+          severity: 'negative',
+          evidence: ['openai: 0/2'],
+        },
+      ],
+    },
     contentOpportunities: [
       {
         targetRef: 'rich:create:best-aeo-platform',
@@ -327,6 +380,8 @@ describe('renderReportHtml', () => {
     const html = renderReportHtml(richReport())
     const expectedSections = [
       'executive-summary',
+      'agency-action-plan',
+      'agency-diagnostics',
       'citation-scorecard',
       'competitor-landscape',
       'ai-source-origin',
@@ -387,6 +442,29 @@ describe('renderReportHtml', () => {
     expect(html).toContain('rival.com')
     expect(html).toContain('Lost citation on aeo platform')
     expect(html).toContain('chatgpt.com')
+  })
+
+  test('defaults to agency mode with diagnostics and detailed evidence sections', () => {
+    const html = renderReportHtml(richReport())
+    expect(html).toContain('AEO Agency Report')
+    expect(html).toContain('id="agency-diagnostics"')
+    expect(html).toContain('id="citation-scorecard"')
+    expect(html).toContain('Diagnose zero-citation providers')
+  })
+
+  test('client mode renders polished actions before concise evidence', () => {
+    const html = renderReportHtml(richReport(), { audience: 'client' })
+    expect(html).toContain('AEO Client Summary')
+    expect(html).toContain('id="client-summary"')
+    expect(html).toContain('id="client-action-plan"')
+    expect(html).toContain('What We Recommend Next')
+    expect(html).toContain('Publish a client-safe guide')
+    expect(html).not.toContain('id="citation-scorecard"')
+
+    const actionIndex = html.indexOf('id="client-action-plan"')
+    const evidenceIndex = html.indexOf('id="client-evidence-summary"')
+    expect(actionIndex).toBeGreaterThan(-1)
+    expect(evidenceIndex).toBeGreaterThan(actionIndex)
   })
 
   test('citation matrix shows cited vs not-cited cells', () => {

--- a/packages/api-routes/test/report.test.ts
+++ b/packages/api-routes/test/report.test.ts
@@ -192,6 +192,10 @@ describe('GET /api/v1/projects/:name/report', () => {
     expect(body.citationsTrend).toEqual([])
     expect(body.insights).toEqual([])
     expect(body.recommendedNextSteps).toEqual([])
+    expect(body.actionPlan.length).toBeGreaterThan(0)
+    expect(body.clientSummary.headline).toContain('No tracked queries')
+    expect(body.clientSummary.actionItems.length).toBeGreaterThan(0)
+    expect(body.agencyDiagnostics.priorities.length).toBeGreaterThan(0)
   })
 
   test('citation scorecard reflects query × provider matrix', async () => {
@@ -343,6 +347,94 @@ describe('GET /api/v1/projects/:name/report', () => {
     )
     expect(topByDomain['reddit.com']).toBe(2)
     expect(topByDomain['youtube.com']).toBe(1)
+  })
+
+  test('builds audience action plan and diagnostics from azcoatings-style signals', async () => {
+    const projectId = insertProject(ctx.db, 'az-actions', {
+      displayName: 'AZ Coatings',
+      canonicalDomain: 'azcoatings.com',
+    })
+    const coatingQuery = insertQuery(ctx.db, projectId, 'best industrial coatings')
+    const guideQuery = insertQuery(ctx.db, projectId, 'commercial floor coating guide')
+    const runId = insertRun(ctx.db, projectId, {
+      createdAt: '2026-05-01T00:00:00Z',
+      finishedAt: '2026-05-01T00:01:00Z',
+    })
+
+    const externalGrounding = JSON.stringify({
+      groundingSources: [
+        { uri: 'https://external-directory.com/coatings', title: 'Coating directory' },
+        { uri: 'https://paintmag.com/industrial-coatings', title: 'Industrial coatings guide' },
+      ],
+    })
+    for (const queryId of [coatingQuery, guideQuery]) {
+      insertSnapshot(ctx.db, runId, queryId, {
+        provider: 'gemini',
+        citationState: 'not-cited',
+        answerMentioned: false,
+        citedDomains: JSON.stringify(['external-directory.com', 'paintmag.com']),
+        rawResponse: externalGrounding,
+      })
+      insertSnapshot(ctx.db, runId, queryId, {
+        provider: 'openai',
+        citationState: 'not-cited',
+        answerMentioned: false,
+        citedDomains: JSON.stringify(['external-directory.com']),
+        rawResponse: externalGrounding,
+      })
+    }
+
+    const syncRunId = insertRun(ctx.db, projectId, { kind: 'gsc-sync' })
+    ctx.db.insert(gscSearchData).values([
+      {
+        id: crypto.randomUUID(),
+        projectId,
+        syncRunId,
+        date: '2026-04-30',
+        query: 'best industrial coatings',
+        page: 'https://azcoatings.com/blog/best-industrial-coatings',
+        clicks: 12,
+        impressions: 1200,
+        ctr: '0.01',
+        position: '8',
+        createdAt: new Date().toISOString(),
+      },
+      {
+        id: crypto.randomUUID(),
+        projectId,
+        syncRunId,
+        date: '2026-04-30',
+        query: 'epoxy floor coatings contractors',
+        page: 'https://azcoatings.com/blog/epoxy-floor-coatings',
+        clicks: 9,
+        impressions: 900,
+        ctr: '0.01',
+        position: '6',
+        createdAt: new Date().toISOString(),
+      },
+    ]).run()
+    ctx.db.insert(gscCoverageSnapshots).values({
+      id: crypto.randomUUID(),
+      projectId,
+      syncRunId,
+      date: '2026-04-30',
+      indexed: 2,
+      notIndexed: 8,
+      reasonBreakdown: '{}',
+      createdAt: new Date().toISOString(),
+    }).run()
+
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/az-actions/report' })
+    const body = JSON.parse(res.body) as ProjectReportDto
+
+    expect(body.actionPlan.some(a => a.category === 'competitors' && a.audience === 'both')).toBe(true)
+    expect(body.actionPlan.some(a => a.category === 'content' && a.title.includes('best industrial coatings'))).toBe(true)
+    expect(body.actionPlan.some(a => a.category === 'indexing' && a.evidence.some(e => e.includes('20% indexed')))).toBe(true)
+    expect(body.actionPlan.some(a => a.category === 'provider' && a.evidence.some(e => e.includes('openai: 0/2')))).toBe(true)
+    expect(body.actionPlan.some(a => a.category === 'search-demand' && a.evidence.some(e => e.includes('epoxy floor coatings contractors')))).toBe(true)
+    expect(body.clientSummary.actionItems.length).toBeGreaterThan(0)
+    expect(body.agencyDiagnostics.priorities.some(a => a.category === 'provider')).toBe(true)
   })
 
   test('GSC section returns top queries, totals, category breakdown', async () => {
@@ -1161,10 +1253,32 @@ describe('GET /api/v1/projects/:name/report.html', () => {
     const disposition = res.headers['content-disposition']
     expect(typeof disposition).toBe('string')
     expect(String(disposition)).toMatch(/^attachment;/)
-    expect(String(disposition)).toMatch(/canonry-report-html-report-\d{4}-\d{2}-\d{2}\.html/)
+    expect(String(disposition)).toMatch(/canonry-report-html-report-agency-\d{4}-\d{2}-\d{2}\.html/)
 
     expect(res.body).toMatch(/^<!DOCTYPE html>/)
     expect(res.body).toContain('HTML Report Co.')
+    expect(res.body).toContain('AEO Agency Report')
     expect(res.body).toContain('<title>')
+  })
+
+  test('renders client HTML when audience=client', async () => {
+    insertProject(ctx.db, 'client-html', { displayName: 'Client HTML Co.' })
+    await ctx.app.ready()
+
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/client-html/report.html?audience=client' })
+    expect(res.statusCode).toBe(200)
+    expect(String(res.headers['content-disposition'])).toMatch(/canonry-report-client-html-client-\d{4}-\d{2}-\d{2}\.html/)
+    expect(res.body).toContain('AEO Client Summary')
+    expect(res.body).toContain('id="client-summary"')
+    expect(res.body).not.toContain('id="citation-scorecard"')
+  })
+
+  test('rejects invalid report audience', async () => {
+    insertProject(ctx.db, 'bad-audience')
+    await ctx.app.ready()
+
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/bad-audience/report.html?audience=internal' })
+    expect(res.statusCode).toBe(400)
+    expect(JSON.parse(res.body).error.code).toBe('VALIDATION_ERROR')
   })
 })

--- a/packages/canonry/src/cli-commands/report.ts
+++ b/packages/canonry/src/cli-commands/report.ts
@@ -1,20 +1,30 @@
 import { runReportCommand } from '../commands/report.js'
 import type { CliCommandSpec } from '../cli-dispatch.js'
 import { getString, requireProject } from '../cli-command-helpers.js'
+import { usageError } from '../cli-error.js'
+import type { ReportAudience } from '@ainyc/canonry-contracts'
 
-const USAGE = 'canonry report <project> [--output <path>] [--format json]'
+const USAGE = 'canonry report <project> [--audience agency|client] [--output <path>] [--format json]'
+
+function parseAudience(value: string | undefined): ReportAudience | undefined {
+  if (value === undefined) return undefined
+  if (value === 'agency' || value === 'client') return value
+  throw usageError(`Error: --audience must be "agency" or "client"\n\nUsage: ${USAGE}`)
+}
 
 export const REPORT_CLI_COMMANDS: readonly CliCommandSpec[] = [
   {
     path: ['report'],
     usage: USAGE,
     options: {
+      audience: { type: 'string' },
       output: { type: 'string', short: 'o' },
     },
     run: async (input) => {
       const project = requireProject(input, 'report', USAGE)
       await runReportCommand(project, {
         format: input.format,
+        audience: parseAudience(getString(input.values, 'audience')),
         output: getString(input.values, 'output'),
       })
     },

--- a/packages/canonry/src/commands/report.ts
+++ b/packages/canonry/src/commands/report.ts
@@ -3,16 +3,19 @@ import path from 'node:path'
 import { createApiClient } from '../client.js'
 import { renderReportHtml } from '@ainyc/canonry-api-routes'
 import type { CliFormat } from '../cli-error.js'
+import type { ReportAudience } from '@ainyc/canonry-contracts'
 
 export interface RunReportCommandOptions {
   format?: CliFormat
-  /** Override the output path. Default: `<cwd>/canonry-report-<project>-<YYYY-MM-DD>.html`. */
+  /** Render audience for HTML output. JSON always prints the full canonical DTO. */
+  audience?: ReportAudience
+  /** Override the output path. Default: `<cwd>/canonry-report-<project>-<audience>-<YYYY-MM-DD>.html`. */
   output?: string
 }
 
-function defaultOutputPath(project: string): string {
+function defaultOutputPath(project: string, audience: ReportAudience): string {
   const date = new Date().toISOString().slice(0, 10)
-  return path.resolve(process.cwd(), `canonry-report-${project}-${date}.html`)
+  return path.resolve(process.cwd(), `canonry-report-${project}-${audience}-${date}.html`)
 }
 
 export async function runReportCommand(
@@ -21,14 +24,15 @@ export async function runReportCommand(
 ): Promise<void> {
   const client = createApiClient()
   const report = await client.getReport(project)
+  const audience = opts.audience ?? 'agency'
 
   if (opts.format === 'json') {
     console.log(JSON.stringify(report, null, 2))
     return
   }
 
-  const html = renderReportHtml(report)
-  const targetPath = opts.output ? path.resolve(opts.output) : defaultOutputPath(project)
+  const html = renderReportHtml(report, { audience })
+  const targetPath = opts.output ? path.resolve(opts.output) : defaultOutputPath(project, audience)
 
   const dir = path.dirname(targetPath)
   if (!fs.existsSync(dir)) {

--- a/packages/canonry/src/mcp/tool-registry.ts
+++ b/packages/canonry/src/mcp/tool-registry.ts
@@ -268,7 +268,7 @@ export const canonryMcpTools = [
     name: 'canonry_report',
     title: 'Get aggregated AEO report',
     description:
-      'Returns the full client-facing AEO report bundle for a project — executive summary, per-query × per-provider citation matrix, competitor landscape, AI citation sources, GSC/GA4 performance, social and AI referrals, indexing health, citations trend, prioritized insights, and recommended next steps. Same payload `canonry report <project>` consumes to render the self-contained HTML.',
+      'Returns the full canonical AEO report bundle for a project — executive summary, client summary, agency diagnostics, action plan, per-query × per-provider citation matrix, competitor landscape, AI citation sources, GSC/GA4 performance, social and AI referrals, indexing health, citations trend, prioritized insights, and recommended next steps. Same payload `canonry report <project>` consumes to render audience-specific HTML.',
     access: 'read',
     tier: 'monitoring',
     inputSchema: projectInputSchema,

--- a/packages/canonry/test/report-command.test.ts
+++ b/packages/canonry/test/report-command.test.ts
@@ -47,6 +47,17 @@ function makeReport(): ProjectReportDto {
     citationsTrend: [],
     insights: [],
     recommendedNextSteps: [],
+    actionPlan: [],
+    clientSummary: {
+      headline: 'No tracked queries have completed a visibility sweep yet',
+      overview: 'No visibility data yet.',
+      actionItems: [],
+      confidenceNotes: [],
+    },
+    agencyDiagnostics: {
+      priorities: [],
+      diagnostics: [],
+    },
     contentOpportunities: [],
     contentGaps: [],
     groundingSources: [],
@@ -94,11 +105,12 @@ describe('runReportCommand', () => {
 
       const files = fs.readdirSync(tmpDir).filter(f => f.endsWith('.html'))
       expect(files.length).toBe(1)
-      expect(files[0]).toMatch(/^canonry-report-demo-\d{4}-\d{2}-\d{2}\.html$/)
+      expect(files[0]).toMatch(/^canonry-report-demo-agency-\d{4}-\d{2}-\d{2}\.html$/)
 
       const html = fs.readFileSync(path.join(tmpDir, files[0]!), 'utf-8')
       expect(html).toMatch(/^<!DOCTYPE html>/)
       expect(html).toContain('id="executive-summary"')
+      expect(html).toContain('AEO Agency Report')
 
       expect(logs.join('\n')).toContain(files[0]!)
     } finally {
@@ -115,6 +127,18 @@ describe('runReportCommand', () => {
     expect(fs.existsSync(target)).toBe(true)
     const html = fs.readFileSync(target, 'utf-8')
     expect(html).toContain('id="executive-summary"')
+  })
+
+  it('renders client HTML when --audience client is supplied', async () => {
+    getReportMock.mockResolvedValue(makeReport())
+    const target = path.join(tmpDir, 'client.html')
+
+    await runReportCommand('demo', { format: 'text', audience: 'client', output: target })
+
+    const html = fs.readFileSync(target, 'utf-8')
+    expect(html).toContain('AEO Client Summary')
+    expect(html).toContain('id="client-summary"')
+    expect(html).not.toContain('id="citation-scorecard"')
   })
 
   it('--format json prints the raw report JSON to stdout, no file written', async () => {

--- a/packages/contracts/src/report.ts
+++ b/packages/contracts/src/report.ts
@@ -383,6 +383,7 @@ export type ReportAudience = 'agency' | 'client'
 export type ReportActionAudience = ReportAudience | 'both'
 export type ReportActionHorizon = 'immediate' | 'short-term' | 'medium-term'
 export type ReportActionConfidence = 'high' | 'medium' | 'low'
+export type ReportTone = 'positive' | 'caution' | 'negative' | 'neutral'
 export type ReportActionCategory =
   | 'content'
   | 'competitors'
@@ -430,6 +431,15 @@ export interface ReportAgencyDiagnostic {
 export interface ReportAgencyDiagnostics {
   priorities: ReportActionPlanItem[]
   diagnostics: ReportAgencyDiagnostic[]
+}
+
+export function reportActionTone(
+  action: Pick<ReportActionPlanItem, 'horizon' | 'confidence'>,
+): ReportTone {
+  if (action.horizon === 'immediate') return 'negative'
+  if (action.confidence === 'high') return 'caution'
+  if (action.confidence === 'low') return 'neutral'
+  return 'caution'
 }
 
 export interface ProjectReportDto {

--- a/packages/contracts/src/report.ts
+++ b/packages/contracts/src/report.ts
@@ -379,6 +379,59 @@ export interface RecommendedNextStep {
   rationale: string
 }
 
+export type ReportAudience = 'agency' | 'client'
+export type ReportActionAudience = ReportAudience | 'both'
+export type ReportActionHorizon = 'immediate' | 'short-term' | 'medium-term'
+export type ReportActionConfidence = 'high' | 'medium' | 'low'
+export type ReportActionCategory =
+  | 'content'
+  | 'competitors'
+  | 'provider'
+  | 'search-demand'
+  | 'indexing'
+  | 'location'
+  | 'monitoring'
+
+export interface ReportActionPlanItem {
+  /** Which report audience should see this action. `both` renders in both modes. */
+  audience: ReportActionAudience
+  /** Stable sort priority. Lower numbers render earlier. */
+  priority: number
+  /** When this should be tackled. */
+  horizon: ReportActionHorizon
+  category: ReportActionCategory
+  title: string
+  /** Direct next step written as an operator/client-friendly imperative. */
+  action: string
+  /** Why this matters. Keep each entry concise and evidence-backed. */
+  why: string[]
+  /** Specific observations that justify the action. */
+  evidence: string[]
+  /** What should move if the action worked. */
+  successMetric: string
+  /** Confidence in the recommendation based on the available evidence. */
+  confidence: ReportActionConfidence
+}
+
+export interface ReportClientSummary {
+  headline: string
+  overview: string
+  actionItems: ReportActionPlanItem[]
+  confidenceNotes: string[]
+}
+
+export interface ReportAgencyDiagnostic {
+  title: string
+  detail: string
+  severity: 'positive' | 'caution' | 'negative' | 'neutral'
+  evidence: string[]
+}
+
+export interface ReportAgencyDiagnostics {
+  priorities: ReportActionPlanItem[]
+  diagnostics: ReportAgencyDiagnostic[]
+}
+
 export interface ProjectReportDto {
   meta: ReportMeta
   executiveSummary: ReportExecutiveSummary
@@ -394,6 +447,12 @@ export interface ProjectReportDto {
   citationsTrend: CitationsTrendPoint[]
   insights: ReportInsight[]
   recommendedNextSteps: RecommendedNextStep[]
+  /** Canonical structured actions shared by the client and agency render modes. */
+  actionPlan: ReportActionPlanItem[]
+  /** Polished client-facing summary and action shortlist. */
+  clientSummary: ReportClientSummary
+  /** Technical, evidence-oriented operator diagnostics for agency mode. */
+  agencyDiagnostics: ReportAgencyDiagnostics
   /**
    * Ranked, action-typed content opportunities sourced from the existing
    * intelligence layer (`buildContentTargetRows`). Empty when no run has


### PR DESCRIPTION
## Summary
- extend the canonical report DTO with `clientSummary`, `agencyDiagnostics`, and a shared structured `actionPlan`
- add agency/client audience rendering for HTML, CLI report output, and the web report tab while keeping JSON/MCP on the full canonical DTO
- keep agency mode as the default and preserve the detailed evidence sections there; client mode leads with a polished summary, action cards, and concise evidence
- include the #423 prerequisite fixes through the current stacked base, including location-scoped history, locationless provider handling, corrected citation denominator copy, and Section 14 next-step numbering

## Tests
- `pnpm --filter @ainyc/canonry-api-routes test -- report.test.ts report-renderer.test.ts`
- `pnpm --filter @ainyc/canonry-web typecheck`
- `pnpm --filter @ainyc/canonry typecheck`
- `pnpm --filter @ainyc/canonry test -- report-command.test.ts`
- `pnpm --filter @ainyc/canonry-api-routes lint`
- `pnpm --filter @ainyc/canonry-web lint`
- `pnpm --filter @ainyc/canonry lint`
- `pnpm --filter @ainyc/canonry-contracts typecheck && pnpm --filter @ainyc/canonry-contracts lint`
