### PR TITLE
fix(telemetry): stable IDs, real-failure metric, opinionated init

### DIFF
--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
-  },
-})

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,8 +1,0 @@
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    environment: 'jsdom',
-    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
-  },
-})

--- a/apps/worker/vitest.config.ts
+++ b/apps/worker/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
-  },
-})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.13.3",
+  "version": "4.14.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/vitest.config.ts
+++ b/packages/api-routes/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
-  },
-})

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.13.3",
+  "version": "4.14.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/commands/init.ts
+++ b/packages/canonry/src/commands/init.ts
@@ -288,6 +288,8 @@ export async function initCommand(opts?: InitOptions): Promise<ResolvedAgentLLM 
     }
   }
 
+  const nextSteps = buildNextSteps()
+
   if (format === 'json') {
     console.log(JSON.stringify({
       initialized: true,
@@ -299,6 +301,7 @@ export async function initCommand(opts?: InitOptions): Promise<ResolvedAgentLLM 
       googleConfigured: !!google,
       skills: skillsSummary,
       skillsTip,
+      nextSteps,
     }, null, 2))
   } else {
     console.log(`\nConfig saved to ${getConfigPath()}`)
@@ -346,13 +349,64 @@ export async function initCommand(opts?: InitOptions): Promise<ResolvedAgentLLM 
   // we generate the anonymousId and fire any telemetry events.
   if (format !== 'json') {
     showFirstRunNotice()
-    console.log('Run "canonry serve" to start the server.')
+    console.log('\nNext steps:')
+    for (const line of nextSteps) {
+      console.log(`  ${line}`)
+    }
   }
 
   trackEvent('cli.init', {
     providerCount: providerNames.length,
     providers: providerNames,
+    setupState: encodeSetupState({
+      hasProvider: !!hasProvider,
+      hasGoogle: !!google,
+      hasAgent: !!agentLLM,
+    }),
+    skillsInstalled: !!skillsSummary,
   })
 
   return agentLLM
+}
+
+/**
+ * Concrete next-step instructions printed after `canonry init`. Listed in
+ * the order the user should follow — analytics on the install funnel show a
+ * large "silent bounce" cohort that runs init and never runs another command,
+ * so the goal is to make the next action unambiguous and immediate (project
+ * → query → run).
+ */
+function buildNextSteps(): string[] {
+  return [
+    '1. Create a project for the domain you want to track:',
+    '     canonry project create my-site --domain example.com --country US --language en',
+    '',
+    '2. Add the questions your customers ask AI assistants:',
+    '     canonry query add my-site "best <category> for <use case>"',
+    '',
+    '3. Run your first sweep:',
+    '     canonry run my-site',
+    '',
+    'Tip: "canonry doctor" verifies your setup. "canonry serve" opens the dashboard.',
+  ]
+}
+
+/**
+ * Compact, stable encoding of the user's post-init configuration state.
+ * Sent with `cli.init` so the install funnel can split bouncers from
+ * activated users by what they actually configured.
+ *
+ * Format: pipe-joined flags (`provider|google` / `provider` / `none`).
+ * Sorted alphabetically so the cardinality stays low.
+ */
+function encodeSetupState(state: {
+  hasProvider: boolean
+  hasGoogle: boolean
+  hasAgent: boolean
+}): string {
+  const flags: string[] = []
+  if (state.hasProvider) flags.push('provider')
+  if (state.hasGoogle) flags.push('google')
+  if (state.hasAgent) flags.push('agent')
+  return flags.length > 0 ? flags.sort().join('|') : 'none'
 }

--- a/packages/canonry/src/job-runner.ts
+++ b/packages/canonry/src/job-runner.ts
@@ -131,6 +131,87 @@ type RunExecutionContext = {
   location?: string
 }
 
