### PR TITLE
fix(web): use recharts v3 click shape for traffic chart bar filtering

### DIFF
--- a/apps/web/src/lib/traffic-event-filter.ts
+++ b/apps/web/src/lib/traffic-event-filter.ts
@@ -40,3 +40,17 @@ export function filterTrafficEvents(
     return true
   })
 }
+
+// Recharts 3.x BarChart onClick passes `MouseHandlerDataParam` (activeTooltipIndex /
+// activeLabel), not the v2 shape with `activePayload`. Look up the bucket from chartData
+// using the index instead.
+export function bucketForChartClick(
+  state: unknown,
+  chartData: readonly { bucket: string }[],
+): string | null {
+  if (!state || typeof state !== 'object') return null
+  const idx = (state as { activeTooltipIndex?: unknown }).activeTooltipIndex
+  if (typeof idx !== 'number' || !Number.isInteger(idx)) return null
+  if (idx < 0 || idx >= chartData.length) return null
+  return chartData[idx]?.bucket ?? null
+}

--- a/apps/web/src/pages/TrafficSourceDetailPage.tsx
+++ b/apps/web/src/pages/TrafficSourceDetailPage.tsx
@@ -31,6 +31,7 @@ import {
   useSyncServerTrafficSource,
 } from '../queries/server-traffic.js'
 import {
+  bucketForChartClick,
   bucketKeyFor,
   filterTrafficEvents,
   identityOf,
@@ -178,11 +179,7 @@ export function TrafficSourceDetailPage() {
   }
 
   const handleChartClick = (state: unknown) => {
-    const payload =
-      state && typeof state === 'object' && 'activePayload' in state
-        ? (state as { activePayload?: Array<{ payload?: ChartRow }> }).activePayload
-        : undefined
-    const bucket = payload?.[0]?.payload?.bucket
+    const bucket = bucketForChartClick(state, chartData)
     if (!bucket) return
     setSelectedBucket((prev) => (prev === bucket ? null : bucket))
   }

--- a/apps/web/test/traffic-event-filter.test.ts
+++ b/apps/web/test/traffic-event-filter.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest'
 import { TrafficEventKinds, type TrafficEventEntry } from '@ainyc/canonry-contracts'
 
 import {
+  bucketForChartClick,
   bucketKeyFor,
   filterTrafficEvents,
   identityOf,
@@ -155,5 +156,55 @@ describe('filterTrafficEvents', () => {
       'hour',
     )
     expect(result).toEqual([])
+  })
+})
+
+describe('bucketForChartClick', () => {
+  const chartData = [
+    { bucket: '2026-05-07T00:00:00.000Z' },
+    { bucket: '2026-05-07T01:00:00.000Z' },
+    { bucket: '2026-05-07T02:00:00.000Z' },
+  ]
+
+  test('returns the bucket at activeTooltipIndex (recharts v3 shape)', () => {
+    // Recharts 3.x BarChart.onClick fires with MouseHandlerDataParam — no activePayload.
+    const state = {
+      activeTooltipIndex: 2,
+      isTooltipActive: true,
+      activeIndex: 2,
+      activeLabel: '5/7 02:00',
+    }
+    expect(bucketForChartClick(state, chartData)).toBe('2026-05-07T02:00:00.000Z')
+  })
+
+  test('returns null when state is null/undefined', () => {
+    expect(bucketForChartClick(null, chartData)).toBeNull()
+    expect(bucketForChartClick(undefined, chartData)).toBeNull()
+  })
+
+  test('returns null when activeTooltipIndex is missing or non-numeric', () => {
+    expect(bucketForChartClick({}, chartData)).toBeNull()
+    expect(bucketForChartClick({ activeTooltipIndex: undefined }, chartData)).toBeNull()
+    expect(bucketForChartClick({ activeTooltipIndex: 'foo' }, chartData)).toBeNull()
+  })
+
+  test('returns null for out-of-range index', () => {
+    expect(bucketForChartClick({ activeTooltipIndex: -1 }, chartData)).toBeNull()
+    expect(bucketForChartClick({ activeTooltipIndex: 3 }, chartData)).toBeNull()
+    expect(bucketForChartClick({ activeTooltipIndex: 99 }, chartData)).toBeNull()
+  })
+
+  test('rejects non-integer activeTooltipIndex', () => {
+    expect(bucketForChartClick({ activeTooltipIndex: 1.5 }, chartData)).toBeNull()
+    expect(bucketForChartClick({ activeTooltipIndex: Number.NaN }, chartData)).toBeNull()
+  })
+
+  test('reading activePayload (the v2 shape) returns null — guards against regression', () => {
+    // If someone re-introduces the v2 read pattern, this would have been the v2 shape.
+    // We deliberately ignore activePayload in v3 and only use activeTooltipIndex.
+    const v2Shape = {
+      activePayload: [{ payload: { bucket: '2026-05-07T01:00:00.000Z' } }],
+    }
+    expect(bucketForChartClick(v2Shape, chartData)).toBeNull()
   })
 })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.21.2",
+  "version": "4.21.3",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.21.2",
+  "version": "4.21.3",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Summary
- PR #456 wired bar-click filtering on the traffic source detail chart but read `state.activePayload[0].payload.bucket` — recharts 3.x `BarChart.onClick` fires `MouseHandlerDataParam` (`activeTooltipIndex` / `activeLabel`) with no `activePayload`, so clicks did nothing.
- Extracts `bucketForChartClick(state, chartData)` into `traffic-event-filter.ts` that reads `activeTooltipIndex` and looks up the bucket by index, with validation for non-object state, non-integer index, and out-of-range index.
- Adds 6 unit tests covering the v3 happy path, null/undefined, missing/non-numeric/non-integer/out-of-range inputs, and a regression guard for the v2 shape; bumps version to 4.21.3.

## Test plan
- [x] `pnpm --filter @ainyc/canonry-web test test/traffic-event-filter.test.ts` (20/20 pass)
- [x] `pnpm --filter @ainyc/canonry-web typecheck`
- [x] `pnpm -r run lint` (via pre-commit hook)
- [ ] Manually click a bar on `/traffic/<sourceId>` and confirm the bucket filter chip appears