### PR TITLE
feat(doctor): generic traffic.source.* checks (adapter-agnostic)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,10 @@ Each check returns `status: ok | warn | fail | skipped`, a stable machine-readab
 | auth | `google.auth.redirect-uri` | project | `publicUrl`-derived redirect URI is valid + advertised |
 | auth | `google.auth.scopes` | project | Granted GSC + Indexing scopes match what's stored |
 | auth | `ga.auth.connection` | project | GA4 service account verifies against the configured property |
+| auth | `traffic.source.credentials` | project | Per-source-type credential validation (today: Cloud Run service-account access token resolves) |
+| auth | `traffic.source.scopes` | project | Per-source-type scope validation (skipped where the adapter has no explicit scope check) |
+| integrations | `traffic.source.connected` | project | At least one non-archived server-side traffic source exists for the project |
+| integrations | `traffic.source.recent-data` | project | Connected sources have crawler/AI-referral events in the last 7d (warn) or 30d (fail) |
 | providers | `config.providers` | global | At least one provider key configured |
 
 ### Adding a new check

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.16.0",
+  "version": "4.16.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/AGENTS.md
+++ b/packages/api-routes/AGENTS.md
@@ -27,7 +27,7 @@ Shared Fastify route plugins used by both the local server (`packages/canonry`) 
 | `src/doctor.ts` | `GET /doctor` and `GET /projects/:name/doctor` — runs check registry, returns `DoctorReport` |
 | `src/doctor/registry.ts` | `ALL_CHECKS` — single source of truth for the doctor check catalog |
 | `src/doctor/runner.ts` | `runChecks()` and `matchesCheckId()` — execute filtered checks, build the report |
-| `src/doctor/checks/*.ts` | Individual `CheckDefinition`s (google-auth, ga-auth, providers) |
+| `src/doctor/checks/*.ts` | Individual `CheckDefinition`s (google-auth, bing-auth, ga-auth, providers, traffic-source). The `traffic-source` checks are adapter-agnostic — they query `traffic_sources` directly for connection/recent-data, and dispatch credential / scope validation through `DoctorContext.trafficSourceValidators[<sourceType>]`. Today only the `cloud-run` validator is registered (built in `index.ts` from the existing `cloudRunCredentialStore` + `resolveCloudRunAccessToken`); future adapters (`wp-plugin`, etc.) plug in by adding a key to that map — no doctor-side changes needed. |
 
 ## Patterns
 

--- a/packages/api-routes/src/doctor.ts
+++ b/packages/api-routes/src/doctor.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from 'fastify'
 import { ALL_CHECKS } from './doctor/registry.js'
 import { runChecks } from './doctor/runner.js'
-import type { DoctorContext } from './doctor/types.js'
+import type { DoctorContext, TrafficSourceValidator } from './doctor/types.js'
 import type { GoogleConnectionStore } from './google.js'
 import type { BingConnectionStore } from './bing.js'
 import type { Ga4CredentialStore } from './ga.js'
@@ -16,6 +16,12 @@ export interface DoctorRoutesOptions {
   /** Used to derive the redirect URI displayed by the redirect-uri check. */
   publicUrl?: string
   providerSummary?: ProviderSummaryEntry[]
+  /**
+   * Map of `traffic_sources.source_type` → adapter validator. Optional — the
+   * generic `traffic.source.credentials` / `traffic.source.scopes` checks
+   * skip with a clear `no-validator` code when an adapter doesn't register.
+   */
+  trafficSourceValidators?: Record<string, TrafficSourceValidator>
 }
 
 function parseCheckIds(raw: string | undefined): string[] {
@@ -49,6 +55,7 @@ export async function doctorRoutes(app: FastifyInstance, opts: DoctorRoutesOptio
       getGoogleAuthConfig: opts.getGoogleAuthConfig,
       redirectUri,
       providerSummary: opts.providerSummary,
+      trafficSourceValidators: opts.trafficSourceValidators,
     }
     return runChecks(ctx, ALL_CHECKS, { checkIds })
   })
@@ -74,6 +81,7 @@ export async function doctorRoutes(app: FastifyInstance, opts: DoctorRoutesOptio
       getGoogleAuthConfig: opts.getGoogleAuthConfig,
       redirectUri,
       providerSummary: opts.providerSummary,
+      trafficSourceValidators: opts.trafficSourceValidators,
     }
     return runChecks(ctx, ALL_CHECKS, { checkIds })
   })

