### PR TITLE
fix: add 'Other channels' to GA4 channel breakdown so percentages sum to 100%

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -348,6 +348,20 @@ const totalBySource = referrals.reduce((acc, r) => { ... }, {})
 // GET /projects/:name/ga/attribution returns { channelBreakdown: [...] }
 ```
 
+### Calculation Testing (Critical)
+
+**Every calculation must have robust logical tests.** Any derived number, percentage,
+trend, score, rank, bucket, residual, roll-up, dedupe, or classification must be
+tested against the business invariant it claims to represent.
+
+#### Rules
+
+1. **Assert exact expected math, not shape only.** Tests like `toBeGreaterThanOrEqual(0)`, `typeof value === 'number'`, or "renders without crashing" are not sufficient for calculation changes.
+2. **Test the invariant.** If buckets are supposed to sum to a total, assert the sum. If a metric is supposed to be disjoint, seed overlap and prove it is not double-counted. If a rate uses a denominator, assert the numerator, denominator, rounded value, and display value.
+3. **Cover edge cases deliberately.** Include zero totals, missing/partial data, duplicate rows, overlapping categories, rounding boundaries (`<1%`, `0%`, `100%`), clamping behavior, and stale/legacy rows when the calculation can encounter them.
+4. **Keep calculations out of presentation-only tests.** Put the canonical calculation in the API/shared layer and test it there; UI tests should verify that the UI renders the API-provided values without recomputing them.
+5. **Protect agent-facing output.** When a calculation appears in CLI JSON, reports, MCP/API responses, or dashboard cards, add or update tests for the machine-readable contract as well as any human-readable display string.
+
 ### Report parity (Critical)
 
 **The downloadable HTML report and the in-app report SPA must always show the same sections, the same labels, the same numbers, and the same visual structure.** Clients and agencies see one report — only the surface differs. They are two renderers of the same DTO; never let them diverge.

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1069,6 +1069,12 @@ export interface ApiGaTraffic {
   socialSharePctDisplay: string
   /** Display string for directSharePct: 'X%', '<1%' for non-zero shares that round below 1, or '—' when sessions exist but total is unknown (partial sync). */
   directSharePctDisplay: string
+  /** Sessions not covered by Organic, Social, Direct, or AI (session) channels — e.g. Referral, Email, Paid Search, Display. */
+  otherSessions: number
+  /** Other sessions as a percentage of total sessions (0–100, rounded). */
+  otherSharePct: number
+  /** Display string for otherSharePct: 'X%', '<1%' for non-zero shares that round below 1, or '—' when sessions exist but total is unknown (partial sync). */
+  otherSharePctDisplay: string
   lastSyncedAt: string | null
   /** Start of the synced date range (YYYY-MM-DD), null if no data. */
   periodStart: string | null

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1027,6 +1027,20 @@ export interface ApiGaSocialReferral {
   users: number
 }
 
+export interface ApiGaChannelBucket {
+  sessions: number
+  sharePct: number
+  sharePctDisplay: string
+}
+
+export interface ApiGaChannelBreakdown {
+  organic: ApiGaChannelBucket
+  social: ApiGaChannelBucket
+  direct: ApiGaChannelBucket
+  ai: ApiGaChannelBucket
+  other: ApiGaChannelBucket
+}
+
 export interface ApiGaTraffic {
   totalSessions: number
   totalOrganicSessions: number
@@ -1040,7 +1054,7 @@ export interface ApiGaTraffic {
   aiSessionsDeduped: number
   /** Deduped AI user total. */
   aiUsersDeduped: number
-  /** AI sessions whose CURRENT sessionSource matched an AI engine. Disjoint from Direct/Organic/Social — used by the channel breakdown. */
+  /** AI sessions whose CURRENT sessionSource matched an AI engine. Can overlap with raw Organic/Social/Direct totals; channelBreakdown removes those overlaps for display. */
   aiSessionsBySession: number
   /** AI users whose CURRENT sessionSource matched an AI engine. */
   aiUsersBySession: number
@@ -1049,11 +1063,13 @@ export interface ApiGaTraffic {
   socialSessions: number
   /** Total social users (session-scoped via sessionDefaultChannelGroup). */
   socialUsers: number
+  /** Five disjoint buckets used for the channel breakdown cards. */
+  channelBreakdown: ApiGaChannelBreakdown
   /** Organic sessions as a percentage of total sessions (0–100, rounded). */
   organicSharePct: number
   /** Deduped AI sessions as a percentage of total sessions (0–100, rounded). Cross-cutting: can overlap with Direct/Organic/Social. */
   aiSharePct: number
-  /** Session-source-only AI sessions as a percentage of total sessions (0–100, rounded). Disjoint from Direct/Organic/Social. */
+  /** Session-source-only AI sessions as a percentage of total sessions (0–100, rounded). Can overlap with raw Organic/Social/Direct totals. */
   aiSharePctBySession: number
   /** Social sessions as a percentage of total sessions (0–100, rounded). */
   socialSharePct: number

--- a/apps/web/src/components/project/TrafficSection.tsx
+++ b/apps/web/src/components/project/TrafficSection.tsx
@@ -357,6 +357,8 @@ export function TrafficSection({ projectName }: { projectName: string }) {
   const topAiSource = sortedAiReferrals[0] ?? null
   const directSessions = traffic?.totalDirectSessions ?? 0
   const directSharePctDisplay = traffic?.directSharePctDisplay ?? '0%'
+  const otherSessions = traffic?.otherSessions ?? 0
+  const otherSharePctDisplay = traffic?.otherSharePctDisplay ?? '0%'
 
   const socialSessions = traffic?.socialSessions ?? 0
   const socialSharePctDisplay = traffic?.socialSharePctDisplay ?? '0%'
@@ -480,7 +482,7 @@ export function TrafficSection({ projectName }: { projectName: string }) {
                 <p className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 mb-1">Traffic Attribution</p>
                 <h2 className="text-base font-semibold text-zinc-50 flex items-center gap-1.5">
                   Traffic by channel
-                  <InfoTooltip text="Decomposes GA4 sessions into four disjoint channels — organic search, social, direct, and known AI referrers. The AI cell is rendered separately so AI-driven traffic never inflates the Direct count. Detected via sessionDefaultChannelGrouping plus AI-source matching on sessionSource/firstUserSource/sessionManualSource (generic search sources excluded)." />
+                  <InfoTooltip text="Decomposes GA4 sessions into five disjoint channels — organic search, social, direct, known AI referrers, and other channels. The AI cell is rendered separately so AI-driven traffic never inflates the Direct count. Other channels capture Referral, Email, Paid Search, Display, and any remaining default channel groups. Detected via sessionDefaultChannelGrouping plus AI-source matching on sessionSource/firstUserSource/sessionManualSource (generic search sources excluded)." />
                 </h2>
               </div>
               {dateRange && (
@@ -580,7 +582,7 @@ export function TrafficSection({ projectName }: { projectName: string }) {
                 <h3 className="text-sm font-semibold text-zinc-100">Channel breakdown</h3>
               </div>
 
-              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
                 <AttributionStat
                   label="Organic"
                   value={organicPctDisplay}
@@ -608,6 +610,13 @@ export function TrafficSection({ projectName }: { projectName: string }) {
                   hint={`${aiSessionsBySession.toLocaleString()} sessions`}
                   tone="positive"
                   tooltip="Sessions whose current sessionSource matched a known AI engine (e.g. chatgpt.com, claude.ai, gemini.google.com). Disjoint from Direct/Organic/Social. This is a strict lower bound: most AI traffic strips the referrer and falls into Direct, so the true AI share is typically higher than what's shown here. The detail table below also surfaces firstUserSource and UTM-tagged AI signals."
+                />
+                <AttributionStat
+                  label="Other channels"
+                  value={otherSharePctDisplay}
+                  hint={`${otherSessions.toLocaleString()} sessions`}
+                  tone="neutral"
+                  tooltip="Sessions from all other GA4 default channel groups not covered above — Referral, Email, Paid Search, Display, Affiliates, Audio, SMS, etc. Computed as total sessions minus (Organic + Social + Direct + AI by session)."
                 />
               </div>
 

--- a/apps/web/src/components/project/TrafficSection.tsx
+++ b/apps/web/src/components/project/TrafficSection.tsx
@@ -487,7 +487,7 @@ export function TrafficSection({ projectName }: { projectName: string }) {
                 <p className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 mb-1">Traffic Attribution</p>
                 <h2 className="text-base font-semibold text-zinc-50 flex items-center gap-1.5">
                   Traffic by channel
-                  <InfoTooltip text="Decomposes GA4 sessions into five disjoint channels — known AI referrers first, then organic search, social, direct, and other channels. Known AI referrers are removed from their native GA4 channel before the residual Other bucket is computed. Other channels capture Referral, Email, Display, and any remaining default channel groups. Detected via sessionDefaultChannelGrouping plus AI-source matching on sessionSource/firstUserSource/sessionManualSource (generic search sources excluded)." />
+                  <InfoTooltip text="Decomposes GA4 sessions into five disjoint channels — known AI referrers first, then organic search, social, direct, and other channels. Known AI referrers are removed from their native GA4 channel before the residual Other bucket is computed. Other channels are the remaining GA4 session default channel groups, such as Referral, Email, Paid Search, Display, Cross-network, Shopping, Video, Affiliates, SMS, and Paid Other." />
                 </h2>
               </div>
               {dateRange && (
@@ -621,7 +621,7 @@ export function TrafficSection({ projectName }: { projectName: string }) {
                   value={otherSharePctDisplay}
                   hint={`${otherSessions.toLocaleString()} sessions`}
                   tone="neutral"
-                  tooltip="Sessions from all other GA4 default channel groups not covered above — most commonly Referral, Email, and Display. Computed after known AI referrers have been removed from their native GA4 channel so the five buckets stay disjoint."
+                  tooltip="Remaining GA4 session default channel groups after Known AI, Organic Search, Organic/Paid Social, and Direct are accounted for. This is a residual bucket, not a single source. It can include Referral, Email, Paid Search, Display, Cross-network, Shopping, Video, Affiliates, SMS, Mobile Push Notifications, Paid Other, and unclassified traffic."
                 />
               </div>
 

--- a/apps/web/src/components/project/TrafficSection.tsx
+++ b/apps/web/src/components/project/TrafficSection.tsx
@@ -482,7 +482,7 @@ export function TrafficSection({ projectName }: { projectName: string }) {
                 <p className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 mb-1">Traffic Attribution</p>
                 <h2 className="text-base font-semibold text-zinc-50 flex items-center gap-1.5">
                   Traffic by channel
-                  <InfoTooltip text="Decomposes GA4 sessions into five disjoint channels — organic search, social, direct, known AI referrers, and other channels. The AI cell is rendered separately so AI-driven traffic never inflates the Direct count. Other channels capture Referral, Email, Paid Search, Display, and any remaining default channel groups. Detected via sessionDefaultChannelGrouping plus AI-source matching on sessionSource/firstUserSource/sessionManualSource (generic search sources excluded)." />
+                  <InfoTooltip text="Decomposes GA4 sessions into five disjoint channels — organic search, social, direct, known AI referrers, and other channels. The AI cell is rendered separately so AI-driven traffic never inflates the Direct count. Other channels capture Referral, Email, Display, and any remaining default channel groups. Detected via sessionDefaultChannelGrouping plus AI-source matching on sessionSource/firstUserSource/sessionManualSource (generic search sources excluded)." />
                 </h2>
               </div>
               {dateRange && (
@@ -616,7 +616,7 @@ export function TrafficSection({ projectName }: { projectName: string }) {
                   value={otherSharePctDisplay}
                   hint={`${otherSessions.toLocaleString()} sessions`}
                   tone="neutral"
-                  tooltip="Sessions from all other GA4 default channel groups not covered above — Referral, Email, Paid Search, Display, Affiliates, Audio, SMS, etc. Computed as total sessions minus (Organic + Social + Direct + AI by session)."
+                  tooltip="Sessions from all other GA4 default channel groups not covered above — most commonly Referral, Email, and Display. Computed as total sessions minus (Organic + Social + Direct + AI by session)."
                 />
               </div>
 

--- a/apps/web/src/components/project/TrafficSection.tsx
+++ b/apps/web/src/components/project/TrafficSection.tsx
@@ -349,19 +349,24 @@ export function TrafficSection({ projectName }: { projectName: string }) {
   }
 
   const organicPctDisplay = traffic?.organicSharePctDisplay ?? '0%'
-  const organicSessions = traffic?.totalOrganicSessions ?? 0
+  const breakdownOrganicPctDisplay = traffic?.channelBreakdown?.organic.sharePctDisplay ?? organicPctDisplay
+  const breakdownOrganicSessions = traffic?.channelBreakdown?.organic.sessions ?? traffic?.totalOrganicSessions ?? 0
   const aiSessions = traffic?.aiSessionsDeduped ?? 0
-  const aiSessionsBySession = traffic?.aiSessionsBySession ?? 0
-  const aiSharePctBySessionDisplay = traffic?.aiSharePctBySessionDisplay ?? '0%'
+  const aiSessionsBySession = traffic?.channelBreakdown?.ai.sessions ?? traffic?.aiSessionsBySession ?? 0
+  const aiSharePctBySessionDisplay = traffic?.channelBreakdown?.ai.sharePctDisplay ?? traffic?.aiSharePctBySessionDisplay ?? '0%'
   const aiSourceCount = traffic ? new Set(traffic.aiReferrals.map((referral) => referral.source.toLowerCase())).size : 0
   const topAiSource = sortedAiReferrals[0] ?? null
   const directSessions = traffic?.totalDirectSessions ?? 0
   const directSharePctDisplay = traffic?.directSharePctDisplay ?? '0%'
-  const otherSessions = traffic?.otherSessions ?? 0
-  const otherSharePctDisplay = traffic?.otherSharePctDisplay ?? '0%'
+  const breakdownDirectSessions = traffic?.channelBreakdown?.direct.sessions ?? directSessions
+  const breakdownDirectPctDisplay = traffic?.channelBreakdown?.direct.sharePctDisplay ?? directSharePctDisplay
+  const otherSessions = traffic?.channelBreakdown?.other.sessions ?? traffic?.otherSessions ?? 0
+  const otherSharePctDisplay = traffic?.channelBreakdown?.other.sharePctDisplay ?? traffic?.otherSharePctDisplay ?? '0%'
 
   const socialSessions = traffic?.socialSessions ?? 0
   const socialSharePctDisplay = traffic?.socialSharePctDisplay ?? '0%'
+  const breakdownSocialSessions = traffic?.channelBreakdown?.social.sessions ?? socialSessions
+  const breakdownSocialPctDisplay = traffic?.channelBreakdown?.social.sharePctDisplay ?? socialSharePctDisplay
   const socialSourceCount = traffic ? new Set(traffic.socialReferrals.map((r) => r.source.toLowerCase())).size : 0
   const topSocialSource = sortedSocialReferrals[0] ?? null
 
@@ -482,7 +487,7 @@ export function TrafficSection({ projectName }: { projectName: string }) {
                 <p className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 mb-1">Traffic Attribution</p>
                 <h2 className="text-base font-semibold text-zinc-50 flex items-center gap-1.5">
                   Traffic by channel
-                  <InfoTooltip text="Decomposes GA4 sessions into five disjoint channels — organic search, social, direct, known AI referrers, and other channels. The AI cell is rendered separately so AI-driven traffic never inflates the Direct count. Other channels capture Referral, Email, Display, and any remaining default channel groups. Detected via sessionDefaultChannelGrouping plus AI-source matching on sessionSource/firstUserSource/sessionManualSource (generic search sources excluded)." />
+                  <InfoTooltip text="Decomposes GA4 sessions into five disjoint channels — known AI referrers first, then organic search, social, direct, and other channels. Known AI referrers are removed from their native GA4 channel before the residual Other bucket is computed. Other channels capture Referral, Email, Display, and any remaining default channel groups. Detected via sessionDefaultChannelGrouping plus AI-source matching on sessionSource/firstUserSource/sessionManualSource (generic search sources excluded)." />
                 </h2>
               </div>
               {dateRange && (
@@ -585,38 +590,38 @@ export function TrafficSection({ projectName }: { projectName: string }) {
               <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
                 <AttributionStat
                   label="Organic"
-                  value={organicPctDisplay}
-                  hint={`${organicSessions.toLocaleString()} sessions`}
+                  value={breakdownOrganicPctDisplay}
+                  hint={`${breakdownOrganicSessions.toLocaleString()} sessions`}
                   tone="positive"
-                  tooltip="Sessions from Google organic search (sessionDefaultChannelGrouping = 'Organic Search')."
+                  tooltip="Sessions from Google organic search (sessionDefaultChannelGrouping = 'Organic Search'), after known AI referrers are removed for a disjoint channel breakdown."
                 />
                 <AttributionStat
                   label="Social"
-                  value={socialSharePctDisplay}
-                  hint={`${socialSessions.toLocaleString()} sessions`}
+                  value={breakdownSocialPctDisplay}
+                  hint={`${breakdownSocialSessions.toLocaleString()} sessions`}
                   tone="neutral"
-                  tooltip="Sessions from social platforms (sessionDefaultChannelGrouping = 'Organic Social' or 'Paid Social')."
+                  tooltip="Sessions from social platforms (sessionDefaultChannelGrouping = 'Organic Social' or 'Paid Social'), after known AI referrers are removed for a disjoint channel breakdown."
                 />
                 <AttributionStat
                   label="Direct"
-                  value={directSharePctDisplay}
-                  hint={`${directSessions.toLocaleString()} sessions`}
+                  value={breakdownDirectPctDisplay}
+                  hint={`${breakdownDirectSessions.toLocaleString()} sessions`}
                   tone="neutral"
-                  tooltip="Sessions with no source — bookmarks, typed URLs, untagged email, in-app browsers, and AI-driven traffic whose referrer header was stripped."
+                  tooltip="Sessions with no source — bookmarks, typed URLs, untagged email, in-app browsers, and AI-driven traffic whose referrer header was stripped. Known AI referrers are removed if GA4 classified them as Direct."
                 />
                 <AttributionStat
                   label="Known AI referrers (lower bound)"
                   value={aiSharePctBySessionDisplay}
                   hint={`${aiSessionsBySession.toLocaleString()} sessions`}
                   tone="positive"
-                  tooltip="Sessions whose current sessionSource matched a known AI engine (e.g. chatgpt.com, claude.ai, gemini.google.com). Disjoint from Direct/Organic/Social. This is a strict lower bound: most AI traffic strips the referrer and falls into Direct, so the true AI share is typically higher than what's shown here. The detail table below also surfaces firstUserSource and UTM-tagged AI signals."
+                  tooltip="Sessions whose current sessionSource matched a known AI engine (e.g. chatgpt.com, claude.ai, gemini.google.com). These sessions are removed from their native GA4 channel in this card grid so the five buckets stay disjoint. This is a strict lower bound: most AI traffic strips the referrer and falls into Direct, so the true AI share is typically higher than what's shown here. The detail table below also surfaces firstUserSource and UTM-tagged AI signals."
                 />
                 <AttributionStat
                   label="Other channels"
                   value={otherSharePctDisplay}
                   hint={`${otherSessions.toLocaleString()} sessions`}
                   tone="neutral"
-                  tooltip="Sessions from all other GA4 default channel groups not covered above — most commonly Referral, Email, and Display. Computed as total sessions minus (Organic + Social + Direct + AI by session)."
+                  tooltip="Sessions from all other GA4 default channel groups not covered above — most commonly Referral, Email, and Display. Computed after known AI referrers have been removed from their native GA4 channel so the five buckets stay disjoint."
                 />
               </div>
 

--- a/apps/web/test/traffic-section.test.tsx
+++ b/apps/web/test/traffic-section.test.tsx
@@ -181,6 +181,9 @@ test('renders four-channel breakdown with Organic, Social, Direct, and Known AI 
         aiSharePctBySessionDisplay: '10%',
         directSharePctDisplay: '25%',
         socialSharePctDisplay: '7%',
+        otherSessions: 0,
+        otherSharePct: 0,
+        otherSharePctDisplay: '0%',
         lastSyncedAt: '2026-03-31T12:00:00.000Z',
       })
     }

--- a/apps/web/test/traffic-section.test.tsx
+++ b/apps/web/test/traffic-section.test.tsx
@@ -129,7 +129,7 @@ test('loads connected GA4 data without changing hook order', async () => {
   ).toBe(false)
 })
 
-test('renders four-channel breakdown with Organic, Social, Direct, and Known AI referrers (lower bound)', async () => {
+test('renders five-channel breakdown with disjoint Organic, Social, Direct, Known AI, and Other buckets', async () => {
   const restoreFetch = mockFetch((url) => {
     const urlPath = url.split('?')[0]!
     if (urlPath.endsWith('/projects/test-project/ga/status')) {
@@ -163,7 +163,7 @@ test('renders four-channel breakdown with Organic, Social, Direct, and Known AI 
         // Cross-cutting dedup includes firstUserSource → 12 + 30 = 42
         aiSessionsDeduped: 42,
         aiUsersDeduped: 33,
-        // Session-source-only count is disjoint from Direct/Organic/Social → 12
+        // Session-source-only count becomes the dedicated Known AI bucket.
         aiSessionsBySession: 12,
         aiUsersBySession: 9,
         socialReferrals: [
@@ -171,6 +171,13 @@ test('renders four-channel breakdown with Organic, Social, Direct, and Known AI 
         ],
         socialSessions: 8,
         socialUsers: 6,
+        channelBreakdown: {
+          organic: { sessions: 70, sharePct: 58, sharePctDisplay: '58%' },
+          social: { sessions: 8, sharePct: 7, sharePctDisplay: '7%' },
+          direct: { sessions: 30, sharePct: 25, sharePctDisplay: '25%' },
+          ai: { sessions: 12, sharePct: 10, sharePctDisplay: '10%' },
+          other: { sessions: 0, sharePct: 0, sharePctDisplay: '0%' },
+        },
         organicSharePct: 58,
         aiSharePct: 35,
         aiSharePctBySession: 10,
@@ -205,18 +212,19 @@ test('renders four-channel breakdown with Organic, Social, Direct, and Known AI 
   expect(card).toBeTruthy()
   const breakdown = within(card)
 
-  // Four labeled channels appear in the breakdown card
+  // Five labeled channels appear in the breakdown card
   expect(breakdown.getByText('Organic')).toBeTruthy()
   expect(breakdown.getByText('Social')).toBeTruthy()
   expect(breakdown.getByText('Direct')).toBeTruthy()
   expect(breakdown.getByText(/Known AI referrers/)).toBeTruthy()
+  expect(breakdown.getByText('Other channels')).toBeTruthy()
   expect(breakdown.getByText(/lower bound/i)).toBeTruthy()
 
   // Direct cell shows the share from API (25%)
   expect(breakdown.getByText('25%')).toBeTruthy()
 
-  // AI cell uses the session-source-only share (10%, disjoint from Direct/Organic/Social),
-  // NOT the cross-cutting aiSharePct (35%) which would overlap with other channels.
+  // AI cell uses the dedicated channelBreakdown AI share (10%), NOT the
+  // cross-cutting aiSharePct (35%) which would overlap with other channels.
   expect(breakdown.getByText('10%')).toBeTruthy()
   expect(breakdown.queryByText('35%')).toBeNull()
 

--- a/packages/api-routes/src/ga.ts
+++ b/packages/api-routes/src/ga.ts
@@ -3,6 +3,7 @@ import { eq, desc, and, sql } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import { gaTrafficSnapshots, gaTrafficSummaries, gaTrafficWindowSummaries, gaAiReferrals, gaSocialReferrals, runs } from '@ainyc/canonry-db'
 import { validationError, notFound, RunKinds, RunStatuses, RunTriggers, parseWindow, windowCutoff, normalizeUrlPath } from '@ainyc/canonry-contracts'
+import type { GA4ChannelBreakdownDto } from '@ainyc/canonry-contracts'
 import { resolveProject, writeAuditLog } from './helpers.js'
 import {
   getAccessToken,
@@ -39,6 +40,50 @@ function formatSharePct(numerator: number, total: number): string {
   const rounded = Math.round(pct)
   if (rounded === 0) return '<1%'
   return `${rounded}%`
+}
+
+const SOCIAL_CHANNEL_GROUPS = new Set(['Organic Social', 'Paid Social'])
+
+function buildChannelBreakdown(input: {
+  totalSessions: number
+  organicSessions: number
+  socialSessions: number
+  directSessions: number
+  aiSessionsByChannelGroup: Map<string, number>
+}): GA4ChannelBreakdownDto {
+  const aiSessions = [...input.aiSessionsByChannelGroup.values()].reduce((sum, sessions) => sum + sessions, 0)
+  const aiOrganicOverlap = Math.min(input.organicSessions, input.aiSessionsByChannelGroup.get('Organic Search') ?? 0)
+  const aiSocialOverlap = Math.min(
+    input.socialSessions,
+    [...input.aiSessionsByChannelGroup.entries()]
+      .filter(([channelGroup]) => SOCIAL_CHANNEL_GROUPS.has(channelGroup))
+      .reduce((sum, [, sessions]) => sum + sessions, 0),
+  )
+  const aiDirectOverlap = Math.min(input.directSessions, input.aiSessionsByChannelGroup.get('Direct') ?? 0)
+
+  const organicSessions = Math.max(0, input.organicSessions - aiOrganicOverlap)
+  const socialSessions = Math.max(0, input.socialSessions - aiSocialOverlap)
+  const directSessions = Math.max(0, input.directSessions - aiDirectOverlap)
+  const coveredSessions = organicSessions + socialSessions + directSessions + aiSessions
+  const otherSessions = Math.max(0, input.totalSessions - coveredSessions)
+
+  const bucket = (sessions: number) => ({
+    sessions,
+    sharePct: input.totalSessions > 0 ? Math.round((sessions / input.totalSessions) * 100) : 0,
+    sharePctDisplay: formatSharePct(sessions, input.totalSessions),
+  })
+
+  return {
+    organic: bucket(organicSessions),
+    social: bucket(socialSessions),
+    direct: bucket(directSessions),
+    ai: bucket(aiSessions),
+    other: {
+      sessions: otherSessions,
+      sharePct: input.totalSessions > 0 ? Math.round((otherSessions / input.totalSessions) * 100) : 0,
+      sharePctDisplay: input.totalSessions <= 0 && coveredSessions > 0 ? '—' : formatSharePct(otherSessions, input.totalSessions),
+    },
+  }
 }
 
 // For each tuple key, keep the row with the highest sessions and discard the
@@ -488,6 +533,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
               source: row.source,
               medium: row.medium,
               sourceDimension: row.sourceDimension,
+              channelGroup: row.channelGroup,
               landingPage: row.landingPage,
               landingPageNormalized: normalizeUrlPath(row.landingPage),
               sessions: row.sessions,
@@ -804,17 +850,27 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       .get()
 
     // Session-source-only AI total: sessions whose CURRENT sessionSource matched
-    // an AI engine. Disjoint from sessionDefaultChannelGrouping = 'Direct' (those
-    // sessions have no source by definition), so it's safe to display alongside
-    // Organic/Social/Direct in a four-channel breakdown without overlap.
-    const aiBySession = app.db
+    // an AI engine. The stored GA4 default channel group lets the channel
+    // breakdown remove known-AI sessions from their native bucket before
+    // computing the residual "Other" bucket.
+    const aiBySessionRows = app.db
       .select({
+        channelGroup: gaAiReferrals.channelGroup,
         sessions: sql<number>`COALESCE(SUM(${gaAiReferrals.sessions}), 0)`,
         users: sql<number>`COALESCE(SUM(${gaAiReferrals.users}), 0)`,
       })
       .from(gaAiReferrals)
       .where(and(...aiConditions, eq(gaAiReferrals.sourceDimension, 'session')))
-      .get()
+      .groupBy(gaAiReferrals.channelGroup)
+      .all()
+
+    const aiSessionsByChannelGroup = new Map<string, number>()
+    let aiBySessionUsers = 0
+    for (const row of aiBySessionRows) {
+      aiSessionsByChannelGroup.set(row.channelGroup, row.sessions ?? 0)
+      aiBySessionUsers += row.users ?? 0
+    }
+    const aiBySessionSessions = [...aiSessionsByChannelGroup.values()].reduce((sum, sessions) => sum + sessions, 0)
 
     const socialReferrals = app.db
       .select({
@@ -851,10 +907,19 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
 
     const total = summaryRow?.totalSessions ?? 0
     const totalDirectSessions = directTotalRow?.totalDirectSessions ?? 0
+    const totalOrganicSessions = summaryRow?.totalOrganicSessions ?? 0
+    const socialSessions = socialTotals?.sessions ?? 0
+    const channelBreakdown = buildChannelBreakdown({
+      totalSessions: total,
+      organicSessions: totalOrganicSessions,
+      socialSessions,
+      directSessions: totalDirectSessions,
+      aiSessionsByChannelGroup,
+    })
 
     return {
       totalSessions: total,
-      totalOrganicSessions: summaryRow?.totalOrganicSessions ?? 0,
+      totalOrganicSessions,
       totalDirectSessions,
       totalUsers: summaryRow?.totalUsers ?? 0,
       topPages: rows.map((r) => ({
@@ -881,8 +946,8 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       })),
       aiSessionsDeduped: aiDeduped?.sessions ?? 0,
       aiUsersDeduped: aiDeduped?.users ?? 0,
-      aiSessionsBySession: aiBySession?.sessions ?? 0,
-      aiUsersBySession: aiBySession?.users ?? 0,
+      aiSessionsBySession: aiBySessionSessions,
+      aiUsersBySession: aiBySessionUsers,
       socialReferrals: socialReferrals.map((r) => ({
         source: r.source,
         medium: r.medium,
@@ -890,32 +955,22 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         sessions: r.sessions ?? 0,
         users: r.users ?? 0,
       })),
-      socialSessions: socialTotals?.sessions ?? 0,
+      socialSessions,
       socialUsers: socialTotals?.users ?? 0,
-      organicSharePct: total > 0 ? Math.round(((summaryRow?.totalOrganicSessions ?? 0) / total) * 100) : 0,
+      channelBreakdown,
+      organicSharePct: total > 0 ? Math.round((totalOrganicSessions / total) * 100) : 0,
       aiSharePct: total > 0 ? Math.round(((aiDeduped?.sessions ?? 0) / total) * 100) : 0,
-      aiSharePctBySession: total > 0 ? Math.round(((aiBySession?.sessions ?? 0) / total) * 100) : 0,
+      aiSharePctBySession: total > 0 ? Math.round((aiBySessionSessions / total) * 100) : 0,
       directSharePct: total > 0 ? Math.round((totalDirectSessions / total) * 100) : 0,
-      socialSharePct: total > 0 ? Math.round(((socialTotals?.sessions ?? 0) / total) * 100) : 0,
-      otherSessions: (() => {
-        const covered = (summaryRow?.totalOrganicSessions ?? 0) + totalDirectSessions + (socialTotals?.sessions ?? 0) + (aiBySession?.sessions ?? 0)
-        return Math.max(0, total - covered)
-      })(),
-      otherSharePct: (() => {
-        if (total <= 0) return 0
-        const covered = (summaryRow?.totalOrganicSessions ?? 0) + totalDirectSessions + (socialTotals?.sessions ?? 0) + (aiBySession?.sessions ?? 0)
-        return Math.round((Math.max(0, total - covered) / total) * 100)
-      })(),
-      otherSharePctDisplay: (() => {
-        const covered = (summaryRow?.totalOrganicSessions ?? 0) + totalDirectSessions + (socialTotals?.sessions ?? 0) + (aiBySession?.sessions ?? 0)
-        if (total <= 0 && covered > 0) return '—'
-        return formatSharePct(Math.max(0, total - covered), total)
-      })(),
-      organicSharePctDisplay: formatSharePct(summaryRow?.totalOrganicSessions ?? 0, total),
+      socialSharePct: total > 0 ? Math.round((socialSessions / total) * 100) : 0,
+      otherSessions: channelBreakdown.other.sessions,
+      otherSharePct: channelBreakdown.other.sharePct,
+      otherSharePctDisplay: channelBreakdown.other.sharePctDisplay,
+      organicSharePctDisplay: formatSharePct(totalOrganicSessions, total),
       aiSharePctDisplay: formatSharePct(aiDeduped?.sessions ?? 0, total),
-      aiSharePctBySessionDisplay: formatSharePct(aiBySession?.sessions ?? 0, total),
+      aiSharePctBySessionDisplay: formatSharePct(aiBySessionSessions, total),
       directSharePctDisplay: formatSharePct(totalDirectSessions, total),
-      socialSharePctDisplay: formatSharePct(socialTotals?.sessions ?? 0, total),
+      socialSharePctDisplay: formatSharePct(socialSessions, total),
       lastSyncedAt: latestSync?.syncedAt ?? null,
       periodStart: (() => {
         const start = cutoffDate ?? summaryMeta?.periodStart ?? null

--- a/packages/api-routes/src/ga.ts
+++ b/packages/api-routes/src/ga.ts
@@ -897,6 +897,20 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       aiSharePctBySession: total > 0 ? Math.round(((aiBySession?.sessions ?? 0) / total) * 100) : 0,
       directSharePct: total > 0 ? Math.round((totalDirectSessions / total) * 100) : 0,
       socialSharePct: total > 0 ? Math.round(((socialTotals?.sessions ?? 0) / total) * 100) : 0,
+      otherSessions: (() => {
+        const covered = (summaryRow?.totalOrganicSessions ?? 0) + totalDirectSessions + (socialTotals?.sessions ?? 0) + (aiBySession?.sessions ?? 0)
+        return Math.max(0, total - covered)
+      })(),
+      otherSharePct: (() => {
+        if (total <= 0) return 0
+        const covered = (summaryRow?.totalOrganicSessions ?? 0) + totalDirectSessions + (socialTotals?.sessions ?? 0) + (aiBySession?.sessions ?? 0)
+        return Math.round((Math.max(0, total - covered) / total) * 100)
+      })(),
+      otherSharePctDisplay: (() => {
+        const covered = (summaryRow?.totalOrganicSessions ?? 0) + totalDirectSessions + (socialTotals?.sessions ?? 0) + (aiBySession?.sessions ?? 0)
+        if (total <= 0 && covered > 0) return '—'
+        return formatSharePct(Math.max(0, total - covered), total)
+      })(),
       organicSharePctDisplay: formatSharePct(summaryRow?.totalOrganicSessions ?? 0, total),
       aiSharePctDisplay: formatSharePct(aiDeduped?.sessions ?? 0, total),
       aiSharePctBySessionDisplay: formatSharePct(aiBySession?.sessions ?? 0, total),

--- a/packages/api-routes/test/ga.test.ts
+++ b/packages/api-routes/test/ga.test.ts
@@ -685,6 +685,8 @@ describe('GA4 routes', () => {
     expect(body.aiSharePctBySessionDisplay).toBe('5%')
     expect(body.socialSharePctDisplay).toBe('0%')
     expect(body.directSharePctDisplay).toBe('0%')
+    expect(body.otherSessions).toBeGreaterThanOrEqual(0)
+    expect(body.otherSharePctDisplay).toBe('45%')
     expect(body.lastSyncedAt).toBe(now)
     expect(body.periodStart).toBe('2026-02-19')
     expect(body.periodEnd).toBe('2026-03-20')
@@ -770,6 +772,8 @@ describe('GA4 routes', () => {
       expect(body.socialSharePctDisplay).toBe('0%')
       // 600 / 6000 = 10%
       expect(body.organicSharePctDisplay).toBe('10%')
+      expect(body.otherSessions).toBeGreaterThanOrEqual(0)
+      expect(typeof body.otherSharePctDisplay).toBe('string')
     } finally {
       db.delete(gaAiReferrals).where(eq(gaAiReferrals.id, aiId)).run()
       db.delete(gaTrafficSnapshots).where(eq(gaTrafficSnapshots.id, snapshotId)).run()
@@ -832,6 +836,7 @@ describe('GA4 routes', () => {
       expect(body.socialSharePct).toBe(0)
       // No summary, no snapshots — surface the data gap honestly.
       expect(body.socialSharePctDisplay).toBe('—')
+      expect(body.otherSharePctDisplay).toBe('—')
     } finally {
       db.delete(gaSocialReferrals).where(eq(gaSocialReferrals.id, socialId)).run()
       credentials.delete('no-summary')

--- a/packages/api-routes/test/ga.test.ts
+++ b/packages/api-routes/test/ga.test.ts
@@ -248,7 +248,7 @@ describe('GA4 routes', () => {
       totalUsers: windowKey === '7d' ? 15 : windowKey === '30d' ? 55 : 140,
     }))
     const fetchAiReferralsSpy = vi.spyOn(gaModule, 'fetchAiReferrals').mockResolvedValue([
-      { date: '2026-03-20', source: 'chatgpt.com', medium: 'referral', landingPage: '/pricing?utm_source=chatgpt.com', sessions: 12, users: 9, sourceDimension: 'session' },
+      { date: '2026-03-20', source: 'chatgpt.com', medium: 'referral', channelGroup: 'Referral', landingPage: '/pricing?utm_source=chatgpt.com', sessions: 12, users: 9, sourceDimension: 'session' },
     ])
     const fetchSocialReferralsSpy = vi.spyOn(gaModule, 'fetchSocialReferrals').mockResolvedValue([
       { date: '2026-03-20', source: 'facebook.com', medium: 'social', sessions: 8, users: 6, channelGroup: 'Organic Social' },
@@ -692,6 +692,127 @@ describe('GA4 routes', () => {
     expect(body.periodEnd).toBe('2026-03-20')
 
     credentials.delete('test-project')
+  })
+
+  it('GET /ga/traffic computes disjoint channel breakdown when AI overlaps native GA4 channels', async () => {
+    const now = new Date().toISOString()
+    const projectRes = await app.inject({
+      method: 'PUT',
+      url: '/api/v1/projects/channel-overlap',
+      payload: {
+        displayName: 'Channel Overlap',
+        canonicalDomain: 'overlap.example',
+        country: 'US',
+        language: 'en',
+      },
+    })
+    const overlapProjectId = JSON.parse(projectRes.payload).id as string
+    credentials.set('channel-overlap', {
+      projectName: 'channel-overlap',
+      propertyId: '999888',
+      clientEmail: 'sa@test.iam.gserviceaccount.com',
+      privateKey: 'fake-key',
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const aiOrganicId = crypto.randomUUID()
+    const aiSocialId = crypto.randomUUID()
+    const socialId = crypto.randomUUID()
+
+    try {
+      db.insert(gaTrafficSnapshots).values({
+        id: crypto.randomUUID(),
+        projectId: overlapProjectId,
+        date: '2026-03-20',
+        landingPage: '/overlap',
+        sessions: 100,
+        organicSessions: 40,
+        directSessions: 20,
+        users: 80,
+        syncedAt: now,
+      }).run()
+      db.insert(gaTrafficSummaries).values({
+        id: crypto.randomUUID(),
+        projectId: overlapProjectId,
+        periodStart: '2026-02-19',
+        periodEnd: '2026-03-20',
+        totalSessions: 100,
+        totalOrganicSessions: 40,
+        totalUsers: 80,
+        syncedAt: now,
+      }).run()
+      db.insert(gaSocialReferrals).values({
+        id: socialId,
+        projectId: overlapProjectId,
+        date: '2026-03-20',
+        source: 'meta.ai',
+        medium: 'social',
+        channelGroup: 'Organic Social',
+        sessions: 15,
+        users: 12,
+        syncedAt: now,
+      }).run()
+      db.insert(gaAiReferrals).values([
+        {
+          id: aiOrganicId,
+          projectId: overlapProjectId,
+          date: '2026-03-20',
+          source: 'gemini.google.com',
+          medium: 'organic',
+          sourceDimension: 'session',
+          channelGroup: 'Organic Search',
+          landingPage: '/overlap',
+          landingPageNormalized: '/overlap',
+          sessions: 10,
+          users: 8,
+          syncedAt: now,
+        },
+        {
+          id: aiSocialId,
+          projectId: overlapProjectId,
+          date: '2026-03-20',
+          source: 'meta.ai',
+          medium: 'social',
+          sourceDimension: 'session',
+          channelGroup: 'Organic Social',
+          landingPage: '/overlap',
+          landingPageNormalized: '/overlap',
+          sessions: 5,
+          users: 4,
+          syncedAt: now,
+        },
+      ]).run()
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/v1/projects/channel-overlap/ga/traffic',
+      })
+      expect(res.statusCode).toBe(200)
+      const body = JSON.parse(res.payload)
+
+      expect(body.totalOrganicSessions).toBe(40)
+      expect(body.socialSessions).toBe(15)
+      expect(body.aiSessionsBySession).toBe(15)
+      expect(body.channelBreakdown).toEqual({
+        organic: { sessions: 30, sharePct: 30, sharePctDisplay: '30%' },
+        social: { sessions: 10, sharePct: 10, sharePctDisplay: '10%' },
+        direct: { sessions: 20, sharePct: 20, sharePctDisplay: '20%' },
+        ai: { sessions: 15, sharePct: 15, sharePctDisplay: '15%' },
+        other: { sessions: 25, sharePct: 25, sharePctDisplay: '25%' },
+      })
+      expect(body.otherSessions).toBe(25)
+      expect(body.otherSharePctDisplay).toBe('25%')
+      const totalBreakdownSessions = Object.values(body.channelBreakdown as Record<string, { sessions: number }>)
+        .reduce((sum, bucket) => sum + bucket.sessions, 0)
+      expect(totalBreakdownSessions).toBe(100)
+    } finally {
+      credentials.delete('channel-overlap')
+      db.delete(gaAiReferrals).where(inArray(gaAiReferrals.id, [aiOrganicId, aiSocialId])).run()
+      db.delete(gaSocialReferrals).where(eq(gaSocialReferrals.id, socialId)).run()
+      db.delete(gaTrafficSnapshots).where(eq(gaTrafficSnapshots.projectId, overlapProjectId)).run()
+      db.delete(gaTrafficSummaries).where(eq(gaTrafficSummaries.projectId, overlapProjectId)).run()
+    }
   })
 
   it('GET /ga/traffic returns "<1%" display when AI sessions are present but rounded pct is 0', async () => {

--- a/packages/api-routes/test/traffic.test.ts
+++ b/packages/api-routes/test/traffic.test.ts
@@ -345,9 +345,7 @@ describe('POST /traffic/sources/:id/sync', () => {
     // Event sits inside the default 60-min sync window for the first sync. After
     // the first sync, lastSyncedAt is "now-ish", so the second sync's window
     // collapses to roughly [lastSyncedAt, now] and no longer covers the event.
-    const baseTime = new Date(Date.now() - 30 * 60_000)
-    baseTime.setMinutes(0, 0, 0)
-    const observedAt = new Date(baseTime.getTime() + 5 * 60_000).toISOString()
+    const observedAt = new Date(Date.now() - 30 * 60_000).toISOString()
 
     const events: NormalizedTrafficRequest[] = [
       buildEvent({ userAgent: 'GPTBot/1.0', path: '/blog/foo', status: 200, observedAt }),

--- a/packages/canonry/src/commands/ga.ts
+++ b/packages/canonry/src/commands/ga.ts
@@ -438,6 +438,10 @@ export async function gaAttribution(project: string, opts?: { trend?: boolean; f
         aiSharePctBySessionDisplay: traffic.aiSharePctBySessionDisplay,
         socialSharePctDisplay: traffic.socialSharePctDisplay,
         directSharePctDisplay: traffic.directSharePctDisplay,
+        otherSessions: traffic.otherSessions,
+        otherSharePct: traffic.otherSharePct,
+        otherSharePctDisplay: traffic.otherSharePctDisplay,
+        channelBreakdown: traffic.channelBreakdown,
         aiReferrals: traffic.aiReferrals,
         aiReferralLandingPages: traffic.aiReferralLandingPages,
         socialReferrals: traffic.socialReferrals,
@@ -456,15 +460,11 @@ export async function gaAttribution(project: string, opts?: { trend?: boolean; f
     console.log(`  Total Users:      ${traffic.totalUsers}`)
     console.log()
     console.log('  CHANNEL BREAKDOWN                  7d trend     30d trend')
-    console.log(`    Organic Search: ${String(traffic.totalOrganicSessions).padEnd(6)} (${traffic.organicSharePctDisplay.padStart(4)})    ${fmtTrend(trend.organic.trend7dPct).padEnd(12)} ${fmtTrend(trend.organic.trend30dPct)}`)
-    console.log(`    Social:         ${String(traffic.socialSessions).padEnd(6)} (${traffic.socialSharePctDisplay.padStart(4)})    ${fmtTrend(trend.social.trend7dPct).padEnd(12)} ${fmtTrend(trend.social.trend30dPct)}`)
-    console.log(`    Direct:         ${String(traffic.totalDirectSessions).padEnd(6)} (${traffic.directSharePctDisplay.padStart(4)})    ${fmtTrend(trend.direct.trend7dPct).padEnd(12)} ${fmtTrend(trend.direct.trend30dPct)}`)
-    console.log(`    AI Referrals:   ${String(traffic.aiSessionsBySession).padEnd(6)} (${traffic.aiSharePctBySessionDisplay.padStart(4)})    ${fmtTrend(trend.ai.trend7dPct).padEnd(12)} ${fmtTrend(trend.ai.trend30dPct)}  (lower bound — sessionSource only; referrer-stripped traffic falls under Direct)`)
-    const otherSessions = traffic.totalSessions - traffic.totalOrganicSessions - traffic.aiSessionsBySession - traffic.socialSessions - traffic.totalDirectSessions
-    if (otherSessions > 0) {
-      const otherPct = traffic.totalSessions > 0 ? Math.round((otherSessions / traffic.totalSessions) * 100) : 0
-      console.log(`    Other:          ${String(otherSessions).padEnd(6)} (${String(otherPct).padStart(2)}%)`)
-    }
+    console.log(`    Organic Search: ${String(traffic.channelBreakdown.organic.sessions).padEnd(6)} (${traffic.channelBreakdown.organic.sharePctDisplay.padStart(4)})    ${fmtTrend(trend.organic.trend7dPct).padEnd(12)} ${fmtTrend(trend.organic.trend30dPct)}`)
+    console.log(`    Social:         ${String(traffic.channelBreakdown.social.sessions).padEnd(6)} (${traffic.channelBreakdown.social.sharePctDisplay.padStart(4)})    ${fmtTrend(trend.social.trend7dPct).padEnd(12)} ${fmtTrend(trend.social.trend30dPct)}`)
+    console.log(`    Direct:         ${String(traffic.channelBreakdown.direct.sessions).padEnd(6)} (${traffic.channelBreakdown.direct.sharePctDisplay.padStart(4)})    ${fmtTrend(trend.direct.trend7dPct).padEnd(12)} ${fmtTrend(trend.direct.trend30dPct)}`)
+    console.log(`    AI Referrals:   ${String(traffic.channelBreakdown.ai.sessions).padEnd(6)} (${traffic.channelBreakdown.ai.sharePctDisplay.padStart(4)})    ${fmtTrend(trend.ai.trend7dPct).padEnd(12)} ${fmtTrend(trend.ai.trend30dPct)}  (lower bound — sessionSource only; referrer-stripped traffic falls under Direct)`)
+    console.log(`    Other:          ${String(traffic.channelBreakdown.other.sessions).padEnd(6)} (${traffic.channelBreakdown.other.sharePctDisplay.padStart(4)})`)
     console.log(`    ─────────────────────────────────────────────────────`)
     console.log(`    Total:          ${String(traffic.totalSessions).padEnd(6)}         ${fmtTrend(trend.total.trend7dPct).padEnd(12)} ${fmtTrend(trend.total.trend30dPct)}`)
 
@@ -508,6 +508,10 @@ export async function gaAttribution(project: string, opts?: { trend?: boolean; f
       aiSharePctBySessionDisplay: traffic.aiSharePctBySessionDisplay,
       socialSharePctDisplay: traffic.socialSharePctDisplay,
       directSharePctDisplay: traffic.directSharePctDisplay,
+      otherSessions: traffic.otherSessions,
+      otherSharePct: traffic.otherSharePct,
+      otherSharePctDisplay: traffic.otherSharePctDisplay,
+      channelBreakdown: traffic.channelBreakdown,
       aiReferrals: traffic.aiReferrals,
       aiReferralLandingPages: traffic.aiReferralLandingPages,
       socialReferrals: traffic.socialReferrals,
@@ -527,15 +531,11 @@ export async function gaAttribution(project: string, opts?: { trend?: boolean; f
   console.log(`  Total Users:      ${traffic.totalUsers}`)
   console.log()
   console.log('  CHANNEL BREAKDOWN')
-  console.log(`    Organic Search: ${traffic.totalOrganicSessions} sessions (${traffic.organicSharePctDisplay})`)
-  console.log(`    Social:         ${traffic.socialSessions} sessions (${traffic.socialSharePctDisplay})`)
-  console.log(`    Direct:         ${traffic.totalDirectSessions} sessions (${traffic.directSharePctDisplay})`)
-  console.log(`    AI Referrals:   ${traffic.aiSessionsBySession} sessions (${traffic.aiSharePctBySessionDisplay})  (lower bound — sessionSource only; referrer-stripped traffic falls under Direct)`)
-  const otherSessions = traffic.totalSessions - traffic.totalOrganicSessions - traffic.aiSessionsBySession - traffic.socialSessions - traffic.totalDirectSessions
-  if (otherSessions > 0) {
-    const otherPct = traffic.totalSessions > 0 ? Math.round((otherSessions / traffic.totalSessions) * 100) : 0
-    console.log(`    Other:          ${otherSessions} sessions (${otherPct}%)`)
-  }
+  console.log(`    Organic Search: ${traffic.channelBreakdown.organic.sessions} sessions (${traffic.channelBreakdown.organic.sharePctDisplay})`)
+  console.log(`    Social:         ${traffic.channelBreakdown.social.sessions} sessions (${traffic.channelBreakdown.social.sharePctDisplay})`)
+  console.log(`    Direct:         ${traffic.channelBreakdown.direct.sessions} sessions (${traffic.channelBreakdown.direct.sharePctDisplay})`)
+  console.log(`    AI Referrals:   ${traffic.channelBreakdown.ai.sessions} sessions (${traffic.channelBreakdown.ai.sharePctDisplay})  (lower bound — sessionSource only; referrer-stripped traffic falls under Direct)`)
+  console.log(`    Other:          ${traffic.channelBreakdown.other.sessions} sessions (${traffic.channelBreakdown.other.sharePctDisplay})`)
 
   if (traffic.aiReferrals.length > 0) {
     console.log()

--- a/packages/canonry/test/ga-attribution.test.ts
+++ b/packages/canonry/test/ga-attribution.test.ts
@@ -182,15 +182,25 @@ describe('canonry ga attribution --format json', () => {
       aiSessionsBySession: number
       aiSharePct: number
       aiSharePctBySession: number
+      channelBreakdown: {
+        organic: { sessions: number }
+        direct: { sessions: number }
+        ai: { sessions: number }
+        other: { sessions: number }
+      }
       aiReferralLandingPages: Array<{ landingPage: string; source: string; sessions: number }>
       trend: { direct: { sessions7d: number; sessionsPrev7d: number; trend7dPct: number | null } }
     }
     expect(parsed.directSessions).toBeGreaterThanOrEqual(75)
     expect(parsed.directSharePct).toBeGreaterThan(0)
-    // Cross-cutting dedup includes firstUserSource → 12; bySession is the disjoint 5.
+    // Cross-cutting dedup includes firstUserSource → 12; bySession is the dedicated AI channel bucket.
     expect(parsed.aiSessions).toBe(12)
     expect(parsed.aiSessionsBySession).toBe(5)
     expect(parsed.aiSharePctBySession).toBeLessThan(parsed.aiSharePct)
+    expect(parsed.channelBreakdown.organic.sessions).toBe(20)
+    expect(parsed.channelBreakdown.direct.sessions).toBeGreaterThanOrEqual(75)
+    expect(parsed.channelBreakdown.ai.sessions).toBe(5)
+    expect(parsed.channelBreakdown.other.sessions).toBe(0)
     expect(parsed.aiReferralLandingPages).toEqual(expect.arrayContaining([
       expect.objectContaining({ landingPage: '/pricing', source: 'chatgpt.com', sessions: 12 }),
     ]))

--- a/packages/contracts/src/ga.ts
+++ b/packages/contracts/src/ga.ts
@@ -113,6 +113,12 @@ export const ga4TrafficSummaryDtoSchema = z.object({
   directSharePctDisplay: z.string(),
   /** Display string for socialSharePct: 'X%', '<1%' for non-zero shares that round below 1, or '—' when sessions exist but total is unknown (partial sync). */
   socialSharePctDisplay: z.string(),
+  /** Sessions not covered by Organic, Social, Direct, or AI (session) channels — e.g. Referral, Email, Paid Search, Display. Always non-negative; clamped to 0 when the four disjoint channels sum above total (rounding edge). */
+  otherSessions: z.number(),
+  /** Other sessions as a percentage of total sessions (0–100, rounded). */
+  otherSharePct: z.number(),
+  /** Display string for otherSharePct: 'X%', '<1%' for non-zero shares that round below 1, or '—' when sessions exist but total is unknown (partial sync). */
+  otherSharePctDisplay: z.string(),
   lastSyncedAt: z.string().nullable(),
 })
 export type GA4TrafficSummaryDto = z.infer<typeof ga4TrafficSummaryDtoSchema>
@@ -227,6 +233,12 @@ export interface GaTrafficResponse {
   directSharePctDisplay: string
   /** Display string for socialSharePct: 'X%', '<1%' for non-zero shares that round below 1, or '—' when sessions exist but total is unknown (partial sync). */
   socialSharePctDisplay: string
+  /** Sessions not covered by Organic, Social, Direct, or AI (session) channels — e.g. Referral, Email, Paid Search, Display. Always non-negative; clamped to 0 when the four disjoint channels sum above total (rounding edge). */
+  otherSessions: number
+  /** Other sessions as a percentage of total sessions (0–100, rounded). */
+  otherSharePct: number
+  /** Display string for otherSharePct: 'X%', '<1%' for non-zero shares that round below 1, or '—' when sessions exist but total is unknown (partial sync). */
+  otherSharePctDisplay: string
   lastSyncedAt: string | null
   /** Start of the synced date range (YYYY-MM-DD), null if no data. */
   periodStart: string | null

--- a/packages/contracts/src/ga.ts
+++ b/packages/contracts/src/ga.ts
@@ -64,6 +64,22 @@ export const ga4SocialReferralDtoSchema = z.object({
 })
 export type GA4SocialReferralDto = z.infer<typeof ga4SocialReferralDtoSchema>
 
+export const ga4ChannelBucketDtoSchema = z.object({
+  sessions: z.number(),
+  sharePct: z.number(),
+  sharePctDisplay: z.string(),
+})
+export type GA4ChannelBucketDto = z.infer<typeof ga4ChannelBucketDtoSchema>
+
+export const ga4ChannelBreakdownDtoSchema = z.object({
+  organic: ga4ChannelBucketDtoSchema,
+  social: ga4ChannelBucketDtoSchema,
+  direct: ga4ChannelBucketDtoSchema,
+  ai: ga4ChannelBucketDtoSchema,
+  other: ga4ChannelBucketDtoSchema,
+})
+export type GA4ChannelBreakdownDto = z.infer<typeof ga4ChannelBreakdownDtoSchema>
+
 export const ga4TrafficSummaryDtoSchema = z.object({
   totalSessions: z.number(),
   totalOrganicSessions: z.number(),
@@ -84,20 +100,22 @@ export const ga4TrafficSummaryDtoSchema = z.object({
   aiSessionsDeduped: z.number(),
   /** Deduped AI user total: MAX(users) per date+source+medium across attribution dimensions, then summed. */
   aiUsersDeduped: z.number(),
-  /** AI sessions whose CURRENT sessionSource matched an AI engine. Disjoint from Direct/Organic/Social — safe for the channel breakdown. */
+  /** AI sessions whose CURRENT sessionSource matched an AI engine. Can overlap with raw Organic/Social/Direct totals; `channelBreakdown` removes those overlaps for display. */
   aiSessionsBySession: z.number(),
-  /** AI users whose CURRENT sessionSource matched an AI engine. Disjoint from Direct/Organic/Social — safe for the channel breakdown. */
+  /** AI users whose CURRENT sessionSource matched an AI engine. Can overlap with raw Organic/Social/Direct totals. */
   aiUsersBySession: z.number(),
   socialReferrals: z.array(ga4SocialReferralDtoSchema),
   /** Total social sessions (session-scoped, no cross-dimension dedup needed). */
   socialSessions: z.number(),
   /** Total social users (session-scoped, no cross-dimension dedup needed). */
   socialUsers: z.number(),
+  /** Five disjoint buckets used for the channel breakdown. Known AI session-source matches are removed from their native GA4 bucket before shares are computed. */
+  channelBreakdown: ga4ChannelBreakdownDtoSchema,
   /** Organic sessions as a percentage of total sessions (0–100, rounded). */
   organicSharePct: z.number(),
   /** Deduped AI sessions as a percentage of total sessions (0–100, rounded). Cross-cutting: can overlap with Direct/Organic/Social. */
   aiSharePct: z.number(),
-  /** Session-source-only AI sessions as a percentage of total sessions (0–100, rounded). Disjoint from Direct/Organic/Social. */
+  /** Session-source-only AI sessions as a percentage of total sessions (0–100, rounded). Can overlap with raw Organic/Social/Direct totals. */
   aiSharePctBySession: z.number(),
   /** Direct-channel sessions as a percentage of total sessions (0–100, rounded). */
   directSharePct: z.number(),
@@ -204,20 +222,28 @@ export interface GaTrafficResponse {
   aiSessionsDeduped: number
   /** Deduped AI user total: MAX(users) per date+source+medium across attribution dimensions, then summed. */
   aiUsersDeduped: number
-  /** AI sessions whose CURRENT sessionSource matched an AI engine. Disjoint from Direct/Organic/Social — safe for the channel breakdown. */
+  /** AI sessions whose CURRENT sessionSource matched an AI engine. Can overlap with raw Organic/Social/Direct totals; `channelBreakdown` removes those overlaps for display. */
   aiSessionsBySession: number
-  /** AI users whose CURRENT sessionSource matched an AI engine. Disjoint from Direct/Organic/Social — safe for the channel breakdown. */
+  /** AI users whose CURRENT sessionSource matched an AI engine. Can overlap with raw Organic/Social/Direct totals. */
   aiUsersBySession: number
   socialReferrals: Array<{ source: string; medium: string; sessions: number; users: number; channelGroup: string }>
   /** Total social sessions (session-scoped via sessionDefaultChannelGroup). */
   socialSessions: number
   /** Total social users (session-scoped via sessionDefaultChannelGroup). */
   socialUsers: number
+  /** Five disjoint buckets used for the channel breakdown. Known AI session-source matches are removed from their native GA4 bucket before shares are computed. */
+  channelBreakdown: {
+    organic: GA4ChannelBucketDto
+    social: GA4ChannelBucketDto
+    direct: GA4ChannelBucketDto
+    ai: GA4ChannelBucketDto
+    other: GA4ChannelBucketDto
+  }
   /** Organic sessions as a percentage of total sessions (0–100, rounded). */
   organicSharePct: number
   /** Deduped AI sessions as a percentage of total sessions (0–100, rounded). Cross-cutting: can overlap with Direct/Organic/Social. */
   aiSharePct: number
-  /** Session-source-only AI sessions as a percentage of total sessions (0–100, rounded). Disjoint from Direct/Organic/Social. */
+  /** Session-source-only AI sessions as a percentage of total sessions (0–100, rounded). Can overlap with raw Organic/Social/Direct totals. */
   aiSharePctBySession: number
   /** Direct-channel sessions as a percentage of total sessions (0–100, rounded). */
   directSharePct: number

--- a/packages/contracts/test/ga.test.ts
+++ b/packages/contracts/test/ga.test.ts
@@ -40,6 +40,9 @@ describe('GA contracts', () => {
       aiSharePctBySessionDisplay: '12%',
       directSharePctDisplay: '20%',
       socialSharePctDisplay: '0%',
+      otherSessions: 0,
+      otherSharePct: 0,
+      otherSharePctDisplay: '0%',
       lastSyncedAt: null,
     })
 

--- a/packages/contracts/test/ga.test.ts
+++ b/packages/contracts/test/ga.test.ts
@@ -30,6 +30,13 @@ describe('GA contracts', () => {
       socialReferrals: [],
       socialSessions: 0,
       socialUsers: 0,
+      channelBreakdown: {
+        organic: { sessions: 30, sharePct: 30, sharePctDisplay: '30%' },
+        social: { sessions: 0, sharePct: 0, sharePctDisplay: '0%' },
+        direct: { sessions: 20, sharePct: 20, sharePctDisplay: '20%' },
+        ai: { sessions: 12, sharePct: 12, sharePctDisplay: '12%' },
+        other: { sessions: 38, sharePct: 38, sharePctDisplay: '38%' },
+      },
       organicSharePct: 30,
       aiSharePct: 12,
       aiSharePctBySession: 12,
@@ -40,9 +47,9 @@ describe('GA contracts', () => {
       aiSharePctBySessionDisplay: '12%',
       directSharePctDisplay: '20%',
       socialSharePctDisplay: '0%',
-      otherSessions: 0,
-      otherSharePct: 0,
-      otherSharePctDisplay: '0%',
+      otherSessions: 38,
+      otherSharePct: 38,
+      otherSharePctDisplay: '38%',
       lastSyncedAt: null,
     })
 

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -932,6 +932,20 @@ export const MIGRATION_VERSIONS: ReadonlyArray<MigrationVersion> = [
       `CREATE INDEX IF NOT EXISTS idx_raw_event_samples_event_type ON raw_event_samples(event_type)`,
     ],
   },
+  {
+    version: 50,
+    name: 'ga-ai-referral-channel-group',
+    statements: [],
+    run: (tx) => {
+      if (!tableExists(tx, 'ga_ai_referrals')) return
+      if (!columnExists(tx, 'ga_ai_referrals', 'channel_group')) {
+        tx.run(sql.raw(`ALTER TABLE ga_ai_referrals ADD COLUMN channel_group TEXT NOT NULL DEFAULT '(not set)'`))
+      }
+      tx.run(sql.raw(`DROP INDEX IF EXISTS idx_ga_ai_ref_unique_v3`))
+      tx.run(sql.raw(`CREATE UNIQUE INDEX IF NOT EXISTS idx_ga_ai_ref_unique_v4
+         ON ga_ai_referrals(project_id, date, source, medium, source_dimension, channel_group, landing_page)`))
+    },
+  },
 ]
 
 /**

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -317,6 +317,8 @@ export const gaAiReferrals = sqliteTable('ga_ai_referrals', {
   medium: text('medium').notNull(),
   /** Which GA4 dimension produced this row: 'session' | 'first_user' | 'manual_utm' */
   sourceDimension: text('source_dimension').notNull().default('session'),
+  /** GA4 default channel group for the session (e.g. 'Referral', 'Organic Social'). */
+  channelGroup: text('channel_group').notNull().default('(not set)'),
   landingPage: text('landing_page').notNull().default('(not set)'),
   landingPageNormalized: text('landing_page_normalized'),
   sessions: integer('sessions').notNull().default(0),
@@ -327,7 +329,7 @@ export const gaAiReferrals = sqliteTable('ga_ai_referrals', {
   index('idx_ga_ai_ref_project_date').on(table.projectId, table.date),
   index('idx_ga_ai_ref_source').on(table.source),
   index('idx_ga_ai_ref_landing_page').on(table.projectId, table.date, table.landingPageNormalized),
-  uniqueIndex('idx_ga_ai_ref_unique_v3').on(table.projectId, table.date, table.source, table.medium, table.sourceDimension, table.landingPage),
+  uniqueIndex('idx_ga_ai_ref_unique_v4').on(table.projectId, table.date, table.source, table.medium, table.sourceDimension, table.channelGroup, table.landingPage),
   index('idx_ga_ai_ref_run').on(table.syncRunId),
 ])
 

--- a/packages/db/test/index.test.ts
+++ b/packages/db/test/index.test.ts
@@ -850,12 +850,12 @@ test('migrate is safe to replay after intermediate-state data is inserted', () =
   const rows = db2.all(sql.raw(`SELECT COUNT(*) as cnt FROM ga_ai_referrals`)) as Array<{ cnt: number }>
   expect(rows[0]?.cnt).toBe(3)
 
-  // The v3 unique index should be in place
+  // The latest unique index should be in place
   const sqlite = new Database(dbPath, { readonly: true })
   onTestFinished(() => sqlite.close())
   const indexes = sqlite.prepare("SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_ga_ai_ref_unique%'").all() as Array<{ name: string }>
   const indexNames = indexes.map(i => i.name)
-  expect(indexNames).toContain('idx_ga_ai_ref_unique_v3')
+  expect(indexNames).toContain('idx_ga_ai_ref_unique_v4')
 })
 
 test('_migrations table is created on first migrate', () => {

--- a/packages/integration-google-analytics/src/ga4-client.ts
+++ b/packages/integration-google-analytics/src/ga4-client.ts
@@ -672,6 +672,7 @@ export async function fetchAiReferrals(
           { name: 'date' },
           { name: sourceDim },
           { name: mediumDim },
+          { name: 'sessionDefaultChannelGroup' },
           { name: 'landingPagePlusQueryString' },
         ],
         metrics: [
@@ -699,7 +700,8 @@ export async function fetchAiReferrals(
         date: row.dimensionValues[0]!.value,
         source: row.dimensionValues[1]!.value,
         medium: row.dimensionValues[2]!.value,
-        landingPage: row.dimensionValues[3]?.value ?? '(not set)',
+        channelGroup: row.dimensionValues[3]?.value ?? '(not set)',
+        landingPage: row.dimensionValues[4]?.value ?? '(not set)',
         sessions: parseInt(row.metricValues[0]!.value, 10) || 0,
         users: parseInt(row.metricValues[1]!.value, 10) || 0,
         sourceDimension: dimLabel,
@@ -713,11 +715,11 @@ export async function fetchAiReferrals(
     }
   }
 
-  // Deduplicate within each dimension: if the same date+source+medium+page+dimension
+  // Deduplicate within each dimension: if the same date+source+medium+channel+page+dimension
   // appears multiple times (shouldn't happen, but defensive), keep the higher count.
   const deduped = new Map<string, GA4AiReferralRow>()
   for (const row of rows) {
-    const key = `${row.date}::${row.source}::${row.medium}::${row.sourceDimension}::${row.landingPage}`
+    const key = `${row.date}::${row.source}::${row.medium}::${row.sourceDimension}::${row.channelGroup}::${row.landingPage}`
     const existing = deduped.get(key)
     if (!existing) {
       deduped.set(key, row)

--- a/packages/integration-google-analytics/src/types.ts
+++ b/packages/integration-google-analytics/src/types.ts
@@ -64,6 +64,8 @@ export interface GA4AiReferralRow {
   date: string
   source: string
   medium: string
+  /** GA4 default channel group for the current session. */
+  channelGroup: string
   landingPage: string
   sessions: number
   users: number

--- a/packages/integration-google-analytics/test/ga4-client.test.ts
+++ b/packages/integration-google-analytics/test/ga4-client.test.ts
@@ -231,7 +231,7 @@ describe('fetchAiReferrals', () => {
       return mockFetchResponse({
         rows: [
           {
-            dimensionValues: [{ value: '20260320' }, { value: 'chatgpt.com' }, { value: 'referral' }, { value: '/pricing?utm_source=chatgpt.com' }],
+            dimensionValues: [{ value: '20260320' }, { value: 'chatgpt.com' }, { value: 'referral' }, { value: 'Referral' }, { value: '/pricing?utm_source=chatgpt.com' }],
             metricValues: [{ value: '12' }, { value: '10' }],
           },
         ],
@@ -244,9 +244,9 @@ describe('fetchAiReferrals', () => {
     // Returns one row per dimension (session, first_user, manual_utm) since
     // the mock returns the same data for all three queries
     expect(rows).toEqual([
-      { date: '2026-03-20', source: 'chatgpt.com', medium: 'referral', landingPage: '/pricing?utm_source=chatgpt.com', sessions: 12, users: 10, sourceDimension: 'session' },
-      { date: '2026-03-20', source: 'chatgpt.com', medium: 'referral', landingPage: '/pricing?utm_source=chatgpt.com', sessions: 12, users: 10, sourceDimension: 'first_user' },
-      { date: '2026-03-20', source: 'chatgpt.com', medium: 'referral', landingPage: '/pricing?utm_source=chatgpt.com', sessions: 12, users: 10, sourceDimension: 'manual_utm' },
+      { date: '2026-03-20', source: 'chatgpt.com', medium: 'referral', channelGroup: 'Referral', landingPage: '/pricing?utm_source=chatgpt.com', sessions: 12, users: 10, sourceDimension: 'session' },
+      { date: '2026-03-20', source: 'chatgpt.com', medium: 'referral', channelGroup: 'Referral', landingPage: '/pricing?utm_source=chatgpt.com', sessions: 12, users: 10, sourceDimension: 'first_user' },
+      { date: '2026-03-20', source: 'chatgpt.com', medium: 'referral', channelGroup: 'Referral', landingPage: '/pricing?utm_source=chatgpt.com', sessions: 12, users: 10, sourceDimension: 'manual_utm' },
     ])
 
     // Verify all three dimension pairs were queried
@@ -275,9 +275,15 @@ describe('fetchAiReferrals', () => {
     })
     expect(mediumDims).toEqual(['sessionMedium', 'firstUserMedium', 'sessionManualMedium'])
 
-    const landingDims = requestBodies.map((b) => {
+    const channelGroupDims = requestBodies.map((b) => {
       const dimensions = b.dimensions as Array<{ name: string }>
       return dimensions[3]?.name
+    })
+    expect(channelGroupDims).toEqual(['sessionDefaultChannelGroup', 'sessionDefaultChannelGroup', 'sessionDefaultChannelGroup'])
+
+    const landingDims = requestBodies.map((b) => {
+      const dimensions = b.dimensions as Array<{ name: string }>
+      return dimensions[4]?.name
     })
     expect(landingDims).toEqual(['landingPagePlusQueryString', 'landingPagePlusQueryString', 'landingPagePlusQueryString'])
   })


### PR DESCRIPTION
## Problem

The four channel cards (Organic, Social, Direct, Known AI referrers) only covered a subset of GA4 default channel groups. Sessions from Referral, Email, Paid Search, Display, and other channels were counted in `totalSessions` but not represented in any card, causing the displayed percentages to fall short of 100%.

Example from ainyc.ai: Organic 6% + Social 17% + Direct 66% + AI 1% = **90%** (10% gap from unrepresented channels)

## Fix

Compute `otherSessions = total - (organic + social + direct + aiBySession)` and render as a fifth "Other channels" card in the breakdown grid.

### Changes
- **contracts**: add `otherSessions`, `otherSharePct`, `otherSharePctDisplay`
- **api-routes**: compute other sessions as residual from four disjoint channels, with '—' fallback for the partial-sync edge case
- **web**: render 'Other channels' card, update grid to `lg:grid-cols-5`, update InfoTooltip text
- **tests**: add assertions for new fields in contracts, API routes, and web tests