### PR TITLE
feat(report): plain-English client view with bigger numbers + explainers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -348,6 +348,51 @@ const totalBySource = referrals.reduce((acc, r) => { ... }, {})
 // GET /projects/:name/ga/attribution returns { channelBreakdown: [...] }
 ```
 
+### Report parity (Critical)
+
+**The downloadable HTML report and the in-app report SPA must always show the same sections, the same labels, the same numbers, and the same visual structure.** Clients and agencies see one report — only the surface differs. They are two renderers of the same DTO; never let them diverge.
+
+#### Rules
+
+1. **One DTO, two renderers.** `apps/web/src/pages/ReportPage.tsx` (SPA) and `packages/api-routes/src/report-renderer.ts` (HTML) consume the same `ProjectReportDto`. Any change to one must land in the other in the same change.
+2. **Section parity per audience.** For each `audience` (`'client' | 'agency'`), the SPA and HTML must render the same ordered set of sections with the same eyebrows, titles, and subtitles.
+3. **Same copy, same numbers.** Tile labels, headlines, action-card copy, evidence-card titles, and chart axis labels must match verbatim across both surfaces. If the SPA says "AI mentions your name", the HTML says "AI mentions your name" — not "Mention coverage".
+4. **Visual parity in spirit.** The HTML can't render React components, but every chart, progress bar, hero block, and badge in the SPA must have a visual equivalent in the HTML (inline SVG, CSS, or table). Don't ship a chart in one surface that doesn't exist in the other.
+5. **Test both renderers.** When you change client/agency copy or section structure, update `packages/api-routes/test/report-renderer.test.ts` so the HTML asserts the new strings, and verify the SPA visually before merging.
+
+#### Anti-patterns
+
+```typescript
+// ❌ Wrong — SPA renames a tile but HTML keeps the old label
+// ReportPage.tsx
+<Metric label="AI mentions your name" value={...} />
+// report-renderer.ts (unchanged, drifts)
+<div class="metric"><div class="label">Mention coverage</div>...</div>
+
+// ✅ Correct — both surfaces updated together
+// ReportPage.tsx
+<Metric label="AI mentions your name" value={...} />
+// report-renderer.ts
+<div class="metric"><div class="label">AI mentions your name</div>...</div>
+```
+
+```typescript
+// ❌ Wrong — adding a chart to the SPA only
+// ReportPage.tsx renders <ProviderBreakdownChart />
+// report-renderer.ts has no equivalent
+
+// ✅ Correct — add an inline-SVG version in the HTML renderer too
+```
+
+#### Checklist for any report change
+
+- [ ] Updated SPA section in `apps/web/src/pages/ReportPage.tsx`
+- [ ] Updated HTML section in `packages/api-routes/src/report-renderer.ts`
+- [ ] Section order matches between SPA and HTML for each audience
+- [ ] All visible strings (eyebrows, titles, subtitles, labels) match verbatim
+- [ ] Charts/progress bars/heroes have visual equivalents in both surfaces
+- [ ] `report-renderer.test.ts` updated to assert the new strings
+
 ### Agent & automation design principles
 
 The CLI and API **are** the agent interface. MCP is allowed only as an adapter over the public API client. It is not a parallel surface and must not introduce capabilities unavailable through API/CLI. No virtual filesystem, no privileged agent SDK. If an AI agent can't do something with `canonry <command> --format json` or an HTTP call, it's a bug.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,10 @@ The web dashboard follows a dark, professional analytics aesthetic inspired by *
 - Custom SVG is allowed only for non-chart visualizations (gauges, sparklines, timelines) where Recharts is overkill.
 - If Recharts is missing a feature, extend `ChartPrimitives.tsx` rather than adding a second library.
 
+### Report parity (Critical)
+
+**The downloadable HTML report (`canonry report` / `GET /report.html`) and the in-app SPA report view must stay perfectly aligned.** They are two renderers of the same `ProjectReportDto` — clients and agencies see one report. Any change to a section, label, headline, chart, tile, or order in `apps/web/src/pages/ReportPage.tsx` must ship the same change in `packages/api-routes/src/report-renderer.ts` in the same commit, and vice versa. Tile labels, eyebrows, titles, subtitles, action-card copy, and evidence-card titles must match verbatim across both. Update `packages/api-routes/test/report-renderer.test.ts` whenever client/agency strings change. See AGENTS.md "Report parity" for the full rule set.
+
 ### Don'ts
 - Don't use hero grids with large descriptive text blocks on the project page. Keep headers compact.
 - Don't put evidence or findings in card grids. Use tables.
@@ -61,6 +65,7 @@ The web dashboard follows a dark, professional analytics aesthetic inspired by *
 - Don't create new component files unless the component is reused across 3+ pages.
 - Don't import `recharts` directly — use `ChartPrimitives.js`.
 - Don't add alternative charting libraries (Highcharts, Chart.js, D3, etc.).
+- Don't change report copy or sections in only one of the SPA / HTML surfaces — they must move together.
 
 ## Skills Maintenance
 

--- a/apps/web/src/pages/ReportPage.tsx
+++ b/apps/web/src/pages/ReportPage.tsx
@@ -214,7 +214,7 @@ export function ReportPage({ projectName }: { projectName: string }) {
     <div>
       <div className="page-header">
         <div className="page-header-left">
-          <p className="eyebrow">AEO Report</p>
+          <p className="eyebrow">AI Visibility Report</p>
           <h1 className="page-title">{report.meta.project.displayName}</h1>
           <p className="page-subtitle">
             {report.meta.project.canonicalDomain} · {report.meta.project.country} / {report.meta.project.language.toUpperCase()}
@@ -259,14 +259,14 @@ export function ReportPage({ projectName }: { projectName: string }) {
       {audience === 'client' ? (
         <>
           <ClientSummarySection report={report} />
-          <WhatsChangedSection report={report} />
+          <WhatsChangedSection report={report} audience="client" />
           <ActionPlanSection report={report} audience="client" />
           <ClientEvidenceSection report={report} />
         </>
       ) : (
         <>
           <ExecutiveSummarySection report={report} />
-          <WhatsChangedSection report={report} />
+          <WhatsChangedSection report={report} audience="agency" />
           <ActionPlanSection report={report} audience="agency" />
           <AgencyDiagnosticsSection report={report} />
           <CitationScorecardSection report={report} />
@@ -292,21 +292,116 @@ function actionAudienceMatches(action: ReportActionPlanItem, audience: ReportAud
   return action.audience === 'both' || action.audience === audience
 }
 
+const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
+  gemini: 'Gemini',
+  openai: 'ChatGPT',
+  claude: 'Claude',
+  perplexity: 'Perplexity',
+  local: 'Local model',
+  'cdp:chatgpt': 'ChatGPT (browser)',
+}
+
+function providerDisplayName(name: string): string {
+  return PROVIDER_DISPLAY_NAMES[name] ?? name.charAt(0).toUpperCase() + name.slice(1)
+}
+
+function clientTrendCopy(delta: ProjectReportDto['whatsChanged']['citationRate']): { text: string; tone: MetricTone; arrow: string } | null {
+  if (!delta) return null
+  if (delta.direction === 'up') {
+    return { text: `Up ${delta.deltaAbs.toFixed(1)} points since last check (was ${delta.prior}%)`, tone: 'positive', arrow: '↑' }
+  }
+  if (delta.direction === 'down') {
+    return { text: `Down ${Math.abs(delta.deltaAbs).toFixed(1)} points since last check (was ${delta.prior}%)`, tone: 'negative', arrow: '↓' }
+  }
+  return { text: `Holding steady since last check (was ${delta.prior}%)`, tone: 'neutral', arrow: '→' }
+}
+
 function ClientSummarySection({ report }: { report: ProjectReportDto }) {
   const exec = report.executiveSummary
+  const sc = report.citationScorecard
+  const totalQ = exec.totalQueryCount
+  const heroNumber = totalQ > 0 ? `${exec.citationRate}%` : '—'
+  const heroSentence = totalQ > 0
+    ? `When customers asked AI ${totalQ} ${totalQ === 1 ? 'question' : 'questions'} about your industry, AI linked to your website in ${exec.citedQueryCount} of ${totalQ === 1 ? 'them' : 'those answers'}.`
+    : 'No AI check has been run yet. Run a check to see how AI tools answer customer questions about your business.'
+  const trend = clientTrendCopy(report.whatsChanged.citationRate)
+  const providerSubtitle = sc.providers.length > 0
+    ? sc.providers.map(providerDisplayName).join(', ')
+    : `${formatNumber(exec.queryCount)} ${exec.queryCount === 1 ? 'question' : 'questions'} tested`
+
   return (
     <section className="page-section-divider">
-      <SectionHeading eyebrow="Client summary" title="How you're appearing" subtitle={report.clientSummary.overview} />
-      <div className="rounded-xl border border-zinc-800/60 bg-zinc-900/30 p-4">
-        <p className="text-sm font-medium text-zinc-100">{report.clientSummary.headline}</p>
-        <p className="mt-1 text-sm text-zinc-400">{report.clientSummary.overview}</p>
+      <div className="rounded-2xl border border-zinc-800/60 bg-zinc-900/40 p-6 sm:p-8">
+        <p className="text-[11px] font-semibold uppercase tracking-wider text-zinc-500">Overview</p>
+        <p className="mt-3 text-6xl font-bold tracking-tight text-zinc-50 sm:text-7xl">{heroNumber}</p>
+        <p className="mt-3 max-w-2xl text-base text-zinc-300 sm:text-lg">{heroSentence}</p>
+        {trend && (
+          <p className={`mt-3 text-sm font-medium ${trend.tone === 'positive' ? 'text-emerald-400' : trend.tone === 'negative' ? 'text-rose-400' : 'text-zinc-400'}`}>
+            <span className="mr-1">{trend.arrow}</span>{trend.text}
+          </p>
+        )}
       </div>
-      <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        <Metric label="Citation coverage" value={formatPercent(exec.citationRate, 0)} tone={trendTone(exec.trend)} subtitle={`${exec.citedQueryCount}/${exec.totalQueryCount} tracked queries cited`} />
-        <Metric label="Mention coverage" value={formatPercent(exec.mentionRate, 0)} subtitle={`${exec.mentionedQueryCount}/${exec.totalQueryCount} tracked queries mentioned`} />
-        <Metric label="Providers checked" value={formatNumber(exec.providerCount)} subtitle={`${formatNumber(exec.queryCount)} tracked queries`} />
-        {exec.gsc && <Metric label="Search impressions" value={formatNumber(exec.gsc.impressions)} subtitle={`${formatNumber(exec.gsc.clicks)} clicks`} />}
+
+      <div className="mt-5 grid gap-4 sm:grid-cols-3">
+        <BigMetricTile
+          label="AI mentions your name"
+          value={`${exec.mentionRate}%`}
+          subtitle={totalQ > 0 ? `Says your name in ${exec.mentionedQueryCount} of ${totalQ} ${totalQ === 1 ? 'answer' : 'answers'}` : 'No data yet'}
+        />
+        <BigMetricTile
+          label="AI links to your website"
+          value={`${exec.citationRate}%`}
+          subtitle={totalQ > 0 ? `Cites your site as a source in ${exec.citedQueryCount} of ${totalQ} ${totalQ === 1 ? 'answer' : 'answers'}` : 'No data yet'}
+        />
+        <BigMetricTile
+          label="AI tools tested"
+          value={formatNumber(exec.providerCount)}
+          subtitle={providerSubtitle}
+        />
       </div>
+
+      <div className="mt-4 rounded-xl border border-zinc-800/60 bg-zinc-950/40 px-4 py-3 text-xs text-zinc-400">
+        <span className="font-semibold text-zinc-200">Mentions and links are different.</span>{' '}
+        A <span className="font-medium text-zinc-200">mention</span> is when AI says your name out loud in its answer.
+        A <span className="font-medium text-zinc-200">link</span> is when AI lists your website as a source it used.
+        AI can do either, both, or neither — that's why we track both.
+      </div>
+
+      {sc.queries.length > 0 && (
+        <div className="mt-5 rounded-xl border border-zinc-800/60 bg-zinc-900/30 p-5">
+          <p className="text-sm font-semibold text-zinc-100">Customer questions we tested</p>
+          <p className="mt-1 text-xs text-zinc-500">These are the {sc.queries.length} {sc.queries.length === 1 ? 'question we asked' : 'questions we asked'} every AI tool. The numbers above measure how often you came up.</p>
+          <ol className="mt-4 grid gap-2 sm:grid-cols-2">
+            {sc.queries.map((q, i) => (
+              <li key={i} className="flex items-start gap-3 rounded-lg border border-zinc-800/60 bg-zinc-950/40 px-3 py-2 text-sm text-zinc-200">
+                <span className="shrink-0 text-xs font-semibold tabular-nums text-zinc-500">{String(i + 1).padStart(2, '0')}</span>
+                <span>"{q}"</span>
+              </li>
+            ))}
+          </ol>
+        </div>
+      )}
+
+      {sc.providerRates.length > 0 && (
+        <div className="mt-5 rounded-xl border border-zinc-800/60 bg-zinc-900/30 p-5">
+          <p className="text-sm font-semibold text-zinc-100">How often each AI tool links to your website</p>
+          <p className="mt-1 text-xs text-zinc-500">Higher is better. Each bar shows the share of customer questions where the AI cited your site.</p>
+          <div className="mt-4 space-y-3">
+            {sc.providerRates.map(r => (
+              <div key={r.provider} className="grid grid-cols-[120px_1fr_120px] items-center gap-3">
+                <span className="text-sm text-zinc-300">{providerDisplayName(r.provider)}</span>
+                <div className="h-3 overflow-hidden rounded-full bg-zinc-800/80">
+                  <div className="h-full rounded-full bg-emerald-500/70" style={{ width: `${Math.max(r.citationRate, 1.5)}%` }} />
+                </div>
+                <span className="text-right text-sm font-semibold text-zinc-100">
+                  {r.citationRate}% <span className="font-normal text-zinc-500">({r.citedCount}/{r.totalCount})</span>
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       {report.clientSummary.confidenceNotes.length > 0 && (
         <div className="mt-4 grid gap-2">
           {report.clientSummary.confidenceNotes.map((note, i) => (
@@ -318,6 +413,32 @@ function ClientSummarySection({ report }: { report: ProjectReportDto }) {
   )
 }
 
+function BigMetricTile({ label, value, subtitle }: { label: string; value: string; subtitle: string }) {
+  return (
+    <div className="rounded-xl border border-zinc-800/60 bg-zinc-900/30 p-5">
+      <p className="text-[11px] font-semibold uppercase tracking-wider text-zinc-500">{label}</p>
+      <p className="mt-3 text-4xl font-bold tracking-tight text-zinc-50 sm:text-5xl">{value}</p>
+      <p className="mt-2 text-xs text-zinc-500">{subtitle}</p>
+    </div>
+  )
+}
+
+function clientHorizonLabel(horizon: ReportActionPlanItem['horizon']): string {
+  switch (horizon) {
+    case 'immediate': return 'Do now'
+    case 'short-term': return 'This month'
+    case 'medium-term': return 'Next quarter'
+  }
+}
+
+function clientConfidenceLabel(confidence: ReportActionPlanItem['confidence']): string {
+  switch (confidence) {
+    case 'high': return 'Strong evidence'
+    case 'medium': return 'Some evidence'
+    case 'low': return 'Worth trying'
+  }
+}
+
 function ActionPlanSection({ report, audience }: { report: ProjectReportDto; audience: ReportAudience }) {
   const rawActions = audience === 'client'
     ? report.clientSummary.actionItems
@@ -325,15 +446,16 @@ function ActionPlanSection({ report, audience }: { report: ProjectReportDto; aud
       ? report.agencyDiagnostics.priorities
       : report.actionPlan.filter(a => actionAudienceMatches(a, audience))
   const actions = dedupeReportActions(report, rawActions)
+  const isClient = audience === 'client'
   return (
     <section className="page-section-divider">
       <SectionHeading
-        eyebrow={audience === 'client' ? 'Client actions' : 'Agency actions'}
-        title={audience === 'client' ? 'What We Recommend Next' : 'Agency Action Plan'}
-        subtitle={audience === 'client' ? 'The short list to approve and execute.' : 'The highest-leverage work, sorted by urgency and evidence strength.'}
+        eyebrow={isClient ? 'Action plan' : 'Agency actions'}
+        title={isClient ? 'What to do next' : 'Agency Action Plan'}
+        subtitle={isClient ? 'Approve these in order. They are sorted by what will move the needle fastest.' : 'The highest-leverage work, sorted by urgency and evidence strength.'}
       />
       {actions.length === 0 ? (
-        <EmptyHint message="No prioritized actions yet." />
+        <EmptyHint message="No recommendations yet — run an AI check to populate this." />
       ) : (
         <div className="grid gap-3 lg:grid-cols-2">
           {actions.map((action, idx) => {
@@ -344,15 +466,15 @@ function ActionPlanSection({ report, audience }: { report: ProjectReportDto; aud
                 <div className="flex items-start gap-3">
                   <div
                     className="flex size-8 shrink-0 items-center justify-center rounded-full bg-zinc-800/80 text-sm font-semibold text-zinc-100"
-                    title="Impact rank — 1 is the highest-leverage action"
+                    title="Priority — 1 will move the needle fastest"
                   >
                     {idx + 1}
                   </div>
                   <div className="min-w-0 flex-1">
                     <div className="mb-2 flex flex-wrap gap-2">
-                      <ToneBadge tone={reportActionTone(action)}>{reportHorizonLabel(action.horizon)}</ToneBadge>
-                      <ToneBadge tone="neutral">{reportActionCategoryLabel(action.category)}</ToneBadge>
-                      <ToneBadge tone="neutral">{reportConfidenceLabel(action.confidence)} confidence</ToneBadge>
+                      <ToneBadge tone={reportActionTone(action)}>{isClient ? clientHorizonLabel(action.horizon) : reportHorizonLabel(action.horizon)}</ToneBadge>
+                      {!isClient && <ToneBadge tone="neutral">{reportActionCategoryLabel(action.category)}</ToneBadge>}
+                      <ToneBadge tone="neutral">{isClient ? clientConfidenceLabel(action.confidence) : `${reportConfidenceLabel(action.confidence)} confidence`}</ToneBadge>
                     </div>
                     <p className="text-sm font-medium text-zinc-100">{action.title}</p>
                   </div>
@@ -361,10 +483,10 @@ function ActionPlanSection({ report, audience }: { report: ProjectReportDto; aud
                 <ProofChips items={proof} limit={3} className="mt-3" />
                 {hasDetails && (
                   <details className="mt-3 text-xs text-zinc-400">
-                    <summary className="cursor-pointer text-zinc-500 hover:text-zinc-300">Evidence details</summary>
+                    <summary className="cursor-pointer text-zinc-500 hover:text-zinc-300">{isClient ? 'See the data behind this' : 'Evidence details'}</summary>
                     {action.why.length > 0 && (
                       <div className="mt-2">
-                        <p className="eyebrow-soft mb-1">Why</p>
+                        <p className="eyebrow-soft mb-1">{isClient ? 'Why this matters' : 'Why'}</p>
                         <ul className="list-disc space-y-1 pl-4">
                           {action.why.map((item, i) => <li key={i}>{item}</li>)}
                         </ul>
@@ -372,7 +494,7 @@ function ActionPlanSection({ report, audience }: { report: ProjectReportDto; aud
                     )}
                     {action.evidence.length > 0 && (
                       <div className="mt-2">
-                        <p className="eyebrow-soft mb-1">Evidence</p>
+                        <p className="eyebrow-soft mb-1">{isClient ? 'What we saw' : 'Evidence'}</p>
                         <ul className="list-disc space-y-1 pl-4">
                           {action.evidence.map((item, i) => <li key={i}>{item}</li>)}
                         </ul>
@@ -381,7 +503,7 @@ function ActionPlanSection({ report, audience }: { report: ProjectReportDto; aud
                   </details>
                 )}
                 <p className="mt-3 border-t border-zinc-800/60 pt-3 text-xs text-zinc-300">
-                  <span className="font-medium">Win condition:</span> {action.successMetric}
+                  <span className="font-medium">{isClient ? 'What success looks like:' : 'Win condition:'}</span> {action.successMetric}
                 </p>
               </article>
             )
@@ -414,77 +536,116 @@ function AgencyDiagnosticsSection({ report }: { report: ProjectReportDto }) {
   )
 }
 
-function ClientEvidenceSection({ report }: { report: ProjectReportDto }) {
-  const cards: Array<{
-    key: string
-    tone: MetricTone
-    title: string
-    detail: string
-    items: string[]
-  }> = []
+function HorizontalBarRow({ label, value, displayValue, max, barClass }: { label: string; value: number; displayValue: string; max: number; barClass: string }) {
+  const pct = max > 0 ? Math.max((value / max) * 100, 1.5) : 0
+  return (
+    <div className="grid grid-cols-[1fr_auto] items-center gap-3 text-sm">
+      <div className="min-w-0">
+        <p className="truncate text-zinc-300" title={label}>{label}</p>
+        <div className="mt-1 h-2 overflow-hidden rounded-full bg-zinc-800/80">
+          <div className={`h-full rounded-full ${barClass}`} style={{ width: `${pct}%` }} />
+        </div>
+      </div>
+      <span className="whitespace-nowrap text-sm font-semibold text-zinc-100">{displayValue}</span>
+    </div>
+  )
+}
 
-  if (report.aiSourceOrigin.topDomains.length > 0) {
-    cards.push({
-      key: 'source-domains',
-      tone: 'neutral',
-      title: 'Sources AI engines trust',
-      detail: 'These domains appeared most often as cited sources outside your owned domain.',
-      items: report.aiSourceOrigin.topDomains.slice(0, 5).map(d => `${d.domain}: ${formatNumber(d.count)} citation${d.count === 1 ? '' : 's'}`),
-    })
-  }
-  if (report.gsc) {
-    cards.push({
-      key: 'search-demand',
-      tone: 'neutral',
-      title: 'Search demand',
-      detail: `Search Console shows ${formatNumber(report.gsc.totalImpressions)} impressions and ${formatNumber(report.gsc.totalClicks)} clicks in the report window.`,
-      items: report.gsc.topQueries.slice(0, 5).map(q => `${q.query}: ${formatNumber(q.impressions)} impressions`),
-    })
-  }
-  if (report.indexingHealth) {
-    cards.push({
-      key: 'indexing',
-      tone: report.indexingHealth.indexedPct >= 90 ? 'positive' : report.indexingHealth.indexedPct >= 70 ? 'caution' : 'negative',
-      title: 'Indexing readiness',
-      detail: `${report.indexingHealth.indexedPct}% of inspected URLs are indexed.`,
-      items: [
-        `${formatNumber(report.indexingHealth.indexed)} indexed`,
-        `${formatNumber(report.indexingHealth.notIndexed)} not indexed`,
-      ],
-    })
-  }
-  const dedupedOpportunities = dedupeReportOpportunities(report)
-  if (dedupedOpportunities.length > 0) {
-    cards.push({
-      key: 'content',
-      tone: 'caution',
-      title: 'Content opportunities',
-      detail: 'Canonry found topics where better content could improve AI citations.',
-      items: dedupedOpportunities.slice(0, 5).map(o => `${o.query}: ${o.action} (${Math.round(o.score)})`),
-    })
-  }
+function ClientEvidenceSection({ report }: { report: ProjectReportDto }) {
+  const ai = report.aiSourceOrigin.topDomains.slice(0, 5)
+  const gsc = report.gsc
+  const indexing = report.indexingHealth
+  const opportunities = dedupeReportOpportunities(report).slice(0, 5)
+
+  const aiMax = ai.length > 0 ? Math.max(...ai.map(d => d.count)) : 0
+  const gscMax = gsc ? Math.max(...gsc.topQueries.slice(0, 5).map(q => q.impressions), 1) : 0
+
+  const hasAnything = ai.length > 0 || gsc !== null || indexing !== null || opportunities.length > 0
 
   return (
     <section className="page-section-divider">
-      <SectionHeading eyebrow="Evidence" title="Why this is the plan" subtitle="Concise support for the client summary. Switch to Agency for the detailed tables and matrices." />
-      {cards.length === 0 ? (
-        <EmptyHint message="No supporting evidence sections are populated yet." />
+      <SectionHeading
+        eyebrow="What we based this on"
+        title="The signals behind this plan"
+        subtitle="The data behind the recommendations above. Switch to Agency for the full breakdowns."
+      />
+      {!hasAnything ? (
+        <EmptyHint message="No supporting evidence yet — this fills in after the first AI check." />
       ) : (
-        <div className="grid gap-3 lg:grid-cols-2">
-          {cards.map(card => (
-            <div key={card.key} className="rounded-xl border border-zinc-800/60 bg-zinc-900/30 p-4">
-              <div className="mb-2 flex items-center gap-2">
-                <ToneBadge tone={card.tone}>{card.tone}</ToneBadge>
-                <p className="text-sm font-medium text-zinc-100">{card.title}</p>
+        <div className="grid gap-4 lg:grid-cols-2">
+          {ai.length > 0 && (
+            <div className="rounded-xl border border-zinc-800/60 bg-zinc-900/30 p-5">
+              <p className="text-sm font-semibold text-zinc-100">Where AI gets its answers</p>
+              <p className="mt-1 text-xs text-zinc-500">The websites AI tools cited most often when answering customer questions about your industry.</p>
+              <div className="mt-4 space-y-3">
+                {ai.map(d => (
+                  <HorizontalBarRow
+                    key={d.domain}
+                    label={d.domain + (d.isCompetitor ? ' (competitor)' : '')}
+                    value={d.count}
+                    displayValue={`${formatNumber(d.count)}×`}
+                    max={aiMax}
+                    barClass="bg-zinc-400/70"
+                  />
+                ))}
               </div>
-              <p className="text-sm text-zinc-400">{card.detail}</p>
-              {card.items.length > 0 && (
-                <ul className="mt-3 list-disc space-y-1 pl-4 text-xs text-zinc-500">
-                  {card.items.map((item, i) => <li key={i}>{item}</li>)}
-                </ul>
+            </div>
+          )}
+          {indexing && (
+            <div className="rounded-xl border border-zinc-800/60 bg-zinc-900/30 p-5">
+              <p className="text-sm font-semibold text-zinc-100">Pages Google can find on your site</p>
+              <p className="mt-1 text-xs text-zinc-500">Google indexing your site increases the chances of it appearing in AI search (especially Gemini).</p>
+              <p className={`mt-4 text-5xl font-bold tracking-tight ${indexing.indexedPct >= 90 ? 'text-emerald-400' : indexing.indexedPct >= 70 ? 'text-amber-400' : 'text-rose-400'}`}>
+                {indexing.indexedPct}%
+              </p>
+              <p className="mt-1 text-xs text-zinc-500">{formatNumber(indexing.indexed)} of {formatNumber(indexing.total)} pages indexed</p>
+              <div className="mt-3 h-3 overflow-hidden rounded-full bg-zinc-800/80">
+                <div
+                  className={`h-full rounded-full ${indexing.indexedPct >= 90 ? 'bg-emerald-500/70' : indexing.indexedPct >= 70 ? 'bg-amber-500/70' : 'bg-rose-500/70'}`}
+                  style={{ width: `${Math.max(indexing.indexedPct, 1.5)}%` }}
+                />
+              </div>
+              <p className="mt-3 text-xs text-zinc-400">
+                <span className="font-medium text-zinc-200">{formatNumber(indexing.notIndexed)}</span> {indexing.notIndexed === 1 ? 'page is' : 'pages are'} not indexed yet.
+              </p>
+            </div>
+          )}
+          {gsc && (
+            <div className="rounded-xl border border-zinc-800/60 bg-zinc-900/30 p-5">
+              <p className="text-sm font-semibold text-zinc-100">What people search Google for</p>
+              <p className="mt-1 text-xs text-zinc-500">
+                You appeared in <span className="font-semibold text-zinc-200">{formatNumber(gsc.totalImpressions)}</span> Google searches and got <span className="font-semibold text-zinc-200">{formatNumber(gsc.totalClicks)}</span> {gsc.totalClicks === 1 ? 'click' : 'clicks'} this period.
+              </p>
+              {gsc.topQueries.length > 0 && (
+                <div className="mt-4 space-y-3">
+                  {gsc.topQueries.slice(0, 5).map(q => (
+                    <HorizontalBarRow
+                      key={q.query}
+                      label={q.query}
+                      value={q.impressions}
+                      displayValue={`${formatNumber(q.impressions)} ${q.impressions === 1 ? 'search' : 'searches'}`}
+                      max={gscMax}
+                      barClass="bg-sky-500/70"
+                    />
+                  ))}
+                </div>
               )}
             </div>
-          ))}
+          )}
+          {opportunities.length > 0 && (
+            <div className="rounded-xl border border-zinc-800/60 bg-zinc-900/30 p-5">
+              <p className="text-sm font-semibold text-zinc-100">Topics where you could improve</p>
+              <p className="mt-1 text-xs text-zinc-500">Customer questions where better content on your site would help AI cite you.</p>
+              <ul className="mt-4 space-y-2 text-sm text-zinc-300">
+                {opportunities.map((o, i) => (
+                  <li key={i} className="rounded-lg border border-zinc-800/60 bg-zinc-950/40 px-3 py-2">
+                    <p className="font-medium text-zinc-100">{o.query}</p>
+                    <p className="mt-0.5 text-xs text-zinc-400">{contentActionLabel(o.action)}</p>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
       )}
     </section>
@@ -686,21 +847,24 @@ function TrafficDeltaTile({
 
 function ProviderMovementsTable({
   movements,
+  audience,
 }: {
   movements: ProjectReportDto['whatsChanged']['providerMovements']
+  audience: ReportAudience
 }) {
   const meaningful = movements.filter(m => m.direction !== 'flat')
   if (meaningful.length === 0) return null
+  const isClient = audience === 'client'
   return (
     <div className="mt-4">
-      <p className="eyebrow mb-2">AI engine movements</p>
+      <p className="eyebrow mb-2">{isClient ? 'How each AI tool changed' : 'AI engine movements'}</p>
       <div className="evidence-table-wrap">
         <table className="evidence-table">
           <thead>
             <tr>
-              <th>Engine</th>
-              <th>Prior</th>
-              <th>Current</th>
+              <th>{isClient ? 'AI tool' : 'Engine'}</th>
+              <th>{isClient ? 'Was' : 'Prior'}</th>
+              <th>{isClient ? 'Now' : 'Current'}</th>
               <th>Change</th>
             </tr>
           </thead>
@@ -713,7 +877,7 @@ function ProviderMovementsTable({
                 : 'text-zinc-300'
               return (
                 <tr key={m.provider}>
-                  <td>{m.provider}</td>
+                  <td>{isClient ? providerDisplayName(m.provider) : m.provider}</td>
                   <td>{m.prior}%</td>
                   <td>{m.current}%</td>
                   <td className={cellClass}>
@@ -733,10 +897,12 @@ function WinsLossesTable({
   insights,
   heading,
   emptyMessage,
+  audience,
 }: {
   insights: readonly ReportInsight[]
   heading: string
   emptyMessage: string
+  audience: ReportAudience
 }) {
   if (insights.length === 0) {
     return (
@@ -746,6 +912,7 @@ function WinsLossesTable({
       </div>
     )
   }
+  const isClient = audience === 'client'
   return (
     <div className="mt-4">
       <p className="eyebrow mb-2">{heading}</p>
@@ -753,22 +920,24 @@ function WinsLossesTable({
         <table className="evidence-table">
           <thead>
             <tr>
-              <th>Severity</th>
-              <th>Title</th>
-              <th>Query</th>
-              <th>Provider</th>
+              {!isClient && <th>Severity</th>}
+              <th>{isClient ? 'What changed' : 'Title'}</th>
+              <th>{isClient ? 'Customer question' : 'Query'}</th>
+              <th>{isClient ? 'AI tool' : 'Provider'}</th>
             </tr>
           </thead>
           <tbody>
             {insights.map(i => (
               <tr key={i.id}>
-                <td>
-                  <ToneBadge tone={SEVERITY_TONE[i.severity]}>{reportSeverityLabel(i.severity)}</ToneBadge>
-                  {i.instanceCount > 1 && <span className="ml-2 text-[11px] text-zinc-500">×{i.instanceCount}</span>}
-                </td>
-                <td className="evidence-query-cell">{i.title}</td>
+                {!isClient && (
+                  <td>
+                    <ToneBadge tone={SEVERITY_TONE[i.severity]}>{reportSeverityLabel(i.severity)}</ToneBadge>
+                    {i.instanceCount > 1 && <span className="ml-2 text-[11px] text-zinc-500">×{i.instanceCount}</span>}
+                  </td>
+                )}
+                <td className="evidence-query-cell">{i.title}{isClient && i.instanceCount > 1 && <span className="ml-2 text-[11px] text-zinc-500">×{i.instanceCount}</span>}</td>
                 <td className="text-xs text-zinc-400">{i.query}</td>
-                <td className="text-xs text-zinc-400">{i.provider}</td>
+                <td className="text-xs text-zinc-400">{isClient ? providerDisplayName(i.provider) : i.provider}</td>
               </tr>
             ))}
           </tbody>
@@ -778,34 +947,42 @@ function WinsLossesTable({
   )
 }
 
-function WhatsChangedSection({ report }: { report: ProjectReportDto }) {
+function WhatsChangedSection({ report, audience }: { report: ProjectReportDto; audience: ReportAudience }) {
   const w = report.whatsChanged
+  const isClient = audience === 'client'
   const everythingEmpty = !w.enoughHistory
     && !w.gscClicksDelta
     && !w.aiReferralsDelta
     && w.wins.length === 0
     && w.regressions.length === 0
+  const heading = (
+    <SectionHeading
+      eyebrow={isClient ? 'Since last check' : 'Section 2'}
+      title={isClient ? "What's different since last check" : "What's Changed"}
+      subtitle={isClient ? undefined : w.headline}
+    />
+  )
   if (everythingEmpty) {
     return (
       <section className="page-section-divider">
-        <SectionHeading eyebrow="Section 2" title="What's Changed" subtitle={w.headline} />
-        <EmptyHint message="Trends will appear after a few more checks." />
+        {heading}
+        <EmptyHint message={isClient ? 'No comparison yet — trends will appear after a few more checks.' : 'Trends will appear after a few more checks.'} />
       </section>
     )
   }
   return (
     <section className="page-section-divider">
-      <SectionHeading eyebrow="Section 2" title="What's Changed" subtitle={w.headline} />
+      {heading}
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
-        <RateDeltaTile label="Citation rate" delta={w.citationRate} unit="%" />
-        <RateDeltaTile label="Mention rate" delta={w.mentionRate} unit="%" />
-        <RateDeltaTile label="Cited queries" delta={w.citedQueryCount} unit="count" />
-        <TrafficDeltaTile label="GSC clicks" delta={w.gscClicksDelta} countLabel="clicks" />
-        <TrafficDeltaTile label="AI referral sessions" delta={w.aiReferralsDelta} countLabel="sessions" />
+        <RateDeltaTile label={isClient ? 'AI links to your website' : 'Citation rate'} delta={w.citationRate} unit="%" />
+        <RateDeltaTile label={isClient ? 'AI mentions your name' : 'Mention rate'} delta={w.mentionRate} unit="%" />
+        <RateDeltaTile label={isClient ? 'Questions AI answered with you' : 'Cited queries'} delta={w.citedQueryCount} unit="count" />
+        <TrafficDeltaTile label={isClient ? 'Visitors from Google' : 'GSC clicks'} delta={w.gscClicksDelta} countLabel={isClient ? 'visits' : 'clicks'} />
+        <TrafficDeltaTile label={isClient ? 'Visitors from AI tools' : 'AI referral sessions'} delta={w.aiReferralsDelta} countLabel={isClient ? 'visits' : 'sessions'} />
       </div>
-      <ProviderMovementsTable movements={w.providerMovements} />
-      <WinsLossesTable insights={w.wins} heading="Wins" emptyMessage="No new gains in the latest check." />
-      <WinsLossesTable insights={w.regressions} heading="Regressions" emptyMessage="No new regressions in the latest check." />
+      <ProviderMovementsTable movements={w.providerMovements} audience={audience} />
+      <WinsLossesTable insights={w.wins} heading={isClient ? 'What got better' : 'Wins'} emptyMessage={isClient ? 'No new wins this period.' : 'No new gains in the latest check.'} audience={audience} />
+      <WinsLossesTable insights={w.regressions} heading={isClient ? 'What got worse' : 'Regressions'} emptyMessage={isClient ? 'Nothing got worse this period.' : 'No new regressions in the latest check.'} audience={audience} />
     </section>
   )
 }

--- a/apps/web/src/pages/ReportPage.tsx
+++ b/apps/web/src/pages/ReportPage.tsx
@@ -176,7 +176,6 @@ function pressureTone(label: CompetitorRow['pressureLabel']): MetricTone {
 export function ReportPage({ projectName }: { projectName: string }) {
   const [downloading, setDownloading] = useState(false)
   const [downloadError, setDownloadError] = useState<string | null>(null)
-  const [audience, setAudience] = useState<ReportAudience>('agency')
 
   const reportQuery = useQuery({
     queryKey: queryKeys.report(projectName),
@@ -187,7 +186,7 @@ export function ReportPage({ projectName }: { projectName: string }) {
     setDownloading(true)
     setDownloadError(null)
     try {
-      await downloadReportHtml(projectName, audience)
+      await downloadReportHtml(projectName, 'client')
     } catch (err) {
       const message = err instanceof ApiError ? err.message : err instanceof Error ? err.message : 'Download failed'
       setDownloadError(message)
@@ -226,24 +225,6 @@ export function ReportPage({ projectName }: { projectName: string }) {
           {downloadError && <p className="mt-2 text-xs text-rose-400">{downloadError}</p>}
         </div>
         <div className="page-header-right">
-          <div className="inline-flex rounded-lg border border-zinc-800/70 bg-zinc-950/60 p-1" role="tablist" aria-label="Report audience">
-            {(['agency', 'client'] as const).map(mode => (
-              <button
-                key={mode}
-                type="button"
-                role="tab"
-                aria-selected={audience === mode}
-                onClick={() => setAudience(mode)}
-                className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${
-                  audience === mode
-                    ? 'bg-zinc-100 text-zinc-950'
-                    : 'text-zinc-400 hover:text-zinc-100'
-                }`}
-              >
-                {mode === 'agency' ? 'Agency' : 'Client'}
-              </button>
-            ))}
-          </div>
           <Button
             variant="secondary"
             size="sm"
