### PR TITLE
feat(telemetry): traffic.synced event + Cloud Run skill docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.18.1",
+  "version": "4.19.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -115,6 +115,8 @@ export interface ApiRoutesOptions {
   pullCloudRunEvents?: TrafficRoutesOptions['pullCloudRunEvents']
   /** Override Cloud Run access-token resolver (tests) — see `TrafficRoutesOptions` */
   resolveCloudRunAccessToken?: TrafficRoutesOptions['resolveCloudRunAccessToken']
+  /** Fired after every traffic sync (success OR failure). Used by canonry to emit `traffic.synced` telemetry. */
+  onTrafficSynced?: TrafficRoutesOptions['onTrafficSynced']
   /** Backlinks feature callbacks — see `backlinksRoutes` for details. */
   getBacklinksStatus?: BacklinksRoutesOptions['getBacklinksStatus']
   onInstallBacklinks?: BacklinksRoutesOptions['onInstallBacklinks']
@@ -276,6 +278,7 @@ export async function apiRoutes(app: FastifyInstance, opts: ApiRoutesOptions) {
       cloudRunCredentialStore: opts.cloudRunCredentialStore,
       pullCloudRunEvents: opts.pullCloudRunEvents,
       resolveCloudRunAccessToken: opts.resolveCloudRunAccessToken,
+      onTrafficSynced: opts.onTrafficSynced,
     } satisfies TrafficRoutesOptions)
     // Always mount the backlinks routes so read endpoints (summary, domains,
     // history, sync list) work off the shared DB. Action routes (install,

--- a/packages/api-routes/src/traffic.ts
+++ b/packages/api-routes/src/traffic.ts
@@ -66,6 +66,25 @@ export interface CloudRunCredentialStore {
   deleteConnection: (projectName: string) => boolean
 }
 
+export interface TrafficSyncedEvent {
+  /** 'completed' = transactional rollup write succeeded. 'failed' = pull or auth failed before any rollup writes. */
+  status: 'completed' | 'failed'
+  /** Stable enum value (e.g. 'cloud-run', 'wp-plugin'). Mirrors `traffic_sources.source_type`. */
+  sourceType: string
+  /** Source row UUID — opaque, no PII. */
+  sourceId: string
+  /** Number of normalized events processed (post-dedupe). 0 for failed syncs. */
+  pulledEvents: number
+  /** Crawler hourly bucket inserts/updates. 0 for failed syncs. */
+  crawlerHits: number
+  /** AI-referral hourly bucket inserts/updates. 0 for failed syncs. */
+  aiReferralHits: number
+  /** End-to-end duration including pull, classification, rollup write. */
+  durationMs: number
+  /** Stable error code on failure. Present only when status === 'failed'. */
+  errorCode?: 'NO_CREDENTIAL' | 'PROVIDER_AUTH' | 'PROVIDER_PULL' | 'INTERNAL'
+}
+
 export interface TrafficRoutesOptions {
   cloudRunCredentialStore?: CloudRunCredentialStore
   /** Override the Cloud Run pull function (for tests). Defaults to `listCloudRunTrafficEvents`. */
@@ -83,6 +102,8 @@ export interface TrafficRoutesOptions {
   defaultMaxPages?: number
   /** Cap on the number of raw_event_samples written per sync. */
   defaultSampleLimit?: number
+  /** Fire-and-forget hook called after every sync completes (success OR failure). Used by canonry to emit telemetry. */
+  onTrafficSynced?: (event: TrafficSyncedEvent) => void
 }
 
 const DEFAULT_SYNC_WINDOW_MINUTES = 43_200
@@ -313,6 +334,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
     )
 
     const startedAt = windowEnd.toISOString()
+    const syncStartedAtMs = windowEnd.getTime()
     const runId = crypto.randomUUID()
     app.db
       .insert(runs)
@@ -328,7 +350,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
       })
       .run()
 
