### PR TITLE
feat(traffic): wire WordPress traffic adapter — connect route, CLI, doctor validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ on:
       - 'scripts/**'
       - 'AGENTS.md'
   pull_request:
-    branches: [main]
+    # No `branches:` filter — run CI on every PR, including stacked PRs
+    # targeting feature branches. This keeps each step of a stack green
+    # without waiting until rebase-to-main.
     paths:
       - '.github/workflows/ci.yml'
       - '.dockerignore'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.22.1",
+  "version": "4.23.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/package.json
+++ b/packages/api-routes/package.json
@@ -27,6 +27,7 @@
     "@ainyc/canonry-integration-google-analytics": "workspace:*",
     "@ainyc/canonry-integration-traffic": "workspace:*",
     "@ainyc/canonry-integration-wordpress": "workspace:*",
+    "@ainyc/canonry-integration-wordpress-traffic": "workspace:*",
     "drizzle-orm": "^0.45.1",
     "fastify": "^5.4.0"
   }

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -43,8 +43,12 @@ import { backlinksRoutes } from './backlinks.js'
 import type { BacklinksRoutesOptions } from './backlinks.js'
 import { trafficRoutes, defaultResolveAccessToken } from './traffic.js'
 import type { TrafficRoutesOptions, CloudRunCredentialStore } from './traffic.js'
+import {
+  listWordpressTrafficEvents,
+  WordpressTrafficApiError,
+} from '@ainyc/canonry-integration-wordpress-traffic'
 import { doctorRoutes } from './doctor.js'
