### PR TITLE
feat(runs): scope answer-visibility runs to a query subset

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.25.0",
+  "version": "4.26.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -655,6 +655,7 @@ const routeCatalog: OpenApiOperation[] = [
               kind: stringSchema,
               trigger: stringSchema,
               providers: stringArraySchema,
+              queries: stringArraySchema,
               location: stringSchema,
               allLocations: booleanSchema,
               noLocation: booleanSchema,

--- a/packages/api-routes/src/run-queue.ts
+++ b/packages/api-routes/src/run-queue.ts
@@ -9,6 +9,8 @@ export interface QueueRunParams {
   trigger?: string
   createdAt?: string
   location?: string | null
+  /** JSON-serialized array of tracked query strings to scope the sweep to. Null = full sweep. */
+  queries?: string | null
 }
 
 export type QueueRunResult =
@@ -44,6 +46,7 @@ export function queueRunIfProjectIdle(db: DatabaseClient, params: QueueRunParams
       status: 'queued',
       trigger,
       location: params.location ?? null,
+      queries: params.queries ?? null,
       createdAt,
     }).run()
 

--- a/packages/api-routes/src/runs.ts
+++ b/packages/api-routes/src/runs.ts
@@ -53,6 +53,28 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
     }
     const providers = rawProviders?.length ? rawProviders : undefined
 
+    // Validate that body.queries (if provided) is a subset of the project's
+    // tracked queries. Untracked queries can't produce snapshots (no queries
+    // row to FK against), so we reject up-front rather than silently dropping.
+    let scopedQueries: string[] | null = null
+    if (body.queries?.length) {
+      const trackedRows = app.db
+        .select({ query: queries.query })
+        .from(queries)
+        .where(eq(queries.projectId, project.id))
+        .all()
+      const tracked = new Set(trackedRows.map(r => r.query))
+      const missing = body.queries.filter(q => !tracked.has(q))
+      if (missing.length) {
+        throw validationError(`Queries not tracked on project "${project.name}": ${missing.join(', ')}`, {
+          missing,
+          tracked: [...tracked],
+        })
+      }
+      scopedQueries = body.queries
+    }
+    const queriesColumn = scopedQueries ? JSON.stringify(scopedQueries) : null
+
     // Resolve location for this run
     let resolvedLocation: LocationContext | null | undefined
     const projectLocations = parseJsonColumn<LocationContext[]>(project.locations, [])
@@ -95,6 +117,7 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
           status: 'queued',
           trigger,
           location: loc.label,
+          queries: queriesColumn,
           createdAt: now,
         }).run()
         newRuns.push({ runId, loc })
@@ -125,6 +148,7 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
       projectId: project.id,
       trigger,
       location: locationLabel,
+      queries: queriesColumn,
     })
 
     if (queueResult.conflict) throw runInProgress(project.name)