+/**
+ * Stable categorization for run failures, used for telemetry only.
+ *
+ * `abort` reasons mean the run never reached any provider work — so the
+ * "failure" is a config/setup problem, not a downstream audit failure.
+ * Those are emitted as `run.aborted` so they don't pollute the
+ * `run.completed status=failed` rate, which should reflect real audit
+ * failures (provider crashes, network errors, etc.).
+ */
+type RunAbortReason =
+  | 'no_provider'
+  | 'project_not_found'
+  | 'quota_exceeded'
+  | 'run_not_found'
+  | 'run_not_executable'
+
+function classifyRunAbortReason(message: string): RunAbortReason | undefined {
+  if (/^No providers configured\b/.test(message)) return 'no_provider'
+  if (/^Project [^ ]+ not found$/.test(message)) return 'project_not_found'
+  if (/^Daily quota exceeded\b/.test(message)) return 'quota_exceeded'
+  if (/^Run [^ ]+ not found$/.test(message)) return 'run_not_found'
+  if (/^Run [^ ]+ is not executable\b/.test(message)) return 'run_not_executable'
+  return undefined
+}
+
+/**
+ * Coarse error category for runtime provider failures, used for telemetry
+ * only. Best-effort regex match — not load-bearing for any control flow,
+ * just a histogram bucket so dashboards can answer "why are real audit
+ * failures happening?" without reading raw error strings.
+ */
+type ProviderErrorCode =
+  | 'PROVIDER_AUTH'
+  | 'RATE_LIMITED'
+  | 'NETWORK'
+  | 'TIMEOUT'
+  | 'PARSE_ERROR'
+  | 'UNKNOWN'
+
+function classifyProviderErrors(
+  errors: ReadonlyMap<ProviderName, string>,
+): ProviderErrorCode {
+  // If every provider failed with the same category, report it. Otherwise
+  // report the most-severe-looking one with a documented priority order.
+  const codes = new Set<ProviderErrorCode>()
+  for (const message of errors.values()) {
+    codes.add(classifyOneProviderError(message))
+  }
+  const priority: ProviderErrorCode[] = [
+    'PROVIDER_AUTH',
+    'RATE_LIMITED',
+    'TIMEOUT',
+    'NETWORK',
+    'PARSE_ERROR',
+    'UNKNOWN',
+  ]
+  for (const code of priority) {
+    if (codes.has(code)) return code
+  }
+  return 'UNKNOWN'
+}
+
+function classifyOneProviderError(message: string): ProviderErrorCode {
+  if (/\b401\b|\b403\b|unauthorized|forbidden|invalid[_ -]?api[_ -]?key|missing[_ -]?api[_ -]?key|authentication/i.test(message)) {
+    return 'PROVIDER_AUTH'
+  }
+  if (/\b429\b|rate[_ -]?limit|too many requests|quota[_ -]?exceeded/i.test(message)) {
+    return 'RATE_LIMITED'
+  }
+  if (/timeout|timed out|ETIMEDOUT/i.test(message)) {
+    return 'TIMEOUT'
+  }
+  if (/ECONNRESET|ECONNREFUSED|ENOTFOUND|EAI_AGAIN|network|fetch failed|socket hang up/i.test(message)) {
+    return 'NETWORK'
+  }
+  if (/parse|unexpected token|invalid json|malformed|JSON\.parse/i.test(message)) {
+    return 'PARSE_ERROR'
+  }
+  return 'UNKNOWN'
+}
+
 export class JobRunner {
   private db: DatabaseClient
   private registry: ProviderRegistry
@@ -460,14 +541,21 @@ export class JobRunner {
 
       this.flushProviderUsage(projectId, providerDispatchCounts)
 
-      // Track run completion telemetry
+      // Track run completion telemetry. When providers actually ran but some
+      // failed, emit an `errorCode` so dashboards can break down real failures
+      // by category (auth, rate-limit, network, parse, …) instead of lumping
+      // them all into "failed."
       const finalStatus = allFailed ? 'failed' : someFailed ? 'partial' : 'completed'
+      const failureCode = providerErrors.size > 0
+        ? classifyProviderErrors(providerErrors)
+        : undefined
       trackEvent('run.completed', {
         status: finalStatus,
         providerCount: executionContext.providerCount,
         providers: executionContext.providers,
         queryCount: executionContext.queryCount,
         durationMs: Date.now() - startTime,
+        ...(failureCode ? { errorCode: failureCode } : {}),
         ...(executionContext.location ? { location: executionContext.location } : {}),
       })
 
@@ -507,15 +595,34 @@ export class JobRunner {
 
       this.flushProviderUsage(projectId, providerDispatchCounts)
 
-      // Track fatal run failures (missing project, quota exceeded, no providers, etc.)
-      trackEvent('run.completed', {
-        status: 'failed',
-        providerCount: executionContext.providerCount,
-        providers: executionContext.providers,
-        queryCount: executionContext.queryCount,
-        durationMs: Date.now() - startTime,
-        ...(executionContext.location ? { location: executionContext.location } : {}),
-      })
+      // Distinguish config-validation aborts (no providers configured, project
+      // missing, quota exceeded) from real runtime failures. The former never
+      // reach any provider work, so reporting them as `run.completed` with
+      // status=failed conflates "user has no providers" with "audit failed."
+      // Emit `run.aborted` with a reason instead — the run is still marked
+      // failed in the DB above so the user sees it, but the telemetry stream
+      // stays clean for monitoring real audit failures.
+      const abortReason = classifyRunAbortReason(errorMessage)
+      if (abortReason) {
+        trackEvent('run.aborted', {
+          reason: abortReason,
+          providerCount: executionContext.providerCount,
+          providers: executionContext.providers,
+          queryCount: executionContext.queryCount,
+          durationMs: Date.now() - startTime,
+          ...(executionContext.location ? { location: executionContext.location } : {}),
+        })
+      } else {
+        trackEvent('run.completed', {
+          status: 'failed',
+          errorCode: 'UNKNOWN',
+          providerCount: executionContext.providerCount,
+          providers: executionContext.providers,
+          queryCount: executionContext.queryCount,
+          durationMs: Date.now() - startTime,
+          ...(executionContext.location ? { location: executionContext.location } : {}),
+        })
+      }
 
       // Notify on failure too
       if (this.onRunCompleted) {

--- a/packages/canonry/src/telemetry.ts
+++ b/packages/canonry/src/telemetry.ts
@@ -1,4 +1,5 @@
 import crypto from 'node:crypto'
+import os from 'node:os'
 import { loadConfig, saveConfigPatch, configExists } from './config.js'
 
 import { createRequire } from 'node:module'
@@ -7,6 +8,9 @@ const { version: VERSION } = _require('../package.json') as { version: string }
 
 const TELEMETRY_ENDPOINT = 'https://ainyc.ai/api/telemetry'
 const TIMEOUT_MS = 3_000
+
+const ANON_ID_ENV_VAR = 'CANONRY_ANONYMOUS_ID'
+const ANON_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 export interface TelemetryEvent {
   anonymousId: string
@@ -40,22 +44,104 @@ export function isTelemetryEnabled(): boolean {
 
 /**
  * Get or create the anonymous install ID.
- * Returns undefined if config doesn't exist yet (pre-init).
+ *
+ * Resolution order:
+ *   1. CANONRY_ANONYMOUS_ID env var — lets harnesses (e.g. a WordPress
+ *      plugin spawning canonry from PHP) pin a stable ID per install.
+ *   2. anonymousId from ~/.canonry/config.yaml — the normal path.
+ *   3. A new UUID, persisted back to config.yaml on first run.
+ *   4. A deterministic machine-derived fallback — used when config does
+ *      not exist or cannot be persisted (no $HOME, ephemeral container,
+ *      read-only fs). Without this, every invocation in such an
+ *      environment would emit a brand-new UUID and poison telemetry.
+ *
+ * Returns undefined only if every fallback fails (should not happen in
+ * practice — `os.hostname()` always returns something).
  */
 export function getOrCreateAnonymousId(): string | undefined {
-  if (!configExists()) return undefined
+  const fromEnv = readEnvAnonymousId()
+  if (fromEnv) return fromEnv
 
+  if (configExists()) {
+    try {
+      const config = loadConfig()
+      if (config.anonymousId) return config.anonymousId
+
+      const id = crypto.randomUUID()
+      config.anonymousId = id
+      try {
+        saveConfigPatch(config)
+      } catch {
+        // Config exists but can't be written (read-only fs, permission denied).
+        // Fall through to the deterministic fallback so we still emit a stable ID.
+        return getDeterministicAnonymousId()
+      }
+      return id
+    } catch {
+      return getDeterministicAnonymousId()
+    }
+  }
+
+  return getDeterministicAnonymousId()
+}
+
+function readEnvAnonymousId(): string | undefined {
+  const raw = process.env[ANON_ID_ENV_VAR]?.trim()
+  if (!raw) return undefined
+  if (!ANON_ID_PATTERN.test(raw)) {
+    // Invalid format — silently ignore so a typo doesn't poison the dataset
+    // with arbitrary strings. UUIDs only.
+    return undefined
+  }
+  return raw.toLowerCase()
+}
+
+/**
+ * Derive a stable per-machine ID from `os.hostname()` and the first non-internal
+ * MAC address. Same machine → same ID, so telemetry from a WP plugin running
+ * canonry as a subprocess in an ephemeral container collapses to one ID per
+ * host instead of one per invocation.
+ *
+ * Formatted as a UUIDv5-shaped string (8-4-4-4-12 hex) for compatibility with
+ * downstream pipelines that validate UUID shape. Not a real UUID — set the
+ * version nibble to "5" (name-based) just to keep parsers happy.
+ */
+function getDeterministicAnonymousId(): string | undefined {
   try {
-    const config = loadConfig()
-    if (config.anonymousId) return config.anonymousId
-
-    const id = crypto.randomUUID()
-    config.anonymousId = id
-    saveConfigPatch(config)
-    return id
+    const hostname = os.hostname() || ''
+    const mac = firstNonInternalMac()
+    const seed = `canonry-anon:${hostname}:${mac}`
+    const hex = crypto.createHash('sha256').update(seed).digest('hex')
+    // Reformat the first 32 hex chars as 8-4-4-4-12, with the UUID version
+    // nibble set to 5 so consumers that validate UUID shape accept it.
+    const a = hex.slice(0, 8)
+    const b = hex.slice(8, 12)
+    const c = '5' + hex.slice(13, 16)
+    // Variant nibble (8-b) for RFC 4122 compatibility
+    const dHi = ((parseInt(hex.slice(16, 18), 16) & 0x3f) | 0x80).toString(16).padStart(2, '0')
+    const d = dHi + hex.slice(18, 20)
+    const e = hex.slice(20, 32)
+    return `${a}-${b}-${c}-${d}-${e}`
   } catch {
     return undefined
   }
+}
+
+function firstNonInternalMac(): string {
+  try {
+    const interfaces = os.networkInterfaces()
+    for (const ifaces of Object.values(interfaces)) {
+      if (!ifaces) continue
+      for (const iface of ifaces) {
+        if (iface.internal) continue
+        if (!iface.mac || iface.mac === '00:00:00:00:00:00') continue
+        return iface.mac
+      }
+    }
+  } catch {
+    // ignore — fall through to constant
+  }
+  return 'no-mac'
 }
 
 /**

--- a/packages/canonry/test/index.test.ts
+++ b/packages/canonry/test/index.test.ts
@@ -590,6 +590,108 @@ describe('canonry', () => {
     }
   })
 
+  it('initCommand prints concrete next-steps so users do not bounce after install', async () => {
+    const tmpDir = path.join(os.tmpdir(), `canonry-init-nextsteps-${crypto.randomUUID()}`)
+    vi.stubEnv('CANONRY_CONFIG_DIR', tmpDir)
+    vi.stubEnv('CANONRY_TELEMETRY_DISABLED', '1') // suppress telemetry POST in tests
+
+    const logs: string[] = []
+    const originalLog = console.log
+    console.log = (msg: string) => logs.push(msg)
+
+    try {
+      await initCommand({
+        force: true,
+        geminiKey: 'test-gemini-key',
+        skipSkills: true,
+      })
+
+      const output = logs.join('\n')
+      // The user must see how to create a project, add a query, and run a sweep.
+      // These are the three steps that determine whether init translates into
+      // a successful first sweep — too many users today bounce after init
+      // because the next move isn't obvious.
+      expect(output).toMatch(/canonry project create/)
+      expect(output).toMatch(/canonry query add/)
+      expect(output).toMatch(/canonry run /)
+      expect(output).toMatch(/canonry doctor/)
+    } finally {
+      console.log = originalLog
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it('initCommand --format json includes nextSteps array for agents', async () => {
+    const tmpDir = path.join(os.tmpdir(), `canonry-init-json-nextsteps-${crypto.randomUUID()}`)
+    vi.stubEnv('CANONRY_CONFIG_DIR', tmpDir)
+    vi.stubEnv('CANONRY_TELEMETRY_DISABLED', '1')
+
+    const logs: string[] = []
+    const originalLog = console.log
+    console.log = (msg: string) => logs.push(msg)
+
+    try {
+      await initCommand({
+        force: true,
+        geminiKey: 'test-gemini-key',
+        skipSkills: true,
+        format: 'json',
+      })
+
+      // Last logged line is the JSON payload.
+      const jsonLine = logs.find(l => l.trim().startsWith('{'))
+      expect(jsonLine).toBeTruthy()
+      const payload = JSON.parse(jsonLine!) as { initialized: boolean; nextSteps?: string[] }
+      expect(payload.initialized).toBe(true)
+      expect(Array.isArray(payload.nextSteps)).toBe(true)
+      expect(payload.nextSteps!.some(s => s.includes('canonry project create'))).toBe(true)
+      expect(payload.nextSteps!.some(s => s.includes('canonry run'))).toBe(true)
+    } finally {
+      console.log = originalLog
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it('initCommand fires cli.init telemetry with setupState reflecting configured surfaces', async () => {
+    const tmpDir = path.join(os.tmpdir(), `canonry-init-setup-state-${crypto.randomUUID()}`)
+    vi.stubEnv('CANONRY_CONFIG_DIR', tmpDir)
+    vi.stubEnv('CANONRY_TELEMETRY_DISABLED', undefined as unknown as string)
+    vi.stubEnv('DO_NOT_TRACK', undefined as unknown as string)
+    vi.stubEnv('CI', undefined as unknown as string)
+
+    const captured: Array<Record<string, unknown>> = []
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = async (_url: string | URL | Request, init?: RequestInit) => {
+      if (init?.body) {
+        try { captured.push(JSON.parse(init.body as string)) } catch { /* ignore */ }
+      }
+      return new Response(JSON.stringify({ ok: true }))
+    }
+
+    try {
+      await initCommand({
+        force: true,
+        geminiKey: 'test-gemini-key',
+        googleClientId: 'gid',
+        googleClientSecret: 'gsecret',
+        skipSkills: true,
+      })
+
+      // Give fire-and-forget telemetry a tick.
+      await new Promise(resolve => setTimeout(resolve, 50))
+
+      const initEvent = captured.find(p => p.event === 'cli.init')
+      expect(initEvent, 'expected a cli.init telemetry event').toBeTruthy()
+      const props = initEvent!.properties as Record<string, unknown>
+      // The install funnel uses setupState to slice "configured a provider" cohorts.
+      expect(props.setupState).toBe('google|provider')
+      expect(props.providerCount).toBe(1)
+    } finally {
+      globalThis.fetch = originalFetch
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
   it('ApiClient gives clear error when server is not running', async () => {
     const client = new ApiClient('http://localhost:19999', 'cnry_fake_key')
     await expect(() => client.listProjects()).rejects.toThrow('Could not connect to canonry server')

--- a/packages/canonry/test/setup.test.ts
+++ b/packages/canonry/test/setup.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+
+/**
+ * Verifies the test-environment guards installed by `test/setup.ts`.
+ *
+ * If any of these regress, individual tests can silently fire real telemetry
+ * or hit external services — the original install-count inflation came from
+ * exactly that kind of accidental side effect.
+ */
+describe('test setup hardening', () => {
+  it('CANONRY_TELEMETRY_DISABLED is forced to 1 for the whole worker', () => {
+    expect(process.env.CANONRY_TELEMETRY_DISABLED).toBe('1')
+  })
+
+  it('blocks fetch to the canonry telemetry endpoint with a clear error', async () => {
+    await expect(
+      globalThis.fetch('https://ainyc.ai/api/telemetry', {
+        method: 'POST',
+        body: JSON.stringify({ event: 'leak' }),
+      }),
+    ).rejects.toThrow(/Blocked telemetry request/)
+  })
+
+  it('blocks fetch to arbitrary external hostnames', async () => {
+    await expect(globalThis.fetch('https://example.com/x')).rejects.toThrow(/Blocked external network request/)
+    await expect(globalThis.fetch(new URL('https://api.openai.com/v1/responses'))).rejects.toThrow(
+      /Blocked external network request/,
+    )
+  })
+
+  it('allows fetch to localhost and 127.0.0.1 (real Fastify integration tests still work)', async () => {
+    // Use a port that nothing is listening on — we just need to confirm the
+    // guard does not pre-throw before the request reaches the network layer.
+    // A real ECONNREFUSED is fine; a "Blocked …" error is the regression.
+    let guardError: unknown
+    try {
+      await globalThis.fetch('http://127.0.0.1:1/none')
+    } catch (err) {
+      guardError = err
+    }
+    expect(String(guardError)).not.toMatch(/Blocked /)
+  })
+})

--- a/packages/canonry/test/telemetry.test.ts
+++ b/packages/canonry/test/telemetry.test.ts
@@ -34,6 +34,7 @@ describe('telemetry', () => {
     'CANONRY_TELEMETRY_DISABLED',
     'DO_NOT_TRACK',
     'CI',
+    'CANONRY_ANONYMOUS_ID',
   ]
 
   beforeEach(() => {
@@ -47,6 +48,7 @@ describe('telemetry', () => {
     delete process.env.CANONRY_TELEMETRY_DISABLED
     delete process.env.DO_NOT_TRACK
     delete process.env.CI
+    delete process.env.CANONRY_ANONYMOUS_ID
   })
 
   afterEach(() => {
@@ -158,9 +160,16 @@ describe('telemetry', () => {
       expect(id1).toBe(id2)
     })
 
-    it('returns undefined when no config exists', async () => {
+    it('falls back to a stable ID when no config exists (no longer returns undefined)', async () => {
+      // Pre-existing behavior was to return undefined when ~/.canonry/config.yaml
+      // didn't exist. That caused subprocess invocations (e.g. a WP plugin
+      // spawning canonry without a writable HOME) to either skip telemetry
+      // entirely OR — if init somehow fired — generate a fresh UUID per call,
+      // poisoning install counts. Now we always return a stable ID.
       const { getOrCreateAnonymousId } = await import('../src/telemetry.js')
-      expect(getOrCreateAnonymousId()).toBe(undefined)
+      const id = getOrCreateAnonymousId()
+      expect(id).toBeTruthy()
+      expect(id!).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
     })
 
     it('returns existing anonymousId from config without generating a new one', async () => {
@@ -171,6 +180,74 @@ describe('telemetry', () => {
 
       const id = getOrCreateAnonymousId()
       expect(id).toBe(existingId)
+    })
+
+    it('honours CANONRY_ANONYMOUS_ID env var (overrides config and pre-init state)', async () => {
+      const { getOrCreateAnonymousId } = await import('../src/telemetry.js')
+      const { saveConfig } = await import('../src/config.js')
+
+      const fixedId = '11111111-2222-3333-4444-555555555555'
+      process.env.CANONRY_ANONYMOUS_ID = fixedId
+
+      // Even with a different ID stored in config, env var wins.
+      saveConfig(makeConfig({ anonymousId: crypto.randomUUID() }))
+      expect(getOrCreateAnonymousId()).toBe(fixedId)
+    })
+
+    it('CANONRY_ANONYMOUS_ID applies even when no config exists (subprocess case)', async () => {
+      const { getOrCreateAnonymousId } = await import('../src/telemetry.js')
+
+      const fixedId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+      process.env.CANONRY_ANONYMOUS_ID = fixedId
+
+      // No config — but the env var still wins, so multiple invocations
+      // share the same ID instead of falling back.
+      expect(getOrCreateAnonymousId()).toBe(fixedId)
+    })
+
+    it('ignores CANONRY_ANONYMOUS_ID with invalid format (not a UUID)', async () => {
+      const { getOrCreateAnonymousId } = await import('../src/telemetry.js')
+
+      process.env.CANONRY_ANONYMOUS_ID = 'not-a-uuid'
+
+      // Invalid format → fall through to deterministic fallback (machine-derived).
+      const id = getOrCreateAnonymousId()
+      expect(id).toBeTruthy()
+      expect(id!).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+    })
+
+    it('falls back to a deterministic machine-derived ID when no config exists', async () => {
+      const { getOrCreateAnonymousId } = await import('../src/telemetry.js')
+
+      const id1 = getOrCreateAnonymousId()
+      const id2 = getOrCreateAnonymousId()
+
+      expect(id1).toBeTruthy()
+      // Same machine, same ID — this is the whole point of the fallback,
+      // so a WP plugin spawning canonry without a writable HOME doesn't
+      // emit a brand-new UUID per invocation.
+      expect(id1).toBe(id2)
+      expect(id1!).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+    })
+
+    it('deterministic fallback differs from a randomly generated config ID', async () => {
+      const { getOrCreateAnonymousId } = await import('../src/telemetry.js')
+      const { saveConfig, loadConfig } = await import('../src/config.js')
+
+      // First, let getOrCreateAnonymousId generate and persist a random UUID.
+      saveConfig(makeConfig())
+      const persistedId = getOrCreateAnonymousId()
+      expect(loadConfig().anonymousId).toBe(persistedId)
+
+      // Now switch CONFIG_DIR to a brand-new directory with no config; the
+      // deterministic fallback should NOT match the previously-persisted UUID.
+      const newDir = path.join(tmpDir, crypto.randomUUID())
+      fs.mkdirSync(newDir, { recursive: true })
+      process.env.CANONRY_CONFIG_DIR = newDir
+
+      const fallbackId = getOrCreateAnonymousId()
+      expect(fallbackId).toBeTruthy()
+      expect(fallbackId).not.toBe(persistedId)
     })
 
     it('preserves all existing config fields when saving the new ID', async () => {
@@ -260,19 +337,27 @@ describe('telemetry', () => {
       }
     })
 
-    it('is a no-op when no config exists (no anonymous ID)', async () => {
+    it('still fires (with deterministic ID) when no config exists, so subprocess invocations are tracked', async () => {
+      // This test pins the behavior we want: even without ~/.canonry/config.yaml,
+      // a subprocess invocation (e.g. WP plugin running canonry from PHP without
+      // a writable HOME) gets a stable, machine-derived anonymousId rather than
+      // emitting a fresh UUID per call.
       const { trackEvent } = await import('../src/telemetry.js')
 
+      let capturedBody: string | undefined
       const originalFetch = globalThis.fetch
-      let fetchCalled = false
-      globalThis.fetch = async () => {
-        fetchCalled = true
-        return new Response()
+      globalThis.fetch = async (_url: string | URL | Request, init?: RequestInit) => {
+        capturedBody = init?.body as string
+        return new Response(JSON.stringify({ ok: true }))
       }
 
       try {
-        trackEvent('test.event')
-        expect(fetchCalled, 'fetch should not be called when no config exists').toBe(false)
+        trackEvent('test.event', { foo: 'bar' })
+        await new Promise(resolve => setTimeout(resolve, 10))
+
+        expect(capturedBody, 'fetch should be called with a deterministic-ID payload').toBeTruthy()
+        const payload = JSON.parse(capturedBody!) as { anonymousId: string }
+        expect(payload.anonymousId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
       } finally {
         globalThis.fetch = originalFetch
       }
@@ -649,16 +734,14 @@ describe('telemetry', () => {
   // ── JobRunner outer-catch telemetry ─────────────────────────────────
 
   describe('JobRunner fatal failure telemetry', () => {
-    it('emits run.completed with status failed when no providers configured', async () => {
+    it('emits run.aborted with reason=no_provider when no providers configured (not run.completed=failed)', async () => {
       const { saveConfig } = await import('../src/config.js')
       saveConfig(makeConfig({ anonymousId: crypto.randomUUID() }))
 
-      // Set up an in-memory SQLite DB
       const dbPath = path.join(os.tmpdir(), `canonry-jr-test-${crypto.randomUUID()}`, 'test.db')
       const db = createClient(dbPath)
       migrate(db)
 
-      // Insert a project and a queued run
       const projectId = crypto.randomUUID()
       const runId = crypto.randomUUID()
       const now = new Date().toISOString()
@@ -686,7 +769,6 @@ describe('telemetry', () => {
       const registry = new ProviderRegistry()
       const runner = new JobRunner(db, registry)
 
-      // Capture telemetry POST
       const capturedPayloads: Array<Record<string, unknown>> = []
       const originalFetch = globalThis.fetch
       globalThis.fetch = async (_url: string | URL | Request, init?: RequestInit) => {
@@ -698,24 +780,21 @@ describe('telemetry', () => {
 
       try {
         await runner.executeRun(runId, projectId)
-
-        // Give fire-and-forget fetch a tick
         await new Promise(resolve => setTimeout(resolve, 50))
 
-        // Verify telemetry was emitted with failure status
-        expect(capturedPayloads.length >= 1, 'expected at least one telemetry event').toBeTruthy()
-        const runEvent = capturedPayloads.find(p => p.event === 'run.completed')
-        expect(runEvent, 'expected a run.completed telemetry event').toBeTruthy()
-        expect(runEvent!.properties).toEqual({
-          status: 'failed',
-          providerCount: 0,
-          providers: [],
-          queryCount: 0,
-          durationMs: (runEvent!.properties as Record<string, unknown>).durationMs,
-        })
-        expect((runEvent!.properties as Record<string, unknown>).status).toBe('failed')
+        // The run never reached any provider work, so we must NOT pollute the
+        // run.completed=failed metric with this config bail.
+        const completedEvent = capturedPayloads.find(p => p.event === 'run.completed')
+        expect(completedEvent, 'no run.completed should be emitted for a config bail').toBeUndefined()
 
-        // Verify the run was marked as failed in the DB
+        const abortEvent = capturedPayloads.find(p => p.event === 'run.aborted')
+        expect(abortEvent, 'expected a run.aborted telemetry event').toBeTruthy()
+        expect((abortEvent!.properties as Record<string, unknown>).reason).toBe('no_provider')
+        expect((abortEvent!.properties as Record<string, unknown>).providerCount).toBe(0)
+        expect((abortEvent!.properties as Record<string, unknown>).queryCount).toBe(0)
+
+        // The run is still recorded as failed in the DB so the user sees it —
+        // the change is purely in the telemetry stream.
         const failedRun = db.select().from(runs).all().find(r => r.id === runId)
         expect(failedRun?.status).toBe('failed')
         expect(failedRun?.error?.includes('No providers configured')).toBeTruthy()
@@ -724,7 +803,7 @@ describe('telemetry', () => {
       }
     })
 
-    it('emits run.completed with status failed when project is missing', async () => {
+    it('emits run.aborted with reason=project_not_found when project is missing', async () => {
       const { saveConfig } = await import('../src/config.js')
       saveConfig(makeConfig({ anonymousId: crypto.randomUUID() }))
 
@@ -732,9 +811,6 @@ describe('telemetry', () => {
       const db = createClient(dbPath)
       migrate(db)
 
-      // Insert a project first (for FK), then a run, then delete the project
-      // Actually, simpler: insert a run with a projectId that references a real project,
-      // but we need FK. Let's create the project, create the run, then use a different projectId for lookup.
       const realProjectId = crypto.randomUUID()
       const runId = crypto.randomUUID()
       const fakeProjectId = crypto.randomUUID()
@@ -752,7 +828,6 @@ describe('telemetry', () => {
         updatedAt: now,
       }).run()
 
-      // Insert run referencing the real project (satisfies FK)
       db.insert(runs).values({
         id: runId,
         projectId: realProjectId,
@@ -773,14 +848,55 @@ describe('telemetry', () => {
       }
 
       try {
-        // Pass fakeProjectId — project lookup will fail
+        // Pass fakeProjectId — project lookup will fail with "Project ... not found"
         await runner.executeRun(runId, fakeProjectId)
         await new Promise(resolve => setTimeout(resolve, 50))
 
-        const runEvent = capturedPayloads.find(p => p.event === 'run.completed')
-        expect(runEvent, 'expected a run.completed telemetry event for missing project').toBeTruthy()
-        expect((runEvent!.properties as Record<string, unknown>).status).toBe('failed')
-        expect((runEvent!.properties as Record<string, unknown>).providerCount).toBe(0)
+        const completedEvent = capturedPayloads.find(p => p.event === 'run.completed')
+        expect(completedEvent, 'no run.completed should be emitted for a project-missing bail').toBeUndefined()
+
+        const abortEvent = capturedPayloads.find(p => p.event === 'run.aborted')
+        expect(abortEvent, 'expected a run.aborted telemetry event').toBeTruthy()
+        expect((abortEvent!.properties as Record<string, unknown>).reason).toBe('project_not_found')
+      } finally {
+        globalThis.fetch = originalFetch
+      }
+    })
+
+    it('emits run.completed status=failed with errorCode=UNKNOWN for non-classified runtime failures', async () => {
+      const { saveConfig } = await import('../src/config.js')
+      saveConfig(makeConfig({ anonymousId: crypto.randomUUID() }))
+
+      const dbPath = path.join(os.tmpdir(), `canonry-jr-test-${crypto.randomUUID()}`, 'test.db')
+      const db = createClient(dbPath)
+      migrate(db)
+
+      // Run with a non-existent runId — triggers the "Run X not found" path,
+      // which is NOT a config-validation abort (it indicates a corrupted run
+      // queue, not a user setup problem).
+      const ghostRunId = crypto.randomUUID()
+      const projectId = crypto.randomUUID()
+
+      const registry = new ProviderRegistry()
+      const runner = new JobRunner(db, registry)
+
+      const capturedPayloads: Array<Record<string, unknown>> = []
+      const originalFetch = globalThis.fetch
+      globalThis.fetch = async (_url: string | URL | Request, init?: RequestInit) => {
+        if (init?.body) {
+          capturedPayloads.push(JSON.parse(init.body as string))
+        }
+        return new Response(JSON.stringify({ ok: true }))
+      }
+
+      try {
+        await runner.executeRun(ghostRunId, projectId)
+        await new Promise(resolve => setTimeout(resolve, 50))
+
+        // "Run X not found" is classified as run_not_found → run.aborted (not a real audit failure)
+        const abortEvent = capturedPayloads.find(p => p.event === 'run.aborted')
+        expect(abortEvent, 'expected a run.aborted for a missing run').toBeTruthy()
+        expect((abortEvent!.properties as Record<string, unknown>).reason).toBe('run_not_found')
       } finally {
         globalThis.fetch = originalFetch
       }

--- a/packages/canonry/vitest.config.ts
+++ b/packages/canonry/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
-  },
-})

--- a/packages/config/vitest.config.ts
+++ b/packages/config/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
-  },
-})

--- a/packages/contracts/vitest.config.ts
+++ b/packages/contracts/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
-  },
-})

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
-  },
-})

--- a/packages/integration-bing/vitest.config.ts
+++ b/packages/integration-bing/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
-  },
-})

--- a/packages/integration-cloud-run/vitest.config.ts
+++ b/packages/integration-cloud-run/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
-  },
-})

--- a/packages/integration-commoncrawl/vitest.config.ts
+++ b/packages/integration-commoncrawl/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    include: ['test/**/*.test.ts'],
-  },
-})

--- a/packages/integration-google-analytics/vitest.config.ts
+++ b/packages/integration-google-analytics/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
-  },
-})

--- a/packages/integration-google/vitest.config.ts
+++ b/packages/integration-google/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
-  },
-})

--- a/packages/integration-traffic/vitest.config.ts
+++ b/packages/integration-traffic/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
-  },
-})

--- a/packages/integration-wordpress/vitest.config.ts
+++ b/packages/integration-wordpress/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
-  },
-})

--- a/packages/intelligence/vitest.config.ts
+++ b/packages/intelligence/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
-  },
-})

--- a/packages/provider-cdp/vitest.config.ts
+++ b/packages/provider-cdp/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
-  },
-})

--- a/packages/provider-claude/vitest.config.ts
+++ b/packages/provider-claude/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
-  },
-})

--- a/packages/provider-gemini/vitest.config.ts
+++ b/packages/provider-gemini/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
-  },
-})