-    const markFailed = (msg: string) => {
+    const markFailed = (msg: string, errorCode: TrafficSyncedEvent['errorCode']) => {
       const failedAt = new Date().toISOString()
       app.db.transaction((tx) => {
         tx
@@ -342,6 +364,21 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
           .where(eq(trafficSources.id, sourceRow.id))
           .run()
       })
+      // Fire-and-forget: never let a telemetry hook take down the sync.
+      try {
+        opts.onTrafficSynced?.({
+          status: 'failed',
+          sourceType: sourceRow.sourceType,
+          sourceId: sourceRow.id,
+          pulledEvents: 0,
+          crawlerHits: 0,
+          aiReferralHits: 0,
+          durationMs: Date.now() - syncStartedAtMs,
+          errorCode,
+        })
+      } catch {
+        // swallow — never block on telemetry
+      }
     }
 
     let accessToken: string
@@ -349,7 +386,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
       accessToken = await resolveAccessToken(credential)
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e)
-      markFailed(msg)
+      markFailed(msg, 'PROVIDER_AUTH')
       throw providerError(`Failed to resolve Cloud Run access token: ${msg}`)
     }
 
@@ -367,7 +404,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
       allEvents = page.events
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e)
-      markFailed(msg)
+      markFailed(msg, 'PROVIDER_PULL')
       throw providerError(`Cloud Run pull failed: ${msg}`)
     }
 
@@ -545,6 +582,21 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
       entityType: 'traffic_source',
       entityId: sourceRow.id,
     })
+
+    // Fire-and-forget telemetry. Never let a hook block the response.
+    try {
+      opts.onTrafficSynced?.({
+        status: 'completed',
+        sourceType: sourceRow.sourceType,
+        sourceId: sourceRow.id,
+        pulledEvents: report.totals.normalizedEvents,
+        crawlerHits: report.totals.crawlerHits,
+        aiReferralHits: report.totals.aiReferralHits,
+        durationMs: Date.now() - syncStartedAtMs,
+      })
+    } catch {
+      // swallow — never block on telemetry
+    }
 
     const response: TrafficSyncResponse = {
       sourceId: sourceRow.id,

--- a/packages/api-routes/test/traffic.test.ts
+++ b/packages/api-routes/test/traffic.test.ts
@@ -52,8 +52,15 @@ function buildEvent(overrides: Partial<NormalizedTrafficRequest> = {}): Normaliz
 
 async function buildHarness(
   events: NormalizedTrafficRequest[],
-  options: { bypassTimeFilter?: boolean } = {},
+  options: {
+    bypassTimeFilter?: boolean
+    /** Force the access-token resolver to fail with this message. */
+    failResolveAccessTokenWith?: string
+    /** Force the Cloud Run pull to fail with this message. */
+    failPullWith?: string
+  } = {},
 ) {
+  const trafficSyncedEvents: Array<unknown> = []
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'traffic-routes-test-'))
   const dbPath = path.join(tmpDir, 'test.db')
   const db = createClient(dbPath)
@@ -79,6 +86,7 @@ async function buildHarness(
     pullCloudRunEvents: async (_token, pullOptions): Promise<CloudRunTrafficEventsPage> => {
       pullInvocations += 1
       observedWindows.push({ startTime: pullOptions.startTime, endTime: pullOptions.endTime })
+      if (options.failPullWith) throw new Error(options.failPullWith)
       // Default: mirror Cloud Logging's behavior and only return events inside the
       // requested window. Tests that exercise cross-sync boundary semantics
       // (where Cloud Logging may legitimately re-return the same event in two
@@ -98,7 +106,11 @@ async function buildHarness(
         filter: 'mock',
       }
     },
-    resolveCloudRunAccessToken: async () => 'mock-access-token',
+    resolveCloudRunAccessToken: async () => {
+      if (options.failResolveAccessTokenWith) throw new Error(options.failResolveAccessTokenWith)
+      return 'mock-access-token'
+    },
+    onTrafficSynced: (event) => { trafficSyncedEvents.push(event) },
   })
   await app.ready()
 