@@ -344,6 +368,7 @@ function formatRun(row: {
   status: string
   trigger: string
   location: string | null
+  queries: string | null
   startedAt: string | null
   finishedAt: string | null
   error: string | null
@@ -356,6 +381,7 @@ function formatRun(row: {
     status: row.status,
     trigger: row.trigger,
     location: row.location,
+    queries: parseJsonColumn<string[] | null>(row.queries, null),
     startedAt: row.startedAt,
     finishedAt: row.finishedAt,
     error: parseRunError(row.error),

--- a/packages/api-routes/test/run-trigger-scoped.test.ts
+++ b/packages/api-routes/test/run-trigger-scoped.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, beforeAll, afterAll, expect } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import Fastify from 'fastify'
+import { eq } from 'drizzle-orm'
+import { createClient, migrate, runs, queries, parseJsonColumn } from '@ainyc/canonry-db'
+import { apiRoutes } from '../src/index.js'
+
+function buildApp() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-run-scoped-test-'))
+  const dbPath = path.join(tmpDir, 'test.db')
+  const db = createClient(dbPath)
+  migrate(db)
+  const app = Fastify()
+  app.register(apiRoutes, { db, skipAuth: true })
+  return { app, db, tmpDir }
+}
+
+async function clearActiveRuns(db: ReturnType<typeof createClient>) {
+  const allRuns = db.select().from(runs).all()
+  for (const r of allRuns) {
+    if (r.status === 'queued' || r.status === 'running') {
+      db.update(runs).set({ status: 'completed' }).where(eq(runs.id, r.id)).run()
+    }
+  }
+}
+
+describe('POST /api/v1/projects/:name/runs — queries scope', () => {
+  let app: ReturnType<typeof Fastify>
+  let db: ReturnType<typeof createClient>
+  let tmpDir: string
+
+  beforeAll(async () => {
+    const ctx = buildApp()
+    app = ctx.app
+    db = ctx.db
+    tmpDir = ctx.tmpDir
+    await app.ready()
+
+    await app.inject({
+      method: 'PUT',
+      url: '/api/v1/projects/scope-proj',
+      payload: {
+        displayName: 'Scope Project',
+        canonicalDomain: 'scope.example.com',
+        country: 'US',
+        language: 'en',
+      },
+    })
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/scope-proj/queries',
+      payload: { queries: ['alpha', 'beta', 'gamma'] },
+    })
+  })
+
+  afterAll(async () => {
+    await app.close()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('persists scope on the run row when a valid subset is provided', async () => {
+    await clearActiveRuns(db)
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/scope-proj/runs',
+      payload: { queries: ['alpha', 'beta'] },
+    })
+    expect(res.statusCode).toBe(201)
+    const body = JSON.parse(res.payload)
+    expect(body.queries).toEqual(['alpha', 'beta'])
+
+    const row = db.select().from(runs).where(eq(runs.id, body.id)).get()
+    expect(row).toBeTruthy()
+    expect(parseJsonColumn<string[]>(row!.queries, [])).toEqual(['alpha', 'beta'])
+  })
+
+  it('leaves queries column null for a full sweep (no queries field)', async () => {
+    await clearActiveRuns(db)
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/scope-proj/runs',
+      payload: {},
+    })
+    expect(res.statusCode).toBe(201)
+    const body = JSON.parse(res.payload)
+    expect(body.queries).toBeNull()
+
+    const row = db.select().from(runs).where(eq(runs.id, body.id)).get()
+    expect(row!.queries).toBeNull()
+  })
+
+  it('rejects queries not tracked on the project with 400 listing the missing values', async () => {
+    await clearActiveRuns(db)
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/scope-proj/runs',
+      payload: { queries: ['alpha', 'untracked-1', 'untracked-2'] },
+    })
+    expect(res.statusCode).toBe(400)
+    const body = JSON.parse(res.payload)
+    expect(body.error.code).toBe('VALIDATION_ERROR')
+    expect(body.error.message).toContain('untracked-1')
+    expect(body.error.message).toContain('untracked-2')
+    expect(body.error.details?.missing).toEqual(['untracked-1', 'untracked-2'])
+
+    // No run inserted on rejection
+    const projectRuns = db
+      .select()
+      .from(runs)
+      .where(eq(runs.projectId, db.select().from(queries).get()!.projectId))
+      .all()
+    expect(projectRuns.every((r) => r.status === 'completed')).toBe(true)
+  })
+
+  it('rejects an empty queries array (Zod schema enforcement)', async () => {
+    await clearActiveRuns(db)
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/scope-proj/runs',
+      payload: { queries: [] },
+    })
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('persists scope on every per-location run when combined with allLocations', async () => {
+    await clearActiveRuns(db)
+
+    await app.inject({
+      method: 'PUT',
+      url: '/api/v1/projects/scope-proj',
+      payload: {
+        displayName: 'Scope Project',
+        canonicalDomain: 'scope.example.com',
+        country: 'US',
+        language: 'en',
+        locations: [
+          { label: 'east', city: 'New York', region: 'NY', country: 'US' },
+          { label: 'west', city: 'San Francisco', region: 'CA', country: 'US' },
+        ],
+      },
+    })
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/scope-proj/runs',
+      payload: { queries: ['alpha'], allLocations: true },
+    })
+    expect(res.statusCode).toBe(207)
+    const body = JSON.parse(res.payload)
+    expect(body).toHaveLength(2)
+    for (const r of body) {
+      expect(r.queries).toEqual(['alpha'])
+      const row = db.select().from(runs).where(eq(runs.id, r.id)).get()
+      expect(parseJsonColumn<string[]>(row!.queries, [])).toEqual(['alpha'])
+    }
+  })
+})

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.25.0",
+  "version": "4.26.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/cli-commands/run.ts
+++ b/packages/canonry/src/cli-commands/run.ts
@@ -47,6 +47,15 @@ export const RUN_CLI_COMMANDS: readonly CliCommandSpec[] = [
             },
           })
         }