@@ -256,34 +237,10 @@ export function ReportPage({ projectName }: { projectName: string }) {
         </div>
       </div>
 
-      {audience === 'client' ? (
-        <>
-          <ClientSummarySection report={report} />
-          <WhatsChangedSection report={report} audience="client" />
-          <ActionPlanSection report={report} audience="client" />
-          <ClientEvidenceSection report={report} />
-        </>
-      ) : (
-        <>
-          <ExecutiveSummarySection report={report} />
-          <WhatsChangedSection report={report} audience="agency" />
-          <ActionPlanSection report={report} audience="agency" />
-          <AgencyDiagnosticsSection report={report} />
-          <CitationScorecardSection report={report} />
-          <CompetitorLandscapeSection report={report} />
-          <AiSourceOriginSection report={report} />
-          <GscPerformanceSection report={report} />
-          <GaTrafficSection report={report} />
-          <SocialReferralsSection report={report} />
-          <AiReferralsSection report={report} />
-          <IndexingHealthSectionView report={report} />
-          <CitationsTrendSection report={report} />
-          <InsightsSection report={report} />
-          <ContentOpportunitiesSection report={report} />
-          <ContentGapsSection report={report} />
-          <NextStepsSection report={report} />
-        </>
-      )}
+      <ClientSummarySection report={report} />
+      <WhatsChangedSection report={report} audience="client" />
+      <ActionPlanSection report={report} audience="client" />
+      <ClientEvidenceSection report={report} />
     </div>
   )
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.12.1",
+  "version": "4.13.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.13.0",
+  "version": "4.13.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/report-renderer.ts
+++ b/packages/api-routes/src/report-renderer.ts
@@ -2370,7 +2370,7 @@ export function renderReportHtml(report: ProjectReportDto, opts: RenderReportHtm
 <body>
 <div class="container">
   <header class="header">
-    <div class="eyebrow">${audience === 'client' ? 'AI Visibility Report' : 'AEO Agency Report'}</div>
+    <div class="eyebrow">AI Visibility Report</div>
     <h1>${escapeHtml(report.meta.project.displayName)}</h1>
     <div class="subtitle">${escapeHtml(report.meta.project.canonicalDomain)} · ${escapeHtml(report.meta.project.country)} / ${escapeHtml(report.meta.project.language.toUpperCase())}${renderHeaderLocationFragment(report.meta.location)} · Generated ${formatDate(report.meta.generatedAt)}</div>
   </header>

--- a/packages/api-routes/src/report-renderer.ts
+++ b/packages/api-routes/src/report-renderer.ts
@@ -141,6 +141,46 @@ function pluralize(count: number, singular: string, plural = `${singular}s`): st
   return count === 1 ? singular : plural
 }
 