-import { CheckStatuses } from '@ainyc/canonry-contracts'
+import { CheckStatuses, TrafficSourceTypes } from '@ainyc/canonry-contracts'
 import type { CheckOutput, TrafficSourceProbe, TrafficSourceValidator } from './doctor/types.js'
 
 declare module 'fastify' {
@@ -115,6 +119,10 @@ export interface ApiRoutesOptions {
   pullCloudRunEvents?: TrafficRoutesOptions['pullCloudRunEvents']
   /** Override Cloud Run access-token resolver (tests) — see `TrafficRoutesOptions` */
   resolveCloudRunAccessToken?: TrafficRoutesOptions['resolveCloudRunAccessToken']
+  /** WordPress traffic-logger credential store — stores Application Passwords in config, not DB */
+  wordpressTrafficCredentialStore?: TrafficRoutesOptions['wordpressTrafficCredentialStore']
+  /** Override WordPress traffic pull (tests) — see `TrafficRoutesOptions` */
+  pullWordpressTrafficEvents?: TrafficRoutesOptions['pullWordpressTrafficEvents']
   /** Fired after every traffic sync (success OR failure). Used by canonry to emit `traffic.synced` telemetry. */
   onTrafficSynced?: TrafficRoutesOptions['onTrafficSynced']
   /** Backlinks feature callbacks — see `backlinksRoutes` for details. */
@@ -278,6 +286,8 @@ export async function apiRoutes(app: FastifyInstance, opts: ApiRoutesOptions) {
       cloudRunCredentialStore: opts.cloudRunCredentialStore,
       pullCloudRunEvents: opts.pullCloudRunEvents,
       resolveCloudRunAccessToken: opts.resolveCloudRunAccessToken,
+      wordpressTrafficCredentialStore: opts.wordpressTrafficCredentialStore,
+      pullWordpressTrafficEvents: opts.pullWordpressTrafficEvents,
       onTrafficSynced: opts.onTrafficSynced,
     } satisfies TrafficRoutesOptions)
     // Always mount the backlinks routes so read endpoints (summary, domains,
@@ -367,6 +377,54 @@ function buildTrafficSourceValidators(opts: ApiRoutesOptions): Record<string, Tr
       // at the IAM layer rather than baked into the token. We surface a
       // skipped result so the framework is uniform without producing a
       // false signal.
+      validateScopes: () => null,
+    }
+  }
+  if (opts.wordpressTrafficCredentialStore) {
+    const store = opts.wordpressTrafficCredentialStore
+    const pullEvents = opts.pullWordpressTrafficEvents ?? listWordpressTrafficEvents
+    validators[TrafficSourceTypes.wordpress] = {
+      validateCredentials: async (source: TrafficSourceProbe): Promise<CheckOutput> => {
+        const record = store.getConnection(source.projectName)
+        if (!record) {
+          return {
+            status: CheckStatuses.fail,
+            code: 'traffic.credentials.missing',
+            summary: `No WordPress traffic credential found in ~/.canonry/config.yaml for project "${source.projectName}".`,
+            remediation: 'Re-run `canonry traffic connect wordpress <project> --url <site> --username <user> --app-password <password>`.',
+          }
+        }
+        try {
+          await pullEvents({
+            baseUrl: record.baseUrl,
+            username: record.username,
+            applicationPassword: record.applicationPassword,
+            pageSize: 1,
+            maxPages: 1,
+          })
+          return {
+            status: CheckStatuses.ok,
+            code: 'traffic.credentials.resolved',
+            summary: `WordPress endpoint responds for "${source.displayName}" (${new URL(record.baseUrl).host}).`,
+          }
+        } catch (e) {
+          const httpStatus = e instanceof WordpressTrafficApiError ? e.status : null
+          const msg = e instanceof Error ? e.message : String(e)
+          return {
+            status: CheckStatuses.fail,
+            code: httpStatus === 401 || httpStatus === 403
+              ? 'traffic.credentials.unauthorized'
+              : 'traffic.credentials.resolve-failed',
+            summary: httpStatus
+              ? `WordPress endpoint returned HTTP ${httpStatus}: ${msg}.`
+              : `WordPress endpoint probe failed: ${msg}.`,
+            remediation: 'Verify the site URL is reachable and the Application Password is valid. Re-connect the source if needed.',
+          }
+        }
+      },
+      // WordPress Application Passwords have no scope concept — auth is
+      // strictly "valid credential or not". Surface a skipped result so the
+      // framework is uniform without producing a false signal.
       validateScopes: () => null,
     }
   }

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -2779,6 +2779,38 @@ const routeCatalog: OpenApiOperation[] = [
   },
   {
     method: 'post',
+    path: '/api/v1/projects/{name}/traffic/connect/wordpress',
+    summary: 'Connect a WordPress traffic-logger source',
+    description:
+      'Probes the WordPress traffic-logger plugin endpoint with the supplied Application Password (single page, `limit=1`) before persisting. On success, stores the credential in `~/.canonry/config.yaml` and creates / updates the project\'s active WordPress `traffic_sources` row. A probe failure (HTTP 4xx/5xx, network error) surfaces as 502 with the upstream status in the message so the caller learns about a bad credential up front instead of at the first sync.',
+    tags: ['traffic'],
+    parameters: [nameParameter],
+    requestBody: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            required: ['baseUrl', 'username', 'applicationPassword'],
+            properties: {
+              baseUrl: { ...stringSchema, description: 'Absolute base URL of the WordPress site (e.g. `https://example.com`).' },
+              username: { ...stringSchema, description: 'WordPress username paired with the Application Password.' },
+              applicationPassword: { ...stringSchema, description: 'WordPress Application Password (raw; the server base64-encodes it for Basic auth).' },
+              displayName: stringSchema,
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: { description: 'Traffic source DTO returned.' },
+      400: { description: 'Invalid WordPress connection request.' },
+      404: { description: 'Project not found.' },
+      502: { description: 'WordPress plugin endpoint probe failed (bad credentials, unreachable host, etc.).' },
+    },
+  },
+  {
+    method: 'post',
     path: '/api/v1/projects/{name}/traffic/sources/{id}/sync',
     summary: 'Trigger a sync run for a traffic source',
     description:

--- a/packages/api-routes/src/traffic.ts
+++ b/packages/api-routes/src/traffic.ts
@@ -20,6 +20,7 @@ import {
   TrafficSourceTypes,
   TrafficSourceAuthModes,
   TrafficEventKinds,
+  trafficConnectWordpressRequestSchema,
 } from '@ainyc/canonry-contracts'
 import type {
   RunStatus,
@@ -44,6 +45,14 @@ import type {
   ListCloudRunTrafficEventsOptions,
 } from '@ainyc/canonry-integration-cloud-run'
 import { buildTrafficProbeReport } from '@ainyc/canonry-integration-traffic'
+import {
+  listWordpressTrafficEvents,
+  WordpressTrafficApiError,
+} from '@ainyc/canonry-integration-wordpress-traffic'
+import type {
+  ListWordpressTrafficEventsOptions,
+  WordpressTrafficEventsPage,
+} from '@ainyc/canonry-integration-wordpress-traffic'
 import { resolveProject, writeAuditLog } from './helpers.js'
 
 export interface CloudRunCredentialRecord {
@@ -64,6 +73,21 @@ export interface CloudRunCredentialRecord {
 export interface CloudRunCredentialStore {
   getConnection: (projectName: string) => CloudRunCredentialRecord | undefined
   upsertConnection: (record: CloudRunCredentialRecord) => CloudRunCredentialRecord
+  deleteConnection: (projectName: string) => boolean
+}
+
+export interface WordpressTrafficCredentialRecord {
+  projectName: string
+  baseUrl: string
+  username: string
+  applicationPassword: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface WordpressTrafficCredentialStore {
+  getConnection: (projectName: string) => WordpressTrafficCredentialRecord | undefined
+  upsertConnection: (record: WordpressTrafficCredentialRecord) => WordpressTrafficCredentialRecord
   deleteConnection: (projectName: string) => boolean
 }
 
@@ -95,6 +119,15 @@ export interface TrafficRoutesOptions {
   ) => Promise<CloudRunTrafficEventsPage>
   /** Override the access-token resolver (for tests). Defaults to service-account JWT exchange. */
   resolveCloudRunAccessToken?: (record: CloudRunCredentialRecord) => Promise<string>
+  /**
+   * Store for WordPress traffic-logger Application Password credentials. When
+   * absent, the WordPress connect / sync routes return a configuration error.
+   */
+  wordpressTrafficCredentialStore?: WordpressTrafficCredentialStore
+  /** Override the WordPress traffic pull function (for tests). Defaults to `listWordpressTrafficEvents`. */
+  pullWordpressTrafficEvents?: (
+    options: ListWordpressTrafficEventsOptions,
+  ) => Promise<WordpressTrafficEventsPage>
   /** Default lookback window in minutes when a sync is triggered without an explicit `since`. */
   defaultSyncWindowMinutes?: number
   /** Default page size for entries.list pulls. */
@@ -427,6 +460,7 @@ async function runBackfillTask(options: RunBackfillTaskOptions): Promise<void> {
 export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOptions) {
   const pullEvents = opts.pullCloudRunEvents ?? listCloudRunTrafficEvents
   const resolveAccessToken = opts.resolveCloudRunAccessToken ?? defaultResolveAccessToken
+  const pullWordpressEvents = opts.pullWordpressTrafficEvents ?? listWordpressTrafficEvents
   const syncWindowMinutes = opts.defaultSyncWindowMinutes ?? DEFAULT_SYNC_WINDOW_MINUTES
   const pageSize = opts.defaultPageSize ?? DEFAULT_PAGE_SIZE
   const maxPages = opts.defaultMaxPages ?? DEFAULT_MAX_PAGES
@@ -548,6 +582,132 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
       projectId: project.id,
       actor: 'api',
       action: 'traffic.cloud-run.connected',
+      entityType: 'traffic_source',
+      entityId: sourceRow.id,
+    })
+
+    return rowToDto(sourceRow)
+  })
+
+  // POST /projects/:name/traffic/connect/wordpress
+  //
+  // Probes the WordPress traffic-logger plugin endpoint with the supplied
+  // Application Password (single-page, limit=1) before persisting — a probe
+  // failure surfaces as `providerError()` so the caller sees a meaningful
+  // diagnostic up front instead of discovering it at the first sync.
+  app.post<{
+    Params: { name: string }
+    Body: {
+      baseUrl?: string
+      username?: string
+      applicationPassword?: string
+      displayName?: string
+    }
+  }>('/projects/:name/traffic/connect/wordpress', async (request) => {
+    const project = resolveProject(app.db, request.params.name)
+    if (!opts.wordpressTrafficCredentialStore) {
+      throw validationError('WordPress traffic credential storage is not configured for this deployment')
+    }
+    const credentialStore = opts.wordpressTrafficCredentialStore
+
+    const parsed = trafficConnectWordpressRequestSchema.safeParse(request.body ?? {})
+    if (!parsed.success) {
+      throw validationError(parsed.error.issues.map((i) => i.message).join('; '))
+    }
+    const { baseUrl, username, applicationPassword, displayName } = parsed.data
+
+    // Probe the plugin endpoint up-front so the caller learns about a bad
+    // URL / wrong credential before we touch any persistent state.
+    try {
+      await pullWordpressEvents({
+        baseUrl,
+        username,
+        applicationPassword,
+        pageSize: 1,
+        maxPages: 1,
+      })
+    } catch (e) {
+      if (e instanceof WordpressTrafficApiError) {
+        throw providerError(
+          `WordPress traffic probe failed (HTTP ${e.status}): ${e.message}${e.body ? ` — ${e.body}` : ''}`,
+        )
+      }
+      const msg = e instanceof Error ? e.message : String(e)
+      throw providerError(`WordPress traffic probe failed: ${msg}`)
+    }
+
+    const now = new Date().toISOString()
+    const existing = credentialStore.getConnection(project.name)
+    credentialStore.upsertConnection({
+      projectName: project.name,
+      baseUrl,
+      username,
+      applicationPassword,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    })
+
+    // Single active WordPress source per project; reconnect updates it.
+    const activeSource = app.db
+      .select()
+      .from(trafficSources)
+      .where(eq(trafficSources.projectId, project.id))
+      .all()
+      .find((row) => row.sourceType === TrafficSourceTypes.wordpress && row.status !== TrafficSourceStatuses.archived)
+
+    // Only non-secret config goes on the row — the Application Password lives
+    // in ~/.canonry/config.yaml via the credential store.
+    const config: Record<string, unknown> = { baseUrl, username }
+    const fallbackName = displayName ?? `WordPress · ${new URL(baseUrl).host}`
+
+    let sourceRow: typeof trafficSources.$inferSelect
+    if (activeSource) {
+      app.db
+        .update(trafficSources)
+        .set({
+          displayName: fallbackName,
+          status: TrafficSourceStatuses.connected,
+          lastError: null,
+          configJson: JSON.stringify(config),
+          updatedAt: now,
+        })
+        .where(eq(trafficSources.id, activeSource.id))
+        .run()
+      sourceRow = app.db
+        .select()
+        .from(trafficSources)
+        .where(eq(trafficSources.id, activeSource.id))
+        .get()!
+    } else {
+      const newId = crypto.randomUUID()
+      app.db
+        .insert(trafficSources)
+        .values({
+          id: newId,
+          projectId: project.id,
+          sourceType: TrafficSourceTypes.wordpress,
+          displayName: fallbackName,
+          status: TrafficSourceStatuses.connected,
+          lastSyncedAt: null,
+          lastCursor: null,
+          lastError: null,
+          archivedAt: null,
+          configJson: JSON.stringify(config),
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run()
+      sourceRow = app.db
+        .select()
+        .from(trafficSources)
+        .where(eq(trafficSources.id, newId))
+        .get()!
+    }
+
+    writeAuditLog(app.db, {
+      projectId: project.id,
+      actor: 'api',
+      action: 'traffic.wordpress.connected',
       entityType: 'traffic_source',
       entityId: sourceRow.id,
     })

--- a/packages/api-routes/test/traffic.test.ts
+++ b/packages/api-routes/test/traffic.test.ts
@@ -22,8 +22,18 @@ import {
 } from '@ainyc/canonry-contracts'
 import type { NormalizedTrafficRequest } from '@ainyc/canonry-contracts'
 import type { CloudRunTrafficEventsPage } from '@ainyc/canonry-integration-cloud-run'
+import type {
+  ListWordpressTrafficEventsOptions,
+  WordpressTrafficEventsPage,
+} from '@ainyc/canonry-integration-wordpress-traffic'
+import { WordpressTrafficApiError } from '@ainyc/canonry-integration-wordpress-traffic'
 import { apiRoutes } from '../src/index.js'
-import type { CloudRunCredentialRecord, CloudRunCredentialStore } from '../src/traffic.js'
+import type {
+  CloudRunCredentialRecord,
+  CloudRunCredentialStore,
+  WordpressTrafficCredentialRecord,
+  WordpressTrafficCredentialStore,
+} from '../src/traffic.js'
 
 function buildEvent(overrides: Partial<NormalizedTrafficRequest> = {}): NormalizedTrafficRequest {
   const base: NormalizedTrafficRequest = {
@@ -58,6 +68,8 @@ async function buildHarness(
     failResolveAccessTokenWith?: string
     /** Force the Cloud Run pull to fail with this message. */
     failPullWith?: string
+    /** Force the WordPress traffic pull (used for probe) to throw a `WordpressTrafficApiError`. */
+    failWpProbeWith?: { status: number; message: string; body?: string }
   } = {},
 ) {
   const trafficSyncedEvents: Array<unknown> = []
@@ -75,6 +87,18 @@ async function buildHarness(
     },
     deleteConnection: (projectName) => credentials.delete(projectName),
   }
+
+  const wpCredentials = new Map<string, WordpressTrafficCredentialRecord>()
+  const wordpressTrafficCredentialStore: WordpressTrafficCredentialStore = {
+    getConnection: (projectName) => wpCredentials.get(projectName),
+    upsertConnection: (record) => {
+      wpCredentials.set(record.projectName, record)
+      return record
+    },
+    deleteConnection: (projectName) => wpCredentials.delete(projectName),
+  }
+
+  const wpProbeInvocations: ListWordpressTrafficEventsOptions[] = []
 
   let pullInvocations = 0
   const observedWindows: Array<{ startTime: string; endTime: string }> = []
@@ -112,6 +136,24 @@ async function buildHarness(
       if (options.failResolveAccessTokenWith) throw new Error(options.failResolveAccessTokenWith)
       return 'mock-access-token'
     },
+    wordpressTrafficCredentialStore,
+    pullWordpressTrafficEvents: async (pullOptions): Promise<WordpressTrafficEventsPage> => {
+      wpProbeInvocations.push(pullOptions)
+      if (options.failWpProbeWith) {
+        throw new WordpressTrafficApiError(
+          options.failWpProbeWith.message,
+          options.failWpProbeWith.status,
+          options.failWpProbeWith.body,
+        )
+      }
+      return {
+        events: [],
+        rawEntryCount: 0,
+        skippedEntryCount: 0,
+        nextCursor: undefined,
+        endpoint: `${pullOptions.baseUrl}/wp-json/canonry/v1/events`,
+      }
+    },
     onTrafficSynced: (event) => { trafficSyncedEvents.push(event) },
   })
   await app.ready()
@@ -132,11 +174,13 @@ async function buildHarness(
     app,
     db,
     credentials,
+    wpCredentials,
     tmpDir,
     getPullCount: () => pullInvocations,
     getObservedWindows: () => observedWindows,
     getObservedFirstSync: () => observedFirstSync,
     getTrafficSyncedEvents: () => trafficSyncedEvents,
+    getWpProbeInvocations: () => wpProbeInvocations,
     close: async () => {
       await app.close()
       fs.rmSync(tmpDir, { recursive: true, force: true })
@@ -233,6 +277,103 @@ describe('POST /traffic/connect/cloud-run', () => {
     const config = JSON.parse(sources[0].configJson) as Record<string, unknown>
     expect(config.gcpProjectId).toBe('new-project')
     expect(config.serviceName).toBe('new-svc')
+  })
+})
+
+describe('POST /traffic/connect/wordpress', () => {
+  let h: Awaited<ReturnType<typeof buildHarness>>
+  beforeEach(async () => { h = await buildHarness([]) })
+  afterEach(async () => { await h.close() })
+
+  const validBody = {
+    baseUrl: 'https://example.com',
+    username: 'canonry-bot',
+    applicationPassword: 'xxxx xxxx xxxx xxxx xxxx xxxx',
+  }
+
+  it('rejects requests with an invalid baseUrl', async () => {
+    const res = await h.app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/test-project/traffic/connect/wordpress',
+      payload: { ...validBody, baseUrl: 'not-a-url' },
+    })
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('rejects requests with empty applicationPassword', async () => {
+    const res = await h.app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/test-project/traffic/connect/wordpress',
+      payload: { ...validBody, applicationPassword: '' },
+    })
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('probes the plugin endpoint, persists credentials, and creates the source row', async () => {
+    const res = await h.app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/test-project/traffic/connect/wordpress',
+      payload: { ...validBody, displayName: 'Example WP' },
+    })
+    expect(res.statusCode).toBe(200)
+    const dto = JSON.parse(res.payload)
+    expect(dto.sourceType).toBe(TrafficSourceTypes.wordpress)
+    expect(dto.status).toBe(TrafficSourceStatuses.connected)
+    expect(dto.displayName).toBe('Example WP')
+    expect(dto.config.baseUrl).toBe('https://example.com')
+    expect(dto.config.username).toBe('canonry-bot')
+    // Application password must never leak into the row config; it lives in
+    // ~/.canonry/config.yaml only.
+    expect(dto.config.applicationPassword).toBeUndefined()
+
+    // Probe ran once before any persistence.
+    const probes = h.getWpProbeInvocations()
+    expect(probes.length).toBe(1)
+    expect(probes[0]!.baseUrl).toBe('https://example.com')
+    expect(probes[0]!.pageSize).toBe(1)
+
+    const stored = h.wpCredentials.get('test-project')
+    expect(stored?.applicationPassword).toBe('xxxx xxxx xxxx xxxx xxxx xxxx')
+
+    const sourceRows = h.db.select().from(trafficSources).all()
+    expect(sourceRows.length).toBe(1)
+    expect(sourceRows[0].sourceType).toBe(TrafficSourceTypes.wordpress)
+  })
+
+  it('returns 502 and persists nothing when the probe fails with bad credentials', async () => {
+    await h.close()
+    h = await buildHarness([], {
+      failWpProbeWith: { status: 401, message: 'Unauthorized', body: 'bad password' },
+    })
+
+    const res = await h.app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/test-project/traffic/connect/wordpress',
+      payload: validBody,
+    })
+    expect(res.statusCode).toBe(502)
+    expect(JSON.parse(res.payload).error.message).toMatch(/HTTP 401/)
+    // Probe ran but neither credential nor source row was written.
+    expect(h.wpCredentials.get('test-project')).toBeUndefined()
+    expect(h.db.select().from(trafficSources).all().length).toBe(0)
+  })
+
+  it('reuses the existing source row on reconnect rather than creating a duplicate', async () => {
+    await h.app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/test-project/traffic/connect/wordpress',
+      payload: validBody,
+    })
+    const second = await h.app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/test-project/traffic/connect/wordpress',
+      payload: { ...validBody, baseUrl: 'https://example.com', username: 'new-bot' },
+    })
+    expect(second.statusCode).toBe(200)
+    const sources = h.db.select().from(trafficSources).all()
+    expect(sources.length).toBe(1)
+    const config = JSON.parse(sources[0].configJson) as Record<string, unknown>
+    expect(config.username).toBe('new-bot')
   })
 })
 

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.22.1",
+  "version": "4.23.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/cli-commands/traffic.ts
+++ b/packages/canonry/src/cli-commands/traffic.ts
@@ -1,6 +1,7 @@
 import {
   trafficBackfill,
   trafficConnectCloudRun,
+  trafficConnectWordpress,
   trafficEvents,
   trafficSources,
   trafficStatus,
@@ -42,13 +43,44 @@ export const TRAFFIC_CLI_COMMANDS: readonly CliCommandSpec[] = [
     },
   },
   {
+    path: ['traffic', 'connect', 'wordpress'],
+    usage: 'canonry traffic connect wordpress <project> --url <wp-site-url> --username <wp-user> --app-password <app-password> [--display-name <name>] [--format json]',
+    options: {
+      url: stringOption(),
+      username: stringOption(),
+      'app-password': stringOption(),
+      'display-name': stringOption(),
+    },
+    run: async (input) => {
+      const project = requireProject(
+        input,
+        'traffic.connect.wordpress',
+        'canonry traffic connect wordpress <project> --url <wp-site-url> --username <wp-user> --app-password <app-password>',
+      )
+      const url = getString(input.values, 'url')
+      if (!url) throw new Error('--url is required')
+      const username = getString(input.values, 'username')
+      if (!username) throw new Error('--username is required')
+      const appPassword = getString(input.values, 'app-password')
+      if (!appPassword) throw new Error('--app-password is required')
+
+      await trafficConnectWordpress(project, {
+        url,
+        username,
+        appPassword,
+        displayName: getString(input.values, 'display-name'),
+        format: input.format,
+      })
+    },
+  },
+  {
     path: ['traffic', 'connect'],
     usage: 'canonry traffic connect <provider> <project> [args]',
     run: async (input) => {
       unknownSubcommand(input.positionals[0], {
         command: 'traffic connect',
         usage: 'canonry traffic connect <provider> <project> [args]',
-        available: ['cloud-run'],
+        available: ['cloud-run', 'wordpress'],
       })
     },
   },