@@ -121,6 +133,7 @@ async function buildHarness(
     tmpDir,
     getPullCount: () => pullInvocations,
     getObservedWindows: () => observedWindows,
+    getTrafficSyncedEvents: () => trafficSyncedEvents,
     close: async () => {
       await app.close()
       fs.rmSync(tmpDir, { recursive: true, force: true })
@@ -624,6 +637,102 @@ describe('POST /traffic/sources/:id/sync', () => {
 
     await app.close()
     fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('fires onTrafficSynced with status=completed and aggregated counts on success', async () => {
+    const observedAt = new Date(Date.now() - 30 * 60_000).toISOString()
+    const events: NormalizedTrafficRequest[] = [
+      buildEvent({ userAgent: 'GPTBot/1.0', path: '/blog/foo', status: 200, observedAt }),
+      buildEvent({ userAgent: 'GPTBot/1.0', path: '/blog/bar', status: 200, observedAt, eventId: 'evt-2' }),
+    ]
+    const h = await buildHarness(events)
+    try {
+      const connectRes = await h.app.inject({
+        method: 'POST',
+        url: '/api/v1/projects/test-project/traffic/connect/cloud-run',
+        payload: { gcpProjectId: 'openclaw-nyc', keyJson: SA_KEY },
+      })
+      const sourceId = JSON.parse(connectRes.payload).id
+
+      const syncRes = await h.app.inject({
+        method: 'POST',
+        url: `/api/v1/projects/test-project/traffic/sources/${sourceId}/sync`,
+        payload: {},
+      })
+      expect(syncRes.statusCode).toBe(200)
+
+      const fired = h.getTrafficSyncedEvents()
+      expect(fired.length).toBe(1)
+      const ev = fired[0] as {
+        status: string; sourceType: string; sourceId: string
+        pulledEvents: number; crawlerHits: number; aiReferralHits: number
+        durationMs: number; errorCode?: string
+      }
+      expect(ev.status).toBe('completed')
+      expect(ev.sourceType).toBe('cloud-run')
+      expect(ev.sourceId).toBe(sourceId)
+      expect(ev.pulledEvents).toBe(2)
+      expect(ev.crawlerHits).toBeGreaterThanOrEqual(2)
+      expect(ev.aiReferralHits).toBe(0)
+      expect(ev.durationMs).toBeGreaterThanOrEqual(0)
+      expect(ev.errorCode).toBeUndefined()
+    } finally {
+      await h.close()
+    }
+  })
+
+  it('fires onTrafficSynced with status=failed and errorCode=PROVIDER_AUTH when token resolution fails', async () => {
+    const h = await buildHarness([], { failResolveAccessTokenWith: 'invalid_grant' })
+    try {
+      const connectRes = await h.app.inject({
+        method: 'POST',
+        url: '/api/v1/projects/test-project/traffic/connect/cloud-run',
+        payload: { gcpProjectId: 'openclaw-nyc', keyJson: SA_KEY },
+      })
+      const sourceId = JSON.parse(connectRes.payload).id
+
+      const syncRes = await h.app.inject({
+        method: 'POST',
+        url: `/api/v1/projects/test-project/traffic/sources/${sourceId}/sync`,
+        payload: {},
+      })
+      expect(syncRes.statusCode).toBe(502)
+
+      const fired = h.getTrafficSyncedEvents()
+      expect(fired.length).toBe(1)
+      const ev = fired[0] as {
+        status: string; pulledEvents: number; errorCode?: string
+      }
+      expect(ev.status).toBe('failed')
+      expect(ev.errorCode).toBe('PROVIDER_AUTH')
+      expect(ev.pulledEvents).toBe(0)
+    } finally {
+      await h.close()
+    }
+  })
+
+  it('fires onTrafficSynced with errorCode=PROVIDER_PULL when the pull throws', async () => {
+    const h = await buildHarness([], { failPullWith: 'Cloud Logging 503 backend unavailable' })
+    try {
+      const connectRes = await h.app.inject({
+        method: 'POST',
+        url: '/api/v1/projects/test-project/traffic/connect/cloud-run',
+        payload: { gcpProjectId: 'openclaw-nyc', keyJson: SA_KEY },
+      })
+      const sourceId = JSON.parse(connectRes.payload).id
+      const syncRes = await h.app.inject({
+        method: 'POST',
+        url: `/api/v1/projects/test-project/traffic/sources/${sourceId}/sync`,
+        payload: {},
+      })
+      expect(syncRes.statusCode).toBe(502)
+
+      const fired = h.getTrafficSyncedEvents()
+      expect(fired.length).toBe(1)
+      expect((fired[0] as { errorCode: string }).errorCode).toBe('PROVIDER_PULL')
+    } finally {
+      await h.close()
+    }
   })
 })
 

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.18.1",
+  "version": "4.19.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -46,7 +46,7 @@ import {
   removeWordpressConnection,
   upsertWordpressConnection,
 } from './wordpress-config.js'
-import { isTelemetryEnabled, getOrCreateAnonymousId } from './telemetry.js'
+import { isTelemetryEnabled, getOrCreateAnonymousId, trackEvent } from './telemetry.js'
 import { JobRunner } from './job-runner.js'
 import { executeGscSync } from './gsc-sync.js'
 import { executeInspectSitemap } from './gsc-inspect-sitemap.js'
@@ -965,6 +965,21 @@ export async function createServer(opts: {
     wordpressConnectionStore,
     ga4CredentialStore,
     cloudRunCredentialStore,
+    onTrafficSynced: (event) => {
+      // Emit anonymous canonry telemetry for every sync (success + fail).
+      // Same envelope shape as run.completed (top-level `errorCode` on
+      // failure, payload in `properties`). Counts are aggregate, sourceId
+      // is an opaque UUID — no PII surface.
+      trackEvent('traffic.synced', {
+        status: event.status,
+        sourceType: event.sourceType,
+        sourceId: event.sourceId,
+        pulledEvents: event.pulledEvents,
+        crawlerHits: event.crawlerHits,
+        aiReferralHits: event.aiReferralHits,
+        durationMs: event.durationMs,
+      }, event.errorCode ? { errorCode: event.errorCode } : undefined)
+    },
     onRunCreated: (runId: string, projectId: string, providers?: string[], location?: import('@ainyc/canonry-contracts').LocationContext | null) => {
       // Fire and forget — run executes in background
       jobRunner.executeRun(runId, projectId, providers, location).catch((err: unknown) => {

--- a/skills/canonry-setup/SKILL.md
+++ b/skills/canonry-setup/SKILL.md
@@ -88,6 +88,7 @@ GA4 is a first-class signal alongside citation tracking. Connect once with `cano
 | `references/aeo-analysis.md` | Interpreting sweep output, diagnosing regressions, planning content fixes |
 | `references/indexing.md` | Submitting URLs, checking GSC/Bing coverage, fixing indexing gaps |
 | `references/wordpress-integration.md` | Connecting to WordPress, editing pages, pushing staging → live |
+| `references/server-side-traffic.md` | Wiring server-log evidence (Cloud Run today; WordPress / others later) for AI Visibility — Server-Side. Connect, sync, manage sources, troubleshoot. |
 
 ---
 

--- a/skills/canonry-setup/references/server-side-traffic.md
+++ b/skills/canonry-setup/references/server-side-traffic.md
@@ -1,0 +1,167 @@
+# Server-side traffic (AI Visibility — Server-Side)
+
+Server-side traffic ingestion captures **what AI engines actually do in
+your server logs** — bots crawling pages, AI products sending
+click-through arrivals — in addition to the citation data that measures
+**what models say** about you. The two surfaces are independent.
+
+## When to use it
+
+Reach for server-side traffic when an analyst or operator asks:
+
+- *"Is GPTBot / ClaudeBot / PerplexityBot actually fetching my pages?"*
+- *"Which paths are AI engines paying attention to?"*
+- *"Are users clicking through from chatgpt.com / claude.ai / etc.?"*
+- *"My citation rate is fine but there's no traffic — why?"*
+
+GA4 referrals (chatgpt.com → your site) catch click-throughs after they
+land. Server logs catch the upstream bot activity AND referrals at the
+edge — including arrivals GA4 missed because of cookie consent, ad
+blockers, or analytics gaps.
+
+## Architecture
+
+Two tables, populated from server-log adapters:
+
+| Table | What's in it |
+|---|---|
+| `crawler_events_hourly` | One row per `(project, source, hour, bot, verification, path, status)` — bot crawls rolled up by hour |
+| `ai_referral_events_hourly` | One row per `(project, source, hour, product, source_domain, evidence_type, landing_path, status)` — click-through arrivals rolled up by hour |
+| `raw_event_samples` | Bounded forensic samples (≤100 per sync) for spot-checking |
+
+Each `traffic_sources` row is one server-log integration for a project.
+Today's only adapter is `cloud-run`; future adapters slot in by
+implementing the same contract.
+
+## Connecting a Cloud Run source
+
+```bash
+# 1. Create a service account in the Cloud project that hosts the Cloud Run
+#    service. Grant it `roles/logging.viewer`. Download the JSON key.
+
+# 2. Connect from canonry CLI:
+canonry traffic connect cloud-run <project> \
+  --gcp-project <gcp-project-id> \
+  --service-account-key <path/to/key.json>
+
+# 3. (Optional) narrow to a specific service or location:
+canonry traffic connect cloud-run <project> \
+  --gcp-project <id> \
+  --service-account-key <path> \
+  --service my-service-name \
+  --location us-east1
+```
+
+Credentials are stored in `~/.canonry/config.yaml` (not the DB). The
+canonical key lives only on the host that runs `canonry serve`. The
+sync flow does NOT echo the private key back in any response.
+
+## Syncing data
+
+```bash
+# Manual sync — defaults to a 30-day lookback on the first run; subsequent
+# runs are clamped forward to lastSyncedAt to avoid re-pulling.
+canonry traffic sync <project> --source <id>
+
+# Override the lookback window (minutes):
+canonry traffic sync <project> --source <id> --since-minutes 4320  # 3 days
+```
+
+Cross-sync dedupe via the `last_event_ids` ring buffer means re-running a
+sync over an overlapping window cannot double-count rolled-up hourly
+hits. Safe to schedule (see "Scheduling" below) or trigger from CI.
+
+## Inspecting source state
+
+```bash
+# All sources with last-24h totals + latest sync run (single-call):
+canonry traffic status <project> --format json
+
+# Just the source list:
+canonry traffic sources <project> --format json
+
+# Windowed events (defaults to last 24h):
+canonry traffic events <project> --kind crawler --limit 200 --format json
+canonry traffic events <project> --kind ai-referral --since 2026-04-01 --until 2026-04-30
+```
+
+The `traffic status` composite returns the same per-source detail
+(24h crawler hits, AI-referral arrivals, raw-event-sample count, latest
+sync-run summary) whether you reach it via the CLI, the API, or the
+MCP `canonry_traffic_status` tool.
+
+## Where the data shows up
+
+| Surface | What's rendered |
+|---|---|
+| Project dashboard `/projects/:name/activity` | Live source table + 24h totals + GA4 referrals (combined view) |
+| Top-level `/traffic` route | Cross-project source admin (connect, sync, archive) |
+| `canonry report <project>` (HTML + SPA) | "AI Visibility — Server-Side" section, ranked above Indexing Health |
+| `canonry doctor --project <name>` | `traffic.source.connected`, `recent-data`, `credentials`, `scopes` checks |
+| MCP toolkit `traffic` | Tools: `canonry_traffic_status`, `_sources_list`, `_source_get`, `_events`, `_connect_cloud_run`, `_sync` |
+
+## Doctor signals
+
+The doctor checks are adapter-agnostic. When they fail or warn:
+
+| Check | Code | What to do |
+|---|---|---|
+| `traffic.source.connected` | `traffic.source.none` | No source — `canonry traffic connect cloud-run …` |
+| `traffic.source.connected` | `traffic.source.all-errored` | Re-connect the source. The check's `details.lastError` shows the underlying reason. |
+| `traffic.source.recent-data` | `traffic.recent-data.stale` | Last sync was >7d ago. Run `canonry traffic sync …` or schedule a recurring sync. |
+| `traffic.source.recent-data` | `traffic.recent-data.empty` | Source connected but no data in 30d. Verify config and credentials with `canonry traffic sources <project>`. |
+| `traffic.source.credentials` | `traffic.credentials.resolve-failed` | Service-account key in `~/.canonry/config.yaml` is invalid or expired. Re-connect. |
+
+## Scheduling
+
+`canonry schedule` supports `--kind traffic-sync`. Recurring syncs are
+safe because of the `last_event_ids` cross-sync dedupe ring buffer
+described above. Recommended cadence:
+
+| Cadence | Use case |
+|---|---|
+| `0 */6 * * *` (every 6h) | Production agencies tracking active client sites |
+| `0 0 * * *` (daily) | Lower-traffic sites or local dev |
+| Manual only | First few weeks while validating data |
+
+## Telemetry
+
+Every successful or failed sync emits a `traffic.synced` event to the
+canonry telemetry pipeline:
+
+```jsonc
+{
+  "event": "traffic.synced",
+  "errorCode": "PROVIDER_AUTH",       // present only when status='failed'
+  "properties": {
+    "status": "completed" | "failed",
+    "sourceType": "cloud-run",        // adapter type
+    "sourceId": "<uuid>",             // opaque
+    "pulledEvents": 234,
+    "crawlerHits": 200,
+    "aiReferralHits": 12,
+    "durationMs": 4150
+  }
+}
+```
+
+Counts are aggregate. The sourceId is an opaque UUID. No raw paths,
+domains, or PII are surfaced.
+
+## Limits & caveats
+
+- **Path-level citation cross-reference is not implemented yet.** The
+  citation store is domain-grain (`query_snapshots.cited_domains`). A
+  future iteration that lands URL-grain citation evidence will extend
+  the `topCrawledPaths` entry with a `citationState` flag. Until then,
+  treat the report's crawled-paths table as "engine attention" — the
+  signal is the bot fetched it, not whether it was cited.
+- **Verified vs unverified.** The headline numbers count only
+  rDNS-verified hits. Unverified bots claim a known UA but couldn't be
+  cross-confirmed via reverse-DNS — they may be the real bot or an
+  imitator. Don't promote unverified counts in client-facing copy.
+- **Cloud Run only in v1.** WordPress plugin and other adapters are
+  planned. The doctor checks and the report renderer are already
+  adapter-agnostic — adding a new adapter is just a new entry in
+  `traffic_sources.source_type` and a `TrafficSourceValidator`
+  registration.


### PR DESCRIPTION
## Summary

Closes the two loose ends called out by the integration assessment:

1. **`traffic.synced` telemetry event** — emit from every sync (success + failure) so the data team can monitor sync volume, failure rates, and durations.
2. **Cloud Run skill reference doc** — `skills/canonry-setup/references/server-side-traffic.md` so external agents can wire the flow without reading the source.

## Telemetry wiring

- `TrafficRoutesOptions` gains `onTrafficSynced(event: TrafficSyncedEvent) => void`. Plumbed through `ApiRoutesOptions` to the canonry server.
- The sync handler fires it from two sites: after the post-write transaction commits (success), and from a new `markFailed(msg, errorCode)` helper (failure paths). Both wrapped in `try/catch` — a misbehaving telemetry hook can never block the sync.
- `packages/canonry/src/server.ts` calls `trackEvent('traffic.synced', { ... }, { errorCode })` from the callback.

### Event shape

| Field | Where | Notes |
|---|---|---|
| `status` | properties | `'completed'` or `'failed'` |
| `sourceType` | properties | Adapter type (e.g. `'cloud-run'`); future-proof for WP/others |
| `sourceId` | properties | Opaque UUID — no PII |
| `pulledEvents` | properties | Post-dedupe count (0 for failed syncs) |
| `crawlerHits` | properties | Aggregate count |
| `aiReferralHits` | properties | Aggregate count |
| `durationMs` | properties | End-to-end duration |
| `errorCode` | **top-level** | One of `NO_CREDENTIAL`, `PROVIDER_AUTH`, `PROVIDER_PULL`, `INTERNAL` — same shape as v3 envelope |

### Receiver follow-up

The ainyc.ai receiver schema currently allows: `cli.command`, `cli.init`, `cli.upgraded`, `run.aborted`, `run.completed`, `serve.started`. **A small follow-up PR in `AINYC/ainyc` will add `traffic.synced`** to `ALLOWED_EVENTS` in `lib/telemetry/validation.ts` — same pattern as the v3 envelope migration in #117.

## Skill docs

New `skills/canonry-setup/references/server-side-traffic.md` covers:

- Architecture (3 rollup tables + `traffic_sources`)
- Cloud Run connect/sync/inspect commands with `--format json` examples
- Where the data surfaces: dashboard `/projects/:name/activity`, top-level `/traffic` admin, project report's "AI Visibility — Server-Side" section, `canonry doctor`, MCP toolkit
- Doctor signal interpretation table (check ID + remediation)
- Scheduling cadences (safe under the cross-sync dedupe ring buffer)
- Telemetry envelope reference
- Limits & caveats (no path-level citation cross-ref yet; verified vs unverified; Cloud Run only in v1)

`skills/canonry-setup/SKILL.md` references TOC gets the new doc.

## Tests

3 new `traffic.test.ts` cases:
- Success path → fires `status='completed'` with aggregated counts and no `errorCode`
- Token-resolve failure → fires `status='failed'`, `errorCode='PROVIDER_AUTH'`
- Pull failure → fires `status='failed'`, `errorCode='PROVIDER_PULL'`

`buildHarness` optionally captures `onTrafficSynced` events and optionally fails the resolver / pull. Existing 32 tests unchanged.

All 2,213 workspace tests pass. typecheck + lint clean.

## Versioning

`4.18.1 → 4.19.0` (minor — adds a public `traffic.synced` telemetry event and `onTrafficSynced` route option).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