--- a/packages/api-routes/src/doctor/checks/traffic-source.ts
+++ b/packages/api-routes/src/doctor/checks/traffic-source.ts
@@ -1,0 +1,360 @@
+import { and, eq, gte, sql } from 'drizzle-orm'
+import {
+  CheckCategories,
+  CheckScopes,
+  CheckStatuses,
+} from '@ainyc/canonry-contracts'
+import {
+  aiReferralEventsHourly,
+  crawlerEventsHourly,
+  trafficSources,
+} from '@ainyc/canonry-db'
+import type { CheckDefinition, CheckOutput, DoctorContext, TrafficSourceProbe } from '../types.js'
+
+/**
+ * Generic doctor checks for the server-side traffic ingestion pipeline. They
+ * stay adapter-agnostic — the `traffic_sources` table is the only thing they
+ * reach into directly; per-adapter credential / scope validation flows
+ * through `DoctorContext.trafficSourceValidators[sourceType]`.
+ *
+ * Today the only adapter is Cloud Run; tomorrow's WordPress / SaaS adapters
+ * register under their own `sourceType` keys and inherit every check below
+ * with no doctor-side changes.
+ */
+
+const RECENT_DATA_WARN_DAYS = 7
+const RECENT_DATA_FAIL_DAYS = 30
+
+function skippedNoProject(): CheckOutput {
+  return {
+    status: CheckStatuses.skipped,
+    code: 'traffic.no-project',
+    summary: 'Project context required for traffic source checks.',
+    remediation: 'Run `canonry doctor --project <name>` to scope this check to a project.',
+  }
+}
+
+function loadProbes(ctx: DoctorContext): TrafficSourceProbe[] {
+  if (!ctx.project) return []
+  const rows = ctx.db
+    .select()
+    .from(trafficSources)
+    .where(
+      and(
+        eq(trafficSources.projectId, ctx.project.id),
+        sql`${trafficSources.status} != 'archived'`,
+      ),
+    )
+    .all()
+  return rows.map((r) => ({
+    id: r.id,
+    projectId: r.projectId,
+    projectName: ctx.project!.name,
+    sourceType: r.sourceType,
+    displayName: r.displayName,
+    status: r.status,
+    lastSyncedAt: r.lastSyncedAt,
+    lastError: r.lastError,
+    configJson: r.configJson,
+  }))
+}
+
+const sourceConnectedCheck: CheckDefinition = {
+  id: 'traffic.source.connected',
+  category: CheckCategories.integrations,
+  scope: CheckScopes.project,
+  title: 'Traffic source connected',
+  run: (ctx) => {
+    if (!ctx.project) return skippedNoProject()
+    const sources = loadProbes(ctx)
+    if (sources.length === 0) {
+      return {
+        status: CheckStatuses.skipped,
+        code: 'traffic.source.none',
+        summary: 'No server-side traffic source connected — server-log AI visibility data unavailable for this project.',
+        remediation: 'Connect a traffic source via `canonry traffic connect <type> <project>` to surface crawler hits and AI-referral arrivals from your server logs.',
+        details: { sourceCount: 0 },
+      }
+    }
+    const errored = sources.filter((s) => s.status === 'error')
+    if (errored.length > 0 && errored.length === sources.length) {
+      return {
+        status: CheckStatuses.fail,
+        code: 'traffic.source.all-errored',
+        summary: `All ${sources.length} traffic source(s) are in error state. No data is being ingested.`,
+        remediation: errored[0]!.lastError
+          ? `Latest error: "${errored[0]!.lastError}". Re-connect the source or run \`canonry traffic sync <project> --source <id>\` to retry.`
+          : 'Run `canonry traffic sources <project>` to inspect the failing source(s) and re-connect.',
+        details: { sourceCount: sources.length, erroredIds: errored.map((s) => s.id) },
+      }
+    }
+    if (errored.length > 0) {
+      return {
+        status: CheckStatuses.warn,
+        code: 'traffic.source.partially-errored',
+        summary: `${errored.length} of ${sources.length} traffic source(s) are in error state.`,
+        remediation: 'Run `canonry traffic sources <project>` to inspect the failing sources individually.',
+        details: { sourceCount: sources.length, erroredIds: errored.map((s) => s.id) },
+      }
+    }
+    return {
+      status: CheckStatuses.ok,
+      code: 'traffic.source.connected',
+      summary: `${sources.length} traffic source(s) connected: ${sources.map((s) => s.displayName).join(', ')}.`,
+      details: { sourceCount: sources.length, sourceTypes: [...new Set(sources.map((s) => s.sourceType))] },
+    }
+  },
+}
+
+const recentDataCheck: CheckDefinition = {
+  id: 'traffic.source.recent-data',
+  category: CheckCategories.integrations,
+  scope: CheckScopes.project,
+  title: 'Traffic source recent data',
+  run: (ctx) => {
+    if (!ctx.project) return skippedNoProject()
+    const sources = loadProbes(ctx)
+    if (sources.length === 0) {
+      return {
+        status: CheckStatuses.skipped,
+        code: 'traffic.recent-data.no-source',
+        summary: 'No traffic source connected — recent-data check skipped.',
+      }
+    }
+
+    const now = new Date()
+    const warnCutoff = new Date(now.getTime() - RECENT_DATA_WARN_DAYS * 24 * 60 * 60_000).toISOString()
+    const failCutoff = new Date(now.getTime() - RECENT_DATA_FAIL_DAYS * 24 * 60 * 60_000).toISOString()
+
+    const recentCrawlers = Number(
+      ctx.db
+        .select({ total: sql<number>`COALESCE(SUM(${crawlerEventsHourly.hits}), 0)` })
+        .from(crawlerEventsHourly)
+        .where(
+          and(
+            eq(crawlerEventsHourly.projectId, ctx.project.id),
+            gte(crawlerEventsHourly.tsHour, warnCutoff),
+          ),
+        )
+        .get()?.total ?? 0,
+    )
+    const recentReferrals = Number(
+      ctx.db
+        .select({ total: sql<number>`COALESCE(SUM(${aiReferralEventsHourly.sessionsOrHits}), 0)` })
+        .from(aiReferralEventsHourly)
+        .where(
+          and(
+            eq(aiReferralEventsHourly.projectId, ctx.project.id),
+            gte(aiReferralEventsHourly.tsHour, warnCutoff),
+          ),
+        )
+        .get()?.total ?? 0,
+    )
+    if (recentCrawlers > 0 || recentReferrals > 0) {
+      return {
+        status: CheckStatuses.ok,
+        code: 'traffic.recent-data.fresh',
+        summary: `${recentCrawlers} crawler hit(s) and ${recentReferrals} AI-referral arrival(s) in the last ${RECENT_DATA_WARN_DAYS} days.`,
+        details: { crawlerHits: recentCrawlers, referralArrivals: recentReferrals, windowDays: RECENT_DATA_WARN_DAYS },
+      }
+    }
+
+    // No data inside the warn window — escalate to fail if also empty inside the failure window.
+    const olderCrawlers = Number(
+      ctx.db
+        .select({ total: sql<number>`COALESCE(SUM(${crawlerEventsHourly.hits}), 0)` })
+        .from(crawlerEventsHourly)
+        .where(
+          and(
+            eq(crawlerEventsHourly.projectId, ctx.project.id),
+            gte(crawlerEventsHourly.tsHour, failCutoff),
+          ),
+        )
+        .get()?.total ?? 0,
+    )
+    const lastSyncedAt = sources.map((s) => s.lastSyncedAt).filter(Boolean).sort().at(-1) ?? null
+    if (olderCrawlers > 0 || lastSyncedAt) {
+      return {
+        status: CheckStatuses.warn,
+        code: 'traffic.recent-data.stale',
+        summary: `No crawler hits or AI-referral arrivals in the last ${RECENT_DATA_WARN_DAYS} days, though older data exists.`,
+        remediation: lastSyncedAt
+          ? `Last sync: ${lastSyncedAt}. Run \`canonry traffic sync <project>\` to refresh, or check the source connection.`
+          : 'Run `canonry traffic sync <project>` to pull recent events.',
+        details: { lastSyncedAt, sourceCount: sources.length },
+      }
+    }
+    return {
+      status: CheckStatuses.fail,
+      code: 'traffic.recent-data.empty',
+      summary: `No traffic data in the last ${RECENT_DATA_FAIL_DAYS} days. The source is connected but isn't ingesting.`,
+      remediation: 'Verify the source\'s configuration with `canonry traffic sources <project>` and run a manual sync to confirm credentials + scopes are still valid.',
+      details: { sourceCount: sources.length },
+    }
+  },
+}
+
+async function runValidator(
+  source: TrafficSourceProbe,
+  validator: ((s: TrafficSourceProbe) => Promise<CheckOutput | null> | CheckOutput | null) | undefined,
+  fallbackId: string,
+  fallbackLabel: string,
+): Promise<{ source: TrafficSourceProbe; output: CheckOutput }> {
+  if (!validator) {
+    return {
+      source,
+      output: {
+        status: CheckStatuses.skipped,
+        code: `traffic.${fallbackId}.no-validator`,
+        summary: `No ${fallbackLabel} validator registered for source type "${source.sourceType}".`,
+      },
+    }
+  }
+  try {
+    const result = await validator(source)
+    if (!result) {
+      return {
+        source,
+        output: {
+          status: CheckStatuses.skipped,
+          code: `traffic.${fallbackId}.unsupported`,
+          summary: `Validator for "${source.sourceType}" does not implement ${fallbackLabel} validation.`,
+        },
+      }
+    }
+    return { source, output: result }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    return {
+      source,
+      output: {
+        status: CheckStatuses.fail,
+        code: `traffic.${fallbackId}.validator-error`,
+        summary: `${fallbackLabel} validator threw: ${msg}.`,
+        remediation: 'Check the source configuration and credentials, then re-run the doctor.',
+      },
+    }
+  }
+}
+
+function summarizePerSourceResults(
+  fallbackId: string,
+  fallbackLabel: string,
+  results: Array<{ source: TrafficSourceProbe; output: CheckOutput }>,
+): CheckOutput {
+  const failed = results.filter((r) => r.output.status === CheckStatuses.fail)
+  const warned = results.filter((r) => r.output.status === CheckStatuses.warn)
+  const skipped = results.filter((r) => r.output.status === CheckStatuses.skipped)
+  const ok = results.filter((r) => r.output.status === CheckStatuses.ok)
+
+  const detail = {
+    sources: results.map((r) => ({
+      id: r.source.id,
+      sourceType: r.source.sourceType,
+      displayName: r.source.displayName,
+      status: r.output.status,
+      code: r.output.code,
+      summary: r.output.summary,
+    })),
+  }
+  if (failed.length > 0) {
+    return {
+      status: CheckStatuses.fail,
+      code: `traffic.${fallbackId}.failed`,
+      summary: `${failed.length} of ${results.length} source(s) failed ${fallbackLabel} validation: ${failed.map((r) => `${r.source.displayName} (${r.output.summary})`).join('; ')}.`,
+      remediation: failed[0]!.output.remediation ?? `Inspect the failing source(s) — see details.sources for per-source codes.`,
+      details: detail,
+    }
+  }
+  if (warned.length > 0) {
+    return {
+      status: CheckStatuses.warn,
+      code: `traffic.${fallbackId}.warned`,
+      summary: `${warned.length} of ${results.length} source(s) raised warnings during ${fallbackLabel} validation.`,
+      remediation: warned[0]!.output.remediation ?? `Review the warning(s) — see details.sources.`,
+      details: detail,
+    }
+  }
+  if (ok.length > 0) {
+    return {
+      status: CheckStatuses.ok,
+      code: `traffic.${fallbackId}.ok`,
+      summary: `${ok.length} source(s) passed ${fallbackLabel} validation${skipped.length > 0 ? ` (${skipped.length} skipped)` : ''}.`,
+      details: detail,
+    }
+  }
+  // All skipped.
+  return {
+    status: CheckStatuses.skipped,
+    code: `traffic.${fallbackId}.all-skipped`,
+    summary: `No source-type validator was available for any of the ${results.length} connected source(s).`,
+    details: detail,
+  }
+}
+
+const credentialsCheck: CheckDefinition = {
+  id: 'traffic.source.credentials',
+  category: CheckCategories.auth,
+  scope: CheckScopes.project,
+  title: 'Traffic source credentials',
+  run: async (ctx) => {
+    if (!ctx.project) return skippedNoProject()
+    const sources = loadProbes(ctx)
+    if (sources.length === 0) {
+      return {
+        status: CheckStatuses.skipped,
+        code: 'traffic.credentials.no-source',
+        summary: 'No traffic source connected — credentials check skipped.',
+      }
+    }
+    const validators = ctx.trafficSourceValidators ?? {}
+    const results = await Promise.all(
+      sources.map((s) =>
+        runValidator(
+          s,
+          validators[s.sourceType]?.validateCredentials?.bind(validators[s.sourceType]),
+          'credentials',
+          'credentials',
+        ),
+      ),
+    )
+    return summarizePerSourceResults('credentials', 'credentials', results)
+  },
+}
+
+const scopesCheck: CheckDefinition = {
+  id: 'traffic.source.scopes',
+  category: CheckCategories.auth,
+  scope: CheckScopes.project,
+  title: 'Traffic source scopes',
+  run: async (ctx) => {
+    if (!ctx.project) return skippedNoProject()
+    const sources = loadProbes(ctx)
+    if (sources.length === 0) {
+      return {
+        status: CheckStatuses.skipped,
+        code: 'traffic.scopes.no-source',
+        summary: 'No traffic source connected — scopes check skipped.',
+      }
+    }
+    const validators = ctx.trafficSourceValidators ?? {}
+    const results = await Promise.all(
+      sources.map((s) =>
+        runValidator(
+          s,
+          validators[s.sourceType]?.validateScopes?.bind(validators[s.sourceType]),
+          'scopes',
+          'scopes',
+        ),
+      ),
+    )
+    return summarizePerSourceResults('scopes', 'scopes', results)
+  },
+}
+
+export const TRAFFIC_SOURCE_CHECKS: readonly CheckDefinition[] = [
+  sourceConnectedCheck,
+  recentDataCheck,
+  credentialsCheck,
+  scopesCheck,
+]

