### PR TITLE
fix(gsc): correct per-query CTR aggregation and add performance pagination

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -713,7 +713,7 @@ export function triggerGscSync(project: string, opts?: { days?: number; full?: b
 
 export function fetchGscPerformance(
   project: string,
-  params?: { startDate?: string; endDate?: string; query?: string; page?: string; limit?: number; window?: MetricsWindow },
+  params?: { startDate?: string; endDate?: string; query?: string; page?: string; limit?: number; offset?: number; window?: MetricsWindow },
 ): Promise<ApiGscPerformanceRow[]> {
   const qs = new URLSearchParams()
   if (params?.startDate) qs.set('startDate', params.startDate)
@@ -722,6 +722,7 @@ export function fetchGscPerformance(
   if (params?.query) qs.set('query', params.query)
   if (params?.page) qs.set('page', params.page)
   if (params?.limit !== undefined) qs.set('limit', String(params.limit))
+  if (params?.offset !== undefined && params.offset > 0) qs.set('offset', String(params.offset))
   const query = qs.toString() ? `?${qs.toString()}` : ''
   return apiFetch(`/projects/${encodeURIComponent(project)}/google/gsc/performance${query}`)
 }

--- a/apps/web/src/components/project/GscSection.tsx
+++ b/apps/web/src/components/project/GscSection.tsx
@@ -67,6 +67,8 @@ export function GscSection({
     page: '',
     limit: '20',
   })
+  const [performanceOffset, setPerformanceOffset] = useState(0)
+  const [performanceHasMore, setPerformanceHasMore] = useState(false)
   const [inspectionFilterUrl, setInspectionFilterUrl] = useState('')
   const [loading, setLoading] = useState(true)
   const [connecting, setConnecting] = useState(false)
@@ -130,15 +132,22 @@ export function GscSection({
     }
   }
 
-  async function loadPerformanceRows() {
+  async function loadPerformanceRows(offsetOverride?: number) {
     setLoadingPerformance(true)
+    const offset = offsetOverride ?? performanceOffset
     try {
+      const pageSize = parseInt(performanceFilters.limit, 10) || 20
+      // Fetch one extra row to detect whether a next page exists without a
+      // separate COUNT query — backed off when the API trims the result back
+      // to `pageSize` for display.
+      const fetchLimit = pageSize + 1
       const filters = {
         startDate: performanceFilters.startDate,
         endDate: performanceFilters.endDate,
         query: performanceFilters.query,
         page: performanceFilters.page,
-        limit: performanceFilters.limit,
+        limit: String(fetchLimit),
+        offset: String(offset),
         window: gscWindow,
       }
       const rows = await queryClient.fetchQuery({
@@ -148,14 +157,17 @@ export function GscSection({
           endDate: performanceFilters.endDate || undefined,
           query: performanceFilters.query || undefined,
           page: performanceFilters.page || undefined,
-          limit: parseInt(performanceFilters.limit, 10) || 20,
+          limit: fetchLimit,
+          offset,
           window: gscWindow,
         }),
         staleTime: GSC_STALE_MS,
       })
-      setPerformance(rows)
+      setPerformanceHasMore(rows.length > pageSize)
+      setPerformance(rows.slice(0, pageSize))
     } catch (err) {
       setPerformance([])
+      setPerformanceHasMore(false)
       setError(err instanceof Error ? err.message : 'Failed to load GSC performance data')
     } finally {
       setLoadingPerformance(false)
@@ -352,7 +364,8 @@ export function GscSection({
   }, [projectName])
 
   useEffect(() => {
-    void loadPerformanceRows()
+    setPerformanceOffset(0)
+    void loadPerformanceRows(0)
   }, [gscWindow])
 
   async function handleConnect() {
@@ -492,7 +505,7 @@ export function GscSection({
             ))}
           </div>
           {gscConn && (
-            <Button type="button" variant="outline" size="sm" disabled={loadingPerformance} onClick={() => void loadPerformanceRows()}>
+            <Button type="button" variant="outline" size="sm" disabled={loadingPerformance} onClick={() => { setPerformanceOffset(0); void loadPerformanceRows(0) }}>
               {loadingPerformance ? 'Refreshing\u2026' : 'Refresh data'}
             </Button>
           )}
@@ -944,7 +957,7 @@ export function GscSection({
                     <p className="eyebrow eyebrow-soft">Performance</p>
                     <h3>Search performance</h3>
                   </div>
-                  <Button type="button" variant="outline" size="sm" disabled={loadingPerformance} onClick={() => void loadPerformanceRows()}>
+                  <Button type="button" variant="outline" size="sm" disabled={loadingPerformance} onClick={() => { setPerformanceOffset(0); void loadPerformanceRows(0) }}>
                     {loadingPerformance ? 'Loading\u2026' : 'Apply filters'}
                   </Button>
                 </div>
@@ -1100,54 +1113,97 @@ export function GscSection({
                   />
                 </div>
                 {performance.length > 0 ? (
-                  <div className="mt-3 overflow-x-auto">
-                    <table className="data-table w-full text-sm">
-                      <thead>
-                        <tr>
-                          <th className="text-left">Date</th>
-                          <th className="text-left">Query</th>
-                          <th className="text-left">Page</th>
-                          {Object.values(SearchMetric).map((col) => (
-                            <th
-                              key={col}
-                              className="text-right"
-                              aria-sort={perfSort?.key === col ? (perfSort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}
-                            >
-                              <button
-                                type="button"
-                                className="w-full cursor-pointer select-none text-right hover:text-zinc-200 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-zinc-400 rounded px-1 -mx-1"
-                                onClick={() =>
-                                  setPerfSort((prev) =>
-                                    prev?.key === col
-                                      ? prev.dir === 'desc'
-                                        ? { key: col, dir: 'asc' }
-                                        : null
-                                      : { key: col, dir: 'desc' },
-                                  )
-                                }
+                  <>
+                    <div className="mt-3 overflow-x-auto">
+                      <table className="data-table w-full text-sm">
+                        <thead>
+                          <tr>
+                            <th className="text-left">Date</th>
+                            <th className="text-left">Query</th>
+                            <th className="text-left">Page</th>
+                            {Object.values(SearchMetric).map((col) => (
+                              <th
+                                key={col}
+                                className="text-right"
+                                aria-sort={perfSort?.key === col ? (perfSort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}
                               >
-                                {SEARCH_METRIC_LABELS[col]}
-                                {perfSort?.key === col ? (perfSort.dir === 'desc' ? ' \u2193' : ' \u2191') : ''}
-                              </button>
-                            </th>
-                          ))}
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {sortedPerformance.map((row, i) => (
-                          <tr key={`${row.date}:${row.query}:${row.page}:${i}`}>
-                            <td className="text-zinc-400">{row.date}</td>
-                            <td className="max-w-xs truncate text-zinc-200">{row.query}</td>
-                            <td className="max-w-xs truncate text-zinc-400">{row.page}</td>
-                            <td className="text-right tabular-nums text-zinc-300">{row.clicks.toLocaleString()}</td>
-                            <td className="text-right tabular-nums text-zinc-400">{row.impressions.toLocaleString()}</td>
-                            <td className="text-right tabular-nums text-zinc-400">{(Number.isFinite(row.ctr) ? row.ctr * 100 : 0).toFixed(1)}%</td>
-                            <td className="text-right tabular-nums text-zinc-400">{row.position.toFixed(1)}</td>
+                                <button
+                                  type="button"
+                                  className="w-full cursor-pointer select-none text-right hover:text-zinc-200 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-zinc-400 rounded px-1 -mx-1"
+                                  onClick={() =>
+                                    setPerfSort((prev) =>
+                                      prev?.key === col
+                                        ? prev.dir === 'desc'
+                                          ? { key: col, dir: 'asc' }
+                                          : null
+                                        : { key: col, dir: 'desc' },
+                                    )
+                                  }
+                                >
+                                  {SEARCH_METRIC_LABELS[col]}
+                                  {perfSort?.key === col ? (perfSort.dir === 'desc' ? ' \u2193' : ' \u2191') : ''}
+                                </button>
+                              </th>
+                            ))}
                           </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
+                        </thead>
+                        <tbody>
+                          {sortedPerformance.map((row, i) => (
+                            <tr key={`${row.date}:${row.query}:${row.page}:${i}`}>
+                              <td className="text-zinc-400">{row.date}</td>
+                              <td className="max-w-xs truncate text-zinc-200">{row.query}</td>
+                              <td className="max-w-xs truncate text-zinc-400">{row.page}</td>
+                              <td className="text-right tabular-nums text-zinc-300">{row.clicks.toLocaleString()}</td>
+                              <td className="text-right tabular-nums text-zinc-400">{row.impressions.toLocaleString()}</td>
+                              <td className="text-right tabular-nums text-zinc-400">{(Number.isFinite(row.ctr) ? row.ctr * 100 : 0).toFixed(1)}%</td>
+                              <td className="text-right tabular-nums text-zinc-400">{row.position.toFixed(1)}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                    {(performanceOffset > 0 || performanceHasMore) && (() => {
+                      const pageSize = parseInt(performanceFilters.limit, 10) || 20
+                      const from = performanceOffset + 1
+                      const to = performanceOffset + performance.length
+                      return (
+                        <div className="mt-3 flex items-center justify-between text-xs text-zinc-500">
+                          <span className="tabular-nums">
+                            Showing {from.toLocaleString()}{' \u2013 '}{to.toLocaleString()}
+                            {performanceHasMore ? '+' : ''}
+                          </span>
+                          <div className="flex items-center gap-2">
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              disabled={loadingPerformance || performanceOffset === 0}
+                              onClick={() => {
+                                const next = Math.max(0, performanceOffset - pageSize)
+                                setPerformanceOffset(next)
+                                void loadPerformanceRows(next)
+                              }}
+                            >
+                              Previous
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              disabled={loadingPerformance || !performanceHasMore}
+                              onClick={() => {
+                                const next = performanceOffset + pageSize
+                                setPerformanceOffset(next)
+                                void loadPerformanceRows(next)
+                              }}
+                            >
+                              Next
+                            </Button>
+                          </div>
+                        </div>
+                      )
+                    })()}
+                  </>
                 ) : (
                   <p className="mt-3 text-sm text-zinc-500">No performance rows match the current filters yet.</p>
                 )}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.23.0",
+  "version": "4.23.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/content-data.ts
+++ b/packages/api-routes/src/content-data.ts
@@ -367,7 +367,19 @@ interface AggregateGscEntry {
   ctr: number
 }
 
-function aggregateGscByQuery(
+interface QueryAccumulator {
+  // GSC stores `page` as a full URL for url-prefix properties; normalize to
+  // a path so it can be joined against `gaTrafficByPage` (which is keyed by
+  // path) and so `ourBestPage.url` / `targetRef` stay consistent regardless
+  // of whether the page is sourced from GSC or from inventory.
+  bestPage: string
+  bestPageImpressions: number
+  totalClicks: number
+  totalImpressions: number
+  weightedPositionSum: number
+}
+
+export function aggregateGscByQuery(
   rows: Array<{
     query: string
     page: string
@@ -377,27 +389,45 @@ function aggregateGscByQuery(
     position: string
   }>,
 ): Map<string, AggregateGscEntry> {
-  const byQuery = new Map<string, AggregateGscEntry>()
+  const accumulators = new Map<string, QueryAccumulator>()
   for (const r of rows) {
-    const existing = byQuery.get(r.query)
-    const candidate: AggregateGscEntry = {
-      // GSC stores `page` as a full URL for url-prefix properties; normalize to
-      // a path so it can be joined against `gaTrafficByPage` (which is keyed by
-      // path) and so `ourBestPage.url` / `targetRef` stay consistent regardless
-      // of whether the page is sourced from GSC or from inventory.
-      page: extractPath(r.page),
-      position: Number(r.position) || 0,
-      impressions: r.impressions,
-      clicks: r.clicks,
-      ctr: Number(r.ctr) || 0,
-    }
+    const page = extractPath(r.page)
+    const position = Number(r.position) || 0
+    const existing = accumulators.get(r.query)
     if (!existing) {
-      byQuery.set(r.query, candidate)
+      accumulators.set(r.query, {
+        bestPage: page,
+        bestPageImpressions: r.impressions,
+        totalClicks: r.clicks,
+        totalImpressions: r.impressions,
+        weightedPositionSum: position * r.impressions,
+      })
       continue
     }
-    if (candidate.impressions > existing.impressions) {
-      byQuery.set(r.query, candidate)
+    existing.totalClicks += r.clicks
+    existing.totalImpressions += r.impressions
+    existing.weightedPositionSum += position * r.impressions
+    if (r.impressions > existing.bestPageImpressions) {
+      existing.bestPage = page
+      existing.bestPageImpressions = r.impressions
     }
+  }
+
+  const byQuery = new Map<string, AggregateGscEntry>()
+  for (const [query, acc] of accumulators) {
+    // CTR and average position must come from the aggregates, not from any
+    // single row. GSC splits a query across many dimension rows (page,
+    // country, device, date); a single click usually lands on one row with
+    // ctr=1.0 while the bulk of impressions sit on separate ctr=0 rows. The
+    // old "pick the row with the most impressions" logic almost always
+    // selected a row with no clicks, so per-query CTR rendered as 0%.
+    byQuery.set(query, {
+      page: acc.bestPage,
+      position: acc.totalImpressions > 0 ? acc.weightedPositionSum / acc.totalImpressions : 0,
+      impressions: acc.totalImpressions,
+      clicks: acc.totalClicks,
+      ctr: acc.totalImpressions > 0 ? acc.totalClicks / acc.totalImpressions : 0,
+    })
   }
   return byQuery
 }

--- a/packages/api-routes/src/google.ts
+++ b/packages/api-routes/src/google.ts
@@ -375,10 +375,10 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
   // GET /projects/:name/google/gsc/performance
   app.get<{
     Params: { name: string }
-    Querystring: { startDate?: string; endDate?: string; query?: string; page?: string; limit?: string; window?: string }
+    Querystring: { startDate?: string; endDate?: string; query?: string; page?: string; limit?: string; offset?: string; window?: string }
   }>('/projects/:name/google/gsc/performance', async (request) => {
     const project = resolveProject(app.db, request.params.name)
-    const { startDate, endDate, query, page, limit } = request.query
+    const { startDate, endDate, query, page, limit, offset } = request.query
 
     // Window-based filtering: when no explicit startDate is provided,
     // use the window param to compute a cutoff date.
@@ -391,12 +391,20 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
     if (query) conditions.push(sql`${gscSearchData.query} LIKE ${'%' + query + '%'}`)
     if (page) conditions.push(sql`${gscSearchData.page} LIKE ${'%' + page + '%'}`)
 
+    const limitVal = Math.max(parseInt(limit ?? '500', 10) || 0, 1)
+    const offsetVal = Math.max(parseInt(offset ?? '0', 10) || 0, 0)
+
+    // Always chain `.offset()` in a single expression — drizzle 0.45 on
+    // better-sqlite3 silently drops `.offset()` when called separately on a
+    // saved query builder (issue #470). The single-expression chain matches
+    // the working pattern used in backlinks.ts.
     const rows = app.db
       .select()
       .from(gscSearchData)
       .where(and(...conditions))
       .orderBy(desc(gscSearchData.date))
-      .limit(parseInt(limit ?? '500', 10))
+      .limit(limitVal)
+      .offset(offsetVal)
       .all()
 
     return rows.map((r) => ({

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -1407,6 +1407,7 @@ const routeCatalog: OpenApiOperation[] = [
       { name: 'query', in: 'query', description: 'Filter by search query.', schema: stringSchema },
       { name: 'page', in: 'query', description: 'Filter by page URL.', schema: stringSchema },
       limitQueryParameter,
+      offsetQueryParameter,
       analyticsWindowParameter,
     ],
     responses: {

--- a/packages/api-routes/test/content-data.test.ts
+++ b/packages/api-routes/test/content-data.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+
+import { aggregateGscByQuery } from '../src/content-data.js'
+
+function row(opts: {
+  query: string
+  page: string
+  impressions: number
+  clicks: number
+  ctr: string
+  position: string
+}) {
+  return opts
+}
+
+describe('aggregateGscByQuery', () => {
+  it('computes CTR from summed clicks and impressions, not from the row with most impressions', () => {
+    // Mirrors the bug in issue #469 ("spray foam insulation"). The row with
+    // the most impressions has ctr=0; the row with the actual click sits on a
+    // different dimension combination with ctr=1.0. The fix must aggregate.
+    const rows = [
+      row({ query: 'spray foam insulation', page: 'https://example.com/a', impressions: 26, clicks: 0, ctr: '0', position: '12' }),
+      row({ query: 'spray foam insulation', page: 'https://example.com/a', impressions: 1, clicks: 1, ctr: '1', position: '8' }),
+      row({ query: 'spray foam insulation', page: 'https://example.com/a', impressions: 1, clicks: 0, ctr: '0', position: '20' }),
+      row({ query: 'spray foam insulation', page: 'https://example.com/a', impressions: 1, clicks: 0, ctr: '0', position: '15' }),
+      row({ query: 'spray foam insulation', page: 'https://example.com/a', impressions: 1, clicks: 0, ctr: '0', position: '10' }),
+    ]
+    const result = aggregateGscByQuery(rows)
+    const entry = result.get('spray foam insulation')
+    expect(entry).toBeDefined()
+    expect(entry!.clicks).toBe(1)
+    expect(entry!.impressions).toBe(30)
+    // 1 / 30 = 0.0333... — must come from the aggregate, not a single row
+    expect(entry!.ctr).toBeCloseTo(1 / 30, 10)
+    // Impression-weighted average position
+    const expectedPosition = (12 * 26 + 8 * 1 + 20 * 1 + 15 * 1 + 10 * 1) / 30
+    expect(entry!.position).toBeCloseTo(expectedPosition, 10)
+  })
+
+  it('uses the page with the most impressions as the representative page', () => {
+    const rows = [
+      row({ query: 'best crm', page: 'https://example.com/winner', impressions: 100, clicks: 5, ctr: '0.05', position: '4' }),
+      row({ query: 'best crm', page: 'https://example.com/loser', impressions: 10, clicks: 1, ctr: '0.1', position: '7' }),
+    ]
+    const result = aggregateGscByQuery(rows)
+    const entry = result.get('best crm')
+    expect(entry).toBeDefined()
+    expect(entry!.page).toBe('/winner')
+    expect(entry!.clicks).toBe(6)
+    expect(entry!.impressions).toBe(110)
+    expect(entry!.ctr).toBeCloseTo(6 / 110, 10)
+  })
+
+  it('normalizes the representative page to a path (matches gaTrafficByPage)', () => {
+    const rows = [
+      row({ query: 'q', page: 'https://example.com/posts/foo', impressions: 5, clicks: 0, ctr: '0', position: '9' }),
+    ]
+    const result = aggregateGscByQuery(rows)
+    expect(result.get('q')!.page).toBe('/posts/foo')
+  })
+
+  it('returns ctr=0 and position=0 when total impressions are zero', () => {
+    const rows = [
+      row({ query: 'zero', page: '/p', impressions: 0, clicks: 0, ctr: '0', position: '0' }),
+    ]
+    const result = aggregateGscByQuery(rows)
+    const entry = result.get('zero')!
+    expect(entry.ctr).toBe(0)
+    expect(entry.position).toBe(0)
+    expect(entry.clicks).toBe(0)
+    expect(entry.impressions).toBe(0)
+  })
+
+  it('aggregates separately per query', () => {
+    const rows = [
+      row({ query: 'a', page: '/x', impressions: 10, clicks: 1, ctr: '0.1', position: '5' }),
+      row({ query: 'b', page: '/y', impressions: 20, clicks: 0, ctr: '0', position: '10' }),
+      row({ query: 'a', page: '/x', impressions: 10, clicks: 0, ctr: '0', position: '7' }),
+    ]
+    const result = aggregateGscByQuery(rows)
+    expect(result.get('a')!.clicks).toBe(1)
+    expect(result.get('a')!.impressions).toBe(20)
+    expect(result.get('a')!.ctr).toBeCloseTo(0.05, 10)
+    expect(result.get('b')!.clicks).toBe(0)
+    expect(result.get('b')!.impressions).toBe(20)
+    expect(result.get('b')!.ctr).toBe(0)
+  })
+
+  it('returns an empty map for no rows', () => {
+    expect(aggregateGscByQuery([]).size).toBe(0)
+  })
+})

--- a/packages/api-routes/test/google.test.ts
+++ b/packages/api-routes/test/google.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
 import Fastify from 'fastify'
-import { createClient, migrate, projects, runs, gscCoverageSnapshots, gscUrlInspections } from '@ainyc/canonry-db'
+import { createClient, migrate, projects, runs, gscCoverageSnapshots, gscUrlInspections, gscSearchData } from '@ainyc/canonry-db'
 import { AppError } from '@ainyc/canonry-contracts'
 import { googleRoutes } from '../src/google.js'
 
@@ -1217,5 +1217,127 @@ describe('googleRoutes: performance filter conditions', () => {
     expect(conditions).toContain('date <= ?')
     expect(conditions).toContain('query LIKE ?')
     expect(conditions).toContain('page LIKE ?')
+  })
+})
+
+describe('googleRoutes: GET /projects/:name/google/gsc/performance offset pagination', () => {
+  let context: ReturnType<typeof buildApp>
+  let projectId: string
+
+  beforeEach(async () => {
+    context = buildApp({ googleClientId: 'cid', googleClientSecret: 'csec' })
+    await context.app.ready()
+    projectId = crypto.randomUUID()
+    const now = '2026-01-01T00:00:00.000Z'
+    context.db.insert(projects).values({
+      id: projectId,
+      name: 'perf',
+      displayName: 'Perf',
+      canonicalDomain: 'perf.example.com',
+      country: 'US',
+      language: 'en',
+      createdAt: now,
+      updatedAt: now,
+    }).run()
+    const syncRunId = crypto.randomUUID()
+    context.db.insert(runs).values({
+      id: syncRunId,
+      projectId,
+      kind: 'gsc-sync',
+      status: 'completed',
+      trigger: 'manual',
+      createdAt: now,
+    }).run()
+    // Seed 6 rows with distinct dates so we can identify each page of results
+    // by date. Ordered by date desc, the rows return: d6, d5, d4, d3, d2, d1.
+    for (let i = 1; i <= 6; i++) {
+      const date = `2026-01-0${i}`
+      context.db.insert(gscSearchData).values({
+        id: crypto.randomUUID(),
+        projectId,
+        syncRunId,
+        date,
+        query: `q${i}`,
+        page: `/p${i}`,
+        country: 'usa',
+        device: 'DESKTOP',
+        impressions: i * 10,
+        clicks: i,
+        ctr: '0.1',
+        position: String(i + 1),
+        createdAt: now,
+      }).run()
+    }
+  })
+
+  afterEach(async () => {
+    await context.app.close()
+    fs.rmSync(context.tmpDir, { recursive: true, force: true })
+  })
+
+  it('paginates rows by offset (issue #470 — drizzle .offset() must apply)', async () => {
+    const page1 = await context.app.inject({
+      method: 'GET',
+      url: '/projects/perf/google/gsc/performance?limit=2&offset=0',
+    })
+    expect(page1.statusCode).toBe(200)
+    const rows1 = page1.json() as Array<{ date: string }>
+    expect(rows1.map(r => r.date)).toEqual(['2026-01-06', '2026-01-05'])
+
+    const page2 = await context.app.inject({
+      method: 'GET',
+      url: '/projects/perf/google/gsc/performance?limit=2&offset=2',
+    })
+    expect(page2.statusCode).toBe(200)
+    const rows2 = page2.json() as Array<{ date: string }>
+    expect(rows2.map(r => r.date)).toEqual(['2026-01-04', '2026-01-03'])
+
+    const page3 = await context.app.inject({
+      method: 'GET',
+      url: '/projects/perf/google/gsc/performance?limit=2&offset=4',
+    })
+    expect(page3.statusCode).toBe(200)
+    const rows3 = page3.json() as Array<{ date: string }>
+    expect(rows3.map(r => r.date)).toEqual(['2026-01-02', '2026-01-01'])
+
+    // Past the end returns an empty page (not the same first page).
+    const page4 = await context.app.inject({
+      method: 'GET',
+      url: '/projects/perf/google/gsc/performance?limit=2&offset=6',
+    })
+    expect(page4.statusCode).toBe(200)
+    expect(page4.json()).toEqual([])
+  })
+
+  it('treats omitted offset as 0 and behaves identically to offset=0', async () => {
+    const noOffset = await context.app.inject({
+      method: 'GET',
+      url: '/projects/perf/google/gsc/performance?limit=3',
+    })
+    const withZero = await context.app.inject({
+      method: 'GET',
+      url: '/projects/perf/google/gsc/performance?limit=3&offset=0',
+    })
+    expect(noOffset.statusCode).toBe(200)
+    expect(withZero.statusCode).toBe(200)
+    expect(noOffset.json()).toEqual(withZero.json())
+  })
+
+  it('clamps negative or non-numeric offset to 0', async () => {
+    const res = await context.app.inject({
+      method: 'GET',
+      url: '/projects/perf/google/gsc/performance?limit=2&offset=-5',
+    })
+    expect(res.statusCode).toBe(200)
+    const rows = res.json() as Array<{ date: string }>
+    expect(rows.map(r => r.date)).toEqual(['2026-01-06', '2026-01-05'])
+
+    const garbage = await context.app.inject({
+      method: 'GET',
+      url: '/projects/perf/google/gsc/performance?limit=2&offset=abc',
+    })
+    expect(garbage.statusCode).toBe(200)
+    const garbageRows = garbage.json() as Array<{ date: string }>
+    expect(garbageRows.map(r => r.date)).toEqual(['2026-01-06', '2026-01-05'])
   })
 })

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.23.0",
+  "version": "4.23.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Summary
- Fix per-query CTR (#469): `aggregateGscByQuery` now sums clicks/impressions across the per-page/country/device/date dimension rows GSC returns and computes CTR + impression-weighted position from the totals. Previously it picked the single row with the most impressions, which almost always had `ctr=0` while the one clicked row sat on a different dimension combo.
- Add performance pagination (#470): the `/projects/:name/google/gsc/performance` endpoint now accepts `offset` (clamped to ≥0), and the GSC dashboard table gets Previous/Next controls plus a "Showing N – M" indicator. The drizzle `.limit().offset()` is chained in a single expression because the saved-builder form silently drops offset on better-sqlite3.
- Tests cover both fixes (CTR aggregation, page ordering across offsets, omitted/negative/garbage offset inputs), plus a small JSX-text rendering fix for the pagination label.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test --filter @ainyc/canonry-api-routes`
- [x] Manual: open GSC tab, verify CTR matches sum-of-clicks / sum-of-impressions for a query, page through results