--- a/packages/provider-local/vitest.config.ts
+++ b/packages/provider-local/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
-  },
-})

--- a/packages/provider-openai/vitest.config.ts
+++ b/packages/provider-openai/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
-  },
-})

--- a/packages/provider-perplexity/vitest.config.ts
+++ b/packages/provider-perplexity/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
-  },
-})

--- a/test-setup/vitest-defaults.ts
+++ b/test-setup/vitest-defaults.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared vitest setup — runs once per worker before any test imports.
+ *
+ * Wired into every package's `vitest.config.ts` via:
+ *   setupFiles: ['../../test-setup/vitest-defaults.ts']
+ *
+ * Hardens the test environment against accidental side effects:
+ *   1. Disables canonry telemetry. Even packages that don't import the
+ *      telemetry module benefit — invokeCli-style tests sometimes pull
+ *      in code paths that fire `cli.command` events.
+ *   2. Replaces `globalThis.fetch` with a guard that throws on any
+ *      non-localhost request, so a test that forgets to mock fetch
+ *      can't silently hit the real internet.
+ *
+ * The fetch guard is compatible with the standard save-and-restore
+ * pattern (`const orig = globalThis.fetch; globalThis.fetch = mockFn; ...; globalThis.fetch = orig`)
+ * — tests capture this guard as `orig`, install their mock, and put
+ * the guard back on cleanup. The guard stays in effect between tests.
+ */
+
+process.env.CANONRY_TELEMETRY_DISABLED = '1'
+
+const TELEMETRY_HOSTS = new Set([
+  'ainyc.ai',
+  'www.ainyc.ai',
+])
+
+const realFetch = globalThis.fetch
+
+function isLocalHost(hostname: string): boolean {
+  return (
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname === '0.0.0.0' ||
+    hostname === '::1' ||
+    hostname.endsWith('.localhost')
+  )
+}
+
+function urlOf(input: string | URL | Request): URL | null {
+  try {
+    if (typeof input === 'string') return new URL(input)
+    if (input instanceof URL) return input
+    if (typeof Request !== 'undefined' && input instanceof Request) return new URL(input.url)
+  } catch {
+    return null
+  }
+  return null
+}
+
+globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+  const url = urlOf(input)
+  if (url) {
+    if (TELEMETRY_HOSTS.has(url.hostname)) {
+      throw new Error(
+        `[test] Blocked telemetry request to ${url.href}. ` +
+        `Tests must mock globalThis.fetch when exercising trackEvent — see test-setup/vitest-defaults.ts.`,
+      )
+    }
+    if (!isLocalHost(url.hostname)) {
+      throw new Error(
+        `[test] Blocked external network request to ${url.href}. ` +
+        `Tests must not hit external services. Mock globalThis.fetch or stub the client.`,
+      )
+    }
+  }
+  return realFetch(input as Parameters<typeof realFetch>[0], init)
+}) as typeof globalThis.fetch

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,81 @@
+import path from 'node:path'
 import { defineConfig } from 'vitest/config'
