### PR TITLE
feat(report): add "AI Visibility — Server-Side" section to project report

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,10 @@ Each check returns `status: ok | warn | fail | skipped`, a stable machine-readab
 | auth | `google.auth.redirect-uri` | project | `publicUrl`-derived redirect URI is valid + advertised |
 | auth | `google.auth.scopes` | project | Granted GSC + Indexing scopes match what's stored |
 | auth | `ga.auth.connection` | project | GA4 service account verifies against the configured property |
+| auth | `traffic.source.credentials` | project | Per-source-type credential validation (today: Cloud Run service-account access token resolves) |
+| auth | `traffic.source.scopes` | project | Per-source-type scope validation (skipped where the adapter has no explicit scope check) |
+| integrations | `traffic.source.connected` | project | At least one non-archived server-side traffic source exists for the project |
+| integrations | `traffic.source.recent-data` | project | Connected sources have crawler/AI-referral events in the last 7d (warn) or 30d (fail) |
 | providers | `config.providers` | global | At least one provider key configured |
 
 ### Adding a new check

--- a/apps/web/src/pages/ReportPage.tsx
+++ b/apps/web/src/pages/ReportPage.tsx
@@ -239,10 +239,104 @@ export function ReportPage({ projectName }: { projectName: string }) {
 
       <ClientSummarySection report={report} />
       <WhatsChangedSection report={report} audience="client" />
+      <ServerActivityClientView report={report} />
       <ActionPlanSection report={report} audience="client" />
       <ClientEvidenceSection report={report} />
     </div>
   )
