### PR TITLE
fix(web): accept string activeTooltipIndex from recharts v3 BarChart click

### DIFF
--- a/apps/web/src/lib/traffic-event-filter.ts
+++ b/apps/web/src/lib/traffic-event-filter.ts
@@ -44,13 +44,27 @@ export function filterTrafficEvents(
 // Recharts 3.x BarChart onClick passes `MouseHandlerDataParam` (activeTooltipIndex /
 // activeLabel), not the v2 shape with `activePayload`. Look up the bucket from chartData
 // using the index instead.
+//
+// The runtime value of `activeTooltipIndex` is always a string (e.g. `"5"`) — recharts
+// internals wrap numeric indices via `String()` (see `combineActiveTooltipIndex.js` and
+// `selectors.js`) even though the TS type advertises `number | TooltipIndex | undefined`.
+// Accept both shapes so the function works against the real recharts output, not just
+// the type.
 export function bucketForChartClick(
   state: unknown,
   chartData: readonly { bucket: string }[],
 ): string | null {
   if (!state || typeof state !== 'object') return null
-  const idx = (state as { activeTooltipIndex?: unknown }).activeTooltipIndex
-  if (typeof idx !== 'number' || !Number.isInteger(idx)) return null
+  const raw = (state as { activeTooltipIndex?: unknown }).activeTooltipIndex
+  let idx: number
+  if (typeof raw === 'number') {
+    idx = raw
+  } else if (typeof raw === 'string' && raw !== '') {
+    idx = Number(raw)
+  } else {
+    return null
+  }
+  if (!Number.isInteger(idx)) return null
   if (idx < 0 || idx >= chartData.length) return null
   return chartData[idx]?.bucket ?? null
 }

--- a/apps/web/test/traffic-event-filter.test.ts
+++ b/apps/web/test/traffic-event-filter.test.ts
@@ -166,15 +166,23 @@ describe('bucketForChartClick', () => {
     { bucket: '2026-05-07T02:00:00.000Z' },
   ]
 
-  test('returns the bucket at activeTooltipIndex (recharts v3 shape)', () => {
-    // Recharts 3.x BarChart.onClick fires with MouseHandlerDataParam — no activePayload.
+  test('returns the bucket at activeTooltipIndex (real recharts v3 shape — STRING)', () => {
+    // Recharts 3.x wraps every numeric tooltip index in String() before storing it
+    // (combineActiveTooltipIndex.js: `return String(clampedIndex)`), so the value
+    // surfaced via the BarChart.onClick MouseHandlerDataParam is a STRING — even though
+    // the TS type advertises `number | TooltipIndex | undefined`. PR #458 tested with
+    // a number and missed this in production.
     const state = {
-      activeTooltipIndex: 2,
+      activeTooltipIndex: '2',
       isTooltipActive: true,
-      activeIndex: 2,
+      activeIndex: '2',
       activeLabel: '5/7 02:00',
     }
     expect(bucketForChartClick(state, chartData)).toBe('2026-05-07T02:00:00.000Z')
+  })
+
+  test('also accepts a number activeTooltipIndex (matches the TS type)', () => {
+    expect(bucketForChartClick({ activeTooltipIndex: 2 }, chartData)).toBe('2026-05-07T02:00:00.000Z')
   })
 
   test('returns null when state is null/undefined', () => {
@@ -185,17 +193,21 @@ describe('bucketForChartClick', () => {
   test('returns null when activeTooltipIndex is missing or non-numeric', () => {
     expect(bucketForChartClick({}, chartData)).toBeNull()
     expect(bucketForChartClick({ activeTooltipIndex: undefined }, chartData)).toBeNull()
+    expect(bucketForChartClick({ activeTooltipIndex: null }, chartData)).toBeNull()
+    expect(bucketForChartClick({ activeTooltipIndex: '' }, chartData)).toBeNull()
     expect(bucketForChartClick({ activeTooltipIndex: 'foo' }, chartData)).toBeNull()
+    expect(bucketForChartClick({ activeTooltipIndex: true }, chartData)).toBeNull()
   })
 
-  test('returns null for out-of-range index', () => {
+  test('returns null for out-of-range index (number or string)', () => {
     expect(bucketForChartClick({ activeTooltipIndex: -1 }, chartData)).toBeNull()
-    expect(bucketForChartClick({ activeTooltipIndex: 3 }, chartData)).toBeNull()
-    expect(bucketForChartClick({ activeTooltipIndex: 99 }, chartData)).toBeNull()
+    expect(bucketForChartClick({ activeTooltipIndex: '3' }, chartData)).toBeNull()
+    expect(bucketForChartClick({ activeTooltipIndex: '99' }, chartData)).toBeNull()
   })
 
   test('rejects non-integer activeTooltipIndex', () => {
     expect(bucketForChartClick({ activeTooltipIndex: 1.5 }, chartData)).toBeNull()
+    expect(bucketForChartClick({ activeTooltipIndex: '1.5' }, chartData)).toBeNull()
     expect(bucketForChartClick({ activeTooltipIndex: Number.NaN }, chartData)).toBeNull()
   })
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.21.3",
+  "version": "4.21.4",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.21.3",
+  "version": "4.21.4",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Summary

- PR #458 read `activeTooltipIndex` as a number, but recharts 3.x wraps every numeric tooltip index via `String()` internally (see `combineActiveTooltipIndex.js` and `selectors.js`; `TooltipIndex = string | null`) — so the previous `typeof idx !== 'number'` check rejected every real click and clicking a bar silently did nothing.
- `bucketForChartClick` now accepts both number and non-empty string, coerces to a number, and validates with `Number.isInteger` + range check.
- The headline test now uses the real string shape recharts produces (PR #458's number-shape test never matched runtime); added explicit number-shape coverage plus null/empty/non-numeric edge cases.

## Test plan

- [x] `vitest run test/traffic-event-filter.test.ts` — 21/21 pass
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [ ] Manual: click a bar in the traffic-source chart and confirm the events table filters to that bucket