### PR TITLE
refactor(web): rename project-level Traffic tab to Activity + server-side panel

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,7 +1,7 @@
-import type { ErrorCode, GroundingSource, ProjectOverviewDto, ScheduleDto, NotificationDto, GscCoverageSummaryDto, GscCoverageSnapshotDto, IndexingRequestResultDto, MetricsWindow, GA4AiReferralHistoryEntry, GA4SessionHistoryEntry, GA4SocialReferralHistoryEntry, InsightDto, HealthSnapshotDto, ProjectReportDto, ReportAudience, RunKind, RunStatus, RunTrigger, RunErrorDto, CitationState, CitationVisibilityResponse, ComputedTransition, BacklinkSummaryDto, BacklinkDomainDto, BacklinkListResponse, BacklinkHistoryEntry, BacklinksInstallStatusDto, BacklinksInstallResultDto, CcAvailableRelease, CcCachedRelease, CcReleaseSyncDto, TrafficSourceDto, TrafficSourceDetailDto, TrafficSourceListResponse, TrafficEventsResponse, TrafficConnectCloudRunRequest, TrafficSyncResponse } from '@ainyc/canonry-contracts'
+import type { ErrorCode, GroundingSource, ProjectOverviewDto, ScheduleDto, NotificationDto, GscCoverageSummaryDto, GscCoverageSnapshotDto, IndexingRequestResultDto, MetricsWindow, GA4AiReferralHistoryEntry, GA4SessionHistoryEntry, GA4SocialReferralHistoryEntry, InsightDto, HealthSnapshotDto, ProjectReportDto, ReportAudience, RunKind, RunStatus, RunTrigger, RunErrorDto, CitationState, CitationVisibilityResponse, ComputedTransition, BacklinkSummaryDto, BacklinkDomainDto, BacklinkListResponse, BacklinkHistoryEntry, BacklinksInstallStatusDto, BacklinksInstallResultDto, CcAvailableRelease, CcCachedRelease, CcReleaseSyncDto, TrafficSourceDto, TrafficSourceDetailDto, TrafficSourceListResponse, TrafficStatusResponse, TrafficEventsResponse, TrafficConnectCloudRunRequest, TrafficSyncResponse } from '@ainyc/canonry-contracts'
 export type { ProjectOverviewDto }
 export type { BacklinkSummaryDto, BacklinkDomainDto, BacklinkListResponse, BacklinkHistoryEntry, BacklinksInstallStatusDto, BacklinksInstallResultDto, CcAvailableRelease, CcCachedRelease, CcReleaseSyncDto }
-export type { TrafficSourceDto, TrafficSourceDetailDto, TrafficSourceListResponse, TrafficEventsResponse, TrafficConnectCloudRunRequest, TrafficSyncResponse }
+export type { TrafficSourceDto, TrafficSourceDetailDto, TrafficSourceListResponse, TrafficStatusResponse, TrafficEventsResponse, TrafficConnectCloudRunRequest, TrafficSyncResponse }
 
 export type { GroundingSource }
 