+
+/**
+ * Workspace-level vitest config — defines every package + app as a project
+ * inline so we don't need a `vitest.config.ts` per package. Each project
+ * inherits the shared `setupFiles` (telemetry-disable + non-localhost fetch
+ * block) from `test-setup/vitest-defaults.ts`.
+ *
+ * Projects can still be filtered: `pnpm test -- --project canonry`.
+ *
+ * Special cases:
+ *   - `apps/web` runs in a jsdom environment and relies on its own
+ *     `apps/web/vite.config.ts` for the React + Tailwind plugins. Vitest
+ *     auto-merges that file when `root` points at the package.
+ *   - `integration-commoncrawl` only has `.test.ts` (no `.test.tsx`), but
+ *     including the broader glob is harmless and keeps every project shape
+ *     identical.
+ */
+
+const SHARED_INCLUDE = ['test/**/*.test.ts', 'test/**/*.test.tsx']
+// Absolute path: when a project sets `root`, vitest resolves relative
+// `setupFiles` against THAT root. Resolve to the workspace once here so every
+// project points at the same shared file.
+const SHARED_SETUP = [path.resolve(import.meta.dirname, 'test-setup/vitest-defaults.ts')]
+
+const NODE_PACKAGES = [
+  'api-routes',
+  'canonry',
+  'config',
+  'contracts',
+  'db',
+  'integration-bing',
+  'integration-cloud-run',
+  'integration-commoncrawl',
+  'integration-google',
+  'integration-google-analytics',
+  'integration-traffic',
+  'integration-wordpress',
+  'intelligence',
+  'provider-cdp',
+  'provider-claude',
+  'provider-gemini',
+  'provider-local',
+  'provider-openai',
+  'provider-perplexity',
+] as const
+
+const NODE_APPS = ['api', 'worker'] as const
 
 export default defineConfig({
   test: {
-    projects: ['packages/*/vitest.config.ts', 'apps/*/vitest.config.ts'],
+    projects: [
+      ...NODE_PACKAGES.map((name) => ({
+        test: {
+          name,
+          root: `./packages/${name}`,
+          include: SHARED_INCLUDE,
+          setupFiles: SHARED_SETUP,
+        },
+      })),
+      ...NODE_APPS.map((name) => ({
+        test: {
+          name,
+          root: `./apps/${name}`,
+          include: SHARED_INCLUDE,
+          setupFiles: SHARED_SETUP,
+        },
+      })),
+      {
+        test: {
+          name: 'web',
+          root: './apps/web',
+          include: SHARED_INCLUDE,
+          setupFiles: SHARED_SETUP,
+          environment: 'jsdom',
+        },
+      },
+    ],
   },
 })


