### PR TITLE
feat(report): client-ready cleanup + 30d window + polished labels

### DIFF
--- a/apps/web/src/pages/ReportPage.tsx
+++ b/apps/web/src/pages/ReportPage.tsx
@@ -5,16 +5,24 @@ import type {
   CitationCell,
   CitationsTrendPoint,
   CompetitorRow,
-  ContentTargetRowDto,
   GscQueryRow,
   IndexingHealthSection,
   ProjectReportDto,
   ReportActionPlanItem,
   ReportAudience,
-  RecommendedNextStep,
   ReportInsight,
 } from '@ainyc/canonry-contracts'
-import { absolutizeProjectUrl, CitationStates, reportActionTone } from '@ainyc/canonry-contracts'
+import {
+  absolutizeProjectUrl,
+  actionConfidenceLabel,
+  CitationStates,
+  contentActionLabel,
+  reportActionCategoryLabel,
+  reportActionTone,
+  reportConfidenceLabel,
+  reportHorizonLabel,
+  reportSeverityLabel,
+} from '@ainyc/canonry-contracts'
 
 import {
   Bar,
@@ -120,26 +128,9 @@ const LOCATION_TREATMENT_LABEL: Record<ProjectReportDto['meta']['providerLocatio
   ignored: 'Ignored',
 }
 
-function severityLabel(severity: ReportInsight['severity']): string {
-  return severity.charAt(0).toUpperCase() + severity.slice(1)
-}
-
-function horizonLabel(horizon: RecommendedNextStep['horizon']): string {
-  switch (horizon) {
-    case 'immediate': return 'Immediate'
-    case 'short-term': return 'Short term'
-    case 'medium-term': return 'Medium term'
-  }
-}
-
-function actionLabel(action: ContentTargetRowDto['action']): string {
-  switch (action) {
-    case 'create': return 'Create'
-    case 'expand': return 'Expand'
-    case 'refresh': return 'Refresh'
-    case 'add-schema': return 'Add schema'
-  }
-}
+// severityLabel / horizonLabel / actionLabel moved to @ainyc/canonry-contracts
+// (`reportSeverityLabel`, `reportHorizonLabel`, `contentActionLabel`) so the
+// HTML report renderer and the web dashboard can't drift on what users see.
 
 function CitedMentionedGlyphs({ cell }: { cell: CitationCell | null }) {
   if (!cell) {
@@ -343,9 +334,9 @@ function ActionPlanSection({ report, audience }: { report: ProjectReportDto; aud
           {actions.map(action => (
             <div key={`${action.priority}-${action.title}`} className="rounded-xl border border-zinc-800/60 bg-zinc-900/30 p-4">
               <div className="mb-3 flex flex-wrap gap-2">
-                <ToneBadge tone={reportActionTone(action)}>{horizonLabel(action.horizon)}</ToneBadge>
-                <ToneBadge tone="neutral">{action.category}</ToneBadge>
-                <ToneBadge tone="neutral">{action.confidence} confidence</ToneBadge>
+                <ToneBadge tone={reportActionTone(action)}>{reportHorizonLabel(action.horizon)}</ToneBadge>
+                <ToneBadge tone="neutral">{reportActionCategoryLabel(action.category)}</ToneBadge>
+                <ToneBadge tone="neutral">{reportConfidenceLabel(action.confidence)} confidence</ToneBadge>
               </div>
               <p className="text-sm font-medium text-zinc-100">{action.title}</p>
               <p className="mt-1 text-sm text-zinc-400">{action.action}</p>
@@ -447,7 +438,7 @@ function ClientEvidenceSection({ report }: { report: ProjectReportDto }) {
       tone: 'caution',
       title: 'Content opportunities',
       detail: 'Canonry found topics where better content could improve AI citations.',
-      items: report.contentOpportunities.slice(0, 5).map(o => `${o.query}: ${actionLabel(o.action)} (${Math.round(o.score)})`),
+      items: report.contentOpportunities.slice(0, 5).map(o => `${o.query}: ${contentActionLabel(o.action)} (score ${Math.round(o.score)}/100)`),
     })
   }
 
@@ -1354,7 +1345,7 @@ function InsightsSection({ report }: { report: ProjectReportDto }) {
             {report.insights.map(i => (
               <tr key={i.id}>
                 <td>
-                  <ToneBadge tone={SEVERITY_TONE[i.severity]}>{severityLabel(i.severity)}</ToneBadge>
+                  <ToneBadge tone={SEVERITY_TONE[i.severity]}>{reportSeverityLabel(i.severity)}</ToneBadge>
                   {i.instanceCount > 1 && (
                     <span className="ml-2 text-[11px] text-zinc-500">×{i.instanceCount}</span>
                   )}
@@ -1384,7 +1375,7 @@ function ContentOpportunitiesSection({ report }: { report: ProjectReportDto }) {
       <SectionHeading
         eyebrow="Section 12"
         title="Content opportunities"
-        subtitle="Queries where you have search demand or competitor citation pressure but aren't winning AI citations. Each row pairs a suggested action with the signals driving the score, the best matching page on your domain, and the competitor URL the AI most often cites. Top 10 shown."
+        subtitle="Queries where you have search demand or competitor citation pressure but aren't winning AI citations. Each row pairs a suggested action with the signals driving the opportunity score (0–100, higher = stronger), the best matching page on your domain, and the competitor URL the AI most often cites. Top 10 shown."
       />
       <div className="evidence-table-wrap">
         <table className="evidence-table">
@@ -1392,7 +1383,7 @@ function ContentOpportunitiesSection({ report }: { report: ProjectReportDto }) {
             <tr>
               <th>Query</th>
               <th>Action</th>
-              <th>Score</th>
+              <th title="Opportunity score (0–100)">Score</th>
               <th>Why</th>
               <th>Our page</th>
               <th>Winning competitor</th>
@@ -1403,8 +1394,11 @@ function ContentOpportunitiesSection({ report }: { report: ProjectReportDto }) {
             {report.contentOpportunities.slice(0, 10).map(o => (
               <tr key={o.targetRef}>
                 <td className="evidence-query-cell">{o.query}</td>
-                <td><ToneBadge tone="neutral">{actionLabel(o.action)}</ToneBadge></td>
-                <td>{Math.round(o.score)}</td>
+                <td><ToneBadge tone="neutral">{contentActionLabel(o.action)}</ToneBadge></td>
+                <td title="Opportunity score (0–100)">
+                  {Math.round(o.score)}
+                  <span className="text-zinc-600"> / 100</span>
+                </td>
                 <td className="text-xs text-zinc-400">
                   {o.drivers.length > 0
                     ? <ul className="list-disc pl-4 space-y-0.5">{o.drivers.map((d, i) => <li key={i}>{d}</li>)}</ul>
@@ -1420,7 +1414,7 @@ function ContentOpportunitiesSection({ report }: { report: ProjectReportDto }) {
                     ? <a href={o.winningCompetitor.url} target="_blank" rel="noreferrer" className="text-blue-400 hover:underline">{o.winningCompetitor.domain}</a>
                     : <span className="text-zinc-600">—</span>}
                 </td>
-                <td><ToneBadge tone="neutral">{o.actionConfidence}</ToneBadge></td>
+                <td><ToneBadge tone="neutral">{actionConfidenceLabel(o.actionConfidence)}</ToneBadge></td>
               </tr>
             ))}
           </tbody>
@@ -1492,7 +1486,7 @@ function NextStepsSection({ report }: { report: ProjectReportDto }) {
           const tone: MetricTone = h === 'immediate' ? 'negative' : h === 'short-term' ? 'caution' : 'neutral'
           return (
             <div key={h} className="rounded-xl border border-zinc-800/60 bg-zinc-900/30 p-4">
-              <ToneBadge tone={tone}>{horizonLabel(h)}</ToneBadge>
+              <ToneBadge tone={tone}>{reportHorizonLabel(h)}</ToneBadge>
               <ul className="mt-3 space-y-3">
                 {steps.map((s, i) => (
                   <li key={i}>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.7.2",
+  "version": "4.8.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/content-data.ts
+++ b/packages/api-routes/src/content-data.ts
@@ -35,6 +35,7 @@ import {
   RunKinds,
   RunStatuses,
   type GroundingSource,
+  type LocationContext,
   type ProviderName,
 } from '@ainyc/canonry-contracts'
 
@@ -44,6 +45,7 @@ interface ProjectRow {
   id: string
   canonicalDomain: string
   ownedDomains?: string | null
+  locations?: string | null
 }
 
 /**
@@ -107,6 +109,7 @@ export function loadOrchestratorInput(
     ownDomain,
     competitors: trackedCompetitors,
     candidateQueries,
+    queryIntentModifiers: buildQueryIntentModifiers(project, locationFilter),
     inventory,
     wpSchemaAudit: new Map(),
     gaTrafficByPage,
@@ -115,6 +118,79 @@ export function loadOrchestratorInput(
     latestRunTimestamp,
     inProgressActions: new Map<string, ExistingActionRef>(),
   }
+}
+
+function buildQueryIntentModifiers(project: ProjectRow, locationFilter: LocationScope): string[] {
+  if (locationFilter === undefined || locationFilter === null) return []
+  const locations = parseJsonColumn<LocationContext[]>(project.locations, [])
+  const currentLocation = locations.find(location => location.label === locationFilter)
+  const raw = currentLocation
+    ? [
+        currentLocation.label,
+        currentLocation.city,
+        currentLocation.region,
+        regionAbbreviation(currentLocation.region),
+        currentLocation.country,
+      ]
+    : [locationFilter]
+  return [...new Set(raw.map(value => value.trim().toLowerCase()).filter(Boolean))]
+}
+
+function regionAbbreviation(region: string): string {
+  return US_REGION_ABBREVIATIONS[region.trim().toLowerCase()] ?? ''
+}
+
+const US_REGION_ABBREVIATIONS: Record<string, string> = {
+  alabama: 'al',
+  alaska: 'ak',
+  arizona: 'az',
+  arkansas: 'ar',
+  california: 'ca',
+  colorado: 'co',
+  connecticut: 'ct',
+  delaware: 'de',
+  florida: 'fl',
+  georgia: 'ga',
+  hawaii: 'hi',
+  idaho: 'id',
+  illinois: 'il',
+  indiana: 'in',
+  iowa: 'ia',
+  kansas: 'ks',
+  kentucky: 'ky',
+  louisiana: 'la',
+  maine: 'me',
+  maryland: 'md',
+  massachusetts: 'ma',
+  michigan: 'mi',
+  minnesota: 'mn',
+  mississippi: 'ms',
+  missouri: 'mo',
+  montana: 'mt',
+  nebraska: 'ne',
+  nevada: 'nv',
+  'new hampshire': 'nh',
+  'new jersey': 'nj',
+  'new mexico': 'nm',
+  'new york': 'ny',
+  'north carolina': 'nc',
+  'north dakota': 'nd',
+  ohio: 'oh',
+  oklahoma: 'ok',
+  oregon: 'or',
+  pennsylvania: 'pa',
+  'rhode island': 'ri',
+  'south carolina': 'sc',
+  'south dakota': 'sd',
+  tennessee: 'tn',
+  texas: 'tx',
+  utah: 'ut',
+  vermont: 'vt',
+  virginia: 'va',
+  washington: 'wa',
+  'west virginia': 'wv',
+  wisconsin: 'wi',
+  wyoming: 'wy',
 }
 
 // ─── Per-domain helpers (each is a tiny focused query) ──────────────────────

--- a/packages/api-routes/src/report-renderer.ts
+++ b/packages/api-routes/src/report-renderer.ts
@@ -8,7 +8,17 @@ import type {
   ReportAudience,
   ReportInsight,
 } from '@ainyc/canonry-contracts'
-import { absolutizeProjectUrl, CitationStates, reportActionTone } from '@ainyc/canonry-contracts'
+import {
+  absolutizeProjectUrl,
+  actionConfidenceLabel,
+  CitationStates,
+  contentActionLabel,
+  reportActionCategoryLabel,
+  reportActionTone,
+  reportConfidenceLabel,
+  reportHorizonLabel,
+  reportSeverityLabel,
+} from '@ainyc/canonry-contracts'
 import {
   groupInsights,
   isTrendBaseline,
@@ -99,11 +109,49 @@ export function formatLandingPageHtml(raw: string): string {
 function formatDate(iso: string): string {
   if (!iso) return '—'
   try {
-    const d = new Date(iso)
-    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+    const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso)
+    const options: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric', year: 'numeric' }
+    const d = dateOnly && dateOnly[1] && dateOnly[2] && dateOnly[3]
+      ? new Date(Date.UTC(Number(dateOnly[1]), Number(dateOnly[2]) - 1, Number(dateOnly[3])))
+      : new Date(iso)
+    if (Number.isNaN(d.getTime())) return iso
+    return d.toLocaleDateString('en-US', dateOnly ? { ...options, timeZone: 'UTC' } : options)
   } catch {
     return iso
   }
+}
+
+function formatDateRange(start: string, end: string): string {
+  if (!start && !end) return ''
+  if (start && end) return `${formatDate(start)} → ${formatDate(end)}`
+  return formatDate(start || end)
+}
+
+function gscDateRange(report: ProjectReportDto): string {
+  const summary = report.executiveSummary.gsc
+  const gsc = report.gsc
+  const start = summary?.periodStart || gsc?.periodStart || gsc?.trend[0]?.date || ''
+  const end = summary?.periodEnd || gsc?.periodEnd || gsc?.trend.at(-1)?.date || ''
+  return formatDateRange(start, end)
+}
+
+function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+  return count === 1 ? singular : plural
+}
+
+function compactInlineList(items: readonly string[], limit = 3): string {
+  const visible = items.slice(0, limit)
+  const more = items.length - visible.length
+  return `${visible.join(', ')}${more > 0 ? `, +${more} more` : ''}`
+}
+
+function renderProofChips(items: readonly string[], limit = 3): string {
+  if (items.length === 0) return ''
+  const visible = items.slice(0, limit)
+  const more = items.length - visible.length
+  const chips = visible.map(item => `<span class="proof-chip">${escapeHtml(item)}</span>`)
+  if (more > 0) chips.push(`<span class="proof-chip">+${more} more</span>`)
+  return `<div class="proof-chips">${chips.join('')}</div>`
 }
 
 function pressureTone(label: CompetitorRow['pressureLabel']): 'positive' | 'caution' | 'negative' | 'neutral' {
@@ -150,7 +198,7 @@ body {
   font-size: 32px;
   font-weight: 700;
   margin: 0 0 8px;
-  letter-spacing: -0.02em;
+  letter-spacing: 0;
 }
 .header .subtitle {
   color: ${COLORS.textMuted};
@@ -158,7 +206,7 @@ body {
 }
 .eyebrow {
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0;
   font-size: 10px;
   color: ${COLORS.textFaint};
   font-weight: 600;
@@ -171,11 +219,75 @@ section.report-section h2 {
   font-size: 22px;
   font-weight: 700;
   margin: 0 0 24px;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
 }
 section.report-section .section-intro {
   color: ${COLORS.textMuted};
   margin-bottom: 24px;
+  max-width: 760px;
+}
+.executive-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(240px, 0.65fr);
+  gap: 16px;
+  margin-bottom: 16px;
+}
+.headline-card {
+  background: #111827;
+  border: 1px solid ${COLORS.border};
+  border-radius: 8px;
+  padding: 28px;
+  min-height: 220px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+.headline-card .hero-kicker {
+  color: ${COLORS.textMuted};
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0;
+}
+.headline-card .hero-title {
+  font-size: 44px;
+  line-height: 1.05;
+  font-weight: 800;
+  letter-spacing: 0;
+  margin: 18px 0;
+}
+.headline-card .hero-subtitle {
+  color: ${COLORS.textMuted};
+  font-size: 15px;
+  max-width: 620px;
+}
+.hero-proof-grid {
+  display: grid;
+  gap: 12px;
+}
+.hero-proof {
+  background: ${COLORS.surface};
+  border: 1px solid ${COLORS.border};
+  border-radius: 8px;
+  padding: 18px;
+}
+.hero-proof .mini-label {
+  color: ${COLORS.textFaint};
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0;
+  margin-bottom: 8px;
+}
+.hero-proof .mini-value {
+  font-size: 30px;
+  line-height: 1;
+  font-weight: 800;
+}
+.hero-proof .mini-copy {
+  color: ${COLORS.textMuted};
+  font-size: 12px;
+  margin-top: 8px;
 }
 .metric-grid {
   display: grid;
@@ -190,7 +302,7 @@ section.report-section .section-intro {
 }
 .metric .label {
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0;
   font-size: 10px;
   color: ${COLORS.textFaint};
   font-weight: 600;
@@ -199,7 +311,7 @@ section.report-section .section-intro {
 .metric .value {
   font-size: 28px;
   font-weight: 700;
-  letter-spacing: -0.02em;
+  letter-spacing: 0;
 }
 .metric .delta {
   font-size: 12px;
@@ -224,10 +336,46 @@ section.report-section .section-intro {
 .finding.tone-neutral { border-left-color: ${COLORS.neutral}; }
 .finding strong { display: block; margin-bottom: 4px; }
 .finding span { color: ${COLORS.textMuted}; font-size: 13px; }
-.location-card { margin-top: 16px; }
-.location-card .location-line { margin: 0 0 12px; font-size: 13px; color: ${COLORS.text}; }
-.location-card .location-line strong { color: ${COLORS.text}; }
-.location-card .location-line .cell-pending { font-size: 12px; }
+.market-scope-card { margin-top: 16px; }
+.market-scope-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+.scope-tile {
+  background: #09090b;
+  border: 1px solid ${COLORS.border};
+  border-radius: 8px;
+  padding: 14px;
+}
+.scope-tile .scope-label {
+  color: ${COLORS.textFaint};
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0;
+  margin-bottom: 8px;
+}
+.scope-tile .scope-value {
+  font-size: 18px;
+  line-height: 1.2;
+  font-weight: 700;
+}
+.scope-tile .scope-copy {
+  color: ${COLORS.textMuted};
+  font-size: 12px;
+  margin-top: 8px;
+}
+.scope-warning {
+  margin-top: 12px;
+  border: 1px solid ${COLORS.caution}55;
+  background: ${COLORS.caution}14;
+  border-radius: 8px;
+  padding: 12px 14px;
+  color: ${COLORS.textMuted};
+  font-size: 13px;
+}
+.scope-warning strong { color: ${COLORS.text}; display: block; margin-bottom: 4px; }
 .source-origin-headline { margin: 0 0 12px; font-size: 14px; color: ${COLORS.text}; }
 .source-origin-headline strong { color: ${COLORS.text}; }
 .source-bars { display: flex; flex-direction: column; gap: 6px; }
@@ -249,18 +397,24 @@ table.report-table th, table.report-table td {
   padding: 10px 12px;
   border-bottom: 1px solid ${COLORS.border};
   vertical-align: top;
-  overflow-wrap: anywhere;
-  word-break: break-word;
+  overflow-wrap: break-word;
+  hyphens: auto;
 }
 table.report-table th {
   font-weight: 600;
   color: ${COLORS.textMuted};
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0;
   font-size: 10px;
 }
 table.report-table td.numeric { text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
 table.report-table td.page-cell { max-width: 0; }
+table.insights-table { table-layout: fixed; }
+table.insights-table th.col-severity, table.insights-table td.col-severity { width: 96px; }
+table.insights-table th.col-query, table.insights-table td.col-query { width: 18%; }
+table.insights-table th.col-provider, table.insights-table td.col-provider { width: 88px; }
+table.insights-table th.col-title, table.insights-table td.col-title { width: 28%; }
+table.insights-table th.col-recommendation, table.insights-table td.col-recommendation { width: auto; }
 table.report-table td.page-cell .page-path {
   display: block;
   font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
@@ -353,7 +507,7 @@ table.report-table td .badge {
 .step .horizon {
   text-transform: uppercase;
   font-size: 10px;
-  letter-spacing: 0.08em;
+  letter-spacing: 0;
   color: ${COLORS.textFaint};
   font-weight: 600;
 }
@@ -368,20 +522,40 @@ table.report-table td .badge {
   background: ${COLORS.surface};
   border: 1px solid ${COLORS.border};
   border-radius: 8px;
-  padding: 18px 20px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.action-card .action-head {
+  display: grid;
+  grid-template-columns: 42px 1fr;
+  gap: 12px;
+  align-items: start;
+}
+.action-card .action-rank {
+  border: 1px solid ${COLORS.border};
+  border-radius: 8px;
+  height: 42px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  font-weight: 800;
+  color: ${COLORS.text};
+  background: #09090b;
 }
 .action-card .action-meta {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  margin-bottom: 10px;
 }
 .action-card h3 {
   font-size: 16px;
-  margin: 0 0 8px;
+  margin: 8px 0 0;
 }
 .action-card p {
-  margin: 0 0 12px;
+  margin: 0;
   color: ${COLORS.textMuted};
 }
 .action-card ul {
@@ -391,6 +565,28 @@ table.report-table td .badge {
   font-size: 13px;
 }
 .action-card li { margin: 4px 0; }
+.proof-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.proof-chip {
+  border: 1px solid ${COLORS.border};
+  border-radius: 8px;
+  padding: 6px 8px;
+  color: ${COLORS.textMuted};
+  font-size: 12px;
+  background: #09090b;
+}
+.action-details {
+  color: ${COLORS.textMuted};
+  font-size: 12px;
+}
+.action-details summary {
+  cursor: pointer;
+  color: ${COLORS.text};
+  font-weight: 600;
+}
 .action-card .success-metric {
   color: ${COLORS.text};
   font-size: 13px;
@@ -426,10 +622,44 @@ table.report-table td .badge {
 .diagnostic-card h3 { font-size: 14px; margin: 0 0 6px; }
 .diagnostic-card p { margin: 0 0 8px; color: ${COLORS.textMuted}; font-size: 13px; }
 .diagnostic-card ul { margin: 0; padding-left: 16px; color: ${COLORS.textMuted}; font-size: 12px; }
+.diagnostic-card .proof-chips { margin-top: 10px; }
 .diagnostic-card.tone-positive { border-left-color: ${COLORS.positive}; }
 .diagnostic-card.tone-caution { border-left-color: ${COLORS.caution}; }
 .diagnostic-card.tone-negative { border-left-color: ${COLORS.negative}; }
 .diagnostic-card.tone-neutral { border-left-color: ${COLORS.neutral}; }
+.opportunity-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+.opportunity-card {
+  background: ${COLORS.surface};
+  border: 1px solid ${COLORS.border};
+  border-radius: 8px;
+  padding: 16px;
+}
+.opportunity-card .opportunity-score {
+  font-size: 32px;
+  line-height: 1;
+  font-weight: 800;
+  margin-bottom: 10px;
+}
+.opportunity-card .opportunity-score-suffix {
+  font-size: 14px;
+  font-weight: 600;
+  color: ${COLORS.textFaint};
+  margin-left: 4px;
+}
+.opportunity-card h3 {
+  font-size: 14px;
+  margin: 0 0 8px;
+}
+.opportunity-card p {
+  color: ${COLORS.textMuted};
+  font-size: 12px;
+  margin: 0;
+}
 .footer {
   margin-top: 96px;
   padding-top: 24px;
@@ -437,6 +667,14 @@ table.report-table td .badge {
   text-align: center;
   color: ${COLORS.textFaint};
   font-size: 12px;
+}
+@media (max-width: 760px) {
+  .container { padding: 32px 16px 72px; }
+  .executive-hero { grid-template-columns: 1fr; }
+  .headline-card .hero-title { font-size: 34px; }
+  .source-bar-row { grid-template-columns: 1fr; gap: 6px; }
+  .source-bar-value { text-align: left; }
+  .chart-grid { grid-template-columns: 1fr; }
 }
 @media print {
   body { background: white; color: black; }
@@ -471,8 +709,97 @@ function locationDisplay(location: ProjectReportDto['meta']['location']): string
 }
 
 function renderHeaderLocationFragment(location: ProjectReportDto['meta']['location']): string {
-  if (!location) return ' · No location set'
-  return ` · Location: ${escapeHtml(locationDisplay(location))}`
+  if (!location) return ' · No market set'
+  return ` · Market: ${escapeHtml(locationDisplay(location))}`
+}
+
+const REPORT_INTENT_STOPWORDS = new Set([
+  'a',
+  'an',
+  'and',
+  'for',
+  'from',
+  'in',
+  'near',
+  'of',
+  'on',
+  'or',
+  'the',
+  'to',
+])
+
+function reportIntentModifiers(report: ProjectReportDto): Set<string> {
+  const location = report.meta.location
+  if (!location) return new Set()
+  return new Set(
+    [location.label, location.city, location.region, location.country]
+      .flatMap(tokenizeReportIntent)
+      .map(normalizeReportIntentToken)
+      .filter(Boolean),
+  )
+}
+
+function dedupeReportActions(
+  report: ProjectReportDto,
+  actions: readonly ReportActionPlanItem[],
+): ReportActionPlanItem[] {
+  const modifiers = reportIntentModifiers(report)
+  if (actions.length <= 1 || modifiers.size === 0) return [...actions]
+
+  const seen = new Set<string>()
+  const result: ReportActionPlanItem[] = []
+  for (const action of actions) {
+    if (action.category !== 'content') {
+      result.push(action)
+      continue
+    }
+    const key = reportIntentKey(extractActionQuery(action), modifiers)
+    if (!key || seen.has(key)) continue
+    seen.add(key)
+    result.push(action)
+  }
+  return result
+}
+
+function dedupeReportOpportunities(
+  report: ProjectReportDto,
+): ProjectReportDto['contentOpportunities'] {
+  const modifiers = reportIntentModifiers(report)
+  const opportunities = report.contentOpportunities
+  if (opportunities.length <= 1 || modifiers.size === 0) return opportunities
+
+  const seen = new Set<string>()
+  return opportunities.filter((opportunity) => {
+    const key = reportIntentKey(opportunity.query, modifiers)
+    if (!key || seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+function extractActionQuery(action: ReportActionPlanItem): string {
+  return action.title.match(/"([^"]+)"/)?.[1]
+    ?? action.successMetric.match(/"([^"]+)"/)?.[1]
+    ?? action.title
+}
+
+function reportIntentKey(value: string, modifiers: ReadonlySet<string>): string {
+  const tokens = tokenizeReportIntent(value)
+    .map(normalizeReportIntentToken)
+    .filter(Boolean)
+    .filter(token => !REPORT_INTENT_STOPWORDS.has(token))
+    .filter(token => !modifiers.has(token))
+  return [...new Set(tokens)].sort().join(' ')
+}
+
+function tokenizeReportIntent(value: string): string[] {
+  return value.toLowerCase().match(/[a-z0-9]+/g) ?? []
+}
+
+function normalizeReportIntentToken(token: string): string {
+  if (token.length > 4 && token.endsWith('ies')) return `${token.slice(0, -3)}y`
+  if (token.length > 4 && token.endsWith('s') && !token.endsWith('ss')) return token.slice(0, -1)
+  return token
 }
 
 function renderLocationCard(report: ProjectReportDto): string {
@@ -480,51 +807,52 @@ function renderLocationCard(report: ProjectReportDto): string {
   const handling = report.meta.providerLocationHandling
   if (!location && handling.length === 0) return ''
 
-  const treatmentTone: Record<string, 'positive' | 'caution' | 'negative' | 'neutral'> = {
-    'request-param': 'positive',
-    prompt: 'positive',
-    'browser-geo': 'caution',
-    ignored: 'negative',
-  }
-  const treatmentLabel: Record<string, string> = {
-    'request-param': 'Request parameter',
-    prompt: 'Prompt-injected',
-    'browser-geo': 'Browser geo',
-    ignored: 'Ignored',
-  }
+  const otherLocations = location?.otherConfiguredLabels ?? []
+  const weakLocationProviders = handling
+    .filter(h => h.treatment === 'ignored' || h.treatment === 'browser-geo')
+    .map(h => h.provider)
 
-  const locationLine = location
-    ? `<p class="location-line"><strong>Location for this run:</strong> ${escapeHtml(locationDisplay(location))}${
-        location.otherConfiguredLabels.length > 0
-          ? ` <span class="cell-pending">— other configured locations (${location.otherConfiguredLabels
-              .map(escapeHtml)
-              .join(', ')}) need their own sweep to compare</span>`
-          : ''
-      }</p>`
-    : `<p class="location-line"><strong>Location for this run:</strong> none — providers received the queries verbatim with no geographic hint.</p>`
+  const marketValue = location ? locationDisplay(location) : 'No market set'
+  const notIncluded = otherLocations.length > 0 ? compactInlineList(otherLocations, 4) : 'None'
+  const interpretation = location
+    ? otherLocations.length > 0
+      ? `${otherLocations.length} configured ${pluralize(otherLocations.length, 'market')} still ${otherLocations.length === 1 ? 'needs' : 'need'} a matching sweep before cross-market recommendations.`
+      : 'Single-market report; findings can be read as the current market view.'
+    : 'No geographic hint was attached to this sweep; read findings as default-market or national results.'
 
-  const handlingRows = handling.length > 0
-    ? handling.map(h => {
-        const tone = treatmentTone[h.treatment] ?? 'neutral'
-        const label = treatmentLabel[h.treatment] ?? h.treatment
-        return `<tr>
-          <td>${escapeHtml(h.provider)}</td>
-          <td><span class="badge tone-${tone}">${escapeHtml(label)}</span></td>
-          <td>${escapeHtml(h.description)}</td>
-        </tr>`
-      }).join('')
-    : ''
-  const handlingTable = handlingRows
-    ? `<table class="report-table">
-        <thead><tr><th>Provider</th><th>Treatment</th><th>How the location reached the model</th></tr></thead>
-        <tbody>${handlingRows}</tbody>
-      </table>`
+  const providerCopy = handling.length > 0
+    ? weakLocationProviders.length > 0
+      ? `${weakLocationProviders.length} ${pluralize(weakLocationProviders.length, 'provider')} need a closer location check.`
+      : `${handling.length} ${pluralize(handling.length, 'provider')} received the market context.`
+    : 'No provider-level location metadata is available for this report.'
+
+  const warning = weakLocationProviders.length > 0
+    ? `<div class="scope-warning">
+        <strong>Location handling needs review</strong>
+        ${escapeHtml(compactInlineList(weakLocationProviders, 4))} used weak or indirect market handling. Treat provider-level differences cautiously.
+      </div>`
     : ''
 
-  return `<div class="chart-card location-card">
-    <h3>Location handling</h3>
-    ${locationLine}
-    ${handlingTable}
+  return `<div class="chart-card market-scope-card">
+    <h3>Market Scope</h3>
+    <div class="market-scope-grid">
+      <div class="scope-tile">
+        <div class="scope-label">Current sweep</div>
+        <div class="scope-value">${escapeHtml(marketValue)}</div>
+        <div class="scope-copy">All findings below are scoped to this run.</div>
+      </div>
+      <div class="scope-tile">
+        <div class="scope-label">Not included</div>
+        <div class="scope-value">${escapeHtml(notIncluded)}</div>
+        <div class="scope-copy">${escapeHtml(interpretation)}</div>
+      </div>
+      <div class="scope-tile">
+        <div class="scope-label">Provider context</div>
+        <div class="scope-value">${handling.length > 0 ? formatNumber(handling.length) : '—'}</div>
+        <div class="scope-copy">${escapeHtml(providerCopy)}</div>
+      </div>
+    </div>
+    ${warning}
   </div>`
 }
 
@@ -540,6 +868,42 @@ function renderExecutiveSummary(report: ProjectReportDto): string {
   const mentionedFragment = s.totalQueryCount > 0
     ? `${s.mentionedQueryCount}/${s.totalQueryCount} ${queryNoun} mentioned`
     : 'no queries'
+  const headlineTitle = s.totalQueryCount > 0
+    ? `${s.citedQueryCount} of ${s.totalQueryCount} tracked ${queryNoun} cite ${report.meta.project.displayName}`
+    : 'No AI citation data yet'
+  const headlineSubtitle = s.totalQueryCount > 0
+    ? `${s.citationRate}% citation coverage and ${s.mentionRate}% mention coverage across ${s.providerCount} ${pluralize(s.providerCount, 'provider')}.`
+    : 'Run a visibility sweep to populate the first citation and mention baseline.'
+  const priorityActions = report.agencyDiagnostics.priorities.length > 0
+    ? report.agencyDiagnostics.priorities
+    : report.actionPlan
+  const actionCount = dedupeReportActions(report, priorityActions).length
+  const heroHtml = `<div class="executive-hero">
+    <div class="headline-card">
+      <div>
+        <div class="hero-kicker">Latest AI visibility sweep</div>
+        <div class="hero-title">${escapeHtml(headlineTitle)}</div>
+      </div>
+      <div class="hero-subtitle">${escapeHtml(headlineSubtitle)}</div>
+    </div>
+    <div class="hero-proof-grid">
+      <div class="hero-proof">
+        <div class="mini-label">Citation trend</div>
+        <div class="mini-value tone-${trendTone}">${escapeHtml(trendLabel)}</div>
+        <div class="mini-copy">${escapeHtml(citedFragment)}</div>
+      </div>
+      <div class="hero-proof">
+        <div class="mini-label">Mention coverage</div>
+        <div class="mini-value">${s.mentionRate}%</div>
+        <div class="mini-copy">${escapeHtml(mentionedFragment)}</div>
+      </div>
+      <div class="hero-proof">
+        <div class="mini-label">Prioritized actions</div>
+        <div class="mini-value">${formatNumber(actionCount)}</div>
+        <div class="mini-copy">Sorted for agency follow-up.</div>
+      </div>
+    </div>
+  </div>`
   const metrics = [
     {
       label: 'Citation rate',
@@ -558,10 +922,11 @@ function renderExecutiveSummary(report: ProjectReportDto): string {
     },
   ]
   if (s.gsc) {
+    const dateRange = gscDateRange(report)
     metrics.push({
       label: 'GSC clicks',
       value: formatNumber(s.gsc.clicks),
-      delta: `${formatNumber(s.gsc.impressions)} imp · ${formatRatio(s.gsc.ctr)} CTR`,
+      delta: `${formatNumber(s.gsc.impressions)} imp · ${formatRatio(s.gsc.ctr)} CTR${dateRange ? ` · ${escapeHtml(dateRange)}` : ''}`,
     })
   }
   if (s.ga) {
@@ -595,9 +960,9 @@ function renderExecutiveSummary(report: ProjectReportDto): string {
       id: 'executive-summary',
       eyebrow: 'Section 1',
       title: 'Executive Summary',
-      intro: 'Two independent signals: Citation rate = share of tracked queries where your domain appeared in the source list the AI used. Mention rate = share of tracked queries where your brand or domain appeared in the answer text itself. A model can mention you without citing your domain, or cite your domain without naming you in the prose. Both are computed per-query so they stay comparable when provider count changes.',
+      intro: 'Citation = source list. Mention = answer text. They are independent signals.',
     },
-    metricsHtml + findingsHtml + locationHtml,
+    heroHtml + metricsHtml + findingsHtml + locationHtml,
   )
 }
 
@@ -657,7 +1022,7 @@ function renderCitationMatrix(scorecard: ProjectReportDto['citationScorecard']):
     return `<tr><td>${escapeHtml(q)}</td>${cells}</tr>`
   }).join('')
 
-  const legend = '<p class="section-intro" style="margin-top:0;font-size:11px;">Each cell shows two flags — <span class="cell-cited">C</span>/<span class="cell-not-cited">c</span> = cited / not cited (your domain in the source list), <span class="cell-cited">M</span>/<span class="cell-not-cited">m</span> = mentioned / not mentioned (your brand in the answer text), <span class="cell-pending">–</span> = no data.</p>'
+  const legend = '<p class="section-intro" style="margin-top:0;font-size:11px;">Legend: <span class="cell-cited">C</span>/<span class="cell-not-cited">c</span> = cited/not, <span class="cell-cited">M</span>/<span class="cell-not-cited">m</span> = mentioned/not, <span class="cell-pending">–</span> = no data.</p>'
 
   return `${legend}<table class="report-table">
     <thead><tr><th>Query</th>${headers}</tr></thead>
@@ -671,7 +1036,7 @@ function renderCitationScorecard(report: ProjectReportDto): string {
     ${renderCitationMatrix(report.citationScorecard)}
   `
   return section(
-    { id: 'citation-scorecard', eyebrow: 'Section 2', title: 'Citation Scorecard', intro: 'Per (query × provider) view of both signals — citations (your domain in the source list) and mentions (your brand in the answer text) — for every tracked query in the latest sweep.' },
+    { id: 'citation-scorecard', eyebrow: 'Section 2', title: 'Citation Scorecard', intro: 'Provider-by-provider citation and mention coverage for the latest sweep.' },
     body,
   )
 }
@@ -775,7 +1140,7 @@ function renderCompetitorLandscape(report: ProjectReportDto): string {
       id: 'competitor-landscape',
       eyebrow: 'Section 3',
       title: 'Competitor Landscape',
-      intro: 'Where tracked competitors appear in AI answers compared to your domain — both in source citations and in the answer text itself.',
+      intro: 'Who AI engines cite and mention instead of the client.',
     },
     `${charts}${table}`,
   )
@@ -823,6 +1188,32 @@ function renderCategoryBars(buckets: AiSourceCategoryBucket[]): string {
   </div>`
 }
 
+function renderShareBars(
+  heading: string,
+  rows: Array<{ label: string; count: number; sharePct: number; color?: string }>,
+  countLabel: string,
+): string {
+  const visibleRows = rows.filter(r => r.count > 0 || r.sharePct > 0)
+  if (visibleRows.length === 0) return ''
+  const bars = visibleRows.map((r, index) => {
+    const pct = Math.max(0, Math.min(100, r.sharePct))
+    const color = r.color ?? COLORS.series[index % COLORS.series.length]
+    return `
+      <div class="source-bar-row">
+        <div class="source-bar-label">${escapeHtml(r.label)}</div>
+        <div class="source-bar-track">
+          <div class="source-bar-fill" style="width:${pct.toFixed(1)}%;background:${color}"></div>
+        </div>
+        <div class="source-bar-value">${formatNumber(r.count)} <span class="source-bar-pct">${escapeHtml(countLabel)} · ${r.sharePct}%</span></div>
+      </div>`
+  }).join('')
+
+  return `<div class="chart-card">
+    <h3>${escapeHtml(heading)}</h3>
+    <div class="source-bars">${bars}</div>
+  </div>`
+}
+
 function renderAiSourceOrigin(report: ProjectReportDto): string {
   const origin = report.aiSourceOrigin
   if (origin.categories.length === 0 && origin.topDomains.length === 0) {
@@ -858,7 +1249,7 @@ function renderAiSourceOrigin(report: ProjectReportDto): string {
       id: 'ai-source-origin',
       eyebrow: 'Section 4',
       title: 'AI Citation Sources',
-      intro: 'Every external website AI engines cited as a source for your tracked queries in the latest sweep, ranked by citation count. Tracked competitors are pulled into their own bucket so you can see how much of the AI’s answer came from rivals; the remaining buckets cover directories, forums, news, and other site types. Your own domains are excluded.',
+      intro: 'External domains AI engines trusted most in the latest sweep.',
     },
     `${headlineFragment}${table}${renderCategoryBars(origin.categories)}`,
   )
@@ -919,13 +1310,16 @@ function renderGsc(report: ProjectReportDto): string {
       <td><span class="badge tone-neutral">${escapeHtml(q.category)}</span></td>
     </tr>`).join('')
 
-  const breakdownRows = gsc.categoryBreakdown.map(c => `
-    <tr>
-      <td>${escapeHtml(c.category)}</td>
-      <td class="numeric">${formatNumber(c.clicks)}</td>
-      <td class="numeric">${formatNumber(c.impressions)}</td>
-      <td class="numeric">${c.sharePct}%</td>
-    </tr>`).join('')
+  const categoryBars = renderShareBars(
+    'Search demand by intent',
+    gsc.categoryBreakdown.map((c, index) => ({
+      label: c.category,
+      count: c.clicks,
+      sharePct: c.sharePct,
+      color: COLORS.series[index % COLORS.series.length],
+    })),
+    'clicks',
+  )
 
   const trendChart = renderLineChart(
     gsc.trend.map(t => ({ x: t.date, y: t.clicks, label: t.date.slice(5) })),
@@ -936,19 +1330,21 @@ function renderGsc(report: ProjectReportDto): string {
   const crossoverBlocks: string[] = []
   if (gsc.trackedButNoGsc.length > 0) {
     crossoverBlocks.push(`<div class="chart-card"><h3>AEO queries without search demand</h3>
-      <p class="section-intro">Tracked AEO queries with no GSC impressions in this window — review whether they represent real search demand.</p>
-      <ul>${gsc.trackedButNoGsc.map(q => `<li>${escapeHtml(q)}</li>`).join('')}</ul>
+      <p class="section-intro">Review whether these still belong in the tracking set.</p>
+      ${renderProofChips(gsc.trackedButNoGsc, 6)}
     </div>`)
   }
   if (gsc.gscButNotTracked.length > 0) {
     crossoverBlocks.push(`<div class="chart-card"><h3>Search queries you should track</h3>
-      <p class="section-intro">GSC top queries (by impressions) that aren't tracked in your AEO project — candidates to add as queries.</p>
-      <ul>${gsc.gscButNotTracked.map(q => `<li>${escapeHtml(q)}</li>`).join('')}</ul>
+      <p class="section-intro">High-impression candidates to add to AEO tracking.</p>
+      ${renderProofChips(gsc.gscButNotTracked, 6)}
     </div>`)
   }
 
+  const dateRange = gscDateRange(report)
+
   return section(
-    { id: 'gsc', eyebrow: 'Section 5', title: 'GSC Performance', intro: 'Your site’s performance in Google’s regular (non-AI) search results — top queries that drove impressions, intent breakdown, and the click trend, sourced from Google Search Console for the most recent sync window.' },
+    { id: 'gsc', eyebrow: 'Section 5', title: 'GSC Performance', intro: `Search demand signals to compare against AI visibility${dateRange ? ` for ${dateRange}` : ''}.` },
     `<div class="metric-grid">
       <div class="metric"><div class="label">Total clicks</div><div class="value">${formatNumber(gsc.totalClicks)}</div></div>
       <div class="metric"><div class="label">Total impressions</div><div class="value">${formatNumber(gsc.totalImpressions)}</div></div>
@@ -962,12 +1358,7 @@ function renderGsc(report: ProjectReportDto): string {
         <tbody>${rows}</tbody>
       </table>
     </div>
-    <div class="chart-card"><h3>Category breakdown</h3>
-      <table class="report-table">
-        <thead><tr><th>Category</th><th class="numeric">Clicks</th><th class="numeric">Imp.</th><th class="numeric">Share</th></tr></thead>
-        <tbody>${breakdownRows}</tbody>
-      </table>
-    </div>
+    ${categoryBars}
     ${crossoverBlocks.join('\n')}`,
   )
 }
@@ -989,15 +1380,19 @@ function renderGa(report: ProjectReportDto): string {
       <td class="numeric">${formatNumber(p.organicSessions)}</td>
     </tr>`).join('')
 
-  const channelRows = ga.channelBreakdown.map(c => `
-    <tr>
-      <td>${escapeHtml(c.channel)}</td>
-      <td class="numeric">${formatNumber(c.sessions)}</td>
-      <td class="numeric">${c.sharePct}%</td>
-    </tr>`).join('')
+  const channelBars = renderShareBars(
+    'Channel mix',
+    ga.channelBreakdown.map((c, index) => ({
+      label: c.channel,
+      count: c.sessions,
+      sharePct: c.sharePct,
+      color: COLORS.series[index % COLORS.series.length],
+    })),
+    'sessions',
+  )
 
   return section(
-    { id: 'ga', eyebrow: 'Section 6', title: 'GA4 Traffic', intro: `Total sessions and users on your site between ${formatDate(ga.periodStart)} and ${formatDate(ga.periodEnd)}, with the top landing pages and channel breakdown — sourced from Google Analytics 4.` },
+    { id: 'ga', eyebrow: 'Section 6', title: 'GA4 Traffic', intro: `Site traffic from ${formatDate(ga.periodStart)} to ${formatDate(ga.periodEnd)}.` },
     `<div class="metric-grid">
       <div class="metric"><div class="label">Total sessions</div><div class="value">${formatNumber(ga.totalSessions)}</div></div>
       <div class="metric"><div class="label">Total users</div><div class="value">${formatNumber(ga.totalUsers)}</div></div>
@@ -1009,12 +1404,7 @@ function renderGa(report: ProjectReportDto): string {
         <tbody>${pageRows}</tbody>
       </table>
     </div>
-    <div class="chart-card"><h3>Channel breakdown</h3>
-      <table class="report-table">
-        <thead><tr><th>Channel</th><th class="numeric">Sessions</th><th class="numeric">Share</th></tr></thead>
-        <tbody>${channelRows}</tbody>
-      </table>
-    </div>`,
+    ${channelBars}`,
   )
 }
 
@@ -1027,12 +1417,16 @@ function renderSocial(report: ProjectReportDto): string {
     )
   }
 
-  const channelRows = social.channels.map(c => `
-    <tr>
-      <td>${escapeHtml(c.channelGroup)}</td>
-      <td class="numeric">${formatNumber(c.sessions)}</td>
-      <td class="numeric">${c.sharePct}%</td>
-    </tr>`).join('')
+  const channelBars = renderShareBars(
+    'Social channel mix',
+    social.channels.map((c, index) => ({
+      label: c.channelGroup,
+      count: c.sessions,
+      sharePct: c.sharePct,
+      color: COLORS.series[index % COLORS.series.length],
+    })),
+    'sessions',
+  )
 
   const campaignRows = social.topCampaigns.map(c => `
     <tr>
@@ -1042,18 +1436,13 @@ function renderSocial(report: ProjectReportDto): string {
     </tr>`).join('')
 
   return section(
-    { id: 'social-referrals', eyebrow: 'Section 7', title: 'Social Referrals', intro: 'Sessions on your site sent by social platforms (LinkedIn, Facebook, X, etc.) — paid versus organic split and the top campaigns that drove them. Sourced from Google Analytics 4.' },
+    { id: 'social-referrals', eyebrow: 'Section 7', title: 'Social Referrals', intro: 'Social traffic split by channel and campaign.' },
     `<div class="metric-grid">
       <div class="metric"><div class="label">Total sessions</div><div class="value">${formatNumber(social.totalSessions)}</div></div>
       <div class="metric"><div class="label">Organic social</div><div class="value">${formatNumber(social.organicSessions)}</div></div>
       <div class="metric"><div class="label">Paid social</div><div class="value">${formatNumber(social.paidSessions)}</div></div>
     </div>
-    <div class="chart-card"><h3>Channel groups</h3>
-      <table class="report-table">
-        <thead><tr><th>Channel</th><th class="numeric">Sessions</th><th class="numeric">Share</th></tr></thead>
-        <tbody>${channelRows}</tbody>
-      </table>
-    </div>
+    ${channelBars}
     <div class="chart-card"><h3>Top campaigns</h3>
       <table class="report-table">
         <thead><tr><th>Source</th><th>Medium</th><th class="numeric">Sessions</th></tr></thead>
@@ -1072,13 +1461,16 @@ function renderAiReferrals(report: ProjectReportDto): string {
     )
   }
 
-  const sourceRows = ai.bySource.map(s => `
-    <tr>
-      <td>${escapeHtml(s.source)}</td>
-      <td class="numeric">${formatNumber(s.sessions)}</td>
-      <td class="numeric">${formatNumber(s.users)}</td>
-      <td class="numeric">${s.sharePct}%</td>
-    </tr>`).join('')
+  const sourceBars = renderShareBars(
+    'AI sessions by source',
+    ai.bySource.map((s, index) => ({
+      label: s.source,
+      count: s.sessions,
+      sharePct: s.sharePct,
+      color: COLORS.series[(index + 2) % COLORS.series.length],
+    })),
+    'sessions',
+  )
 
   const pageRows = ai.topLandingPages.map(p => `
     <tr>
@@ -1094,18 +1486,13 @@ function renderAiReferrals(report: ProjectReportDto): string {
   )
 
   return section(
-    { id: 'ai-referrals', eyebrow: 'Section 8', title: 'AI Referral Traffic', intro: 'Sessions on your site referred by AI answer engines (ChatGPT, Perplexity, Claude, Copilot, Gemini, etc.) — broken down by referrer with a daily trend and the top landing pages. Sourced from Google Analytics 4.' },
+    { id: 'ai-referrals', eyebrow: 'Section 8', title: 'AI Referral Traffic', intro: 'Traffic arriving from AI answer engines.' },
     `<div class="metric-grid">
       <div class="metric"><div class="label">Total sessions</div><div class="value">${formatNumber(ai.totalSessions)}</div></div>
       <div class="metric"><div class="label">Total users</div><div class="value">${formatNumber(ai.totalUsers)}</div></div>
     </div>
     ${trendChart}
-    <div class="chart-card"><h3>Sessions by source</h3>
-      <table class="report-table">
-        <thead><tr><th>Source</th><th class="numeric">Sessions</th><th class="numeric">Users</th><th class="numeric">Share</th></tr></thead>
-        <tbody>${sourceRows}</tbody>
-      </table>
-    </div>
+    ${sourceBars}
     <div class="chart-card"><h3>Top AI landing pages</h3>
       <table class="report-table">
         <thead><tr><th>Page</th><th class="numeric">Sessions</th><th class="numeric">Users</th></tr></thead>
@@ -1146,7 +1533,7 @@ function renderIndexingHealth(report: ProjectReportDto): string {
   const legend = segments.map(s => `<span><span class="legend-swatch" style="background:${s.color}"></span>${escapeHtml(s.label)}: ${s.count}</span>`).join('')
 
   return section(
-    { id: 'indexing-health', eyebrow: 'Section 9', title: 'Indexing Health', intro: `What share of your tracked URLs are currently indexed in ${ih.provider === 'google' ? 'Google' : 'Bing'} — sourced from ${ih.provider === 'google' ? 'Google Search Console URL Inspection' : 'Bing Webmaster Tools URL Inspection'}. Pages absent from the index can’t be retrieved by AI engines either.` },
+    { id: 'indexing-health', eyebrow: 'Section 9', title: 'Indexing Health', intro: `Pages absent from ${ih.provider === 'google' ? 'Google' : 'Bing'} are harder for AI engines to retrieve.` },
     `<div class="metric-grid">
       <div class="metric"><div class="label">Indexed</div><div class="value tone-positive">${formatNumber(ih.indexed)}</div></div>
       <div class="metric"><div class="label">Total inspected</div><div class="value">${formatNumber(ih.total)}</div></div>
@@ -1191,7 +1578,7 @@ function renderCitationsTrend(report: ProjectReportDto): string {
     </tr>`).join('')
 
   return section(
-    { id: 'citations-trend', eyebrow: 'Section 10', title: 'Citations Over Time', intro: 'Citation rate across every visibility sweep — the share of tracked queries cited by at least one provider, with a per-provider breakdown beneath. Computed per-query so the headline stays comparable across runs that ran a different mix of providers.' },
+    { id: 'citations-trend', eyebrow: 'Section 10', title: 'Citations Over Time', intro: 'Citation coverage across completed visibility sweeps.' },
     `${chart}
     <div class="chart-card"><h3>Run-by-run breakdown</h3>
       <table class="report-table">
@@ -1222,28 +1609,42 @@ function renderInsights(report: ProjectReportDto): string {
         ? ` <span class="badge tone-neutral">× ${count}</span>`
         : ''
       return `<tr>
-        <td><span class="badge tone-${tone}">${escapeHtml(i.severity)}</span></td>
-        <td>${escapeHtml(i.title)}${countChip}</td>
-        <td>${escapeHtml(i.query)}</td>
-        <td>${escapeHtml(i.provider)}</td>
-        <td>${i.recommendation ? escapeHtml(i.recommendation) : '<span class="cell-pending">—</span>'}</td>
+        <td class="col-severity"><span class="badge tone-${tone}">${escapeHtml(reportSeverityLabel(i.severity))}</span></td>
+        <td class="col-title">${escapeHtml(i.title)}${countChip}</td>
+        <td class="col-query">${escapeHtml(i.query)}</td>
+        <td class="col-provider">${escapeHtml(i.provider)}</td>
+        <td class="col-recommendation">${i.recommendation ? escapeHtml(i.recommendation) : '<span class="cell-pending">—</span>'}</td>
       </tr>`
     }).join('')
 
   return section(
-    { id: 'insights', eyebrow: 'Section 11', title: 'Insights & Alerts', intro: 'Regressions (citations lost), gains (citations won), and opportunities surfaced by the intelligence engine across the most recent sweeps — ordered by severity and recurrence.' },
-    `<table class="report-table">
-      <thead><tr><th>Severity</th><th>Title</th><th>Query</th><th>Provider</th><th>Recommendation</th></tr></thead>
+    { id: 'insights', eyebrow: 'Section 11', title: 'Insights & Alerts', intro: 'Regressions, gains, and recurring alerts ordered by severity.' },
+    `<table class="report-table insights-table">
+      <thead><tr>
+        <th class="col-severity">Severity</th>
+        <th class="col-title">Title</th>
+        <th class="col-query">Query</th>
+        <th class="col-provider">Provider</th>
+        <th class="col-recommendation">Recommendation</th>
+      </tr></thead>
       <tbody>${rows}</tbody>
     </table>`,
   )
 }
 
 function renderOpportunities(report: ProjectReportDto): string {
-  const opps = report.contentOpportunities
+  const opps = dedupeReportOpportunities(report)
   if (opps.length === 0) return ''
 
   const canonical = report.meta.project.canonicalDomain
+  const highlights = `<div class="opportunity-grid">
+    ${opps.slice(0, 3).map(o => `<article class="opportunity-card">
+      <div class="opportunity-score" title="Opportunity score (0–100, higher = stronger)">${Math.round(o.score)}<span class="opportunity-score-suffix">/100</span></div>
+      <h3>${escapeHtml(o.query)}</h3>
+      <p>${escapeHtml(contentActionLabel(o.action))} · ${escapeHtml(actionConfidenceLabel(o.actionConfidence))} confidence</p>
+      ${renderProofChips(o.drivers, 2)}
+    </article>`).join('')}
+  </div>`
   const rows = opps.slice(0, 10).map((o) => {
     const ourPage = o.ourBestPage
       ? `<a href="${escapeHtml(absolutizeProjectUrl(o.ourBestPage.url, canonical))}">${escapeHtml(o.ourBestPage.url)}</a>`
@@ -1256,12 +1657,12 @@ function renderOpportunities(report: ProjectReportDto): string {
       : '<span class="cell-not-cited">No driver signal yet</span>'
     return `<tr>
       <td>${escapeHtml(o.query)}</td>
-      <td><span class="badge tone-neutral">${escapeHtml(o.action)}</span></td>
-      <td class="numeric">${Math.round(o.score)}</td>
+      <td><span class="badge tone-neutral">${escapeHtml(contentActionLabel(o.action))}</span></td>
+      <td class="numeric" title="Opportunity score (0–100)">${Math.round(o.score)}</td>
       <td>${drivers}</td>
       <td>${ourPage}</td>
       <td>${winning}</td>
-      <td><span class="badge tone-neutral">${escapeHtml(o.actionConfidence)}</span></td>
+      <td><span class="badge tone-neutral">${escapeHtml(actionConfidenceLabel(o.actionConfidence))}</span></td>
     </tr>`
   }).join('')
 
@@ -1270,10 +1671,10 @@ function renderOpportunities(report: ProjectReportDto): string {
       id: 'content-opportunities',
       eyebrow: 'Section 12',
       title: 'Content Opportunities',
-      intro: 'Queries where you have search demand or competitor citation pressure but aren’t winning AI citations. Each row pairs a suggested action (create / refresh / expand / add-schema) with the signals driving the score, the best matching page on your domain, and the competitor URL the AI most often cites. Top 10 shown.',
+      intro: 'Queries where content work has the clearest path to more AI citations. Opportunity score is 0–100, higher = stronger.',
     },
-    `<table class="report-table">
-      <thead><tr><th>Query</th><th>Action</th><th class="numeric">Score</th><th>Why</th><th>Our page</th><th>Winning competitor</th><th>Confidence</th></tr></thead>
+    `${highlights}<table class="report-table">
+      <thead><tr><th>Query</th><th>Action</th><th class="numeric" title="Opportunity score (0–100)">Score</th><th>Why</th><th>Our page</th><th>Winning competitor</th><th>Confidence</th></tr></thead>
       <tbody>${rows}</tbody>
     </table>`,
   )
@@ -1297,7 +1698,7 @@ function renderContentGaps(report: ProjectReportDto): string {
       id: 'content-gaps',
       eyebrow: 'Section 13',
       title: 'Content Gaps',
-      intro: 'Tracked queries where multiple competitors are cited by AI engines but you are not — explicit "they are answering, you are missing" signal. Sorted by recent miss rate, then by number of competitors cited. Top 10 shown.',
+      intro: 'Tracked queries where competitors are cited and the client is missing.',
     },
     `<table class="report-table">
       <thead><tr><th>Query</th><th class="numeric">Competitors cited</th><th>Domains</th><th class="numeric">Miss rate</th></tr></thead>
@@ -1313,7 +1714,7 @@ function renderRecommendedNextSteps(report: ProjectReportDto): string {
   const steps = report.recommendedNextSteps
   if (steps.length === 0) {
     return section(
-      { id: 'recommended-next-steps', eyebrow: 'Section 14', title: 'Recommended Next Steps', intro: 'Action items bucketed by horizon (immediate, short-term, medium-term), drawn from open insights and the highest-ranked content opportunities.' },
+      { id: 'recommended-next-steps', eyebrow: 'Section 14', title: 'Recommended Next Steps', intro: 'Action items bucketed by timing.' },
       renderEmpty('No outstanding actions.'),
     )
   }
@@ -1326,7 +1727,7 @@ function renderRecommendedNextSteps(report: ProjectReportDto): string {
     </div>`).join('')
 
   return section(
-    { id: 'recommended-next-steps', eyebrow: 'Section 14', title: 'Recommended Next Steps', intro: 'Action items bucketed by horizon (immediate, short-term, medium-term), drawn from open insights and the highest-ranked content opportunities.' },
+    { id: 'recommended-next-steps', eyebrow: 'Section 14', title: 'Recommended Next Steps', intro: 'Action items bucketed by timing.' },
     `<div class="steps">${items}</div>`,
   )
 }
@@ -1338,7 +1739,7 @@ function actionAudienceMatches(action: ReportActionPlanItem, audience: ReportAud
 function renderActionCards(actions: readonly ReportActionPlanItem[]): string {
   if (actions.length === 0) return renderEmpty('No prioritized actions yet.')
   return `<div class="action-card-grid">
-    ${actions.map(action => {
+    ${actions.map((action, idx) => {
       const tone = reportActionTone(action)
       const why = action.why.length > 0
         ? `<ul>${action.why.map(item => `<li>${escapeHtml(item)}</li>`).join('')}</ul>`
@@ -1346,36 +1747,50 @@ function renderActionCards(actions: readonly ReportActionPlanItem[]): string {
       const evidence = action.evidence.length > 0
         ? `<ul>${action.evidence.map(item => `<li>${escapeHtml(item)}</li>`).join('')}</ul>`
         : ''
+      const proof = renderProofChips(action.evidence.length > 0 ? action.evidence : action.why, 3)
+      const details = why || evidence
+        ? `<details class="action-details">
+            <summary>Evidence details</summary>
+            ${why ? `<div><strong>Why</strong>${why}</div>` : ''}
+            ${evidence ? `<div><strong>Evidence</strong>${evidence}</div>` : ''}
+          </details>`
+        : ''
       return `<article class="action-card">
-        <div class="action-meta">
-          <span class="badge tone-${tone}">${escapeHtml(action.horizon)}</span>
-          <span class="badge tone-neutral">${escapeHtml(action.category)}</span>
-          <span class="badge tone-neutral">${escapeHtml(action.confidence)} confidence</span>
+        <div class="action-head">
+          <div class="action-rank" title="Impact rank — 1 is the highest-leverage action">${idx + 1}</div>
+          <div>
+            <div class="action-meta">
+              <span class="badge tone-${tone}">${escapeHtml(reportHorizonLabel(action.horizon))}</span>
+              <span class="badge tone-neutral">${escapeHtml(reportActionCategoryLabel(action.category))}</span>
+              <span class="badge tone-neutral">${escapeHtml(reportConfidenceLabel(action.confidence))} confidence</span>
+            </div>
+            <h3>${escapeHtml(action.title)}</h3>
+          </div>
         </div>
-        <h3>${escapeHtml(action.title)}</h3>
         <p>${escapeHtml(action.action)}</p>
-        ${why ? `<div><strong>Why</strong>${why}</div>` : ''}
-        ${evidence ? `<div><strong>Evidence</strong>${evidence}</div>` : ''}
-        <div class="success-metric"><strong>Success metric:</strong> ${escapeHtml(action.successMetric)}</div>
+        ${proof}
+        ${details}
+        <div class="success-metric"><strong>Win condition:</strong> ${escapeHtml(action.successMetric)}</div>
       </article>`
     }).join('')}
   </div>`
 }
 
 function renderAudienceActionPlan(report: ProjectReportDto, audience: ReportAudience): string {
-  const actions = audience === 'client'
+  const rawActions = audience === 'client'
     ? report.clientSummary.actionItems
     : report.agencyDiagnostics.priorities.length > 0
       ? report.agencyDiagnostics.priorities
       : report.actionPlan.filter(a => actionAudienceMatches(a, audience))
+  const actions = dedupeReportActions(report, rawActions)
   return section(
     {
       id: audience === 'client' ? 'client-action-plan' : 'agency-action-plan',
       eyebrow: audience === 'client' ? 'Client actions' : 'Agency actions',
       title: audience === 'client' ? 'What We Recommend Next' : 'Agency Action Plan',
       intro: audience === 'client'
-        ? 'Polished next steps the client can understand, backed by concise evidence from the report.'
-        : 'Technical priorities pulled from the canonical action plan, sorted by urgency and evidence strength.',
+        ? 'The short list to approve and execute.'
+        : 'The highest-leverage work, sorted by urgency and evidence strength.',
     },
     renderActionCards(actions),
   )
@@ -1431,11 +1846,12 @@ function renderClientEvidenceSummary(report: ProjectReportDto): string {
       <ul><li>${formatNumber(report.indexingHealth.indexed)} indexed</li><li>${formatNumber(report.indexingHealth.notIndexed)} not indexed</li></ul>
     </div>`)
   }
-  if (report.contentOpportunities.length > 0) {
+  const opportunities = dedupeReportOpportunities(report)
+  if (opportunities.length > 0) {
     evidenceCards.push(`<div class="diagnostic-card tone-caution">
       <h3>Content opportunities</h3>
       <p>Canonry found topics where better content could improve AI citations.</p>
-      <ul>${report.contentOpportunities.slice(0, 5).map(o => `<li>${escapeHtml(o.query)}: ${escapeHtml(o.action)} (${Math.round(o.score)})</li>`).join('')}</ul>
+      <ul>${opportunities.slice(0, 5).map(o => `<li>${escapeHtml(o.query)}: ${escapeHtml(o.action)} (${Math.round(o.score)})</li>`).join('')}</ul>
     </div>`)
   }
   return section(
@@ -1451,12 +1867,13 @@ function renderClientEvidenceSummary(report: ProjectReportDto): string {
 
 function renderAgencyDiagnostics(report: ProjectReportDto): string {
   const diagnostics = report.agencyDiagnostics.diagnostics
+    .filter(d => d.title !== 'Location caveat')
   const body = diagnostics.length > 0
     ? `<div class="diagnostics-grid">
         ${diagnostics.map(d => `<div class="diagnostic-card tone-${d.severity}">
           <h3>${escapeHtml(d.title)}</h3>
           <p>${escapeHtml(d.detail)}</p>
-          ${d.evidence.length > 0 ? `<ul>${d.evidence.map(e => `<li>${escapeHtml(e)}</li>`).join('')}</ul>` : ''}
+          ${renderProofChips(d.evidence, 3)}
         </div>`).join('')}
       </div>`
     : renderEmpty('No agency diagnostics available yet.')
@@ -1465,7 +1882,7 @@ function renderAgencyDiagnostics(report: ProjectReportDto): string {
       id: 'agency-diagnostics',
       eyebrow: 'Agency diagnostics',
       title: 'Technical Diagnostics',
-      intro: 'Operator-facing diagnostics for content, provider, source-domain, search-demand, indexing, and location follow-up.',
+      intro: 'Fast-read operator flags behind the action plan.',
     },
     body,
   )

--- a/packages/api-routes/src/report.ts
+++ b/packages/api-routes/src/report.ts
@@ -7,6 +7,7 @@ import {
   gaSocialReferrals,
   gaTrafficSnapshots,
   gaTrafficSummaries,
+  gaTrafficWindowSummaries,
   gscCoverageSnapshots,
   gscSearchData,
   insights,
@@ -66,6 +67,21 @@ const TOP_CAMPAIGN_LIMIT = 10
 // Keeps a months-old undismissed regression from cluttering today's
 // report while still surfacing alerts that recur within recent history.
 const INSIGHT_LOOKBACK_RUNS = 5
+// Trailing window for GSC and GA report sections. Anchored on the most
+// recent date present in each dataset (not "today") so reports remain
+// usable when a sync hasn't run for a few days; the two sections may end
+// on slightly different dates but always span the same number of days.
+const REPORT_WINDOW_DAYS = 30
+
+// Returns the inclusive start-date string (YYYY-MM-DD) for a window of
+// `windowDays` ending on `endDate`. `endDate` must already be YYYY-MM-DD.
+function windowStartDate(endDate: string, windowDays: number): string {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(endDate)
+  if (!m) return endDate
+  const d = new Date(Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3])))
+  d.setUTCDate(d.getUTCDate() - (windowDays - 1))
+  return d.toISOString().slice(0, 10)
+}
 
 function safeNum(value: unknown): number {
   if (typeof value === 'number') return value
@@ -136,7 +152,18 @@ function buildGscSection(
   canonicalDomain: string,
   trackedQueries: string[],
 ): ProjectReportDto['gsc'] {
-  const rows = db.select().from(gscSearchData).where(eq(gscSearchData.projectId, projectId)).all()
+  const allRows = db.select().from(gscSearchData).where(eq(gscSearchData.projectId, projectId)).all()
+  if (allRows.length === 0) return null
+
+  // Constrain to the most recent REPORT_WINDOW_DAYS of data so the GSC
+  // section aligns with the GA section. GSC retains up to 16 months, but the
+  // report only ever shows 30 days. Anchor on the latest date in the dataset
+  // rather than "today" — when GSC sync is a few days behind the report
+  // should still cover a full 30-day window of real data.
+  let maxDate = ''
+  for (const r of allRows) if (r.date > maxDate) maxDate = r.date
+  const startDate = windowStartDate(maxDate, REPORT_WINDOW_DAYS)
+  const rows = allRows.filter(r => r.date >= startDate && r.date <= maxDate)
   if (rows.length === 0) return null
 
   let totalClicks = 0
@@ -194,6 +221,8 @@ function buildGscSection(
   const trend = [...trendAgg.entries()]
     .map(([date, agg]) => ({ date, clicks: agg.clicks, impressions: agg.impressions }))
     .sort((a, b) => a.date.localeCompare(b.date))
+  const periodStart = trend[0]?.date ?? ''
+  const periodEnd = trend.at(-1)?.date ?? ''
 
   const trackedSet = new Set(trackedQueries.map(q => q.toLowerCase()))
   const gscQuerySet = new Set([...queryAgg.keys()].map(q => q.toLowerCase()))
@@ -209,6 +238,8 @@ function buildGscSection(
     .slice(0, TOP_QUERIES_LIMIT)
 
   return {
+    periodStart,
+    periodEnd,
     totalClicks,
     totalImpressions,
     ctr,
@@ -222,29 +253,63 @@ function buildGscSection(
 }
 
 function buildGaSection(db: DatabaseClient, projectId: string): ProjectReportDto['ga'] {
-  const summaryRow = db
+  // Prefer the dedicated 30-day window summary so totalUsers reflects the
+  // deduplicated count from GA4 (summing per-page snapshots overcounts users
+  // who landed on multiple pages — that's exactly what this table fixes).
+  const windowSummary = db
     .select()
-    .from(gaTrafficSummaries)
-    .where(eq(gaTrafficSummaries.projectId, projectId))
-    .orderBy(desc(gaTrafficSummaries.syncedAt))
+    .from(gaTrafficWindowSummaries)
+    .where(
+      and(
+        eq(gaTrafficWindowSummaries.projectId, projectId),
+        eq(gaTrafficWindowSummaries.windowKey, '30d'),
+      ),
+    )
     .limit(1)
     .get()
 
-  const snapshotRows = db
+  // Fallback when window summaries haven't been backfilled yet — the older
+  // gaTrafficSummaries table still holds aggregate totals.
+  const fallbackSummary = windowSummary
+    ? null
+    : db
+        .select()
+        .from(gaTrafficSummaries)
+        .where(eq(gaTrafficSummaries.projectId, projectId))
+        .orderBy(desc(gaTrafficSummaries.syncedAt))
+        .limit(1)
+        .get()
+
+  const allSnapshotRows = db
     .select()
     .from(gaTrafficSnapshots)
     .where(eq(gaTrafficSnapshots.projectId, projectId))
     .all()
 
-  if (!summaryRow && snapshotRows.length === 0) return null
+  if (!windowSummary && !fallbackSummary && allSnapshotRows.length === 0) return null
 
-  const totalSessions = summaryRow?.totalSessions ?? snapshotRows.reduce((s, r) => s + r.sessions, 0)
-  const totalUsers = summaryRow?.totalUsers ?? snapshotRows.reduce((s, r) => s + r.users, 0)
-  const totalOrganicSessions = summaryRow?.totalOrganicSessions
+  // Match the GSC section: filter per-page snapshots to the most recent
+  // REPORT_WINDOW_DAYS so the landing-page table and channel mix describe the
+  // same window the headline totals do.
+  let snapshotMaxDate = ''
+  for (const r of allSnapshotRows) if (r.date > snapshotMaxDate) snapshotMaxDate = r.date
+  const snapshotStartDate = snapshotMaxDate ? windowStartDate(snapshotMaxDate, REPORT_WINDOW_DAYS) : ''
+  const snapshotRows = snapshotStartDate
+    ? allSnapshotRows.filter(r => r.date >= snapshotStartDate && r.date <= snapshotMaxDate)
+    : allSnapshotRows
+
+  const totalSessions = windowSummary?.totalSessions
+    ?? fallbackSummary?.totalSessions
+    ?? snapshotRows.reduce((s, r) => s + r.sessions, 0)
+  const totalUsers = windowSummary?.totalUsers
+    ?? fallbackSummary?.totalUsers
+    ?? snapshotRows.reduce((s, r) => s + r.users, 0)
+  const totalOrganicSessions = windowSummary?.totalOrganicSessions
+    ?? fallbackSummary?.totalOrganicSessions
     ?? snapshotRows.reduce((s, r) => s + r.organicSessions, 0)
 
   const pageAgg = new Map<string, { sessions: number; users: number; organic: number }>()
-  let directSessions = 0
+  let directSessions = windowSummary?.totalDirectSessions ?? 0
   for (const r of snapshotRows) {
     const page = r.landingPageNormalized ?? r.landingPage
     const existing = pageAgg.get(page) ?? { sessions: 0, users: 0, organic: 0 }
@@ -252,7 +317,7 @@ function buildGaSection(db: DatabaseClient, projectId: string): ProjectReportDto
     existing.users += r.users
     existing.organic += r.organicSessions
     pageAgg.set(page, existing)
-    if (r.directSessions != null) directSessions += r.directSessions
+    if (!windowSummary && r.directSessions != null) directSessions += r.directSessions
   }
 
   const topLandingPages = [...pageAgg.entries()]
@@ -287,12 +352,20 @@ function buildGaSection(db: DatabaseClient, projectId: string): ProjectReportDto
     }
   }
 
+  // Period reflects whichever totals source was used. Window summary is the
+  // authoritative 30d span; otherwise we report the snapshot-derived window
+  // (which is also 30 days), with the legacy summary as a final fallback.
+  const periodStart = windowSummary?.periodStart
+    ?? (snapshotStartDate || fallbackSummary?.periodStart || '')
+  const periodEnd = windowSummary?.periodEnd
+    ?? (snapshotMaxDate || fallbackSummary?.periodEnd || '')
+
   return {
     totalSessions,
     totalUsers,
     totalOrganicSessions,
-    periodStart: summaryRow?.periodStart ?? '',
-    periodEnd: summaryRow?.periodEnd ?? '',
+    periodStart,
+    periodEnd,
     topLandingPages,
     channelBreakdown,
   }
@@ -1107,22 +1180,6 @@ function buildAgencyDiagnostics(input: ReportActionPlanInput & {
     evidence: input.contentOpportunities.slice(0, 3).map(o => `${o.query}: ${o.action} (${Math.round(o.score)})`),
   })
 
-  if (input.reportLocation) {
-    diagnostics.push({
-      title: 'Location caveat',
-      detail: input.reportLocation.otherConfiguredLabels.length > 0
-        ? 'This report is scoped to the latest run location; other configured locations need separate interpretation.'
-        : 'This report is scoped to one configured location.',
-      severity: input.reportLocation.otherConfiguredLabels.length > 0 ? 'caution' : 'neutral',
-      evidence: [
-        `Current location: ${input.reportLocation.label}`,
-        ...(input.reportLocation.otherConfiguredLabels.length > 0
-          ? [`Other configured locations: ${compactList(input.reportLocation.otherConfiguredLabels)}`]
-          : []),
-      ],
-    })
-  }
-
   return {
     priorities: input.actionPlan.filter(a => actionAudienceMatches(a, 'agency')).slice(0, 6),
     diagnostics,
@@ -1291,6 +1348,8 @@ function buildProjectReport(db: DatabaseClient, projectName: string): ProjectRep
           impressions: gscSection.totalImpressions,
           ctr: gscSection.ctr,
           avgPosition: gscSection.avgPosition,
+          periodStart: gscSection.periodStart,
+          periodEnd: gscSection.periodEnd,
         }
       : null,
     ga: gaSection

--- a/packages/api-routes/test/report-renderer.test.ts
+++ b/packages/api-routes/test/report-renderer.test.ts
@@ -122,7 +122,7 @@ function richReport(): ProjectReportDto {
       queryCount: 5,
       competitorCount: 3,
       providerCount: 2,
-      gsc: { clicks: 1000, impressions: 5000, ctr: 0.2, avgPosition: 4.5 },
+      gsc: { clicks: 1000, impressions: 5000, ctr: 0.2, avgPosition: 4.5, periodStart: '2026-04-01', periodEnd: '2026-04-30' },
       ga: { sessions: 12000, users: 9000, periodStart: '2026-04-01', periodEnd: '2026-04-30' },
       findings: [
         { title: 'Citation rate at 65%', detail: 'Up from previous run.', tone: 'positive' },
@@ -173,6 +173,8 @@ function richReport(): ProjectReportDto {
       ],
     },
     gsc: {
+      periodStart: '2026-04-01',
+      periodEnd: '2026-04-30',
       totalClicks: 1000,
       totalImpressions: 5000,
       ctr: 0.2,
@@ -433,6 +435,20 @@ describe('renderReportHtml', () => {
     expect(html).toMatch(/<title>[^<]*Rich Project[^<]*<\/title>/)
   })
 
+  test('renders date-only reporting ranges without timezone shifting the day', () => {
+    const html = renderReportHtml(richReport())
+    expect(html).toContain('Apr 1, 2026')
+    expect(html).toContain('Apr 30, 2026')
+  })
+
+  test('renders the GSC date range beside the click metric', () => {
+    const html = renderReportHtml(richReport())
+    const executive = html.split('id="executive-summary"')[1]?.split('id="agency-action-plan"')[0] ?? ''
+    const gsc = html.split('id="gsc"')[1]?.split('</section>')[0] ?? ''
+    expect(executive).toContain('5.0K imp · 20.0% CTR · Apr 1, 2026 → Apr 30, 2026')
+    expect(gsc).toContain('Search demand signals to compare against AI visibility for Apr 1, 2026 → Apr 30, 2026.')
+  })
+
   test('handles empty data without throwing', () => {
     expect(() => renderReportHtml(emptyReport())).not.toThrow()
   })
@@ -450,6 +466,172 @@ describe('renderReportHtml', () => {
     expect(html).toContain('id="agency-diagnostics"')
     expect(html).toContain('id="citation-scorecard"')
     expect(html).toContain('Diagnose zero-citation providers')
+  })
+
+  test('renders market scope without visible provider implementation details', () => {
+    const html = renderReportHtml(richReport())
+    const executive = html.split('id="executive-summary"')[1]?.split('id="agency-action-plan"')[0] ?? ''
+    expect(executive).toContain('Market Scope')
+    expect(executive).toContain('Current sweep')
+    expect(executive).toContain('Not included')
+    expect(executive).toContain('florida')
+    expect(executive).not.toContain('Location handling')
+    expect(executive).not.toContain('web_search_preview')
+    expect(executive).not.toContain('How the location reached the model')
+  })
+
+  test('filters legacy location caveat diagnostics from the visible agency report', () => {
+    const report = richReport()
+    report.agencyDiagnostics.diagnostics.push({
+      title: 'Location caveat',
+      detail: 'This report is scoped to the latest run location.',
+      severity: 'caution',
+      evidence: ['Current location: michigan'],
+    })
+    const html = renderReportHtml(report)
+    const diagnostics = html.split('id="agency-diagnostics"')[1]?.split('</section>')[0] ?? ''
+    expect(diagnostics).not.toContain('Location caveat')
+  })
+
+  test('collapses market-modified duplicate content recommendations in saved report payloads', () => {
+    const report = richReport()
+    const baseAction: ProjectReportDto['actionPlan'][number] = {
+      audience: 'both',
+      priority: 20,
+      horizon: 'medium-term',
+      category: 'content',
+      title: 'Create content for "polyurea roof coating"',
+      action: 'Create / so it directly answers the tracked query.',
+      why: ['4 GSC impressions'],
+      evidence: ['Opportunity score 1 with medium confidence'],
+      successMetric: 'A future sweep cites demo.example.com for "polyurea roof coating".',
+      confidence: 'medium',
+    }
+    const marketAction: ProjectReportDto['actionPlan'][number] = {
+      ...baseAction,
+      priority: 21,
+      title: 'Create content for "polyurea roof coating michigan"',
+      action: 'Create a new page for "polyurea roof coating michigan".',
+      why: ['no existing page'],
+      evidence: ['Opportunity score 0 with low confidence'],
+      successMetric: 'A future sweep cites demo.example.com for "polyurea roof coating michigan".',
+      confidence: 'low',
+    }
+    report.actionPlan = [baseAction, marketAction]
+    report.clientSummary.actionItems = [baseAction, marketAction]
+    report.agencyDiagnostics.priorities = [baseAction, marketAction]
+    report.contentOpportunities = [
+      {
+        targetRef: 'polyurea',
+        query: 'polyurea roof coating',
+        action: 'create',
+        ourBestPage: null,
+        winningCompetitor: null,
+        score: 1,
+        scoreBreakdown: { demand: 1, competitor: 0, absence: 1, gapSeverity: 1 },
+        drivers: ['4 GSC impressions'],
+        demandSource: 'gsc',
+        actionConfidence: 'medium',
+        existingAction: null,
+      },
+      {
+        targetRef: 'polyurea-michigan',
+        query: 'polyurea roof coating michigan',
+        action: 'create',
+        ourBestPage: null,
+        winningCompetitor: null,
+        score: 0,
+        scoreBreakdown: { demand: 0, competitor: 0, absence: 1, gapSeverity: 1 },
+        drivers: ['no existing page'],
+        demandSource: 'gsc',
+        actionConfidence: 'low',
+        existingAction: null,
+      },
+    ]
+
+    const html = renderReportHtml(report)
+    const actions = html.split('id="agency-action-plan"')[1]?.split('</section>')[0] ?? ''
+    const opportunities = html.split('id="content-opportunities"')[1]?.split('</section>')[0] ?? ''
+
+    expect(actions).toContain('Create content for &quot;polyurea roof coating&quot;')
+    expect(actions).not.toContain('polyurea roof coating michigan')
+    expect(opportunities).toContain('polyurea roof coating')
+    expect(opportunities).not.toContain('polyurea roof coating michigan')
+  })
+
+  test('action card badges show polished labels, not raw enum codes', () => {
+    // The DTO carries lowercase, hyphenated codes (`'short-term'`, `'high'`,
+    // `'search-demand'`, etc.) that exist for sorting/routing/tone — they
+    // must not reach the user. Symptom we're guarding against: badges that
+    // read "short-term" or "high confidence" instead of "Short term" /
+    // "High confidence". Same class of bug as the rank-number leak.
+    const report = richReport()
+    report.actionPlan = [{
+      audience: 'agency',
+      priority: 50,
+      horizon: 'short-term',
+      category: 'search-demand',
+      title: 'Audit GSC alignment',
+      action: 'Review tracked queries against GSC demand.',
+      why: ['mismatch hides opportunity'],
+      evidence: [],
+      successMetric: 'Tracked set matches GSC.',
+      confidence: 'medium',
+    }]
+    report.agencyDiagnostics.priorities = report.actionPlan
+    const cards = renderReportHtml(report).split('id="agency-action-plan"')[1]?.split('</section>')[0] ?? ''
+    expect(cards).toContain('Short term')
+    expect(cards).toContain('Search demand')
+    expect(cards).toContain('Medium confidence')
+    expect(cards).not.toMatch(/>short-term</)
+    expect(cards).not.toMatch(/>search-demand</)
+    expect(cards).not.toMatch(/>medium confidence</)
+  })
+
+  test('insights table severity badge shows "Critical" not "critical"', () => {
+    const report = richReport()
+    report.insights = [{
+      id: 'i-x',
+      type: 'regression',
+      severity: 'critical',
+      title: 'Lost citation',
+      query: 'q',
+      provider: 'gemini',
+      recommendation: null,
+      createdAt: '2026-04-30T00:00:00Z',
+      instanceCount: 1,
+    }]
+    const block = renderReportHtml(report).split('id="insights"')[1]?.split('</section>')[0] ?? ''
+    expect(block).toContain('>Critical<')
+    expect(block).not.toMatch(/>critical</)
+  })
+
+  test('opportunity card surfaces score scale and title-cased action/confidence', () => {
+    // The opportunity score is 0–100; rendered bare ("87"), users mistake it
+    // for a percent, a rank, or some scoped quality grade. Always pair it
+    // with "/100" or a tooltip so the scale is unambiguous. Action/confidence
+    // chips stay polished too.
+    const html = renderReportHtml(richReport())
+    const opps = html.split('id="content-opportunities"')[1]?.split('</section>')[0] ?? ''
+    expect(opps).toContain('/100')
+    expect(opps).toContain('>Create<')
+    expect(opps).toContain('>High<')
+    expect(opps).not.toMatch(/>create</)
+    expect(opps).not.toMatch(/>high</)
+  })
+
+  test('action rank is sequential 1..N, not the internal priority code', () => {
+    // The DTO's `priority` is a stable internal sort key (10 = competitors,
+    // 20-21 = content, 30 = indexing, 40 = provider, ...). Surfacing those
+    // raw values to the client confused readers — they read "10" as a score.
+    // The renderer should display the visible position in the impact-sorted
+    // list (1, 2, 3, ...) while letting `priority` keep its sort role.
+    const report = richReport()
+    const cards = renderReportHtml(report).split('id="agency-action-plan"')[1]?.split('</section>')[0] ?? ''
+    const ranks = [...cards.matchAll(/<div class="action-rank"[^>]*>(\d+)<\/div>/g)].map(m => m[1])
+    expect(ranks).toEqual(['1', '2'])
+    expect(ranks).not.toContain('10')
+    expect(ranks).not.toContain('20')
   })
 
   test('client mode renders polished actions before concise evidence', () => {
@@ -477,10 +659,15 @@ describe('renderReportHtml', () => {
     expect(html).toContain('openai')
   })
 
-  test('inline CSS allows long table cells to wrap', () => {
+  test('inline CSS allows long table cells to wrap on word boundaries', () => {
+    // overflow-wrap: anywhere broke mid-word inside quoted query strings
+    // (e.g. "polyurea roof coating" in the Insights & Alerts table). Switching
+    // to break-word + hyphens: auto wraps at word boundaries first and only
+    // splits long tokens when no boundary fits.
     const html = renderReportHtml(emptyReport())
-    expect(html).toContain('overflow-wrap: anywhere')
-    expect(html).toContain('word-break: break-word')
+    expect(html).toContain('overflow-wrap: break-word')
+    expect(html).toContain('hyphens: auto')
+    expect(html).not.toContain('overflow-wrap: anywhere')
   })
 
   test('renders landing page URLs with full URL accessible via title', () => {

--- a/packages/api-routes/test/report.test.ts
+++ b/packages/api-routes/test/report.test.ts
@@ -17,6 +17,7 @@ import {
   gscCoverageSnapshots,
   gaTrafficSnapshots,
   gaTrafficSummaries,
+  gaTrafficWindowSummaries,
   gaAiReferrals,
   gaSocialReferrals,
 } from '@ainyc/canonry-db'
@@ -390,7 +391,7 @@ describe('GET /api/v1/projects/:name/report', () => {
         id: crypto.randomUUID(),
         projectId,
         syncRunId,
-        date: '2026-04-30',
+        date: '2026-04-01',
         query: 'best industrial coatings',
         page: 'https://azcoatings.com/blog/best-industrial-coatings',
         clicks: 12,
@@ -445,7 +446,7 @@ describe('GET /api/v1/projects/:name/report', () => {
         id: crypto.randomUUID(),
         projectId,
         syncRunId,
-        date: '2026-04-30',
+        date: '2026-04-01',
         query: 'gsc-test brand',
         page: 'https://gsc-test.example.com/',
         clicks: 100,
@@ -476,13 +477,132 @@ describe('GET /api/v1/projects/:name/report', () => {
     expect(body.gsc).not.toBeNull()
     expect(body.gsc!.totalClicks).toBe(130)
     expect(body.gsc!.totalImpressions).toBe(1100)
+    expect(body.gsc!.periodStart).toBe('2026-04-01')
+    expect(body.gsc!.periodEnd).toBe('2026-04-30')
     expect(body.gsc!.topQueries.length).toBe(2)
     expect(body.gsc!.topQueries[0]!.query).toBe('gsc-test brand')
 
     const brandRow = body.gsc!.categoryBreakdown.find(c => c.category === 'brand')
     expect(brandRow?.clicks).toBe(100)
 
-    expect(body.executiveSummary.gsc).toMatchObject({ clicks: 130, impressions: 1100 })
+    expect(body.executiveSummary.gsc).toMatchObject({
+      clicks: 130,
+      impressions: 1100,
+      periodStart: '2026-04-01',
+      periodEnd: '2026-04-30',
+    })
+  })
+
+  test('GSC section trims to the most recent 30 days when older history is present', async () => {
+    // GSC retains up to 16 months. The report only ever shows 30 days so it
+    // stays aligned with the GA window. Older rows must be excluded from the
+    // headline totals (and the period must reflect the trimmed window).
+    const projectId = insertProject(ctx.db, 'gsc-window')
+    const syncRunId = insertRun(ctx.db, projectId, { kind: 'gsc-sync' })
+    const baseRow = {
+      projectId,
+      syncRunId,
+      query: 'gsc-window topic',
+      page: 'https://gsc-window.example.com/',
+      ctr: '0.05',
+      position: '5',
+      createdAt: new Date().toISOString(),
+    }
+    ctx.db.insert(gscSearchData).values([
+      // Inside the 30-day window (anchored to 2026-04-30, so 2026-04-01 onwards):
+      { id: crypto.randomUUID(), ...baseRow, date: '2026-04-01', clicks: 5, impressions: 100 },
+      { id: crypto.randomUUID(), ...baseRow, date: '2026-04-30', clicks: 10, impressions: 200 },
+      // Outside the 30-day window (>= 31 days before max date):
+      { id: crypto.randomUUID(), ...baseRow, date: '2026-03-15', clicks: 999, impressions: 9999 },
+      { id: crypto.randomUUID(), ...baseRow, date: '2025-12-01', clicks: 999, impressions: 9999 },
+    ]).run()
+
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/gsc-window/report' })
+    const body = JSON.parse(res.body) as ProjectReportDto
+
+    expect(body.gsc).not.toBeNull()
+    expect(body.gsc!.totalClicks).toBe(15)
+    expect(body.gsc!.totalImpressions).toBe(300)
+    expect(body.gsc!.periodStart).toBe('2026-04-01')
+    expect(body.gsc!.periodEnd).toBe('2026-04-30')
+  })
+
+  test('GA section uses the 30d window summary for accurate deduplicated user totals', async () => {
+    // gaTrafficSnapshots.users overcounts when a user lands on multiple pages.
+    // gaTrafficWindowSummaries['30d'] holds the deduplicated GA4 figure — when
+    // it exists, it must drive the headline. The period must match too so the
+    // GA range stays aligned with the 30-day GSC range.
+    const projectId = insertProject(ctx.db, 'ga-window')
+    ctx.db.insert(gaTrafficWindowSummaries).values({
+      id: crypto.randomUUID(),
+      projectId,
+      windowKey: '30d',
+      periodStart: '2026-04-01',
+      periodEnd: '2026-04-30',
+      totalSessions: 7777,
+      totalOrganicSessions: 4444,
+      totalDirectSessions: 1111,
+      totalUsers: 5555,
+      syncedAt: new Date().toISOString(),
+    }).run()
+    // Older legacy summary row that should be ignored when the window summary exists.
+    ctx.db.insert(gaTrafficSummaries).values({
+      id: crypto.randomUUID(),
+      projectId,
+      periodStart: '2024-01-01',
+      periodEnd: '2024-12-31',
+      totalSessions: 1,
+      totalOrganicSessions: 1,
+      totalUsers: 1,
+      syncedAt: new Date().toISOString(),
+    }).run()
+
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/ga-window/report' })
+    const body = JSON.parse(res.body) as ProjectReportDto
+
+    expect(body.ga).not.toBeNull()
+    expect(body.ga!.totalSessions).toBe(7777)
+    expect(body.ga!.totalUsers).toBe(5555)
+    expect(body.ga!.totalOrganicSessions).toBe(4444)
+    expect(body.ga!.periodStart).toBe('2026-04-01')
+    expect(body.ga!.periodEnd).toBe('2026-04-30')
+    // Direct-channel total must come from the window summary, not be summed from snapshots.
+    const direct = body.ga!.channelBreakdown.find(c => c.channel === 'Direct')
+    expect(direct?.sessions).toBe(1111)
+  })
+
+  test('GA section trims per-page snapshots to the same 30-day window', async () => {
+    const projectId = insertProject(ctx.db, 'ga-page-window')
+    ctx.db.insert(gaTrafficWindowSummaries).values({
+      id: crypto.randomUUID(),
+      projectId,
+      windowKey: '30d',
+      periodStart: '2026-04-01',
+      periodEnd: '2026-04-30',
+      totalSessions: 1500,
+      totalOrganicSessions: 1000,
+      totalDirectSessions: 200,
+      totalUsers: 1200,
+      syncedAt: new Date().toISOString(),
+    }).run()
+    ctx.db.insert(gaTrafficSnapshots).values([
+      { id: crypto.randomUUID(), projectId, date: '2026-04-30', landingPage: '/', sessions: 500, organicSessions: 300, users: 400, syncedAt: new Date().toISOString() },
+      { id: crypto.randomUUID(), projectId, date: '2026-04-15', landingPage: '/blog', sessions: 200, organicSessions: 150, users: 180, syncedAt: new Date().toISOString() },
+      // Old page outside the window — must be excluded from topLandingPages.
+      { id: crypto.randomUUID(), projectId, date: '2025-09-01', landingPage: '/legacy', sessions: 9999, organicSessions: 9999, users: 9999, syncedAt: new Date().toISOString() },
+    ]).run()
+
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/ga-page-window/report' })
+    const body = JSON.parse(res.body) as ProjectReportDto
+
+    expect(body.ga).not.toBeNull()
+    const pages = body.ga!.topLandingPages.map(p => p.page)
+    expect(pages).toContain('/')
+    expect(pages).toContain('/blog')
+    expect(pages).not.toContain('/legacy')
   })
 
   test('GA traffic, social referral, AI referral sections aggregate from GA tables', async () => {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.7.2",
+  "version": "4.8.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/contracts/src/content.ts
+++ b/packages/contracts/src/content.ts
@@ -8,6 +8,16 @@ export const contentActionSchema = z.enum(['create', 'expand', 'refresh', 'add-s
 export type ContentAction = z.infer<typeof contentActionSchema>
 export const ContentActions = contentActionSchema.enum
 
+/** Title-cased label for `ContentAction` — never render the raw enum to UI. */
+export function contentActionLabel(action: ContentAction): string {
+  switch (action) {
+    case 'create': return 'Create'
+    case 'expand': return 'Expand'
+    case 'refresh': return 'Refresh'
+    case 'add-schema': return 'Add schema'
+  }
+}
+
 export const demandSourceSchema = z.enum(['gsc', 'competitor-evidence', 'both'])
 export type DemandSource = z.infer<typeof demandSourceSchema>
 export const DemandSources = demandSourceSchema.enum
@@ -15,6 +25,15 @@ export const DemandSources = demandSourceSchema.enum
 export const actionConfidenceSchema = z.enum(['high', 'medium', 'low'])
 export type ActionConfidence = z.infer<typeof actionConfidenceSchema>
 export const ActionConfidences = actionConfidenceSchema.enum
+
+/** Title-cased label for `ActionConfidence` — never render the raw enum to UI. */
+export function actionConfidenceLabel(confidence: ActionConfidence): string {
+  switch (confidence) {
+    case 'high': return 'High'
+    case 'medium': return 'Medium'
+    case 'low': return 'Low'
+  }
+}
 
 export const pageTypeSchema = z.enum([
   'blog-post',

--- a/packages/contracts/src/report.ts
+++ b/packages/contracts/src/report.ts
@@ -106,6 +106,8 @@ export interface ReportExecutiveSummary {
     impressions: number
     ctr: number
     avgPosition: number
+    periodStart: string
+    periodEnd: string
   } | null
   /** GA4 totals across the most-recent sync period. Null when GA4 is not connected. */
   ga: {
@@ -235,6 +237,8 @@ export interface GscQueryRow {
 }
 
 export interface GscSection {
+  periodStart: string
+  periodEnd: string
   totalClicks: number
   totalImpressions: number
   ctr: number
@@ -440,6 +444,50 @@ export function reportActionTone(
   if (action.confidence === 'high') return 'caution'
   if (action.confidence === 'low') return 'neutral'
   return 'caution'
+}
+
+/**
+ * Human-readable labels for enum values that appear in the report DTO. The
+ * underlying field values (e.g. `'short-term'`, `'add-schema'`) are stable
+ * identifiers used for routing, sorting, and tone — never render them
+ * directly to the UI. Always run them through these helpers so titles,
+ * badges, and summaries read like prose.
+ */
+export function reportSeverityLabel(severity: ReportInsight['severity']): string {
+  switch (severity) {
+    case 'critical': return 'Critical'
+    case 'high': return 'High'
+    case 'medium': return 'Medium'
+    case 'low': return 'Low'
+  }
+}
+
+export function reportHorizonLabel(horizon: ReportActionHorizon): string {
+  switch (horizon) {
+    case 'immediate': return 'Immediate'
+    case 'short-term': return 'Short term'
+    case 'medium-term': return 'Medium term'
+  }
+}
+
+export function reportActionCategoryLabel(category: ReportActionCategory): string {
+  switch (category) {
+    case 'content': return 'Content'
+    case 'competitors': return 'Competitors'
+    case 'provider': return 'Provider'
+    case 'search-demand': return 'Search demand'
+    case 'indexing': return 'Indexing'
+    case 'location': return 'Location'
+    case 'monitoring': return 'Monitoring'
+  }
+}
+
+export function reportConfidenceLabel(confidence: ReportActionConfidence): string {
+  switch (confidence) {
+    case 'high': return 'High'
+    case 'medium': return 'Medium'
+    case 'low': return 'Low'
+  }
 }
 
 export interface ProjectReportDto {

--- a/packages/intelligence/src/content-targets.ts
+++ b/packages/intelligence/src/content-targets.ts
@@ -84,6 +84,12 @@ export interface OrchestratorInput {
   competitors: string[]
 
   candidateQueries: CandidateQuery[]
+  /**
+   * Optional terms to ignore when grouping recommendation targets by user intent.
+   * Report callers pass the active market tokens here so "roof coating" and
+   * "roof coating michigan" do not become duplicate content recommendations.
+   */
+  queryIntentModifiers?: readonly string[]
   inventory: SitePage[]
   wpSchemaAudit: Map<string, boolean>
   gaTrafficByPage: Map<string, number>
@@ -179,7 +185,10 @@ export function buildContentTargetRows(input: OrchestratorInput): ContentTargetR
     })
   }
 
-  return rows.sort((a, b) => b.score - a.score)
+  return dedupeByIntent(
+    rows.sort((a, b) => b.score - a.score),
+    input.queryIntentModifiers ?? [],
+  )
 }
 
 // ─── Sources ────────────────────────────────────────────────────────────────
@@ -276,6 +285,64 @@ function computeAiReferralFactor(totalAiReferralSessions: number, competitorCoun
   const baseline = Math.min(totalAiReferralSessions / 1000, 0.5)
   const competitorBoost = competitorCount > 0 ? 0.1 : 0
   return Math.min(baseline + competitorBoost, 1.0)
+}
+
+const QUERY_INTENT_STOPWORDS = new Set([
+  'a',
+  'an',
+  'and',
+  'at',
+  'by',
+  'for',
+  'from',
+  'in',
+  'near',
+  'of',
+  'on',
+  'or',
+  'the',
+  'to',
+])
+
+function dedupeByIntent(
+  rows: ContentTargetRowDto[],
+  modifiers: readonly string[],
+): ContentTargetRowDto[] {
+  if (rows.length <= 1 || modifiers.length === 0) return rows
+
+  const seen = new Set<string>()
+  const result: ContentTargetRowDto[] = []
+  const modifierTokens = new Set(
+    modifiers.flatMap(tokenizeQuery).map(normalizeToken).filter(Boolean),
+  )
+
+  for (const row of rows) {
+    const key = intentKey(row.query, modifierTokens)
+    if (!key || seen.has(key)) continue
+    seen.add(key)
+    result.push(row)
+  }
+
+  return result
+}
+
+function intentKey(query: string, modifierTokens: ReadonlySet<string>): string {
+  const tokens = tokenizeQuery(query)
+    .map(normalizeToken)
+    .filter(Boolean)
+    .filter(token => !QUERY_INTENT_STOPWORDS.has(token))
+    .filter(token => !modifierTokens.has(token))
+  return [...new Set(tokens)].sort().join(' ')
+}
+
+function tokenizeQuery(value: string): string[] {
+  return value.toLowerCase().match(/[a-z0-9]+/g) ?? []
+}
+
+function normalizeToken(token: string): string {
+  if (token.length > 4 && token.endsWith('ies')) return `${token.slice(0, -3)}y`
+  if (token.length > 4 && token.endsWith('s') && !token.endsWith('ss')) return token.slice(0, -1)
+  return token
 }
 
 function pickTopCompetitor(

--- a/packages/intelligence/test/content-targets.test.ts
+++ b/packages/intelligence/test/content-targets.test.ts
@@ -253,6 +253,42 @@ describe('buildContentTargetRows', () => {
     expect(rows[0].score).toBeGreaterThan(rows[1].score)
   })
 
+  it('dedupes market-modified query variants when intent modifiers are supplied', () => {
+    const baseQuery = emptyCandidate({
+      query: 'polyurea roof coating',
+      gscImpressions: 400,
+      gscClicks: 4,
+      recentMissRate: 1,
+      runsOfHistory: 5,
+    })
+    const marketQuery = emptyCandidate({
+      query: 'polyurea roof coating michigan',
+      gscImpressions: 25,
+      gscClicks: 0,
+      recentMissRate: 1,
+      runsOfHistory: 5,
+    })
+
+    const unscoped = buildContentTargetRows(
+      emptyInput({
+        candidateQueries: [baseQuery, marketQuery],
+      }),
+    )
+    expect(unscoped.map(row => row.query).sort()).toEqual([
+      'polyurea roof coating',
+      'polyurea roof coating michigan',
+    ])
+
+    const scoped = buildContentTargetRows(
+      emptyInput({
+        queryIntentModifiers: ['michigan', 'detroit', 'mi'],
+        candidateQueries: [baseQuery, marketQuery],
+      }),
+    )
+    expect(scoped).toHaveLength(1)
+    expect(scoped[0].query).toBe('polyurea roof coating')
+  })
+
   it('annotates rows with existingAction when in-progress actions exist', () => {
     const rows = buildContentTargetRows(
       emptyInput({


### PR DESCRIPTION
## Summary
- Bundles the client-report cleanup from #425 with three follow-on fixes: Insights & Alerts wrapped mid-word inside quoted query strings (switched to `overflow-wrap: break-word` + per-column widths); GSC and GA date ranges drifted apart (both now clamped to a 30-day window — GA prefers `gaTrafficWindowSummaries['30d']` for deduped user totals, GSC filters to the last 30 days anchored on the latest data date); action cards displayed the internal priority sort key (10/20/30…) as a big bold number — replaced with sequential 1..N rank.
- Audit on top surfaced the same class of leak everywhere — raw enum codes (`short-term`, `search-demand`, `high`, `critical`, `create`) shown as labels and bare opportunity scores (`87`) with no scale. Promoted `reportSeverityLabel` / `reportHorizonLabel` / `reportActionCategoryLabel` / `reportConfidenceLabel` into `@ainyc/canonry-contracts` and `contentActionLabel` / `actionConfidenceLabel` into the content domain so the HTML renderer and React dashboard share one source of truth.
- Opportunity scores now render as `87/100` with tooltips and an updated section subtitle. Version bumped to 4.8.0.

## Test plan
- [x] `pnpm run typecheck` and `pnpm run lint` clean across the workspace
- [x] `pnpm run test` — 2073 tests pass (added 6 new: 3 GSC/GA window, 1 sequential rank, 3 polished-label assertions)
- [x] Generate an HTML report against a project with >30d of GSC history and verify the GSC and GA sections both label as 30-day windows
- [x] Verify Insights & Alerts table wraps cleanly with multi-word queries
- [x] Verify action cards show "1, 2, 3" ranks and badges read "Short term" / "Search demand" / "High confidence"