### PR TITLE
docs(readme): mention server-side traffic feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@
 **Agent-first AEO operating platform. Open source. Self-hosted.**
 
 - Track citations across Gemini, ChatGPT, Claude, Perplexity, and local LLMs
+- Watch AI engines crawl and refer traffic via [server-log ingestion](skills/canonry-setup/references/server-side-traffic.md) — Cloud Run today, more sources coming
 - Diagnose against real traffic with built-in [GSC](docs/google-search-console-setup.md), [GA4](docs/google-analytics-setup.md), and [Bing Webmaster](docs/bing-webmaster-setup.md)
 - Execute fixes via [WordPress](docs/wordpress-setup.md), JSON-LD schema, and indexing submissions
 - Manage many clients declaratively — config-as-code YAML + `canonry apply`
-- Schedule recurring visibility checks with webhook alerts on regressions
+- Schedule recurring visibility checks AND traffic syncs, with webhook alerts on regressions
 - Generate client-ready HTML reports — `canonry report <project>`
 - Drive from your own agent via the [67-tool MCP adapter](docs/mcp.md) or webhooks
 - Or use **Aero** — Canonry's built-in agent that wakes up after every run
@@ -65,7 +66,7 @@ Configure during `canonry init`, in the dashboard `/settings`, or as env vars.
 | **Architecture & data model** | [docs/architecture.md](docs/architecture.md) · [docs/data-model.md](docs/data-model.md) |
 | **Aero — built-in agent** | [skills/aero/SKILL.md](skills/aero/SKILL.md) |
 | **MCP — Claude Desktop / Cursor / Codex** | [docs/mcp.md](docs/mcp.md) |
-| **Integrations** | [GSC](docs/google-search-console-setup.md) · [GA4](docs/google-analytics-setup.md) · [Bing](docs/bing-webmaster-setup.md) · [WordPress](docs/wordpress-setup.md) |
+| **Integrations** | [GSC](docs/google-search-console-setup.md) · [GA4](docs/google-analytics-setup.md) · [Bing](docs/bing-webmaster-setup.md) · [WordPress](docs/wordpress-setup.md) · [Server-side traffic (Cloud Run logs)](skills/canonry-setup/references/server-side-traffic.md) |
 | **Deployment** — Docker, Railway, Render, systemd, Tailscale | [docs/deployment.md](docs/deployment.md) |
 | **API** — 118+ endpoints | `GET /api/v1/openapi.json` (no auth) |
 | **Skills bundle** for Claude Code / Codex | `canonry skills install` ([details](skills/canonry-setup/SKILL.md)) |


### PR DESCRIPTION
## Summary

Two thin updates to the top-of-README bullets and the Documentation index after #444–#449 land:

- **New bullet** — "Watch AI engines crawl and refer traffic via server-log ingestion — Cloud Run today, more sources coming." Links to the skill reference doc that covers the full flow (architecture, connect, sync, doctor signals, scheduling, telemetry, caveats).
- **Schedule bullet** expanded — now reads "Schedule recurring visibility checks AND traffic syncs, with webhook alerts on regressions" to reflect the kind dimension added in #449.
- **Documentation index** — server-side-traffic added to the Integrations row alongside GSC / GA4 / Bing / WordPress.

No version bump (docs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)