### PR TITLE
docs(readme): remove license badge from header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Canonry <img src="apps/web/public/favicon-32.png" alt="Canonry canary icon" width="24" />
 
-[![npm version](https://img.shields.io/npm/v/@ainyc/canonry)](https://www.npmjs.com/package/@ainyc/canonry) [![License: FSL-1.1-ALv2](https://img.shields.io/badge/License-FSL--1.1--ALv2-blue.svg)](https://fsl.software/) [![Node.js >= 22.14](https://img.shields.io/badge/node-%3E%3D22.14-brightgreen)](https://nodejs.org)
+[![npm version](https://img.shields.io/npm/v/@ainyc/canonry)](https://www.npmjs.com/package/@ainyc/canonry) [![Node.js >= 22.14](https://img.shields.io/badge/node-%3E%3D22.14-brightgreen)](https://nodejs.org)
 
 **Agent-first AEO operating platform. Open source. Self-hosted.**
 


### PR DESCRIPTION
## Summary
- Drops the FSL-1.1-ALv2 license badge from the README header row, leaving the npm version and Node.js badges.
- The `## License` section further down the README is untouched.

## Test plan
- [x] `pnpm lint` (ran via pre-commit hook)