### PR TITLE
feat(traffic): WordPress traffic-logger pull adapter foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ on:
       - 'scripts/**'
       - 'AGENTS.md'
   pull_request:
-    branches: [main]
+    # No `branches:` filter — run CI on every PR, including stacked PRs
+    # targeting feature branches. This keeps each step of a stack green
+    # without waiting until rebase-to-main.
     paths:
       - '.github/workflows/ci.yml'
       - '.dockerignore'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.22.0",
+  "version": "4.22.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.21.4",
+  "version": "4.22.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.22.1",
+  "version": "4.23.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/package.json
+++ b/packages/api-routes/package.json
@@ -27,6 +27,7 @@
     "@ainyc/canonry-integration-google-analytics": "workspace:*",
     "@ainyc/canonry-integration-traffic": "workspace:*",
     "@ainyc/canonry-integration-wordpress": "workspace:*",
+    "@ainyc/canonry-integration-wordpress-traffic": "workspace:*",
     "drizzle-orm": "^0.45.1",
     "fastify": "^5.4.0"
   }

--- a/packages/api-routes/src/doctor/checks/traffic-source.ts
+++ b/packages/api-routes/src/doctor/checks/traffic-source.ts
@@ -173,8 +173,20 @@ const recentDataCheck: CheckDefinition = {
         )
         .get()?.total ?? 0,
     )
+    const olderReferrals = Number(
+      ctx.db
+        .select({ total: sql<number>`COALESCE(SUM(${aiReferralEventsHourly.sessionsOrHits}), 0)` })
+        .from(aiReferralEventsHourly)
+        .where(
+          and(
+            eq(aiReferralEventsHourly.projectId, ctx.project.id),
+            gte(aiReferralEventsHourly.tsHour, failCutoff),
+          ),
+        )
+        .get()?.total ?? 0,
+    )
     const lastSyncedAt = sources.map((s) => s.lastSyncedAt).filter(Boolean).sort().at(-1) ?? null