+        if (getStringArray(input.values, 'query')?.length) {
+          throw usageError('Error: --query cannot be combined with --all (query scope is project-specific)', {
+            message: '--query cannot be combined with --all (query scope is project-specific)',
+            details: {
+              command: 'run',
+              usage: 'canonry run <project> --query <q>... [--provider <name>] [--wait] [--format json]',
+            },
+          })
+        }
         await triggerRunAll({
           provider: getString(input.values, 'provider'),
           wait: getBoolean(input.values, 'wait'),

--- a/packages/canonry/src/cli-commands/run.ts
+++ b/packages/canonry/src/cli-commands/run.ts
@@ -1,6 +1,6 @@
 import { cancelRun, listRuns, showRun, triggerRun, triggerRunAll } from '../commands/run.js'
 import type { CliCommandSpec } from '../cli-dispatch.js'
-import { getBoolean, getString, parseIntegerOption, requirePositional, requireProject, stringOption } from '../cli-command-helpers.js'
+import { getBoolean, getString, getStringArray, multiStringOption, parseIntegerOption, requirePositional, requireProject, stringOption } from '../cli-command-helpers.js'
 import { usageError } from '../cli-error.js'
 
 export const RUN_CLI_COMMANDS: readonly CliCommandSpec[] = [
@@ -26,9 +26,10 @@ export const RUN_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['run'],
-    usage: 'canonry run <project|--all> [--provider <name>] [--location <label>] [--all-locations] [--no-location] [--wait] [--format json]',
+    usage: 'canonry run <project|--all> [--provider <name>] [--query <q>...] [--location <label>] [--all-locations] [--no-location] [--wait] [--format json]',
     options: {
       provider: stringOption(),
+      query: multiStringOption(),
       wait: { type: 'boolean', default: false },
       all: { type: 'boolean', default: false },
       location: stringOption(),
@@ -59,12 +60,13 @@ export const RUN_CLI_COMMANDS: readonly CliCommandSpec[] = [
       const project = requireProject(
         input,
         'run',
-        'canonry run <project> [--provider <name>] [--wait] [--format json]',
+        'canonry run <project> [--provider <name>] [--query <q>...] [--wait] [--format json]',
         'project name is required (or use --all)',
       )
 
       await triggerRun(project, {
         provider: getString(input.values, 'provider'),
+        queries: getStringArray(input.values, 'query'),
         wait: getBoolean(input.values, 'wait'),
         location: getString(input.values, 'location'),
         allLocations: getBoolean(input.values, 'all-locations'),

--- a/packages/canonry/src/commands/run.ts
+++ b/packages/canonry/src/commands/run.ts
@@ -8,7 +8,7 @@ function getClient() {
 
 const TERMINAL_STATUSES = new Set(['completed', 'partial', 'failed', 'cancelled'])
 
-export async function triggerRun(project: string, opts?: { provider?: string; wait?: boolean; format?: string; location?: string; allLocations?: boolean; noLocation?: boolean }): Promise<void> {
+export async function triggerRun(project: string, opts?: { provider?: string; queries?: string[]; wait?: boolean; format?: string; location?: string; allLocations?: boolean; noLocation?: boolean }): Promise<void> {
   const client = getClient()
   const body: Record<string, unknown> = {}
   if (opts?.provider) {
@@ -16,6 +16,9 @@ export async function triggerRun(project: string, opts?: { provider?: string; wa
     const providerInputs = opts.provider.split(',').map(s => s.trim()).filter(Boolean)
     const resolved = providerInputs.flatMap(p => resolveProviderInput(p))
     body.providers = resolved.length > 0 ? resolved : providerInputs
+  }
+  if (opts?.queries?.length) {
+    body.queries = opts.queries
   }
   if (opts?.location) {
     body.location = opts.location

--- a/packages/canonry/src/job-runner.ts
+++ b/packages/canonry/src/job-runner.ts
@@ -324,12 +324,19 @@ export class JobRunner {
 
       log.info('run.dispatch', { runId, providerCount: activeProviders.length, providers: activeProviders.map(p => p.adapter.name) })
 
-      // Fetch queries for the project
-      projectQueries = this.db
-        .select()
-        .from(queries)
-        .where(eq(queries.projectId, projectId))
-        .all()
+      // Fetch queries for the project (scope to existingRun.queries if set)
+      const scopedQueryNames = parseJsonColumn<string[] | null>(existingRun.queries, null)
+      projectQueries = scopedQueryNames
+        ? this.db
+            .select()
+            .from(queries)
+            .where(and(eq(queries.projectId, projectId), inArray(queries.query, scopedQueryNames)))
+            .all()
+        : this.db
+            .select()
+            .from(queries)
+            .where(eq(queries.projectId, projectId))
+            .all()
 
       // Fetch competitors for the project
       const projectCompetitors = this.db
@@ -694,13 +701,14 @@ export class JobRunner {
     }
   }
 
-  private getRunState(runId: string): { status: string; finishedAt: string | null; error: string | null; trigger: string | null } | undefined {
+  private getRunState(runId: string): { status: string; finishedAt: string | null; error: string | null; trigger: string | null; queries: string | null } | undefined {
     return this.db
       .select({
         status: runs.status,
         finishedAt: runs.finishedAt,
         error: runs.error,
         trigger: runs.trigger,
+        queries: runs.queries,
       })
       .from(runs)
       .where(eq(runs.id, runId))

--- a/packages/canonry/src/mcp/tool-registry.ts
+++ b/packages/canonry/src/mcp/tool-registry.ts
@@ -984,7 +984,7 @@ export const canonryMcpTools = [
   defineTool({
     name: 'canonry_run_trigger',
     title: 'Trigger run',
-    description: 'Trigger an answer-visibility run for a Canonry project.',
+    description: "Trigger an answer-visibility run for a Canonry project. Pass request.queries[] to scope the sweep to a subset of the project's tracked queries; omit for a full sweep.",
     access: 'write',
     tier: 'core',
     inputSchema: runTriggerInputSchema,

--- a/packages/canonry/test/cli-run-contract.test.ts
+++ b/packages/canonry/test/cli-run-contract.test.ts
@@ -3,7 +3,8 @@ import os from 'node:os'
 import fs from 'node:fs'
 import path from 'node:path'
 import crypto from 'node:crypto'
-import { createClient, migrate, apiKeys, runs } from '@ainyc/canonry-db'
+import { eq } from 'drizzle-orm'
+import { createClient, migrate, apiKeys, runs, parseJsonColumn } from '@ainyc/canonry-db'
 import { createServer } from '../src/server.js'
 import { ApiClient } from '../src/client.js'
 import { invokeCli } from './cli-test-utils.js'
@@ -184,6 +185,38 @@ describe('run lifecycle CLI contract', () => {
     expect(parsed).toHaveLength(1)
     expect(parsed[0]?.id).toBe(latestRunId)
     expect(parsed[0]?.id).not.toBe(olderRunId)
+  })
+
+  it('forwards repeatable --query flags as a queries[] body field', async () => {
+    await client.appendQueries('test-proj', ['alpha', 'beta', 'gamma'])
+
+    const result = await invokeCli([
+      'run', 'test-proj',
+      '--query', 'alpha',
+      '--query', 'beta',
+      '--format', 'json',
+    ])
+
+    expect(result.exitCode).toBe(undefined)
+    const parsed = JSON.parse(result.stdout) as { id: string; queries: string[] }
+    expect(parsed.queries).toEqual(['alpha', 'beta'])
+
+    const row = db.select().from(runs).where(eq(runs.id, parsed.id)).get()
+    expect(row).toBeTruthy()
+    expect(parseJsonColumn<string[]>(row!.queries, [])).toEqual(['alpha', 'beta'])
+  })
+
+  it('returns 400 when --query lists an untracked query', async () => {
+    await client.appendQueries('test-proj', ['alpha'])
+
+    const result = await invokeCli([
+      'run', 'test-proj',
+      '--query', 'untracked',
+      '--format', 'json',
+    ])
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toContain('untracked')
   })
 
   it('prints a JSON usage error for runs <project> --limit with a non-integer value', async () => {

--- a/packages/canonry/test/cli-run-contract.test.ts
+++ b/packages/canonry/test/cli-run-contract.test.ts
@@ -219,6 +219,19 @@ describe('run lifecycle CLI contract', () => {
     expect(result.stderr).toContain('untracked')
   })
 
+  it('rejects --query when combined with --all', async () => {
+    const result = await invokeCli([
+      'run', '--all',
+      '--query', 'alpha',
+      '--format', 'json',
+    ])
+
+    expect(result.exitCode).toBe(1)
+    const parsed = JSON.parse(result.stderr) as { error: { code: string; message: string } }
+    expect(parsed.error.code).toBe('CLI_USAGE_ERROR')
+    expect(parsed.error.message).toContain('--query cannot be combined with --all')
+  })
+
   it('prints a JSON usage error for runs <project> --limit with a non-integer value', async () => {
     const result = await invokeCli(['runs', 'test-proj', '--limit', 'bogus', '--format', 'json'])
 

--- a/packages/canonry/test/job-runner-scoped-queries.test.ts
+++ b/packages/canonry/test/job-runner-scoped-queries.test.ts
@@ -1,0 +1,147 @@
+import { test, expect, onTestFinished } from 'vitest'
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { eq } from 'drizzle-orm'
+import type {
+  ProviderAdapter,
+  ProviderConfig,
+  ProviderHealthcheckResult,
+  TrackedQueryInput,
+  RawQueryResult,
+  NormalizedQueryResult,
+} from '@ainyc/canonry-contracts'
+import { createClient, migrate, queries, projects, querySnapshots, runs } from '@ainyc/canonry-db'
+import { JobRunner } from '../src/job-runner.js'
+import { ProviderRegistry } from '../src/provider-registry.js'
+
+function buildEnv() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-scoped-queries-'))
+  onTestFinished(() => fs.rmSync(tmpDir, { recursive: true, force: true }))
+  const dbPath = path.join(tmpDir, 'test.db')
+  const db = createClient(dbPath)
+  migrate(db)
+  return { db }
+}
+
+function buildStubAdapter(seenQueries: string[]): ProviderAdapter {
+  return {
+    name: 'gemini',
+    validateConfig(_config: ProviderConfig): ProviderHealthcheckResult {
+      return { ok: true, provider: 'gemini', message: 'ok' }
+    },
+    async healthcheck(_config: ProviderConfig): Promise<ProviderHealthcheckResult> {
+      return { ok: true, provider: 'gemini', message: 'ok' }
+    },
+    async executeTrackedQuery(input: TrackedQueryInput, _config: ProviderConfig): Promise<RawQueryResult> {
+      seenQueries.push(input.query)
+      return {
+        provider: 'gemini',
+        rawResponse: {},
+        model: 'stub-model',
+        groundingSources: [],
+        searchQueries: [],
+      }
+    },
+    normalizeResult(_raw: RawQueryResult): NormalizedQueryResult {
+      return {
+        provider: 'gemini',
+        answerText: 'stub',
+        citedDomains: [],
+        groundingSources: [],
+        searchQueries: [],
+      }
+    },
+    async generateText(_prompt: string, _config: ProviderConfig): Promise<string> {
+      return 'stub'
+    },
+  }
+}
+
+function buildRegistry(adapter: ProviderAdapter): ProviderRegistry {
+  const registry = new ProviderRegistry()
+  registry.register(adapter, {
+    provider: 'gemini',
+    apiKey: 'test-key',
+    quotaPolicy: {
+      maxConcurrency: 2,
+      maxRequestsPerMinute: 60,
+      maxRequestsPerDay: 1000,
+    },
+  })
+  return registry
+}
+
+function seed(db: ReturnType<typeof createClient>, queriesList: string[], runQueriesJson: string | null) {
+  const projectId = crypto.randomUUID()
+  const runId = crypto.randomUUID()
+  const now = new Date().toISOString()
+
+  db.insert(projects).values({
+    id: projectId,
+    name: 'scoped',
+    displayName: 'Scoped Project',
+    canonicalDomain: 'example.com',
+    ownedDomains: '[]',
+    country: 'US',
+    language: 'en',
+    providers: '[]',
+    createdAt: now,
+    updatedAt: now,
+  }).run()
+
+  for (const q of queriesList) {
+    db.insert(queries).values({
+      id: crypto.randomUUID(),
+      projectId,
+      query: q,
+      createdAt: now,
+    }).run()
+  }
+
+  db.insert(runs).values({
+    id: runId,
+    projectId,
+    status: 'queued',
+    queries: runQueriesJson,
+    createdAt: now,
+  }).run()
+
+  return { projectId, runId }
+}
+
+test('JobRunner sweeps only the scoped queries when runs.queries is set', async () => {
+  const { db } = buildEnv()
+  const seen: string[] = []
+  const registry = buildRegistry(buildStubAdapter(seen))
+
+  const { projectId, runId } = seed(db, ['alpha', 'beta', 'gamma'], JSON.stringify(['alpha', 'beta']))
+
+  const runner = new JobRunner(db, registry)
+  await runner.executeRun(runId, projectId)
+
+  expect(seen.sort()).toEqual(['alpha', 'beta'])
+
+  const snapshots = db.select().from(querySnapshots).where(eq(querySnapshots.runId, runId)).all()
+  expect(snapshots).toHaveLength(2)
+
+  const finalRun = db.select().from(runs).where(eq(runs.id, runId)).get()
+  expect(finalRun?.status).toBe('completed')
+})
+
+test('JobRunner falls back to full sweep when runs.queries is null', async () => {
+  const { db } = buildEnv()
+  const seen: string[] = []
+  const registry = buildRegistry(buildStubAdapter(seen))
+
+  const { projectId, runId } = seed(db, ['alpha', 'beta', 'gamma'], null)
+
+  const runner = new JobRunner(db, registry)
+  await runner.executeRun(runId, projectId)
+
+  expect(seen.sort()).toEqual(['alpha', 'beta', 'gamma'])
+
+  const snapshots = db.select().from(querySnapshots).where(eq(querySnapshots.runId, runId)).all()
+  expect(snapshots).toHaveLength(3)
+})

--- a/packages/contracts/src/run.ts
+++ b/packages/contracts/src/run.ts
@@ -41,6 +41,7 @@ export const runTriggerRequestSchema = z.object({
   kind: z.literal(RunKinds['answer-visibility']).optional(),
   trigger: z.literal(RunTriggers.manual).optional(),
   providers: z.array(providerNameSchema).optional(),
+  queries: z.array(z.string().min(1)).min(1).optional(),
   location: z.string().min(1).optional(),
   allLocations: z.boolean().optional(),
   noLocation: z.boolean().optional(),

--- a/packages/contracts/src/run.ts
+++ b/packages/contracts/src/run.ts
@@ -77,6 +77,7 @@ export const runDtoSchema = z.object({
   status: runStatusSchema,
   trigger: runTriggerSchema.default('manual'),
   location: z.string().nullable().optional(),
+  queries: z.array(z.string()).nullable().optional(),
   startedAt: z.string().nullable().optional(),
   finishedAt: z.string().nullable().optional(),
   error: runErrorSchema.nullable().optional(),

--- a/packages/contracts/test/run-trigger-schema.test.ts
+++ b/packages/contracts/test/run-trigger-schema.test.ts
@@ -1,5 +1,31 @@
 import { describe, expect, it } from 'vitest'
-import { runTriggerRequestSchema } from '../src/run.js'
+import { runDtoSchema, runTriggerRequestSchema } from '../src/run.js'
+
+describe('runDtoSchema.queries', () => {
+  it('parses a run row with a queries array', () => {
+    const result = runDtoSchema.parse({
+      id: 'run_1',
+      projectId: 'proj_1',
+      kind: 'answer-visibility',
+      status: 'queued',
+      queries: ['alpha', 'beta'],
+      createdAt: '2026-05-13T00:00:00.000Z',
+    })
+    expect(result.queries).toEqual(['alpha', 'beta'])
+  })
+
+  it('parses a run row with queries explicitly null (full sweep)', () => {
+    const result = runDtoSchema.parse({
+      id: 'run_1',
+      projectId: 'proj_1',
+      kind: 'answer-visibility',
+      status: 'queued',
+      queries: null,
+      createdAt: '2026-05-13T00:00:00.000Z',
+    })
+    expect(result.queries).toBeNull()
+  })
+})
 
 describe('runTriggerRequestSchema.queries', () => {
   it('accepts requests with no queries field (full-sweep default)', () => {

--- a/packages/contracts/test/run-trigger-schema.test.ts
+++ b/packages/contracts/test/run-trigger-schema.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { runTriggerRequestSchema } from '../src/run.js'
+
+describe('runTriggerRequestSchema.queries', () => {
+  it('accepts requests with no queries field (full-sweep default)', () => {
+    const result = runTriggerRequestSchema.safeParse({})
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.queries).toBeUndefined()
+    }
+  })
+
+  it('accepts a non-empty array of query strings', () => {
+    const result = runTriggerRequestSchema.safeParse({ queries: ['alpha', 'beta'] })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.queries).toEqual(['alpha', 'beta'])
+    }
+  })
+
+  it('rejects an empty queries array', () => {
+    const result = runTriggerRequestSchema.safeParse({ queries: [] })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects queries with empty strings', () => {
+    const result = runTriggerRequestSchema.safeParse({ queries: [''] })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects non-string queries entries', () => {
+    const result = runTriggerRequestSchema.safeParse({ queries: [42] })
+    expect(result.success).toBe(false)
+  })
+
+  it('allows queries to combine with location', () => {
+    const result = runTriggerRequestSchema.safeParse({
+      queries: ['alpha'],
+      location: 'michigan',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('allows queries to combine with allLocations', () => {
+    const result = runTriggerRequestSchema.safeParse({
+      queries: ['alpha'],
+      allLocations: true,
+    })
+    expect(result.success).toBe(true)
+  })
+})

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1096,6 +1096,17 @@ export const MIGRATION_VERSIONS: ReadonlyArray<MigrationVersion> = [
       `CREATE INDEX IF NOT EXISTS idx_discovery_sessions_run ON discovery_sessions(run_id)`,
     ],
   },
+  {
+    version: 57,
+    name: 'runs-scoped-queries',
+    // Persists an optional subset of tracked queries to sweep on a per-run
+    // basis. NULL = full sweep (the default and only behavior pre-v57); a JSON
+    // array of query strings = scope. The job runner reads this to filter the
+    // query fetch via `inArray`.
+    statements: [
+      `ALTER TABLE runs ADD COLUMN queries TEXT`,
+    ],
+  },
 ]
 
 /**

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -50,6 +50,7 @@ export const runs = sqliteTable('runs', {
   status: text('status').notNull().default('queued'),
   trigger: text('trigger').notNull().default('manual'),
   location: text('location'),
+  queries: text('queries'),
   sourceId: text('source_id'),
   startedAt: text('started_at'),
   finishedAt: text('finished_at'),

--- a/skills/canonry-setup/references/canonry-cli.md
+++ b/skills/canonry-setup/references/canonry-cli.md
@@ -52,6 +52,7 @@ canonry snapshot "Acme Corp" --domain acme.example.com --format json
 
 canonry run <project>                             # sweep all configured providers
 canonry run <project> --provider gemini           # single provider only
+canonry run <project> --query "alpha" --query "beta"  # scope sweep to a subset of tracked queries (repeatable)
 canonry run <project> --wait                      # block until complete
 canonry run <project> --location <label>          # run with specific location context
 canonry run <project> --all-locations             # run for every configured location


### PR DESCRIPTION
## Summary

Adds an optional `queries[]` field to the run-trigger request so callers can sweep only a subset of a project's tracked queries instead of the full set. The scope is validated as a subset of tracked queries (untracked entries return 400 with the missing values), persisted on the `runs` row via migration 57, and read by the job runner via `inArray` so only the listed queries produce snapshots. Surface coverage: contracts schema, API + run-queue, job-runner, repeatable `canonry run --query <q>` CLI flag, and the `canonry_run_trigger` MCP tool description.

This unblocks surgical reactive sweeps (e.g. re-run a single query when an AI crawler hits its target URL) without polluting the project's permanent tracked-query set. Default behavior is unchanged — runs without the field continue to sweep every tracked query.

## Test plan

- [x] 7 new contracts tests (`run-trigger-schema.test.ts`) covering accept/reject of the new field
- [x] 5 new api-routes tests (`run-trigger-scoped.test.ts`) covering subset persistence, validation, and `allLocations` × `queries` interaction
- [x] 2 new job-runner tests (`job-runner-scoped-queries.test.ts`) — scoped sweep produces only N snapshots; null scope = full-sweep regression baseline
- [x] 2 new CLI contract tests for `canonry run --query`
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` — 2502/2502 pass