+}
+
+/**
+ * Client-friendly summary of server-side AI visibility data.
+ * Hidden when no source is connected (per the agreed empty-state policy: silent for client).
+ * When `hasData=false` (source connected but nothing synced yet), shows one short
+ * line so users know their connection is healthy.
+ */
+function ServerActivityClientView({ report }: { report: ProjectReportDto }) {
+  const sa = report.serverActivity
+  if (!sa) return null
+
+  if (!sa.hasData) {
+    return (
+      <section className="page-section-divider">
+        <SectionHeading
+          eyebrow="AI engine attention"
+          title="Server-side AI visibility"
+          subtitle="Live telemetry from your server logs."
+        />
+        <p className="text-sm text-zinc-500">
+          Your server-side traffic source is connected. Numbers will appear after the next sync.
+        </p>
+      </section>
+    )
+  }
+
+  const verifiedDelta = renderClientDelta(sa.verifiedCrawlerHits, 'crawls')
+  const referralDelta = renderClientDelta(sa.referralArrivals, 'arrivals')
+  // For the client view we cap at the top 5 entries — agencies see the full breakdown in the HTML report.
+  const topOperators = sa.byOperator.filter(o => o.verifiedHits > 0 || o.referralArrivals > 0).slice(0, 5)
+
+  return (
+    <section className="page-section-divider">
+      <SectionHeading
+        eyebrow="AI engine attention"
+        title="Server-side AI visibility"
+        subtitle="What AI engines actually do in your server logs over the last 7 days — the other half of citations."
+      />
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Metric
+          label="AI bots visited your site"
+          value={formatNumber(sa.verifiedCrawlerHits.current)}
+          subtitle={verifiedDelta}
+        />
+        <Metric
+          label="People clicked through from AI"
+          value={formatNumber(sa.referralArrivals.current)}
+          subtitle={referralDelta}
+        />
+      </div>
+      {topOperators.length > 0 && (
+        <div className="mt-4">
+          <p className="eyebrow mb-2">By AI engine</p>
+          <div className="evidence-table-wrap">
+            <table className="evidence-table">
+              <thead>
+                <tr>
+                  <th>Engine</th>
+                  <th>Bot visits (7d)</th>
+                  <th>Click-throughs</th>
+                </tr>
+              </thead>
+              <tbody>
+                {topOperators.map(o => (
+                  <tr key={o.operator}>
+                    <td className="evidence-query-cell">{o.operator}</td>
+                    <td>{formatNumber(o.verifiedHits)}</td>
+                    <td>{formatNumber(o.referralArrivals)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <p className="mt-2 text-[11px] text-zinc-500">
+            Verified visits only. We confirm each bot via reverse-DNS so the numbers above can't be inflated by anyone faking a user agent.
+          </p>
+        </div>
+      )}
+    </section>
+  )
+}
+
+function renderClientDelta(
+  d: { current: number; prior: number; deltaPct: number | null },
+  countLabel: string,
+): string {
+  if (d.deltaPct === null) {
+    return d.prior === 0 ? 'First baseline week' : ''
+  }
+  if (d.deltaPct > 0) return `Up ${d.deltaPct}% vs prior 7 days (${formatNumber(d.prior)} ${countLabel})`
+  if (d.deltaPct < 0) return `Down ${Math.abs(d.deltaPct)}% vs prior 7 days (${formatNumber(d.prior)} ${countLabel})`
+  return `Flat vs prior 7 days (${formatNumber(d.prior)} ${countLabel})`
 }
 
 function actionAudienceMatches(action: ReportActionPlanItem, audience: ReportAudience): boolean {
@@ -1619,7 +1713,7 @@ function IndexingHealthSectionView({ report }: { report: ProjectReportDto }) {
   if (!ih || !ih.provider) {
     return (
       <section className="page-section-divider">
-        <SectionHeading eyebrow="Section 10" title="Indexing Health" subtitle="Connect Google Search Console or Bing Webmaster Tools to populate this section." />
+        <SectionHeading eyebrow="Section 11" title="Indexing Health" subtitle="Connect Google Search Console or Bing Webmaster Tools to populate this section." />
         <EmptyHint message="No indexing data — connect Google Search Console or Bing Webmaster Tools." />
       </section>
     )
@@ -1627,7 +1721,7 @@ function IndexingHealthSectionView({ report }: { report: ProjectReportDto }) {
   const indexingSubtitle = `Pages absent from ${ih.provider === 'google' ? 'Google' : 'Bing'} are harder for AI engines to retrieve.`
   return (
     <section className="page-section-divider">
-      <SectionHeading eyebrow="Section 10" title="Indexing Health" subtitle={indexingSubtitle} />
+      <SectionHeading eyebrow="Section 11" title="Indexing Health" subtitle={indexingSubtitle} />
       <div className="grid gap-3 sm:grid-cols-3">
         <Metric label="Indexed" value={formatNumber(ih.indexed)} tone="positive" />
         <Metric label="Total inspected" value={formatNumber(ih.total)} />
@@ -1679,7 +1773,7 @@ function CitationsTrendSection({ report }: { report: ProjectReportDto }) {
   if (trend.length === 0) {
     return (
       <section className="page-section-divider">
-        <SectionHeading eyebrow="Section 11" title="Citations Over Time" subtitle="Citation coverage across recent checks." />
+        <SectionHeading eyebrow="Section 12" title="Citations Over Time" subtitle="Citation coverage across recent checks." />
         <EmptyHint message="Run multiple checks to see a trend." />
       </section>
     )
@@ -1687,14 +1781,14 @@ function CitationsTrendSection({ report }: { report: ProjectReportDto }) {
   if (isTrendBaseline(trend)) {
     return (
       <section className="page-section-divider">
-        <SectionHeading eyebrow="Section 11" title="Citations Over Time" subtitle="Citation coverage across recent checks." />
+        <SectionHeading eyebrow="Section 12" title="Citations Over Time" subtitle="Citation coverage across recent checks." />
         <EmptyHint message={`Building baseline (${trend.length} of ${MIN_TREND_POINTS} checks completed). Trend will appear once more checks are recorded.`} />
       </section>
     )
   }
   return (
     <section className="page-section-divider">
-      <SectionHeading eyebrow="Section 11" title="Citations Over Time" subtitle="Citation coverage across recent checks." />
+      <SectionHeading eyebrow="Section 12" title="Citations Over Time" subtitle="Citation coverage across recent checks." />
       <div className="h-64 rounded-xl border border-zinc-800/60 bg-zinc-900/30 p-3">
         <ResponsiveContainer width="100%" height="100%">
           <LineChart data={trend} margin={{ left: 8, right: 12, top: 8, bottom: 8 }}>
@@ -1754,14 +1848,14 @@ function InsightsSection({ report }: { report: ProjectReportDto }) {
   if (report.insights.length === 0) {
     return (
       <section className="page-section-divider">
-        <SectionHeading eyebrow="Section 12" title="Insights &amp; Alerts" subtitle="Regressions, gains, and recurring alerts ordered by severity." />
+        <SectionHeading eyebrow="Section 13" title="Insights &amp; Alerts" subtitle="Regressions, gains, and recurring alerts ordered by severity." />
         <EmptyHint message="No active insights — everything looks stable." />
       </section>
     )
   }
   return (
     <section className="page-section-divider">
-      <SectionHeading eyebrow="Section 12" title="Insights &amp; Alerts" subtitle="Regressions, gains, and recurring alerts ordered by severity." />
+      <SectionHeading eyebrow="Section 13" title="Insights &amp; Alerts" subtitle="Regressions, gains, and recurring alerts ordered by severity." />
       <div className="evidence-table-wrap">
         <table className="evidence-table">
           <thead>
@@ -1805,7 +1899,7 @@ function ContentOpportunitiesSection({ report }: { report: ProjectReportDto }) {
   return (
     <section className="page-section-divider">
       <SectionHeading
-        eyebrow="Section 13"
+        eyebrow="Section 14"
         title="Content Opportunities"
         subtitle="Queries where content work has the clearest path to more AI citations. Opportunity score is 0–100, higher = stronger."
       />
@@ -1873,7 +1967,7 @@ function ContentGapsSection({ report }: { report: ProjectReportDto }) {
   return (
     <section className="page-section-divider">
       <SectionHeading
-        eyebrow="Section 14"
+        eyebrow="Section 15"
         title="Content Gaps"
         subtitle="Tracked queries where competitors are cited and the client is missing."
       />
@@ -1915,14 +2009,14 @@ function NextStepsSection({ report }: { report: ProjectReportDto }) {
   if (report.recommendedNextSteps.length === 0) {
     return (
       <section className="page-section-divider">
-        <SectionHeading eyebrow="Section 15" title="Recommended Next Steps" subtitle="Action items bucketed by timing." />
+        <SectionHeading eyebrow="Section 16" title="Recommended Next Steps" subtitle="Action items bucketed by timing." />
         <EmptyHint message="No prioritized actions yet." />
       </section>
     )
   }
   return (
     <section className="page-section-divider">
-      <SectionHeading eyebrow="Section 15" title="Recommended Next Steps" subtitle="Action items bucketed by timing." />
+      <SectionHeading eyebrow="Section 16" title="Recommended Next Steps" subtitle="Action items bucketed by timing." />
       <div className="space-y-2">
         {report.recommendedNextSteps.map((s, i) => (
           <div key={i} className="flex items-start gap-3 rounded-lg border border-zinc-800/60 bg-zinc-900/30 px-3 py-2.5">

--- a/apps/web/src/pages/ReportPage.tsx
+++ b/apps/web/src/pages/ReportPage.tsx
@@ -19,6 +19,7 @@ import {
   contentActionLabel,
   dedupeReportActions,
   dedupeReportOpportunities,
+  formatDeltaCopy,
   reportActionCategoryLabel,
   reportActionTone,
   reportConfidenceLabel,
@@ -246,6 +247,14 @@ export function ReportPage({ projectName }: { projectName: string }) {
   )
 }
 
+// Section heading for the server-side AI visibility view. Mirrors the
+// HTML renderer's `serverActivityHeading('client', …)` per the
+// report-parity rule — eyebrow, title, and subtitle must match verbatim.
+const SERVER_ACTIVITY_TITLE = 'AI Visibility — Server-Side'
+const SERVER_ACTIVITY_EYEBROW_CLIENT = 'AI engine attention'
+const SERVER_ACTIVITY_INTRO_HAS_DATA = 'What AI engines actually do in your server logs over the last 7 days — the other half of citations.'
+const SERVER_ACTIVITY_INTRO_NO_DATA = 'Live telemetry from your server logs.'
+
 /**
  * Client-friendly summary of server-side AI visibility data.
  * Hidden when no source is connected (per the agreed empty-state policy: silent for client).
@@ -260,9 +269,9 @@ function ServerActivityClientView({ report }: { report: ProjectReportDto }) {
     return (
       <section className="page-section-divider">
         <SectionHeading
-          eyebrow="AI engine attention"
-          title="Server-side AI visibility"
-          subtitle="Live telemetry from your server logs."
+          eyebrow={SERVER_ACTIVITY_EYEBROW_CLIENT}
+          title={SERVER_ACTIVITY_TITLE}
+          subtitle={SERVER_ACTIVITY_INTRO_NO_DATA}
         />
         <p className="text-sm text-zinc-500">
           Your server-side traffic source is connected. Numbers will appear after the next sync.
@@ -271,17 +280,17 @@ function ServerActivityClientView({ report }: { report: ProjectReportDto }) {
     )
   }
 
-  const verifiedDelta = renderClientDelta(sa.verifiedCrawlerHits, 'crawls')
-  const referralDelta = renderClientDelta(sa.referralArrivals, 'arrivals')
+  const verifiedDelta = formatDeltaCopy(sa.verifiedCrawlerHits, 'crawls')
+  const referralDelta = formatDeltaCopy(sa.referralArrivals, 'arrivals')
   // For the client view we cap at the top 5 entries — agencies see the full breakdown in the HTML report.
   const topOperators = sa.byOperator.filter(o => o.verifiedHits > 0 || o.referralArrivals > 0).slice(0, 5)
 
   return (
     <section className="page-section-divider">
       <SectionHeading
-        eyebrow="AI engine attention"
-        title="Server-side AI visibility"
-        subtitle="What AI engines actually do in your server logs over the last 7 days — the other half of citations."
+        eyebrow={SERVER_ACTIVITY_EYEBROW_CLIENT}
+        title={SERVER_ACTIVITY_TITLE}
+        subtitle={SERVER_ACTIVITY_INTRO_HAS_DATA}
       />
       <div className="grid gap-3 sm:grid-cols-2">
         <Metric
@@ -325,18 +334,6 @@ function ServerActivityClientView({ report }: { report: ProjectReportDto }) {
       )}
     </section>
   )
-}
-
-function renderClientDelta(
-  d: { current: number; prior: number; deltaPct: number | null },
-  countLabel: string,
-): string {
-  if (d.deltaPct === null) {
-    return d.prior === 0 ? 'First baseline week' : ''
-  }
-  if (d.deltaPct > 0) return `Up ${d.deltaPct}% vs prior 7 days (${formatNumber(d.prior)} ${countLabel})`
-  if (d.deltaPct < 0) return `Down ${Math.abs(d.deltaPct)}% vs prior 7 days (${formatNumber(d.prior)} ${countLabel})`
-  return `Flat vs prior 7 days (${formatNumber(d.prior)} ${countLabel})`
 }
 
 function actionAudienceMatches(action: ReportActionPlanItem, audience: ReportAudience): boolean {

--- a/apps/web/src/pages/ReportPage.tsx
+++ b/apps/web/src/pages/ReportPage.tsx
@@ -297,12 +297,12 @@ function ServerActivityClientView({ report }: { report: ProjectReportDto }) {
       </div>
       {topOperators.length > 0 && (
         <div className="mt-4">
-          <p className="eyebrow mb-2">By AI engine</p>
+          <p className="eyebrow mb-2">By AI tool</p>
           <div className="evidence-table-wrap">
             <table className="evidence-table">
               <thead>
                 <tr>
-                  <th>Engine</th>
+                  <th>AI tool</th>
                   <th>Bot visits (7d)</th>
                   <th>Click-throughs</th>
                 </tr>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.18.0",
+  "version": "4.18.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.17.1",
+  "version": "4.18.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/AGENTS.md
+++ b/packages/api-routes/AGENTS.md
@@ -27,7 +27,7 @@ Shared Fastify route plugins used by both the local server (`packages/canonry`) 
 | `src/doctor.ts` | `GET /doctor` and `GET /projects/:name/doctor` — runs check registry, returns `DoctorReport` |
 | `src/doctor/registry.ts` | `ALL_CHECKS` — single source of truth for the doctor check catalog |
 | `src/doctor/runner.ts` | `runChecks()` and `matchesCheckId()` — execute filtered checks, build the report |
-| `src/doctor/checks/*.ts` | Individual `CheckDefinition`s (google-auth, ga-auth, providers) |
+| `src/doctor/checks/*.ts` | Individual `CheckDefinition`s (google-auth, bing-auth, ga-auth, providers, traffic-source). The `traffic-source` checks are adapter-agnostic — they query `traffic_sources` directly for connection/recent-data, and dispatch credential / scope validation through `DoctorContext.trafficSourceValidators[<sourceType>]`. Today only the `cloud-run` validator is registered (built in `index.ts` from the existing `cloudRunCredentialStore` + `resolveCloudRunAccessToken`); future adapters (`wp-plugin`, etc.) plug in by adding a key to that map — no doctor-side changes needed. |
 
 ## Patterns
 

--- a/packages/api-routes/src/doctor.ts
+++ b/packages/api-routes/src/doctor.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from 'fastify'
 import { ALL_CHECKS } from './doctor/registry.js'
 import { runChecks } from './doctor/runner.js'
-import type { DoctorContext } from './doctor/types.js'
+import type { DoctorContext, TrafficSourceValidator } from './doctor/types.js'
 import type { GoogleConnectionStore } from './google.js'
 import type { BingConnectionStore } from './bing.js'
 import type { Ga4CredentialStore } from './ga.js'
@@ -16,6 +16,12 @@ export interface DoctorRoutesOptions {
   /** Used to derive the redirect URI displayed by the redirect-uri check. */
   publicUrl?: string
   providerSummary?: ProviderSummaryEntry[]
+  /**
+   * Map of `traffic_sources.source_type` → adapter validator. Optional — the
+   * generic `traffic.source.credentials` / `traffic.source.scopes` checks
+   * skip with a clear `no-validator` code when an adapter doesn't register.
+   */
+  trafficSourceValidators?: Record<string, TrafficSourceValidator>
 }
 
 function parseCheckIds(raw: string | undefined): string[] {
@@ -49,6 +55,7 @@ export async function doctorRoutes(app: FastifyInstance, opts: DoctorRoutesOptio
       getGoogleAuthConfig: opts.getGoogleAuthConfig,
       redirectUri,
       providerSummary: opts.providerSummary,
+      trafficSourceValidators: opts.trafficSourceValidators,
     }
     return runChecks(ctx, ALL_CHECKS, { checkIds })
   })
@@ -74,6 +81,7 @@ export async function doctorRoutes(app: FastifyInstance, opts: DoctorRoutesOptio
       getGoogleAuthConfig: opts.getGoogleAuthConfig,
       redirectUri,
       providerSummary: opts.providerSummary,
+      trafficSourceValidators: opts.trafficSourceValidators,
     }
     return runChecks(ctx, ALL_CHECKS, { checkIds })
   })

--- a/packages/api-routes/src/doctor/checks/traffic-source.ts
+++ b/packages/api-routes/src/doctor/checks/traffic-source.ts
@@ -1,0 +1,361 @@
+import { and, eq, gte, ne, sql } from 'drizzle-orm'
+import {
+  CheckCategories,
+  CheckScopes,
+  CheckStatuses,
+  TrafficSourceStatuses,
+} from '@ainyc/canonry-contracts'
+import {
+  aiReferralEventsHourly,
+  crawlerEventsHourly,
+  trafficSources,
+} from '@ainyc/canonry-db'
+import type { CheckDefinition, CheckOutput, DoctorContext, TrafficSourceProbe } from '../types.js'
+
+/**
+ * Generic doctor checks for the server-side traffic ingestion pipeline. They
+ * stay adapter-agnostic — the `traffic_sources` table is the only thing they
+ * reach into directly; per-adapter credential / scope validation flows
+ * through `DoctorContext.trafficSourceValidators[sourceType]`.
+ *
+ * Today the only adapter is Cloud Run; tomorrow's WordPress / SaaS adapters
+ * register under their own `sourceType` keys and inherit every check below
+ * with no doctor-side changes.
+ */
+
+const RECENT_DATA_WARN_DAYS = 7
+const RECENT_DATA_FAIL_DAYS = 30
+
+function skippedNoProject(): CheckOutput {
+  return {
+    status: CheckStatuses.skipped,
+    code: 'traffic.no-project',
+    summary: 'Project context required for traffic source checks.',
+    remediation: 'Run `canonry doctor --project <name>` to scope this check to a project.',
+  }
+}
+
+function loadProbes(ctx: DoctorContext): TrafficSourceProbe[] {
+  if (!ctx.project) return []
+  const rows = ctx.db
+    .select()
+    .from(trafficSources)
+    .where(
+      and(
+        eq(trafficSources.projectId, ctx.project.id),
+        ne(trafficSources.status, TrafficSourceStatuses.archived),
+      ),
+    )
+    .all()
+  return rows.map((r) => ({
+    id: r.id,
+    projectId: r.projectId,
+    projectName: ctx.project!.name,
+    sourceType: r.sourceType,
+    displayName: r.displayName,
+    status: r.status,
+    lastSyncedAt: r.lastSyncedAt,
+    lastError: r.lastError,
+    configJson: r.configJson,
+  }))
+}
+
+const sourceConnectedCheck: CheckDefinition = {
+  id: 'traffic.source.connected',
+  category: CheckCategories.integrations,
+  scope: CheckScopes.project,
+  title: 'Traffic source connected',
+  run: (ctx) => {
+    if (!ctx.project) return skippedNoProject()
+    const sources = loadProbes(ctx)
+    if (sources.length === 0) {
+      return {
+        status: CheckStatuses.skipped,
+        code: 'traffic.source.none',
+        summary: 'No server-side traffic source connected — server-log AI visibility data unavailable for this project.',
+        remediation: 'Connect a traffic source via `canonry traffic connect <type> <project>` to surface crawler hits and AI-referral arrivals from your server logs.',
+        details: { sourceCount: 0 },
+      }
+    }
+    const errored = sources.filter((s) => s.status === 'error')
+    if (errored.length > 0 && errored.length === sources.length) {
+      return {
+        status: CheckStatuses.fail,
+        code: 'traffic.source.all-errored',
+        summary: `All ${sources.length} traffic source(s) are in error state. No data is being ingested.`,
+        remediation: errored[0]!.lastError
+          ? `Latest error: "${errored[0]!.lastError}". Re-connect the source or run \`canonry traffic sync <project> --source <id>\` to retry.`
+          : 'Run `canonry traffic sources <project>` to inspect the failing source(s) and re-connect.',
+        details: { sourceCount: sources.length, erroredIds: errored.map((s) => s.id) },
+      }
+    }
+    if (errored.length > 0) {
+      return {
+        status: CheckStatuses.warn,
+        code: 'traffic.source.partially-errored',
+        summary: `${errored.length} of ${sources.length} traffic source(s) are in error state.`,
+        remediation: 'Run `canonry traffic sources <project>` to inspect the failing sources individually.',
+        details: { sourceCount: sources.length, erroredIds: errored.map((s) => s.id) },
+      }
+    }
+    return {
+      status: CheckStatuses.ok,
+      code: 'traffic.source.connected',
+      summary: `${sources.length} traffic source(s) connected: ${sources.map((s) => s.displayName).join(', ')}.`,
+      details: { sourceCount: sources.length, sourceTypes: [...new Set(sources.map((s) => s.sourceType))] },
+    }
+  },
+}
+
+const recentDataCheck: CheckDefinition = {
+  id: 'traffic.source.recent-data',
+  category: CheckCategories.integrations,
+  scope: CheckScopes.project,
+  title: 'Traffic source recent data',
+  run: (ctx) => {
+    if (!ctx.project) return skippedNoProject()
+    const sources = loadProbes(ctx)
+    if (sources.length === 0) {
+      return {
+        status: CheckStatuses.skipped,
+        code: 'traffic.recent-data.no-source',
+        summary: 'No traffic source connected — recent-data check skipped.',
+      }
+    }
+
+    const now = new Date()
+    const warnCutoff = new Date(now.getTime() - RECENT_DATA_WARN_DAYS * 24 * 60 * 60_000).toISOString()
+    const failCutoff = new Date(now.getTime() - RECENT_DATA_FAIL_DAYS * 24 * 60 * 60_000).toISOString()
+
+    const recentCrawlers = Number(
+      ctx.db
+        .select({ total: sql<number>`COALESCE(SUM(${crawlerEventsHourly.hits}), 0)` })
+        .from(crawlerEventsHourly)
+        .where(
+          and(
+            eq(crawlerEventsHourly.projectId, ctx.project.id),
+            gte(crawlerEventsHourly.tsHour, warnCutoff),
+          ),
+        )
+        .get()?.total ?? 0,
+    )
+    const recentReferrals = Number(
+      ctx.db
+        .select({ total: sql<number>`COALESCE(SUM(${aiReferralEventsHourly.sessionsOrHits}), 0)` })
+        .from(aiReferralEventsHourly)
+        .where(
+          and(
+            eq(aiReferralEventsHourly.projectId, ctx.project.id),
+            gte(aiReferralEventsHourly.tsHour, warnCutoff),
+          ),
+        )
+        .get()?.total ?? 0,
+    )
+    if (recentCrawlers > 0 || recentReferrals > 0) {
+      return {
+        status: CheckStatuses.ok,
+        code: 'traffic.recent-data.fresh',
+        summary: `${recentCrawlers} crawler hit(s) and ${recentReferrals} AI-referral arrival(s) in the last ${RECENT_DATA_WARN_DAYS} days.`,
+        details: { crawlerHits: recentCrawlers, referralArrivals: recentReferrals, windowDays: RECENT_DATA_WARN_DAYS },
+      }
+    }
+
+    // No data inside the warn window — escalate to fail if also empty inside the failure window.
+    const olderCrawlers = Number(
+      ctx.db
+        .select({ total: sql<number>`COALESCE(SUM(${crawlerEventsHourly.hits}), 0)` })
+        .from(crawlerEventsHourly)
+        .where(
+          and(
+            eq(crawlerEventsHourly.projectId, ctx.project.id),
+            gte(crawlerEventsHourly.tsHour, failCutoff),
+          ),
+        )
+        .get()?.total ?? 0,
+    )
+    const lastSyncedAt = sources.map((s) => s.lastSyncedAt).filter(Boolean).sort().at(-1) ?? null
+    if (olderCrawlers > 0 || lastSyncedAt) {
+      return {
+        status: CheckStatuses.warn,
+        code: 'traffic.recent-data.stale',
+        summary: `No crawler hits or AI-referral arrivals in the last ${RECENT_DATA_WARN_DAYS} days, though older data exists.`,
+        remediation: lastSyncedAt
+          ? `Last sync: ${lastSyncedAt}. Run \`canonry traffic sync <project>\` to refresh, or check the source connection.`
+          : 'Run `canonry traffic sync <project>` to pull recent events.',
+        details: { lastSyncedAt, sourceCount: sources.length },
+      }
+    }
+    return {
+      status: CheckStatuses.fail,
+      code: 'traffic.recent-data.empty',
+      summary: `No traffic data in the last ${RECENT_DATA_FAIL_DAYS} days. The source is connected but isn't ingesting.`,
+      remediation: 'Verify the source\'s configuration with `canonry traffic sources <project>` and run a manual sync to confirm credentials + scopes are still valid.',
+      details: { sourceCount: sources.length },
+    }
+  },
+}
+
+async function runValidator(
+  source: TrafficSourceProbe,
+  validator: ((s: TrafficSourceProbe) => Promise<CheckOutput | null> | CheckOutput | null) | undefined,
+  fallbackId: string,
+  fallbackLabel: string,
+): Promise<{ source: TrafficSourceProbe; output: CheckOutput }> {
+  if (!validator) {
+    return {
+      source,
+      output: {
+        status: CheckStatuses.skipped,
+        code: `traffic.${fallbackId}.no-validator`,
+        summary: `No ${fallbackLabel} validator registered for source type "${source.sourceType}".`,
+      },
+    }
+  }
+  try {
+    const result = await validator(source)
+    if (!result) {
+      return {
+        source,
+        output: {
+          status: CheckStatuses.skipped,
+          code: `traffic.${fallbackId}.unsupported`,
+          summary: `Validator for "${source.sourceType}" does not implement ${fallbackLabel} validation.`,
+        },
+      }
+    }
+    return { source, output: result }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    return {
+      source,
+      output: {
+        status: CheckStatuses.fail,
+        code: `traffic.${fallbackId}.validator-error`,
+        summary: `${fallbackLabel} validator threw: ${msg}.`,
+        remediation: 'Check the source configuration and credentials, then re-run the doctor.',
+      },
+    }
+  }
+}
+
+function summarizePerSourceResults(
+  fallbackId: string,
+  fallbackLabel: string,
+  results: Array<{ source: TrafficSourceProbe; output: CheckOutput }>,
+): CheckOutput {
+  const failed = results.filter((r) => r.output.status === CheckStatuses.fail)
+  const warned = results.filter((r) => r.output.status === CheckStatuses.warn)
+  const skipped = results.filter((r) => r.output.status === CheckStatuses.skipped)
+  const ok = results.filter((r) => r.output.status === CheckStatuses.ok)
+
+  const detail = {
+    sources: results.map((r) => ({
+      id: r.source.id,
+      sourceType: r.source.sourceType,
+      displayName: r.source.displayName,
+      status: r.output.status,
+      code: r.output.code,
+      summary: r.output.summary,
+    })),
+  }
+  if (failed.length > 0) {
+    return {
+      status: CheckStatuses.fail,
+      code: `traffic.${fallbackId}.failed`,
+      summary: `${failed.length} of ${results.length} source(s) failed ${fallbackLabel} validation: ${failed.map((r) => `${r.source.displayName} (${r.output.summary})`).join('; ')}.`,
+      remediation: failed[0]!.output.remediation ?? `Inspect the failing source(s) — see details.sources for per-source codes.`,
+      details: detail,
+    }
+  }
+  if (warned.length > 0) {
+    return {
+      status: CheckStatuses.warn,
+      code: `traffic.${fallbackId}.warned`,
+      summary: `${warned.length} of ${results.length} source(s) raised warnings during ${fallbackLabel} validation.`,
+      remediation: warned[0]!.output.remediation ?? `Review the warning(s) — see details.sources.`,
+      details: detail,
+    }
+  }
+  if (ok.length > 0) {
+    return {
+      status: CheckStatuses.ok,
+      code: `traffic.${fallbackId}.ok`,
+      summary: `${ok.length} source(s) passed ${fallbackLabel} validation${skipped.length > 0 ? ` (${skipped.length} skipped)` : ''}.`,
+      details: detail,
+    }
+  }
+  // All skipped.
+  return {
+    status: CheckStatuses.skipped,
+    code: `traffic.${fallbackId}.all-skipped`,
+    summary: `No source-type validator was available for any of the ${results.length} connected source(s).`,
+    details: detail,
+  }
+}
+
+const credentialsCheck: CheckDefinition = {
+  id: 'traffic.source.credentials',
+  category: CheckCategories.auth,
+  scope: CheckScopes.project,
+  title: 'Traffic source credentials',
+  run: async (ctx) => {
+    if (!ctx.project) return skippedNoProject()
+    const sources = loadProbes(ctx)
+    if (sources.length === 0) {
+      return {
+        status: CheckStatuses.skipped,
+        code: 'traffic.credentials.no-source',
+        summary: 'No traffic source connected — credentials check skipped.',
+      }
+    }
+    const validators = ctx.trafficSourceValidators ?? {}
+    const results = await Promise.all(
+      sources.map((s) =>
+        runValidator(
+          s,
+          validators[s.sourceType]?.validateCredentials?.bind(validators[s.sourceType]),
+          'credentials',
+          'credentials',
+        ),
+      ),
+    )
+    return summarizePerSourceResults('credentials', 'credentials', results)
+  },
+}
+
+const scopesCheck: CheckDefinition = {
+  id: 'traffic.source.scopes',
+  category: CheckCategories.auth,
+  scope: CheckScopes.project,
+  title: 'Traffic source scopes',
+  run: async (ctx) => {
+    if (!ctx.project) return skippedNoProject()
+    const sources = loadProbes(ctx)
+    if (sources.length === 0) {
+      return {
+        status: CheckStatuses.skipped,
+        code: 'traffic.scopes.no-source',
+        summary: 'No traffic source connected — scopes check skipped.',
+      }
+    }
+    const validators = ctx.trafficSourceValidators ?? {}
+    const results = await Promise.all(
+      sources.map((s) =>
+        runValidator(
+          s,
+          validators[s.sourceType]?.validateScopes?.bind(validators[s.sourceType]),
+          'scopes',
+          'scopes',
+        ),
+      ),
+    )
+    return summarizePerSourceResults('scopes', 'scopes', results)
+  },
+}
+
+export const TRAFFIC_SOURCE_CHECKS: readonly CheckDefinition[] = [
+  sourceConnectedCheck,
+  recentDataCheck,
+  credentialsCheck,
+  scopesCheck,
+]

--- a/packages/api-routes/src/doctor/registry.ts
+++ b/packages/api-routes/src/doctor/registry.ts
@@ -2,6 +2,7 @@ import { BING_AUTH_CHECKS } from './checks/bing-auth.js'
 import { GA_AUTH_CHECKS } from './checks/ga-auth.js'
 import { GOOGLE_AUTH_CHECKS } from './checks/google-auth.js'
 import { PROVIDERS_CHECKS } from './checks/providers.js'
+import { TRAFFIC_SOURCE_CHECKS } from './checks/traffic-source.js'
 import type { CheckDefinition } from './types.js'
 
 export const ALL_CHECKS: readonly CheckDefinition[] = [
@@ -9,6 +10,7 @@ export const ALL_CHECKS: readonly CheckDefinition[] = [
   ...BING_AUTH_CHECKS,
   ...GA_AUTH_CHECKS,
   ...PROVIDERS_CHECKS,
+  ...TRAFFIC_SOURCE_CHECKS,
 ]
 
 export const CHECK_BY_ID: Record<string, CheckDefinition> = Object.fromEntries(

--- a/packages/api-routes/src/doctor/types.ts
+++ b/packages/api-routes/src/doctor/types.ts
@@ -5,6 +5,36 @@ import type { BingConnectionStore } from '../bing.js'
 import type { Ga4CredentialStore } from '../ga.js'
 import type { ProviderSummaryEntry } from '../settings.js'
 
+/**
+ * Generic traffic-source row shape passed to a `TrafficSourceValidator`.
+ * Mirrors the public columns of `trafficSources`; this surface stays
+ * deliberately loose so future adapters (WordPress plugin, others) don't
+ * need to teach the doctor framework anything new.
+ */
+export interface TrafficSourceProbe {
+  id: string
+  projectId: string
+  projectName: string
+  sourceType: string
+  displayName: string
+  status: string
+  lastSyncedAt: string | null
+  lastError: string | null
+  configJson: string
+}
+
+/**
+ * Per-source-type validation hook. Adapters register a validator under their
+ * `sourceType` key (e.g. `'cloud-run'`, `'wp-plugin'`). Each method returns a
+ * `CheckOutput` (ok / warn / fail / skipped) for a single source row, or null
+ * to indicate the validator does not implement that check (the runner will
+ * surface a `skipped` result with `code: '<id>.no-validator'`).
+ */
+export interface TrafficSourceValidator {
+  validateCredentials?(source: TrafficSourceProbe): Promise<CheckOutput | null> | CheckOutput | null
+  validateScopes?(source: TrafficSourceProbe): Promise<CheckOutput | null> | CheckOutput | null
+}
+
 export interface DoctorContext {
   db: DatabaseClient
   /** When the check is project-scoped, this resolves to the project row. */
@@ -16,6 +46,13 @@ export interface DoctorContext {
   /** Resolved redirect URI (publicUrl + /api/v1/google/callback) used by the OAuth flow. */
   redirectUri?: string
   providerSummary?: ProviderSummaryEntry[]
+  /**
+   * Map of `traffic_sources.source_type` → adapter-specific validator. The
+   * generic `traffic.source.credentials` / `traffic.source.scopes` checks
+   * dispatch to the matching entry. Sources whose type has no validator
+   * registered surface a `skipped` result rather than a fail.
+   */
+  trafficSourceValidators?: Record<string, TrafficSourceValidator>
 }
 
 export interface ProjectInfo {

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -41,9 +41,11 @@ import { wordpressRoutes } from './wordpress.js'
 import type { WordpressRoutesOptions } from './wordpress.js'
 import { backlinksRoutes } from './backlinks.js'
 import type { BacklinksRoutesOptions } from './backlinks.js'
-import { trafficRoutes } from './traffic.js'
+import { trafficRoutes, defaultResolveAccessToken } from './traffic.js'
 import type { TrafficRoutesOptions, CloudRunCredentialStore } from './traffic.js'
 import { doctorRoutes } from './doctor.js'
+import { CheckStatuses } from '@ainyc/canonry-contracts'
+import type { CheckOutput, TrafficSourceProbe, TrafficSourceValidator } from './doctor/types.js'
 
 declare module 'fastify' {
   interface FastifyInstance {
@@ -296,6 +298,7 @@ export async function apiRoutes(app: FastifyInstance, opts: ApiRoutesOptions) {
       getGoogleAuthConfig: opts.getGoogleAuthConfig,
       publicUrl: opts.publicUrl,
       providerSummary: opts.providerSummary,
+      trafficSourceValidators: buildTrafficSourceValidators(opts),
     })
     // Local-only extension hook: canonry passes the Aero agent routes here
     // so they live inside the authenticated scope. Cloud leaves it undefined.
@@ -313,3 +316,56 @@ export type { SafeWebhookTarget } from './webhooks.js'
 export type { RunRoutesOptions } from './runs.js'
 export { renderReportHtml } from './report-renderer.js'
 export type { RenderReportHtmlOptions } from './report-renderer.js'
+
+/**
+ * Build the per-source-type validator map consumed by the generic
+ * `traffic.source.credentials` and `traffic.source.scopes` doctor checks.
+ *
+ * Today only Cloud Run has an adapter, so this returns at most one entry
+ * (`'cloud-run'`). Future adapters (WordPress plugin, others) plug in by
+ * adding their own entry here behind the same `TrafficSourceValidator`
+ * interface — no doctor-side changes needed.
+ */
+function buildTrafficSourceValidators(opts: ApiRoutesOptions): Record<string, TrafficSourceValidator> | undefined {
+  const validators: Record<string, TrafficSourceValidator> = {}
+  if (opts.cloudRunCredentialStore) {
+    const store = opts.cloudRunCredentialStore
+    const resolveToken = opts.resolveCloudRunAccessToken ?? defaultResolveAccessToken
+    validators['cloud-run'] = {
+      validateCredentials: async (source: TrafficSourceProbe): Promise<CheckOutput> => {
+        const record = store.getConnection(source.projectName)
+        if (!record) {
+          return {
+            status: CheckStatuses.fail,
+            code: 'traffic.credentials.missing',
+            summary: `No Cloud Run credential found in ~/.canonry/config.yaml for project "${source.projectName}".`,
+            remediation: 'Re-run `canonry traffic connect cloud-run <project> --gcp-project <id> --service-account-key <path>`.',
+          }
+        }
+        try {
+          await resolveToken(record)
+          return {
+            status: CheckStatuses.ok,
+            code: 'traffic.credentials.resolved',
+            summary: `Cloud Run access token resolves for "${source.displayName}" (project ${record.gcpProjectId}).`,
+          }
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e)
+          return {
+            status: CheckStatuses.fail,
+            code: 'traffic.credentials.resolve-failed',
+            summary: `Failed to resolve Cloud Run access token: ${msg}.`,
+            remediation: 'Verify the service-account key in ~/.canonry/config.yaml is unexpired and well-formed. Re-connect the source if needed.',
+          }
+        }
+      },
+      // Cloud Run scopes are implicit in the service-account key — Cloud
+      // Logging viewer is the only required scope today, and it's enforced
+      // at the IAM layer rather than baked into the token. We surface a
+      // skipped result so the framework is uniform without producing a
+      // false signal.
+      validateScopes: () => null,
+    }
+  }
+  return Object.keys(validators).length > 0 ? validators : undefined
+}

--- a/packages/api-routes/src/report-renderer.ts
+++ b/packages/api-routes/src/report-renderer.ts
@@ -1812,18 +1812,26 @@ function renderAiReferrals(report: ProjectReportDto): string {
   )
 }
 
-function renderServerActivity(report: ProjectReportDto): string {
+function renderServerActivity(report: ProjectReportDto, audience: ReportAudience): string {
   const sa = report.serverActivity
+  const isClient = audience === 'client'
+  // Client view stays silent when no source is connected — surfacing a
+  // "connect a Cloud Run source" call-to-action to a client who has no
+  // technical access produces noise. Agency view shows the prompt because
+  // the operator is the audience that can act on it.
   if (!sa) {
+    if (isClient) return ''
     return section(
       { id: 'server-activity', eyebrow: 'Section 10', title: 'AI Visibility — Server-Side' },
-      renderEmpty('Connect a server-side traffic source (e.g. Cloud Run logs) to surface what AI engines do directly in your server logs — distinct from GA4 click-throughs.'),
+      renderEmpty('Connect a server-side traffic source to surface what AI engines do directly in your server logs — distinct from GA4 click-throughs.'),
     )
   }
   if (!sa.hasData) {
     return section(
       { id: 'server-activity', eyebrow: 'Section 10', title: 'AI Visibility — Server-Side' },
-      renderEmpty('Source connected — collecting your first data. Numbers will appear after the next sync.'),
+      renderEmpty(isClient
+        ? 'Your server-side traffic source is connected. Numbers will appear after the next sync.'
+        : 'Source connected — collecting your first data. Numbers will appear after the next sync.'),
     )
   }
 
@@ -1836,6 +1844,48 @@ function renderServerActivity(report: ProjectReportDto): string {
     return `<span class="${tone}">${arrow} ${Math.abs(d.deltaPct)}% vs prior 7d (${formatNumber(d.prior)} ${suffix})</span>`
   }
 
+  // ── Client view (lightweight; mirrors the SPA's ServerActivityClientView) ──
+  if (isClient) {
+    const clientOperators = sa.byOperator
+      .filter(o => o.verifiedHits > 0 || o.referralArrivals > 0)
+      .slice(0, 5)
+    const clientOperatorRows = clientOperators.map(o => `
+    <tr>
+      <td>${escapeHtml(o.operator)}</td>
+      <td class="numeric">${formatNumber(o.verifiedHits)}</td>
+      <td class="numeric">${formatNumber(o.referralArrivals)}</td>
+    </tr>`).join('')
+
+    return section(
+      {
+        id: 'server-activity',
+        eyebrow: 'AI engine attention',
+        title: 'AI Visibility — Server-Side',
+        intro: 'What AI engines actually do in your server logs over the last 7 days — the other half of citations.',
+      },
+      `<div class="metric-grid">
+        <div class="metric">
+          <div class="label">AI bots visited your site</div>
+          <div class="value">${formatNumber(sa.verifiedCrawlerHits.current)}</div>
+          <div class="subtitle">${formatDelta(sa.verifiedCrawlerHits, 'crawls')}</div>
+        </div>
+        <div class="metric">
+          <div class="label">People clicked through from AI</div>
+          <div class="value">${formatNumber(sa.referralArrivals.current)}</div>
+          <div class="subtitle">${formatDelta(sa.referralArrivals, 'arrivals')}</div>
+        </div>
+      </div>
+      ${clientOperatorRows ? `<div class="chart-card"><h3>By AI tool</h3>
+        <table class="report-table">
+          <thead><tr><th>AI tool</th><th class="numeric">Bot visits (7d)</th><th class="numeric">Click-throughs</th></tr></thead>
+          <tbody>${clientOperatorRows}</tbody>
+        </table>
+        <p class="meta">Verified visits only. We confirm each bot via reverse-DNS so the numbers above can't be inflated by anyone faking a user agent.</p>
+      </div>` : ''}`,
+    )
+  }
+
+  // ── Agency view (full forensic detail) ──
   const operatorRows = sa.byOperator.map(o => {
     const deltaText = o.deltaPct === null
       ? '—'
@@ -2448,6 +2498,10 @@ export function renderReportHtml(report: ProjectReportDto, opts: RenderReportHtm
     ? [
         renderClientSummary(report),
         renderWhatsChanged(report, 'client'),
+        // Server-side AI visibility runs between WhatsChanged and the action
+        // plan in BOTH the SPA and HTML so clients see the same ordered set
+        // of sections in either surface (per the report-parity rule).
+        renderServerActivity(report, 'client'),
         renderAudienceActionPlan(report, 'client'),
         renderClientEvidenceSummary(report),
       ].join('\n')
@@ -2463,7 +2517,7 @@ export function renderReportHtml(report: ProjectReportDto, opts: RenderReportHtm
         renderGa(report),
         renderSocial(report),
         renderAiReferrals(report),
-        renderServerActivity(report),
+        renderServerActivity(report, 'agency'),
         renderIndexingHealth(report),
         renderCitationsTrend(report),
         renderInsights(report),

--- a/packages/api-routes/src/report-renderer.ts
+++ b/packages/api-routes/src/report-renderer.ts
@@ -15,8 +15,10 @@ import {
   contentActionLabel,
   dedupeReportActions,
   dedupeReportOpportunities,
+  deltaTone,
   formatDate,
   formatDateRange,
+  formatDeltaCopy,
   formatIsoDate,
   formatNumber,
   formatRatio,
@@ -1812,6 +1814,28 @@ function renderAiReferrals(report: ProjectReportDto): string {
   )
 }
 
+// Section heading metadata for "AI Visibility — Server-Side". The SPA and
+// HTML must render the SAME eyebrow/title/intro per audience — see the
+// report-parity rule in `AGENTS.md`.
+function serverActivityHeading(audience: ReportAudience, hasData: boolean): {
+  id: string
+  eyebrow: string
+  title: string
+  intro: string
+} {
+  const isClient = audience === 'client'
+  return {
+    id: 'server-activity',
+    eyebrow: isClient ? 'AI engine attention' : 'Section 10',
+    title: 'AI Visibility — Server-Side',
+    intro: isClient
+      ? hasData
+        ? 'What AI engines actually do in your server logs over the last 7 days — the other half of citations.'
+        : 'Live telemetry from your server logs.'
+      : 'What AI engines actually do in your server logs — direct evidence, complementary to citations (which measure what they say).',
+  }
+}
+
 function renderServerActivity(report: ProjectReportDto, audience: ReportAudience): string {
   const sa = report.serverActivity
   const isClient = audience === 'client'
@@ -1822,13 +1846,13 @@ function renderServerActivity(report: ProjectReportDto, audience: ReportAudience
   if (!sa) {
     if (isClient) return ''
     return section(
-      { id: 'server-activity', eyebrow: 'Section 10', title: 'AI Visibility — Server-Side' },
+      serverActivityHeading('agency', false),
       renderEmpty('Connect a server-side traffic source to surface what AI engines do directly in your server logs — distinct from GA4 click-throughs.'),
     )
   }
   if (!sa.hasData) {
     return section(
-      { id: 'server-activity', eyebrow: 'Section 10', title: 'AI Visibility — Server-Side' },
+      serverActivityHeading(audience, false),
       renderEmpty(isClient
         ? 'Your server-side traffic source is connected. Numbers will appear after the next sync.'
         : 'Source connected — collecting your first data. Numbers will appear after the next sync.'),
@@ -1836,12 +1860,9 @@ function renderServerActivity(report: ProjectReportDto, audience: ReportAudience
   }
 
   const formatDelta = (d: { current: number; prior: number; deltaPct: number | null }, suffix: string) => {
-    if (d.deltaPct === null) {
-      return d.prior === 0 ? `<span class="meta">no prior baseline</span>` : ''
-    }
-    const tone = d.deltaPct > 0 ? 'tone-positive' : d.deltaPct < 0 ? 'tone-negative' : 'tone-neutral'
-    const arrow = d.deltaPct > 0 ? '↑' : d.deltaPct < 0 ? '↓' : '→'
-    return `<span class="${tone}">${arrow} ${Math.abs(d.deltaPct)}% vs prior 7d (${formatNumber(d.prior)} ${suffix})</span>`
+    const copy = formatDeltaCopy(d, suffix)
+    if (!copy) return ''
+    return `<span class="tone-${deltaTone(d.deltaPct)}">${escapeHtml(copy)}</span>`
   }
 
   // ── Client view (lightweight; mirrors the SPA's ServerActivityClientView) ──
@@ -1857,12 +1878,7 @@ function renderServerActivity(report: ProjectReportDto, audience: ReportAudience
     </tr>`).join('')
 
     return section(
-      {
-        id: 'server-activity',
-        eyebrow: 'AI engine attention',
-        title: 'AI Visibility — Server-Side',
-        intro: 'What AI engines actually do in your server logs over the last 7 days — the other half of citations.',
-      },
+      serverActivityHeading('client', true),
       `<div class="metric-grid">
         <div class="metric">
           <div class="label">AI bots visited your site</div>
@@ -1890,14 +1906,14 @@ function renderServerActivity(report: ProjectReportDto, audience: ReportAudience
     const deltaText = o.deltaPct === null
       ? '—'
       : `${o.deltaPct > 0 ? '+' : ''}${o.deltaPct}%`
-    const deltaTone = o.deltaPct === null ? '' : (o.deltaPct > 0 ? 'tone-positive' : o.deltaPct < 0 ? 'tone-negative' : 'tone-neutral')
+    const toneClass = o.deltaPct === null ? '' : `tone-${deltaTone(o.deltaPct)}`
     return `
     <tr>
       <td>${escapeHtml(o.operator)}</td>
       <td class="numeric">${formatNumber(o.verifiedHits)}</td>
       <td class="numeric meta">${formatNumber(o.unverifiedHits)}</td>
       <td class="numeric">${formatNumber(o.referralArrivals)}</td>
-      <td class="numeric ${deltaTone}">${deltaText}</td>
+      <td class="numeric ${toneClass}">${deltaText}</td>
     </tr>`
   }).join('')
 
@@ -1931,12 +1947,7 @@ function renderServerActivity(report: ProjectReportDto, audience: ReportAudience
     : ''
 
   return section(
-    {
-      id: 'server-activity',
-      eyebrow: 'Section 10',
-      title: 'AI Visibility — Server-Side',
-      intro: 'What AI engines actually do in your server logs — direct evidence, complementary to citations (which measure what they say).',
-    },
+    serverActivityHeading('agency', true),
     `<div class="metric-grid">
       <div class="metric">
         <div class="label">Verified crawler hits (7d)</div>

--- a/packages/api-routes/src/report-renderer.ts
+++ b/packages/api-routes/src/report-renderer.ts
@@ -1812,11 +1812,129 @@ function renderAiReferrals(report: ProjectReportDto): string {
   )
 }
 
+function renderServerActivity(report: ProjectReportDto): string {
+  const sa = report.serverActivity
+  if (!sa) {
+    return section(
+      { id: 'server-activity', eyebrow: 'Section 10', title: 'AI Visibility — Server-Side' },
+      renderEmpty('Connect a server-side traffic source (e.g. Cloud Run logs) to surface what AI engines do directly in your server logs — distinct from GA4 click-throughs.'),
+    )
+  }
+  if (!sa.hasData) {
+    return section(
+      { id: 'server-activity', eyebrow: 'Section 10', title: 'AI Visibility — Server-Side' },
+      renderEmpty('Source connected — collecting your first data. Numbers will appear after the next sync.'),
+    )
+  }
+
+  const formatDelta = (d: { current: number; prior: number; deltaPct: number | null }, suffix: string) => {
+    if (d.deltaPct === null) {
+      return d.prior === 0 ? `<span class="meta">no prior baseline</span>` : ''
+    }
+    const tone = d.deltaPct > 0 ? 'tone-positive' : d.deltaPct < 0 ? 'tone-negative' : 'tone-neutral'
+    const arrow = d.deltaPct > 0 ? '↑' : d.deltaPct < 0 ? '↓' : '→'
+    return `<span class="${tone}">${arrow} ${Math.abs(d.deltaPct)}% vs prior 7d (${formatNumber(d.prior)} ${suffix})</span>`
+  }
+
+  const operatorRows = sa.byOperator.map(o => {
+    const deltaText = o.deltaPct === null
+      ? '—'
+      : `${o.deltaPct > 0 ? '+' : ''}${o.deltaPct}%`
+    const deltaTone = o.deltaPct === null ? '' : (o.deltaPct > 0 ? 'tone-positive' : o.deltaPct < 0 ? 'tone-negative' : 'tone-neutral')
+    return `
+    <tr>
+      <td>${escapeHtml(o.operator)}</td>
+      <td class="numeric">${formatNumber(o.verifiedHits)}</td>
+      <td class="numeric meta">${formatNumber(o.unverifiedHits)}</td>
+      <td class="numeric">${formatNumber(o.referralArrivals)}</td>
+      <td class="numeric ${deltaTone}">${deltaText}</td>
+    </tr>`
+  }).join('')
+
+  const pathRows = sa.topCrawledPaths.map(p => `
+    <tr>
+      <td class="page-cell">${formatLandingPageHtml(p.path)}</td>
+      <td class="numeric">${formatNumber(p.verifiedHits)}</td>
+      <td class="numeric">${p.distinctOperators}</td>
+    </tr>`).join('')
+
+  const referralProductRows = sa.referralProducts.map(p => `
+    <tr>
+      <td>${escapeHtml(p.product)}</td>
+      <td class="numeric">${formatNumber(p.arrivals)}</td>
+      <td class="numeric">${p.distinctLandingPaths}</td>
+    </tr>`).join('')
+
+  const referralLandingRows = sa.topReferralLandingPaths.map(p => `
+    <tr>
+      <td class="page-cell">${formatLandingPageHtml(p.path)}</td>
+      <td class="numeric">${formatNumber(p.arrivals)}</td>
+      <td class="numeric">${p.distinctProducts}</td>
+    </tr>`).join('')
+
+  const trendChart = sa.dailyTrend.length > 0
+    ? renderLineChart(
+        sa.dailyTrend.map(d => ({ x: d.date, y: d.verifiedCrawlerHits, label: d.date.slice(5) })),
+        COLORS.series[1]!,
+        'Verified crawler hits over time (last 14 days)',
+      )
+    : ''
+
+  return section(
+    {
+      id: 'server-activity',
+      eyebrow: 'Section 10',
+      title: 'AI Visibility — Server-Side',
+      intro: 'What AI engines actually do in your server logs — direct evidence, complementary to citations (which measure what they say).',
+    },
+    `<div class="metric-grid">
+      <div class="metric">
+        <div class="label">Verified crawler hits (7d)</div>
+        <div class="value">${formatNumber(sa.verifiedCrawlerHits.current)}</div>
+        <div class="subtitle">${formatDelta(sa.verifiedCrawlerHits, 'hits')}</div>
+      </div>
+      <div class="metric">
+        <div class="label">AI-referral arrivals (7d)</div>
+        <div class="value">${formatNumber(sa.referralArrivals.current)}</div>
+        <div class="subtitle">${formatDelta(sa.referralArrivals, 'arrivals')}</div>
+      </div>
+    </div>
+    ${trendChart}
+    ${operatorRows ? `<div class="chart-card"><h3>Per AI operator</h3>
+      <p class="meta">Verified means rDNS-confirmed. Unverified bots claim the user-agent but couldn't be verified — could be the real bot or an imitator.</p>
+      <table class="report-table">
+        <thead><tr><th>Operator</th><th class="numeric">Verified hits</th><th class="numeric">Unverified</th><th class="numeric">Referral arrivals</th><th class="numeric">7d delta</th></tr></thead>
+        <tbody>${operatorRows}</tbody>
+      </table>
+    </div>` : ''}
+    ${pathRows ? `<div class="chart-card"><h3>Top crawled paths</h3>
+      <p class="meta">Pages AI bots fetched most often (verified only, last 7d).</p>
+      <table class="report-table">
+        <thead><tr><th>Path</th><th class="numeric">Verified hits</th><th class="numeric">Distinct operators</th></tr></thead>
+        <tbody>${pathRows}</tbody>
+      </table>
+    </div>` : ''}
+    ${referralProductRows ? `<div class="chart-card"><h3>Click-throughs by AI product</h3>
+      <p class="meta">Where humans landed coming from each AI product (chatgpt.com, claude.ai, …).</p>
+      <table class="report-table">
+        <thead><tr><th>Product</th><th class="numeric">Arrivals</th><th class="numeric">Distinct landing paths</th></tr></thead>
+        <tbody>${referralProductRows}</tbody>
+      </table>
+    </div>` : ''}
+    ${referralLandingRows ? `<div class="chart-card"><h3>Top AI-referral landing paths</h3>
+      <table class="report-table">
+        <thead><tr><th>Path</th><th class="numeric">Arrivals</th><th class="numeric">Distinct products</th></tr></thead>
+        <tbody>${referralLandingRows}</tbody>
+      </table>
+    </div>` : ''}`,
+  )
+}
+
 function renderIndexingHealth(report: ProjectReportDto): string {
   const ih = report.indexingHealth
   if (!ih) {
     return section(
-      { id: 'indexing-health', eyebrow: 'Section 10', title: 'Indexing Health' },
+      { id: 'indexing-health', eyebrow: 'Section 11', title: 'Indexing Health' },
       renderEmpty('Connect Google Search Console or Bing Webmaster Tools and run a sitemap inspection.'),
     )
   }
@@ -1843,7 +1961,7 @@ function renderIndexingHealth(report: ProjectReportDto): string {
   const legend = segments.map(s => `<span><span class="legend-swatch" style="background:${s.color}"></span>${escapeHtml(s.label)}: ${s.count}</span>`).join('')
 
   return section(
-    { id: 'indexing-health', eyebrow: 'Section 10', title: 'Indexing Health', intro: `Pages absent from ${ih.provider === 'google' ? 'Google' : 'Bing'} are harder for AI engines to retrieve.` },
+    { id: 'indexing-health', eyebrow: 'Section 11', title: 'Indexing Health', intro: `Pages absent from ${ih.provider === 'google' ? 'Google' : 'Bing'} are harder for AI engines to retrieve.` },
     `<div class="metric-grid">
       <div class="metric"><div class="label">Indexed</div><div class="value tone-positive">${formatNumber(ih.indexed)}</div></div>
       <div class="metric"><div class="label">Total inspected</div><div class="value">${formatNumber(ih.total)}</div></div>
@@ -1861,14 +1979,14 @@ function renderCitationsTrend(report: ProjectReportDto): string {
   const trend = report.citationsTrend
   if (trend.length === 0) {
     return section(
-      { id: 'citations-trend', eyebrow: 'Section 11', title: 'Citations Over Time' },
+      { id: 'citations-trend', eyebrow: 'Section 12', title: 'Citations Over Time' },
       renderEmpty('Run multiple checks to see a trend.'),
     )
   }
 
   if (isTrendBaseline(trend)) {
     return section(
-      { id: 'citations-trend', eyebrow: 'Section 11', title: 'Citations Over Time' },
+      { id: 'citations-trend', eyebrow: 'Section 12', title: 'Citations Over Time' },
       renderEmpty(`Building baseline (${trend.length} of ${MIN_TREND_POINTS} checks completed). Trend will appear once more checks are recorded.`),
     )
   }
@@ -1888,7 +2006,7 @@ function renderCitationsTrend(report: ProjectReportDto): string {
     </tr>`).join('')
 
   return section(
-    { id: 'citations-trend', eyebrow: 'Section 11', title: 'Citations Over Time', intro: 'Citation coverage across recent checks.' },
+    { id: 'citations-trend', eyebrow: 'Section 12', title: 'Citations Over Time', intro: 'Citation coverage across recent checks.' },
     `${chart}
     <div class="chart-card"><h3>Check-by-check breakdown</h3>
       <table class="report-table">
@@ -1903,7 +2021,7 @@ function renderInsights(report: ProjectReportDto): string {
   const list = report.insights
   if (list.length === 0) {
     return section(
-      { id: 'insights', eyebrow: 'Section 12', title: 'Insights & Alerts' },
+      { id: 'insights', eyebrow: 'Section 13', title: 'Insights & Alerts' },
       renderEmpty('No insights yet — run a check to generate alerts.'),
     )
   }
@@ -1928,7 +2046,7 @@ function renderInsights(report: ProjectReportDto): string {
     }).join('')
 
   return section(
-    { id: 'insights', eyebrow: 'Section 12', title: 'Insights & Alerts', intro: 'Regressions, gains, and recurring alerts ordered by severity.' },
+    { id: 'insights', eyebrow: 'Section 13', title: 'Insights & Alerts', intro: 'Regressions, gains, and recurring alerts ordered by severity.' },
     `<table class="report-table insights-table">
       <thead><tr>
         <th class="col-severity">Severity</th>
@@ -1979,7 +2097,7 @@ function renderOpportunities(report: ProjectReportDto): string {
   return section(
     {
       id: 'content-opportunities',
-      eyebrow: 'Section 13',
+      eyebrow: 'Section 14',
       title: 'Content Opportunities',
       intro: 'Queries where content work has the clearest path to more AI citations. Opportunity score is 0–100, higher = stronger.',
     },
@@ -2006,7 +2124,7 @@ function renderContentGaps(report: ProjectReportDto): string {
   return section(
     {
       id: 'content-gaps',
-      eyebrow: 'Section 14',
+      eyebrow: 'Section 15',
       title: 'Content Gaps',
       intro: 'Tracked queries where competitors are cited and the client is missing.',
     },
@@ -2024,7 +2142,7 @@ function renderRecommendedNextSteps(report: ProjectReportDto): string {
   const steps = report.recommendedNextSteps
   if (steps.length === 0) {
     return section(
-      { id: 'recommended-next-steps', eyebrow: 'Section 15', title: 'Recommended Next Steps', intro: 'Action items bucketed by timing.' },
+      { id: 'recommended-next-steps', eyebrow: 'Section 16', title: 'Recommended Next Steps', intro: 'Action items bucketed by timing.' },
       renderEmpty('No outstanding actions.'),
     )
   }
@@ -2037,7 +2155,7 @@ function renderRecommendedNextSteps(report: ProjectReportDto): string {
     </div>`).join('')
 
   return section(
-    { id: 'recommended-next-steps', eyebrow: 'Section 15', title: 'Recommended Next Steps', intro: 'Action items bucketed by timing.' },
+    { id: 'recommended-next-steps', eyebrow: 'Section 16', title: 'Recommended Next Steps', intro: 'Action items bucketed by timing.' },
     `<div class="steps">${items}</div>`,
   )
 }
@@ -2345,6 +2463,7 @@ export function renderReportHtml(report: ProjectReportDto, opts: RenderReportHtm
         renderGa(report),
         renderSocial(report),
         renderAiReferrals(report),
+        renderServerActivity(report),
         renderIndexingHealth(report),
         renderCitationsTrend(report),
         renderInsights(report),

--- a/packages/api-routes/src/report.ts
+++ b/packages/api-routes/src/report.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, inArray, lte, or, sql } from 'drizzle-orm'
+import { and, desc, eq, gte, inArray, lte, ne, or, sql } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import {
   aiReferralEventsHourly,
@@ -23,6 +23,7 @@ import {
   CitationStates,
   RunKinds,
   RunStatuses,
+  TrafficSourceStatuses,
   getProviderLocationHandling,
   validationError,
   type CitationsTrendPoint,
@@ -526,15 +527,15 @@ function buildAiReferrals(db: DatabaseClient, projectId: string): ProjectReportD
  */
 function buildServerActivity(db: DatabaseClient, projectId: string): ProjectReportDto['serverActivity'] {
   // 1. Bail if no traffic source is connected at all.
+  // Treat archived sources as "not connected" — we don't want to surface
+  // historical data for a host migration the user has moved past.
   const sourceRows = db
     .select({ id: trafficSources.id })
     .from(trafficSources)
     .where(
       and(
         eq(trafficSources.projectId, projectId),
-        // Treat archived sources as "not connected" — we don't want to surface
-        // historical data for a host migration the user has moved past.
-        sql`${trafficSources.status} != 'archived'`,
+        ne(trafficSources.status, TrafficSourceStatuses.archived),
       ),
     )
     .all()

--- a/packages/api-routes/src/report.ts
+++ b/packages/api-routes/src/report.ts
@@ -1,8 +1,10 @@
-import { and, desc, eq, inArray, or } from 'drizzle-orm'
+import { and, desc, eq, gte, inArray, lte, or, sql } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import {
+  aiReferralEventsHourly,
   bingCoverageSnapshots,
   competitors,
+  crawlerEventsHourly,
   gaAiReferrals,
   gaSocialReferrals,
   gaTrafficSnapshots,
@@ -15,6 +17,7 @@ import {
   parseJsonColumn,
   querySnapshots,
   runs,
+  trafficSources,
 } from '@ainyc/canonry-db'
 import {
   CitationStates,
@@ -75,6 +78,11 @@ const INSIGHT_LOOKBACK_RUNS = 5
 // usable when a sync hasn't run for a few days; the two sections may end
 // on slightly different dates but always span the same number of days.
 const REPORT_WINDOW_DAYS = 30
+
+// Server-side AI visibility section windows (last-7d headline + 7d prior for delta + 14d trend).
+const SERVER_ACTIVITY_HEADLINE_DAYS = 7
+const SERVER_ACTIVITY_TREND_DAYS = 14
+const SERVER_ACTIVITY_TOP_PATHS_LIMIT = 10
 
 // Returns the inclusive start-date string (YYYY-MM-DD) for a window of
 // `windowDays` ending on `endDate`. `endDate` must already be YYYY-MM-DD.
@@ -499,6 +507,324 @@ function buildAiReferrals(db: DatabaseClient, projectId: string): ProjectReportD
     .slice(0, TOP_AI_REFERRAL_PAGES_LIMIT)
 
   return { totalSessions: total, totalUsers, bySource, trend, topLandingPages }
+}
+
+/**
+ * Server-side AI Visibility section.
+ *
+ * Reads from the traffic-sync rollup tables (`crawler_events_hourly`,
+ * `ai_referral_events_hourly`) and packages them into a renderer-friendly
+ * shape. Returns null when the project has no non-archived traffic source
+ * connected at all (different signal from "connected but no data yet" —
+ * the latter returns a populated section with `hasData=false` and zeroed
+ * counters so the UI can show a "we're collecting" empty state).
+ *
+ * Headline numbers use VERIFIED crawler hits only — claimed-unverified
+ * bots are common (anyone can put GPTBot in their UA) and would inflate
+ * trust. Unverified counts are surfaced separately in the per-operator
+ * breakdown for the agency audience.
+ */
+function buildServerActivity(db: DatabaseClient, projectId: string): ProjectReportDto['serverActivity'] {
+  // 1. Bail if no traffic source is connected at all.
+  const sourceRows = db
+    .select({ id: trafficSources.id })
+    .from(trafficSources)
+    .where(
+      and(
+        eq(trafficSources.projectId, projectId),
+        // Treat archived sources as "not connected" — we don't want to surface
+        // historical data for a host migration the user has moved past.
+        sql`${trafficSources.status} != 'archived'`,
+      ),
+    )
+    .all()
+  if (sourceRows.length === 0) return null
+
+  const now = new Date()
+  const headlineEnd = now.toISOString()
+  const headlineStartMs = now.getTime() - SERVER_ACTIVITY_HEADLINE_DAYS * 24 * 60 * 60_000
+  const priorStartMs = headlineStartMs - SERVER_ACTIVITY_HEADLINE_DAYS * 24 * 60 * 60_000
+  const trendStartMs = now.getTime() - SERVER_ACTIVITY_TREND_DAYS * 24 * 60 * 60_000
+
+  const headlineStart = new Date(headlineStartMs).toISOString()
+  const priorStart = new Date(priorStartMs).toISOString()
+  const trendStart = new Date(trendStartMs).toISOString()
+
+  // 2. Headline + prior totals (verified crawlers + referral arrivals).
+  const sumVerifiedCrawlers = (windowStartIso: string, windowEndIso: string) =>
+    Number(
+      db
+        .select({ total: sql<number>`COALESCE(SUM(${crawlerEventsHourly.hits}), 0)` })
+        .from(crawlerEventsHourly)
+        .where(
+          and(
+            eq(crawlerEventsHourly.projectId, projectId),
+            eq(crawlerEventsHourly.verificationStatus, 'verified'),
+            gte(crawlerEventsHourly.tsHour, windowStartIso),
+            lte(crawlerEventsHourly.tsHour, windowEndIso),
+          ),
+        )
+        .get()?.total ?? 0,
+    )
+
+  const sumReferrals = (windowStartIso: string, windowEndIso: string) =>
+    Number(
+      db
+        .select({ total: sql<number>`COALESCE(SUM(${aiReferralEventsHourly.sessionsOrHits}), 0)` })
+        .from(aiReferralEventsHourly)
+        .where(
+          and(
+            eq(aiReferralEventsHourly.projectId, projectId),
+            gte(aiReferralEventsHourly.tsHour, windowStartIso),
+            lte(aiReferralEventsHourly.tsHour, windowEndIso),
+          ),
+        )
+        .get()?.total ?? 0,
+    )
+
+  const verifiedCurrent = sumVerifiedCrawlers(headlineStart, headlineEnd)
+  const verifiedPrior = sumVerifiedCrawlers(priorStart, headlineStart)
+  const referralCurrent = sumReferrals(headlineStart, headlineEnd)
+  const referralPrior = sumReferrals(priorStart, headlineStart)
+
+  // 3. Per-operator: verified hits, unverified hits, referral arrivals over headline window.
+  const crawlerByOperatorRows = db
+    .select({
+      operator: crawlerEventsHourly.operator,
+      verificationStatus: crawlerEventsHourly.verificationStatus,
+      hits: sql<number>`COALESCE(SUM(${crawlerEventsHourly.hits}), 0)`,
+    })
+    .from(crawlerEventsHourly)
+    .where(
+      and(
+        eq(crawlerEventsHourly.projectId, projectId),
+        gte(crawlerEventsHourly.tsHour, headlineStart),
+        lte(crawlerEventsHourly.tsHour, headlineEnd),
+      ),
+    )
+    .groupBy(crawlerEventsHourly.operator, crawlerEventsHourly.verificationStatus)
+    .all()
+
+  const crawlerByOperatorPriorRows = db
+    .select({
+      operator: crawlerEventsHourly.operator,
+      hits: sql<number>`COALESCE(SUM(${crawlerEventsHourly.hits}), 0)`,
+    })
+    .from(crawlerEventsHourly)
+    .where(
+      and(
+        eq(crawlerEventsHourly.projectId, projectId),
+        eq(crawlerEventsHourly.verificationStatus, 'verified'),
+        gte(crawlerEventsHourly.tsHour, priorStart),
+        lte(crawlerEventsHourly.tsHour, headlineStart),
+      ),
+    )
+    .groupBy(crawlerEventsHourly.operator)
+    .all()
+
+  const referralByOperatorRows = db
+    .select({
+      operator: aiReferralEventsHourly.operator,
+      hits: sql<number>`COALESCE(SUM(${aiReferralEventsHourly.sessionsOrHits}), 0)`,
+    })
+    .from(aiReferralEventsHourly)
+    .where(
+      and(
+        eq(aiReferralEventsHourly.projectId, projectId),
+        gte(aiReferralEventsHourly.tsHour, headlineStart),
+        lte(aiReferralEventsHourly.tsHour, headlineEnd),
+      ),
+    )
+    .groupBy(aiReferralEventsHourly.operator)
+    .all()
+
+  const operatorAgg = new Map<string, {
+    verified: number; unverified: number; referrals: number; prior: number
+  }>()
+  const ensureOp = (op: string) => {
+    let entry = operatorAgg.get(op)
+    if (!entry) {
+      entry = { verified: 0, unverified: 0, referrals: 0, prior: 0 }
+      operatorAgg.set(op, entry)
+    }
+    return entry
+  }
+  for (const r of crawlerByOperatorRows) {
+    const entry = ensureOp(r.operator)
+    if (r.verificationStatus === 'verified') entry.verified += Number(r.hits)
+    else entry.unverified += Number(r.hits)
+  }
+  for (const r of crawlerByOperatorPriorRows) {
+    ensureOp(r.operator).prior += Number(r.hits)
+  }
+  for (const r of referralByOperatorRows) {
+    ensureOp(r.operator).referrals += Number(r.hits)
+  }
+
+  const byOperator = [...operatorAgg.entries()]
+    .map(([operator, v]) => ({
+      operator,
+      verifiedHits: v.verified,
+      unverifiedHits: v.unverified,
+      referralArrivals: v.referrals,
+      deltaPct: deltaPercent(v.verified, v.prior),
+    }))
+    // Sort by total signal: verified hits first, then referrals as tiebreaker.
+    .sort((a, b) =>
+      b.verifiedHits - a.verifiedHits || b.referralArrivals - a.referralArrivals,
+    )
+
+  // 4. Top crawled paths (verified only).
+  const topPathsRows = db
+    .select({
+      path: crawlerEventsHourly.pathNormalized,
+      hits: sql<number>`COALESCE(SUM(${crawlerEventsHourly.hits}), 0)`,
+      operators: sql<number>`COUNT(DISTINCT ${crawlerEventsHourly.operator})`,
+    })
+    .from(crawlerEventsHourly)
+    .where(
+      and(
+        eq(crawlerEventsHourly.projectId, projectId),
+        eq(crawlerEventsHourly.verificationStatus, 'verified'),
+        gte(crawlerEventsHourly.tsHour, headlineStart),
+        lte(crawlerEventsHourly.tsHour, headlineEnd),
+      ),
+    )
+    .groupBy(crawlerEventsHourly.pathNormalized)
+    .orderBy(desc(sql`SUM(${crawlerEventsHourly.hits})`))
+    .limit(SERVER_ACTIVITY_TOP_PATHS_LIMIT)
+    .all()
+  const topCrawledPaths = topPathsRows.map(r => ({
+    path: r.path,
+    verifiedHits: Number(r.hits),
+    distinctOperators: Number(r.operators),
+  }))
+
+  // 5. AI products that sent referrals + their distinct landing pages.
+  const referralProductsRows = db
+    .select({
+      product: aiReferralEventsHourly.product,
+      arrivals: sql<number>`COALESCE(SUM(${aiReferralEventsHourly.sessionsOrHits}), 0)`,
+      landingPaths: sql<number>`COUNT(DISTINCT ${aiReferralEventsHourly.landingPathNormalized})`,
+    })
+    .from(aiReferralEventsHourly)
+    .where(
+      and(
+        eq(aiReferralEventsHourly.projectId, projectId),
+        gte(aiReferralEventsHourly.tsHour, headlineStart),
+        lte(aiReferralEventsHourly.tsHour, headlineEnd),
+      ),
+    )
+    .groupBy(aiReferralEventsHourly.product)
+    .orderBy(desc(sql`SUM(${aiReferralEventsHourly.sessionsOrHits})`))
+    .all()
+  const referralProducts = referralProductsRows.map(r => ({
+    product: r.product,
+    arrivals: Number(r.arrivals),
+    distinctLandingPaths: Number(r.landingPaths),
+  }))
+
+  // 6. Top referral landing paths (where humans actually land coming from AI products).
+  const topReferralRows = db
+    .select({
+      path: aiReferralEventsHourly.landingPathNormalized,
+      arrivals: sql<number>`COALESCE(SUM(${aiReferralEventsHourly.sessionsOrHits}), 0)`,
+      products: sql<number>`COUNT(DISTINCT ${aiReferralEventsHourly.product})`,
+    })
+    .from(aiReferralEventsHourly)
+    .where(
+      and(
+        eq(aiReferralEventsHourly.projectId, projectId),
+        gte(aiReferralEventsHourly.tsHour, headlineStart),
+        lte(aiReferralEventsHourly.tsHour, headlineEnd),
+      ),
+    )
+    .groupBy(aiReferralEventsHourly.landingPathNormalized)
+    .orderBy(desc(sql`SUM(${aiReferralEventsHourly.sessionsOrHits})`))
+    .limit(SERVER_ACTIVITY_TOP_PATHS_LIMIT)
+    .all()
+  const topReferralLandingPaths = topReferralRows.map(r => ({
+    path: r.path,
+    arrivals: Number(r.arrivals),
+    distinctProducts: Number(r.products),
+  }))
+
+  // 7. Daily trend (last 14d) — bucket tsHour to YYYY-MM-DD via SQLite SUBSTR.
+  const crawlerTrendRows = db
+    .select({
+      date: sql<string>`SUBSTR(${crawlerEventsHourly.tsHour}, 1, 10)`,
+      hits: sql<number>`COALESCE(SUM(${crawlerEventsHourly.hits}), 0)`,
+    })
+    .from(crawlerEventsHourly)
+    .where(
+      and(
+        eq(crawlerEventsHourly.projectId, projectId),
+        eq(crawlerEventsHourly.verificationStatus, 'verified'),
+        gte(crawlerEventsHourly.tsHour, trendStart),
+        lte(crawlerEventsHourly.tsHour, headlineEnd),
+      ),
+    )
+    .groupBy(sql`SUBSTR(${crawlerEventsHourly.tsHour}, 1, 10)`)
+    .all()
+  const referralTrendRows = db
+    .select({
+      date: sql<string>`SUBSTR(${aiReferralEventsHourly.tsHour}, 1, 10)`,
+      hits: sql<number>`COALESCE(SUM(${aiReferralEventsHourly.sessionsOrHits}), 0)`,
+    })
+    .from(aiReferralEventsHourly)
+    .where(
+      and(
+        eq(aiReferralEventsHourly.projectId, projectId),
+        gte(aiReferralEventsHourly.tsHour, trendStart),
+        lte(aiReferralEventsHourly.tsHour, headlineEnd),
+      ),
+    )
+    .groupBy(sql`SUBSTR(${aiReferralEventsHourly.tsHour}, 1, 10)`)
+    .all()
+
+  const dailyTrendMap = new Map<string, { verifiedCrawlerHits: number; referralArrivals: number }>()
+  for (const r of crawlerTrendRows) {
+    const e = dailyTrendMap.get(r.date) ?? { verifiedCrawlerHits: 0, referralArrivals: 0 }
+    e.verifiedCrawlerHits += Number(r.hits)
+    dailyTrendMap.set(r.date, e)
+  }
+  for (const r of referralTrendRows) {
+    const e = dailyTrendMap.get(r.date) ?? { verifiedCrawlerHits: 0, referralArrivals: 0 }
+    e.referralArrivals += Number(r.hits)
+    dailyTrendMap.set(r.date, e)
+  }
+  const dailyTrend = [...dailyTrendMap.entries()]
+    .map(([date, v]) => ({ date, ...v }))
+    .sort((a, b) => a.date.localeCompare(b.date))
+
+  return {
+    windowStart: headlineStart,
+    windowEnd: headlineEnd,
+    hasData: verifiedCurrent + referralCurrent + verifiedPrior + referralPrior > 0
+      || byOperator.length > 0
+      || topCrawledPaths.length > 0
+      || referralProducts.length > 0,
+    verifiedCrawlerHits: {
+      current: verifiedCurrent,
+      prior: verifiedPrior,
+      deltaPct: deltaPercent(verifiedCurrent, verifiedPrior),
+    },
+    referralArrivals: {
+      current: referralCurrent,
+      prior: referralPrior,
+      deltaPct: deltaPercent(referralCurrent, referralPrior),
+    },
+    byOperator,
+    topCrawledPaths,
+    referralProducts,
+    dailyTrend,
+    topReferralLandingPaths,
+  }
+}
+
+function deltaPercent(current: number, prior: number): number | null {
+  if (prior <= 0) return null
+  return Math.round(((current - prior) / prior) * 100)
 }
 
 function buildIndexingHealth(db: DatabaseClient, projectId: string): ProjectReportDto['indexingHealth'] {
@@ -1396,6 +1722,7 @@ function buildProjectReport(db: DatabaseClient, projectName: string): ProjectRep
   const gaSection = buildGaSection(db, project.id)
   const socialSection = buildSocialReferrals(db, project.id)
   const aiReferralsSection = buildAiReferrals(db, project.id)
+  const serverActivitySection = buildServerActivity(db, project.id)
   const indexingHealthSection = buildIndexingHealth(db, project.id)
   const citationsTrend = buildCitationsTrend(db, project.id, queryLookup, latestRunLocation)
   const insightList = buildInsightList(db, project.id, latestRunLocation)
@@ -1584,6 +1911,7 @@ function buildProjectReport(db: DatabaseClient, projectName: string): ProjectRep
     ga: gaSection,
     socialReferrals: socialSection,
     aiReferrals: aiReferralsSection,
+    serverActivity: serverActivitySection,
     indexingHealth: indexingHealthSection,
     citationsTrend,
     whatsChanged,

--- a/packages/api-routes/src/report.ts
+++ b/packages/api-routes/src/report.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, inArray, lte, ne, or, sql } from 'drizzle-orm'
+import { and, desc, eq, gte, inArray, lt, lte, ne, or, sql } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import {
   aiReferralEventsHourly,
@@ -24,6 +24,8 @@ import {
   RunKinds,
   RunStatuses,
   TrafficSourceStatuses,
+  VerificationStatuses,
+  deltaPercent,
   getProviderLocationHandling,
   validationError,
   type CitationsTrendPoint,
@@ -552,7 +554,11 @@ function buildServerActivity(db: DatabaseClient, projectId: string): ProjectRepo
   const trendStart = new Date(trendStartMs).toISOString()
 
   // 2. Headline + prior totals (verified crawlers + referral arrivals).
-  const sumVerifiedCrawlers = (windowStartIso: string, windowEndIso: string) =>
+  // The headline upper bound uses `lte` (inclusive) so the current hour bucket
+  // counts. The prior upper bound uses `lt` (strict) against `headlineStart` so a
+  // row with `tsHour` exactly equal to the boundary lands in the headline window
+  // only — never both. Latent double-count if `now` aligned to an hour exactly.
+  const sumVerifiedCrawlers = (windowStartIso: string, windowEndIso: string, exclusiveEnd = false) =>
     Number(
       db
         .select({ total: sql<number>`COALESCE(SUM(${crawlerEventsHourly.hits}), 0)` })
@@ -560,15 +566,17 @@ function buildServerActivity(db: DatabaseClient, projectId: string): ProjectRepo
         .where(
           and(
             eq(crawlerEventsHourly.projectId, projectId),
-            eq(crawlerEventsHourly.verificationStatus, 'verified'),
+            eq(crawlerEventsHourly.verificationStatus, VerificationStatuses.verified),
             gte(crawlerEventsHourly.tsHour, windowStartIso),
-            lte(crawlerEventsHourly.tsHour, windowEndIso),
+            exclusiveEnd
+              ? lt(crawlerEventsHourly.tsHour, windowEndIso)
+              : lte(crawlerEventsHourly.tsHour, windowEndIso),
           ),
         )
         .get()?.total ?? 0,
     )
 
-  const sumReferrals = (windowStartIso: string, windowEndIso: string) =>
+  const sumReferrals = (windowStartIso: string, windowEndIso: string, exclusiveEnd = false) =>
     Number(
       db
         .select({ total: sql<number>`COALESCE(SUM(${aiReferralEventsHourly.sessionsOrHits}), 0)` })
@@ -577,16 +585,18 @@ function buildServerActivity(db: DatabaseClient, projectId: string): ProjectRepo
           and(
             eq(aiReferralEventsHourly.projectId, projectId),
             gte(aiReferralEventsHourly.tsHour, windowStartIso),
-            lte(aiReferralEventsHourly.tsHour, windowEndIso),
+            exclusiveEnd
+              ? lt(aiReferralEventsHourly.tsHour, windowEndIso)
+              : lte(aiReferralEventsHourly.tsHour, windowEndIso),
           ),
         )
         .get()?.total ?? 0,
     )
 
   const verifiedCurrent = sumVerifiedCrawlers(headlineStart, headlineEnd)
-  const verifiedPrior = sumVerifiedCrawlers(priorStart, headlineStart)
+  const verifiedPrior = sumVerifiedCrawlers(priorStart, headlineStart, true)
   const referralCurrent = sumReferrals(headlineStart, headlineEnd)
-  const referralPrior = sumReferrals(priorStart, headlineStart)
+  const referralPrior = sumReferrals(priorStart, headlineStart, true)
 
   // 3. Per-operator: verified hits, unverified hits, referral arrivals over headline window.
   const crawlerByOperatorRows = db
@@ -615,9 +625,9 @@ function buildServerActivity(db: DatabaseClient, projectId: string): ProjectRepo
     .where(
       and(
         eq(crawlerEventsHourly.projectId, projectId),
-        eq(crawlerEventsHourly.verificationStatus, 'verified'),
+        eq(crawlerEventsHourly.verificationStatus, VerificationStatuses.verified),
         gte(crawlerEventsHourly.tsHour, priorStart),
-        lte(crawlerEventsHourly.tsHour, headlineStart),
+        lt(crawlerEventsHourly.tsHour, headlineStart),
       ),
     )
     .groupBy(crawlerEventsHourly.operator)
@@ -652,7 +662,7 @@ function buildServerActivity(db: DatabaseClient, projectId: string): ProjectRepo
   }
   for (const r of crawlerByOperatorRows) {
     const entry = ensureOp(r.operator)
-    if (r.verificationStatus === 'verified') entry.verified += Number(r.hits)
+    if (r.verificationStatus === VerificationStatuses.verified) entry.verified += Number(r.hits)
     else entry.unverified += Number(r.hits)
   }
   for (const r of crawlerByOperatorPriorRows) {
@@ -686,7 +696,7 @@ function buildServerActivity(db: DatabaseClient, projectId: string): ProjectRepo
     .where(
       and(
         eq(crawlerEventsHourly.projectId, projectId),
-        eq(crawlerEventsHourly.verificationStatus, 'verified'),
+        eq(crawlerEventsHourly.verificationStatus, VerificationStatuses.verified),
         gte(crawlerEventsHourly.tsHour, headlineStart),
         lte(crawlerEventsHourly.tsHour, headlineEnd),
       ),
@@ -760,7 +770,7 @@ function buildServerActivity(db: DatabaseClient, projectId: string): ProjectRepo
     .where(
       and(
         eq(crawlerEventsHourly.projectId, projectId),
-        eq(crawlerEventsHourly.verificationStatus, 'verified'),
+        eq(crawlerEventsHourly.verificationStatus, VerificationStatuses.verified),
         gte(crawlerEventsHourly.tsHour, trendStart),
         lte(crawlerEventsHourly.tsHour, headlineEnd),
       ),
@@ -821,11 +831,6 @@ function buildServerActivity(db: DatabaseClient, projectId: string): ProjectRepo
     dailyTrend,
     topReferralLandingPaths,
   }
-}
-
-function deltaPercent(current: number, prior: number): number | null {
-  if (prior <= 0) return null
-  return Math.round(((current - prior) / prior) * 100)
 }
 
 function buildIndexingHealth(db: DatabaseClient, projectId: string): ProjectReportDto['indexingHealth'] {

--- a/packages/api-routes/src/traffic.ts
+++ b/packages/api-routes/src/traffic.ts
@@ -117,7 +117,7 @@ function rowToDto(row: typeof trafficSources.$inferSelect): TrafficSourceDto {
   }
 }
 
-async function defaultResolveAccessToken(record: CloudRunCredentialRecord): Promise<string> {
+export async function defaultResolveAccessToken(record: CloudRunCredentialRecord): Promise<string> {
   if (record.authMode === TrafficSourceAuthModes['service-account']) {
     if (!record.clientEmail || !record.privateKey) {
       throw validationError('Service-account credentials missing client_email or private_key')

--- a/packages/api-routes/test/doctor-traffic-source.test.ts
+++ b/packages/api-routes/test/doctor-traffic-source.test.ts
@@ -1,0 +1,308 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import crypto from 'node:crypto'
+import {
+  createClient,
+  migrate,
+  projects,
+  trafficSources,
+  crawlerEventsHourly,
+} from '@ainyc/canonry-db'
+import { TRAFFIC_SOURCE_CHECKS } from '../src/doctor/checks/traffic-source.js'
+import type { CheckOutput, DoctorContext, ProjectInfo, TrafficSourceProbe, TrafficSourceValidator } from '../src/doctor/types.js'
+
+const [
+  sourceConnectedCheck,
+  recentDataCheck,
+  credentialsCheck,
+  scopesCheck,
+] = TRAFFIC_SOURCE_CHECKS
+
+interface Harness {
+  db: ReturnType<typeof createClient>
+  tmpDir: string
+  project: ProjectInfo
+  close: () => void
+}
+
+function buildHarness(): Harness {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'doctor-traffic-test-'))
+  const db = createClient(path.join(tmpDir, 'test.db'))
+  migrate(db)
+  const projectId = crypto.randomUUID()
+  const now = new Date().toISOString()
+  db.insert(projects).values({
+    id: projectId,
+    name: 'test-project',
+    displayName: 'Test',
+    canonicalDomain: 'example.com',
+    country: 'US',
+    language: 'en',
+    queries: '[]',
+    competitors: '[]',
+    providers: '[]',
+    createdAt: now,
+    updatedAt: now,
+  } as typeof projects.$inferInsert).run()
+  return {
+    db,
+    tmpDir,
+    project: { id: projectId, name: 'test-project', canonicalDomain: 'example.com', displayName: 'Test' },
+    close: () => fs.rmSync(tmpDir, { recursive: true, force: true }),
+  }
+}
+
+function isoMinusDays(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60_000).toISOString()
+}
+
+function insertTrafficSource(
+  h: Harness,
+  args: {
+    sourceType?: string
+    status?: string
+    displayName?: string
+    lastSyncedAt?: string | null
+    lastError?: string | null
+  } = {},
+): string {
+  const id = crypto.randomUUID()
+  const now = new Date().toISOString()
+  h.db.insert(trafficSources).values({
+    id,
+    projectId: h.project.id,
+    sourceType: args.sourceType ?? 'cloud-run',
+    displayName: args.displayName ?? 'Source',
+    status: args.status ?? 'connected',
+    lastSyncedAt: args.lastSyncedAt ?? null,
+    lastCursor: null,
+    lastError: args.lastError ?? null,
+    lastEventIds: null,
+    archivedAt: args.status === 'archived' ? now : null,
+    configJson: '{}',
+    createdAt: now,
+    updatedAt: now,
+  }).run()
+  return id
+}
+
+function insertCrawlerHit(h: Harness, sourceId: string, opts: { tsHour?: string; hits?: number } = {}) {
+  h.db.insert(crawlerEventsHourly).values({
+    projectId: h.project.id,
+    sourceId,
+    tsHour: opts.tsHour ?? isoMinusDays(1),
+    botId: 'gptbot',
+    operator: 'OpenAI',
+    verificationStatus: 'verified',
+    pathNormalized: '/blog',
+    status: 200,
+    hits: opts.hits ?? 1,
+    sampledUserAgent: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  }).run()
+}
+
+function ctxFor(h: Harness, validators?: Record<string, TrafficSourceValidator>): DoctorContext {
+  return {
+    db: h.db,
+    project: h.project,
+    trafficSourceValidators: validators,
+  }
+}
+
+let h: Harness
+
+beforeEach(() => { h = buildHarness() })
+afterEach(() => { h.close() })
+
+describe('traffic.source.connected', () => {
+  it('skips when no traffic source connected', async () => {
+    const r = await sourceConnectedCheck.run(ctxFor(h))
+    expect(r.status).toBe('skipped')
+    expect(r.code).toBe('traffic.source.none')
+  })
+
+  it('returns ok when at least one source is connected', async () => {
+    insertTrafficSource(h)
+    const r = await sourceConnectedCheck.run(ctxFor(h))
+    expect(r.status).toBe('ok')
+    expect(r.code).toBe('traffic.source.connected')
+    expect(r.details?.sourceCount).toBe(1)
+  })
+
+  it('warns when one of several sources is errored', async () => {
+    insertTrafficSource(h, { displayName: 'A' })
+    insertTrafficSource(h, { displayName: 'B', status: 'error', lastError: 'auth bad' })
+    const r = await sourceConnectedCheck.run(ctxFor(h))
+    expect(r.status).toBe('warn')
+    expect(r.code).toBe('traffic.source.partially-errored')
+  })
+
+  it('fails when all sources are errored', async () => {
+    insertTrafficSource(h, { status: 'error', lastError: 'auth bad' })
+    const r = await sourceConnectedCheck.run(ctxFor(h))
+    expect(r.status).toBe('fail')
+    expect(r.code).toBe('traffic.source.all-errored')
+    expect(r.remediation).toContain('auth bad')
+  })
+
+  it('treats archived-only sources as no source', async () => {
+    insertTrafficSource(h, { status: 'archived' })
+    const r = await sourceConnectedCheck.run(ctxFor(h))
+    expect(r.status).toBe('skipped')
+    expect(r.code).toBe('traffic.source.none')
+  })
+
+  it('skips with helpful message when project context missing', async () => {
+    const ctx: DoctorContext = { db: h.db, project: null }
+    const r = await sourceConnectedCheck.run(ctx)
+    expect(r.status).toBe('skipped')
+    expect(r.code).toBe('traffic.no-project')
+  })
+})
+
+describe('traffic.source.recent-data', () => {
+  it('returns ok when crawler hits exist in the last 7 days', async () => {
+    const sourceId = insertTrafficSource(h)
+    insertCrawlerHit(h, sourceId, { tsHour: isoMinusDays(2) })
+    const r = await recentDataCheck.run(ctxFor(h))
+    expect(r.status).toBe('ok')
+    expect(r.code).toBe('traffic.recent-data.fresh')
+  })
+
+  it('warns when older data exists but recent window is empty', async () => {
+    const sourceId = insertTrafficSource(h, { lastSyncedAt: isoMinusDays(15) })
+    insertCrawlerHit(h, sourceId, { tsHour: isoMinusDays(15) })
+    const r = await recentDataCheck.run(ctxFor(h))
+    expect(r.status).toBe('warn')
+    expect(r.code).toBe('traffic.recent-data.stale')
+  })
+
+  it('fails when source connected but never produced any data', async () => {
+    insertTrafficSource(h)
+    const r = await recentDataCheck.run(ctxFor(h))
+    expect(r.status).toBe('fail')
+    expect(r.code).toBe('traffic.recent-data.empty')
+  })
+})
+
+describe('traffic.source.credentials', () => {
+  it('skips when no source connected', async () => {
+    const r = await credentialsCheck.run(ctxFor(h))
+    expect(r.status).toBe('skipped')
+    expect(r.code).toBe('traffic.credentials.no-source')
+  })
+
+  it('marks all-skipped when source has no validator registered', async () => {
+    insertTrafficSource(h, { sourceType: 'unknown-future-adapter' })
+    const r = await credentialsCheck.run(ctxFor(h, {}))
+    expect(r.status).toBe('skipped')
+    expect(r.code).toBe('traffic.credentials.all-skipped')
+  })
+
+  it('returns ok when validator confirms credentials', async () => {
+    insertTrafficSource(h)
+    const validator: TrafficSourceValidator = {
+      validateCredentials: () => ({
+        status: 'ok',
+        code: 'cloud-run.token-resolved',
+        summary: 'token ok',
+      }),
+    }
+    const r = await credentialsCheck.run(ctxFor(h, { 'cloud-run': validator }))
+    expect(r.status).toBe('ok')
+    expect(r.code).toBe('traffic.credentials.ok')
+  })
+
+  it('fails when validator returns a fail result', async () => {
+    insertTrafficSource(h, { displayName: 'Prod' })
+    const validator: TrafficSourceValidator = {
+      validateCredentials: () => ({
+        status: 'fail',
+        code: 'cloud-run.token-missing',
+        summary: 'no token',
+        remediation: 're-connect',
+      }),
+    }
+    const r = await credentialsCheck.run(ctxFor(h, { 'cloud-run': validator }))
+    expect(r.status).toBe('fail')
+    expect(r.code).toBe('traffic.credentials.failed')
+    expect(r.summary).toContain('Prod')
+  })
+
+  it('catches validator exceptions and surfaces a fail result', async () => {
+    insertTrafficSource(h)
+    const validator: TrafficSourceValidator = {
+      validateCredentials: () => { throw new Error('network down') },
+    }
+    const r = await credentialsCheck.run(ctxFor(h, { 'cloud-run': validator }))
+    expect(r.status).toBe('fail')
+    const detail = r.details as { sources: Array<{ code: string }> }
+    expect(detail.sources[0]!.code).toBe('traffic.credentials.validator-error')
+  })
+
+  it('per-source dispatches by sourceType — only the matching adapter runs', async () => {
+    insertTrafficSource(h, { sourceType: 'cloud-run', displayName: 'GCP' })
+    insertTrafficSource(h, { sourceType: 'wp-plugin', displayName: 'WP' })
+    let cloudRunCalled = 0
+    let wpCalled = 0
+    const validators = {
+      'cloud-run': {
+        validateCredentials: () => { cloudRunCalled++; return { status: 'ok' as const, code: 'cr.ok', summary: 'cr ok' } },
+      },
+      'wp-plugin': {
+        validateCredentials: () => { wpCalled++; return { status: 'ok' as const, code: 'wp.ok', summary: 'wp ok' } },
+      },
+    } satisfies Record<string, TrafficSourceValidator>
+    const r = await credentialsCheck.run(ctxFor(h, validators))
+    expect(cloudRunCalled).toBe(1)
+    expect(wpCalled).toBe(1)
+    expect(r.status).toBe('ok')
+    const detail = r.details as { sources: Array<{ sourceType: string }> }
+    expect(detail.sources.map((s) => s.sourceType).sort()).toEqual(['cloud-run', 'wp-plugin'])
+  })
+})
+
+describe('traffic.source.scopes', () => {
+  it('skips when no source connected', async () => {
+    const r = await scopesCheck.run(ctxFor(h))
+    expect(r.status).toBe('skipped')
+    expect(r.code).toBe('traffic.scopes.no-source')
+  })
+
+  it('marks unsupported when validator returns null (e.g. Cloud Run without explicit scopes)', async () => {
+    insertTrafficSource(h)
+    const validator: TrafficSourceValidator = {
+      validateScopes: () => null,
+    }
+    const r = await scopesCheck.run(ctxFor(h, { 'cloud-run': validator }))
+    // null result becomes a per-source `unsupported` skipped — overall result is all-skipped.
+    expect(r.status).toBe('skipped')
+    expect(r.code).toBe('traffic.scopes.all-skipped')
+    const detail = r.details as { sources: Array<{ code: string }> }
+    expect(detail.sources[0]!.code).toBe('traffic.scopes.unsupported')
+  })
+})
+
+describe('check definitions', () => {
+  it('exports four checks at well-known IDs', () => {
+    const ids = TRAFFIC_SOURCE_CHECKS.map((c) => c.id)
+    expect(ids).toEqual([
+      'traffic.source.connected',
+      'traffic.source.recent-data',
+      'traffic.source.credentials',
+      'traffic.source.scopes',
+    ])
+  })
+
+  it('all are project-scoped', () => {
+    for (const c of TRAFFIC_SOURCE_CHECKS) expect(c.scope).toBe('project')
+  })
+})
+
+// Suppress unused-warnings by referencing the type used in the validator factories.
+export type _Suppress = TrafficSourceProbe extends infer T ? T : never
+export type _CheckOutput = CheckOutput

--- a/packages/api-routes/test/report-renderer.test.ts
+++ b/packages/api-routes/test/report-renderer.test.ts
@@ -41,6 +41,7 @@ function emptyReport(): ProjectReportDto {
     ga: null,
     socialReferrals: null,
     aiReferrals: null,
+    serverActivity: null,
     indexingHealth: null,
     citationsTrend: [],
     whatsChanged: {
@@ -245,6 +246,33 @@ function richReport(): ProjectReportDto {
       ],
       topLandingPages: [
         { page: '/', sessions: 120, users: 90 },
+      ],
+    },
+    serverActivity: {
+      windowStart: '2026-04-25T00:00:00.000Z',
+      windowEnd: '2026-05-02T00:00:00.000Z',
+      hasData: true,
+      verifiedCrawlerHits: { current: 234, prior: 117, deltaPct: 100 },
+      referralArrivals: { current: 12, prior: 6, deltaPct: 100 },
+      byOperator: [
+        { operator: 'OpenAI', verifiedHits: 140, unverifiedHits: 10, referralArrivals: 8, deltaPct: 75 },
+        { operator: 'Anthropic', verifiedHits: 70, unverifiedHits: 0, referralArrivals: 3, deltaPct: 40 },
+        { operator: 'Google AI', verifiedHits: 24, unverifiedHits: 5, referralArrivals: 1, deltaPct: null },
+      ],
+      topCrawledPaths: [
+        { path: '/blog/foo', verifiedHits: 80, distinctOperators: 2 },
+        { path: '/pricing', verifiedHits: 50, distinctOperators: 1 },
+      ],
+      referralProducts: [
+        { product: 'ChatGPT', arrivals: 8, distinctLandingPaths: 3 },
+        { product: 'Claude', arrivals: 3, distinctLandingPaths: 1 },
+      ],
+      dailyTrend: [
+        { date: '2026-04-29', verifiedCrawlerHits: 30, referralArrivals: 2 },
+        { date: '2026-04-30', verifiedCrawlerHits: 45, referralArrivals: 3 },
+      ],
+      topReferralLandingPaths: [
+        { path: '/landing', arrivals: 5, distinctProducts: 2 },
       ],
     },
     indexingHealth: {
@@ -486,6 +514,83 @@ describe('renderReportHtml', () => {
     const gsc = html.split('id="gsc"')[1]?.split('</section>')[0] ?? ''
     expect(executive).toContain('5.0K imp · 20.0% CTR · Apr 1, 2026 → Apr 30, 2026')
     expect(gsc).toContain('Search demand signals to compare against AI visibility for Apr 1, 2026 → Apr 30, 2026.')
+  })
+
+  test('agency HTML includes the AI Visibility — Server-Side section with Section 10 eyebrow', () => {
+    const html = renderReportHtml(richReport(), { audience: 'agency' })
+    expect(html).toContain('id="server-activity"')
+    expect(html).toContain('AI Visibility — Server-Side')
+    expect(html).toContain('Section 10')
+    // Headline numbers and explanatory copy that anchor analyst trust
+    expect(html).toContain('Verified crawler hits (7d)')
+    expect(html).toContain('AI-referral arrivals (7d)')
+    expect(html).toContain('rDNS-confirmed')
+    // Per-operator breakdown headings
+    expect(html).toContain('Per AI operator')
+    expect(html).toContain('Top crawled paths')
+    expect(html).toContain('Click-throughs by AI product')
+    // Specific row values from richReport()
+    expect(html).toContain('OpenAI')
+    expect(html).toContain('Anthropic')
+    expect(html).toContain('/blog/foo')
+  })
+
+  test('client HTML includes the AI Visibility — Server-Side section between WhatsChanged and the action plan', () => {
+    const html = renderReportHtml(richReport(), { audience: 'client' })
+    // Per the report-parity rule, what the SPA shows the client (between
+    // WhatsChanged and ActionPlan) must also be in the downloadable HTML.
+    expect(html).toContain('id="server-activity"')
+    expect(html).toContain('AI Visibility — Server-Side')
+    // Plain-English client labels (NOT the analyst "Verified crawler hits" copy)
+    expect(html).toContain('AI bots visited your site')
+    expect(html).toContain('People clicked through from AI')
+    expect(html).toContain('reverse-DNS')
+    // Section eyebrow in client view is the friendlier "AI engine attention" label
+    expect(html).toContain('AI engine attention')
+    // Per-engine breakdown rendered with operator names
+    expect(html).toContain('OpenAI')
+    // The agency-only labels MUST NOT appear in the client view
+    expect(html).not.toContain('Verified crawler hits (7d)')
+    expect(html).not.toContain('Top crawled paths')
+    // Section 10 eyebrow is agency-only
+    expect(html).not.toContain('Section 10')
+  })
+
+  test('client HTML hides the section entirely when no traffic source is connected', () => {
+    const report = richReport()
+    report.serverActivity = null
+    const html = renderReportHtml(report, { audience: 'client' })
+    expect(html).not.toContain('id="server-activity"')
+    expect(html).not.toContain('AI Visibility — Server-Side')
+  })
+
+  test('agency HTML shows the connect prompt when no source is connected', () => {
+    const report = richReport()
+    report.serverActivity = null
+    const html = renderReportHtml(report, { audience: 'agency' })
+    expect(html).toContain('id="server-activity"')
+    expect(html).toContain('Connect a server-side traffic source')
+  })
+
+  test('renumbered agency sections 11-16 retain their post-Server-Side ordering', () => {
+    const html = renderReportHtml(richReport(), { audience: 'agency' })
+    // Section 10 = AI Visibility — Server-Side (added by this PR)
+    // Section 11 = Indexing Health (was Section 10)
+    // Section 12 = Citations Over Time (was Section 11)
+    // Section 13 = Insights (was Section 12)
+    // Sections after that are not anchored on these eyebrows in the agency
+    // assembly, but we assert 11–13 to lock in the renumbering invariant.
+    expect(html).toContain('Section 11')
+    expect(html).toContain('Indexing Health')
+    expect(html).toContain('Section 12')
+    expect(html).toContain('Citations Over Time')
+    // The `serverActivity` block must come BEFORE Indexing Health in the
+    // emitted HTML — this enforces section ordering at the rendered level.
+    const saIdx = html.indexOf('id="server-activity"')
+    const ihIdx = html.indexOf('id="indexing-health"')
+    expect(saIdx).toBeGreaterThan(0)
+    expect(ihIdx).toBeGreaterThan(0)
+    expect(saIdx).toBeLessThan(ihIdx)
   })
 
   test('handles empty data without throwing', () => {

--- a/packages/api-routes/test/report-renderer.test.ts
+++ b/packages/api-routes/test/report-renderer.test.ts
@@ -593,6 +593,42 @@ describe('renderReportHtml', () => {
     expect(saIdx).toBeLessThan(ihIdx)
   })
 
+  // Locks in the report-parity rule for the metric subtitle: the SPA's
+  // `formatDeltaCopy` from contracts is the canonical text format; the
+  // HTML wraps it in a tone span but emits the same human-readable copy.
+  test('server-activity metric subtitle uses the shared formatDeltaCopy text', () => {
+    const agencyHtml = renderReportHtml(richReport(), { audience: 'agency' })
+    expect(agencyHtml).toContain('Up 100% vs prior 7 days (117 hits)')
+    expect(agencyHtml).toContain('Up 100% vs prior 7 days (6 arrivals)')
+    // Tone class wraps the copy
+    expect(agencyHtml).toMatch(/<span class="tone-positive">Up 100% vs prior 7 days/)
+
+    const clientHtml = renderReportHtml(richReport(), { audience: 'client' })
+    expect(clientHtml).toContain('Up 100% vs prior 7 days (117 crawls)')
+    expect(clientHtml).toContain('Up 100% vs prior 7 days (6 arrivals)')
+  })
+
+  test('client view of empty server-activity uses the friendly heading, not "Section 10"', () => {
+    const report = richReport()
+    report.serverActivity = {
+      ...report.serverActivity!,
+      hasData: false,
+      verifiedCrawlerHits: { current: 0, prior: 0, deltaPct: null },
+      referralArrivals: { current: 0, prior: 0, deltaPct: null },
+      byOperator: [],
+      topCrawledPaths: [],
+      referralProducts: [],
+      dailyTrend: [],
+      topReferralLandingPaths: [],
+    }
+    const html = renderReportHtml(report, { audience: 'client' })
+    expect(html).toContain('id="server-activity"')
+    expect(html).toContain('AI engine attention')
+    expect(html).toContain('AI Visibility — Server-Side')
+    // Section 10 is the agency-numbered eyebrow and must not leak to clients
+    expect(html).not.toContain('Section 10')
+  })
+
   test('handles empty data without throwing', () => {
     expect(() => renderReportHtml(emptyReport())).not.toThrow()
   })

--- a/packages/api-routes/test/report.test.ts
+++ b/packages/api-routes/test/report.test.ts
@@ -20,6 +20,9 @@ import {
   gaTrafficWindowSummaries,
   gaAiReferrals,
   gaSocialReferrals,
+  trafficSources,
+  crawlerEventsHourly,
+  aiReferralEventsHourly,
 } from '@ainyc/canonry-db'
 import { apiRoutes } from '../src/index.js'
 import type { ProjectReportDto } from '@ainyc/canonry-contracts'
@@ -1441,6 +1444,224 @@ describe('GET /api/v1/projects/:name/report', () => {
     expect(Object.keys(body1.executiveSummary).sort()).toEqual(
       Object.keys(body2.executiveSummary).sort(),
     )
+  })
+})
+
+describe('serverActivity (AI visibility — server-side)', () => {
+  let ctx: ReturnType<typeof buildApp>
+  beforeEach(() => { ctx = buildApp() })
+  afterEach(async () => {
+    await ctx.app.close()
+    fs.rmSync(ctx.tmpDir, { recursive: true, force: true })
+  })
+
+  function insertTrafficSource(projectId: string, status = 'connected') {
+    const sourceId = crypto.randomUUID()
+    const now = new Date().toISOString()
+    ctx.db.insert(trafficSources).values({
+      id: sourceId,
+      projectId,
+      sourceType: 'cloud-run',
+      displayName: 'Test source',
+      status,
+      lastSyncedAt: null,
+      lastCursor: null,
+      lastError: null,
+      lastEventIds: null,
+      archivedAt: status === 'archived' ? now : null,
+      configJson: '{}',
+      createdAt: now,
+      updatedAt: now,
+    }).run()
+    return sourceId
+  }
+
+  function isoMinusDays(days: number): string {
+    return new Date(Date.now() - days * 24 * 60 * 60_000).toISOString()
+  }
+
+  function insertCrawler(
+    projectId: string,
+    sourceId: string,
+    args: {
+      tsHour?: string
+      operator?: string
+      verificationStatus?: string
+      pathNormalized?: string
+      hits: number
+      botId?: string
+    },
+  ) {
+    const now = new Date().toISOString()
+    ctx.db.insert(crawlerEventsHourly).values({
+      projectId,
+      sourceId,
+      tsHour: args.tsHour ?? isoMinusDays(1),
+      botId: args.botId ?? 'gptbot',
+      operator: args.operator ?? 'OpenAI',
+      verificationStatus: args.verificationStatus ?? 'verified',
+      pathNormalized: args.pathNormalized ?? '/blog',
+      status: 200,
+      hits: args.hits,
+      sampledUserAgent: null,
+      createdAt: now,
+      updatedAt: now,
+    }).run()
+  }
+
+  function insertReferral(
+    projectId: string,
+    sourceId: string,
+    args: {
+      tsHour?: string
+      product?: string
+      operator?: string
+      sourceDomain?: string
+      landingPathNormalized?: string
+      hits: number
+    },
+  ) {
+    const now = new Date().toISOString()
+    ctx.db.insert(aiReferralEventsHourly).values({
+      projectId,
+      sourceId,
+      tsHour: args.tsHour ?? isoMinusDays(1),
+      product: args.product ?? 'ChatGPT',
+      operator: args.operator ?? 'OpenAI',
+      sourceDomain: args.sourceDomain ?? 'chatgpt.com',
+      evidenceType: 'utm',
+      landingPathNormalized: args.landingPathNormalized ?? '/landing',
+      status: 200,
+      sessionsOrHits: args.hits,
+      usersEstimated: null,
+      createdAt: now,
+      updatedAt: now,
+    }).run()
+  }
+
+  test('returns null when no traffic source is connected', async () => {
+    insertProject(ctx.db, 'no-source')
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/no-source/report' })
+    const body = JSON.parse(res.body) as ProjectReportDto
+    expect(body.serverActivity).toBeNull()
+  })
+
+  test('treats archived-only sources as no source', async () => {
+    const projectId = insertProject(ctx.db, 'archived-only')
+    insertTrafficSource(projectId, 'archived')
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/archived-only/report' })
+    const body = JSON.parse(res.body) as ProjectReportDto
+    expect(body.serverActivity).toBeNull()
+  })
+
+  test('returns hasData=false when source connected but no events yet', async () => {
+    const projectId = insertProject(ctx.db, 'no-events')
+    insertTrafficSource(projectId)
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/no-events/report' })
+    const body = JSON.parse(res.body) as ProjectReportDto
+    expect(body.serverActivity).not.toBeNull()
+    expect(body.serverActivity!.hasData).toBe(false)
+    expect(body.serverActivity!.verifiedCrawlerHits.current).toBe(0)
+    expect(body.serverActivity!.byOperator.length).toBe(0)
+    expect(body.serverActivity!.topCrawledPaths.length).toBe(0)
+    expect(body.serverActivity!.referralProducts.length).toBe(0)
+  })
+
+  test('headline crawler total uses verified-only; unverified is per-operator only', async () => {
+    const projectId = insertProject(ctx.db, 'verified-isolation')
+    const sourceId = insertTrafficSource(projectId)
+    // 7-day window — events at d-1
+    insertCrawler(projectId, sourceId, { hits: 30, verificationStatus: 'verified' })
+    insertCrawler(projectId, sourceId, { hits: 17, verificationStatus: 'claimed_unverified', operator: 'OpenAI' })
+    insertCrawler(projectId, sourceId, { hits: 5, verificationStatus: 'unknown_ai_like', operator: 'Other' })
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/verified-isolation/report' })
+    const body = JSON.parse(res.body) as ProjectReportDto
+    const sa = body.serverActivity!
+    // Headline counts ONLY verified
+    expect(sa.verifiedCrawlerHits.current).toBe(30)
+    // OpenAI row contains both verified + unverified, isolated
+    const openai = sa.byOperator.find(o => o.operator === 'OpenAI')!
+    expect(openai.verifiedHits).toBe(30)
+    expect(openai.unverifiedHits).toBe(17)
+    // Other row only has unverified — verified=0
+    const other = sa.byOperator.find(o => o.operator === 'Other')!
+    expect(other.verifiedHits).toBe(0)
+    expect(other.unverifiedHits).toBe(5)
+  })
+
+  test('deltaPct compares last-7d to prior 7d on verified hits', async () => {
+    const projectId = insertProject(ctx.db, 'delta-pct')
+    const sourceId = insertTrafficSource(projectId)
+    // current window (d-1): 100 verified
+    insertCrawler(projectId, sourceId, { tsHour: isoMinusDays(1), hits: 100 })
+    // prior window (d-10): 50 verified — 100% increase
+    insertCrawler(projectId, sourceId, { tsHour: isoMinusDays(10), hits: 50 })
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/delta-pct/report' })
+    const sa = (JSON.parse(res.body) as ProjectReportDto).serverActivity!
+    expect(sa.verifiedCrawlerHits.current).toBe(100)
+    expect(sa.verifiedCrawlerHits.prior).toBe(50)
+    expect(sa.verifiedCrawlerHits.deltaPct).toBe(100)
+  })
+
+  test('deltaPct is null when prior window is empty (no false 100% jumps from zero)', async () => {
+    const projectId = insertProject(ctx.db, 'delta-null')
+    const sourceId = insertTrafficSource(projectId)
+    insertCrawler(projectId, sourceId, { tsHour: isoMinusDays(1), hits: 100 })
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/delta-null/report' })
+    const sa = (JSON.parse(res.body) as ProjectReportDto).serverActivity!
+    expect(sa.verifiedCrawlerHits.deltaPct).toBeNull()
+  })
+
+  test('top crawled paths sorted descending by hits, verified only', async () => {
+    const projectId = insertProject(ctx.db, 'top-paths')
+    const sourceId = insertTrafficSource(projectId)
+    insertCrawler(projectId, sourceId, { pathNormalized: '/a', hits: 5 })
+    insertCrawler(projectId, sourceId, { pathNormalized: '/b', hits: 20 })
+    insertCrawler(projectId, sourceId, { pathNormalized: '/c', hits: 10 })
+    insertCrawler(projectId, sourceId, { pathNormalized: '/d', hits: 999, verificationStatus: 'claimed_unverified' })
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/top-paths/report' })
+    const sa = (JSON.parse(res.body) as ProjectReportDto).serverActivity!
+    // Verified only — /d (unverified) excluded
+    expect(sa.topCrawledPaths.map(p => p.path)).toEqual(['/b', '/c', '/a'])
+    expect(sa.topCrawledPaths[0]!.verifiedHits).toBe(20)
+  })
+
+  test('referral products aggregated and counted with distinct landing paths', async () => {
+    const projectId = insertProject(ctx.db, 'referral-products')
+    const sourceId = insertTrafficSource(projectId)
+    insertReferral(projectId, sourceId, { product: 'ChatGPT', landingPathNormalized: '/p1', hits: 3 })
+    insertReferral(projectId, sourceId, { product: 'ChatGPT', landingPathNormalized: '/p2', hits: 2 })
+    insertReferral(projectId, sourceId, { product: 'Claude', landingPathNormalized: '/p1', hits: 1 })
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/referral-products/report' })
+    const sa = (JSON.parse(res.body) as ProjectReportDto).serverActivity!
+    expect(sa.referralProducts).toHaveLength(2)
+    const chatgpt = sa.referralProducts.find(p => p.product === 'ChatGPT')!
+    expect(chatgpt.arrivals).toBe(5)
+    expect(chatgpt.distinctLandingPaths).toBe(2)
+    const claude = sa.referralProducts.find(p => p.product === 'Claude')!
+    expect(claude.arrivals).toBe(1)
+    expect(claude.distinctLandingPaths).toBe(1)
+  })
+
+  test('events outside the 14-day trend window are excluded', async () => {
+    const projectId = insertProject(ctx.db, 'trend-window')
+    const sourceId = insertTrafficSource(projectId)
+    insertCrawler(projectId, sourceId, { tsHour: isoMinusDays(2), hits: 7 })
+    insertCrawler(projectId, sourceId, { tsHour: isoMinusDays(20), hits: 999 })
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/trend-window/report' })
+    const sa = (JSON.parse(res.body) as ProjectReportDto).serverActivity!
+    // 999 is older than 14d — must not appear in dailyTrend
+    const totalTrendHits = sa.dailyTrend.reduce((acc, d) => acc + d.verifiedCrawlerHits, 0)
+    expect(totalTrendHits).toBe(7)
   })
 })
 

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.18.0",
+  "version": "4.18.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.17.1",
+  "version": "4.18.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/contracts/src/formatting.ts
+++ b/packages/contracts/src/formatting.ts
@@ -44,3 +44,33 @@ export function formatDateRange(start: string, end: string): string {
   if (start && end) return `${formatDate(start)} → ${formatDate(end)}`
   return formatDate(start || end)
 }
+
+export interface DeltaWindow {
+  current: number
+  prior: number
+  deltaPct: number | null
+}
+
+export function deltaPercent(current: number, prior: number): number | null {
+  if (prior <= 0) return null
+  return Math.round(((current - prior) / prior) * 100)
+}
+
+export type DeltaTone = 'positive' | 'negative' | 'neutral'
+
+export function deltaTone(deltaPct: number | null): DeltaTone {
+  if (deltaPct === null || deltaPct === 0) return 'neutral'
+  return deltaPct > 0 ? 'positive' : 'negative'
+}
+
+// Canonical subtitle copy for a "current vs prior window" tile. Used by
+// both the SPA and the HTML renderer so they stay verbatim-identical per
+// the report-parity rule.
+export function formatDeltaCopy(d: DeltaWindow, suffix: string, windowLabel = 'vs prior 7 days'): string {
+  if (d.deltaPct === null) {
+    return d.prior === 0 ? 'First baseline week' : ''
+  }
+  if (d.deltaPct > 0) return `Up ${d.deltaPct}% ${windowLabel} (${formatNumber(d.prior)} ${suffix})`
+  if (d.deltaPct < 0) return `Down ${Math.abs(d.deltaPct)}% ${windowLabel} (${formatNumber(d.prior)} ${suffix})`
+  return `Flat ${windowLabel} (${formatNumber(d.prior)} ${suffix})`
+}

--- a/packages/contracts/src/report.ts
+++ b/packages/contracts/src/report.ts
@@ -315,6 +315,80 @@ export interface AiReferralSection {
   }>
 }
 
+/**
+ * Server-side AI visibility — what AI engines actually do in your server logs.
+ * Distinct from `aiReferrals` (GA4 click-throughs) and `mentions/cited`
+ * (model-side answer presence). Sourced from `crawler_events_hourly` and
+ * `ai_referral_events_hourly` populated by the traffic-sync pipeline.
+ *
+ * Headline framing: "AI Visibility — Server-Side" (parallels "AI Citations").
+ *
+ * Section is null when the project has no traffic source connected at all.
+ * When `hasData=false`, a source is connected but no events have synced yet
+ * (different empty state from "no source").
+ */
+export interface ServerActivitySection {
+  /** ISO8601 inclusive lower bound of the report window (default: 7 days). */
+  windowStart: string
+  /** ISO8601 inclusive upper bound. */
+  windowEnd: string
+  hasData: boolean
+
+  /** Last-7d total verified crawler hits, with prior 7d for delta. */
+  verifiedCrawlerHits: { current: number; prior: number; deltaPct: number | null }
+  /** Last-7d AI-referral arrivals (clicks landing on the site). */
+  referralArrivals: { current: number; prior: number; deltaPct: number | null }
+
+  /** Per-AI-operator breakdown (OpenAI, Anthropic, Google AI, Perplexity, …). */
+  byOperator: Array<{
+    operator: string
+    verifiedHits: number
+    /** Shown to agency audience only — claimed-bot UA, rDNS not confirmed. */
+    unverifiedHits: number
+    referralArrivals: number
+    deltaPct: number | null
+  }>
+
+  /**
+   * Top crawled paths (verified only, last-7d). Path-level citation cross-reference
+   * is intentionally NOT included today — the citation store is domain-grain
+   * (`query_snapshots.cited_domains` is a JSON array of hostnames), so a path-level
+   * "cited?" flag would be misleading. A future iteration that lands URL-grain
+   * citation evidence can extend this entry with a `citationState` field without
+   * breaking the contract.
+   */
+  topCrawledPaths: Array<{
+    path: string
+    verifiedHits: number
+    /** How many distinct AI operators crawled this path in the window. */
+    distinctOperators: number
+  }>
+
+  /** AI products that sent ≥1 click-through in the window (referral by destination). */
+  referralProducts: Array<{
+    product: string
+    arrivals: number
+    distinctLandingPaths: number
+  }>
+
+  /** Daily trend, last 14d for sparkline / chart rendering. */
+  dailyTrend: Array<{
+    date: string
+    verifiedCrawlerHits: number
+    referralArrivals: number
+  }>
+
+  /**
+   * Top landing paths for AI-referral arrivals (last-7d).
+   * Complements `topCrawledPaths` (what bots fetch) with what humans actually land on.
+   */
+  topReferralLandingPaths: Array<{
+    path: string
+    arrivals: number
+    distinctProducts: number
+  }>
+}
+
 export interface IndexingHealthSection {
   /** Source: 'google' | 'bing' | null when neither is connected. */
   provider: 'google' | 'bing' | null
@@ -580,6 +654,8 @@ export interface ProjectReportDto {
   ga: GaTrafficSection | null
   socialReferrals: SocialReferralSection | null
   aiReferrals: AiReferralSection | null
+  /** Server-side log-evidence visibility (crawls + click-through arrivals). Null when no traffic source connected. */
+  serverActivity: ServerActivitySection | null
   indexingHealth: IndexingHealthSection | null
   citationsTrend: CitationsTrendPoint[]
   /**

--- a/packages/contracts/src/traffic.ts
+++ b/packages/contracts/src/traffic.ts
@@ -78,6 +78,13 @@ export const trafficSourceAuthModeSchema = z.enum(['oauth', 'service-account'])
 export type TrafficSourceAuthMode = z.infer<typeof trafficSourceAuthModeSchema>
 export const TrafficSourceAuthModes = trafficSourceAuthModeSchema.enum
 
+// Crawler verification tiers. See `packages/integration-traffic/AGENTS.md`:
+// UA-only matches stay `claimed_unverified` until IP/rDNS verification is wired;
+// `unknown_ai_like` is reserved for behavioral heuristics.
+export const verificationStatusSchema = z.enum(['verified', 'claimed_unverified', 'unknown_ai_like'])
+export type VerificationStatus = z.infer<typeof verificationStatusSchema>
+export const VerificationStatuses = verificationStatusSchema.enum
+
 export const cloudRunSourceConfigSchema = z.object({
   gcpProjectId: z.string().min(1),
   serviceName: z.string().nullable().optional(),

--- a/packages/contracts/test/formatting.test.ts
+++ b/packages/contracts/test/formatting.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from 'vitest'
 import {
+  deltaPercent,
+  deltaTone,
   formatDate,
   formatDateRange,
+  formatDeltaCopy,
   formatIsoDate,
   formatNumber,
   formatRatio,
@@ -95,5 +98,69 @@ describe('formatDateRange', () => {
   test('only one side falls through to a single formatted date', () => {
     expect(formatDateRange('2026-05-01', '')).toBe('May 1, 2026')
     expect(formatDateRange('', '2026-05-08')).toBe('May 8, 2026')
+  })
+})
+
+describe('deltaPercent', () => {
+  test('returns null when prior is zero or negative', () => {
+    expect(deltaPercent(100, 0)).toBeNull()
+    expect(deltaPercent(0, 0)).toBeNull()
+    expect(deltaPercent(50, -1)).toBeNull()
+  })
+
+  test('rounds to nearest integer percent', () => {
+    expect(deltaPercent(150, 100)).toBe(50)
+    expect(deltaPercent(50, 100)).toBe(-50)
+    expect(deltaPercent(100, 100)).toBe(0)
+    expect(deltaPercent(101, 100)).toBe(1)
+    expect(deltaPercent(102, 99)).toBe(3) // (102-99)/99 = 0.0303 → 3
+  })
+})
+
+describe('deltaTone', () => {
+  test('null and zero are neutral', () => {
+    expect(deltaTone(null)).toBe('neutral')
+    expect(deltaTone(0)).toBe('neutral')
+  })
+
+  test('positive deltas are positive tone', () => {
+    expect(deltaTone(1)).toBe('positive')
+    expect(deltaTone(100)).toBe('positive')
+  })
+
+  test('negative deltas are negative tone', () => {
+    expect(deltaTone(-1)).toBe('negative')
+    expect(deltaTone(-100)).toBe('negative')
+  })
+})
+
+describe('formatDeltaCopy', () => {
+  test('null deltaPct with zero prior signals first baseline week', () => {
+    expect(formatDeltaCopy({ current: 100, prior: 0, deltaPct: null }, 'crawls'))
+      .toBe('First baseline week')
+  })
+
+  test('null deltaPct with non-zero prior renders empty (no signal)', () => {
+    expect(formatDeltaCopy({ current: 0, prior: 50, deltaPct: null }, 'crawls')).toBe('')
+  })
+
+  test('positive delta uses Up phrasing with prior count', () => {
+    expect(formatDeltaCopy({ current: 200, prior: 100, deltaPct: 100 }, 'crawls'))
+      .toBe('Up 100% vs prior 7 days (100 crawls)')
+  })
+
+  test('negative delta uses Down phrasing with absolute value', () => {
+    expect(formatDeltaCopy({ current: 50, prior: 100, deltaPct: -50 }, 'arrivals'))
+      .toBe('Down 50% vs prior 7 days (100 arrivals)')
+  })
+
+  test('zero delta uses Flat phrasing', () => {
+    expect(formatDeltaCopy({ current: 100, prior: 100, deltaPct: 0 }, 'hits'))
+      .toBe('Flat vs prior 7 days (100 hits)')
+  })
+
+  test('windowLabel can be overridden', () => {
+    expect(formatDeltaCopy({ current: 200, prior: 100, deltaPct: 100 }, 'hits', 'vs prior 30 days'))
+      .toBe('Up 100% vs prior 30 days (100 hits)')
   })
 })


### PR DESCRIPTION
## Summary

Wires server-side traffic data (`crawler_events_hourly` + `ai_referral_events_hourly`, populated by traffic-sync) into the project report. Previously: every renderer ignored these tables. After this PR: agencies and clients both see what AI engines actually do in their server logs — direct evidence, complementary to citations (which measure what the model says about you).

## UX principles baked in

The framing was the harder part of this PR than the wiring. Three rules drove every decision:

1. **Verified-first headline numbers.** Anyone can put `GPTBot` in their UA. Only rDNS-verified hits drive the headline; unverified is a second-class column for agency forensics. We never inflate trust.
2. **Operator-level grouping.** Most users know "OpenAI" but not `GPTBot` / `OAI-SearchBot` / `ChatGPT-User`. The `byOperator` breakdown rolls bot IDs up to the parent AI company.
3. **Honest empty states.** Section is `null` when no source is connected (silent on client view, no clutter). `hasData=false` when connected but unsynced (one-line "we're collecting" prompt). Period-over-period `deltaPct` is `null` when prior=0, so a brand-new connection doesn't fabricate "+100% from zero".

## What's NOT in this PR

The crawl × citation diagnostics (cited-not-crawled / crawled-not-cited) were intentionally descoped: `query_snapshots.cited_domains` stores **domain-grain** JSON, not URL-grain. A path-level "isCited" flag would be misleading. Left as a future extension once URL-grain citation evidence lands.

## Contract

`packages/contracts/src/report.ts` — new `ServerActivitySection` interface on `ProjectReportDto`:

| Field | Purpose |
|---|---|
| `verifiedCrawlerHits` / `referralArrivals` | 7d totals + prior 7d + deltaPct |
| `byOperator` | Per-AI-company aggregation (verified, unverified, referrals, delta) |
| `topCrawledPaths` | Top 10 verified-only crawled paths with distinct-operator count |
| `referralProducts` / `topReferralLandingPaths` | Click-through-side detail |
| `dailyTrend` | 14-day series for sparkline / chart |

## Builder

`packages/api-routes/src/report.ts` → `buildServerActivity()`:
- Returns `null` when no non-archived traffic source exists (different from "connected but empty").
- 5 grouped SQL queries + 2 trend queries — no row-level loading.
- Date bucketing via SQLite `SUBSTR(tsHour, 1, 10)`.

## Renderers (per the report parity rule)

**HTML (`report-renderer.ts`) — agency view:**
- New `renderServerActivity()` at Section 10, between AI Referral Traffic (9) and Indexing Health.
- All sections 10–15 renumbered to 11–16 to make room (mechanical sed; no other behavior changes).
- Tables for byOperator / topCrawledPaths / referralProducts / topReferralLandingPaths. Inline SVG line chart for verified-crawler daily trend.
- Plain-English copy explains verified-vs-unverified to non-technical agency clients.

**SPA (`apps/web/src/pages/ReportPage.tsx`) — client view:**
- New `ServerActivityClientView` between WhatsChanged and ActionPlan.
- Hidden when `serverActivity=null`.
- Headline metrics + top-5 per-engine table. Reuses existing `Metric`, `SectionHeading`, `formatNumber`.

The 1.4k existing dead-code SPA components (`AiReferralsSection`, `GaTrafficSection`, etc. defined but never invoked) had their section eyebrows renumbered for consistency. Otherwise unchanged.

## Test plan

- [x] 9 new tests in `report.test.ts` covering: null when no source, archived-only treated as no source, `hasData=false` when connected but empty, verified-only headline isolation (unverified counts in per-operator only), deltaPct correctness vs prior 7d, deltaPct null when prior is empty, top-paths sort + verified-only filter, referralProducts distinct landing paths, 14-day trend boundary.
- [x] Existing 1,300+ workspace tests pass — 2,219 / 2,219.
- [x] `pnpm typecheck` clean across workspace.
- [x] `pnpm lint` clean across workspace.

## Versioning

`4.15.2 → 4.16.0` (minor — new public field on `ProjectReportDto`).

## Follow-ups (not in this PR)

- **Insight engine wiring** — the original #3 scope split into 3a (this PR — report integration) and 3b (insight rules firing on traffic data). Will land separately.
- **URL-grain citation cross-reference** — once query snapshots store URL-grain citation evidence (not just domain-grain), we can extend `topCrawledPaths` with a `citationState` field and add the diagnostics subsection.
- **Client-view "click-through paths" detail** — currently shown only in agency HTML. Worth a follow-up once we see real referral data flowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)