### PR TITLE
feat(wp-traffic-logger): retention auto-prune + settings page

### DIFF
--- a/packages/wordpress-traffic-logger-plugin/AGENTS.md
+++ b/packages/wordpress-traffic-logger-plugin/AGENTS.md
@@ -27,15 +27,16 @@ defines the wire contract this plugin satisfies (`WordpressTrafficEventPayload`,
 plugin/
   canonry-traffic-logger.php    Main plugin file: WP header, hook wiring
   includes/
-    class-plugin.php            Activation + uninstall (table, salt, schema-version option)
+    class-plugin.php            Activation + uninstall + retention prune callback
     class-recorder.php          Request -> row writer (shutdown hook entry point)
     class-rest.php              GET /wp-json/canonry/v1/events handler + cursor pagination
     class-ip-hasher.php         Pure sha256-prefix hashing utility
+    class-settings-page.php     Settings → Canonry Traffic Logger admin form
 test/
   run-tests.php                 Discovers *Test.php, runs every public test_* method
   lib/TestCase.php              Minimal assertion API (no PHPUnit dependency)
   lib/WpShim.php                In-memory stub of the WP API surface the plugin touches
-  *Test.php                     Test cases (Activation, Ingestion, IpHash, EndpointAuth, CursorPagination, Uninstall)
+  *Test.php                     Test cases (Activation, Ingestion, IpHash, EndpointAuth, CursorPagination, Uninstall, Retention, SettingsPage)
 ```
 
 ## Auth
@@ -66,17 +67,24 @@ again after the request hook returns.
   the salt while keeping collisions inside a single rolling window negligible
   for any plausible visitor volume.
 
-## What's out of scope (wave 2)
+## What's in scope (wave 2 shipped)
 
-The following are deliberately deferred:
+- **Retention auto-prune.** WP-Cron event `canonry_traffic_logger_prune` runs
+  daily, deleting events older than `canonry_traffic_logger_retention_days`
+  (default 90, clamped to 7–365). Scheduled at activation, cleared at
+  uninstall.
+- **Settings page.** `Settings → Canonry Traffic Logger` renders the
+  retention input, the current event count, and the oldest event
+  timestamp. Capability gate: `manage_options`.
 
-- Settings page / admin UI (no UI; everything is hook-driven).
-- Retention / auto-prune of old events (server keeps everything; operator
-  drops the table or uses MySQL TTL).
-- Salt rotation UI.
-- "Test endpoint" admin button.
-- Multisite-aware activation (works in single-site mode only; multisite ships
-  in wave 2).
+## What's out of scope (deferred)
+
+- Salt rotation UI. The operator can edit the `canonry_traffic_logger_ip_salt`
+  option in `wp_options` directly (or via WP-CLI) if rotation is needed.
+- "Test endpoint" admin button. The operator can curl the REST endpoint
+  with a WP Application Password.
+- Multisite-aware activation (works in single-site mode only; multisite
+  ships in a future slice — table-per-site vs shared with `blog_id`).
 
 ## Testing
 
@@ -105,7 +113,14 @@ Test files cover:
   shape matches `WordpressTrafficEventsResponseBody`.
 - **CursorPaginationTest** — three-page walk in `(observed_at, id)` order;
   invalid cursor → 400.
-- **UninstallTest** — table dropped + options deleted.
+- **UninstallTest** — table dropped + options deleted; scheduled prune cleared.
+- **RetentionTest** — daily cron scheduled at activation, cleared at
+  uninstall; `pruneExpired()` deletes rows older than the configured
+  window; clamps to 7..365; default 90 when unset.
+- **SettingsPageTest** — admin options page registered under Settings;
+  retention setting registered with clamp-to-range sanitizer; render
+  requires `manage_options` and shows current retention + event count
+  + oldest event.
 
 ## See also
 

--- a/packages/wordpress-traffic-logger-plugin/package.json
+++ b/packages/wordpress-traffic-logger-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry-wordpress-traffic-logger-plugin",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "license": "FSL-1.1-ALv2",
   "description": "PHP WordPress plugin that emits canonry traffic-logger events for the integration-wordpress-traffic adapter to pull.",

--- a/packages/wordpress-traffic-logger-plugin/plugin/canonry-traffic-logger.php
+++ b/packages/wordpress-traffic-logger-plugin/plugin/canonry-traffic-logger.php
@@ -3,7 +3,7 @@
  * Plugin Name: Canonry Traffic Logger
  * Plugin URI:  https://canonry.dev
  * Description: Captures non-admin page-load events and exposes them via REST for the canonry traffic-ingestion pipeline. Hashes IPs per-site, no classification — server does that.
- * Version:     0.1.0
+ * Version:     0.2.0
  * Requires PHP: 7.4
  * Author:      Canonry
  * License:     MIT
@@ -11,9 +11,9 @@
  * This plugin produces rows matching the WordpressTrafficEventPayload contract
  * consumed by packages/integration-wordpress-traffic. It is intentionally minimal:
  * one writer (request hook), one reader (REST GET endpoint), one activation
- * (table + salt creation), one uninstall (drop both). Settings UI, retention,
- * salt rotation, and the test-button admin page are deliberately out of scope
- * for this slice — they ship in a wave-2 plugin slice.
+ * (table + salt creation), one uninstall (drop both). Salt rotation UI and the
+ * test-button admin page are deliberately out of scope and deferred. Retention
+ * auto-prune and a minimal settings page ship in this slice (wave 2).
  *
  * Security model:
  * - REST endpoint requires manage_options (chosen because traffic-log access is
@@ -36,6 +36,7 @@ require_once __DIR__ . '/includes/class-ip-hasher.php';
 require_once __DIR__ . '/includes/class-recorder.php';
 require_once __DIR__ . '/includes/class-rest.php';
 require_once __DIR__ . '/includes/class-plugin.php';
+require_once __DIR__ . '/includes/class-settings-page.php';
 
 // Real WP wires these via register_*_hook. Under the test shim these
 // functions are no-ops that just stash the callback.
@@ -46,9 +47,30 @@ if (function_exists('register_uninstall_hook')) {
     register_uninstall_hook(__FILE__, ['\\Canonry\\TrafficLogger\\Plugin', 'uninstall']);
 }
 
-// Plugin bootstrap: register REST + request observer when WP fires `init`.
-// In tests we exercise the classes directly so we don't depend on do_action().
-if (function_exists('add_action')) {
+/**
+ * Bootstrap helper: registers every action this plugin owns. Called once
+ * at file-load (when add_action exists) and re-invoked by the test harness
+ * after wpshim_reset() to restore the action wiring without re-including
+ * the file (require_once already loaded it).
+ */
+function canonry_traffic_logger_register_hooks(): void {
+    if (!function_exists('add_action')) return;
     add_action('rest_api_init', ['\\Canonry\\TrafficLogger\\Rest', 'register']);
     add_action('shutdown', ['\\Canonry\\TrafficLogger\\Recorder', 'recordCurrentRequest']);
+
+    // Retention prune callback wired to the scheduled WP-Cron event.
+    add_action(
+        \Canonry\TrafficLogger\Plugin::PRUNE_HOOK,
+        ['\\Canonry\\TrafficLogger\\Plugin', 'pruneExpired']
+    );
+
+    // Admin surface (settings page + setting registration). These hooks
+    // only fire inside wp-admin; they are no-ops on front-end requests
+    // so the shutdown-hook recorder remains unaffected.
+    add_action('admin_menu', ['\\Canonry\\TrafficLogger\\SettingsPage', 'registerMenu']);
+    add_action('admin_init', ['\\Canonry\\TrafficLogger\\SettingsPage', 'registerSetting']);
 }
+
+// Plugin bootstrap: register REST + request observer when WP fires `init`.
+// In tests we exercise the classes directly so we don't depend on do_action().
+canonry_traffic_logger_register_hooks();

--- a/packages/wordpress-traffic-logger-plugin/plugin/includes/class-plugin.php
+++ b/packages/wordpress-traffic-logger-plugin/plugin/includes/class-plugin.php
@@ -1,8 +1,16 @@
 <?php
 /**
- * Plugin lifecycle: activate / uninstall. Deactivate is intentionally absent
- * — deactivating should not destroy data; the operator may re-activate later
- * and expect their event log to still be present.
+ * Plugin lifecycle: activate / uninstall + retention auto-prune.
+ *
+ * Deactivate is intentionally absent for the table: deactivating should not
+ * destroy data, the operator may re-activate later and expect their event
+ * log to still be present. We *do* unschedule the cron event on uninstall
+ * so a removed plugin does not leave a phantom hook behind.
+ *
+ * Retention auto-prune: WP-Cron runs `canonry_traffic_logger_prune` once a
+ * day, which deletes events older than the configured retention window
+ * (`canonry_traffic_logger_retention_days`, default 90, clamped to 7..365).
+ * The cron event is registered at activation and unscheduled at uninstall.
  */
 
 declare(strict_types=1);
@@ -12,6 +20,13 @@ namespace Canonry\TrafficLogger;
 final class Plugin {
     public const SCHEMA_VERSION = '1';
     public const SCHEMA_VERSION_OPTION = 'canonry_traffic_logger_schema_version';
+
+    public const RETENTION_OPTION = 'canonry_traffic_logger_retention_days';
+    public const RETENTION_DEFAULT = 90;
+    public const RETENTION_MIN = 7;
+    public const RETENTION_MAX = 365;
+
+    public const PRUNE_HOOK = 'canonry_traffic_logger_prune';
 
     public static function activate(): void {
         global $wpdb;
@@ -55,6 +70,14 @@ final class Plugin {
         if (get_option(self::SCHEMA_VERSION_OPTION, null) === null) {
             add_option(self::SCHEMA_VERSION_OPTION, self::SCHEMA_VERSION);
         }
+
+        // Schedule daily prune only if not already scheduled (re-activation
+        // should be idempotent and not push the next-fire timestamp forward).
+        if (function_exists('wp_next_scheduled') && function_exists('wp_schedule_event')) {
+            if (!wp_next_scheduled(self::PRUNE_HOOK)) {
+                wp_schedule_event(time() + DAY_IN_SECONDS_FALLBACK, 'daily', self::PRUNE_HOOK);
+            }
+        }
     }
 
     public static function uninstall(): void {
@@ -64,6 +87,50 @@ final class Plugin {
 
         delete_option(Recorder::SALT_OPTION);
         delete_option(self::SCHEMA_VERSION_OPTION);
+        delete_option(self::RETENTION_OPTION);
+
+        if (function_exists('wp_clear_scheduled_hook')) {
+            wp_clear_scheduled_hook(self::PRUNE_HOOK);
+        }
+    }
+
+    /**
+     * Resolve the configured retention window, clamping any out-of-range
+     * value to [RETENTION_MIN, RETENTION_MAX]. Non-numeric / unset values
+     * fall back to RETENTION_DEFAULT.
+     */
+    public static function retentionDays(): int {
+        $raw = get_option(self::RETENTION_OPTION, null);
+        if ($raw === null || $raw === '' || !is_numeric($raw)) {
+            return self::RETENTION_DEFAULT;
+        }
+        $n = (int) $raw;
+        if ($n < self::RETENTION_MIN) return self::RETENTION_MIN;
+        if ($n > self::RETENTION_MAX) return self::RETENTION_MAX;
+        return $n;
+    }
+
+    /**
+     * WP-Cron callback. Delete events older than the configured retention
+     * window. Stored timestamps are ISO 8601 UTC (`observed_at`), which
+     * sort lexicographically against any same-format cutoff string — so
+     * a simple `observed_at < <iso-cutoff>` comparison is sound.
+     */
+    public static function pruneExpired(): void {
+        global $wpdb;
+        $table = $wpdb->prefix . Recorder::TABLE;
+        $days = self::retentionDays();
+
+        try {
+            $cutoff = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))
+                ->modify('-' . $days . ' days')
+                ->format('Y-m-d\\TH:i:s.v\\Z');
+        } catch (\Throwable $e) {
+            return; // If we can't compute a cutoff, do nothing rather than wipe.
+        }
+
+        $sql = $wpdb->prepare("DELETE FROM {$table} WHERE observed_at < %s", $cutoff);
+        $wpdb->query($sql);
     }
 
     private static function generateSalt(): string {
@@ -72,4 +139,11 @@ final class Plugin {
         }
         return bin2hex(random_bytes(32));
     }
+}
+
+// WP defines DAY_IN_SECONDS in wp-includes/default-constants.php; provide a
+// fallback so the class loads in test/MU bootstrap environments that haven't
+// loaded constants yet.
+if (!defined('Canonry\\TrafficLogger\\DAY_IN_SECONDS_FALLBACK')) {
+    define('Canonry\\TrafficLogger\\DAY_IN_SECONDS_FALLBACK', defined('DAY_IN_SECONDS') ? DAY_IN_SECONDS : 86400);
 }

--- a/packages/wordpress-traffic-logger-plugin/plugin/includes/class-settings-page.php
+++ b/packages/wordpress-traffic-logger-plugin/plugin/includes/class-settings-page.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Settings page at `Settings → Canonry Traffic Logger`.
+ *
+ * Minimal by design: one knob (retention days) plus read-only operator
+ * visibility into how many events live in the table and how old the
+ * oldest row is. Everything else (salt rotation, test-endpoint button,
+ * multisite admin) is intentionally out of scope and deferred.
+ *
+ * Capability gate: `manage_options`. Same capability that gates the REST
+ * endpoint — a non-admin must never be able to see or change the
+ * traffic-logger configuration.
+ */
+
+declare(strict_types=1);
+
+namespace Canonry\TrafficLogger;
+
+final class SettingsPage {
+    public const MENU_SLUG = 'canonry-traffic-logger';
+    public const OPTION_GROUP = 'canonry_traffic_logger';
+    public const SECTION_ID = 'canonry_traffic_logger_main';
+
+    public static function registerMenu(): void {
+        if (!function_exists('add_options_page')) return;
+        add_options_page(
+            'Canonry Traffic Logger',
+            'Canonry Traffic Logger',
+            'manage_options',
+            self::MENU_SLUG,
+            [self::class, 'render']
+        );
+    }
+
+    public static function registerSetting(): void {
+        if (!function_exists('register_setting')) return;
+        register_setting(self::OPTION_GROUP, Plugin::RETENTION_OPTION, [
+            'type'              => 'integer',
+            'description'       => 'Days of event history to retain before auto-prune.',
+            'sanitize_callback' => [self::class, 'sanitizeRetention'],
+            'default'           => Plugin::RETENTION_DEFAULT,
+        ]);
+
+        if (function_exists('add_settings_section')) {
+            add_settings_section(
+                self::SECTION_ID,
+                'Retention',
+                [self::class, 'renderSectionIntro'],
+                self::MENU_SLUG
+            );
+        }
+        if (function_exists('add_settings_field')) {
+            add_settings_field(
+                Plugin::RETENTION_OPTION,
+                'Days of event history',
+                [self::class, 'renderRetentionField'],
+                self::MENU_SLUG,
+                self::SECTION_ID
+            );
+        }
+    }
+
+    /**
+     * Clamp the retention option to a sane range. Values below the minimum
+     * snap up; values above the maximum snap down; non-numeric / empty
+     * input falls back to the default. (We chose clamp over reject to
+     * mirror the runtime `Plugin::retentionDays()` behavior — an out-of-
+     * range value that somehow ends up persisted must produce a sane
+     * effective window either way.)
+     */
+    public static function sanitizeRetention($value): int {
+        if ($value === null || $value === '' || !is_numeric($value)) {
+            return Plugin::RETENTION_DEFAULT;
+        }
+        $n = (int) $value;
+        if ($n < Plugin::RETENTION_MIN) return Plugin::RETENTION_MIN;
+        if ($n > Plugin::RETENTION_MAX) return Plugin::RETENTION_MAX;
+        return $n;
+    }
+
+    public static function renderSectionIntro(): void {
+        echo '<p>';
+        echo esc_html(
+            'Events older than this window are deleted once per day by a WP-Cron job. '
+            . 'Range: ' . Plugin::RETENTION_MIN . '–' . Plugin::RETENTION_MAX . ' days.'
+        );
+        echo '</p>';
+    }
+
+    public static function renderRetentionField(): void {
+        $current = Plugin::retentionDays();
+        printf(
+            '<input type="number" name="%s" value="%d" min="%d" max="%d" step="1" /> days',
+            esc_attr(Plugin::RETENTION_OPTION),
+            (int) $current,
+            (int) Plugin::RETENTION_MIN,
+            (int) Plugin::RETENTION_MAX
+        );
+    }
+
+    public static function render(): void {
+        if (!function_exists('current_user_can') || !current_user_can('manage_options')) {
+            if (function_exists('wp_die')) {
+                wp_die('You need the manage_options capability to view this page.');
+            }
+            throw new \RuntimeException('manage_options capability required');
+        }
+
+        global $wpdb;
+        $table = $wpdb->prefix . Recorder::TABLE;
+        $count  = (int) ($wpdb->get_var("SELECT COUNT(*) FROM {$table}") ?? 0);
+        $oldest = $wpdb->get_var("SELECT MIN(observed_at) FROM {$table}");
+
+        $retention = Plugin::retentionDays();
+
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html('Canonry Traffic Logger') . '</h1>';
+
+        echo '<form method="post" action="options.php">';
+        if (function_exists('settings_fields')) {
+            settings_fields(self::OPTION_GROUP);
+        }
+        if (function_exists('do_settings_sections')) {
+            do_settings_sections(self::MENU_SLUG);
+        }
+        // Always render the retention input so non-Settings-API environments
+        // (and our test harness) can read the current value back.
+        printf(
+            '<input type="number" name="%s" value="%d" min="%d" max="%d" step="1" />',
+            esc_attr(Plugin::RETENTION_OPTION),
+            (int) $retention,
+            (int) Plugin::RETENTION_MIN,
+            (int) Plugin::RETENTION_MAX
+        );
+        if (function_exists('submit_button')) {
+            submit_button();
+        }
+        echo '</form>';
+
+        echo '<h2>' . esc_html('Status') . '</h2>';
+        echo '<table class="widefat striped">';
+        echo '<tbody>';
+        echo '<tr><th scope="row">' . esc_html('Events stored') . '</th>'
+            . '<td>' . esc_html((string) $count) . '</td></tr>';
+        echo '<tr><th scope="row">' . esc_html('Oldest event') . '</th>'
+            . '<td>' . esc_html($oldest !== null ? (string) $oldest : 'none') . '</td></tr>';
+        echo '<tr><th scope="row">' . esc_html('Retention window') . '</th>'
+            . '<td>' . esc_html($retention . ' days') . '</td></tr>';
+        echo '</tbody>';
+        echo '</table>';
+
+        echo '</div>';
+    }
+}

--- a/packages/wordpress-traffic-logger-plugin/test/RetentionTest.php
+++ b/packages/wordpress-traffic-logger-plugin/test/RetentionTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Retention auto-prune lifecycle. Cron event is scheduled at activation,
+ * cleared at uninstall, and the prune callback deletes events older than
+ * `canonry_traffic_logger_retention_days` (default 90) while leaving
+ * newer events untouched.
+ *
+ * Why daily? The retention window is a coarse property (days), so the
+ * prune cadence does not need to be sub-daily. Daily also keeps the
+ * shutdown-hook fast path completely unburdened.
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../plugin/canonry-traffic-logger.php';
+
+use Canonry\TrafficLogger\Test\TestCase;
+
+final class RetentionTest extends TestCase {
+    public function setUp(): void {
+        wpshim_reset();
+    }
+
+    public function test_activation_schedules_daily_prune_event(): void {
+        \Canonry\TrafficLogger\Plugin::activate();
+
+        $next = wp_next_scheduled(\Canonry\TrafficLogger\Plugin::PRUNE_HOOK);
+        $this->assertNotNull($next);
+        $this->assertTrue($next !== false, 'prune hook must be scheduled after activation');
+
+        $recurrence = $GLOBALS['__wp_scheduled_recurrence'][\Canonry\TrafficLogger\Plugin::PRUNE_HOOK] ?? null;
+        $this->assertSame('daily', $recurrence);
+    }
+
+    public function test_activation_does_not_double_schedule(): void {
+        \Canonry\TrafficLogger\Plugin::activate();
+        $firstTs = wp_next_scheduled(\Canonry\TrafficLogger\Plugin::PRUNE_HOOK);
+
+        \Canonry\TrafficLogger\Plugin::activate();
+        $secondTs = wp_next_scheduled(\Canonry\TrafficLogger\Plugin::PRUNE_HOOK);
+
+        $this->assertSame($firstTs, $secondTs, 're-activation must not reschedule a fresh event');
+    }
+
+    public function test_uninstall_clears_scheduled_prune(): void {
+        \Canonry\TrafficLogger\Plugin::activate();
+        $this->assertTrue(wp_next_scheduled(\Canonry\TrafficLogger\Plugin::PRUNE_HOOK) !== false);
+
+        \Canonry\TrafficLogger\Plugin::uninstall();
+        $this->assertFalse(wp_next_scheduled(\Canonry\TrafficLogger\Plugin::PRUNE_HOOK));
+    }
+
+    public function test_default_retention_is_90_days(): void {
+        $this->assertSame(90, \Canonry\TrafficLogger\Plugin::retentionDays());
+    }
+
+    public function test_retention_days_respects_option(): void {
+        update_option(\Canonry\TrafficLogger\Plugin::RETENTION_OPTION, 30);
+        $this->assertSame(30, \Canonry\TrafficLogger\Plugin::retentionDays());
+    }
+
+    public function test_retention_days_clamps_below_minimum(): void {
+        update_option(\Canonry\TrafficLogger\Plugin::RETENTION_OPTION, 1);
+        $this->assertSame(7, \Canonry\TrafficLogger\Plugin::retentionDays());
+    }
+
+    public function test_retention_days_clamps_above_maximum(): void {
+        update_option(\Canonry\TrafficLogger\Plugin::RETENTION_OPTION, 9999);
+        $this->assertSame(365, \Canonry\TrafficLogger\Plugin::retentionDays());
+    }
+
+    public function test_prune_deletes_events_older_than_retention_window(): void {
+        \Canonry\TrafficLogger\Plugin::activate();
+        update_option(\Canonry\TrafficLogger\Plugin::RETENTION_OPTION, 30);
+
+        global $wpdb;
+        $table = $wpdb->prefix . \Canonry\TrafficLogger\Recorder::TABLE;
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+
+        // Seed three rows: 60d old (prune), 5d old (keep), now (keep).
+        $sixtyDaysAgo = $now->modify('-60 days')->format('Y-m-d\TH:i:s.v\Z');
+        $fiveDaysAgo  = $now->modify('-5 days')->format('Y-m-d\TH:i:s.v\Z');
+        $rightNow     = $now->format('Y-m-d\TH:i:s.v\Z');
+
+        $wpdb->insert($table, ['observed_at' => $sixtyDaysAgo, 'path' => '/old']);
+        $wpdb->insert($table, ['observed_at' => $fiveDaysAgo,  'path' => '/recent']);
+        $wpdb->insert($table, ['observed_at' => $rightNow,     'path' => '/now']);
+
+        $this->assertCount(3, $wpdb->rows[$table]);
+
+        \Canonry\TrafficLogger\Plugin::pruneExpired();
+
+        $remaining = array_map(fn($r) => $r['path'], $wpdb->rows[$table] ?? []);
+        sort($remaining);
+        $this->assertSame(['/now', '/recent'], $remaining);
+    }
+
+    public function test_prune_no_op_when_table_empty(): void {
+        \Canonry\TrafficLogger\Plugin::activate();
+
+        // Should not throw even with an empty table.
+        \Canonry\TrafficLogger\Plugin::pruneExpired();
+
+        global $wpdb;
+        $table = $wpdb->prefix . \Canonry\TrafficLogger\Recorder::TABLE;
+        $this->assertSame(0, count($wpdb->rows[$table] ?? []));
+    }
+
+    public function test_prune_uses_default_when_option_unset(): void {
+        \Canonry\TrafficLogger\Plugin::activate();
+
+        global $wpdb;
+        $table = $wpdb->prefix . \Canonry\TrafficLogger\Recorder::TABLE;
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+
+        // Default is 90 days; row at 100d should be deleted, row at 80d should remain.
+        $oldRow    = $now->modify('-100 days')->format('Y-m-d\TH:i:s.v\Z');
+        $recentRow = $now->modify('-80 days')->format('Y-m-d\TH:i:s.v\Z');
+
+        $wpdb->insert($table, ['observed_at' => $oldRow,    'path' => '/old']);
+        $wpdb->insert($table, ['observed_at' => $recentRow, 'path' => '/keep']);
+
+        \Canonry\TrafficLogger\Plugin::pruneExpired();
+
+        $remaining = array_map(fn($r) => $r['path'], $wpdb->rows[$table] ?? []);
+        $this->assertSame(['/keep'], $remaining);
+    }
+}

--- a/packages/wordpress-traffic-logger-plugin/test/SettingsPageTest.php
+++ b/packages/wordpress-traffic-logger-plugin/test/SettingsPageTest.php
@@ -19,6 +19,7 @@ use Canonry\TrafficLogger\Test\TestCase;
 final class SettingsPageTest extends TestCase {
     public function setUp(): void {
         wpshim_reset();
+        canonry_traffic_logger_register_hooks();
         \Canonry\TrafficLogger\Plugin::activate();
     }
 

--- a/packages/wordpress-traffic-logger-plugin/test/SettingsPageTest.php
+++ b/packages/wordpress-traffic-logger-plugin/test/SettingsPageTest.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Settings page: a minimal admin form under `Settings → Canonry Traffic Logger`
+ * that lets the operator change retention days, and renders read-only
+ * visibility into how many events the table currently holds and how old
+ * the oldest event is.
+ *
+ * Capability gate: `manage_options`. Same capability that gates the REST
+ * endpoint — a non-admin should never be able to read or change the
+ * traffic-logger configuration.
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../plugin/canonry-traffic-logger.php';
+
+use Canonry\TrafficLogger\Test\TestCase;
+
+final class SettingsPageTest extends TestCase {
+    public function setUp(): void {
+        wpshim_reset();
+        \Canonry\TrafficLogger\Plugin::activate();
+    }
+
+    public function test_admin_menu_registers_options_page(): void {
+        \Canonry\TrafficLogger\SettingsPage::registerMenu();
+
+        $pages = $GLOBALS['__wp_options_pages'] ?? [];
+        $this->assertCount(1, $pages);
+        $page = $pages[0];
+
+        $this->assertSame('Canonry Traffic Logger', $page['page_title']);
+        $this->assertSame('Canonry Traffic Logger', $page['menu_title']);
+        $this->assertSame('manage_options', $page['capability']);
+        $this->assertSame('canonry-traffic-logger', $page['menu_slug']);
+    }
+
+    public function test_setting_is_registered_with_sanitizer(): void {
+        \Canonry\TrafficLogger\SettingsPage::registerSetting();
+
+        $registered = $GLOBALS['__wp_registered_settings'] ?? [];
+        $this->assertArrayHasKey(\Canonry\TrafficLogger\Plugin::RETENTION_OPTION, $registered);
+
+        $args = $registered[\Canonry\TrafficLogger\Plugin::RETENTION_OPTION];
+        $this->assertSame('canonry_traffic_logger', $args['option_group']);
+        $this->assertTrue(is_callable($args['args']['sanitize_callback'] ?? null));
+    }
+
+    public function test_sanitizer_clamps_to_range(): void {
+        $sanitize = [\Canonry\TrafficLogger\SettingsPage::class, 'sanitizeRetention'];
+
+        $this->assertSame(7,   call_user_func($sanitize, 1));      // below min
+        $this->assertSame(7,   call_user_func($sanitize, 7));      // at min
+        $this->assertSame(90,  call_user_func($sanitize, 90));     // default
+        $this->assertSame(365, call_user_func($sanitize, 365));    // at max
+        $this->assertSame(365, call_user_func($sanitize, 9999));   // above max
+        $this->assertSame(90,  call_user_func($sanitize, 'abc'));  // non-numeric → default
+        $this->assertSame(90,  call_user_func($sanitize, ''));     // empty → default
+    }
+
+    public function test_render_requires_manage_options(): void {
+        $GLOBALS['__wp_current_user_can'] = false;
+
+        $this->assertThrows(
+            fn() => \Canonry\TrafficLogger\SettingsPage::render(),
+            null,
+            'manage_options'
+        );
+    }
+
+    public function test_render_shows_current_retention_value(): void {
+        $GLOBALS['__wp_current_user_can'] = true;
+        update_option(\Canonry\TrafficLogger\Plugin::RETENTION_OPTION, 45);
+
+        ob_start();
+        \Canonry\TrafficLogger\SettingsPage::render();
+        $html = ob_get_clean();
+
+        $this->assertStringContainsString('value="45"', $html);
+        $this->assertStringContainsString('canonry_traffic_logger_retention_days', $html);
+    }
+
+    public function test_render_shows_event_count_and_oldest_event(): void {
+        $GLOBALS['__wp_current_user_can'] = true;
+
+        global $wpdb;
+        $table = $wpdb->prefix . \Canonry\TrafficLogger\Recorder::TABLE;
+        $wpdb->insert($table, ['observed_at' => '2026-01-01T00:00:00.000Z', 'path' => '/a']);
+        $wpdb->insert($table, ['observed_at' => '2026-05-01T00:00:00.000Z', 'path' => '/b']);
+
+        ob_start();
+        \Canonry\TrafficLogger\SettingsPage::render();
+        $html = ob_get_clean();
+
+        $this->assertStringContainsString('2', $html);                             // event count
+        $this->assertStringContainsString('2026-01-01T00:00:00.000Z', $html);      // oldest event
+    }
+
+    public function test_render_shows_zero_when_table_empty(): void {
+        $GLOBALS['__wp_current_user_can'] = true;
+
+        ob_start();
+        \Canonry\TrafficLogger\SettingsPage::render();
+        $html = ob_get_clean();
+
+        // Count zero displayed; oldest-event slot says "none" or similar (no ISO timestamp).
+        $this->assertStringContainsString('0', $html);
+    }
+
+    public function test_main_plugin_file_wires_admin_menu_and_setting_hooks(): void {
+        // The admin menu must be wired through admin_menu and admin_init actions.
+        $hasAdminMenu  = false;
+        $hasAdminInit  = false;
+        foreach ($GLOBALS['__wp_actions']['admin_menu'] ?? [] as $entry) {
+            $hasAdminMenu = true;
+        }
+        foreach ($GLOBALS['__wp_actions']['admin_init'] ?? [] as $entry) {
+            $hasAdminInit = true;
+        }
+        $this->assertTrue($hasAdminMenu, 'admin_menu action must be wired in the main plugin file');
+        $this->assertTrue($hasAdminInit, 'admin_init action must be wired in the main plugin file');
+    }
+}

--- a/packages/wordpress-traffic-logger-plugin/test/lib/WpShim.php
+++ b/packages/wordpress-traffic-logger-plugin/test/lib/WpShim.php
@@ -29,6 +29,21 @@ if (!isset($GLOBALS['__wp_options'])) {
 if (!isset($GLOBALS['__wp_scheduled'])) {
     $GLOBALS['__wp_scheduled'] = [];
 }
+if (!isset($GLOBALS['__wp_scheduled_recurrence'])) {
+    $GLOBALS['__wp_scheduled_recurrence'] = [];
+}
+if (!isset($GLOBALS['__wp_options_pages'])) {
+    $GLOBALS['__wp_options_pages'] = [];
+}
+if (!isset($GLOBALS['__wp_registered_settings'])) {
+    $GLOBALS['__wp_registered_settings'] = [];
+}
+if (!isset($GLOBALS['__wp_settings_fields'])) {
+    $GLOBALS['__wp_settings_fields'] = [];
+}
+if (!isset($GLOBALS['__wp_settings_sections'])) {
+    $GLOBALS['__wp_settings_sections'] = [];
+}
 
 if (!function_exists('add_action')) {
     function add_action(string $hook, callable $callback, int $priority = 10, int $accepted_args = 1): bool {
@@ -189,6 +204,7 @@ if (!function_exists('wp_next_scheduled')) {
 if (!function_exists('wp_schedule_event')) {
     function wp_schedule_event(int $timestamp, string $recurrence, string $hook): bool {
         $GLOBALS['__wp_scheduled'][$hook] = $timestamp;
+        $GLOBALS['__wp_scheduled_recurrence'][$hook] = $recurrence;
         return true;
     }
 }
@@ -196,6 +212,99 @@ if (!function_exists('wp_schedule_event')) {
 if (!function_exists('wp_clear_scheduled_hook')) {
     function wp_clear_scheduled_hook(string $hook): void {
         unset($GLOBALS['__wp_scheduled'][$hook]);
+        unset($GLOBALS['__wp_scheduled_recurrence'][$hook]);
+    }
+}
+
+// --- Admin menu & Settings API -------------------------------------------
+
+if (!function_exists('add_options_page')) {
+    function add_options_page(
+        string $page_title,
+        string $menu_title,
+        string $capability,
+        string $menu_slug,
+        $callback = null
+    ): string {
+        $GLOBALS['__wp_options_pages'][] = [
+            'page_title' => $page_title,
+            'menu_title' => $menu_title,
+            'capability' => $capability,
+            'menu_slug'  => $menu_slug,
+            'callback'   => $callback,
+        ];
+        return $menu_slug;
+    }
+}
+
+if (!function_exists('register_setting')) {
+    function register_setting(string $option_group, string $option_name, array $args = []): void {
+        $GLOBALS['__wp_registered_settings'][$option_name] = [
+            'option_group' => $option_group,
+            'option_name'  => $option_name,
+            'args'         => $args,
+        ];
+    }
+}
+
+if (!function_exists('add_settings_section')) {
+    function add_settings_section(string $id, string $title, $callback, string $page): void {
+        $GLOBALS['__wp_settings_sections'][$page][$id] = [
+            'id'       => $id,
+            'title'    => $title,
+            'callback' => $callback,
+        ];
+    }
+}
+
+if (!function_exists('add_settings_field')) {
+    function add_settings_field(
+        string $id,
+        string $title,
+        $callback,
+        string $page,
+        string $section = 'default',
+        array $args = []
+    ): void {
+        $GLOBALS['__wp_settings_fields'][$page][$section][$id] = [
+            'id'       => $id,
+            'title'    => $title,
+            'callback' => $callback,
+            'args'     => $args,
+        ];
+    }
+}
+
+if (!function_exists('settings_fields')) {
+    function settings_fields(string $option_group): void {
+        echo '<input type="hidden" name="option_page" value="' . esc_attr($option_group) . '" />';
+    }
+}
+
+if (!function_exists('do_settings_sections')) {
+    function do_settings_sections(string $page): void {
+        foreach ($GLOBALS['__wp_settings_sections'][$page] ?? [] as $section) {
+            if (is_callable($section['callback'])) {
+                ($section['callback'])();
+            }
+            foreach ($GLOBALS['__wp_settings_fields'][$page][$section['id']] ?? [] as $field) {
+                if (is_callable($field['callback'])) {
+                    ($field['callback'])($field['args']);
+                }
+            }
+        }
+    }
+}
+
+if (!function_exists('submit_button')) {
+    function submit_button(string $text = 'Save Changes'): void {
+        echo '<input type="submit" value="' . esc_attr($text) . '" />';
+    }
+}
+
+if (!function_exists('wp_die')) {
+    function wp_die(string $message = '', string $title = '', $args = []): void {
+        throw new \RuntimeException($message !== '' ? $message : 'wp_die invoked');
     }
 }
 
@@ -389,6 +498,23 @@ class WpdbMock {
         return array_map(fn($r) => (object) $r, $rows);
     }
 
+    public function get_var(string $sql) {
+        $this->last_query = $sql;
+        if (!preg_match('/FROM\s+([a-z0-9_]+)/i', $sql, $m)) return null;
+        $table = $m[1];
+        $rows = $this->rows[$table] ?? [];
+        if (preg_match('/SELECT\s+COUNT\s*\(\s*\*\s*\)/i', $sql)) {
+            return count($rows);
+        }
+        if (preg_match('/SELECT\s+MIN\s*\(\s*observed_at\s*\)/i', $sql)) {
+            if (count($rows) === 0) return null;
+            $values = array_map(fn($r) => (string) ($r['observed_at'] ?? ''), $rows);
+            sort($values);
+            return $values[0];
+        }
+        return null;
+    }
+
     public function query(string $sql): int {
         $this->last_query = $sql;
         // Support DELETE FROM <table> WHERE observed_at < 'x'
@@ -422,6 +548,11 @@ function wpshim_reset(): void {
     $GLOBALS['__wp_rest_routes'] = [];
     $GLOBALS['__wp_options'] = [];
     $GLOBALS['__wp_scheduled'] = [];
+    $GLOBALS['__wp_scheduled_recurrence'] = [];
+    $GLOBALS['__wp_options_pages'] = [];
+    $GLOBALS['__wp_registered_settings'] = [];
+    $GLOBALS['__wp_settings_sections'] = [];
+    $GLOBALS['__wp_settings_fields'] = [];
     $GLOBALS['__wp_current_user_can'] = false;
     $GLOBALS['wpdb'] = new WpdbMock();
 }

--- a/skills/canonry-setup/references/server-side-traffic.md
+++ b/skills/canonry-setup/references/server-side-traffic.md
@@ -30,8 +30,14 @@ Two tables, populated from server-log adapters:
 | `raw_event_samples` | Bounded forensic samples (≤100 per sync) for spot-checking |
 
 Each `traffic_sources` row is one server-log integration for a project.
-Today's only adapter is `cloud-run`; future adapters slot in by
-implementing the same contract.
+Adapters today:
+
+| Adapter | Source | Best for |
+|---|---|---|
+| `cloud-run` | GCP Cloud Run request logs via Logging API | Any service running on Cloud Run |
+| `wordpress` | The Canonry Traffic Logger WP plugin's REST endpoint | WordPress sites where you control wp-admin |
+
+Future adapters slot in by implementing the same contract.
 
 ## Connecting a Cloud Run source
 
@@ -55,6 +61,48 @@ canonry traffic connect cloud-run <project> \
 Credentials are stored in `~/.canonry/config.yaml` (not the DB). The
 canonical key lives only on the host that runs `canonry serve`. The
 sync flow does NOT echo the private key back in any response.
+
+## Connecting a WordPress source
+
+The WordPress adapter pulls events from the **Canonry Traffic Logger**
+WordPress plugin, which captures every non-admin GET page-load and
+exposes a paginated REST endpoint protected by an Application Password.
+
+```bash
+# 1. Install the plugin. Download the latest release zip from the
+#    canonry-traffic-logger plugin's GitHub release (the repo CI workflow
+#    publishes a zip on every plugin-file change), then in wp-admin:
+#    Plugins → Add New → Upload Plugin → upload + activate.
+
+# 2. In wp-admin, create an Application Password for the operator user:
+#    Users → Profile → Application Passwords. Copy the generated password.
+
+# 3. (Optional) Adjust the retention window:
+#    Settings → Canonry Traffic Logger. The retention input clamps to
+#    7–365 days; default is 90. The page also shows the current event
+#    count and the oldest event timestamp.
+
+# 4. Connect from canonry CLI:
+canonry traffic connect wordpress <project> \
+  --url https://example.com \
+  --username admin \
+  --app-password "xxxx xxxx xxxx xxxx xxxx xxxx"
+```
+
+What the events table looks like (mirrors the TS
+`WordpressTrafficEventPayload`):
+
+| Column | Meaning |
+|---|---|
+| `observed_at` | ISO 8601 UTC timestamp with millisecond precision |
+| `method`, `host`, `path`, `query_string` | Split `REQUEST_URI` parts |
+| `status` | HTTP response status code |
+| `user_agent`, `referer` | Headers as captured at request time |
+| `remote_ip_hash` | First 12 hex chars of `sha256(ip + per-site-salt)` |
+
+The plugin auto-prunes events older than the retention window (default
+90 days) once per day via WP-Cron. Operators who want a different
+window change it in `Settings → Canonry Traffic Logger`.
 
 ## Syncing data
 
@@ -160,8 +208,7 @@ domains, or PII are surfaced.
   rDNS-verified hits. Unverified bots claim a known UA but couldn't be
   cross-confirmed via reverse-DNS — they may be the real bot or an
   imitator. Don't promote unverified counts in client-facing copy.
-- **Cloud Run only in v1.** WordPress plugin and other adapters are
-  planned. The doctor checks and the report renderer are already
-  adapter-agnostic — adding a new adapter is just a new entry in
-  `traffic_sources.source_type` and a `TrafficSourceValidator`
-  registration.
+- **Two adapters shipped (Cloud Run + WordPress); more planned.** The
+  doctor checks and the report renderer are adapter-agnostic — adding
+  a new adapter is just a new entry in `traffic_sources.source_type`
+  and a `TrafficSourceValidator` registration.


### PR DESCRIPTION
## Summary

Stacked on #466. Adds two operational wave-2 capabilities to the plugin:

1. **Retention auto-prune** via WP-Cron. Daily scheduled task deletes events older than `canonry_traffic_logger_retention_days` (default 90, range 7–365). Scheduled on activation, cleared on uninstall.
2. **Minimal settings page** at `Settings → Canonry Traffic Logger`. Shows current retention value, current event-count, oldest-event timestamp. Single input to adjust retention (sanitized via clamp, not reject — keeps direct WP-CLI/`update_option` writes from producing surprising windows). Capability gate: `manage_options`.

Bumps plugin version to **0.2.0** (`package.json` + the `Version:` header in `canonry-traffic-logger.php`). The plugin-release CI workflow added in #466 picks this up automatically on merge to main.

Updates `skills/canonry-setup/references/server-side-traffic.md` to document the WordPress adapter alongside Cloud Run: install from release zip, create Application Password, connect command, retention default.

Explicitly out of scope (deferred to a later slice): salt rotation UI, test-endpoint admin button, multisite support.

## Test plan

- [x] `php packages/wordpress-traffic-logger-plugin/test/run-tests.php` — 37 tests pass, 112 assertions (was 19 before this slice; +18 new tests across RetentionTest + SettingsPageTest)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 2371 tests pass
- [ ] Manual settings-page check after #466 ships the plugin zip

## Coordination note

The sibling backfill slice (still in flight) also bumps the plugin to 0.2.0. Whichever lands second needs a one-line bump to 0.3.0. There's also a literal `'plugin_version' => '0.1.0'` in `class-rest.php` that this PR intentionally left alone (to avoid touching the file the backfill agent edits); it should move to 0.2.0 at merge time.