+const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
+  gemini: 'Gemini',
+  openai: 'ChatGPT',
+  claude: 'Claude',
+  perplexity: 'Perplexity',
+  local: 'Local model',
+  'cdp:chatgpt': 'ChatGPT (browser)',
+}
+
+function providerDisplayName(name: string): string {
+  return PROVIDER_DISPLAY_NAMES[name] ?? name.charAt(0).toUpperCase() + name.slice(1)
+}
+
+function clientHorizonLabel(horizon: ReportActionPlanItem['horizon']): string {
+  switch (horizon) {
+    case 'immediate': return 'Do now'
+    case 'short-term': return 'This month'
+    case 'medium-term': return 'Next quarter'
+  }
+}
+
+function clientConfidenceLabel(confidence: ReportActionPlanItem['confidence']): string {
+  switch (confidence) {
+    case 'high': return 'Strong evidence'
+    case 'medium': return 'Some evidence'
+    case 'low': return 'Worth trying'
+  }
+}
+
+function clientTrendCopy(delta: ProjectReportDto['whatsChanged']['citationRate']): { text: string; tone: 'positive' | 'negative' | 'neutral'; arrow: string } | null {
+  if (!delta) return null
+  if (delta.direction === 'up') {
+    return { text: `Up ${delta.deltaAbs.toFixed(1)} points since last check (was ${delta.prior}%)`, tone: 'positive', arrow: '↑' }
+  }
+  if (delta.direction === 'down') {
+    return { text: `Down ${Math.abs(delta.deltaAbs).toFixed(1)} points since last check (was ${delta.prior}%)`, tone: 'negative', arrow: '↓' }
+  }
+  return { text: `Holding steady since last check (was ${delta.prior}%)`, tone: 'neutral', arrow: '→' }
+}
+
 function compactInlineList(items: readonly string[], limit = 3): string {
   const visible = items.slice(0, limit)
   const more = items.length - visible.length
@@ -670,6 +710,222 @@ table.report-table td .badge {
   color: ${COLORS.textFaint};
   font-size: 12px;
 }
+.client-hero {
+  background: ${COLORS.surface};
+  border: 1px solid ${COLORS.border};
+  border-radius: 16px;
+  padding: 32px;
+  margin-bottom: 24px;
+}
+.client-hero .client-hero-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 11px;
+  font-weight: 600;
+  color: ${COLORS.textFaint};
+}
+.client-hero .client-hero-number {
+  font-size: 80px;
+  line-height: 1;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: ${COLORS.text};
+  margin: 14px 0 18px;
+}
+.client-hero .client-hero-sentence {
+  font-size: 17px;
+  color: #d4d4d8;
+  max-width: 720px;
+  margin: 0;
+}
+.client-hero .client-hero-trend {
+  margin-top: 14px;
+  font-size: 14px;
+  font-weight: 500;
+}
+.client-hero .client-hero-trend.tone-positive { color: ${COLORS.positive}; }
+.client-hero .client-hero-trend.tone-negative { color: ${COLORS.negative}; }
+.client-hero .client-hero-trend.tone-neutral { color: ${COLORS.textMuted}; }
+.client-metric-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  margin-bottom: 24px;
+}
+.client-metric-tile {
+  background: ${COLORS.surface};
+  border: 1px solid ${COLORS.border};
+  border-radius: 12px;
+  padding: 22px 24px;
+}
+.client-metric-tile .label {
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 11px;
+  font-weight: 600;
+  color: ${COLORS.textFaint};
+  margin-bottom: 14px;
+}
+.client-metric-tile .value {
+  font-size: 48px;
+  line-height: 1;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: ${COLORS.text};
+}
+.client-metric-tile .subtitle {
+  margin-top: 10px;
+  font-size: 12px;
+  color: ${COLORS.textMuted};
+}
+.client-card {
+  background: ${COLORS.surface};
+  border: 1px solid ${COLORS.border};
+  border-radius: 12px;
+  padding: 22px 24px;
+  margin-bottom: 16px;
+}
+.client-card h3 {
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0 0 4px;
+}
+.client-card .card-subtitle {
+  font-size: 12px;
+  color: ${COLORS.textMuted};
+  margin: 0 0 18px;
+}
+.client-bar-list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.client-bar-row {
+  display: grid;
+  grid-template-columns: 140px 1fr 130px;
+  align-items: center;
+  gap: 14px;
+  font-size: 13px;
+}
+.client-bar-row .bar-label { color: #d4d4d8; }
+.client-bar-row .bar-track {
+  height: 10px;
+  background: ${COLORS.border};
+  border-radius: 999px;
+  overflow: hidden;
+}
+.client-bar-row .bar-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: ${COLORS.positive}b3;
+}
+.client-bar-row .bar-fill.bar-fill-neutral { background: #a1a1aaaa; }
+.client-bar-row .bar-fill.bar-fill-sky { background: #38bdf8b3; }
+.client-bar-row .bar-value {
+  text-align: right;
+  font-size: 13px;
+  font-weight: 600;
+  color: ${COLORS.text};
+  font-variant-numeric: tabular-nums;
+}
+.client-bar-row .bar-value-sub { color: ${COLORS.textFaint}; font-weight: 400; }
+.client-progress-number {
+  font-size: 56px;
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  margin: 12px 0 4px;
+}
+.client-progress-number.tone-positive { color: ${COLORS.positive}; }
+.client-progress-number.tone-caution { color: ${COLORS.caution}; }
+.client-progress-number.tone-negative { color: ${COLORS.negative}; }
+.client-progress-bar {
+  height: 12px;
+  background: ${COLORS.border};
+  border-radius: 999px;
+  overflow: hidden;
+  margin: 12px 0 14px;
+}
+.client-progress-fill { height: 100%; border-radius: 999px; }
+.client-progress-fill.tone-positive { background: ${COLORS.positive}b3; }
+.client-progress-fill.tone-caution { background: ${COLORS.caution}b3; }
+.client-progress-fill.tone-negative { background: ${COLORS.negative}b3; }
+.client-evidence-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  gap: 16px;
+}
+.client-opportunity-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.client-opportunity-list li {
+  background: #09090b;
+  border: 1px solid ${COLORS.border};
+  border-radius: 8px;
+  padding: 10px 14px;
+}
+.client-opportunity-list li .op-query {
+  font-weight: 500;
+  color: ${COLORS.text};
+  font-size: 13px;
+}
+.client-opportunity-list li .op-action {
+  margin-top: 2px;
+  font-size: 11px;
+  color: ${COLORS.textMuted};
+}
+.client-confidence-note {
+  background: ${COLORS.surface};
+  border: 1px solid ${COLORS.border};
+  border-radius: 8px;
+  padding: 10px 14px;
+  font-size: 12px;
+  color: ${COLORS.textMuted};
+  margin-bottom: 6px;
+}
+.client-explainer {
+  background: #09090b;
+  border: 1px solid ${COLORS.border};
+  border-radius: 12px;
+  padding: 12px 16px;
+  font-size: 12px;
+  color: ${COLORS.textMuted};
+  margin-bottom: 16px;
+  line-height: 1.6;
+}
+.client-explainer strong { color: ${COLORS.text}; }
+.client-explainer .term { color: #d4d4d8; font-weight: 500; }
+.client-questions-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.client-questions-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  background: #09090b;
+  border: 1px solid ${COLORS.border};
+  border-radius: 8px;
+  padding: 10px 14px;
+  font-size: 13px;
+  color: #d4d4d8;
+}
+.client-questions-list li .qnum {
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 600;
+  color: ${COLORS.textFaint};
+  font-variant-numeric: tabular-nums;
+}
 @media (max-width: 760px) {
   .container { padding: 32px 16px 72px; }
   .executive-hero { grid-template-columns: 1fr; }
@@ -677,6 +933,9 @@ table.report-table td .badge {
   .source-bar-row { grid-template-columns: 1fr; gap: 6px; }
   .source-bar-value { text-align: left; }
   .chart-grid { grid-template-columns: 1fr; }
+  .client-hero .client-hero-number { font-size: 56px; }
+  .client-metric-tile .value { font-size: 36px; }
+  .client-bar-row { grid-template-columns: 100px 1fr 100px; gap: 10px; }
 }
 @media print {
   body { background: white; color: black; }
@@ -931,21 +1190,27 @@ const WHATS_CHANGED_PERIOD_DAYS = 14
 
 function renderProviderMovements(
   movements: ProjectReportDto['whatsChanged']['providerMovements'],
+  audience: ReportAudience,
 ): string {
   const meaningful = movements.filter(m => m.direction !== 'flat')
   if (meaningful.length === 0) return ''
+  const isClient = audience === 'client'
   const rows = meaningful.map(m => {
     const sign = m.deltaAbs > 0 ? '+' : ''
     return `<tr>
-      <td>${escapeHtml(m.provider)}</td>
+      <td>${escapeHtml(isClient ? providerDisplayName(m.provider) : m.provider)}</td>
       <td class="numeric">${m.prior}%</td>
       <td class="numeric">${m.current}%</td>
       <td class="numeric ${deltaToneClass(m.direction)}">${sign}${m.deltaAbs.toFixed(1)}% ${deltaArrow(m.direction)}</td>
     </tr>`
   }).join('')
-  return `<div class="chart-card"><h3>AI engine movements</h3>
+  const heading = isClient ? 'How each AI tool changed' : 'AI engine movements'
+  const colA = isClient ? 'AI tool' : 'Engine'
+  const colB = isClient ? 'Was' : 'Prior'
+  const colC = isClient ? 'Now' : 'Current'
+  return `<div class="chart-card"><h3>${heading}</h3>
     <table class="report-table">
-      <thead><tr><th>Engine</th><th class="numeric">Prior</th><th class="numeric">Current</th><th class="numeric">Change</th></tr></thead>
+      <thead><tr><th>${colA}</th><th class="numeric">${colB}</th><th class="numeric">${colC}</th><th class="numeric">Change</th></tr></thead>
       <tbody>${rows}</tbody>
     </table>
   </div>`
@@ -955,50 +1220,62 @@ function renderWinsLosses(
   insights: readonly ReportInsight[],
   heading: string,
   emptyMessage: string,
+  audience: ReportAudience,
 ): string {
   if (insights.length === 0) {
     return `<div class="chart-card"><h3>${escapeHtml(heading)}</h3>
       <p class="section-intro">${escapeHtml(emptyMessage)}</p>
     </div>`
   }
+  const isClient = audience === 'client'
   const rows = insights.map(i => {
     const tone = severityTone(i.severity)
     const countChip = i.instanceCount > 1 ? ` <span class="badge tone-neutral">× ${i.instanceCount}</span>` : ''
+    const severityCell = isClient ? '' : `<td><span class="badge tone-${tone}">${escapeHtml(reportSeverityLabel(i.severity))}</span></td>`
     return `<tr>
-      <td><span class="badge tone-${tone}">${escapeHtml(reportSeverityLabel(i.severity))}</span></td>
+      ${severityCell}
       <td>${escapeHtml(i.title)}${countChip}</td>
       <td>${escapeHtml(i.query)}</td>
-      <td>${escapeHtml(i.provider)}</td>
+      <td>${escapeHtml(isClient ? providerDisplayName(i.provider) : i.provider)}</td>
     </tr>`
   }).join('')
+  const headers = isClient
+    ? `<tr><th>What changed</th><th>Customer question</th><th>AI tool</th></tr>`
+    : `<tr><th>Severity</th><th>Title</th><th>Query</th><th>Provider</th></tr>`
   return `<div class="chart-card"><h3>${escapeHtml(heading)}</h3>
     <table class="report-table">
-      <thead><tr><th>Severity</th><th>Title</th><th>Query</th><th>Provider</th></tr></thead>
+      <thead>${headers}</thead>
       <tbody>${rows}</tbody>
     </table>
   </div>`
 }
 
-function renderWhatsChanged(report: ProjectReportDto): string {
+function renderWhatsChanged(report: ProjectReportDto, audience: ReportAudience): string {
   const w = report.whatsChanged
+  const isClient = audience === 'client'
+  const eyebrow = isClient ? 'Since last check' : 'Section 2'
+  const title = isClient ? "What's different since last check" : "What's Changed"
+  const intro = isClient ? '' : w.headline
   if (!w.enoughHistory && !w.gscClicksDelta && !w.aiReferralsDelta && w.wins.length === 0 && w.regressions.length === 0) {
     return section(
-      { id: 'whats-changed', eyebrow: 'Section 2', title: "What's Changed", intro: w.headline },
-      renderEmpty('Trends will appear after a few more checks.'),
+      { id: 'whats-changed', eyebrow, title, intro },
+      renderEmpty(isClient ? 'No comparison yet — trends will appear after a few more checks.' : 'Trends will appear after a few more checks.'),
     )
   }
   const rateTiles = `<div class="metric-grid">
-    ${renderRateDeltaTile('Citation rate', w.citationRate, '%')}
-    ${renderRateDeltaTile('Mention rate', w.mentionRate, '%')}
-    ${renderRateDeltaTile('Cited queries', w.citedQueryCount, 'count')}
-    ${renderTrafficDeltaTile('GSC clicks', w.gscClicksDelta, 'clicks')}
-    ${renderTrafficDeltaTile('AI referral sessions', w.aiReferralsDelta, 'sessions')}
+    ${renderRateDeltaTile(isClient ? 'AI links to your website' : 'Citation rate', w.citationRate, '%')}
+    ${renderRateDeltaTile(isClient ? 'AI mentions your name' : 'Mention rate', w.mentionRate, '%')}
+    ${renderRateDeltaTile(isClient ? 'Questions AI answered with you' : 'Cited queries', w.citedQueryCount, 'count')}
+    ${renderTrafficDeltaTile(isClient ? 'Visitors from Google' : 'GSC clicks', w.gscClicksDelta, isClient ? 'visits' : 'clicks')}
+    ${renderTrafficDeltaTile(isClient ? 'Visitors from AI tools' : 'AI referral sessions', w.aiReferralsDelta, isClient ? 'visits' : 'sessions')}
   </div>`
-  const movements = renderProviderMovements(w.providerMovements)
-  const wins = renderWinsLosses(w.wins, 'Wins', 'No new gains in the latest check.')
-  const regressions = renderWinsLosses(w.regressions, 'Regressions', 'No new regressions in the latest check.')
+  const movements = renderProviderMovements(w.providerMovements, audience)
+  const winsHeading = isClient ? 'What got better' : 'Wins'
+  const lossesHeading = isClient ? 'What got worse' : 'Regressions'
+  const wins = renderWinsLosses(w.wins, winsHeading, isClient ? 'No new wins this period.' : 'No new gains in the latest check.', audience)
+  const regressions = renderWinsLosses(w.regressions, lossesHeading, isClient ? 'Nothing got worse this period.' : 'No new regressions in the latest check.', audience)
   return section(
-    { id: 'whats-changed', eyebrow: 'Section 2', title: "What's Changed", intro: w.headline },
+    { id: 'whats-changed', eyebrow, title, intro },
     `${rateTiles}${movements}${wins}${regressions}`,
   )
 }
@@ -1773,8 +2050,9 @@ function actionAudienceMatches(action: ReportActionPlanItem, audience: ReportAud
   return action.audience === 'both' || action.audience === audience
 }
 
-function renderActionCards(actions: readonly ReportActionPlanItem[]): string {
-  if (actions.length === 0) return renderEmpty('No prioritized actions yet.')
+function renderActionCards(actions: readonly ReportActionPlanItem[], audience: ReportAudience): string {
+  const isClient = audience === 'client'
+  if (actions.length === 0) return renderEmpty(isClient ? 'No recommendations yet — run an AI check to populate this.' : 'No prioritized actions yet.')
   return `<div class="action-card-grid">
     ${actions.map((action, idx) => {
       const tone = reportActionTone(action)
@@ -1787,19 +2065,23 @@ function renderActionCards(actions: readonly ReportActionPlanItem[]): string {
       const proof = renderProofChips(action.evidence.length > 0 ? action.evidence : action.why, 3)
       const details = why || evidence
         ? `<details class="action-details">
-            <summary>Evidence details</summary>
-            ${why ? `<div><strong>Why</strong>${why}</div>` : ''}
-            ${evidence ? `<div><strong>Evidence</strong>${evidence}</div>` : ''}
+            <summary>${isClient ? 'See the data behind this' : 'Evidence details'}</summary>
+            ${why ? `<div><strong>${isClient ? 'Why this matters' : 'Why'}</strong>${why}</div>` : ''}
+            ${evidence ? `<div><strong>${isClient ? 'What we saw' : 'Evidence'}</strong>${evidence}</div>` : ''}
           </details>`
         : ''
+      const horizonLabel = isClient ? clientHorizonLabel(action.horizon) : reportHorizonLabel(action.horizon)
+      const confidenceLabel = isClient ? clientConfidenceLabel(action.confidence) : `${reportConfidenceLabel(action.confidence)} confidence`
+      const categoryBadge = isClient ? '' : `<span class="badge tone-neutral">${escapeHtml(reportActionCategoryLabel(action.category))}</span>`
+      const successLabel = isClient ? 'What success looks like:' : 'Win condition:'
       return `<article class="action-card">
         <div class="action-head">
-          <div class="action-rank" title="Impact rank — 1 is the highest-leverage action">${idx + 1}</div>
+          <div class="action-rank" title="${isClient ? 'Priority — 1 will move the needle fastest' : 'Impact rank — 1 is the highest-leverage action'}">${idx + 1}</div>
           <div>
             <div class="action-meta">
-              <span class="badge tone-${tone}">${escapeHtml(reportHorizonLabel(action.horizon))}</span>
-              <span class="badge tone-neutral">${escapeHtml(reportActionCategoryLabel(action.category))}</span>
-              <span class="badge tone-neutral">${escapeHtml(reportConfidenceLabel(action.confidence))} confidence</span>
+              <span class="badge tone-${tone}">${escapeHtml(horizonLabel)}</span>
+              ${categoryBadge}
+              <span class="badge tone-neutral">${escapeHtml(confidenceLabel)}</span>
             </div>
             <h3>${escapeHtml(action.title)}</h3>
           </div>
@@ -1807,7 +2089,7 @@ function renderActionCards(actions: readonly ReportActionPlanItem[]): string {
         <p>${escapeHtml(action.action)}</p>
         ${proof}
         ${details}
-        <div class="success-metric"><strong>Win condition:</strong> ${escapeHtml(action.successMetric)}</div>
+        <div class="success-metric"><strong>${successLabel}</strong> ${escapeHtml(action.successMetric)}</div>
       </article>`
     }).join('')}
   </div>`
@@ -1823,82 +2105,184 @@ function renderAudienceActionPlan(report: ProjectReportDto, audience: ReportAudi
   return section(
     {
       id: audience === 'client' ? 'client-action-plan' : 'agency-action-plan',
-      eyebrow: audience === 'client' ? 'Client actions' : 'Agency actions',
-      title: audience === 'client' ? 'What We Recommend Next' : 'Agency Action Plan',
+      eyebrow: audience === 'client' ? 'Action plan' : 'Agency actions',
+      title: audience === 'client' ? 'What to do next' : 'Agency Action Plan',
       intro: audience === 'client'
-        ? 'The short list to approve and execute.'
+        ? 'Approve these in order. They are sorted by what will move the needle fastest.'
         : 'The highest-leverage work, sorted by urgency and evidence strength.',
     },
-    renderActionCards(actions),
+    renderActionCards(actions, audience),
   )
 }
 
 function renderClientSummary(report: ProjectReportDto): string {
   const s = report.executiveSummary
-  const metrics = `<div class="metric-grid">
-    <div class="metric"><div class="label">Citation coverage</div><div class="value">${s.citationRate}%</div><div class="delta">${s.citedQueryCount}/${s.totalQueryCount} tracked queries cited</div></div>
-    <div class="metric"><div class="label">Mention coverage</div><div class="value">${s.mentionRate}%</div><div class="delta">${s.mentionedQueryCount}/${s.totalQueryCount} tracked queries mentioned</div></div>
-    <div class="metric"><div class="label">Providers checked</div><div class="value">${formatNumber(s.providerCount)}</div><div class="delta">${formatNumber(s.queryCount)} tracked queries</div></div>
-  </div>`
-  const notes = report.clientSummary.confidenceNotes.length > 0
-    ? `<div class="client-notes">${report.clientSummary.confidenceNotes.map(note => `<div class="client-note">${escapeHtml(note)}</div>`).join('')}</div>`
+  const sc = report.citationScorecard
+  const totalQ = s.totalQueryCount
+  const heroNumber = totalQ > 0 ? `${s.citationRate}%` : '—'
+  const heroSentence = totalQ > 0
+    ? `When customers asked AI ${totalQ} ${pluralize(totalQ, 'question')} about your industry, AI linked to your website in ${s.citedQueryCount} of ${totalQ === 1 ? 'them' : 'those answers'}.`
+    : 'No AI check has been run yet. Run a check to see how AI tools answer customer questions about your business.'
+  const trend = clientTrendCopy(report.whatsChanged.citationRate)
+  const heroTrend = trend
+    ? `<p class="client-hero-trend tone-${trend.tone}"><span style="margin-right:6px;">${trend.arrow}</span>${escapeHtml(trend.text)}</p>`
     : ''
-  return section(
-    {
-      id: 'client-summary',
-      eyebrow: 'Client summary',
-      title: "How You're Appearing",
-      intro: report.clientSummary.overview,
-    },
-    `<div class="chart-card">
-      <h3>${escapeHtml(report.clientSummary.headline)}</h3>
-      <p class="source-origin-headline">${escapeHtml(report.clientSummary.overview)}</p>
+  const hero = `<div class="client-hero">
+    <div class="client-hero-eyebrow">Overview</div>
+    <div class="client-hero-number">${heroNumber}</div>
+    <p class="client-hero-sentence">${escapeHtml(heroSentence)}</p>
+    ${heroTrend}
+  </div>`
+
+  const providerSubtitle = sc.providers.length > 0
+    ? sc.providers.map(providerDisplayName).join(', ')
+    : `${formatNumber(s.queryCount)} ${pluralize(s.queryCount, 'question')} tested`
+
+  const tiles = `<div class="client-metric-grid">
+    <div class="client-metric-tile">
+      <div class="label">AI mentions your name</div>
+      <div class="value">${s.mentionRate}%</div>
+      <div class="subtitle">${totalQ > 0 ? `Says your name in ${s.mentionedQueryCount} of ${totalQ} ${pluralize(totalQ, 'answer')}` : 'No data yet'}</div>
     </div>
-    ${metrics}
-    ${notes}`,
-  )
+    <div class="client-metric-tile">
+      <div class="label">AI links to your website</div>
+      <div class="value">${s.citationRate}%</div>
+      <div class="subtitle">${totalQ > 0 ? `Cites your site as a source in ${s.citedQueryCount} of ${totalQ} ${pluralize(totalQ, 'answer')}` : 'No data yet'}</div>
+    </div>
+    <div class="client-metric-tile">
+      <div class="label">AI tools tested</div>
+      <div class="value">${formatNumber(s.providerCount)}</div>
+      <div class="subtitle">${escapeHtml(providerSubtitle)}</div>
+    </div>
+  </div>`
+
+  const explainer = `<div class="client-explainer">
+    <strong>Mentions and links are different.</strong>
+    A <span class="term">mention</span> is when AI says your name out loud in its answer.
+    A <span class="term">link</span> is when AI lists your website as a source it used.
+    AI can do either, both, or neither — that's why we track both.
+  </div>`
+
+  const questions = sc.queries.length > 0
+    ? `<div class="client-card">
+        <h3>Customer questions we tested</h3>
+        <p class="card-subtitle">These are the ${sc.queries.length} ${pluralize(sc.queries.length, 'question we asked', 'questions we asked')} every AI tool. The numbers above measure how often you came up.</p>
+        <ol class="client-questions-list">
+          ${sc.queries.map((q, i) => `<li><span class="qnum">${String(i + 1).padStart(2, '0')}</span><span>"${escapeHtml(q)}"</span></li>`).join('')}
+        </ol>
+      </div>`
+    : ''
+
+  const providerBars = sc.providerRates.length > 0
+    ? `<div class="client-card">
+        <h3>How often each AI tool links to your website</h3>
+        <p class="card-subtitle">Higher is better. Each bar shows the share of customer questions where the AI cited your site.</p>
+        <div class="client-bar-list">
+          ${sc.providerRates.map(r => {
+            const pct = Math.max(r.citationRate, 1.5)
+            return `<div class="client-bar-row">
+              <span class="bar-label">${escapeHtml(providerDisplayName(r.provider))}</span>
+              <div class="bar-track"><div class="bar-fill" style="width:${pct}%"></div></div>
+              <span class="bar-value">${r.citationRate}% <span class="bar-value-sub">(${r.citedCount}/${r.totalCount})</span></span>
+            </div>`
+          }).join('')}
+        </div>
+      </div>`
+    : ''
+
+  const notes = report.clientSummary.confidenceNotes.length > 0
+    ? `<div>${report.clientSummary.confidenceNotes.map(note => `<div class="client-confidence-note">${escapeHtml(note)}</div>`).join('')}</div>`
+    : ''
+
+  return `<section class="report-section" id="client-summary">${hero}${tiles}${explainer}${questions}${providerBars}${notes}</section>`
 }
 
 function renderClientEvidenceSummary(report: ProjectReportDto): string {
-  const evidenceCards: string[] = []
-  if (report.aiSourceOrigin.topDomains.length > 0) {
-    evidenceCards.push(`<div class="diagnostic-card tone-neutral">
-      <h3>Sources AI engines trust</h3>
-      <p>These domains appeared most often as cited sources outside your owned domain.</p>
-      <ul>${report.aiSourceOrigin.topDomains.slice(0, 5).map(d => `<li>${escapeHtml(d.domain)}: ${formatNumber(d.count)} citation${d.count === 1 ? '' : 's'}</li>`).join('')}</ul>
+  const ai = report.aiSourceOrigin.topDomains.slice(0, 5)
+  const gsc = report.gsc
+  const indexing = report.indexingHealth
+  const opportunities = dedupeReportOpportunities(report).slice(0, 5)
+
+  const aiMax = ai.length > 0 ? Math.max(...ai.map(d => d.count)) : 0
+  const gscMax = gsc ? Math.max(...gsc.topQueries.slice(0, 5).map(q => q.impressions), 1) : 0
+
+  const cards: string[] = []
+
+  if (ai.length > 0) {
+    cards.push(`<div class="client-card">
+      <h3>Where AI gets its answers</h3>
+      <p class="card-subtitle">The websites AI tools cited most often when answering customer questions about your industry.</p>
+      <div class="client-bar-list">
+        ${ai.map(d => {
+          const pct = aiMax > 0 ? Math.max((d.count / aiMax) * 100, 1.5) : 0
+          const label = escapeHtml(d.domain) + (d.isCompetitor ? ' <span style="color:'+COLORS.textFaint+';font-size:11px;">(competitor)</span>' : '')
+          return `<div class="client-bar-row">
+            <span class="bar-label">${label}</span>
+            <div class="bar-track"><div class="bar-fill bar-fill-neutral" style="width:${pct}%"></div></div>
+            <span class="bar-value">${formatNumber(d.count)}×</span>
+          </div>`
+        }).join('')}
+      </div>
     </div>`)
   }
-  if (report.gsc) {
-    evidenceCards.push(`<div class="diagnostic-card tone-neutral">
-      <h3>Search demand</h3>
-      <p>Search Console shows ${formatNumber(report.gsc.totalImpressions)} impressions and ${formatNumber(report.gsc.totalClicks)} clicks in the report window.</p>
-      <ul>${report.gsc.topQueries.slice(0, 5).map(q => `<li>${escapeHtml(q.query)}: ${formatNumber(q.impressions)} impressions</li>`).join('')}</ul>
+
+  if (indexing) {
+    const tone = indexing.indexedPct >= 90 ? 'positive' : indexing.indexedPct >= 70 ? 'caution' : 'negative'
+    const fillPct = Math.max(indexing.indexedPct, 1.5)
+    cards.push(`<div class="client-card">
+      <h3>Pages Google can find on your site</h3>
+      <p class="card-subtitle">Google indexing your site increases the chances of it appearing in AI search (especially Gemini).</p>
+      <div class="client-progress-number tone-${tone}">${indexing.indexedPct}%</div>
+      <div style="font-size:12px;color:${COLORS.textMuted};">${formatNumber(indexing.indexed)} of ${formatNumber(indexing.total)} pages indexed</div>
+      <div class="client-progress-bar"><div class="client-progress-fill tone-${tone}" style="width:${fillPct}%"></div></div>
+      <p style="margin:0;font-size:12px;color:${COLORS.textMuted};"><strong style="color:${COLORS.text};">${formatNumber(indexing.notIndexed)}</strong> ${pluralize(indexing.notIndexed, 'page is', 'pages are')} not indexed yet.</p>
     </div>`)
   }
-  if (report.indexingHealth) {
-    const tone = report.indexingHealth.indexedPct >= 90 ? 'positive' : report.indexingHealth.indexedPct >= 70 ? 'caution' : 'negative'
-    evidenceCards.push(`<div class="diagnostic-card tone-${tone}">
-      <h3>Indexing readiness</h3>
-      <p>${report.indexingHealth.indexedPct}% of inspected URLs are indexed.</p>
-      <ul><li>${formatNumber(report.indexingHealth.indexed)} indexed</li><li>${formatNumber(report.indexingHealth.notIndexed)} not indexed</li></ul>
+
+  if (gsc) {
+    const queries = gsc.topQueries.slice(0, 5)
+    const queryRows = queries.length > 0
+      ? `<div class="client-bar-list">
+          ${queries.map(q => {
+            const pct = gscMax > 0 ? Math.max((q.impressions / gscMax) * 100, 1.5) : 0
+            return `<div class="client-bar-row">
+              <span class="bar-label">${escapeHtml(q.query)}</span>
+              <div class="bar-track"><div class="bar-fill bar-fill-sky" style="width:${pct}%"></div></div>
+              <span class="bar-value">${formatNumber(q.impressions)} ${pluralize(q.impressions, 'search', 'searches')}</span>
+            </div>`
+          }).join('')}
+        </div>`
+      : ''
+    cards.push(`<div class="client-card">
+      <h3>What people search Google for</h3>
+      <p class="card-subtitle">You appeared in <strong style="color:${COLORS.text};">${formatNumber(gsc.totalImpressions)}</strong> Google searches and got <strong style="color:${COLORS.text};">${formatNumber(gsc.totalClicks)}</strong> ${pluralize(gsc.totalClicks, 'click')} this period.</p>
+      ${queryRows}
     </div>`)
   }
-  const opportunities = dedupeReportOpportunities(report)
+
   if (opportunities.length > 0) {
-    evidenceCards.push(`<div class="diagnostic-card tone-caution">
-      <h3>Content opportunities</h3>
-      <p>Canonry found topics where better content could improve AI citations.</p>
-      <ul>${opportunities.slice(0, 5).map(o => `<li>${escapeHtml(o.query)}: ${escapeHtml(o.action)} (${Math.round(o.score)})</li>`).join('')}</ul>
+    cards.push(`<div class="client-card">
+      <h3>Topics where you could improve</h3>
+      <p class="card-subtitle">Customer questions where better content on your site would help AI cite you.</p>
+      <ul class="client-opportunity-list">
+        ${opportunities.map(o => `<li>
+          <div class="op-query">${escapeHtml(o.query)}</div>
+          <div class="op-action">${escapeHtml(contentActionLabel(o.action))}</div>
+        </li>`).join('')}
+      </ul>
     </div>`)
   }
+
   return section(
     {
       id: 'client-evidence-summary',
-      eyebrow: 'Evidence',
-      title: 'Why This Is The Plan',
-      intro: 'A concise evidence view for the client summary. The agency report keeps the full matrices and detailed tables.',
+      eyebrow: 'What we based this on',
+      title: 'The signals behind this plan',
+      intro: 'The data behind the recommendations above. Switch to Agency for the full breakdowns.',
     },
-    evidenceCards.length > 0 ? `<div class="diagnostics-grid">${evidenceCards.join('')}</div>` : renderEmpty('No supporting evidence sections are populated yet.'),
+    cards.length > 0
+      ? `<div class="client-evidence-grid">${cards.join('')}</div>`
+      : renderEmpty('No supporting evidence yet — this fills in after the first AI check.'),
   )
 }
 
@@ -1949,13 +2333,13 @@ export function renderReportHtml(report: ProjectReportDto, opts: RenderReportHtm
   const sections = audience === 'client'
     ? [
         renderClientSummary(report),
-        renderWhatsChanged(report),
+        renderWhatsChanged(report, 'client'),
         renderAudienceActionPlan(report, 'client'),
         renderClientEvidenceSummary(report),
       ].join('\n')
     : [
         renderExecutiveSummary(report),
-        renderWhatsChanged(report),
+        renderWhatsChanged(report, 'agency'),
         renderAudienceActionPlan(report, 'agency'),
         renderAgencyDiagnostics(report),
         renderCitationScorecard(report),
@@ -1986,7 +2370,7 @@ export function renderReportHtml(report: ProjectReportDto, opts: RenderReportHtm
 <body>
 <div class="container">
   <header class="header">
-    <div class="eyebrow">${audience === 'client' ? 'AEO Client Summary' : 'AEO Agency Report'}</div>
+    <div class="eyebrow">${audience === 'client' ? 'AI Visibility Report' : 'AEO Agency Report'}</div>
     <h1>${escapeHtml(report.meta.project.displayName)}</h1>
     <div class="subtitle">${escapeHtml(report.meta.project.canonicalDomain)} · ${escapeHtml(report.meta.project.country)} / ${escapeHtml(report.meta.project.language.toUpperCase())}${renderHeaderLocationFragment(report.meta.location)} · Generated ${formatDate(report.meta.generatedAt)}</div>
   </header>

--- a/packages/api-routes/test/report-renderer.test.ts
+++ b/packages/api-routes/test/report-renderer.test.ts
@@ -660,10 +660,10 @@ describe('renderReportHtml', () => {
 
   test('client mode renders polished actions before concise evidence', () => {
     const html = renderReportHtml(richReport(), { audience: 'client' })
-    expect(html).toContain('AEO Client Summary')
+    expect(html).toContain('AI Visibility Report')
     expect(html).toContain('id="client-summary"')
     expect(html).toContain('id="client-action-plan"')
-    expect(html).toContain('What We Recommend Next')
+    expect(html).toContain('What to do next')
     expect(html).toContain('Publish a client-safe guide')
     expect(html).not.toContain('id="citation-scorecard"')
 
@@ -671,6 +671,58 @@ describe('renderReportHtml', () => {
     const evidenceIndex = html.indexOf('id="client-evidence-summary"')
     expect(actionIndex).toBeGreaterThan(-1)
     expect(evidenceIndex).toBeGreaterThan(actionIndex)
+  })
+
+  test('client mode uses plain-English labels — no AEO/SEO jargon', () => {
+    const html = renderReportHtml(richReport(), { audience: 'client' })
+    // Strip the embedded JSON payload — it carries the canonical DTO with
+    // analyst vocabulary, but is invisible to the reader.
+    const visible = html.split('<script')[0]
+    // Hero + tile labels
+    expect(visible).toContain('>Overview<')
+    expect(visible).toContain('AI mentions your name')
+    expect(visible).toContain('AI links to your website')
+    expect(visible).toContain('AI tools tested')
+    expect(visible).toContain('How often each AI tool links to your website')
+    // Mentions vs links explainer must exist
+    expect(visible).toContain('Mentions and links are different')
+    // Customer questions list must render the queries
+    expect(visible).toContain('Customer questions we tested')
+    expect(visible).toContain('aeo platform')
+    // Action plan + evidence
+    expect(visible).toContain('What to do next')
+    expect(visible).toContain('What success looks like:')
+    expect(visible).toContain('What we based this on')
+    expect(visible).toContain('The signals behind this plan')
+    // The old jargon labels must not appear in the rendered UI
+    expect(visible).not.toContain('Citation coverage')
+    expect(visible).not.toContain('Mention coverage')
+    expect(visible).not.toContain('Providers checked')
+    expect(visible).not.toContain('Win condition:')
+    expect(visible).not.toContain('Why This Is The Plan')
+    expect(visible).not.toContain('Sources AI engines trust')
+  })
+
+  test('client whats-changed uses plain-English tile labels', () => {
+    const html = renderReportHtml(richReport(), { audience: 'client' })
+    const visible = html.split('<script')[0]
+    expect(visible).toContain('Since last check')
+    // Apostrophe is HTML-escaped in the rendered title
+    expect(visible).toContain('different since last check')
+    // Engine column header should be the client label, not 'Engine'
+    expect(visible).not.toContain('>Engine<')
+    expect(visible).not.toContain('>Prior<')
+  })
+
+  test('agency mode keeps analyst vocabulary (no client labels leak)', () => {
+    const html = renderReportHtml(richReport(), { audience: 'agency' })
+    const visible = html.split('<script')[0]
+    expect(visible).toContain('Citation rate')
+    expect(visible).toContain('Mention rate')
+    expect(visible).toContain('Win condition:')
+    expect(visible).not.toContain('AI links to your website')
+    expect(visible).not.toContain('What success looks like:')
+    expect(visible).not.toContain('id="client-summary"')
   })
 
   test('citation matrix shows cited vs not-cited cells', () => {

--- a/packages/api-routes/test/report-renderer.test.ts
+++ b/packages/api-routes/test/report-renderer.test.ts
@@ -486,7 +486,7 @@ describe('renderReportHtml', () => {
 
   test('defaults to agency mode with diagnostics and detailed evidence sections', () => {
     const html = renderReportHtml(richReport())
-    expect(html).toContain('AEO Agency Report')
+    expect(html).toContain('AI Visibility Report')
     expect(html).toContain('id="agency-diagnostics"')
     expect(html).toContain('id="citation-scorecard"')
     expect(html).toContain('Diagnose zero-citation providers')

--- a/packages/api-routes/test/report.test.ts
+++ b/packages/api-routes/test/report.test.ts
@@ -1470,7 +1470,7 @@ describe('GET /api/v1/projects/:name/report.html', () => {
 
     expect(res.body).toMatch(/^<!DOCTYPE html>/)
     expect(res.body).toContain('HTML Report Co.')
-    expect(res.body).toContain('AEO Agency Report')
+    expect(res.body).toContain('AI Visibility Report')
     expect(res.body).toContain('<title>')
   })
 

--- a/packages/api-routes/test/report.test.ts
+++ b/packages/api-routes/test/report.test.ts
@@ -1481,7 +1481,7 @@ describe('GET /api/v1/projects/:name/report.html', () => {
     const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/client-html/report.html?audience=client' })
     expect(res.statusCode).toBe(200)
     expect(String(res.headers['content-disposition'])).toMatch(/canonry-report-client-html-client-\d{4}-\d{2}-\d{2}\.html/)
-    expect(res.body).toContain('AEO Client Summary')
+    expect(res.body).toContain('AI Visibility Report')
     expect(res.body).toContain('id="client-summary"')
     expect(res.body).not.toContain('id="citation-scorecard"')
   })

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.13.0",
+  "version": "4.13.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.12.1",
+  "version": "4.13.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/test/report-command.test.ts
+++ b/packages/canonry/test/report-command.test.ts
@@ -148,7 +148,7 @@ describe('runReportCommand', () => {
     await runReportCommand('demo', { format: 'text', audience: 'client', output: target })
 
     const html = fs.readFileSync(target, 'utf-8')
-    expect(html).toContain('AEO Client Summary')
+    expect(html).toContain('AI Visibility Report')
     expect(html).toContain('id="client-summary"')
     expect(html).not.toContain('id="citation-scorecard"')
   })

--- a/packages/canonry/test/report-command.test.ts
+++ b/packages/canonry/test/report-command.test.ts
@@ -122,7 +122,7 @@ describe('runReportCommand', () => {
       const html = fs.readFileSync(path.join(tmpDir, files[0]!), 'utf-8')
       expect(html).toMatch(/^<!DOCTYPE html>/)
       expect(html).toContain('id="executive-summary"')
-      expect(html).toContain('AEO Agency Report')
+      expect(html).toContain('AI Visibility Report')
 
       expect(logs.join('\n')).toContain(files[0]!)
     } finally {


### PR DESCRIPTION
## Summary

Rewrites the **client** audience of the AEO report so it reads for an average small-business owner, not an analyst. The downloadable HTML and the in-app SPA move together — and a new **Report parity (Critical)** rule in `AGENTS.md` / `CLAUDE.md` codifies that they always must.

The **agency** view is intentionally untouched apart from the top page eyebrow ("AEO Report" → "AI Visibility Report") and the audience-prop plumbing in shared sections (\`WhatsChanged\`, action plan, etc.); analyst labels (\`Citation rate\`, \`Mention rate\`, \`Win condition:\`, severity badges, horizon labels) remain. A new test locks this in: \`agency mode keeps analyst vocabulary (no client labels leak)\`.

## What changed in the client view

- **80px hero "Overview"** number with a one-sentence plain-English headline ("When customers asked AI 11 questions about your industry, AI linked to your website in 5 of those answers.") and a colored trend line.
- **48px metric tiles** relabeled: *AI mentions your name*, *AI links to your website*, *AI tools tested* (lists ChatGPT/Gemini/Claude/Perplexity by display name).
- **Mention vs link explainer** caption right under the tiles, plus subtitles that reinforce the distinction ("Says your name in 5 of 11 answers" vs "Cites your site as a source in 5 of 11 answers").
- **"Customer questions we tested"** card listing every query from \`citationScorecard.queries\` so readers see exactly what they're being scored against.
- **Per-engine progress bars**, big indexing % with a colored progress bar, top-searches & top-sources bar lists. Indexing copy now: *"Google indexing your site increases the chances of it appearing in AI search (especially Gemini)."*
- **What's Changed** tiles, action plan badges, wins/losses tables use plain labels (*Do now / This month / Next quarter*, *Strong / Some / Worth-trying evidence*, *What success looks like:*, *What got better / What got worse*).

## Test plan

- [x] \`pnpm typecheck && pnpm lint && pnpm test\` (2092 passing)
- [x] HTML side rendered with rich fixture data and visually verified in Chrome — hero, tiles, explainer, questions list, per-engine bars, indexing card, action plan cards, evidence cards
- [x] 5 new renderer tests cover the new client labels and ensure agency view doesn't inherit them
- [ ] Visit \`/projects/<name>/report\` in the SPA, toggle Client/Agency, and download the HTML to confirm parity

Bumps to \`4.13.0\`.