--- a/packages/canonry/src/cli-commands/traffic.ts
+++ b/packages/canonry/src/cli-commands/traffic.ts
@@ -44,30 +44,30 @@ export const TRAFFIC_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['traffic', 'connect', 'wordpress'],
-    usage: 'canonry traffic connect wordpress <project> --url <wp-site-url> --username <wp-user> --app-password <app-password> [--display-name <name>] [--format json]',
+    usage: 'canonry traffic connect wordpress <project> --url <wp-site-url> --username <wp-user> (--app-password <pw> | --app-password-file <path>) [--display-name <name>] [--format json]',
     options: {
       url: stringOption(),
       username: stringOption(),
       'app-password': stringOption(),
+      'app-password-file': stringOption(),
       'display-name': stringOption(),
     },
     run: async (input) => {
       const project = requireProject(
         input,
         'traffic.connect.wordpress',
-        'canonry traffic connect wordpress <project> --url <wp-site-url> --username <wp-user> --app-password <app-password>',
+        'canonry traffic connect wordpress <project> --url <wp-site-url> --username <wp-user> (--app-password <pw> | --app-password-file <path>)',
       )
       const url = getString(input.values, 'url')
       if (!url) throw new Error('--url is required')
       const username = getString(input.values, 'username')
       if (!username) throw new Error('--username is required')
-      const appPassword = getString(input.values, 'app-password')
-      if (!appPassword) throw new Error('--app-password is required')
 
       await trafficConnectWordpress(project, {
         url,
         username,
-        appPassword,
+        appPassword: getString(input.values, 'app-password'),
+        appPasswordFile: getString(input.values, 'app-password-file'),
         displayName: getString(input.values, 'display-name'),
         format: input.format,
       })

--- a/packages/canonry/src/client.ts
+++ b/packages/canonry/src/client.ts
@@ -77,6 +77,7 @@ import type {
   TrafficStatusResponse,
   TrafficEventsResponse,
   TrafficConnectCloudRunRequest,
+  TrafficConnectWordpressRequest,
   TrafficSyncResponse,
   TrafficBackfillResponse,
 } from '@ainyc/canonry-contracts'
@@ -801,6 +802,14 @@ export class ApiClient {
     return this.request<TrafficSourceDto>(
       'POST',
       `/projects/${encodeURIComponent(project)}/traffic/connect/cloud-run`,
+      body,
+    )
+  }
+
+  async trafficConnectWordpress(project: string, body: TrafficConnectWordpressRequest): Promise<TrafficSourceDto> {
+    return this.request<TrafficSourceDto>(
+      'POST',
+      `/projects/${encodeURIComponent(project)}/traffic/connect/wordpress`,
       body,
     )
   }

--- a/packages/canonry/src/commands/traffic.ts
+++ b/packages/canonry/src/commands/traffic.ts
@@ -19,7 +19,10 @@ function getClient() {
 export async function trafficConnectWordpress(project: string, opts: {
   url: string
   username: string
-  appPassword: string
+  /** Inline Application Password value. Mutually exclusive with `appPasswordFile`. */
+  appPassword?: string
+  /** Path to a file containing the Application Password. Preferred — keeps the secret out of shell history. */
+  appPasswordFile?: string
   displayName?: string
   format?: string
 }): Promise<void> {
@@ -39,11 +42,34 @@ export async function trafficConnectWordpress(project: string, opts: {
       details: { project },
     })
   }
-  if (!opts.appPassword) {
+  if (opts.appPassword && opts.appPasswordFile) {
+    throw new CliError({
+      code: 'TRAFFIC_WP_APP_PASSWORD_CONFLICT',
+      message: '--app-password and --app-password-file are mutually exclusive',
+      displayMessage: 'Error: pass either --app-password <pw> or --app-password-file <path>, not both',
+      details: { project },
+    })
+  }
+  let applicationPassword = opts.appPassword?.trim() ?? ''
+  if (!applicationPassword && opts.appPasswordFile) {
+    const fs = await import('node:fs')
+    try {
+      applicationPassword = fs.readFileSync(opts.appPasswordFile, 'utf-8').trim()
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      throw new CliError({
+        code: 'TRAFFIC_WP_APP_PASSWORD_FILE_READ_ERROR',
+        message: `Failed to read --app-password-file: ${msg}`,
+        displayMessage: `Error: failed to read --app-password-file "${opts.appPasswordFile}": ${msg}`,
+        details: { project, appPasswordFile: opts.appPasswordFile },
+      })
+    }
+  }
+  if (!applicationPassword) {
     throw new CliError({
       code: 'TRAFFIC_WP_APP_PASSWORD_REQUIRED',
-      message: '--app-password is required',
-      displayMessage: 'Error: --app-password is required',
+      message: '--app-password or --app-password-file is required',
+      displayMessage: 'Error: pass --app-password <pw> or --app-password-file <path>',
       details: { project },
     })
   }
@@ -52,7 +78,7 @@ export async function trafficConnectWordpress(project: string, opts: {
   const result: TrafficSourceDto = await client.trafficConnectWordpress(project, {
     baseUrl: opts.url,
     username: opts.username,
-    applicationPassword: opts.appPassword,
+    applicationPassword,
     displayName: opts.displayName,
   })
 

--- a/packages/canonry/src/commands/traffic.ts
+++ b/packages/canonry/src/commands/traffic.ts
@@ -16,6 +16,61 @@ function getClient() {
   return createApiClient()
 }
 
+export async function trafficConnectWordpress(project: string, opts: {
+  url: string
+  username: string
+  appPassword: string
+  displayName?: string
+  format?: string
+}): Promise<void> {
+  if (!opts.url) {
+    throw new CliError({
+      code: 'TRAFFIC_WP_URL_REQUIRED',
+      message: '--url is required',
+      displayMessage: 'Error: --url is required',
+      details: { project },
+    })
+  }
+  if (!opts.username) {
+    throw new CliError({
+      code: 'TRAFFIC_WP_USERNAME_REQUIRED',
+      message: '--username is required',
+      displayMessage: 'Error: --username is required',
+      details: { project },
+    })
+  }
+  if (!opts.appPassword) {
+    throw new CliError({
+      code: 'TRAFFIC_WP_APP_PASSWORD_REQUIRED',
+      message: '--app-password is required',
+      displayMessage: 'Error: --app-password is required',
+      details: { project },
+    })
+  }
+
+  const client = getClient()
+  const result: TrafficSourceDto = await client.trafficConnectWordpress(project, {
+    baseUrl: opts.url,
+    username: opts.username,
+    applicationPassword: opts.appPassword,
+    displayName: opts.displayName,
+  })
+
+  if (opts.format === 'json') {
+    console.log(JSON.stringify(result, null, 2))
+    return
+  }
+
+  console.log(`WordPress traffic source connected for project "${project}".`)
+  console.log(`  Source ID:    ${result.id}`)
+  console.log(`  Display name: ${result.displayName}`)
+  console.log(`  Status:       ${result.status}`)
+  console.log(`  Site URL:     ${result.config.baseUrl ?? '(unset)'}`)
+  console.log(`  Username:     ${result.config.username ?? '(unset)'}`)
+  console.log('')
+  console.log(`Next: canonry traffic sync ${project} --source ${result.id}`)
+}
+
 export async function trafficConnectCloudRun(project: string, opts: {
   gcpProject: string
   service?: string

--- a/packages/canonry/src/mcp/openapi-classification.ts
+++ b/packages/canonry/src/mcp/openapi-classification.ts
@@ -96,6 +96,7 @@ export const MCP_OPENAPI_OPERATION_CLASSIFICATIONS = {
   'GET /api/v1/projects/{name}/bing/performance': 'deferred',
   'POST /api/v1/projects/{name}/wordpress/connect': 'deferred',
   'POST /api/v1/projects/{name}/traffic/connect/cloud-run': 'included',
+  'POST /api/v1/projects/{name}/traffic/connect/wordpress': 'included',
   'POST /api/v1/projects/{name}/traffic/sources/{id}/sync': 'included',
   'POST /api/v1/projects/{name}/traffic/sources/{id}/backfill': 'included',
   'GET /api/v1/projects/{name}/traffic/sources': 'included',

--- a/packages/canonry/src/mcp/tool-registry.ts
+++ b/packages/canonry/src/mcp/tool-registry.ts
@@ -15,6 +15,7 @@ import {
   schedulableRunKindSchema,
   scheduleUpsertRequestSchema,
   trafficConnectCloudRunRequestSchema,
+  trafficConnectWordpressRequestSchema,
   trafficEventKindSchema,
   type NotificationEvent,
 } from '@ainyc/canonry-contracts'
@@ -227,6 +228,11 @@ const memoryForgetInputSchema = z.object({
 const trafficConnectCloudRunInputSchema = z.object({
   project: projectNameSchema,
   request: trafficConnectCloudRunRequestSchema,
+})
+
+const trafficConnectWordpressInputSchema = z.object({
+  project: projectNameSchema,
+  request: trafficConnectWordpressRequestSchema,
 })
 
 const trafficSyncInputSchema = z.object({
@@ -845,6 +851,17 @@ export const canonryMcpTools = [
     annotations: writeAnnotations({ idempotentHint: true, openWorldHint: true }),
     openApiOperations: ['POST /api/v1/projects/{name}/traffic/connect/cloud-run'],
     handler: (client, input) => client.trafficConnectCloudRun(input.project, input.request),
+  }),
+  defineTool({
+    name: 'canonry_traffic_connect_wordpress',
+    title: 'Connect WordPress traffic-logger source',
+    description: 'Connect a WordPress site (running the canonry traffic-logger plugin) as a server-side traffic source. Probes the plugin endpoint with the supplied Application Password before persisting — a bad credential or unreachable host surfaces as a 502 error. Reconnecting updates the existing active WordPress source in place. The Application Password is stored in ~/.canonry/config.yaml (not the DB) and never echoed back.',
+    access: 'write',
+    tier: 'traffic',
+    inputSchema: trafficConnectWordpressInputSchema,
+    annotations: writeAnnotations({ idempotentHint: true, openWorldHint: true }),
+    openApiOperations: ['POST /api/v1/projects/{name}/traffic/connect/wordpress'],
+    handler: (client, input) => client.trafficConnectWordpress(input.project, input.request),
   }),
   defineTool({
     name: 'canonry_traffic_sync',

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -41,6 +41,11 @@ import {
   removeCloudRunConnection,
 } from './cloud-run-config.js'
 import {
+  getWordpressTrafficConnection,
+  upsertWordpressTrafficConnection,
+  removeWordpressTrafficConnection,
+} from './wordpress-traffic-config.js'
+import {
   getWordpressConnection,
   patchWordpressConnection,
   removeWordpressConnection,
@@ -513,6 +518,31 @@ export async function createServer(opts: {
     },
   } as const
 
+  // WordPress traffic-logger credential store — stores Application Passwords
+  // in ~/.canonry/config.yaml under `wordpressTraffic.connections`.
+  const wordpressTrafficCredentialStore = {
+    getConnection: (projectName: string) => {
+      return getWordpressTrafficConnection(opts.config, projectName)
+    },
+    upsertConnection: (record: {
+      projectName: string
+      baseUrl: string
+      username: string
+      applicationPassword: string
+      createdAt: string
+      updatedAt: string
+    }) => {
+      const updated = upsertWordpressTrafficConnection(opts.config, record)
+      saveConfigPatch(opts.config)
+      return updated
+    },
+    deleteConnection: (projectName: string) => {
+      const removed = removeWordpressTrafficConnection(opts.config, projectName)
+      if (removed) saveConfigPatch(opts.config)
+      return removed
+    },
+  } as const
+
   const googleStateSecret = process.env.GOOGLE_STATE_SECRET ?? crypto.randomBytes(32).toString('hex')
 
   const googleConnectionStore = {
@@ -965,6 +995,7 @@ export async function createServer(opts: {
     wordpressConnectionStore,
     ga4CredentialStore,
     cloudRunCredentialStore,
+    wordpressTrafficCredentialStore,
     onTrafficSynced: (event) => {
       // Emit anonymous canonry telemetry for every sync (success + fail).
       // Same envelope shape as run.completed (top-level `errorCode` on

--- a/packages/canonry/test/mcp-registry.test.ts
+++ b/packages/canonry/test/mcp-registry.test.ts
@@ -65,6 +65,7 @@ const expectedToolNames = [
   'canonry_traffic_status',
   'canonry_traffic_events',
   'canonry_traffic_connect_cloud_run',
+  'canonry_traffic_connect_wordpress',
   'canonry_traffic_sync',
   'canonry_traffic_backfill',
   'canonry_project_upsert',
@@ -94,7 +95,7 @@ const expectedToolNames = [
 
 describe('MCP tool registry', () => {
   it('ships the curated v1 surface', () => {
-    expect(CANONRY_MCP_TOOL_COUNT).toBe(74)
+    expect(CANONRY_MCP_TOOL_COUNT).toBe(75)
     expect(CANONRY_MCP_READ_TOOL_COUNT).toBe(49)
     expect(canonryMcpTools.map(tool => tool.name)).toEqual(expectedToolNames)
     const readNames = canonryMcpTools.filter(tool => tool.access === 'read').map(tool => tool.name)
@@ -135,7 +136,7 @@ describe('MCP tool registry', () => {
     expect(counts.get('setup')).toBe(21)
     expect(counts.get('gsc')).toBe(7)
     expect(counts.get('ga')).toBe(8)
-    expect(counts.get('traffic')).toBe(7)
+    expect(counts.get('traffic')).toBe(8)
     expect(counts.get('agent')).toBe(5)
   })
 

--- a/packages/canonry/test/mcp-stdio.test.ts
+++ b/packages/canonry/test/mcp-stdio.test.ts
@@ -171,7 +171,7 @@ describe('canonry-mcp stdio', () => {
     await client.connect(transport)
 
     const list = await client.listTools()
-    expect(list.tools).toHaveLength(76)
+    expect(list.tools).toHaveLength(77)
     const names = list.tools.map(tool => tool.name)
     expect(names).toContain('canonry_insights_list')
     expect(names).toContain('canonry_project_overview')

--- a/packages/canonry/test/traffic-commands.test.ts
+++ b/packages/canonry/test/traffic-commands.test.ts
@@ -185,7 +185,7 @@ describe('traffic CLI commands', () => {
     expect(result.stderr).toMatch(/--username/)
   })
 
-  it('rejects traffic connect wordpress without --app-password', async () => {
+  it('rejects traffic connect wordpress without --app-password or --app-password-file', async () => {
     const result = await invokeCli([
       'traffic', 'connect', 'wordpress', 'test-proj',
       '--url', 'https://example.com',
@@ -193,6 +193,29 @@ describe('traffic CLI commands', () => {
     ])
     expect(result.exitCode).not.toBe(0)
     expect(result.stderr).toMatch(/--app-password/)
+  })
+
+  it('rejects traffic connect wordpress when both --app-password and --app-password-file are passed', async () => {
+    const result = await invokeCli([
+      'traffic', 'connect', 'wordpress', 'test-proj',
+      '--url', 'https://example.com',
+      '--username', 'bot',
+      '--app-password', 'pw',
+      '--app-password-file', '/tmp/pw.txt',
+    ])
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toMatch(/not both/i)
+  })
+
+  it('reports a clear error when --app-password-file cannot be read', async () => {
+    const result = await invokeCli([
+      'traffic', 'connect', 'wordpress', 'test-proj',
+      '--url', 'https://example.com',
+      '--username', 'bot',
+      '--app-password-file', '/tmp/this-file-really-does-not-exist-wpxyzzy.txt',
+    ])
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toMatch(/failed to read --app-password-file/i)
   })
 
   it('rejects traffic sync without --source', async () => {

--- a/packages/canonry/test/traffic-commands.test.ts
+++ b/packages/canonry/test/traffic-commands.test.ts
@@ -165,6 +165,36 @@ describe('traffic CLI commands', () => {
     expect(yaml.cloudRun?.connections?.[0]?.clientEmail).toBe('sa@openclaw-nyc.iam.gserviceaccount.com')
   })
 
+  it('rejects traffic connect wordpress without --url', async () => {
+    const result = await invokeCli([
+      'traffic', 'connect', 'wordpress', 'test-proj',
+      '--username', 'bot',
+      '--app-password', 'pw',
+    ])
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toMatch(/--url/)
+  })
+
+  it('rejects traffic connect wordpress without --username', async () => {
+    const result = await invokeCli([
+      'traffic', 'connect', 'wordpress', 'test-proj',
+      '--url', 'https://example.com',
+      '--app-password', 'pw',
+    ])
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toMatch(/--username/)
+  })
+
+  it('rejects traffic connect wordpress without --app-password', async () => {
+    const result = await invokeCli([
+      'traffic', 'connect', 'wordpress', 'test-proj',
+      '--url', 'https://example.com',
+      '--username', 'bot',
+    ])
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toMatch(/--app-password/)
+  })
+
   it('rejects traffic sync without --source', async () => {
     const result = await invokeCli(['traffic', 'sync', 'test-proj'])
     expect(result.exitCode).not.toBe(0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,9 @@ importers:
       '@ainyc/canonry-integration-wordpress':
         specifier: workspace:*
         version: link:../integration-wordpress
+      '@ainyc/canonry-integration-wordpress-traffic':
+        specifier: workspace:*
+        version: link:../integration-wordpress-traffic
       '@ainyc/canonry-intelligence':
         specifier: workspace:*
         version: link:../intelligence


### PR DESCRIPTION
## Summary
- Stacked on top of `arberx/wordpress-php-logs`. Takes the WordPress adapter from "compiles" to "you can connect a site". Sync + backfill still reject the `wordpress` sourceType — that's the next PR.
- `POST /traffic/connect/wordpress` probes the plugin endpoint (`limit=1`) before touching state. Bad credentials / unreachable host return 502 with the upstream HTTP status instead of silently persisting then failing at first sync.
- Application Password lives in `~/.canonry/config.yaml` under `wordpressTraffic.connections` (never in the DB). On reconnect, the existing active source row is updated in place.
- API + CLI + MCP parity: `ApiClient.trafficConnectWordpress`, `canonry traffic connect wordpress`, `canonry_traffic_connect_wordpress` MCP tool. OpenAPI classification, tool counts (74→75), and toolkit counts (`traffic` 7→8) updated.
- Doctor validator registered for `wordpress` source type — runs the same `limit=1` probe; maps HTTP 401/403 to a distinct `traffic.credentials.unauthorized` code.

## Test plan
- [x] Unit: invalid baseUrl, empty password, happy-path persist, 502 on probe failure leaves no state behind, reconnect updates in place.
- [x] CLI: flag validation for `--url`, `--username`, `--app-password`.
- [x] MCP registry counts + OpenAPI contract coverage updated.
- [x] Full workspace: 2369 tests pass, typecheck + lint clean.
- [ ] Manual end-to-end against a real WP install (depends on plugin which is out of repo).

## What's next (separate PR)
- Drop the hardcoded `cloud-run` guards in `/traffic/sources/:id/sync` and `/backfill` — dispatch to per-source-type pull + credential resolver.
- WordPress uses opaque cursor pagination instead of Cloud Run's timestamp window, so the dispatcher needs to extract the rollup-write txn into a shared helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)