-    if (olderCrawlers > 0 || lastSyncedAt) {
+    if (olderCrawlers > 0 || olderReferrals > 0 || lastSyncedAt) {
       return {
         status: CheckStatuses.warn,
         code: 'traffic.recent-data.stale',

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -43,8 +43,12 @@ import { backlinksRoutes } from './backlinks.js'
 import type { BacklinksRoutesOptions } from './backlinks.js'
 import { trafficRoutes, defaultResolveAccessToken } from './traffic.js'
 import type { TrafficRoutesOptions, CloudRunCredentialStore } from './traffic.js'
+import {
+  listWordpressTrafficEvents,
+  WordpressTrafficApiError,
+} from '@ainyc/canonry-integration-wordpress-traffic'
 import { doctorRoutes } from './doctor.js'
-import { CheckStatuses } from '@ainyc/canonry-contracts'
+import { CheckStatuses, TrafficSourceTypes } from '@ainyc/canonry-contracts'
 import type { CheckOutput, TrafficSourceProbe, TrafficSourceValidator } from './doctor/types.js'
 
 declare module 'fastify' {
@@ -115,6 +119,10 @@ export interface ApiRoutesOptions {
   pullCloudRunEvents?: TrafficRoutesOptions['pullCloudRunEvents']
   /** Override Cloud Run access-token resolver (tests) — see `TrafficRoutesOptions` */
   resolveCloudRunAccessToken?: TrafficRoutesOptions['resolveCloudRunAccessToken']
+  /** WordPress traffic-logger credential store — stores Application Passwords in config, not DB */
+  wordpressTrafficCredentialStore?: TrafficRoutesOptions['wordpressTrafficCredentialStore']
+  /** Override WordPress traffic pull (tests) — see `TrafficRoutesOptions` */
+  pullWordpressTrafficEvents?: TrafficRoutesOptions['pullWordpressTrafficEvents']
   /** Fired after every traffic sync (success OR failure). Used by canonry to emit `traffic.synced` telemetry. */
   onTrafficSynced?: TrafficRoutesOptions['onTrafficSynced']
   /** Backlinks feature callbacks — see `backlinksRoutes` for details. */
@@ -278,6 +286,8 @@ export async function apiRoutes(app: FastifyInstance, opts: ApiRoutesOptions) {
       cloudRunCredentialStore: opts.cloudRunCredentialStore,
       pullCloudRunEvents: opts.pullCloudRunEvents,
       resolveCloudRunAccessToken: opts.resolveCloudRunAccessToken,
+      wordpressTrafficCredentialStore: opts.wordpressTrafficCredentialStore,
+      pullWordpressTrafficEvents: opts.pullWordpressTrafficEvents,
       onTrafficSynced: opts.onTrafficSynced,
     } satisfies TrafficRoutesOptions)
     // Always mount the backlinks routes so read endpoints (summary, domains,
@@ -367,6 +377,54 @@ function buildTrafficSourceValidators(opts: ApiRoutesOptions): Record<string, Tr
       // at the IAM layer rather than baked into the token. We surface a
       // skipped result so the framework is uniform without producing a
       // false signal.
+      validateScopes: () => null,
+    }
+  }
+  if (opts.wordpressTrafficCredentialStore) {
+    const store = opts.wordpressTrafficCredentialStore
+    const pullEvents = opts.pullWordpressTrafficEvents ?? listWordpressTrafficEvents
+    validators[TrafficSourceTypes.wordpress] = {
+      validateCredentials: async (source: TrafficSourceProbe): Promise<CheckOutput> => {
+        const record = store.getConnection(source.projectName)
+        if (!record) {
+          return {
+            status: CheckStatuses.fail,
+            code: 'traffic.credentials.missing',
+            summary: `No WordPress traffic credential found in ~/.canonry/config.yaml for project "${source.projectName}".`,
+            remediation: 'Re-run `canonry traffic connect wordpress <project> --url <site> --username <user> --app-password <password>`.',
+          }
+        }
+        try {
+          await pullEvents({
+            baseUrl: record.baseUrl,
+            username: record.username,
+            applicationPassword: record.applicationPassword,
+            pageSize: 1,
+            maxPages: 1,
+          })
+          return {
+            status: CheckStatuses.ok,
+            code: 'traffic.credentials.resolved',
+            summary: `WordPress endpoint responds for "${source.displayName}" (${new URL(record.baseUrl).host}).`,
+          }
+        } catch (e) {
+          const httpStatus = e instanceof WordpressTrafficApiError ? e.status : null
+          const msg = e instanceof Error ? e.message : String(e)
+          return {
+            status: CheckStatuses.fail,
+            code: httpStatus === 401 || httpStatus === 403
+              ? 'traffic.credentials.unauthorized'
+              : 'traffic.credentials.resolve-failed',
+            summary: httpStatus
+              ? `WordPress endpoint returned HTTP ${httpStatus}: ${msg}.`
+              : `WordPress endpoint probe failed: ${msg}.`,
+            remediation: 'Verify the site URL is reachable and the Application Password is valid. Re-connect the source if needed.',
+          }
+        }
+      },
+      // WordPress Application Passwords have no scope concept — auth is
+      // strictly "valid credential or not". Surface a skipped result so the
+      // framework is uniform without producing a false signal.
       validateScopes: () => null,
     }
   }

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -2779,6 +2779,38 @@ const routeCatalog: OpenApiOperation[] = [
   },
   {
     method: 'post',
+    path: '/api/v1/projects/{name}/traffic/connect/wordpress',
+    summary: 'Connect a WordPress traffic-logger source',
+    description:
+      'Probes the WordPress traffic-logger plugin endpoint with the supplied Application Password (single page, `limit=1`) before persisting. On success, stores the credential in `~/.canonry/config.yaml` and creates / updates the project\'s active WordPress `traffic_sources` row. A probe failure (HTTP 4xx/5xx, network error) surfaces as 502 with the upstream status in the message so the caller learns about a bad credential up front instead of at the first sync.',
+    tags: ['traffic'],
+    parameters: [nameParameter],
+    requestBody: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            required: ['baseUrl', 'username', 'applicationPassword'],
+            properties: {
+              baseUrl: { ...stringSchema, description: 'Absolute base URL of the WordPress site (e.g. `https://example.com`).' },
+              username: { ...stringSchema, description: 'WordPress username paired with the Application Password.' },
+              applicationPassword: { ...stringSchema, description: 'WordPress Application Password (raw; the server base64-encodes it for Basic auth).' },
+              displayName: stringSchema,
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: { description: 'Traffic source DTO returned.' },
+      400: { description: 'Invalid WordPress connection request.' },
+      404: { description: 'Project not found.' },
+      502: { description: 'WordPress plugin endpoint probe failed (bad credentials, unreachable host, etc.).' },
+    },
+  },
+  {
+    method: 'post',
     path: '/api/v1/projects/{name}/traffic/sources/{id}/sync',
     summary: 'Trigger a sync run for a traffic source',
     description:

--- a/packages/api-routes/src/traffic.ts
+++ b/packages/api-routes/src/traffic.ts
@@ -20,6 +20,7 @@ import {
   TrafficSourceTypes,
   TrafficSourceAuthModes,
   TrafficEventKinds,
+  trafficConnectWordpressRequestSchema,
 } from '@ainyc/canonry-contracts'
 import type {
   RunStatus,
@@ -44,6 +45,14 @@ import type {
   ListCloudRunTrafficEventsOptions,
 } from '@ainyc/canonry-integration-cloud-run'
 import { buildTrafficProbeReport } from '@ainyc/canonry-integration-traffic'
+import {
+  listWordpressTrafficEvents,
+  WordpressTrafficApiError,
+} from '@ainyc/canonry-integration-wordpress-traffic'
+import type {
+  ListWordpressTrafficEventsOptions,
+  WordpressTrafficEventsPage,
+} from '@ainyc/canonry-integration-wordpress-traffic'
 import { resolveProject, writeAuditLog } from './helpers.js'
 
 export interface CloudRunCredentialRecord {
@@ -64,6 +73,21 @@ export interface CloudRunCredentialRecord {
 export interface CloudRunCredentialStore {
   getConnection: (projectName: string) => CloudRunCredentialRecord | undefined
   upsertConnection: (record: CloudRunCredentialRecord) => CloudRunCredentialRecord
+  deleteConnection: (projectName: string) => boolean
+}
+
+export interface WordpressTrafficCredentialRecord {
+  projectName: string
+  baseUrl: string
+  username: string
+  applicationPassword: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface WordpressTrafficCredentialStore {
+  getConnection: (projectName: string) => WordpressTrafficCredentialRecord | undefined
+  upsertConnection: (record: WordpressTrafficCredentialRecord) => WordpressTrafficCredentialRecord
   deleteConnection: (projectName: string) => boolean
 }
 
@@ -95,6 +119,15 @@ export interface TrafficRoutesOptions {
   ) => Promise<CloudRunTrafficEventsPage>
   /** Override the access-token resolver (for tests). Defaults to service-account JWT exchange. */
   resolveCloudRunAccessToken?: (record: CloudRunCredentialRecord) => Promise<string>
+  /**
+   * Store for WordPress traffic-logger Application Password credentials. When
+   * absent, the WordPress connect / sync routes return a configuration error.
+   */
+  wordpressTrafficCredentialStore?: WordpressTrafficCredentialStore
+  /** Override the WordPress traffic pull function (for tests). Defaults to `listWordpressTrafficEvents`. */
+  pullWordpressTrafficEvents?: (
+    options: ListWordpressTrafficEventsOptions,
+  ) => Promise<WordpressTrafficEventsPage>
   /** Default lookback window in minutes when a sync is triggered without an explicit `since`. */
   defaultSyncWindowMinutes?: number
   /** Default page size for entries.list pulls. */
@@ -427,6 +460,7 @@ async function runBackfillTask(options: RunBackfillTaskOptions): Promise<void> {
 export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOptions) {
   const pullEvents = opts.pullCloudRunEvents ?? listCloudRunTrafficEvents
   const resolveAccessToken = opts.resolveCloudRunAccessToken ?? defaultResolveAccessToken
+  const pullWordpressEvents = opts.pullWordpressTrafficEvents ?? listWordpressTrafficEvents
   const syncWindowMinutes = opts.defaultSyncWindowMinutes ?? DEFAULT_SYNC_WINDOW_MINUTES
   const pageSize = opts.defaultPageSize ?? DEFAULT_PAGE_SIZE
   const maxPages = opts.defaultMaxPages ?? DEFAULT_MAX_PAGES
@@ -548,6 +582,132 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
       projectId: project.id,
       actor: 'api',
       action: 'traffic.cloud-run.connected',
+      entityType: 'traffic_source',
+      entityId: sourceRow.id,
+    })
+
+    return rowToDto(sourceRow)
+  })
+
+  // POST /projects/:name/traffic/connect/wordpress
+  //
+  // Probes the WordPress traffic-logger plugin endpoint with the supplied
+  // Application Password (single-page, limit=1) before persisting — a probe
+  // failure surfaces as `providerError()` so the caller sees a meaningful
+  // diagnostic up front instead of discovering it at the first sync.
+  app.post<{
+    Params: { name: string }
+    Body: {
+      baseUrl?: string
+      username?: string
+      applicationPassword?: string
+      displayName?: string
+    }
+  }>('/projects/:name/traffic/connect/wordpress', async (request) => {
+    const project = resolveProject(app.db, request.params.name)
+    if (!opts.wordpressTrafficCredentialStore) {
+      throw validationError('WordPress traffic credential storage is not configured for this deployment')
+    }
+    const credentialStore = opts.wordpressTrafficCredentialStore
+
+    const parsed = trafficConnectWordpressRequestSchema.safeParse(request.body ?? {})
+    if (!parsed.success) {
+      throw validationError(parsed.error.issues.map((i) => i.message).join('; '))
+    }
+    const { baseUrl, username, applicationPassword, displayName } = parsed.data
+
+    // Probe the plugin endpoint up-front so the caller learns about a bad
+    // URL / wrong credential before we touch any persistent state.
+    try {
+      await pullWordpressEvents({
+        baseUrl,
+        username,
+        applicationPassword,
+        pageSize: 1,
+        maxPages: 1,
+      })
+    } catch (e) {
+      if (e instanceof WordpressTrafficApiError) {
+        throw providerError(
+          `WordPress traffic probe failed (HTTP ${e.status}): ${e.message}${e.body ? ` — ${e.body}` : ''}`,
+        )
+      }
+      const msg = e instanceof Error ? e.message : String(e)
+      throw providerError(`WordPress traffic probe failed: ${msg}`)
+    }
+
+    const now = new Date().toISOString()
+    const existing = credentialStore.getConnection(project.name)
+    credentialStore.upsertConnection({
+      projectName: project.name,
+      baseUrl,
+      username,
+      applicationPassword,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    })
+
+    // Single active WordPress source per project; reconnect updates it.
+    const activeSource = app.db
+      .select()
+      .from(trafficSources)
+      .where(eq(trafficSources.projectId, project.id))
+      .all()
+      .find((row) => row.sourceType === TrafficSourceTypes.wordpress && row.status !== TrafficSourceStatuses.archived)
+
+    // Only non-secret config goes on the row — the Application Password lives
+    // in ~/.canonry/config.yaml via the credential store.
+    const config: Record<string, unknown> = { baseUrl, username }
+    const fallbackName = displayName ?? `WordPress · ${new URL(baseUrl).host}`
+
+    let sourceRow: typeof trafficSources.$inferSelect
+    if (activeSource) {
+      app.db
+        .update(trafficSources)
+        .set({
+          displayName: fallbackName,
+          status: TrafficSourceStatuses.connected,
+          lastError: null,
+          configJson: JSON.stringify(config),
+          updatedAt: now,
+        })
+        .where(eq(trafficSources.id, activeSource.id))
+        .run()
+      sourceRow = app.db
+        .select()
+        .from(trafficSources)
+        .where(eq(trafficSources.id, activeSource.id))
+        .get()!
+    } else {
+      const newId = crypto.randomUUID()
+      app.db
+        .insert(trafficSources)
+        .values({
+          id: newId,
+          projectId: project.id,
+          sourceType: TrafficSourceTypes.wordpress,
+          displayName: fallbackName,
+          status: TrafficSourceStatuses.connected,
+          lastSyncedAt: null,
+          lastCursor: null,
+          lastError: null,
+          archivedAt: null,
+          configJson: JSON.stringify(config),
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run()
+      sourceRow = app.db
+        .select()
+        .from(trafficSources)
+        .where(eq(trafficSources.id, newId))
+        .get()!
+    }
+
+    writeAuditLog(app.db, {
+      projectId: project.id,
+      actor: 'api',
+      action: 'traffic.wordpress.connected',
       entityType: 'traffic_source',
       entityId: sourceRow.id,
     })

--- a/packages/api-routes/src/traffic.ts
+++ b/packages/api-routes/src/traffic.ts
@@ -286,8 +286,10 @@ async function runBackfillTask(options: RunBackfillTaskOptions): Promise<void> {
   const currentLastSyncedMs = sourceRow.lastSyncedAt
     ? new Date(sourceRow.lastSyncedAt).getTime()
     : Number.NEGATIVE_INFINITY
+  // Advance to windowEnd (the pull's upper bound), not finishedAt — see the
+  // sync-route comment for why. Backfill never moves the cursor backwards.
   const nextLastSyncedAt = Math.max(currentLastSyncedMs, windowEnd.getTime()) === windowEnd.getTime()
-    ? finishedAt
+    ? windowEndIso
     : sourceRow.lastSyncedAt!
 
   try {
@@ -686,43 +688,65 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
       throw providerError(`Cloud Run pull failed: ${msg}`)
     }
 
-    // Cross-sync dedupe: drop events whose normalized eventId was already
-    // observed in the previous successful sync. The lastSyncedAt clamp
-    // narrows the fetch window, but events with timestamp == lastSyncedAt
-    // (boundary second) can still appear in two consecutive pulls.
-    const seenEventIds = new Set(parseJsonColumn<string[]>(sourceRow.lastEventIds, []))
-    const dedupedEvents = seenEventIds.size === 0
-      ? allEvents
-      : allEvents.filter(e => !seenEventIds.has(e.eventId))
-
-    // Build the next sync's seen-set: new event IDs (newest-first) PREPENDED
-    // to the previous seen IDs, deduplicated, capped at MAX_TRACKED_EVENT_IDS.
-    // We must retain the previous IDs because Cloud Logging can re-return the
-    // same boundary event on more than one subsequent sync; replacing would
-    // let it re-enter on the third sync.
-    const newSorted = dedupedEvents
-      .slice()
-      .sort((a, b) => (a.observedAt < b.observedAt ? 1 : a.observedAt > b.observedAt ? -1 : 0))
-      .map(e => e.eventId)
-    const previousIds = parseJsonColumn<string[]>(sourceRow.lastEventIds, [])
-    const merged: string[] = []
-    const mergedSet = new Set<string>()
-    for (const id of [...newSorted, ...previousIds]) {
-      if (mergedSet.has(id)) continue
-      mergedSet.add(id)
-      merged.push(id)
-      if (merged.length >= MAX_TRACKED_EVENT_IDS) break
-    }
-    const nextEventIds = merged
-
-    const report = buildTrafficProbeReport(dedupedEvents, { sampleLimit })
-    const finishedAt = new Date().toISOString()
-
     let crawlerBucketRows = 0
     let aiReferralBucketRows = 0
     let sampleRows = 0
+    // These get assigned inside the transaction (after we re-read the row to
+    // beat the read-then-write race on concurrent syncs) and read after the
+    // transaction commits for the response + telemetry payload.
+    let finishedAt = new Date().toISOString()
+    let pulledEventsCount = 0
+    let crawlerHitsCount = 0
+    let aiReferralHitsCount = 0
+    let unknownHitsCount = 0
 
     app.db.transaction((tx) => {
+      // Re-read sourceRow inside the txn so a concurrent sync that committed
+      // first is visible — otherwise both syncs would dedupe against the same
+      // stale lastEventIds and the second commit would clobber the first
+      // sync's ring buffer.
+      const latestRow = tx
+        .select()
+        .from(trafficSources)
+        .where(eq(trafficSources.id, sourceRow.id))
+        .get()!
+
+      // Cross-sync dedupe: drop events whose normalized eventId was already
+      // observed in the previous successful sync. The lastSyncedAt clamp
+      // narrows the fetch window, but events with timestamp == lastSyncedAt
+      // (boundary second) can still appear in two consecutive pulls.
+      const previousIds = parseJsonColumn<string[]>(latestRow.lastEventIds, [])
+      const seenEventIds = new Set(previousIds)
+      const dedupedEvents = seenEventIds.size === 0
+        ? allEvents
+        : allEvents.filter(e => !seenEventIds.has(e.eventId))
+
+      // Build the next sync's seen-set: new event IDs (newest-first) PREPENDED
+      // to the previous seen IDs, deduplicated, capped at MAX_TRACKED_EVENT_IDS.
+      // We must retain the previous IDs because Cloud Logging can re-return
+      // the same boundary event on more than one subsequent sync; replacing
+      // would let it re-enter on the third sync.
+      const newSorted = dedupedEvents
+        .slice()
+        .sort((a, b) => (a.observedAt < b.observedAt ? 1 : a.observedAt > b.observedAt ? -1 : 0))
+        .map(e => e.eventId)
+      const merged: string[] = []
+      const mergedSet = new Set<string>()
+      for (const id of [...newSorted, ...previousIds]) {
+        if (mergedSet.has(id)) continue
+        mergedSet.add(id)
+        merged.push(id)
+        if (merged.length >= MAX_TRACKED_EVENT_IDS) break
+      }
+      const nextEventIds = merged
+
+      const report = buildTrafficProbeReport(dedupedEvents, { sampleLimit })
+      finishedAt = new Date().toISOString()
+      pulledEventsCount = report.totals.normalizedEvents
+      crawlerHitsCount = report.totals.crawlerHits
+      aiReferralHitsCount = report.totals.aiReferralHits
+      unknownHitsCount = report.totals.unknownHits
+
       // Upsert crawler hourly buckets — composite PK lets us accumulate `hits`.
       for (const bucket of report.crawlerEventsHourly) {
         const status = bucket.status ?? 0
@@ -838,7 +862,11 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
         .update(trafficSources)
         .set({
           status: TrafficSourceStatuses.connected,
-          lastSyncedAt: finishedAt,
+          // Advance to windowEnd, not finishedAt — events arriving at the
+          // source between windowEnd and finishedAt aren't in this pull's
+          // range. If we stored finishedAt, the next sync's clamp would skip
+          // past them and they'd be lost.
+          lastSyncedAt: windowEnd.toISOString(),
           lastError: null,
           lastEventIds: JSON.stringify(nextEventIds),
           updatedAt: finishedAt,
@@ -867,9 +895,9 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
         status: 'completed',
         sourceType: sourceRow.sourceType,
         sourceId: sourceRow.id,
-        pulledEvents: report.totals.normalizedEvents,
-        crawlerHits: report.totals.crawlerHits,
-        aiReferralHits: report.totals.aiReferralHits,
+        pulledEvents: pulledEventsCount,
+        crawlerHits: crawlerHitsCount,
+        aiReferralHits: aiReferralHitsCount,
         durationMs: Date.now() - syncStartedAtMs,
       })
     } catch {
@@ -880,10 +908,10 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
       sourceId: sourceRow.id,
       runId,
       syncedAt: finishedAt,
-      pulledEvents: report.totals.normalizedEvents,
-      crawlerHits: report.totals.crawlerHits,
-      aiReferralHits: report.totals.aiReferralHits,
-      unknownHits: report.totals.unknownHits,
+      pulledEvents: pulledEventsCount,
+      crawlerHits: crawlerHitsCount,
+      aiReferralHits: aiReferralHitsCount,
+      unknownHits: unknownHitsCount,
       crawlerBucketRows,
       aiReferralBucketRows,
       sampleRows,

--- a/packages/api-routes/test/doctor-traffic-source.test.ts
+++ b/packages/api-routes/test/doctor-traffic-source.test.ts
@@ -9,6 +9,7 @@ import {
   projects,
   trafficSources,
   crawlerEventsHourly,
+  aiReferralEventsHourly,
 } from '@ainyc/canonry-db'
 import { TRAFFIC_SOURCE_CHECKS } from '../src/doctor/checks/traffic-source.js'
 import type { CheckOutput, DoctorContext, ProjectInfo, TrafficSourceProbe, TrafficSourceValidator } from '../src/doctor/types.js'
@@ -105,6 +106,24 @@ function insertCrawlerHit(h: Harness, sourceId: string, opts: { tsHour?: string;
   }).run()
 }
 
+function insertReferralHit(h: Harness, sourceId: string, opts: { tsHour?: string; hits?: number } = {}) {
+  h.db.insert(aiReferralEventsHourly).values({
+    projectId: h.project.id,
+    sourceId,
+    tsHour: opts.tsHour ?? isoMinusDays(1),
+    product: 'ChatGPT',
+    operator: 'OpenAI',
+    sourceDomain: 'chatgpt.com',
+    evidenceType: 'referer',
+    landingPathNormalized: '/blog',
+    status: 200,
+    sessionsOrHits: opts.hits ?? 1,
+    usersEstimated: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  }).run()
+}
+
 function ctxFor(h: Harness, validators?: Record<string, TrafficSourceValidator>): DoctorContext {
   return {
     db: h.db,
@@ -176,6 +195,18 @@ describe('traffic.source.recent-data', () => {
   it('warns when older data exists but recent window is empty', async () => {
     const sourceId = insertTrafficSource(h, { lastSyncedAt: isoMinusDays(15) })
     insertCrawlerHit(h, sourceId, { tsHour: isoMinusDays(15) })
+    const r = await recentDataCheck.run(ctxFor(h))
+    expect(r.status).toBe('warn')
+    expect(r.code).toBe('traffic.recent-data.stale')
+  })
+
+  it('warns (not fails) when only older AI referrals exist and lastSyncedAt is null', async () => {
+    // Regression: the older-data fallback used to count only crawler hits;
+    // a project with AI-referral history but no crawler history and a
+    // nulled-out lastSyncedAt (e.g. data inserted via backfill/migration
+    // without advancing the cursor) would be misreported as `empty`.
+    const sourceId = insertTrafficSource(h, { lastSyncedAt: null })
+    insertReferralHit(h, sourceId, { tsHour: isoMinusDays(15) })
     const r = await recentDataCheck.run(ctxFor(h))
     expect(r.status).toBe('warn')
     expect(r.code).toBe('traffic.recent-data.stale')

--- a/packages/api-routes/test/traffic.test.ts
+++ b/packages/api-routes/test/traffic.test.ts
@@ -364,6 +364,68 @@ describe('POST /traffic/sources/:id/sync', () => {
     }
   })
 
+  it('advances lastSyncedAt to windowEnd (not finishedAt) so events in the processing gap survive into the next sync', async () => {
+    // Regression: if lastSyncedAt rolled forward to the transaction's
+    // finishedAt instead of the pull's windowEnd, then events with
+    // observedAt in (windowEnd, finishedAt] would be lost forever — sync 1
+    // didn't pull them (timestamp > endTime) and sync 2 would clamp past
+    // them. Assert the cursor matches windowEnd exactly, and that a new
+    // event at the boundary is picked up by the next sync.
+    const observedAt = new Date(Date.now() - 30 * 60_000).toISOString()
+    const events: NormalizedTrafficRequest[] = [
+      buildEvent({ eventId: 'evt-1', userAgent: 'GPTBot/1.0', path: '/blog/foo', status: 200, observedAt }),
+    ]
+    const h = await buildHarness(events)
+    try {
+      const connectRes = await h.app.inject({
+        method: 'POST',
+        url: '/api/v1/projects/test-project/traffic/connect/cloud-run',
+        payload: { gcpProjectId: 'openclaw-nyc', keyJson: SA_KEY },
+      })
+      const sourceId = JSON.parse(connectRes.payload).id
+
+      await h.app.inject({
+        method: 'POST',
+        url: `/api/v1/projects/test-project/traffic/sources/${sourceId}/sync`,
+        payload: {},
+      })
+      const firstWindow = h.getObservedWindows()[0]!
+
+      const sourceAfterFirst = h.db
+        .select()
+        .from(trafficSources)
+        .where(eq(trafficSources.id, sourceId))
+        .get()!
+      expect(sourceAfterFirst.lastSyncedAt).toBe(firstWindow.endTime)
+
+      // Inject a new event AT the boundary timestamp — observable only by
+      // sync 2 if its windowStart equals sync 1's windowEnd.
+      events.push(buildEvent({
+        eventId: 'evt-boundary',
+        userAgent: 'GPTBot/1.0',
+        path: '/blog/boundary',
+        status: 200,
+        observedAt: firstWindow.endTime,
+      }))
+
+      const second = await h.app.inject({
+        method: 'POST',
+        url: `/api/v1/projects/test-project/traffic/sources/${sourceId}/sync`,
+        payload: {},
+      })
+      expect(JSON.parse(second.payload).pulledEvents).toBe(1)
+      const paths = h.db
+        .select()
+        .from(crawlerEventsHourly)
+        .all()
+        .map((r) => r.pathNormalized)
+        .sort()
+      expect(paths).toEqual(['/blog/boundary', '/blog/foo'])
+    } finally {
+      await h.close()
+    }
+  })
+
   it('clamps windowStart to lastSyncedAt so overlapping syncs do not double-count', async () => {
     // Event sits inside the default sync window for the first sync. After
     // the first sync, lastSyncedAt is "now-ish", so the second sync's window

--- a/packages/api-routes/test/traffic.test.ts
+++ b/packages/api-routes/test/traffic.test.ts
@@ -22,8 +22,18 @@ import {
 } from '@ainyc/canonry-contracts'
 import type { NormalizedTrafficRequest } from '@ainyc/canonry-contracts'
 import type { CloudRunTrafficEventsPage } from '@ainyc/canonry-integration-cloud-run'
+import type {
+  ListWordpressTrafficEventsOptions,
+  WordpressTrafficEventsPage,
+} from '@ainyc/canonry-integration-wordpress-traffic'
+import { WordpressTrafficApiError } from '@ainyc/canonry-integration-wordpress-traffic'
 import { apiRoutes } from '../src/index.js'
-import type { CloudRunCredentialRecord, CloudRunCredentialStore } from '../src/traffic.js'
+import type {
+  CloudRunCredentialRecord,
+  CloudRunCredentialStore,
+  WordpressTrafficCredentialRecord,
+  WordpressTrafficCredentialStore,
+} from '../src/traffic.js'
 
 function buildEvent(overrides: Partial<NormalizedTrafficRequest> = {}): NormalizedTrafficRequest {
   const base: NormalizedTrafficRequest = {
@@ -58,6 +68,8 @@ async function buildHarness(
     failResolveAccessTokenWith?: string
     /** Force the Cloud Run pull to fail with this message. */
     failPullWith?: string
+    /** Force the WordPress traffic pull (used for probe) to throw a `WordpressTrafficApiError`. */
+    failWpProbeWith?: { status: number; message: string; body?: string }
   } = {},
 ) {
   const trafficSyncedEvents: Array<unknown> = []
@@ -75,6 +87,18 @@ async function buildHarness(
     },
     deleteConnection: (projectName) => credentials.delete(projectName),
   }
+
+  const wpCredentials = new Map<string, WordpressTrafficCredentialRecord>()
+  const wordpressTrafficCredentialStore: WordpressTrafficCredentialStore = {
+    getConnection: (projectName) => wpCredentials.get(projectName),
+    upsertConnection: (record) => {
+      wpCredentials.set(record.projectName, record)
+      return record
+    },
+    deleteConnection: (projectName) => wpCredentials.delete(projectName),
+  }
+
+  const wpProbeInvocations: ListWordpressTrafficEventsOptions[] = []
 
   let pullInvocations = 0
   const observedWindows: Array<{ startTime: string; endTime: string }> = []
@@ -112,6 +136,24 @@ async function buildHarness(
       if (options.failResolveAccessTokenWith) throw new Error(options.failResolveAccessTokenWith)
       return 'mock-access-token'
     },
+    wordpressTrafficCredentialStore,
+    pullWordpressTrafficEvents: async (pullOptions): Promise<WordpressTrafficEventsPage> => {
+      wpProbeInvocations.push(pullOptions)
+      if (options.failWpProbeWith) {
+        throw new WordpressTrafficApiError(
+          options.failWpProbeWith.message,
+          options.failWpProbeWith.status,
+          options.failWpProbeWith.body,
+        )
+      }
+      return {
+        events: [],
+        rawEntryCount: 0,
+        skippedEntryCount: 0,
+        nextCursor: undefined,
+        endpoint: `${pullOptions.baseUrl}/wp-json/canonry/v1/events`,
+      }
+    },
     onTrafficSynced: (event) => { trafficSyncedEvents.push(event) },
   })
   await app.ready()
@@ -132,11 +174,13 @@ async function buildHarness(
     app,
     db,
     credentials,
+    wpCredentials,
     tmpDir,
     getPullCount: () => pullInvocations,
     getObservedWindows: () => observedWindows,
     getObservedFirstSync: () => observedFirstSync,
     getTrafficSyncedEvents: () => trafficSyncedEvents,
+    getWpProbeInvocations: () => wpProbeInvocations,
     close: async () => {
       await app.close()
       fs.rmSync(tmpDir, { recursive: true, force: true })
@@ -233,6 +277,103 @@ describe('POST /traffic/connect/cloud-run', () => {
     const config = JSON.parse(sources[0].configJson) as Record<string, unknown>
     expect(config.gcpProjectId).toBe('new-project')
     expect(config.serviceName).toBe('new-svc')
+  })
+})
+
+describe('POST /traffic/connect/wordpress', () => {
+  let h: Awaited<ReturnType<typeof buildHarness>>
+  beforeEach(async () => { h = await buildHarness([]) })
+  afterEach(async () => { await h.close() })
+
+  const validBody = {
+    baseUrl: 'https://example.com',
+    username: 'canonry-bot',
+    applicationPassword: 'xxxx xxxx xxxx xxxx xxxx xxxx',
+  }
+
+  it('rejects requests with an invalid baseUrl', async () => {
+    const res = await h.app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/test-project/traffic/connect/wordpress',
+      payload: { ...validBody, baseUrl: 'not-a-url' },
+    })
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('rejects requests with empty applicationPassword', async () => {
+    const res = await h.app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/test-project/traffic/connect/wordpress',
+      payload: { ...validBody, applicationPassword: '' },
+    })
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('probes the plugin endpoint, persists credentials, and creates the source row', async () => {
+    const res = await h.app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/test-project/traffic/connect/wordpress',
+      payload: { ...validBody, displayName: 'Example WP' },
+    })
+    expect(res.statusCode).toBe(200)
+    const dto = JSON.parse(res.payload)
+    expect(dto.sourceType).toBe(TrafficSourceTypes.wordpress)
+    expect(dto.status).toBe(TrafficSourceStatuses.connected)
+    expect(dto.displayName).toBe('Example WP')
+    expect(dto.config.baseUrl).toBe('https://example.com')
+    expect(dto.config.username).toBe('canonry-bot')
+    // Application password must never leak into the row config; it lives in
+    // ~/.canonry/config.yaml only.
+    expect(dto.config.applicationPassword).toBeUndefined()
+
+    // Probe ran once before any persistence.
+    const probes = h.getWpProbeInvocations()
+    expect(probes.length).toBe(1)
+    expect(probes[0]!.baseUrl).toBe('https://example.com')
+    expect(probes[0]!.pageSize).toBe(1)
+
+    const stored = h.wpCredentials.get('test-project')
+    expect(stored?.applicationPassword).toBe('xxxx xxxx xxxx xxxx xxxx xxxx')
+
+    const sourceRows = h.db.select().from(trafficSources).all()
+    expect(sourceRows.length).toBe(1)
+    expect(sourceRows[0].sourceType).toBe(TrafficSourceTypes.wordpress)
+  })
+
+  it('returns 502 and persists nothing when the probe fails with bad credentials', async () => {
+    await h.close()
+    h = await buildHarness([], {
+      failWpProbeWith: { status: 401, message: 'Unauthorized', body: 'bad password' },
+    })
+
+    const res = await h.app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/test-project/traffic/connect/wordpress',
+      payload: validBody,
+    })
+    expect(res.statusCode).toBe(502)
+    expect(JSON.parse(res.payload).error.message).toMatch(/HTTP 401/)
+    // Probe ran but neither credential nor source row was written.
+    expect(h.wpCredentials.get('test-project')).toBeUndefined()
+    expect(h.db.select().from(trafficSources).all().length).toBe(0)
+  })
+
+  it('reuses the existing source row on reconnect rather than creating a duplicate', async () => {
+    await h.app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/test-project/traffic/connect/wordpress',
+      payload: validBody,
+    })
+    const second = await h.app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/test-project/traffic/connect/wordpress',
+      payload: { ...validBody, baseUrl: 'https://example.com', username: 'new-bot' },
+    })
+    expect(second.statusCode).toBe(200)
+    const sources = h.db.select().from(trafficSources).all()
+    expect(sources.length).toBe(1)
+    const config = JSON.parse(sources[0].configJson) as Record<string, unknown>
+    expect(config.username).toBe('new-bot')
   })
 })
 

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.22.1",
+  "version": "4.23.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.21.4",
+  "version": "4.22.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.22.0",
+  "version": "4.22.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/cli-commands/traffic.ts
+++ b/packages/canonry/src/cli-commands/traffic.ts
@@ -1,6 +1,7 @@
 import {
   trafficBackfill,
   trafficConnectCloudRun,
+  trafficConnectWordpress,
   trafficEvents,
   trafficSources,
   trafficStatus,
@@ -42,13 +43,44 @@ export const TRAFFIC_CLI_COMMANDS: readonly CliCommandSpec[] = [
     },
   },
   {
+    path: ['traffic', 'connect', 'wordpress'],
+    usage: 'canonry traffic connect wordpress <project> --url <wp-site-url> --username <wp-user> (--app-password <pw> | --app-password-file <path>) [--display-name <name>] [--format json]',
+    options: {
+      url: stringOption(),
+      username: stringOption(),
+      'app-password': stringOption(),
+      'app-password-file': stringOption(),
+      'display-name': stringOption(),
+    },
+    run: async (input) => {
+      const project = requireProject(
+        input,
+        'traffic.connect.wordpress',
+        'canonry traffic connect wordpress <project> --url <wp-site-url> --username <wp-user> (--app-password <pw> | --app-password-file <path>)',
+      )
+      const url = getString(input.values, 'url')
+      if (!url) throw new Error('--url is required')
+      const username = getString(input.values, 'username')
+      if (!username) throw new Error('--username is required')
+
+      await trafficConnectWordpress(project, {
+        url,
+        username,
+        appPassword: getString(input.values, 'app-password'),
+        appPasswordFile: getString(input.values, 'app-password-file'),
+        displayName: getString(input.values, 'display-name'),
+        format: input.format,
+      })
+    },
+  },
+  {
     path: ['traffic', 'connect'],
     usage: 'canonry traffic connect <provider> <project> [args]',
     run: async (input) => {
       unknownSubcommand(input.positionals[0], {
         command: 'traffic connect',
         usage: 'canonry traffic connect <provider> <project> [args]',
-        available: ['cloud-run'],
+        available: ['cloud-run', 'wordpress'],
       })
     },
   },

--- a/packages/canonry/src/client.ts
+++ b/packages/canonry/src/client.ts
@@ -77,6 +77,7 @@ import type {
   TrafficStatusResponse,
   TrafficEventsResponse,
   TrafficConnectCloudRunRequest,
+  TrafficConnectWordpressRequest,
   TrafficSyncResponse,
   TrafficBackfillResponse,
 } from '@ainyc/canonry-contracts'
@@ -801,6 +802,14 @@ export class ApiClient {
     return this.request<TrafficSourceDto>(
       'POST',
       `/projects/${encodeURIComponent(project)}/traffic/connect/cloud-run`,
+      body,
+    )
+  }
+
+  async trafficConnectWordpress(project: string, body: TrafficConnectWordpressRequest): Promise<TrafficSourceDto> {
+    return this.request<TrafficSourceDto>(
+      'POST',
+      `/projects/${encodeURIComponent(project)}/traffic/connect/wordpress`,
       body,
     )
   }

--- a/packages/canonry/src/commands/traffic.ts
+++ b/packages/canonry/src/commands/traffic.ts
@@ -16,6 +16,87 @@ function getClient() {
   return createApiClient()
 }
 
+export async function trafficConnectWordpress(project: string, opts: {
+  url: string
+  username: string
+  /** Inline Application Password value. Mutually exclusive with `appPasswordFile`. */
+  appPassword?: string
+  /** Path to a file containing the Application Password. Preferred — keeps the secret out of shell history. */
+  appPasswordFile?: string
+  displayName?: string
+  format?: string
+}): Promise<void> {
+  if (!opts.url) {
+    throw new CliError({
+      code: 'TRAFFIC_WP_URL_REQUIRED',
+      message: '--url is required',
+      displayMessage: 'Error: --url is required',
+      details: { project },
+    })
+  }
+  if (!opts.username) {
+    throw new CliError({
+      code: 'TRAFFIC_WP_USERNAME_REQUIRED',
+      message: '--username is required',
+      displayMessage: 'Error: --username is required',
+      details: { project },
+    })
+  }
+  if (opts.appPassword && opts.appPasswordFile) {
+    throw new CliError({
+      code: 'TRAFFIC_WP_APP_PASSWORD_CONFLICT',
+      message: '--app-password and --app-password-file are mutually exclusive',
+      displayMessage: 'Error: pass either --app-password <pw> or --app-password-file <path>, not both',
+      details: { project },
+    })
+  }
+  let applicationPassword = opts.appPassword?.trim() ?? ''
+  if (!applicationPassword && opts.appPasswordFile) {
+    const fs = await import('node:fs')
+    try {
+      applicationPassword = fs.readFileSync(opts.appPasswordFile, 'utf-8').trim()
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      throw new CliError({
+        code: 'TRAFFIC_WP_APP_PASSWORD_FILE_READ_ERROR',
+        message: `Failed to read --app-password-file: ${msg}`,
+        displayMessage: `Error: failed to read --app-password-file "${opts.appPasswordFile}": ${msg}`,
+        details: { project, appPasswordFile: opts.appPasswordFile },
+      })
+    }
+  }
+  if (!applicationPassword) {
+    throw new CliError({
+      code: 'TRAFFIC_WP_APP_PASSWORD_REQUIRED',
+      message: '--app-password or --app-password-file is required',
+      displayMessage: 'Error: pass --app-password <pw> or --app-password-file <path>',
+      details: { project },
+    })
+  }
+
+  const client = getClient()
+  const result: TrafficSourceDto = await client.trafficConnectWordpress(project, {
+    baseUrl: opts.url,
+    username: opts.username,
+    applicationPassword,
+    displayName: opts.displayName,
+  })
+
+  if (opts.format === 'json') {
+    console.log(JSON.stringify(result, null, 2))
+    return
+  }
+
+  console.log(`WordPress traffic source connected for project "${project}".`)
+  console.log(`  Source ID:    ${result.id}`)
+  console.log(`  Display name: ${result.displayName}`)
+  console.log(`  Status:       ${result.status}`)
+  console.log(`  Site URL:     ${result.config.baseUrl ?? '(unset)'}`)
+  console.log(`  Username:     ${result.config.username ?? '(unset)'}`)
+  console.log('')
+  console.log(`Next: canonry traffic sync ${project} --source ${result.id}`)
+}
+
 export async function trafficConnectCloudRun(project: string, opts: {
   gcpProject: string
   service?: string

--- a/packages/canonry/src/config.ts
+++ b/packages/canonry/src/config.ts
@@ -110,6 +110,24 @@ export interface WordpressConfigEntry {
   connections?: WordpressConnectionConfigEntry[]
 }
 
+/**
+ * Per-project WordPress traffic-logger connection. Separate from `wordpress.connections`,
+ * which is the content-publishing client. Authenticates against the WP traffic plugin's
+ * REST endpoint using a WordPress Application Password.
+ */
+export interface WordpressTrafficConnectionConfigEntry {
+  projectName: string
+  baseUrl: string
+  username: string
+  applicationPassword: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface WordpressTrafficConfigEntry {
+  connections?: WordpressTrafficConnectionConfigEntry[]
+}
+
 export interface AgentConfigEntry {
   /** Agent mode. Only 'disabled' is valid until the native loop ships. */
   mode?: 'disabled'
@@ -136,6 +154,7 @@ export interface CanonryConfig {
   ga4?: Ga4ConfigEntry
   cloudRun?: CloudRunConfigEntry
   wordpress?: WordpressConfigEntry
+  wordpressTraffic?: WordpressTrafficConfigEntry
   // Dashboard password hash (SHA-256 hex) — set during first dashboard visit
   dashboardPasswordHash?: string
   // Telemetry (opt-out: undefined/true = enabled, false = disabled)

--- a/packages/canonry/src/mcp/openapi-classification.ts
+++ b/packages/canonry/src/mcp/openapi-classification.ts
@@ -96,6 +96,7 @@ export const MCP_OPENAPI_OPERATION_CLASSIFICATIONS = {
   'GET /api/v1/projects/{name}/bing/performance': 'deferred',
   'POST /api/v1/projects/{name}/wordpress/connect': 'deferred',
   'POST /api/v1/projects/{name}/traffic/connect/cloud-run': 'included',
+  'POST /api/v1/projects/{name}/traffic/connect/wordpress': 'included',
   'POST /api/v1/projects/{name}/traffic/sources/{id}/sync': 'included',
   'POST /api/v1/projects/{name}/traffic/sources/{id}/backfill': 'included',
   'GET /api/v1/projects/{name}/traffic/sources': 'included',

--- a/packages/canonry/src/mcp/tool-registry.ts
+++ b/packages/canonry/src/mcp/tool-registry.ts
@@ -15,6 +15,7 @@ import {
   schedulableRunKindSchema,
   scheduleUpsertRequestSchema,
   trafficConnectCloudRunRequestSchema,
+  trafficConnectWordpressRequestSchema,
   trafficEventKindSchema,
   type NotificationEvent,
 } from '@ainyc/canonry-contracts'
@@ -227,6 +228,11 @@ const memoryForgetInputSchema = z.object({
 const trafficConnectCloudRunInputSchema = z.object({
   project: projectNameSchema,
   request: trafficConnectCloudRunRequestSchema,
+})
+
+const trafficConnectWordpressInputSchema = z.object({
+  project: projectNameSchema,
+  request: trafficConnectWordpressRequestSchema,
 })
 
 const trafficSyncInputSchema = z.object({
@@ -845,6 +851,17 @@ export const canonryMcpTools = [
     annotations: writeAnnotations({ idempotentHint: true, openWorldHint: true }),
     openApiOperations: ['POST /api/v1/projects/{name}/traffic/connect/cloud-run'],
     handler: (client, input) => client.trafficConnectCloudRun(input.project, input.request),
+  }),
+  defineTool({
+    name: 'canonry_traffic_connect_wordpress',
+    title: 'Connect WordPress traffic-logger source',
+    description: 'Connect a WordPress site (running the canonry traffic-logger plugin) as a server-side traffic source. Probes the plugin endpoint with the supplied Application Password before persisting — a bad credential or unreachable host surfaces as a 502 error. Reconnecting updates the existing active WordPress source in place. The Application Password is stored in ~/.canonry/config.yaml (not the DB) and never echoed back.',
+    access: 'write',
+    tier: 'traffic',
+    inputSchema: trafficConnectWordpressInputSchema,
+    annotations: writeAnnotations({ idempotentHint: true, openWorldHint: true }),
+    openApiOperations: ['POST /api/v1/projects/{name}/traffic/connect/wordpress'],
+    handler: (client, input) => client.trafficConnectWordpress(input.project, input.request),
   }),
   defineTool({
     name: 'canonry_traffic_sync',

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -41,6 +41,11 @@ import {
   removeCloudRunConnection,
 } from './cloud-run-config.js'
 import {
+  getWordpressTrafficConnection,
+  upsertWordpressTrafficConnection,
+  removeWordpressTrafficConnection,
+} from './wordpress-traffic-config.js'
+import {
   getWordpressConnection,
   patchWordpressConnection,
   removeWordpressConnection,
@@ -513,6 +518,31 @@ export async function createServer(opts: {
     },
   } as const
 
+  // WordPress traffic-logger credential store — stores Application Passwords
+  // in ~/.canonry/config.yaml under `wordpressTraffic.connections`.
+  const wordpressTrafficCredentialStore = {
+    getConnection: (projectName: string) => {
+      return getWordpressTrafficConnection(opts.config, projectName)
+    },
+    upsertConnection: (record: {
+      projectName: string
+      baseUrl: string
+      username: string
+      applicationPassword: string
+      createdAt: string
+      updatedAt: string
+    }) => {
+      const updated = upsertWordpressTrafficConnection(opts.config, record)
+      saveConfigPatch(opts.config)
+      return updated
+    },
+    deleteConnection: (projectName: string) => {
+      const removed = removeWordpressTrafficConnection(opts.config, projectName)
+      if (removed) saveConfigPatch(opts.config)
+      return removed
+    },
+  } as const
+
   const googleStateSecret = process.env.GOOGLE_STATE_SECRET ?? crypto.randomBytes(32).toString('hex')
 
   const googleConnectionStore = {
@@ -965,6 +995,7 @@ export async function createServer(opts: {
     wordpressConnectionStore,
     ga4CredentialStore,
     cloudRunCredentialStore,
+    wordpressTrafficCredentialStore,
     onTrafficSynced: (event) => {
       // Emit anonymous canonry telemetry for every sync (success + fail).
       // Same envelope shape as run.completed (top-level `errorCode` on

--- a/packages/canonry/src/wordpress-traffic-config.ts
+++ b/packages/canonry/src/wordpress-traffic-config.ts
@@ -1,0 +1,54 @@
+import type { CanonryConfig, WordpressTrafficConnectionConfigEntry } from './config.js'
+
+function ensureConnections(config: CanonryConfig): WordpressTrafficConnectionConfigEntry[] {
+  if (!config.wordpressTraffic) config.wordpressTraffic = {}
+  if (!config.wordpressTraffic.connections) config.wordpressTraffic.connections = []
+  return config.wordpressTraffic.connections
+}
+
+export function listWordpressTrafficConnections(
+  config: CanonryConfig,
+): WordpressTrafficConnectionConfigEntry[] {
+  return config.wordpressTraffic?.connections ?? []
+}
+
+export function getWordpressTrafficConnection(
+  config: CanonryConfig,
+  projectName: string,
+): WordpressTrafficConnectionConfigEntry | undefined {
+  return (config.wordpressTraffic?.connections ?? []).find((c) => c.projectName === projectName)
+}
+
+export function upsertWordpressTrafficConnection(
+  config: CanonryConfig,
+  connection: WordpressTrafficConnectionConfigEntry,
+): WordpressTrafficConnectionConfigEntry {
+  const connections = ensureConnections(config)
+  const index = connections.findIndex((c) => c.projectName === connection.projectName)
+
+  if (index === -1) {
+    connections.push(connection)
+    return connection
+  }
+
+  connections[index] = connection
+  return connection
+}
+
+export function removeWordpressTrafficConnection(
+  config: CanonryConfig,
+  projectName: string,
+): boolean {
+  const connections = config.wordpressTraffic?.connections
+  if (!connections?.length) return false
+
+  const next = connections.filter((c) => c.projectName !== projectName)
+  if (next.length === connections.length) return false
+
+  if (!config.wordpressTraffic) return false
+  config.wordpressTraffic.connections = next
+  if (next.length === 0) {
+    delete config.wordpressTraffic
+  }
+  return true
+}

--- a/packages/canonry/test/mcp-registry.test.ts
+++ b/packages/canonry/test/mcp-registry.test.ts
@@ -65,6 +65,7 @@ const expectedToolNames = [
   'canonry_traffic_status',
   'canonry_traffic_events',
   'canonry_traffic_connect_cloud_run',
+  'canonry_traffic_connect_wordpress',
   'canonry_traffic_sync',
   'canonry_traffic_backfill',
   'canonry_project_upsert',
@@ -94,7 +95,7 @@ const expectedToolNames = [
 
 describe('MCP tool registry', () => {
   it('ships the curated v1 surface', () => {
-    expect(CANONRY_MCP_TOOL_COUNT).toBe(74)
+    expect(CANONRY_MCP_TOOL_COUNT).toBe(75)
     expect(CANONRY_MCP_READ_TOOL_COUNT).toBe(49)
     expect(canonryMcpTools.map(tool => tool.name)).toEqual(expectedToolNames)
     const readNames = canonryMcpTools.filter(tool => tool.access === 'read').map(tool => tool.name)
@@ -135,7 +136,7 @@ describe('MCP tool registry', () => {
     expect(counts.get('setup')).toBe(21)
     expect(counts.get('gsc')).toBe(7)
     expect(counts.get('ga')).toBe(8)
-    expect(counts.get('traffic')).toBe(7)
+    expect(counts.get('traffic')).toBe(8)
     expect(counts.get('agent')).toBe(5)
   })
 

--- a/packages/canonry/test/mcp-stdio.test.ts
+++ b/packages/canonry/test/mcp-stdio.test.ts
@@ -171,7 +171,7 @@ describe('canonry-mcp stdio', () => {
     await client.connect(transport)
 
     const list = await client.listTools()
-    expect(list.tools).toHaveLength(76)
+    expect(list.tools).toHaveLength(77)
     const names = list.tools.map(tool => tool.name)
     expect(names).toContain('canonry_insights_list')
     expect(names).toContain('canonry_project_overview')

--- a/packages/canonry/test/traffic-commands.test.ts
+++ b/packages/canonry/test/traffic-commands.test.ts
@@ -165,6 +165,59 @@ describe('traffic CLI commands', () => {
     expect(yaml.cloudRun?.connections?.[0]?.clientEmail).toBe('sa@openclaw-nyc.iam.gserviceaccount.com')
   })
 
+  it('rejects traffic connect wordpress without --url', async () => {
+    const result = await invokeCli([
+      'traffic', 'connect', 'wordpress', 'test-proj',
+      '--username', 'bot',
+      '--app-password', 'pw',
+    ])
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toMatch(/--url/)
+  })
+
+  it('rejects traffic connect wordpress without --username', async () => {
+    const result = await invokeCli([
+      'traffic', 'connect', 'wordpress', 'test-proj',
+      '--url', 'https://example.com',
+      '--app-password', 'pw',
+    ])
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toMatch(/--username/)
+  })
+
+  it('rejects traffic connect wordpress without --app-password or --app-password-file', async () => {
+    const result = await invokeCli([
+      'traffic', 'connect', 'wordpress', 'test-proj',
+      '--url', 'https://example.com',
+      '--username', 'bot',
+    ])
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toMatch(/--app-password/)
+  })
+
+  it('rejects traffic connect wordpress when both --app-password and --app-password-file are passed', async () => {
+    const result = await invokeCli([
+      'traffic', 'connect', 'wordpress', 'test-proj',
+      '--url', 'https://example.com',
+      '--username', 'bot',
+      '--app-password', 'pw',
+      '--app-password-file', '/tmp/pw.txt',
+    ])
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toMatch(/not both/i)
+  })
+
+  it('reports a clear error when --app-password-file cannot be read', async () => {
+    const result = await invokeCli([
+      'traffic', 'connect', 'wordpress', 'test-proj',
+      '--url', 'https://example.com',
+      '--username', 'bot',
+      '--app-password-file', '/tmp/this-file-really-does-not-exist-wpxyzzy.txt',
+    ])
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toMatch(/failed to read --app-password-file/i)
+  })
+
   it('rejects traffic sync without --source', async () => {
     const result = await invokeCli(['traffic', 'sync', 'test-proj'])
     expect(result.exitCode).not.toBe(0)

--- a/packages/canonry/test/wordpress-traffic-config.test.ts
+++ b/packages/canonry/test/wordpress-traffic-config.test.ts
@@ -1,0 +1,86 @@
+import { test, expect } from 'vitest'
+
+import type { CanonryConfig } from '../src/config.js'
+import {
+  getWordpressTrafficConnection,
+  listWordpressTrafficConnections,
+  upsertWordpressTrafficConnection,
+  removeWordpressTrafficConnection,
+} from '../src/wordpress-traffic-config.js'
+
+function makeConfig(): CanonryConfig {
+  return {
+    apiUrl: 'http://localhost:4100',
+    database: '/tmp/canonry.db',
+    apiKey: 'cnry_test',
+  }
+}
+
+test('wordpress-traffic config helpers persist an application-password connection scoped by project name', () => {
+  const config = makeConfig()
+  const now = new Date().toISOString()
+
+  upsertWordpressTrafficConnection(config, {
+    projectName: 'demo',
+    baseUrl: 'https://example.com',
+    username: 'canonry-bot',
+    applicationPassword: 'xxxx xxxx xxxx xxxx xxxx xxxx',
+    createdAt: now,
+    updatedAt: now,
+  })
+
+  const conn = getWordpressTrafficConnection(config, 'demo')
+  expect(conn).toBeDefined()
+  expect(conn?.baseUrl).toBe('https://example.com')
+  expect(conn?.username).toBe('canonry-bot')
+  expect(conn?.applicationPassword).toBe('xxxx xxxx xxxx xxxx xxxx xxxx')
+})
+
+test('upsertWordpressTrafficConnection replaces the existing entry for the same project', () => {
+  const config = makeConfig()
+  const now = new Date().toISOString()
+
+  upsertWordpressTrafficConnection(config, {
+    projectName: 'demo',
+    baseUrl: 'https://example.com',
+    username: 'bot-1',
+    applicationPassword: 'pw-1',
+    createdAt: now,
+    updatedAt: now,
+  })
+  upsertWordpressTrafficConnection(config, {
+    projectName: 'demo',
+    baseUrl: 'https://example.com',
+    username: 'bot-2',
+    applicationPassword: 'pw-2',
+    createdAt: now,
+    updatedAt: now,
+  })
+
+  expect(listWordpressTrafficConnections(config).length).toBe(1)
+  expect(getWordpressTrafficConnection(config, 'demo')?.username).toBe('bot-2')
+  expect(getWordpressTrafficConnection(config, 'demo')?.applicationPassword).toBe('pw-2')
+})
+
+test('removeWordpressTrafficConnection deletes the entry and prunes the empty wordpressTraffic block', () => {
+  const config = makeConfig()
+  const now = new Date().toISOString()
+
+  upsertWordpressTrafficConnection(config, {
+    projectName: 'demo',
+    baseUrl: 'https://example.com',
+    username: 'bot',
+    applicationPassword: 'pw',
+    createdAt: now,
+    updatedAt: now,
+  })
+
+  expect(removeWordpressTrafficConnection(config, 'demo')).toBe(true)
+  expect(getWordpressTrafficConnection(config, 'demo')).toBeUndefined()
+  expect(config.wordpressTraffic).toBeUndefined()
+})
+
+test('removeWordpressTrafficConnection returns false when nothing to delete', () => {
+  const config = makeConfig()
+  expect(removeWordpressTrafficConnection(config, 'demo')).toBe(false)
+})

--- a/packages/contracts/src/traffic.ts
+++ b/packages/contracts/src/traffic.ts
@@ -93,6 +93,16 @@ export const cloudRunSourceConfigSchema = z.object({
 })
 export type CloudRunSourceConfig = z.infer<typeof cloudRunSourceConfigSchema>
 
+/**
+ * Persisted in `traffic_sources.configJson` for `sourceType = 'wordpress'`.
+ * Credentials (Application Password) live in `~/.canonry/config.yaml`, never here.
+ */
+export const wordpressTrafficSourceConfigSchema = z.object({
+  baseUrl: z.string().url(),
+  username: z.string().min(1),
+})
+export type WordpressTrafficSourceConfig = z.infer<typeof wordpressTrafficSourceConfigSchema>
+
 export const trafficSourceDtoSchema = z.object({
   id: z.string(),
   projectId: z.string(),
@@ -118,6 +128,15 @@ export const trafficConnectCloudRunRequestSchema = z.object({
   keyJson: z.string().optional(),
 })
 export type TrafficConnectCloudRunRequest = z.infer<typeof trafficConnectCloudRunRequestSchema>
+
+export const trafficConnectWordpressRequestSchema = z.object({
+  baseUrl: z.string().url(),
+  username: z.string().min(1),
+  /** WordPress Application Password (the same auth used by the content client). */
+  applicationPassword: z.string().min(1),
+  displayName: z.string().min(1).optional(),
+})
+export type TrafficConnectWordpressRequest = z.infer<typeof trafficConnectWordpressRequestSchema>
 
 export const trafficSyncResponseSchema = z.object({
   sourceId: z.string(),

--- a/packages/contracts/test/traffic.test.ts
+++ b/packages/contracts/test/traffic.test.ts
@@ -4,6 +4,8 @@ import {
   TrafficEvidenceKinds,
   TrafficSourceTypes,
   normalizedTrafficRequestSchema,
+  trafficConnectWordpressRequestSchema,
+  wordpressTrafficSourceConfigSchema,
 } from '../src/traffic.js'
 
 describe('traffic contracts', () => {
@@ -41,5 +43,60 @@ describe('traffic contracts', () => {
     expect(parsed.evidenceKind).toBe(TrafficEvidenceKinds['raw-request'])
     expect(parsed.confidence).toBe(TrafficEventConfidences.observed)
     expect(parsed.path).toBe('/blog/post')
+  })
+})
+
+describe('wordpressTrafficSourceConfigSchema', () => {
+  it('accepts a valid WordPress traffic source config', () => {
+    const parsed = wordpressTrafficSourceConfigSchema.parse({
+      baseUrl: 'https://example.com',
+      username: 'canonry-bot',
+    })
+    expect(parsed.baseUrl).toBe('https://example.com')
+    expect(parsed.username).toBe('canonry-bot')
+  })
+
+  it('rejects an invalid baseUrl', () => {
+    expect(() => wordpressTrafficSourceConfigSchema.parse({
+      baseUrl: 'not-a-url',
+      username: 'canonry-bot',
+    })).toThrow()
+  })
+
+  it('rejects an empty username', () => {
+    expect(() => wordpressTrafficSourceConfigSchema.parse({
+      baseUrl: 'https://example.com',
+      username: '',
+    })).toThrow()
+  })
+})
+
+describe('trafficConnectWordpressRequestSchema', () => {
+  it('accepts a connect request with all required fields', () => {
+    const parsed = trafficConnectWordpressRequestSchema.parse({
+      baseUrl: 'https://example.com',
+      username: 'canonry-bot',
+      applicationPassword: 'xxxx xxxx xxxx xxxx xxxx xxxx',
+      displayName: 'Example WordPress',
+    })
+    expect(parsed.applicationPassword).toBe('xxxx xxxx xxxx xxxx xxxx xxxx')
+    expect(parsed.displayName).toBe('Example WordPress')
+  })
+
+  it('allows omitting displayName', () => {
+    const parsed = trafficConnectWordpressRequestSchema.parse({
+      baseUrl: 'https://example.com',
+      username: 'canonry-bot',
+      applicationPassword: 'pw',
+    })
+    expect(parsed.displayName).toBeUndefined()
+  })
+
+  it('rejects an empty applicationPassword', () => {
+    expect(() => trafficConnectWordpressRequestSchema.parse({
+      baseUrl: 'https://example.com',
+      username: 'canonry-bot',
+      applicationPassword: '',
+    })).toThrow()
   })
 })

--- a/packages/integration-traffic/src/classifier.ts
+++ b/packages/integration-traffic/src/classifier.ts
@@ -12,6 +12,16 @@ function hostMatches(host: string, domain: string): boolean {
   return normalizedHost === normalizedDomain || normalizedHost.endsWith(`.${normalizedDomain}`)
 }
 
+// UTM source values are often a short label rather than a hostname (e.g.
+// `utm_source=chatgpt` for `chatgpt.com`). Match against the first DNS label
+// of the rule's domain so we don't miss the short form.
+function utmTokenMatchesDomain(utmSource: string, domain: string): boolean {
+  if (hostMatches(utmSource, domain)) return true
+  const normalizedUtm = normalizeHost(utmSource)
+  const firstLabel = normalizeHost(domain).split('.')[0]
+  return Boolean(firstLabel) && normalizedUtm === firstLabel
+}
+
 function hostFromUrl(value: string | null): string | null {
   if (!value) return null
   try {
@@ -73,7 +83,7 @@ export function classifyAiReferral(event: NormalizedTrafficRequest): ClassifiedA
 
   const utmSource = utmSourceFromQuery(event.queryString)
   if (utmSource) {
-    const rule = DEFAULT_AI_REFERRER_RULES.find((candidate) => hostMatches(utmSource, candidate.domain))
+    const rule = DEFAULT_AI_REFERRER_RULES.find((candidate) => utmTokenMatchesDomain(utmSource, candidate.domain))
     if (rule) {
       return {
         operator: rule.operator,
@@ -91,7 +101,7 @@ export function classifyAiReferral(event: NormalizedTrafficRequest): ClassifiedA
   // signal on cached sites.
   const refererUtmSource = utmSourceFromUrl(event.referer)
   if (refererUtmSource) {
-    const rule = DEFAULT_AI_REFERRER_RULES.find((candidate) => hostMatches(refererUtmSource, candidate.domain))
+    const rule = DEFAULT_AI_REFERRER_RULES.find((candidate) => utmTokenMatchesDomain(refererUtmSource, candidate.domain))
     if (rule) {
       return {
         operator: rule.operator,

--- a/packages/integration-traffic/src/rollup.ts
+++ b/packages/integration-traffic/src/rollup.ts
@@ -147,20 +147,23 @@ export function buildTrafficProbeReport(
 
     if (!crawler && !aiReferral) unknownHits += 1
 
-    if (samples.length < sampleLimit) {
-      samples.push({
-        eventId: event.eventId,
-        observedAt: event.observedAt,
-        sourceType: event.sourceType,
-        path: event.path,
-        pathNormalized,
-        status: event.status,
-        userAgent: event.userAgent,
-        referer: event.referer,
-        crawler,
-        aiReferral,
-      })
-    }
+    // Keep the most-recent `sampleLimit` events by iteration order, not the
+    // first ones we see. Pulls run timestamp-asc, so a FIFO retention would
+    // surface only the oldest slice of the window — the least useful for
+    // classifier debugging.
+    samples.push({
+      eventId: event.eventId,
+      observedAt: event.observedAt,
+      sourceType: event.sourceType,
+      path: event.path,
+      pathNormalized,
+      status: event.status,
+      userAgent: event.userAgent,
+      referer: event.referer,
+      crawler,
+      aiReferral,
+    })
+    if (samples.length > sampleLimit) samples.shift()
   }
 
   return {

--- a/packages/integration-traffic/test/analysis.test.ts
+++ b/packages/integration-traffic/test/analysis.test.ts
@@ -197,4 +197,38 @@ describe('traffic analysis', () => {
     expect(report.topBots[0]).toEqual({ botId: 'openai-gptbot', operator: 'OpenAI', hits: 2 })
     expect(report.topAiReferrers[0]).toEqual({ sourceDomain: 'claude.ai', product: 'Claude', hits: 1 })
   })
+
+  it('matches short-form utm_source tokens against the rule domain first label', () => {
+    // Real sites frequently emit `utm_source=chatgpt` instead of the
+    // fully-qualified `chatgpt.com`. Both should classify identically.
+    expect(classifyAiReferral(event({
+      referer: null,
+      queryString: 'utm_source=chatgpt',
+    }))).toMatchObject({ product: 'ChatGPT', evidenceType: 'utm' })
+    expect(classifyAiReferral(event({
+      referer: null,
+      queryString: 'utm_source=perplexity',
+    }))).toMatchObject({ product: 'Perplexity', evidenceType: 'utm' })
+    expect(classifyAiReferral(event({
+      referer: null,
+      queryString: 'utm_source=claude',
+    }))).toMatchObject({ product: 'Claude', evidenceType: 'utm' })
+    // Non-rule short tokens stay unmatched.
+    expect(classifyAiReferral(event({
+      referer: null,
+      queryString: 'utm_source=newsletter',
+    }))).toBeNull()
+  })
+
+  it('keeps the newest sampleLimit events instead of the oldest', () => {
+    // Pulls run timestamp-asc — a FIFO cap would surface only the oldest
+    // events in the window, the least useful slice for classifier debugging.
+    const events = Array.from({ length: 5 }, (_, i) => event({
+      eventId: `e-${i}`,
+      observedAt: `2026-05-01T12:0${i}:00.000Z`,
+      path: `/p${i}`,
+    }))
+    const report = buildTrafficProbeReport(events, { sampleLimit: 2 })
+    expect(report.samples.map((s) => s.eventId)).toEqual(['e-3', 'e-4'])
+  })
 })

--- a/packages/integration-wordpress-traffic/AGENTS.md
+++ b/packages/integration-wordpress-traffic/AGENTS.md
@@ -1,0 +1,62 @@
+# integration-wordpress-traffic
+
+## Purpose
+
+WordPress traffic-logger integration — pulls candidate AI traffic events
+(crawler hits + AI-referral hits) from the canonry traffic-logger WordPress
+plugin's REST endpoint (`/wp-json/canonry/v1/events`) and normalizes them
+into provider-neutral `NormalizedTrafficRequest` events for the traffic
+ingestion pipeline.
+
+Companion package: `packages/integration-wordpress/` (content-publishing
+client) is **separate** — that handles page/SEO/schema management on a WP
+site and shares only the Application-Password auth pattern.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `src/client.ts` | `listWordpressTrafficEvents` — cursor-paginated pull, `WordpressTrafficApiError` |
+| `src/normalize.ts` | `normalizeWordpressTrafficEvent` — converts a plugin event row into a `NormalizedTrafficRequest` |
+| `src/types.ts` | Adapter option/response shapes (`WordpressTrafficEventPayload`, `ListWordpressTrafficEventsOptions`, `WordpressTrafficEventsPage`) |
+| `src/index.ts` | Re-exports public API |
+
+## Patterns
+
+- **Application-Password auth.** Callers pass a WordPress username + Application
+  Password (the same scheme used by `packages/integration-wordpress/`). This
+  package base64-encodes them for HTTP Basic auth. Credentials are caller-supplied
+  per request — they live in `~/.canonry/config.yaml` under `wordpressTraffic.connections`.
+- **Pull-only, cursor-paginated.** `listWordpressTrafficEvents` accepts an opaque
+  `cursor` string returned from the previous page (`next_cursor`). No push,
+  no SaaS relay.
+- **No classification.** This package only pulls + normalizes. UA pattern
+  matching and AI-referer detection happen in `packages/integration-traffic`
+  alongside Cloud Run events, so classifier rules evolve without plugin updates.
+- **IP hashing happens upstream.** The plugin hashes (sha256 prefix) or omits
+  client IPs before writing event rows, so this adapter never sees raw IPs.
+  Every WordPress event currently stays `claimed_unverified` — IP/rDNS
+  verification needs raw IPs and is future work.
+- **Provider-neutral output.** Every adapter in the traffic stack emits the
+  same `NormalizedTrafficRequest` shape from `@ainyc/canonry-contracts`. Do
+  not leak WordPress-specific types past the package boundary.
+
+## Common Mistakes
+
+- **Storing the Application Password in this package.** Credentials live in
+  `~/.canonry/config.yaml` and are supplied per call.
+- **Adding UA/referer classification here.** All classification lives in
+  `packages/integration-traffic` so Cloud Run, WordPress, and future adapters
+  share one rule set.
+- **Calling `fetch` against the raw `baseUrl`.** Always append
+  `/wp-json/canonry/v1/events` — `resolveEndpoint` does this. Hand-rolled URL
+  composition will drop trailing slashes or double up paths.
+
+## See Also
+
+- `packages/contracts/src/traffic.ts` — `NormalizedTrafficRequest`,
+  `wordpressTrafficSourceConfigSchema`, `trafficConnectWordpressRequestSchema`
+- `packages/integration-traffic/` — provider-neutral classifier + hourly rollup
+- `packages/integration-cloud-run/` — sibling pull adapter; mirror this file
+  layout when adding a new adapter
+- `plans/server-side-ai-traffic-ingestion.md` — overall traffic plan

--- a/packages/integration-wordpress-traffic/CLAUDE.md
+++ b/packages/integration-wordpress-traffic/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/integration-wordpress-traffic/package.json
+++ b/packages/integration-wordpress-traffic/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@ainyc/canonry-integration-wordpress-traffic",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "license": "FSL-1.1-ALv2",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "types": "./src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "vitest run",
+    "lint": "eslint src/ test/"
+  },
+  "dependencies": {
+    "@ainyc/canonry-contracts": "workspace:*"
+  }
+}

--- a/packages/integration-wordpress-traffic/src/client.ts
+++ b/packages/integration-wordpress-traffic/src/client.ts
@@ -1,0 +1,137 @@
+import { normalizeWordpressTrafficEvent } from './normalize.js'
+import type {
+  ListWordpressTrafficEventsOptions,
+  WordpressTrafficEventsPage,
+  WordpressTrafficEventsResponseBody,
+} from './types.js'
+
+const WORDPRESS_TRAFFIC_ENDPOINT_PATH = '/wp-json/canonry/v1/events'
+const DEFAULT_PAGE_SIZE = 500
+const DEFAULT_MAX_PAGES = 1
+const DEFAULT_TIMEOUT_MS = 30_000
+
+export class WordpressTrafficApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly body?: string,
+  ) {
+    super(message)
+    this.name = 'WordpressTrafficApiError'
+  }
+}
+
+function trimRequired(name: string, value: string): string {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    throw new WordpressTrafficApiError(`${name} is required`, 400)
+  }
+  return trimmed
+}
+
+function normalizePageSize(pageSize: number | undefined): number {
+  if (pageSize === undefined) return DEFAULT_PAGE_SIZE
+  if (!Number.isInteger(pageSize) || pageSize < 1) {
+    throw new WordpressTrafficApiError('pageSize must be a positive integer', 400)
+  }
+  return pageSize
+}
+
+function normalizeMaxPages(maxPages: number | undefined): number {
+  if (maxPages === undefined) return DEFAULT_MAX_PAGES
+  if (!Number.isInteger(maxPages) || maxPages < 1) {
+    throw new WordpressTrafficApiError('maxPages must be a positive integer', 400)
+  }
+  return maxPages
+}
+
+function resolveEndpoint(baseUrl: string): string {
+  const trimmed = trimRequired('baseUrl', baseUrl).replace(/\/+$/, '')
+  return `${trimmed}${WORDPRESS_TRAFFIC_ENDPOINT_PATH}`
+}
+
+function buildBasicAuthHeader(username: string, applicationPassword: string): string {
+  const credentials = `${trimRequired('username', username)}:${trimRequired('applicationPassword', applicationPassword)}`
+  return `Basic ${Buffer.from(credentials, 'utf8').toString('base64')}`
+}
+
+async function readErrorBody(response: Response): Promise<string | undefined> {
+  const text = await response.text().catch(() => '')
+  if (!text) return undefined
+  return text.length <= 500 ? text : `${text.slice(0, 500)}... [truncated]`
+}
+
+/**
+ * Fetch a page (or up to `maxPages` pages) of WordPress traffic events from
+ * the canonry traffic-logger plugin's REST endpoint, normalize each event into
+ * `NormalizedTrafficRequest`, and return the merged page along with the
+ * opaque cursor to resume from.
+ *
+ * Pure pull adapter — no DB, no classification, no credential storage. The
+ * caller (API route or sync orchestrator) supplies the WordPress Application
+ * Password and persists the returned cursor.
+ */
+export async function listWordpressTrafficEvents(
+  options: ListWordpressTrafficEventsOptions,
+): Promise<WordpressTrafficEventsPage> {
+  const endpoint = resolveEndpoint(options.baseUrl)
+  const authHeader = buildBasicAuthHeader(options.username, options.applicationPassword)
+  const pageSize = normalizePageSize(options.pageSize)
+  const maxPages = normalizeMaxPages(options.maxPages)
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+
+  let cursor = options.cursor
+  let rawEntryCount = 0
+  let skippedEntryCount = 0
+  const events: WordpressTrafficEventsPage['events'] = []
+
+  for (let page = 0; page < maxPages; page += 1) {
+    const url = new URL(endpoint)
+    url.searchParams.set('limit', String(pageSize))
+    if (cursor !== undefined && cursor !== '') {
+      url.searchParams.set('cursor', cursor)
+    }
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Authorization: authHeader,
+        Accept: 'application/json',
+      },
+      signal: AbortSignal.timeout(timeoutMs),
+    })
+
+    if (!response.ok) {
+      const body = await readErrorBody(response)
+      throw new WordpressTrafficApiError(
+        `WordPress traffic endpoint returned HTTP ${response.status}`,
+        response.status,
+        body,
+      )
+    }
+
+    const body = (await response.json()) as WordpressTrafficEventsResponseBody
+    const entries = body.events ?? []
+    rawEntryCount += entries.length
+
+    for (const entry of entries) {
+      const normalized = normalizeWordpressTrafficEvent(entry)
+      if (normalized) {
+        events.push(normalized)
+      } else {
+        skippedEntryCount += 1
+      }
+    }
+
+    cursor = body.next_cursor ?? undefined
+    if (!body.has_more || !cursor) break
+  }
+
+  return {
+    events,
+    rawEntryCount,
+    skippedEntryCount,
+    nextCursor: cursor,
+    endpoint,
+  }
+}

--- a/packages/integration-wordpress-traffic/src/index.ts
+++ b/packages/integration-wordpress-traffic/src/index.ts
@@ -1,0 +1,3 @@
+export * from './client.js'
+export * from './normalize.js'
+export type * from './types.js'

--- a/packages/integration-wordpress-traffic/src/normalize.ts
+++ b/packages/integration-wordpress-traffic/src/normalize.ts
@@ -1,0 +1,57 @@
+import {
+  TrafficEventConfidences,
+  TrafficEvidenceKinds,
+  TrafficSourceTypes,
+  type NormalizedTrafficRequest,
+} from '@ainyc/canonry-contracts'
+import type { WordpressTrafficEventPayload } from './types.js'
+
+function trimOrNull(value: string | null | undefined): string | null {
+  if (value === null || value === undefined) return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function buildEventId(event: WordpressTrafficEventPayload): string {
+  return `wordpress:${event.observed_at}:${event.id}`
+}
+
+export function normalizeWordpressTrafficEvent(
+  event: WordpressTrafficEventPayload,
+): NormalizedTrafficRequest | null {
+  if (!event.observed_at) return null
+  if (!event.path || event.path.trim().length === 0) return null
+  if (typeof event.id !== 'number' || !Number.isFinite(event.id)) return null
+
+  const path = event.path
+  const queryString = trimOrNull(event.query_string)
+  const host = trimOrNull(event.host)
+  const requestUrl = host
+    ? `https://${host}${path}${queryString ? `?${queryString}` : ''}`
+    : `${path}${queryString ? `?${queryString}` : ''}`
+
+  return {
+    sourceType: TrafficSourceTypes.wordpress,
+    evidenceKind: TrafficEvidenceKinds['raw-request'],
+    confidence: TrafficEventConfidences.observed,
+    eventId: buildEventId(event),
+    observedAt: event.observed_at,
+    method: trimOrNull(event.method),
+    requestUrl,
+    host,
+    path,
+    queryString,
+    status: typeof event.status === 'number' && Number.isFinite(event.status) ? event.status : null,
+    userAgent: trimOrNull(event.user_agent),
+    remoteIp: trimOrNull(event.remote_ip_hash),
+    referer: trimOrNull(event.referer),
+    latencyMs: null,
+    requestSizeBytes: null,
+    responseSizeBytes: null,
+    providerResource: {
+      type: 'wordpress_site',
+      labels: host ? { host } : {},
+    },
+    providerLabels: {},
+  }
+}

--- a/packages/integration-wordpress-traffic/src/normalize.ts
+++ b/packages/integration-wordpress-traffic/src/normalize.ts
@@ -20,10 +20,10 @@ export function normalizeWordpressTrafficEvent(
   event: WordpressTrafficEventPayload,
 ): NormalizedTrafficRequest | null {
   if (!event.observed_at) return null
-  if (!event.path || event.path.trim().length === 0) return null
   if (typeof event.id !== 'number' || !Number.isFinite(event.id)) return null
 
-  const path = event.path
+  const path = event.path?.trim()
+  if (!path) return null
   const queryString = trimOrNull(event.query_string)
   const host = trimOrNull(event.host)
   const requestUrl = host

--- a/packages/integration-wordpress-traffic/src/types.ts
+++ b/packages/integration-wordpress-traffic/src/types.ts
@@ -1,0 +1,74 @@
+import type { NormalizedTrafficRequest } from '@ainyc/canonry-contracts'
+
+/**
+ * Wire shape of one event row emitted by the canonry traffic-logger plugin's
+ * `GET /wp-json/canonry/v1/events` endpoint. Field names mirror the plugin's
+ * DB column names so the plugin can serialize rows directly without an
+ * intermediate transform.
+ *
+ * The plugin captures requests post-hygiene-filter (no static assets, no
+ * `/wp-admin/`, no POSTs by default). It does NOT classify — UA pattern /
+ * referer matching happens server-side in `packages/integration-traffic`.
+ *
+ * IPs are hashed by the plugin (sha256 prefix) before the row is written, so
+ * canonry never sees raw client IPs. Verification stays `claimed_unverified`
+ * for every WordPress event until rDNS / IP-range verification is wired.
+ */
+export interface WordpressTrafficEventPayload {
+  /** Plugin-assigned auto-increment id; used as the pagination cursor. */
+  id: number
+  /** ISO 8601 timestamp recorded by the plugin at request time. */
+  observed_at: string
+  method: string | null
+  /** Request `Host` header (host only, no scheme). */
+  host: string | null
+  /** Path component; always populated, never includes the query string. */
+  path: string
+  /** Query string (without the leading `?`); null if none. */
+  query_string: string | null
+  /** HTTP response status as observed by the plugin. */
+  status: number | null
+  user_agent: string | null
+  /** SHA-256 prefix or null when hashing is disabled and no IP was captured. */
+  remote_ip_hash: string | null
+  referer: string | null
+}
+
+/**
+ * Top-level response shape of `GET /wp-json/canonry/v1/events`.
+ * `next_cursor` is opaque to canonry — pass it back verbatim as `?cursor=`.
+ */
+export interface WordpressTrafficEventsResponseBody {
+  events: WordpressTrafficEventPayload[]
+  next_cursor: string | null
+  has_more: boolean
+  /** Optional site metadata for diagnostics; not required for normalization. */
+  site?: {
+    url?: string
+    wordpress_version?: string
+    plugin_version?: string
+  }
+}
+
+export interface ListWordpressTrafficEventsOptions {
+  /** Absolute base URL of the WP site, e.g. `https://example.com`. The plugin path is appended automatically. */
+  baseUrl: string
+  /** WordPress username paired with the Application Password. */
+  username: string
+  /** WordPress Application Password (raw; the client base64-encodes it for Basic auth). */
+  applicationPassword: string
+  /** Opaque cursor returned from a previous page's `next_cursor`. */
+  cursor?: string
+  pageSize?: number
+  maxPages?: number
+  timeoutMs?: number
+}
+
+export interface WordpressTrafficEventsPage {
+  events: NormalizedTrafficRequest[]
+  rawEntryCount: number
+  skippedEntryCount: number
+  nextCursor?: string
+  /** Resolved REST endpoint path, useful for diagnostics. */
+  endpoint: string
+}

--- a/packages/integration-wordpress-traffic/test/wordpress-traffic-client.test.ts
+++ b/packages/integration-wordpress-traffic/test/wordpress-traffic-client.test.ts
@@ -112,6 +112,37 @@ describe('normalizeWordpressTrafficEvent', () => {
     expect(event?.userAgent).toBeNull()
     expect(event?.queryString).toBeNull()
   })
+
+  it('trims surrounding whitespace on path and rejects whitespace-only paths', () => {
+    const trimmed = normalizeWordpressTrafficEvent({
+      id: 1,
+      observed_at: '2026-05-11T12:00:00.000Z',
+      method: 'GET',
+      host: 'example.com',
+      path: '  /blog  ',
+      query_string: null,
+      status: 200,
+      user_agent: 'GPTBot/1.2',
+      remote_ip_hash: null,
+      referer: null,
+    })
+
+    expect(trimmed?.path).toBe('/blog')
+    expect(trimmed?.requestUrl).toBe('https://example.com/blog')
+
+    expect(normalizeWordpressTrafficEvent({
+      id: 1,
+      observed_at: '2026-05-11T12:00:00.000Z',
+      method: 'GET',
+      host: 'example.com',
+      path: '   ',
+      query_string: null,
+      status: 200,
+      user_agent: 'GPTBot/1.2',
+      remote_ip_hash: null,
+      referer: null,
+    })).toBeNull()
+  })
 })
 
 describe('listWordpressTrafficEvents', () => {

--- a/packages/integration-wordpress-traffic/test/wordpress-traffic-client.test.ts
+++ b/packages/integration-wordpress-traffic/test/wordpress-traffic-client.test.ts
@@ -1,0 +1,314 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  WordpressTrafficApiError,
+  listWordpressTrafficEvents,
+  normalizeWordpressTrafficEvent,
+} from '../src/index.js'
+
+describe('normalizeWordpressTrafficEvent', () => {
+  it('normalizes a plugin event row into a NormalizedTrafficRequest', () => {
+    const event = normalizeWordpressTrafficEvent({
+      id: 42,
+      observed_at: '2026-05-11T12:00:00.000Z',
+      method: 'GET',
+      host: 'example.com',
+      path: '/blog/post',
+      query_string: 'utm_source=chatgpt.com',
+      status: 200,
+      user_agent: 'GPTBot/1.2',
+      remote_ip_hash: 'sha256:abc',
+      referer: 'https://chatgpt.com/',
+    })
+
+    expect(event).toMatchObject({
+      sourceType: 'wordpress',
+      evidenceKind: 'raw-request',
+      confidence: 'observed',
+      eventId: 'wordpress:2026-05-11T12:00:00.000Z:42',
+      observedAt: '2026-05-11T12:00:00.000Z',
+      method: 'GET',
+      requestUrl: 'https://example.com/blog/post?utm_source=chatgpt.com',
+      host: 'example.com',
+      path: '/blog/post',
+      queryString: 'utm_source=chatgpt.com',
+      status: 200,
+      userAgent: 'GPTBot/1.2',
+      remoteIp: 'sha256:abc',
+      referer: 'https://chatgpt.com/',
+      latencyMs: null,
+      requestSizeBytes: null,
+      responseSizeBytes: null,
+      providerResource: {
+        type: 'wordpress_site',
+        labels: { host: 'example.com' },
+      },
+      providerLabels: {},
+    })
+  })
+
+  it('returns null for events missing required fields', () => {
+    expect(normalizeWordpressTrafficEvent({
+      id: 0,
+      observed_at: '',
+      method: null,
+      host: null,
+      path: '',
+      query_string: null,
+      status: null,
+      user_agent: null,
+      remote_ip_hash: null,
+      referer: null,
+    })).toBeNull()
+
+    expect(normalizeWordpressTrafficEvent({
+      id: 1,
+      observed_at: '2026-05-11T12:00:00.000Z',
+      method: null,
+      host: null,
+      path: '',
+      query_string: null,
+      status: null,
+      user_agent: null,
+      remote_ip_hash: null,
+      referer: null,
+    })).toBeNull()
+  })
+
+  it('omits the host from labels when the plugin did not capture it', () => {
+    const event = normalizeWordpressTrafficEvent({
+      id: 1,
+      observed_at: '2026-05-11T12:00:00.000Z',
+      method: 'GET',
+      host: null,
+      path: '/about',
+      query_string: null,
+      status: 200,
+      user_agent: 'Mozilla/5.0',
+      remote_ip_hash: null,
+      referer: null,
+    })
+
+    expect(event).not.toBeNull()
+    expect(event?.host).toBeNull()
+    expect(event?.requestUrl).toBe('/about')
+    expect(event?.providerResource.labels).toEqual({})
+  })
+
+  it('trims empty strings to null so blanks do not survive into the rollup', () => {
+    const event = normalizeWordpressTrafficEvent({
+      id: 1,
+      observed_at: '2026-05-11T12:00:00.000Z',
+      method: '  ',
+      host: 'example.com',
+      path: '/x',
+      query_string: '   ',
+      status: 200,
+      user_agent: '',
+      remote_ip_hash: null,
+      referer: null,
+    })
+
+    expect(event?.method).toBeNull()
+    expect(event?.userAgent).toBeNull()
+    expect(event?.queryString).toBeNull()
+  })
+})
+
+describe('listWordpressTrafficEvents', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  it('hits the plugin endpoint with Basic auth and normalizes the page', async () => {
+    fetchSpy.mockImplementation(async () => (
+      new Response(JSON.stringify({
+        events: [
+          {
+            id: 1,
+            observed_at: '2026-05-11T12:00:00.000Z',
+            method: 'GET',
+            host: 'example.com',
+            path: '/one',
+            query_string: null,
+            status: 200,
+            user_agent: 'GPTBot/1.2',
+            remote_ip_hash: 'sha256:abc',
+            referer: null,
+          },
+        ],
+        next_cursor: null,
+        has_more: false,
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    ))
+
+    const result = await listWordpressTrafficEvents({
+      baseUrl: 'https://example.com',
+      username: 'canonry-bot',
+      applicationPassword: 'xxxx xxxx xxxx xxxx xxxx xxxx',
+    })
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchSpy.mock.calls[0]!
+    expect(String(url)).toBe('https://example.com/wp-json/canonry/v1/events?limit=500')
+    expect((init as RequestInit).method).toBe('GET')
+    const headers = (init as RequestInit).headers as Record<string, string>
+    expect(headers.Authorization).toBe(
+      `Basic ${Buffer.from('canonry-bot:xxxx xxxx xxxx xxxx xxxx xxxx', 'utf8').toString('base64')}`,
+    )
+    expect(headers.Accept).toBe('application/json')
+
+    expect(result.endpoint).toBe('https://example.com/wp-json/canonry/v1/events')
+    expect(result.events).toHaveLength(1)
+    expect(result.events[0]!.path).toBe('/one')
+    expect(result.rawEntryCount).toBe(1)
+    expect(result.skippedEntryCount).toBe(0)
+    expect(result.nextCursor).toBeUndefined()
+  })
+
+  it('strips a trailing slash from baseUrl when composing the endpoint', async () => {
+    fetchSpy.mockImplementation(async () => (
+      new Response(JSON.stringify({ events: [], next_cursor: null, has_more: false }), {
+        status: 200, headers: { 'Content-Type': 'application/json' },
+      })
+    ))
+
+    const result = await listWordpressTrafficEvents({
+      baseUrl: 'https://example.com/',
+      username: 'u',
+      applicationPassword: 'p',
+    })
+
+    expect(result.endpoint).toBe('https://example.com/wp-json/canonry/v1/events')
+    expect(String(fetchSpy.mock.calls[0]![0])).toBe(
+      'https://example.com/wp-json/canonry/v1/events?limit=500',
+    )
+  })
+
+  it('paginates through multiple pages until has_more is false', async () => {
+    const urls: string[] = []
+    fetchSpy.mockImplementation(async (input) => {
+      urls.push(String(input))
+      const u = new URL(String(input))
+      const cursor = u.searchParams.get('cursor')
+      if (!cursor) {
+        return new Response(JSON.stringify({
+          events: [
+            { id: 1, observed_at: '2026-05-11T12:00:00.000Z', method: 'GET', host: 'x', path: '/a', query_string: null, status: 200, user_agent: 'a', remote_ip_hash: null, referer: null },
+          ],
+          next_cursor: '1',
+          has_more: true,
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      return new Response(JSON.stringify({
+        events: [
+          { id: 2, observed_at: '2026-05-11T12:01:00.000Z', method: 'GET', host: 'x', path: '/b', query_string: null, status: 200, user_agent: 'a', remote_ip_hash: null, referer: null },
+        ],
+        next_cursor: null,
+        has_more: false,
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    })
+
+    const result = await listWordpressTrafficEvents({
+      baseUrl: 'https://example.com',
+      username: 'u',
+      applicationPassword: 'p',
+      maxPages: 5,
+      pageSize: 100,
+    })
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+    expect(urls[0]).toBe('https://example.com/wp-json/canonry/v1/events?limit=100')
+    expect(urls[1]).toBe('https://example.com/wp-json/canonry/v1/events?limit=100&cursor=1')
+    expect(result.events.map((event) => event.path)).toEqual(['/a', '/b'])
+    expect(result.rawEntryCount).toBe(2)
+    expect(result.nextCursor).toBeUndefined()
+  })
+
+  it('stops paginating once maxPages is reached and surfaces the next cursor', async () => {
+    fetchSpy.mockImplementation(async () => (
+      new Response(JSON.stringify({
+        events: [
+          { id: 1, observed_at: '2026-05-11T12:00:00.000Z', method: 'GET', host: 'x', path: '/a', query_string: null, status: 200, user_agent: 'a', remote_ip_hash: null, referer: null },
+        ],
+        next_cursor: '999',
+        has_more: true,
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    ))
+
+    const result = await listWordpressTrafficEvents({
+      baseUrl: 'https://example.com',
+      username: 'u',
+      applicationPassword: 'p',
+      maxPages: 1,
+    })
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(result.nextCursor).toBe('999')
+  })
+
+  it('counts events that fail normalization as skipped without throwing', async () => {
+    fetchSpy.mockImplementation(async () => (
+      new Response(JSON.stringify({
+        events: [
+          { id: 1, observed_at: '2026-05-11T12:00:00.000Z', method: 'GET', host: 'x', path: '/a', query_string: null, status: 200, user_agent: 'a', remote_ip_hash: null, referer: null },
+          { id: 2, observed_at: '', method: null, host: null, path: '', query_string: null, status: null, user_agent: null, remote_ip_hash: null, referer: null },
+        ],
+        next_cursor: null,
+        has_more: false,
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    ))
+
+    const result = await listWordpressTrafficEvents({
+      baseUrl: 'https://example.com',
+      username: 'u',
+      applicationPassword: 'p',
+    })
+
+    expect(result.events).toHaveLength(1)
+    expect(result.rawEntryCount).toBe(2)
+    expect(result.skippedEntryCount).toBe(1)
+  })
+
+  it('throws WordpressTrafficApiError on non-2xx responses with truncated body', async () => {
+    fetchSpy.mockImplementation(async () => (
+      new Response('Unauthorized — bad Application Password', {
+        status: 401,
+        headers: { 'Content-Type': 'text/plain' },
+      })
+    ))
+
+    await expect(listWordpressTrafficEvents({
+      baseUrl: 'https://example.com',
+      username: 'u',
+      applicationPassword: 'p',
+    })).rejects.toMatchObject({
+      name: 'WordpressTrafficApiError',
+      status: 401,
+    })
+  })
+
+  it('rejects empty credentials before issuing a request', async () => {
+    await expect(listWordpressTrafficEvents({
+      baseUrl: 'https://example.com',
+      username: '',
+      applicationPassword: 'p',
+    })).rejects.toBeInstanceOf(WordpressTrafficApiError)
+    await expect(listWordpressTrafficEvents({
+      baseUrl: 'https://example.com',
+      username: 'u',
+      applicationPassword: '   ',
+    })).rejects.toBeInstanceOf(WordpressTrafficApiError)
+    await expect(listWordpressTrafficEvents({
+      baseUrl: '',
+      username: 'u',
+      applicationPassword: 'p',
+    })).rejects.toBeInstanceOf(WordpressTrafficApiError)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/integration-wordpress-traffic/tsconfig.json
+++ b/packages/integration-wordpress-traffic/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,6 +410,12 @@ importers:
         specifier: workspace:*
         version: link:../contracts
 
+  packages/integration-wordpress-traffic:
+    dependencies:
+      '@ainyc/canonry-contracts':
+        specifier: workspace:*
+        version: link:../contracts
+
   packages/intelligence:
     dependencies:
       '@ainyc/canonry-contracts':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,9 @@ importers:
       '@ainyc/canonry-integration-wordpress':
         specifier: workspace:*
         version: link:../integration-wordpress
+      '@ainyc/canonry-integration-wordpress-traffic':
+        specifier: workspace:*
+        version: link:../integration-wordpress-traffic
       '@ainyc/canonry-intelligence':
         specifier: workspace:*
         version: link:../intelligence

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -37,6 +37,7 @@ const NODE_PACKAGES = [
   'integration-google-analytics',
   'integration-traffic',
   'integration-wordpress',
+  'integration-wordpress-traffic',
   'intelligence',
   'provider-cdp',
   'provider-claude',


### PR DESCRIPTION
## Summary

Foundation for a WordPress server-side traffic source alongside the existing Cloud Run adapter, per [`plans/server-side-ai-traffic-ingestion.md`](../blob/main/plans/server-side-ai-traffic-ingestion.md). Adds the new `@ainyc/canonry-integration-wordpress-traffic` package with `listWordpressTrafficEvents()` (cursor-paginated pull, Application-Password Basic auth, normalizes plugin event rows into the shared `NormalizedTrafficRequest` shape) and `wordpressTrafficSourceConfigSchema` + `trafficConnectWordpressRequestSchema` in contracts. Adds a separate `wordpressTraffic.connections` block to `~/.canonry/config.yaml` (kept independent from the existing content-publishing `wordpress.connections` per the "two plugins" decision) plus list/get/upsert/remove helpers. Classification stays server-side in `packages/integration-traffic` so adapter rules can evolve without plugin updates; IPs arrive pre-hashed from the plugin so every WP event stays `claimed_unverified` for now.

## Test plan

- [x] `pnpm typecheck` — 23 workspace projects clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 216 files / 2356 tests pass (11 new adapter tests + 4 config-helper tests + 6 new contract assertions)
- [x] Follow-up slices: API route + sync dispatch branch, `canonry traffic connect wordpress` CLI, doctor validator for `'wordpress'`, and the PHP MU-plugin itself