### PR TITLE
docs(readme): drop "Built by AI NYC" footer line

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,3 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md).
 ## License
 
 [FSL-1.1-ALv2](./LICENSE). Free to use, modify, and self-host. Each version converts to Apache 2.0 after two years.
-
----
-
-Built by [AI NYC](https://ainyc.ai)


### PR DESCRIPTION
## Summary
- Removes the trailing horizontal rule + "Built by AI NYC" acknowledgment from the bottom of `README.md`. License block now ends the file.

## Test plan
- [x] `README.md` renders cleanly on GitHub (license is the final section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)