### PR TITLE
feat(web): clickable chart bars + identity/operator/path filters

### DIFF
--- a/apps/web/src/lib/traffic-event-filter.ts
+++ b/apps/web/src/lib/traffic-event-filter.ts
@@ -1,0 +1,42 @@
+import { TrafficEventKinds, type TrafficEventEntry } from '@ainyc/canonry-contracts'
+
+export type EventGranularity = 'hour' | 'day'
+
+export interface TrafficEventFilters {
+  selectedBucket: string | null
+  identity: string
+  operator: string
+  pathQuery: string
+}
+
+export function identityOf(event: TrafficEventEntry): string {
+  return event.kind === TrafficEventKinds.crawler ? event.botId : event.product
+}
+
+export function pathOf(event: TrafficEventEntry): string {
+  return event.kind === TrafficEventKinds.crawler ? event.pathNormalized : event.landingPathNormalized
+}
+
+export function bucketKeyFor(tsHour: string, granularity: EventGranularity): string {
+  if (granularity === 'hour') return tsHour
+  const d = new Date(tsHour)
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+export function filterTrafficEvents(
+  events: readonly TrafficEventEntry[],
+  filters: TrafficEventFilters,
+  granularity: EventGranularity,
+): TrafficEventEntry[] {
+  const needle = filters.pathQuery.trim().toLowerCase()
+  return events.filter((event) => {
+    if (filters.selectedBucket && bucketKeyFor(event.tsHour, granularity) !== filters.selectedBucket) return false
+    if (filters.identity && identityOf(event) !== filters.identity) return false
+    if (filters.operator && event.operator !== filters.operator) return false
+    if (needle && !pathOf(event).toLowerCase().includes(needle)) return false
+    return true
+  })
+}

--- a/apps/web/src/pages/TrafficSourceDetailPage.tsx
+++ b/apps/web/src/pages/TrafficSourceDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react'
 import { Link, useParams } from '@tanstack/react-router'
-import { ArrowLeft, RefreshCw } from 'lucide-react'
+import { ArrowLeft, RefreshCw, X } from 'lucide-react'
 
 import { TrafficEventKinds, type TrafficEventEntry } from '@ainyc/canonry-contracts'
 
@@ -13,6 +13,7 @@ import {
   Bar,
   BarChart,
   CartesianGrid,
+  Cell,
   CHART_AXIS_STROKE,
   CHART_AXIS_TICK,
   CHART_GRID_STROKE,
@@ -29,9 +30,15 @@ import {
   useServerTrafficSource,
   useSyncServerTrafficSource,
 } from '../queries/server-traffic.js'
+import {
+  bucketKeyFor,
+  filterTrafficEvents,
+  identityOf,
+  type EventGranularity,
+} from '../lib/traffic-event-filter.js'
 
 type SeriesKind = 'crawler' | 'ai-referral'
-type Granularity = 'hour' | 'day'
+type Granularity = EventGranularity
 
 interface WindowOption {
   value: number
@@ -84,6 +91,10 @@ export function TrafficSourceDetailPage() {
   const [visibleSeries, setVisibleSeries] = useState<Set<SeriesKind>>(
     () => new Set<SeriesKind>(['crawler', 'ai-referral']),
   )
+  const [selectedBucket, setSelectedBucket] = useState<string | null>(null)
+  const [identityFilter, setIdentityFilter] = useState<string>('')
+  const [operatorFilter, setOperatorFilter] = useState<string>('')
+  const [pathFilter, setPathFilter] = useState<string>('')
   const [syncError, setSyncError] = useState<string | null>(null)
   const [syncResult, setSyncResult] = useState<string | null>(null)
 
@@ -115,6 +126,40 @@ export function TrafficSourceDetailPage() {
     [allEvents, visibleSeries],
   )
 
+  const identityOptions = useMemo(() => {
+    const set = new Set<string>()
+    for (const e of allEvents) set.add(identityOf(e))
+    if (identityFilter) set.add(identityFilter)
+    return [...set].sort((a, b) => a.localeCompare(b))
+  }, [allEvents, identityFilter])
+
+  const operatorOptions = useMemo(() => {
+    const set = new Set<string>()
+    for (const e of allEvents) set.add(e.operator)
+    if (operatorFilter) set.add(operatorFilter)
+    return [...set].sort((a, b) => a.localeCompare(b))
+  }, [allEvents, operatorFilter])
+
+  const filteredEvents = useMemo(
+    () =>
+      filterTrafficEvents(
+        visibleEvents,
+        {
+          selectedBucket,
+          identity: identityFilter,
+          operator: operatorFilter,
+          pathQuery: pathFilter,
+        },
+        activeWindow.granularity,
+      ),
+    [visibleEvents, selectedBucket, identityFilter, operatorFilter, pathFilter, activeWindow.granularity],
+  )
+
+  const selectedBucketLabel = useMemo(
+    () => (selectedBucket ? bucketLabelFor(selectedBucket, activeWindow.granularity) : null),
+    [selectedBucket, activeWindow.granularity],
+  )
+
   const chartData = useMemo(
     () => buildChartData(allEvents, activeWindow.granularity, eventsQuery.data?.windowStart, eventsQuery.data?.windowEnd),
     [allEvents, activeWindow.granularity, eventsQuery.data?.windowStart, eventsQuery.data?.windowEnd],
@@ -131,6 +176,25 @@ export function TrafficSourceDetailPage() {
       return next
     })
   }
+
+  const handleChartClick = (state: unknown) => {
+    const payload =
+      state && typeof state === 'object' && 'activePayload' in state
+        ? (state as { activePayload?: Array<{ payload?: ChartRow }> }).activePayload
+        : undefined
+    const bucket = payload?.[0]?.payload?.bucket
+    if (!bucket) return
+    setSelectedBucket((prev) => (prev === bucket ? null : bucket))
+  }
+
+  const clearAllFilters = () => {
+    setSelectedBucket(null)
+    setIdentityFilter('')
+    setOperatorFilter('')
+    setPathFilter('')
+  }
+
+  const hasRowFilter = Boolean(selectedBucket || identityFilter || operatorFilter || pathFilter.trim())
 
   const handleSync = async () => {
     setSyncError(null)
@@ -282,7 +346,10 @@ export function TrafficSourceDetailPage() {
                 type="button"
                 className={`filter-chip ${windowMinutes === opt.value ? 'filter-chip-active' : ''}`}
                 aria-pressed={windowMinutes === opt.value}
-                onClick={() => setWindowMinutes(opt.value)}
+                onClick={() => {
+                  setWindowMinutes(opt.value)
+                  setSelectedBucket(null)
+                }}
               >
                 {opt.label}
               </button>
@@ -312,7 +379,12 @@ export function TrafficSourceDetailPage() {
           ) : (
             <div className="h-72">
               <ResponsiveContainer>
-                <BarChart data={chartData} margin={{ top: 4, right: 4, bottom: 0, left: 0 }}>
+                <BarChart
+                  data={chartData}
+                  margin={{ top: 4, right: 4, bottom: 0, left: 0 }}
+                  onClick={handleChartClick}
+                  style={{ cursor: 'pointer' }}
+                >
                   <CartesianGrid stroke={CHART_GRID_STROKE} strokeDasharray="3 3" />
                   <XAxis
                     dataKey="label"
@@ -324,10 +396,24 @@ export function TrafficSourceDetailPage() {
                   <YAxis tick={CHART_AXIS_TICK} stroke={CHART_AXIS_STROKE} allowDecimals={false} />
                   <RechartsTooltip {...CHART_TOOLTIP_STYLE} />
                   {visibleSeries.has('crawler') ? (
-                    <Bar dataKey="crawler" name="Crawler" fill={CRAWLER_COLOR} stackId="a" />
+                    <Bar dataKey="crawler" name="Crawler" fill={CRAWLER_COLOR} stackId="a">
+                      {chartData.map((row) => (
+                        <Cell
+                          key={row.bucket}
+                          fillOpacity={selectedBucket && selectedBucket !== row.bucket ? 0.25 : 1}
+                        />
+                      ))}
+                    </Bar>
                   ) : null}
                   {visibleSeries.has('ai-referral') ? (
-                    <Bar dataKey="aiReferral" name="AI referral" fill={AI_REFERRAL_COLOR} stackId="a" />
+                    <Bar dataKey="aiReferral" name="AI referral" fill={AI_REFERRAL_COLOR} stackId="a">
+                      {chartData.map((row) => (
+                        <Cell
+                          key={row.bucket}
+                          fillOpacity={selectedBucket && selectedBucket !== row.bucket ? 0.25 : 1}
+                        />
+                      ))}
+                    </Bar>
                   ) : null}
                 </BarChart>
               </ResponsiveContainer>
@@ -337,8 +423,77 @@ export function TrafficSourceDetailPage() {
       </section>
 
       <section>
-        <p className="mb-4 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">Event rows</p>
-        <EventsTable events={visibleEvents} />
+        <div className="mb-4 flex flex-wrap items-end justify-between gap-x-4 gap-y-2">
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500">Event rows</p>
+            <p className="mt-1 text-xs text-zinc-500">
+              Showing <span className="tabular-nums text-zinc-300">{filteredEvents.length.toLocaleString('en-US')}</span> of{' '}
+              <span className="tabular-nums text-zinc-500">{visibleEvents.length.toLocaleString('en-US')}</span> events
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <select
+              aria-label="Filter by identity"
+              value={identityFilter}
+              onChange={(e) => setIdentityFilter(e.target.value)}
+              className="rounded-md border border-zinc-800 bg-zinc-950 px-2.5 py-1.5 text-xs text-zinc-200 focus:outline-none focus-visible:ring-1 focus-visible:ring-zinc-600"
+            >
+              <option value="">All identities</option>
+              {identityOptions.map((opt) => (
+                <option key={opt} value={opt}>
+                  {opt}
+                </option>
+              ))}
+            </select>
+            <select
+              aria-label="Filter by operator"
+              value={operatorFilter}
+              onChange={(e) => setOperatorFilter(e.target.value)}
+              className="rounded-md border border-zinc-800 bg-zinc-950 px-2.5 py-1.5 text-xs text-zinc-200 focus:outline-none focus-visible:ring-1 focus-visible:ring-zinc-600"
+            >
+              <option value="">All operators</option>
+              {operatorOptions.map((opt) => (
+                <option key={opt} value={opt}>
+                  {opt}
+                </option>
+              ))}
+            </select>
+            <input
+              type="search"
+              aria-label="Filter by path"
+              placeholder="path contains…"
+              value={pathFilter}
+              onChange={(e) => setPathFilter(e.target.value)}
+              className="w-44 rounded-md border border-zinc-800 bg-zinc-950 px-2.5 py-1.5 text-xs text-zinc-200 placeholder:text-zinc-600 focus:outline-none focus-visible:ring-1 focus-visible:ring-zinc-600"
+            />
+          </div>
+        </div>
+
+        {hasRowFilter ? (
+          <div className="mb-3 flex flex-wrap items-center gap-2">
+            {selectedBucketLabel ? (
+              <ActiveFilterPill label={`Bucket: ${selectedBucketLabel}`} onClear={() => setSelectedBucket(null)} />
+            ) : null}
+            {identityFilter ? (
+              <ActiveFilterPill label={`Identity: ${identityFilter}`} onClear={() => setIdentityFilter('')} />
+            ) : null}
+            {operatorFilter ? (
+              <ActiveFilterPill label={`Operator: ${operatorFilter}`} onClear={() => setOperatorFilter('')} />
+            ) : null}
+            {pathFilter.trim() ? (
+              <ActiveFilterPill label={`Path: ${pathFilter.trim()}`} onClear={() => setPathFilter('')} />
+            ) : null}
+            <button
+              type="button"
+              onClick={clearAllFilters}
+              className="text-xs text-zinc-500 underline-offset-4 hover:text-zinc-200 hover:underline"
+            >
+              Clear all
+            </button>
+          </div>
+        ) : null}
+
+        <EventsTable events={filteredEvents} />
       </section>
     </div>
   )
@@ -349,15 +504,6 @@ interface ChartRow {
   label: string
   crawler: number
   aiReferral: number
-}
-
-function bucketKeyFor(tsHour: string, granularity: Granularity): string {
-  if (granularity === 'hour') return tsHour
-  const d = new Date(tsHour)
-  const y = d.getFullYear()
-  const m = String(d.getMonth() + 1).padStart(2, '0')
-  const day = String(d.getDate()).padStart(2, '0')
-  return `${y}-${m}-${day}`
 }
 
 function bucketLabelFor(key: string, granularity: Granularity): string {
@@ -418,6 +564,22 @@ function buildChartData(
   }
 
   return [...byBucket.values()].sort((a, b) => (a.bucket < b.bucket ? -1 : a.bucket > b.bucket ? 1 : 0))
+}
+
+function ActiveFilterPill({ label, onClear }: { label: string; onClear: () => void }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full border border-zinc-700 bg-zinc-800/60 px-2.5 py-1 text-[11px] text-zinc-200">
+      {label}
+      <button
+        type="button"
+        onClick={onClear}
+        aria-label={`Clear ${label}`}
+        className="rounded-full p-0.5 text-zinc-400 hover:bg-zinc-700/60 hover:text-zinc-100"
+      >
+        <X className="size-3" />
+      </button>
+    </span>
+  )
 }
 
 function SeriesToggle({

--- a/apps/web/test/traffic-event-filter.test.ts
+++ b/apps/web/test/traffic-event-filter.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from 'vitest'
+import { TrafficEventKinds, type TrafficEventEntry } from '@ainyc/canonry-contracts'
+
+import {
+  bucketKeyFor,
+  filterTrafficEvents,
+  identityOf,
+  pathOf,
+} from '../src/lib/traffic-event-filter.js'
+
+function crawler(overrides: Partial<Extract<TrafficEventEntry, { kind: 'crawler' }>> = {}): TrafficEventEntry {
+  return {
+    kind: TrafficEventKinds.crawler,
+    sourceId: 'src-1',
+    tsHour: '2026-05-07T02:00:00.000Z',
+    botId: 'GPTBot',
+    operator: 'OpenAI',
+    verificationStatus: 'claimed_unverified',
+    pathNormalized: '/sitemap.xml',
+    status: 200,
+    hits: 1,
+    ...overrides,
+  }
+}
+
+function aiReferral(overrides: Partial<Extract<TrafficEventEntry, { kind: 'ai-referral' }>> = {}): TrafficEventEntry {
+  return {
+    kind: TrafficEventKinds['ai-referral'],
+    sourceId: 'src-1',
+    tsHour: '2026-05-07T02:00:00.000Z',
+    product: 'ChatGPT',
+    operator: 'OpenAI',
+    sourceDomain: 'chat.openai.com',
+    evidenceType: 'referer',
+    landingPathNormalized: '/blog/post',
+    status: 200,
+    hits: 1,
+    ...overrides,
+  }
+}
+
+describe('identityOf', () => {
+  test('returns botId for crawler events', () => {
+    expect(identityOf(crawler({ botId: 'anthropic-claudebot' }))).toBe('anthropic-claudebot')
+  })
+
+  test('returns product for ai-referral events', () => {
+    expect(identityOf(aiReferral({ product: 'Perplexity' }))).toBe('Perplexity')
+  })
+})
+
+describe('pathOf', () => {
+  test('returns pathNormalized for crawler events', () => {
+    expect(pathOf(crawler({ pathNormalized: '/robots.txt' }))).toBe('/robots.txt')
+  })
+
+  test('returns landingPathNormalized for ai-referral events', () => {
+    expect(pathOf(aiReferral({ landingPathNormalized: '/landing' }))).toBe('/landing')
+  })
+})
+
+describe('bucketKeyFor', () => {
+  test('passes through the ISO timestamp at hour granularity', () => {
+    expect(bucketKeyFor('2026-05-07T02:00:00.000Z', 'hour')).toBe('2026-05-07T02:00:00.000Z')
+  })
+
+  test('reduces to local YYYY-MM-DD at day granularity', () => {
+    // Construct a known timestamp; the helper uses local-time getters intentionally
+    // so this assertion holds across TZs only when the input local date matches.
+    const iso = new Date(2026, 4, 7, 14, 0, 0).toISOString() // May 7, 14:00 local
+    expect(bucketKeyFor(iso, 'day')).toBe('2026-05-07')
+  })
+})
+
+describe('filterTrafficEvents', () => {
+  const events: TrafficEventEntry[] = [
+    crawler({ tsHour: '2026-05-07T02:00:00.000Z', botId: 'GPTBot', operator: 'OpenAI', pathNormalized: '/sitemap.xml' }),
+    crawler({ tsHour: '2026-05-07T03:00:00.000Z', botId: 'anthropic-claudebot', operator: 'Anthropic', pathNormalized: '/robots.txt' }),
+    aiReferral({ tsHour: '2026-05-08T05:00:00.000Z', product: 'ChatGPT', operator: 'OpenAI', landingPathNormalized: '/blog/post' }),
+    aiReferral({ tsHour: '2026-05-07T02:00:00.000Z', product: 'Perplexity', operator: 'Perplexity', landingPathNormalized: '/sitemap.xml' }),
+  ]
+
+  test('returns all events when no filters set', () => {
+    const result = filterTrafficEvents(
+      events,
+      { selectedBucket: null, identity: '', operator: '', pathQuery: '' },
+      'hour',
+    )
+    expect(result.length).toBe(4)
+  })
+
+  test('filters by selected bucket at hour granularity', () => {
+    const result = filterTrafficEvents(
+      events,
+      { selectedBucket: '2026-05-07T02:00:00.000Z', identity: '', operator: '', pathQuery: '' },
+      'hour',
+    )
+    expect(result.length).toBe(2)
+    expect(result.every((e) => e.tsHour === '2026-05-07T02:00:00.000Z')).toBe(true)
+  })
+
+  test('filters by identity (covers both crawler.botId and ai-referral.product)', () => {
+    const result = filterTrafficEvents(
+      events,
+      { selectedBucket: null, identity: 'Perplexity', operator: '', pathQuery: '' },
+      'hour',
+    )
+    expect(result.length).toBe(1)
+    expect(identityOf(result[0]!)).toBe('Perplexity')
+  })
+
+  test('filters by operator', () => {
+    const result = filterTrafficEvents(
+      events,
+      { selectedBucket: null, identity: '', operator: 'OpenAI', pathQuery: '' },
+      'hour',
+    )
+    expect(result.length).toBe(2)
+    expect(result.every((e) => e.operator === 'OpenAI')).toBe(true)
+  })
+
+  test('filters path with case-insensitive substring match', () => {
+    const result = filterTrafficEvents(
+      events,
+      { selectedBucket: null, identity: '', operator: '', pathQuery: 'SITEMAP' },
+      'hour',
+    )
+    expect(result.length).toBe(2)
+    expect(result.every((e) => pathOf(e).includes('/sitemap.xml'))).toBe(true)
+  })
+
+  test('trims path query whitespace', () => {
+    const result = filterTrafficEvents(
+      events,
+      { selectedBucket: null, identity: '', operator: '', pathQuery: '   ' },
+      'hour',
+    )
+    expect(result.length).toBe(4)
+  })
+
+  test('combines all filters with AND semantics', () => {
+    const result = filterTrafficEvents(
+      events,
+      { selectedBucket: '2026-05-07T02:00:00.000Z', identity: 'GPTBot', operator: 'OpenAI', pathQuery: 'sitemap' },
+      'hour',
+    )
+    expect(result.length).toBe(1)
+    expect(identityOf(result[0]!)).toBe('GPTBot')
+  })
+
+  test('returns empty when conflicting filters match nothing', () => {
+    const result = filterTrafficEvents(
+      events,
+      { selectedBucket: '2026-05-07T02:00:00.000Z', identity: 'anthropic-claudebot', operator: '', pathQuery: '' },
+      'hour',
+    )
+    expect(result).toEqual([])
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.21.1",
+  "version": "4.21.2",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.21.1",
+  "version": "4.21.2",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Summary
- Click a bar in the traffic source detail chart to scope the event table to that bucket; the selected bar stays at full opacity while the others dim, and a pill lets you clear the selection.
- Add identity, operator, and path filters above the event table, with active-filter pills and a single "Clear all" reset. Selected filter values stay in their dropdown options even after the underlying data narrows, so the controls always match the active pills.
- Extract the filter logic into `apps/web/src/lib/traffic-event-filter.ts` with a Vitest suite covering identity/path/operator/bucket combinations and the `bucketKeyFor` granularity helper.

## Test plan
- [x] `pnpm --filter @ainyc/canonry-web typecheck`
- [x] `pnpm --filter @ainyc/canonry-web lint`
- [x] `pnpm --filter @ainyc/canonry-web exec vitest run test/traffic-event-filter.test.ts`
- [ ] Manual: click a bar, verify the event table filters; combine with identity/operator/path; switch windows and confirm pills + dropdowns stay in sync.