--- a/packages/api-routes/src/doctor/checks/traffic-source.ts
+++ b/packages/api-routes/src/doctor/checks/traffic-source.ts
@@ -1,8 +1,9 @@
-import { and, eq, gte, sql } from 'drizzle-orm'
+import { and, eq, gte, ne, sql } from 'drizzle-orm'
 import {
   CheckCategories,
   CheckScopes,
   CheckStatuses,
+  TrafficSourceStatuses,
 } from '@ainyc/canonry-contracts'
 import {
   aiReferralEventsHourly,
@@ -42,7 +43,7 @@ function loadProbes(ctx: DoctorContext): TrafficSourceProbe[] {
     .where(
       and(
         eq(trafficSources.projectId, ctx.project.id),
-        sql`${trafficSources.status} != 'archived'`,
+        ne(trafficSources.status, TrafficSourceStatuses.archived),
       ),
     )
     .all()

--- a/packages/api-routes/src/doctor/registry.ts
+++ b/packages/api-routes/src/doctor/registry.ts
@@ -2,6 +2,7 @@ import { BING_AUTH_CHECKS } from './checks/bing-auth.js'
 import { GA_AUTH_CHECKS } from './checks/ga-auth.js'
 import { GOOGLE_AUTH_CHECKS } from './checks/google-auth.js'
 import { PROVIDERS_CHECKS } from './checks/providers.js'
+import { TRAFFIC_SOURCE_CHECKS } from './checks/traffic-source.js'
 import type { CheckDefinition } from './types.js'
 
 export const ALL_CHECKS: readonly CheckDefinition[] = [
@@ -9,6 +10,7 @@ export const ALL_CHECKS: readonly CheckDefinition[] = [
   ...BING_AUTH_CHECKS,
   ...GA_AUTH_CHECKS,
   ...PROVIDERS_CHECKS,
+  ...TRAFFIC_SOURCE_CHECKS,
 ]
 
 export const CHECK_BY_ID: Record<string, CheckDefinition> = Object.fromEntries(

--- a/packages/api-routes/src/doctor/types.ts
+++ b/packages/api-routes/src/doctor/types.ts
@@ -5,6 +5,36 @@ import type { BingConnectionStore } from '../bing.js'
 import type { Ga4CredentialStore } from '../ga.js'
 import type { ProviderSummaryEntry } from '../settings.js'
 
+/**
+ * Generic traffic-source row shape passed to a `TrafficSourceValidator`.
+ * Mirrors the public columns of `trafficSources`; this surface stays
+ * deliberately loose so future adapters (WordPress plugin, others) don't
+ * need to teach the doctor framework anything new.
+ */
+export interface TrafficSourceProbe {
+  id: string
+  projectId: string
+  projectName: string
+  sourceType: string
+  displayName: string
+  status: string
+  lastSyncedAt: string | null
+  lastError: string | null
+  configJson: string
+}
+
+/**
+ * Per-source-type validation hook. Adapters register a validator under their
+ * `sourceType` key (e.g. `'cloud-run'`, `'wp-plugin'`). Each method returns a
+ * `CheckOutput` (ok / warn / fail / skipped) for a single source row, or null
+ * to indicate the validator does not implement that check (the runner will
+ * surface a `skipped` result with `code: '<id>.no-validator'`).
+ */
+export interface TrafficSourceValidator {
+  validateCredentials?(source: TrafficSourceProbe): Promise<CheckOutput | null> | CheckOutput | null
+  validateScopes?(source: TrafficSourceProbe): Promise<CheckOutput | null> | CheckOutput | null
+}
+
 export interface DoctorContext {
   db: DatabaseClient
   /** When the check is project-scoped, this resolves to the project row. */
@@ -16,6 +46,13 @@ export interface DoctorContext {
   /** Resolved redirect URI (publicUrl + /api/v1/google/callback) used by the OAuth flow. */
   redirectUri?: string
   providerSummary?: ProviderSummaryEntry[]
+  /**
+   * Map of `traffic_sources.source_type` → adapter-specific validator. The
+   * generic `traffic.source.credentials` / `traffic.source.scopes` checks
+   * dispatch to the matching entry. Sources whose type has no validator
+   * registered surface a `skipped` result rather than a fail.
+   */
+  trafficSourceValidators?: Record<string, TrafficSourceValidator>
 }
 
 export interface ProjectInfo {

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -41,9 +41,11 @@ import { wordpressRoutes } from './wordpress.js'
 import type { WordpressRoutesOptions } from './wordpress.js'
 import { backlinksRoutes } from './backlinks.js'
 import type { BacklinksRoutesOptions } from './backlinks.js'
-import { trafficRoutes } from './traffic.js'
+import { trafficRoutes, defaultResolveAccessToken } from './traffic.js'
 import type { TrafficRoutesOptions, CloudRunCredentialStore } from './traffic.js'
 import { doctorRoutes } from './doctor.js'
+import { CheckStatuses } from '@ainyc/canonry-contracts'
+import type { CheckOutput, TrafficSourceProbe, TrafficSourceValidator } from './doctor/types.js'
 
 declare module 'fastify' {
   interface FastifyInstance {
@@ -296,6 +298,7 @@ export async function apiRoutes(app: FastifyInstance, opts: ApiRoutesOptions) {
       getGoogleAuthConfig: opts.getGoogleAuthConfig,
       publicUrl: opts.publicUrl,
       providerSummary: opts.providerSummary,
+      trafficSourceValidators: buildTrafficSourceValidators(opts),
     })
     // Local-only extension hook: canonry passes the Aero agent routes here
     // so they live inside the authenticated scope. Cloud leaves it undefined.
@@ -313,3 +316,56 @@ export type { SafeWebhookTarget } from './webhooks.js'
 export type { RunRoutesOptions } from './runs.js'
 export { renderReportHtml } from './report-renderer.js'
 export type { RenderReportHtmlOptions } from './report-renderer.js'
+
+/**
+ * Build the per-source-type validator map consumed by the generic
+ * `traffic.source.credentials` and `traffic.source.scopes` doctor checks.
+ *
+ * Today only Cloud Run has an adapter, so this returns at most one entry
+ * (`'cloud-run'`). Future adapters (WordPress plugin, others) plug in by
+ * adding their own entry here behind the same `TrafficSourceValidator`
+ * interface — no doctor-side changes needed.
+ */
+function buildTrafficSourceValidators(opts: ApiRoutesOptions): Record<string, TrafficSourceValidator> | undefined {
+  const validators: Record<string, TrafficSourceValidator> = {}
+  if (opts.cloudRunCredentialStore) {
+    const store = opts.cloudRunCredentialStore
+    const resolveToken = opts.resolveCloudRunAccessToken ?? defaultResolveAccessToken
+    validators['cloud-run'] = {
+      validateCredentials: async (source: TrafficSourceProbe): Promise<CheckOutput> => {
+        const record = store.getConnection(source.projectName)
+        if (!record) {
+          return {
+            status: CheckStatuses.fail,
+            code: 'traffic.credentials.missing',
+            summary: `No Cloud Run credential found in ~/.canonry/config.yaml for project "${source.projectName}".`,
+            remediation: 'Re-run `canonry traffic connect cloud-run <project> --gcp-project <id> --service-account-key <path>`.',
+          }
+        }
+        try {
+          await resolveToken(record)
+          return {
+            status: CheckStatuses.ok,
+            code: 'traffic.credentials.resolved',
+            summary: `Cloud Run access token resolves for "${source.displayName}" (project ${record.gcpProjectId}).`,
+          }
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e)
+          return {
+            status: CheckStatuses.fail,
+            code: 'traffic.credentials.resolve-failed',
+            summary: `Failed to resolve Cloud Run access token: ${msg}.`,
+            remediation: 'Verify the service-account key in ~/.canonry/config.yaml is unexpired and well-formed. Re-connect the source if needed.',
+          }
+        }
+      },
+      // Cloud Run scopes are implicit in the service-account key — Cloud
+      // Logging viewer is the only required scope today, and it's enforced
+      // at the IAM layer rather than baked into the token. We surface a
+      // skipped result so the framework is uniform without producing a
+      // false signal.
+      validateScopes: () => null,
+    }
+  }
+  return Object.keys(validators).length > 0 ? validators : undefined
+}

--- a/packages/api-routes/src/traffic.ts
+++ b/packages/api-routes/src/traffic.ts
@@ -117,7 +117,7 @@ function rowToDto(row: typeof trafficSources.$inferSelect): TrafficSourceDto {
   }
 }
 
-async function defaultResolveAccessToken(record: CloudRunCredentialRecord): Promise<string> {
+export async function defaultResolveAccessToken(record: CloudRunCredentialRecord): Promise<string> {
   if (record.authMode === TrafficSourceAuthModes['service-account']) {
     if (!record.clientEmail || !record.privateKey) {
       throw validationError('Service-account credentials missing client_email or private_key')

--- a/packages/api-routes/test/doctor-traffic-source.test.ts
+++ b/packages/api-routes/test/doctor-traffic-source.test.ts
@@ -1,0 +1,308 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import crypto from 'node:crypto'
+import {
+  createClient,
+  migrate,
+  projects,
+  trafficSources,
+  crawlerEventsHourly,
+} from '@ainyc/canonry-db'
+import { TRAFFIC_SOURCE_CHECKS } from '../src/doctor/checks/traffic-source.js'
+import type { CheckOutput, DoctorContext, ProjectInfo, TrafficSourceProbe, TrafficSourceValidator } from '../src/doctor/types.js'
+
+const [
+  sourceConnectedCheck,
+  recentDataCheck,
+  credentialsCheck,
+  scopesCheck,
+] = TRAFFIC_SOURCE_CHECKS
+
+interface Harness {
+  db: ReturnType<typeof createClient>
+  tmpDir: string
+  project: ProjectInfo
+  close: () => void
+}
+
+function buildHarness(): Harness {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'doctor-traffic-test-'))
+  const db = createClient(path.join(tmpDir, 'test.db'))
+  migrate(db)
+  const projectId = crypto.randomUUID()
+  const now = new Date().toISOString()
+  db.insert(projects).values({
+    id: projectId,
+    name: 'test-project',
+    displayName: 'Test',
+    canonicalDomain: 'example.com',
+    country: 'US',
+    language: 'en',
+    queries: '[]',
+    competitors: '[]',
+    providers: '[]',
+    createdAt: now,
+    updatedAt: now,
+  } as typeof projects.$inferInsert).run()
+  return {
+    db,
+    tmpDir,
+    project: { id: projectId, name: 'test-project', canonicalDomain: 'example.com', displayName: 'Test' },
+    close: () => fs.rmSync(tmpDir, { recursive: true, force: true }),
+  }
+}
+
+function isoMinusDays(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60_000).toISOString()
+}
+
+function insertTrafficSource(
+  h: Harness,
+  args: {
+    sourceType?: string
+    status?: string
+    displayName?: string
+    lastSyncedAt?: string | null
+    lastError?: string | null
+  } = {},
+): string {
+  const id = crypto.randomUUID()
+  const now = new Date().toISOString()
+  h.db.insert(trafficSources).values({
+    id,
+    projectId: h.project.id,
+    sourceType: args.sourceType ?? 'cloud-run',
+    displayName: args.displayName ?? 'Source',
+    status: args.status ?? 'connected',
+    lastSyncedAt: args.lastSyncedAt ?? null,
+    lastCursor: null,
+    lastError: args.lastError ?? null,
+    lastEventIds: null,
+    archivedAt: args.status === 'archived' ? now : null,
+    configJson: '{}',
+    createdAt: now,
+    updatedAt: now,
+  }).run()
+  return id
+}
+
+function insertCrawlerHit(h: Harness, sourceId: string, opts: { tsHour?: string; hits?: number } = {}) {
+  h.db.insert(crawlerEventsHourly).values({
+    projectId: h.project.id,
+    sourceId,
+    tsHour: opts.tsHour ?? isoMinusDays(1),
+    botId: 'gptbot',
+    operator: 'OpenAI',
+    verificationStatus: 'verified',
+    pathNormalized: '/blog',
+    status: 200,
+    hits: opts.hits ?? 1,
+    sampledUserAgent: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  }).run()
+}
+
+function ctxFor(h: Harness, validators?: Record<string, TrafficSourceValidator>): DoctorContext {
+  return {
+    db: h.db,
+    project: h.project,
+    trafficSourceValidators: validators,
+  }
+}
+
+let h: Harness
+
+beforeEach(() => { h = buildHarness() })
+afterEach(() => { h.close() })
+
+describe('traffic.source.connected', () => {
+  it('skips when no traffic source connected', async () => {
+    const r = await sourceConnectedCheck.run(ctxFor(h))
+    expect(r.status).toBe('skipped')
+    expect(r.code).toBe('traffic.source.none')
+  })
+
+  it('returns ok when at least one source is connected', async () => {
+    insertTrafficSource(h)
+    const r = await sourceConnectedCheck.run(ctxFor(h))
+    expect(r.status).toBe('ok')
+    expect(r.code).toBe('traffic.source.connected')
+    expect(r.details?.sourceCount).toBe(1)
+  })
+
+  it('warns when one of several sources is errored', async () => {
+    insertTrafficSource(h, { displayName: 'A' })
+    insertTrafficSource(h, { displayName: 'B', status: 'error', lastError: 'auth bad' })
+    const r = await sourceConnectedCheck.run(ctxFor(h))
+    expect(r.status).toBe('warn')
+    expect(r.code).toBe('traffic.source.partially-errored')
+  })
+
+  it('fails when all sources are errored', async () => {
+    insertTrafficSource(h, { status: 'error', lastError: 'auth bad' })
+    const r = await sourceConnectedCheck.run(ctxFor(h))
+    expect(r.status).toBe('fail')
+    expect(r.code).toBe('traffic.source.all-errored')
+    expect(r.remediation).toContain('auth bad')
+  })
+
+  it('treats archived-only sources as no source', async () => {
+    insertTrafficSource(h, { status: 'archived' })
+    const r = await sourceConnectedCheck.run(ctxFor(h))
+    expect(r.status).toBe('skipped')
+    expect(r.code).toBe('traffic.source.none')
+  })
+
+  it('skips with helpful message when project context missing', async () => {
+    const ctx: DoctorContext = { db: h.db, project: null }
+    const r = await sourceConnectedCheck.run(ctx)
+    expect(r.status).toBe('skipped')
+    expect(r.code).toBe('traffic.no-project')
+  })
+})
+
+describe('traffic.source.recent-data', () => {
+  it('returns ok when crawler hits exist in the last 7 days', async () => {
+    const sourceId = insertTrafficSource(h)
+    insertCrawlerHit(h, sourceId, { tsHour: isoMinusDays(2) })
+    const r = await recentDataCheck.run(ctxFor(h))
+    expect(r.status).toBe('ok')
+    expect(r.code).toBe('traffic.recent-data.fresh')
+  })
+
+  it('warns when older data exists but recent window is empty', async () => {
+    const sourceId = insertTrafficSource(h, { lastSyncedAt: isoMinusDays(15) })
+    insertCrawlerHit(h, sourceId, { tsHour: isoMinusDays(15) })
+    const r = await recentDataCheck.run(ctxFor(h))
+    expect(r.status).toBe('warn')
+    expect(r.code).toBe('traffic.recent-data.stale')
+  })
+
+  it('fails when source connected but never produced any data', async () => {
+    insertTrafficSource(h)
+    const r = await recentDataCheck.run(ctxFor(h))
+    expect(r.status).toBe('fail')
+    expect(r.code).toBe('traffic.recent-data.empty')
+  })
+})
+
+describe('traffic.source.credentials', () => {
+  it('skips when no source connected', async () => {
+    const r = await credentialsCheck.run(ctxFor(h))
+    expect(r.status).toBe('skipped')
+    expect(r.code).toBe('traffic.credentials.no-source')
+  })
+
+  it('marks all-skipped when source has no validator registered', async () => {
+    insertTrafficSource(h, { sourceType: 'unknown-future-adapter' })
+    const r = await credentialsCheck.run(ctxFor(h, {}))
+    expect(r.status).toBe('skipped')
+    expect(r.code).toBe('traffic.credentials.all-skipped')
+  })
+
+  it('returns ok when validator confirms credentials', async () => {
+    insertTrafficSource(h)
+    const validator: TrafficSourceValidator = {
+      validateCredentials: () => ({
+        status: 'ok',
+        code: 'cloud-run.token-resolved',
+        summary: 'token ok',
+      }),
+    }
+    const r = await credentialsCheck.run(ctxFor(h, { 'cloud-run': validator }))
+    expect(r.status).toBe('ok')
+    expect(r.code).toBe('traffic.credentials.ok')
+  })
+
+  it('fails when validator returns a fail result', async () => {
+    insertTrafficSource(h, { displayName: 'Prod' })
+    const validator: TrafficSourceValidator = {
+      validateCredentials: () => ({
+        status: 'fail',
+        code: 'cloud-run.token-missing',
+        summary: 'no token',
+        remediation: 're-connect',
+      }),
+    }
+    const r = await credentialsCheck.run(ctxFor(h, { 'cloud-run': validator }))
+    expect(r.status).toBe('fail')
+    expect(r.code).toBe('traffic.credentials.failed')
+    expect(r.summary).toContain('Prod')
+  })
+
+  it('catches validator exceptions and surfaces a fail result', async () => {
+    insertTrafficSource(h)
+    const validator: TrafficSourceValidator = {
+      validateCredentials: () => { throw new Error('network down') },
+    }
+    const r = await credentialsCheck.run(ctxFor(h, { 'cloud-run': validator }))
+    expect(r.status).toBe('fail')
+    const detail = r.details as { sources: Array<{ code: string }> }
+    expect(detail.sources[0]!.code).toBe('traffic.credentials.validator-error')
+  })
+
+  it('per-source dispatches by sourceType — only the matching adapter runs', async () => {
+    insertTrafficSource(h, { sourceType: 'cloud-run', displayName: 'GCP' })
+    insertTrafficSource(h, { sourceType: 'wp-plugin', displayName: 'WP' })
+    let cloudRunCalled = 0
+    let wpCalled = 0
+    const validators = {
+      'cloud-run': {
+        validateCredentials: () => { cloudRunCalled++; return { status: 'ok' as const, code: 'cr.ok', summary: 'cr ok' } },
+      },
+      'wp-plugin': {
+        validateCredentials: () => { wpCalled++; return { status: 'ok' as const, code: 'wp.ok', summary: 'wp ok' } },
+      },
+    } satisfies Record<string, TrafficSourceValidator>
+    const r = await credentialsCheck.run(ctxFor(h, validators))
+    expect(cloudRunCalled).toBe(1)
+    expect(wpCalled).toBe(1)
+    expect(r.status).toBe('ok')
+    const detail = r.details as { sources: Array<{ sourceType: string }> }
+    expect(detail.sources.map((s) => s.sourceType).sort()).toEqual(['cloud-run', 'wp-plugin'])
+  })
+})
+
+describe('traffic.source.scopes', () => {
+  it('skips when no source connected', async () => {
+    const r = await scopesCheck.run(ctxFor(h))
+    expect(r.status).toBe('skipped')
+    expect(r.code).toBe('traffic.scopes.no-source')
+  })
+
+  it('marks unsupported when validator returns null (e.g. Cloud Run without explicit scopes)', async () => {
+    insertTrafficSource(h)
+    const validator: TrafficSourceValidator = {
+      validateScopes: () => null,
+    }
+    const r = await scopesCheck.run(ctxFor(h, { 'cloud-run': validator }))
+    // null result becomes a per-source `unsupported` skipped — overall result is all-skipped.
+    expect(r.status).toBe('skipped')
+    expect(r.code).toBe('traffic.scopes.all-skipped')
+    const detail = r.details as { sources: Array<{ code: string }> }
+    expect(detail.sources[0]!.code).toBe('traffic.scopes.unsupported')
+  })
+})
+
+describe('check definitions', () => {
+  it('exports four checks at well-known IDs', () => {
+    const ids = TRAFFIC_SOURCE_CHECKS.map((c) => c.id)
+    expect(ids).toEqual([
+      'traffic.source.connected',
+      'traffic.source.recent-data',
+      'traffic.source.credentials',
+      'traffic.source.scopes',
+    ])
+  })
+
+  it('all are project-scoped', () => {
+    for (const c of TRAFFIC_SOURCE_CHECKS) expect(c.scope).toBe('project')
+  })
+})
+
+// Suppress unused-warnings by referencing the type used in the validator factories.
+export type _Suppress = TrafficSourceProbe extends infer T ? T : never
+export type _CheckOutput = CheckOutput

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.16.0",
+  "version": "4.16.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Summary

Adds four doctor checks at the `traffic.source.*` namespace that validate the server-side traffic ingestion pipeline. **Designed adapter-agnostic from day one** — today's only adapter is Cloud Run; tomorrow's WordPress plugin (and any other source type) inherits every check below by registering a `TrafficSourceValidator` under its own `sourceType` key. No doctor-side changes needed when a new adapter ships.

**Stacks on #446** — set base to `arberx/traffic-into-report` so the diff focuses on doctor work. Will auto-retarget after #446 lands.

## Checks

| ID | Category | What it does |
|---|---|---|
| `traffic.source.connected` | integrations | At least one non-archived source exists; `warn` when partial errors, `fail` when all errored, `skip` when none |
| `traffic.source.recent-data` | integrations | Crawler / AI-referral events in last 7d (`ok`); older data only → `warn`; empty 30d → `fail` |
| `traffic.source.credentials` | auth | Per-source-type credential validation via injected validator |
| `traffic.source.scopes` | auth | Per-source-type scope validation; validator returning `null` becomes a clear `unsupported` skip |

## Adapter dispatch — the load-bearing piece

```ts
DoctorContext.trafficSourceValidators: Record<sourceType, TrafficSourceValidator>
```

The generic checks load probes from `traffic_sources` (project-scoped), group by `sourceType`, dispatch each to the matching validator, and aggregate per-source results into a single `CheckOutput`.

Three behavioural guarantees:
- **No validator registered for a source's `sourceType`** → per-source `traffic.<id>.no-validator` skip (never a false fail).
- **Validator throws** → per-source `traffic.<id>.validator-error` fail with the exception message.
- **Validator returns null** → per-source `traffic.<id>.unsupported` skip (used by Cloud Run for `validateScopes` since Cloud Run scopes are IAM-side, not token-side).

## Cloud Run validator (today's only adapter)

`buildTrafficSourceValidators(opts)` in `packages/api-routes/src/index.ts` wires `'cloud-run'` from the existing `cloudRunCredentialStore` + `resolveCloudRunAccessToken`. `validateCredentials` looks up the per-project record and tries to resolve an access token (reusing the exact same `defaultResolveAccessToken` that the sync path uses, now exported). `validateScopes` returns null intentionally.

## Test plan

- [x] 19 new tests (`packages/api-routes/test/doctor-traffic-source.test.ts`) covering all status × cohort cells: skip-no-source, ok, warn-partial, fail-all, archived-as-none, no-project context, stale-data, empty-data, validator dispatch, validator throws, per-source-type isolation (cloud-run + wp-plugin together), null-result handling.
- [x] `pnpm typecheck` clean.
- [x] `pnpm lint` clean.
- [x] `pnpm exec vitest run` — 2,238 / 2,238 pass.

## Docs

- Root `AGENTS.md` doctor table gains 4 new rows.
- `packages/api-routes/AGENTS.md` doctor section now explains the adapter-dispatch pattern so a new adapter author can plug in without reading code.

## Versioning

`4.16.0 → 4.16.1` (patch — additive doctor surface, no public API breakage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)