### PR DESCRIPTION
## Summary

Three fixes for telemetry pollution and the install-funnel "silent bounce", plus test-environment hardening.

- **Stable anonymousId** (`packages/canonry/src/telemetry.ts`): honor `CANONRY_ANONYMOUS_ID` env var; fall back to a deterministic `hostname + MAC` ID when `~/.canonry/config.yaml` can't be persisted. Stops WP-plugin subprocess invocations from emitting a fresh UUID per call (the source of ~45% install-count inflation).
- **`run.aborted` vs `run.completed`** (`packages/canonry/src/job-runner.ts`): config-validation bails (`no_provider`, `project_not_found`, `quota_exceeded`, `run_not_found`, `run_not_executable`) now emit `run.aborted` with a `reason` instead of `run.completed status=failed`, so the failure-rate metric reflects real audit failures (was 90% bogus). Real provider failures gain an `errorCode` field (`PROVIDER_AUTH` / `RATE_LIMITED` / `NETWORK` / `TIMEOUT` / `PARSE_ERROR` / `UNKNOWN`).
- **Init guidance** (`packages/canonry/src/commands/init.ts`): replace "Run canonry serve" with a numbered project → query → run playbook (also exposed in `--format json` as `nextSteps`). `cli.init` telemetry now carries `setupState` and `skillsInstalled` so the install funnel can separate bouncers from activated users.
- **Test hardening**: shared `test-setup/vitest-defaults.ts` forces `CANONRY_TELEMETRY_DISABLED=1` and wraps `globalThis.fetch` to throw on non-localhost calls (extra-loud message for `ainyc.ai`). Consolidated 22 per-package `vitest.config.ts` files into a single root config with inline projects.

Version bumped to 4.14.0.

## Test plan

- [x] `pnpm test` — 2,155 / 2,155 pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `vitest run --project canonry` filter still works
- [x] `vitest run --project web` (jsdom) auto-merges with `apps/web/vite.config.ts` for React plugin
- [x] New tests cover env-var override, deterministic fallback, `run.aborted` semantics, init next-steps + setupState, and the setup-file guards themselves