@@ -1163,11 +1163,16 @@ export function disconnectGa(project: string): Promise<void> {
 export type ApiTrafficSource = TrafficSourceDto
 export type ApiTrafficSourceDetail = TrafficSourceDetailDto
 export type ApiTrafficSourceList = TrafficSourceListResponse
+export type ApiTrafficStatus = TrafficStatusResponse
 export type ApiTrafficEvents = TrafficEventsResponse
 export type ApiTrafficSyncResult = TrafficSyncResponse
 
 export function fetchServerTrafficSources(project: string): Promise<TrafficSourceListResponse> {
   return apiFetch(`/projects/${encodeURIComponent(project)}/traffic/sources`)
+}
+
+export function fetchServerTrafficStatus(project: string): Promise<TrafficStatusResponse> {
+  return apiFetch(`/projects/${encodeURIComponent(project)}/traffic/status`)
 }
 
 export function fetchServerTrafficSource(project: string, sourceId: string): Promise<TrafficSourceDetailDto> {

--- a/apps/web/src/components/project/ActivitySection.tsx
+++ b/apps/web/src/components/project/ActivitySection.tsx
@@ -17,11 +17,17 @@ import {
   formatChartDateTick,
 } from '../shared/ChartPrimitives.js'
 
+import { Link } from '@tanstack/react-router'
 import { Button } from '../ui/button.js'
 import { Card } from '../ui/card.js'
 import { InfoTooltip } from '../shared/InfoTooltip.js'
+import { ToneBadge } from '../shared/ToneBadge.js'
 import type { MetricsWindow } from '@ainyc/canonry-contracts'
 import type { MetricTone } from '../../view-models.js'
+import {
+  toneFromTrafficSourceStatus,
+  useServerTrafficStatus,
+} from '../../queries/server-traffic.js'
 import {
   connectGa,
   fetchGaStatus,
@@ -74,7 +80,107 @@ function relativeTime(iso: string): string {
   return `${days}d ago`
 }
 
-export function TrafficSection({ projectName }: { projectName: string }) {
+function ServerActivityPanel({ projectName }: { projectName: string }) {
+  const { data, isLoading, isError } = useServerTrafficStatus(projectName)
+
+  if (isLoading) {
+    return (
+      <Card className="p-5">
+        <div className="text-sm text-zinc-500">Loading server activity…</div>
+      </Card>
+    )
+  }
+  if (isError) {
+    return (
+      <Card className="p-5">
+        <div className="text-sm text-rose-400">Failed to load server activity.</div>
+      </Card>
+    )
+  }
+  const sources = data?.sources ?? []
+
+  return (
+    <section>
+      <div className="flex items-baseline justify-between mb-3">
+        <div>
+          <div className="eyebrow">Server activity (last 24h)</div>
+          <h2 className="text-lg font-semibold text-zinc-50">Engine crawler &amp; AI-referral hits</h2>
+          <p className="text-xs text-zinc-500 mt-1">
+            Server-side log evidence of bots crawling the site and AI-referral arrivals — orthogonal
+            to GA4 click-through traffic below. {' '}
+            <Link to="/traffic" className="text-blue-400 hover:underline">Manage sources →</Link>
+          </p>
+        </div>
+      </div>
+
+      {sources.length === 0 ? (
+        <Card className="p-5">
+          <div className="text-sm text-zinc-400">
+            No server traffic source connected yet.{' '}
+            <Link to="/traffic" className="text-blue-400 hover:underline">
+              Connect a Cloud Run source
+            </Link>{' '}
+            to surface bot crawls and AI referrals straight from server logs.
+          </div>
+        </Card>
+      ) : (
+        <Card className="overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-zinc-900/50 text-[10px] uppercase tracking-wide text-zinc-500">
+              <tr>
+                <th className="text-left px-4 py-2 font-medium">Source</th>
+                <th className="text-left px-4 py-2 font-medium">Status</th>
+                <th className="text-right px-4 py-2 font-medium">Crawler hits 24h</th>
+                <th className="text-right px-4 py-2 font-medium">AI-referral 24h</th>
+                <th className="text-right px-4 py-2 font-medium">Last sync</th>
+                <th className="text-left px-4 py-2 font-medium" aria-label="open" />
+              </tr>
+            </thead>
+            <tbody>
+              {sources.map((s) => (
+                <tr key={s.id} className="border-t border-zinc-800/60">
+                  <td className="px-4 py-3 text-zinc-100">{s.displayName}</td>
+                  <td className="px-4 py-3">
+                    <ToneBadge tone={toneFromTrafficSourceStatus(s.status)}>{s.status}</ToneBadge>
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums text-zinc-100">
+                    {s.totals24h.crawlerHits.toLocaleString('en-US')}
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums text-zinc-100">
+                    {s.totals24h.aiReferralHits.toLocaleString('en-US')}
+                  </td>
+                  <td className="px-4 py-3 text-right text-zinc-400 text-xs">
+                    {s.lastSyncedAt ? relativeTime(s.lastSyncedAt) : 'never'}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <Link
+                      to="/traffic/$projectName/$sourceId"
+                      params={{ projectName, sourceId: s.id }}
+                      className="text-blue-400 hover:underline text-xs"
+                    >
+                      Detail →
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </Card>
+      )}
+    </section>
+  )
+}
+
+export function ActivitySection({ projectName }: { projectName: string }) {
+  return (
+    <div className="space-y-10">
+      <ServerActivityPanel projectName={projectName} />
+      <ClickThroughActivity projectName={projectName} />
+    </div>
+  )
+}
+
+function ClickThroughActivity({ projectName }: { projectName: string }) {
   const queryClient = useQueryClient()
   const [status, setStatus] = useState<ApiGaStatus | null>(null)
   const [traffic, setTraffic] = useState<ApiGaTraffic | null>(null)

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -17,7 +17,7 @@ import { EvidenceTable } from '../components/project/EvidenceTable.js'
 import { CompetitorTable } from '../components/project/CompetitorTable.js'
 import { SearchConsoleSummaryCard } from '../components/project/SearchConsoleSummaryCard.js'
 import { BingSummaryMetric } from '../components/project/BingSummaryMetric.js'
-import { TrafficSection } from '../components/project/TrafficSection.js'
+import { ActivitySection } from '../components/project/ActivitySection.js'
 import { GscSection } from '../components/project/GscSection.js'
 import { BacklinksSection } from '../components/project/BacklinksSection.js'
 import { CitationVisibilitySection } from '../components/project/CitationVisibilitySection.js'
@@ -67,7 +67,7 @@ import { useDrawer } from '../hooks/use-drawer.js'
 import { findProjectVm } from '../mock-data.js'
 import type { ProjectCommandCenterVm, RunHistoryPoint } from '../view-models.js'
 
-export type ProjectPageTab = 'overview' | 'search-console' | 'report' | 'traffic' | 'inbound'
+export type ProjectPageTab = 'overview' | 'search-console' | 'report' | 'activity' | 'inbound'
 
 type SearchConsoleWorkspace = 'google' | 'bing'
 
@@ -1288,7 +1288,7 @@ export function ProjectPage({
   const projectTabItems: Array<{ key: ProjectPageTab; label: string; href: string }> = [
     { key: 'overview', label: 'Overview', href: `/projects/${model.project.id}` },
     { key: 'search-console', label: 'Search Engine Intelligence', href: `/projects/${model.project.id}/search-console` },
-    { key: 'traffic', label: 'Traffic', href: `/projects/${model.project.id}/traffic` },
+    { key: 'activity', label: 'Activity', href: `/projects/${model.project.id}/activity` },
     { key: 'report', label: 'Report', href: `/projects/${model.project.id}/report` },
     { key: 'inbound', label: 'Inbound', href: `/projects/${model.project.id}/inbound` },
   ]
@@ -1692,8 +1692,8 @@ export function ProjectPage({
         </>
       ) : tab === 'report' ? (
         <ReportPage projectName={model.project.name} />
-      ) : tab === 'traffic' ? (
-        <TrafficSection projectName={model.project.name} />
+      ) : tab === 'activity' ? (
+        <ActivitySection projectName={model.project.name} />
       ) : tab === 'inbound' ? (
         <BacklinksSection projectName={model.project.name} />
       ) : (

--- a/apps/web/src/queries/query-keys.ts
+++ b/apps/web/src/queries/query-keys.ts
@@ -50,6 +50,7 @@ export const queryKeys = {
     all: ['server-traffic'] as const,
     project: (project: string) => ['server-traffic', project] as const,
     sources: (project: string) => ['server-traffic', project, 'sources'] as const,
+    status: (project: string) => ['server-traffic', project, 'status'] as const,
     sourceDetail: (project: string, sourceId: string) =>
       ['server-traffic', project, 'sources', sourceId] as const,
     events: (

--- a/apps/web/src/queries/server-traffic.ts
+++ b/apps/web/src/queries/server-traffic.ts
@@ -8,10 +8,12 @@ import {
   fetchServerTrafficEvents,
   fetchServerTrafficSource,
   fetchServerTrafficSources,
+  fetchServerTrafficStatus,
   triggerServerTrafficSync,
   type ApiTrafficEvents,
   type ApiTrafficSourceDetail,
   type ApiTrafficSourceList,
+  type ApiTrafficStatus,
   type ApiTrafficSyncResult,
   type TrafficConnectCloudRunRequest,
 } from '../api.js'
@@ -59,6 +61,15 @@ export function useServerTrafficSources(project: string | null) {
   return useQuery<ApiTrafficSourceList>({
     queryKey: project ? queryKeys.serverTraffic.sources(project) : ['server-traffic', 'disabled'],
     queryFn: () => fetchServerTrafficSources(project!),
+    enabled: Boolean(project),
+    staleTime: TRAFFIC_STALE_MS,
+  })
+}
+
+export function useServerTrafficStatus(project: string | null) {
+  return useQuery<ApiTrafficStatus>({
+    queryKey: project ? queryKeys.serverTraffic.status(project) : ['server-traffic', 'status-disabled'],
+    queryFn: () => fetchServerTrafficStatus(project!),
     enabled: Boolean(project),
     staleTime: TRAFFIC_STALE_MS,
   })

--- a/apps/web/src/router/routes.tsx
+++ b/apps/web/src/router/routes.tsx
@@ -83,10 +83,10 @@ export const projectReportRoute = createRoute({
   component: () => <ProjectPage tab="report" />,
 })
 
-export const projectTrafficRoute = createRoute({
+export const projectActivityRoute = createRoute({
   getParentRoute: () => projectLayoutRoute,
-  path: '/traffic',
-  component: () => <ProjectPage tab="traffic" />,
+  path: '/activity',
+  component: () => <ProjectPage tab="activity" />,
 })
 
 export const projectInboundRoute = createRoute({
@@ -153,7 +153,7 @@ export const routeTree = rootRoute.addChildren([
     projectOverviewRoute,
     projectSearchConsoleRoute,
     projectReportRoute,
-    projectTrafficRoute,
+    projectActivityRoute,
     projectInboundRoute,
   ]),
   runsRoute,

--- a/apps/web/test/activity-section.test.tsx
+++ b/apps/web/test/activity-section.test.tsx
@@ -18,15 +18,15 @@ vi.mock('recharts', () => {
   }
 })
 
-import { TrafficSection } from '../src/components/project/TrafficSection.js'
+import { ActivitySection } from '../src/components/project/ActivitySection.js'
 
-function renderTrafficSection() {
+function renderActivitySection() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   })
   return render(
     <QueryClientProvider client={queryClient}>
-      <TrafficSection projectName="test-project" />
+      <ActivitySection projectName="test-project" />
     </QueryClientProvider>,
   )
 }
@@ -114,7 +114,7 @@ test('loads connected GA4 data without changing hook order', async () => {
   const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
   onTestFinished(() => consoleErrorSpy.mockRestore())
 
-  renderTrafficSection()
+  renderActivitySection()
 
   await waitFor(() => {
     expect(screen.getByText('AI vs. total sessions')).toBeTruthy()
@@ -201,7 +201,7 @@ test('renders five-channel breakdown with disjoint Organic, Social, Direct, Know
   })
   onTestFinished(restoreFetch)
 
-  renderTrafficSection()
+  renderActivitySection()
 
   await waitFor(() => {
     expect(screen.getByText('Channel breakdown')).toBeTruthy()
@@ -301,7 +301,7 @@ test('social table collapses to top 25 with show-all toggle and surfaces Other-s
   })
   onTestFinished(restoreFetch)
 
-  renderTrafficSection()
+  renderActivitySection()
 
   await waitFor(() => {
     expect(screen.getByText('Source / medium')).toBeTruthy()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.15.1",
+  "version": "4.15.2",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.15.1",
+  "version": "4.15.2",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Summary

Resolves the "traffic" naming collision across two surfaces (project-level GA4 referrals tab + top-level Cloud Run logs page) and lands a small server-side panel inside the renamed tab so the unification is visible.

**Stacks on #444** — set this PR's base to that branch so the diff focuses on just the rename. After #444 merges, GitHub will retarget this to main.

## What changes

- **Tab rename**: project-level `traffic` → `activity` (key, label, route path, type union).
- **File rename**: `TrafficSection.tsx` → `ActivitySection.tsx` (93% similarity preserved).
- **Test rename**: `traffic-section.test.tsx` → `activity-section.test.tsx` (98% similarity).
- **New `ServerActivityPanel`** rendered above the existing GA4 content. Pulls from the existing `GET /traffic/status` composite endpoint to show per-source 24h crawler hits, AI-referral hits, status, and last-sync timestamp; empty state directs the user to `/traffic` to connect a source.
- **Existing `TrafficSection` body** moved into a private `ClickThroughActivity` component that `ActivitySection` composes alongside `ServerActivityPanel`. No behavior change to the GA4 referrals view.
- **New API client + hook**:
  - `fetchServerTrafficStatus(project)` in `api.ts`
  - `ApiTrafficStatus` type alias
  - `useServerTrafficStatus(project)` in `queries/server-traffic.ts`
  - `queryKeys.serverTraffic.status(project)`

## What is intentionally NOT changed

- Top-level `/traffic` and `/traffic/$projectName/$sourceId` routes (the cross-project source-admin surface) stay. The naming collision is resolved at the visible/per-project level, which is where users encounter it. Changing the top-level UX is out of this PR's scope.
- The internal 1.4k lines of GA4 rendering (now `ClickThroughActivity`) are not refactored — only the export wrapper changed.

## Test plan

- [x] `pnpm typecheck` clean across workspace.
- [x] `pnpm lint` clean across workspace.
- [x] `pnpm exec vitest run` — 2,210 / 2,210 tests pass.
- [x] Existing `activity-section.test.tsx` (3 tests) renders the new `ActivitySection` and continues to pass — the GA4 sub-section is unchanged from the test's perspective.

## Versioning

`4.15.1` → `4.15.2` in both root and `packages/canonry/package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)