### PR TITLE
fix(web): render every location after multi-location fan-out (#477)

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -224,35 +224,22 @@ export interface ApiCompetitor {
   createdAt: string
 }
 
+export interface ApiTimelineRunEntry {
+  runId: string
+  createdAt: string
+  citationState: string
+  transition: string
+  answerMentioned?: boolean
+  visibilityState?: string
+  visibilityTransition?: string
+  location?: string | null
+}
+
 export interface ApiTimelineEntry {
   query: string
-  runs: {
-    runId: string
-    createdAt: string
-    citationState: string
-    transition: string
-    answerMentioned?: boolean
-    visibilityState?: string
-    visibilityTransition?: string
-  }[]
-  providerRuns?: Record<string, {
-    runId: string
-    createdAt: string
-    citationState: string
-    transition: string
-    answerMentioned?: boolean
-    visibilityState?: string
-    visibilityTransition?: string
-  }[]>
-  modelRuns?: Record<string, {
-    runId: string
-    createdAt: string
-    citationState: string
-    transition: string
-    answerMentioned?: boolean
-    visibilityState?: string
-    visibilityTransition?: string
-  }[]>
+  runs: ApiTimelineRunEntry[]
+  providerRuns?: Record<string, ApiTimelineRunEntry[]>
+  modelRuns?: Record<string, ApiTimelineRunEntry[]>
 }
 
 export interface ApiAuditEntry {

--- a/apps/web/src/build-dashboard.ts
+++ b/apps/web/src/build-dashboard.ts
@@ -145,26 +145,35 @@ function summaryFromRun(run: ApiRun): string {
 function buildEvidenceFromTimeline(
   projectName: string,
   timeline: ApiTimelineEntry[],
-  latestRunDetail: ApiRunDetail | null,
+  latestRunDetails: ApiRunDetail[],
   savedQueries: ApiQuery[],
 ): CitationInsightVm[] {
   const results: CitationInsightVm[] = []
   let idx = 0
   const seenQueries = new Set<string>()
 
-  if (latestRunDetail) {
-    // Group snapshots by query+provider for multi-provider support
+  if (latestRunDetails.length > 0) {
+    // Multi-location runs fan out as one ApiRunDetail per location, all with the
+    // same `createdAt`. Bucket snapshots by (query × provider × location) so each
+    // location's evidence row survives the aggregate instead of being clobbered.
+    const allSnapshots = latestRunDetails.flatMap(r => r.snapshots)
     const snapshotsByKey = new Map<string, ApiRunDetail['snapshots'][number]>()
-    for (const snap of latestRunDetail.snapshots) {
+    for (const snap of allSnapshots) {
       if (snap.query) {
-        const key = `${snap.query}::${snap.provider}`
+        const key = `${snap.query}::${snap.provider}::${snap.location ?? ''}`
         snapshotsByKey.set(key, snap)
       }
     }
 
+    // Locations seen across the latest-run group (one entry per fan-out location).
+    // When a project runs without any location, the set contains a single null entry
+    // so the (query × provider) loop still emits a row.
+    const locationsInLatestRun = new Set<string | null>(allSnapshots.map(s => s.location ?? null))
+    if (locationsInLatestRun.size === 0) locationsInLatestRun.add(null)
+
     // Collect unique providers from the full timeline history (not just the latest run)
     // so that providers that errored or were absent in the latest run still show badges.
-    const providersFromLatestRun = new Set(latestRunDetail.snapshots.map(s => s.provider))
+    const providersFromLatestRun = new Set(allSnapshots.map(s => s.provider))
     const providersFromHistory = new Set(
       timeline.flatMap(entry =>
         Object.keys(entry.providerRuns ?? {})
@@ -179,97 +188,103 @@ function buildEvidenceFromTimeline(
       const latestRun = entry.runs.at(-1)
       const transition = latestRun?.transition ?? 'not-cited'
       for (const provider of providers) {
-        const snap = snapshotsByKey.get(`${entry.query}::${provider}`)
-        // Only skip if provider has zero history for this query AND no snapshot in latest run
-        const hasHistory = (entry.providerRuns?.[provider]?.length ?? 0) > 0
-        if (!snap && !hasHistory) continue
+        // Emit one evidence row per location observed in the latest-run group.
+        // `null` represents the "no location configured" case (single-location or
+        // project-wide runs); when set, each row carries that location's snapshot.
+        for (const location of locationsInLatestRun) {
+          const locKey = location ?? ''
+          const snap = snapshotsByKey.get(`${entry.query}::${provider}::${locKey}`)
+          // Only skip if provider has zero history for this query AND no snapshot in this location
+          const hasHistory = (entry.providerRuns?.[provider]?.length ?? 0) > 0
+          if (!snap && !hasHistory) continue
 
-        // Prefer provider-level history for continuity across model changes; fall back to model-scoped then query-level
-        const model = snap?.model ?? null
-        const modelKey = model ? `${provider}:${model}` : null
-        const modelHistory = modelKey ? entry.modelRuns?.[modelKey] : undefined
-        const providerHistory = entry.providerRuns?.[provider]
-        const effectiveHistory = (providerHistory?.length ? providerHistory : null)
-          ?? (modelHistory?.length ? modelHistory : null)
-        const baseHistoryScope: EvidenceHistoryScope = providerHistory?.length
-          ? 'provider'
-          : modelHistory?.length
+          // Prefer provider-level history for continuity across model changes; fall back to model-scoped then query-level
+          const model = snap?.model ?? null
+          const modelKey = model ? `${provider}:${model}` : null
+          const modelHistory = modelKey ? entry.modelRuns?.[modelKey] : undefined
+          const providerHistory = entry.providerRuns?.[provider]
+          const effectiveHistory = (providerHistory?.length ? providerHistory : null)
+            ?? (modelHistory?.length ? modelHistory : null)
+          const baseHistoryScope: EvidenceHistoryScope = providerHistory?.length
+            ? 'provider'
+            : modelHistory?.length
+              ? 'model'
+              : 'query'
+
+          const effectiveTransition = effectiveHistory
+            ? effectiveHistory.at(-1)!.transition
+            : transition
+          const effectiveVisibilityTransition = effectiveHistory
+            ? (effectiveHistory.at(-1)!.visibilityTransition ?? (effectiveHistory.at(-1)!.visibilityState === 'visible' ? 'visible' : 'not-visible'))
+            : (latestRun?.visibilityTransition ?? (latestRun?.visibilityState === 'visible' ? 'visible' : 'not-visible'))
+
+          // When a provider is missing from the latest run, keep showing its last
+          // observed provider-level state instead of leaking the query-level
+          // transition from another provider into this synthetic badge row.
+          const latestProviderState = effectiveHistory?.at(-1)?.citationState
+          const latestProviderVisibilityState = effectiveHistory?.at(-1)?.visibilityState
+          const snapState: CitationState = snap
+            ? effectiveTransition === 'lost' ? 'lost'
+              : effectiveTransition === 'emerging' ? 'emerging'
+              : snap.citationState === CitationStates.cited ? 'cited' : 'not-cited'
+            : latestProviderState === CitationStates.cited ? 'cited' : 'not-cited'
+          const snapVisibilityState = (snap?.visibilityState as CitationInsightVm['visibilityState'] | undefined)
+            ?? (latestProviderVisibilityState === 'visible' ? 'visible' : latestProviderVisibilityState === 'pending' ? 'pending' : 'not-visible')
+
+          const streak = effectiveHistory
+            ? computeStreak(effectiveHistory)
+            : computeStreak(entry.runs)
+          const visibilityStreak = effectiveHistory
+            ? computeVisibilityStreak(effectiveHistory)
+            : computeVisibilityStreak(entry.runs)
+
+          const runModels = buildRunModelMap(entry, provider)
+          const runHistory = (effectiveHistory ?? entry.runs)
+            .map(r => ({
+              runId: r.runId,
+              citationState: r.citationState,
+              createdAt: r.createdAt,
+              model: runModels.get(r.runId) ?? null,
+              answerMentioned: r.answerMentioned,
+              visibilityState: r.visibilityState as RunHistoryPoint['visibilityState'] | undefined,
+              visibilityTransition: r.visibilityTransition,
+            }))
+          const modelsSeen = collectModels(runHistory)
+          const historyScope: EvidenceHistoryScope = baseHistoryScope === 'provider' && modelsSeen.length <= 1
             ? 'model'
-            : 'query'
+            : baseHistoryScope
+          const modelTransitions = computeModelTransitions(runHistory)
 
-        const effectiveTransition = effectiveHistory
-          ? effectiveHistory.at(-1)!.transition
-          : transition
-        const effectiveVisibilityTransition = effectiveHistory
-          ? (effectiveHistory.at(-1)!.visibilityTransition ?? (effectiveHistory.at(-1)!.visibilityState === 'visible' ? 'visible' : 'not-visible'))
-          : (latestRun?.visibilityTransition ?? (latestRun?.visibilityState === 'visible' ? 'visible' : 'not-visible'))
-
-        // When a provider is missing from the latest run, keep showing its last
-        // observed provider-level state instead of leaking the query-level
-        // transition from another provider into this synthetic badge row.
-        const latestProviderState = effectiveHistory?.at(-1)?.citationState
-        const latestProviderVisibilityState = effectiveHistory?.at(-1)?.visibilityState
-        const snapState: CitationState = snap
-          ? effectiveTransition === 'lost' ? 'lost'
-            : effectiveTransition === 'emerging' ? 'emerging'
-            : snap.citationState === CitationStates.cited ? 'cited' : 'not-cited'
-          : latestProviderState === CitationStates.cited ? 'cited' : 'not-cited'
-        const snapVisibilityState = (snap?.visibilityState as CitationInsightVm['visibilityState'] | undefined)
-          ?? (latestProviderVisibilityState === 'visible' ? 'visible' : latestProviderVisibilityState === 'pending' ? 'pending' : 'not-visible')
-
-        const streak = effectiveHistory
-          ? computeStreak(effectiveHistory)
-          : computeStreak(entry.runs)
-        const visibilityStreak = effectiveHistory
-          ? computeVisibilityStreak(effectiveHistory)
-          : computeVisibilityStreak(entry.runs)
-
-        const runModels = buildRunModelMap(entry, provider)
-        const runHistory = (effectiveHistory ?? entry.runs)
-          .map(r => ({
-            runId: r.runId,
-            citationState: r.citationState,
-            createdAt: r.createdAt,
-            model: runModels.get(r.runId) ?? null,
-            answerMentioned: r.answerMentioned,
-            visibilityState: r.visibilityState as RunHistoryPoint['visibilityState'] | undefined,
-            visibilityTransition: r.visibilityTransition,
-          }))
-        const modelsSeen = collectModels(runHistory)
-        const historyScope: EvidenceHistoryScope = baseHistoryScope === 'provider' && modelsSeen.length <= 1
-          ? 'model'
-          : baseHistoryScope
-        const modelTransitions = computeModelTransitions(runHistory)
-
-        results.push({
-          id: `evidence_${projectName}_${idx++}`,
-          query: entry.query,
-          provider: snap?.provider ?? provider,
-          model: snap?.model ?? null,
-          location: snap?.location ?? null,
-          citationState: snapState,
-          answerMentioned: snap?.answerMentioned,
-          visibilityState: snapVisibilityState,
-          visibilityChangeLabel: changeLabel(effectiveVisibilityTransition, visibilityStreak, {
-            positive: 'visible',
-            negative: 'not visible',
-            first: 'first visibility',
-          }),
-          changeLabel: changeLabel(effectiveTransition, streak),
-          answerSnippet: snap?.answerText ?? '',
-          citedDomains: snap?.citedDomains ?? [],
-          evidenceUrls: [],
-          competitorDomains: snap?.competitorOverlap ?? [],
-          recommendedCompetitors: snap?.recommendedCompetitors ?? [],
-          matchedTerms: snap?.matchedTerms ?? [],
-          relatedTechnicalSignals: [],
-          groundingSources: snap?.groundingSources ?? [],
-          summary: visibilityEvidenceSummary(snapVisibilityState, effectiveVisibilityTransition, entry.query),
-          runHistory,
-          historyScope,
-          modelsSeen,
-          modelTransitions,
-        })
+          results.push({
+            id: `evidence_${projectName}_${idx++}`,
+            query: entry.query,
+            provider: snap?.provider ?? provider,
+            model: snap?.model ?? null,
+            location: snap?.location ?? location,
+            citationState: snapState,
+            answerMentioned: snap?.answerMentioned,
+            visibilityState: snapVisibilityState,
+            visibilityChangeLabel: changeLabel(effectiveVisibilityTransition, visibilityStreak, {
+              positive: 'visible',
+              negative: 'not visible',
+              first: 'first visibility',
+            }),
+            changeLabel: changeLabel(effectiveTransition, streak),
+            answerSnippet: snap?.answerText ?? '',
+            citedDomains: snap?.citedDomains ?? [],
+            evidenceUrls: [],
+            competitorDomains: snap?.competitorOverlap ?? [],
+            recommendedCompetitors: snap?.recommendedCompetitors ?? [],
+            matchedTerms: snap?.matchedTerms ?? [],
+            relatedTechnicalSignals: [],
+            groundingSources: snap?.groundingSources ?? [],
+            summary: visibilityEvidenceSummary(snapVisibilityState, effectiveVisibilityTransition, entry.query),
+            runHistory,
+            historyScope,
+            modelsSeen,
+            modelTransitions,
+          })
+        }
       }
     }
   }
@@ -431,7 +446,10 @@ export interface ProjectData {
   queries: ApiQuery[]
   competitors: ApiCompetitor[]
   timeline: ApiTimelineEntry[]
-  latestRunDetail: ApiRunDetail | null
+  /** All runs in the latest fan-out group (same `createdAt`). Each entry is one
+   * location for a multi-location sweep, or a single-element array for a
+   * single-location / project-wide run. Empty when the project has never run. */
+  latestRunDetails: ApiRunDetail[]
   previousRunDetail: ApiRunDetail | null
   gscCoverage?: ApiGscCoverageSummary | null
   bingCoverage?: ApiBingCoverageSummary | null
@@ -447,7 +465,7 @@ export function buildProjectCommandCenter(data: ProjectData): ProjectCommandCent
   // Evidence cards stay client-side for now: per Q8 of the deepening plan, the
   // /timeline endpoint is the source for per-query history. Eventually a
   // dedicated /evidence endpoint replaces this client-side derivation.
-  const evidence = buildEvidenceFromTimeline(dto.name, data.timeline, data.latestRunDetail, data.queries)
+  const evidence = buildEvidenceFromTimeline(dto.name, data.timeline, data.latestRunDetails, data.queries)
 
   const sortedRuns = [...data.runs].sort((a, b) => b.createdAt.localeCompare(a.createdAt))
   const runItems = sortedRuns.map(r => toRunListItem(r, data.project.displayName || data.project.name))

--- a/apps/web/src/build-dashboard.ts
+++ b/apps/web/src/build-dashboard.ts
@@ -188,21 +188,41 @@ function buildEvidenceFromTimeline(
       const latestRun = entry.runs.at(-1)
       const transition = latestRun?.transition ?? 'not-cited'
       for (const provider of providers) {
-        // Emit one evidence row per location observed in the latest-run group.
-        // `null` represents the "no location configured" case (single-location or
-        // project-wide runs); when set, each row carries that location's snapshot.
-        for (const location of locationsInLatestRun) {
+        // Determine which locations actually have a snapshot for this
+        // (query × provider). When at least one does, emit a row per
+        // snap-carrying location. When none do but the provider has
+        // history, emit a single synthetic fallback row so the badge
+        // still appears without multiplying it N× across locations.
+        const locationsWithSnap = [...locationsInLatestRun]
+          .filter(loc => snapshotsByKey.has(`${entry.query}::${provider}::${loc ?? ''}`))
+        const hasHistory = (entry.providerRuns?.[provider]?.length ?? 0) > 0
+        const rowLocations: (string | null)[] = locationsWithSnap.length > 0
+          ? locationsWithSnap
+          : (hasHistory ? [null] : [])
+        for (const location of rowLocations) {
           const locKey = location ?? ''
           const snap = snapshotsByKey.get(`${entry.query}::${provider}::${locKey}`)
-          // Only skip if provider has zero history for this query AND no snapshot in this location
-          const hasHistory = (entry.providerRuns?.[provider]?.length ?? 0) > 0
-          if (!snap && !hasHistory) continue
 
-          // Prefer provider-level history for continuity across model changes; fall back to model-scoped then query-level
+          // Prefer provider-level history for continuity across model changes;
+          // fall back to model-scoped then query-level. Filter to this loop's
+          // location so transition/streak labels reflect the actual location
+          // being rendered — otherwise the most recent cross-location snapshot
+          // would leak into every per-location row.
           const model = snap?.model ?? null
           const modelKey = model ? `${provider}:${model}` : null
-          const modelHistory = modelKey ? entry.modelRuns?.[modelKey] : undefined
-          const providerHistory = entry.providerRuns?.[provider]
+          const rawProviderHistory = entry.providerRuns?.[provider]
+          const rawModelHistory = modelKey ? entry.modelRuns?.[modelKey] : undefined
+          const filterByLocation = <T extends { location?: string | null }>(rows: T[] | undefined): T[] | undefined =>
+            rows?.filter(r => (r.location ?? null) === location)
+          // History-only synthetic rows (location === null, snap missing)
+          // legitimately summarize cross-location continuity, so keep the
+          // unfiltered series in that case.
+          const providerHistory = locationsWithSnap.length > 0
+            ? filterByLocation(rawProviderHistory)
+            : rawProviderHistory
+          const modelHistory = locationsWithSnap.length > 0
+            ? filterByLocation(rawModelHistory)
+            : rawModelHistory
           const effectiveHistory = (providerHistory?.length ? providerHistory : null)
             ?? (modelHistory?.length ? modelHistory : null)
           const baseHistoryScope: EvidenceHistoryScope = providerHistory?.length
@@ -450,7 +470,10 @@ export interface ProjectData {
    * location for a multi-location sweep, or a single-element array for a
    * single-location / project-wide run. Empty when the project has never run. */
   latestRunDetails: ApiRunDetail[]
-  previousRunDetail: ApiRunDetail | null
+  /** All runs in the previous fan-out group (same `createdAt`). Mirrors
+   * `latestRunDetails` so snapshot-diff and other consumers see every
+   * location, not just an arbitrary one. */
+  previousRunDetails: ApiRunDetail[]
   gscCoverage?: ApiGscCoverageSummary | null
   bingCoverage?: ApiBingCoverageSummary | null
   dbInsights?: InsightDto[] | null

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -1101,9 +1101,26 @@ export function ProjectPage({
     r => r.kind === RunKinds['answer-visibility'] && (r.status === RunStatuses.running || r.status === RunStatuses.queued),
   )
 
+  // Show every configured location as a filter chip, regardless of whether the
+  // current evidence aggregate has rows for it. Multi-location sweeps can land
+  // a chip-less location whenever the latest-run aggregate drops snapshots; we
+  // still want the user to be able to select it (the table renders an empty
+  // state if there are no matching rows).
+  const configuredLocationLabels = useMemo(
+    () => (model?.project.locations ?? []).map((loc: { label: string }) => loc.label),
+    [model?.project.locations],
+  )
   const locationLabelsInEvidence = useMemo(() => new Set(visibilityEvidence.map(e => e.location ?? '')), [visibilityEvidence])
   const hasNullLocationEvidence = locationLabelsInEvidence.has('')
-  const distinctLocationsWithEvidence = useMemo(() => [...locationLabelsInEvidence].filter(Boolean), [locationLabelsInEvidence])
+  const distinctLocationsForCompare = useMemo(() => {
+    // "Compare" needs ≥2 locations with selectable data. Prefer evidence-backed
+    // locations, but fall back to configured locations so a fresh project that
+    // hasn't aggregated evidence yet still surfaces the compare control once
+    // it has multiple locations configured.
+    const evidenceLabels = [...locationLabelsInEvidence].filter(Boolean)
+    if (evidenceLabels.length > 1) return evidenceLabels
+    return configuredLocationLabels
+  }, [locationLabelsInEvidence, configuredLocationLabels])
 
   useEffect(() => {
     if (locationFilter === undefined || locationFilter === '' || !projectName) {
@@ -1605,17 +1622,15 @@ export function ProjectPage({
                   All locations
                 </button>
                 {model.project.locations.map((loc: { label: string }) => (
-                  locationLabelsInEvidence.has(loc.label) && (
-                    <button
-                      key={loc.label}
-                      className={`filter-chip ${locationFilter === loc.label ? 'filter-chip-active' : ''}`}
-                      type="button"
-                      aria-pressed={locationFilter === loc.label}
-                      onClick={() => { setLocationFilter(loc.label); setCompareLocations(false) }}
-                    >
-                      {loc.label}
-                    </button>
-                  )
+                  <button
+                    key={loc.label}
+                    className={`filter-chip ${locationFilter === loc.label ? 'filter-chip-active' : ''}`}
+                    type="button"
+                    aria-pressed={locationFilter === loc.label}
+                    onClick={() => { setLocationFilter(loc.label); setCompareLocations(false) }}
+                  >
+                    {loc.label}
+                  </button>
                 ))}
                 {hasNullLocationEvidence && (
                   <button
@@ -1627,7 +1642,7 @@ export function ProjectPage({
                     No location
                   </button>
                 )}
-                {distinctLocationsWithEvidence.length > 1 && locationFilter === undefined && (
+                {distinctLocationsForCompare.length > 1 && locationFilter === undefined && (
                   <button
                     className={`filter-chip filter-chip-compare ${compareLocations ? 'filter-chip-active' : ''}`}
                     type="button"

--- a/apps/web/src/queries/use-dashboard.ts
+++ b/apps/web/src/queries/use-dashboard.ts
@@ -59,19 +59,36 @@ export function useDashboard(initialDashboard?: DashboardVm | null) {
         .filter(r => (r.status === 'completed' || r.status === 'partial') && r.kind === 'answer-visibility')
         .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
 
+      // Multi-location sweeps fan out into one run per location with an identical
+      // `createdAt`. Group the top run with any siblings that share its timestamp
+      // so all locations land in the latest-run aggregate. Without this, the
+      // dashboard collapses to a single non-deterministic location and the other
+      // locations' snapshots silently disappear.
+      const latestCreatedAt = completedRuns[0]?.createdAt ?? null
+      const latestRunGroup = latestCreatedAt
+        ? completedRuns.filter(r => r.createdAt === latestCreatedAt)
+        : []
+      const latestRunIds = latestRunGroup.map(r => r.id)
+      const previousCreatedAt = completedRuns.find(r => r.createdAt !== latestCreatedAt)?.createdAt ?? null
+      const previousRun = previousCreatedAt
+        ? completedRuns.find(r => r.createdAt === previousCreatedAt) ?? null
+        : null
+
       return {
-        queryKey: queryKeys.projects.detail(project.id, completedRuns[0]?.id),
+        queryKey: queryKeys.projects.detail(project.id, latestRunIds.join(',') || undefined),
         queryFn: async (): Promise<ProjectData> => {
-          const latestRunId = completedRuns[0]?.id
-          const [qs, comps, timeline, latestRunDetail, previousRunDetail, gscCoverage, bingCoverage, dbInsights, overview] = await Promise.all([
+          const [qs, comps, timeline, latestRunDetails, previousRunDetail, gscCoverage, bingCoverage, dbInsights, overview] = await Promise.all([
             fetchQueries(project.name).catch(() => []),
             fetchCompetitors(project.name).catch(() => []),
             fetchTimeline(project.name).catch(() => []),
-            latestRunId ? fetchRunDetail(latestRunId).catch(() => null) : Promise.resolve(null),
-            completedRuns[1] ? fetchRunDetail(completedRuns[1].id).catch(() => null) : Promise.resolve(null),
+            latestRunIds.length
+              ? Promise.all(latestRunIds.map(id => fetchRunDetail(id).catch(() => null)))
+                  .then(results => results.filter((r): r is NonNullable<typeof r> => r != null))
+              : Promise.resolve([]),
+            previousRun ? fetchRunDetail(previousRun.id).catch(() => null) : Promise.resolve(null),
             fetchGscCoverage(project.name).catch(() => null),
             fetchBingCoverage(project.name).catch(() => null),
-            latestRunId ? fetchInsights(project.name, latestRunId).catch(() => null) : Promise.resolve(null),
+            latestRunIds[0] ? fetchInsights(project.name, latestRunIds[0]).catch(() => null) : Promise.resolve(null),
             fetchProjectOverview(project.name).catch(() => null),
           ])
 
@@ -81,7 +98,7 @@ export function useDashboard(initialDashboard?: DashboardVm | null) {
             queries: qs,
             competitors: comps,
             timeline,
-            latestRunDetail,
+            latestRunDetails,
             previousRunDetail,
             gscCoverage,
             bingCoverage,

--- a/apps/web/src/queries/use-dashboard.ts
+++ b/apps/web/src/queries/use-dashboard.ts
@@ -65,19 +65,24 @@ export function useDashboard(initialDashboard?: DashboardVm | null) {
       // dashboard collapses to a single non-deterministic location and the other
       // locations' snapshots silently disappear.
       const latestCreatedAt = completedRuns[0]?.createdAt ?? null
-      const latestRunGroup = latestCreatedAt
-        ? completedRuns.filter(r => r.createdAt === latestCreatedAt)
+      const latestRunIds = latestCreatedAt
+        ? completedRuns.filter(r => r.createdAt === latestCreatedAt).map(r => r.id)
         : []
-      const latestRunIds = latestRunGroup.map(r => r.id)
-      const previousCreatedAt = completedRuns.find(r => r.createdAt !== latestCreatedAt)?.createdAt ?? null
-      const previousRun = previousCreatedAt
-        ? completedRuns.find(r => r.createdAt === previousCreatedAt) ?? null
-        : null
+      // Mirror the fan-out grouping for the previous batch so snapshot-diff
+      // and any other consumer of "previous run" sees every location, not
+      // just the first one we happen to encounter.
+      const previousBatchCreatedAt = completedRuns.find(r => r.createdAt !== latestCreatedAt)?.createdAt ?? null
+      const previousRunIds = previousBatchCreatedAt
+        ? completedRuns.filter(r => r.createdAt === previousBatchCreatedAt).map(r => r.id)
+        : []
+      // Sort IDs so the query key stays stable regardless of upstream ordering
+      // (`GET /runs` has no ORDER BY, so SQLite can return rows in any order).
+      const latestRunIdsKey = [...latestRunIds].sort().join(',')
 
       return {
-        queryKey: queryKeys.projects.detail(project.id, latestRunIds.join(',') || undefined),
+        queryKey: queryKeys.projects.detail(project.id, latestRunIdsKey || undefined),
         queryFn: async (): Promise<ProjectData> => {
-          const [qs, comps, timeline, latestRunDetails, previousRunDetail, gscCoverage, bingCoverage, dbInsights, overview] = await Promise.all([
+          const [qs, comps, timeline, latestRunDetails, previousRunDetails, gscCoverage, bingCoverage, dbInsights, overview] = await Promise.all([
             fetchQueries(project.name).catch(() => []),
             fetchCompetitors(project.name).catch(() => []),
             fetchTimeline(project.name).catch(() => []),
@@ -85,10 +90,15 @@ export function useDashboard(initialDashboard?: DashboardVm | null) {
               ? Promise.all(latestRunIds.map(id => fetchRunDetail(id).catch(() => null)))
                   .then(results => results.filter((r): r is NonNullable<typeof r> => r != null))
               : Promise.resolve([]),
-            previousRun ? fetchRunDetail(previousRun.id).catch(() => null) : Promise.resolve(null),
+            previousRunIds.length
+              ? Promise.all(previousRunIds.map(id => fetchRunDetail(id).catch(() => null)))
+                  .then(results => results.filter((r): r is NonNullable<typeof r> => r != null))
+              : Promise.resolve([]),
             fetchGscCoverage(project.name).catch(() => null),
             fetchBingCoverage(project.name).catch(() => null),
-            latestRunIds[0] ? fetchInsights(project.name, latestRunIds[0]).catch(() => null) : Promise.resolve(null),
+            // Project-wide insights — per-run filtering would miss the other
+            // locations' runs when an answer-visibility sweep fans out.
+            fetchInsights(project.name).catch(() => null),
             fetchProjectOverview(project.name).catch(() => null),
           ])
 
@@ -99,7 +109,7 @@ export function useDashboard(initialDashboard?: DashboardVm | null) {
             competitors: comps,
             timeline,
             latestRunDetails,
-            previousRunDetail,
+            previousRunDetails,
             gscCoverage,
             bingCoverage,
             dbInsights,

--- a/apps/web/test/build-dashboard.test.ts
+++ b/apps/web/test/build-dashboard.test.ts
@@ -104,7 +104,7 @@ test('buildProjectCommandCenter preserves provider continuity while marking mixe
         ],
       },
     }],
-    latestRunDetail: {
+    latestRunDetails: [{
       id: 'run_2',
       projectId: 'proj_1',
       kind: 'answer-visibility',
@@ -129,7 +129,7 @@ test('buildProjectCommandCenter preserves provider continuity while marking mixe
         searchQueries: [],
         createdAt: '2026-03-15T00:00:00Z',
       }],
-    },
+    }],
     previousRunDetail: {
       id: 'run_1',
       projectId: 'proj_1',
@@ -235,7 +235,7 @@ test('buildProjectCommandCenter keeps historical-only provider badges on their o
       },
       modelRuns: {},
     }],
-    latestRunDetail: {
+    latestRunDetails: [{
       id: 'run_2',
       projectId: 'proj_history',
       kind: 'answer-visibility',
@@ -261,7 +261,7 @@ test('buildProjectCommandCenter keeps historical-only provider badges on their o
         location: null,
         createdAt: '2026-03-22T00:00:00Z',
       }],
-    },
+    }],
     previousRunDetail: null,
   }
 
@@ -297,7 +297,7 @@ test('buildProjectCommandCenter populates score gauges from the overview DTO whe
     queries: [],
     competitors: [],
     timeline: [],
-    latestRunDetail: null,
+    latestRunDetails: [],
     previousRunDetail: null,
     overview: {
       project: {
@@ -372,7 +372,7 @@ test('buildProjectCommandCenter surfaces synthesized attention items (e.g. stale
     queries: [],
     competitors: [],
     timeline: [],
-    latestRunDetail: null,
+    latestRunDetails: [],
     previousRunDetail: null,
     overview: {
       project: {
@@ -428,4 +428,126 @@ test('buildProjectCommandCenter surfaces synthesized attention items (e.g. stale
   const stale = vm.insights.find(i => i.id === 'stale_visibility')!
   expect(stale.tone).toBe('caution')
   expect(stale.actionLabel).toBe('Stale')
+})
+
+test('buildProjectCommandCenter emits one evidence row per location when a multi-location sweep fans out', () => {
+  // Regression test for issue #477. Two same-timestamp runs (one per location)
+  // must both surface evidence rows; the latest-run aggregate previously
+  // collapsed to one non-deterministic location and dropped the other.
+  const sharedCreatedAt = '2026-05-13T17:23:20.060Z'
+  const data: ProjectData = {
+    project: {
+      id: 'proj_multi',
+      name: 'azcoatings',
+      displayName: 'AZ Coatings',
+      canonicalDomain: 'azcoatings.example',
+      ownedDomains: [],
+      country: 'US',
+      language: 'en',
+      tags: [],
+      labels: {},
+      providers: ['gemini'],
+      configSource: 'api',
+      configRevision: 1,
+      createdAt: '2026-05-10T00:00:00Z',
+      updatedAt: '2026-05-13T00:00:00Z',
+      locations: [
+        { label: 'florida', kind: 'state', value: 'Florida' },
+        { label: 'michigan', kind: 'state', value: 'Michigan' },
+      ],
+    },
+    runs: [
+      { id: 'run_fl', projectId: 'proj_multi', kind: 'answer-visibility', status: 'completed', trigger: 'manual', startedAt: sharedCreatedAt, finishedAt: sharedCreatedAt, error: null, createdAt: sharedCreatedAt },
+      { id: 'run_mi', projectId: 'proj_multi', kind: 'answer-visibility', status: 'completed', trigger: 'manual', startedAt: sharedCreatedAt, finishedAt: sharedCreatedAt, error: null, createdAt: sharedCreatedAt },
+    ],
+    queries: [{ id: 'kw_1', query: 'polyurea roof coating', createdAt: '2026-05-10T00:00:00Z' }],
+    competitors: [],
+    timeline: [{
+      query: 'polyurea roof coating',
+      runs: [
+        { runId: 'run_fl', createdAt: sharedCreatedAt, citationState: 'cited', transition: 'new' },
+        { runId: 'run_mi', createdAt: sharedCreatedAt, citationState: 'not-cited', transition: 'new' },
+      ],
+      providerRuns: {
+        gemini: [
+          { runId: 'run_fl', createdAt: sharedCreatedAt, citationState: 'cited', transition: 'new' },
+          { runId: 'run_mi', createdAt: sharedCreatedAt, citationState: 'not-cited', transition: 'new' },
+        ],
+      },
+      modelRuns: {},
+    }],
+    latestRunDetails: [
+      {
+        id: 'run_fl',
+        projectId: 'proj_multi',
+        kind: 'answer-visibility',
+        status: 'completed',
+        trigger: 'manual',
+        startedAt: sharedCreatedAt,
+        finishedAt: sharedCreatedAt,
+        error: null,
+        createdAt: sharedCreatedAt,
+        snapshots: [{
+          id: 'snap_fl',
+          runId: 'run_fl',
+          queryId: 'kw_1',
+          query: 'polyurea roof coating',
+          provider: 'gemini',
+          model: 'gemini-3-flash',
+          citationState: 'cited',
+          answerMentioned: true,
+          answerText: 'AZ Coatings is one Florida vendor for polyurea roof coating.',
+          citedDomains: ['azcoatings.example'],
+          competitorOverlap: [],
+          groundingSources: [],
+          searchQueries: [],
+          location: 'florida',
+          createdAt: sharedCreatedAt,
+        }],
+      },
+      {
+        id: 'run_mi',
+        projectId: 'proj_multi',
+        kind: 'answer-visibility',
+        status: 'completed',
+        trigger: 'manual',
+        startedAt: sharedCreatedAt,
+        finishedAt: sharedCreatedAt,
+        error: null,
+        createdAt: sharedCreatedAt,
+        snapshots: [{
+          id: 'snap_mi',
+          runId: 'run_mi',
+          queryId: 'kw_1',
+          query: 'polyurea roof coating',
+          provider: 'gemini',
+          model: 'gemini-3-flash',
+          citationState: 'not-cited',
+          answerMentioned: false,
+          answerText: 'Several Michigan suppliers offer roof coatings.',
+          citedDomains: [],
+          competitorOverlap: [],
+          groundingSources: [],
+          searchQueries: [],
+          location: 'michigan',
+          createdAt: sharedCreatedAt,
+        }],
+      },
+    ],
+    previousRunDetail: null,
+  }
+
+  const vm = buildProjectCommandCenter(data)
+  const evidence = vm.visibilityEvidence
+  const florida = evidence.find(e => e.location === 'florida')
+  const michigan = evidence.find(e => e.location === 'michigan')
+
+  expect(florida).toBeDefined()
+  expect(michigan).toBeDefined()
+  expect(florida?.citationState).toBe('cited')
+  expect(michigan?.citationState).toBe('not-cited')
+  expect(florida?.citedDomains).toEqual(['azcoatings.example'])
+  expect(michigan?.citedDomains).toEqual([])
+  expect(florida?.answerSnippet).toContain('Florida')
+  expect(michigan?.answerSnippet).toContain('Michigan')
 })

--- a/apps/web/test/build-dashboard.test.ts
+++ b/apps/web/test/build-dashboard.test.ts
@@ -130,7 +130,7 @@ test('buildProjectCommandCenter preserves provider continuity while marking mixe
         createdAt: '2026-03-15T00:00:00Z',
       }],
     }],
-    previousRunDetail: {
+    previousRunDetails: [{
       id: 'run_1',
       projectId: 'proj_1',
       kind: 'answer-visibility',
@@ -155,7 +155,7 @@ test('buildProjectCommandCenter preserves provider continuity while marking mixe
         searchQueries: [],
         createdAt: '2026-03-14T00:00:00Z',
       }],
-    },
+    }],
   }
 
   const evidence = buildProjectCommandCenter(data).visibilityEvidence[0]!
@@ -262,7 +262,7 @@ test('buildProjectCommandCenter keeps historical-only provider badges on their o
         createdAt: '2026-03-22T00:00:00Z',
       }],
     }],
-    previousRunDetail: null,
+    previousRunDetails: [],
   }
 
   const evidence = buildProjectCommandCenter(data).visibilityEvidence
@@ -298,7 +298,7 @@ test('buildProjectCommandCenter populates score gauges from the overview DTO whe
     competitors: [],
     timeline: [],
     latestRunDetails: [],
-    previousRunDetail: null,
+    previousRunDetails: [],
     overview: {
       project: {
         id: 'proj_overview',
@@ -373,7 +373,7 @@ test('buildProjectCommandCenter surfaces synthesized attention items (e.g. stale
     competitors: [],
     timeline: [],
     latestRunDetails: [],
-    previousRunDetail: null,
+    previousRunDetails: [],
     overview: {
       project: {
         id: 'proj_attention',
@@ -452,8 +452,8 @@ test('buildProjectCommandCenter emits one evidence row per location when a multi
       createdAt: '2026-05-10T00:00:00Z',
       updatedAt: '2026-05-13T00:00:00Z',
       locations: [
-        { label: 'florida', kind: 'state', value: 'Florida' },
-        { label: 'michigan', kind: 'state', value: 'Michigan' },
+        { label: 'florida', city: 'Orlando', region: 'Florida', country: 'US' },
+        { label: 'michigan', city: 'Detroit', region: 'Michigan', country: 'US' },
       ],
     },
     runs: [
@@ -534,7 +534,7 @@ test('buildProjectCommandCenter emits one evidence row per location when a multi
         }],
       },
     ],
-    previousRunDetail: null,
+    previousRunDetails: [],
   }
 
   const vm = buildProjectCommandCenter(data)
@@ -550,4 +550,252 @@ test('buildProjectCommandCenter emits one evidence row per location when a multi
   expect(michigan?.citedDomains).toEqual([])
   expect(florida?.answerSnippet).toContain('Florida')
   expect(michigan?.answerSnippet).toContain('Michigan')
+})
+
+test('buildProjectCommandCenter scopes per-location streak/changeLabel to that location only', () => {
+  // Florida has been "cited" consistently across both prior and current runs.
+  // Michigan was "cited" previously but is "not-cited" in the latest run, so
+  // its row should display a "lost" transition derived from michigan's own
+  // history, not florida's continued-cited streak.
+  const prevCreatedAt = '2026-05-12T17:23:20.060Z'
+  const latestCreatedAt = '2026-05-13T17:23:20.060Z'
+  const data: ProjectData = {
+    project: {
+      id: 'proj_loc_history',
+      name: 'azcoatings',
+      displayName: 'AZ Coatings',
+      canonicalDomain: 'azcoatings.example',
+      ownedDomains: [],
+      country: 'US',
+      language: 'en',
+      tags: [],
+      labels: {},
+      providers: ['gemini'],
+      configSource: 'api',
+      configRevision: 1,
+      createdAt: '2026-05-10T00:00:00Z',
+      updatedAt: latestCreatedAt,
+      locations: [
+        { label: 'florida', city: 'Orlando', region: 'Florida', country: 'US' },
+        { label: 'michigan', city: 'Detroit', region: 'Michigan', country: 'US' },
+      ],
+    },
+    runs: [
+      { id: 'run_fl_prev', projectId: 'proj_loc_history', kind: 'answer-visibility', status: 'completed', trigger: 'manual', startedAt: prevCreatedAt, finishedAt: prevCreatedAt, error: null, createdAt: prevCreatedAt },
+      { id: 'run_mi_prev', projectId: 'proj_loc_history', kind: 'answer-visibility', status: 'completed', trigger: 'manual', startedAt: prevCreatedAt, finishedAt: prevCreatedAt, error: null, createdAt: prevCreatedAt },
+      { id: 'run_fl', projectId: 'proj_loc_history', kind: 'answer-visibility', status: 'completed', trigger: 'manual', startedAt: latestCreatedAt, finishedAt: latestCreatedAt, error: null, createdAt: latestCreatedAt },
+      { id: 'run_mi', projectId: 'proj_loc_history', kind: 'answer-visibility', status: 'completed', trigger: 'manual', startedAt: latestCreatedAt, finishedAt: latestCreatedAt, error: null, createdAt: latestCreatedAt },
+    ],
+    queries: [{ id: 'kw_1', query: 'polyurea roof coating', createdAt: '2026-05-10T00:00:00Z' }],
+    competitors: [],
+    timeline: [{
+      query: 'polyurea roof coating',
+      runs: [
+        { runId: 'run_fl_prev', createdAt: prevCreatedAt, citationState: 'cited', transition: 'new', location: 'florida' },
+        { runId: 'run_mi_prev', createdAt: prevCreatedAt, citationState: 'cited', transition: 'cited', location: 'michigan' },
+        { runId: 'run_fl', createdAt: latestCreatedAt, citationState: 'cited', transition: 'cited', location: 'florida' },
+        { runId: 'run_mi', createdAt: latestCreatedAt, citationState: 'not-cited', transition: 'lost', location: 'michigan' },
+      ],
+      providerRuns: {
+        gemini: [
+          { runId: 'run_fl_prev', createdAt: prevCreatedAt, citationState: 'cited', transition: 'new', location: 'florida' },
+          { runId: 'run_mi_prev', createdAt: prevCreatedAt, citationState: 'cited', transition: 'cited', location: 'michigan' },
+          { runId: 'run_fl', createdAt: latestCreatedAt, citationState: 'cited', transition: 'cited', location: 'florida' },
+          { runId: 'run_mi', createdAt: latestCreatedAt, citationState: 'not-cited', transition: 'lost', location: 'michigan' },
+        ],
+      },
+      modelRuns: {},
+    }],
+    latestRunDetails: [
+      {
+        id: 'run_fl',
+        projectId: 'proj_loc_history',
+        kind: 'answer-visibility',
+        status: 'completed',
+        trigger: 'manual',
+        startedAt: latestCreatedAt,
+        finishedAt: latestCreatedAt,
+        error: null,
+        createdAt: latestCreatedAt,
+        snapshots: [{
+          id: 'snap_fl',
+          runId: 'run_fl',
+          queryId: 'kw_1',
+          query: 'polyurea roof coating',
+          provider: 'gemini',
+          model: 'gemini-3-flash',
+          citationState: 'cited',
+          answerMentioned: true,
+          answerText: 'florida snap',
+          citedDomains: ['azcoatings.example'],
+          competitorOverlap: [],
+          groundingSources: [],
+          searchQueries: [],
+          location: 'florida',
+          createdAt: latestCreatedAt,
+        }],
+      },
+      {
+        id: 'run_mi',
+        projectId: 'proj_loc_history',
+        kind: 'answer-visibility',
+        status: 'completed',
+        trigger: 'manual',
+        startedAt: latestCreatedAt,
+        finishedAt: latestCreatedAt,
+        error: null,
+        createdAt: latestCreatedAt,
+        snapshots: [{
+          id: 'snap_mi',
+          runId: 'run_mi',
+          queryId: 'kw_1',
+          query: 'polyurea roof coating',
+          provider: 'gemini',
+          model: 'gemini-3-flash',
+          citationState: 'not-cited',
+          answerMentioned: false,
+          answerText: 'michigan snap',
+          citedDomains: [],
+          competitorOverlap: [],
+          groundingSources: [],
+          searchQueries: [],
+          location: 'michigan',
+          createdAt: latestCreatedAt,
+        }],
+      },
+    ],
+    previousRunDetails: [],
+  }
+
+  const evidence = buildProjectCommandCenter(data).visibilityEvidence
+  const florida = evidence.find(e => e.location === 'florida')
+  const michigan = evidence.find(e => e.location === 'michigan')
+
+  expect(florida?.citationState).toBe('cited')
+  expect(michigan?.citationState).toBe('lost')
+  // Florida's runHistory should contain only florida entries — michigan's
+  // "lost" transition must not leak into florida's chart.
+  expect(florida?.runHistory.map(r => r.runId)).toEqual(['run_fl_prev', 'run_fl'])
+  expect(michigan?.runHistory.map(r => r.runId)).toEqual(['run_mi_prev', 'run_mi'])
+})
+
+test('buildProjectCommandCenter emits a single history-only row when no location has a snap', () => {
+  // openai has no snapshot in the latest run for either location but does
+  // have provider-level history. Pre-fix, this would emit one row per
+  // configured location with identical data; the fix should produce a
+  // single synthetic fallback row with null location.
+  const sharedCreatedAt = '2026-05-13T17:23:20.060Z'
+  const data: ProjectData = {
+    project: {
+      id: 'proj_history_only',
+      name: 'azcoatings',
+      displayName: 'AZ Coatings',
+      canonicalDomain: 'azcoatings.example',
+      ownedDomains: [],
+      country: 'US',
+      language: 'en',
+      tags: [],
+      labels: {},
+      providers: ['gemini', 'openai'],
+      configSource: 'api',
+      configRevision: 1,
+      createdAt: '2026-05-10T00:00:00Z',
+      updatedAt: sharedCreatedAt,
+      locations: [
+        { label: 'florida', city: 'Orlando', region: 'Florida', country: 'US' },
+        { label: 'michigan', city: 'Detroit', region: 'Michigan', country: 'US' },
+      ],
+    },
+    runs: [
+      { id: 'run_fl', projectId: 'proj_history_only', kind: 'answer-visibility', status: 'completed', trigger: 'manual', startedAt: sharedCreatedAt, finishedAt: sharedCreatedAt, error: null, createdAt: sharedCreatedAt },
+      { id: 'run_mi', projectId: 'proj_history_only', kind: 'answer-visibility', status: 'completed', trigger: 'manual', startedAt: sharedCreatedAt, finishedAt: sharedCreatedAt, error: null, createdAt: sharedCreatedAt },
+    ],
+    queries: [{ id: 'kw_1', query: 'polyurea roof coating', createdAt: '2026-05-10T00:00:00Z' }],
+    competitors: [],
+    timeline: [{
+      query: 'polyurea roof coating',
+      runs: [
+        { runId: 'run_fl', createdAt: sharedCreatedAt, citationState: 'cited', transition: 'new', location: 'florida' },
+        { runId: 'run_mi', createdAt: sharedCreatedAt, citationState: 'not-cited', transition: 'new', location: 'michigan' },
+      ],
+      providerRuns: {
+        gemini: [
+          { runId: 'run_fl', createdAt: sharedCreatedAt, citationState: 'cited', transition: 'new', location: 'florida' },
+          { runId: 'run_mi', createdAt: sharedCreatedAt, citationState: 'not-cited', transition: 'new', location: 'michigan' },
+        ],
+        openai: [
+          { runId: 'older_run', createdAt: '2026-05-01T00:00:00Z', citationState: 'cited', transition: 'cited', location: 'florida' },
+        ],
+      },
+      modelRuns: {},
+    }],
+    latestRunDetails: [
+      {
+        id: 'run_fl',
+        projectId: 'proj_history_only',
+        kind: 'answer-visibility',
+        status: 'completed',
+        trigger: 'manual',
+        startedAt: sharedCreatedAt,
+        finishedAt: sharedCreatedAt,
+        error: null,
+        createdAt: sharedCreatedAt,
+        snapshots: [{
+          id: 'snap_fl',
+          runId: 'run_fl',
+          queryId: 'kw_1',
+          query: 'polyurea roof coating',
+          provider: 'gemini',
+          model: 'gemini-3-flash',
+          citationState: 'cited',
+          answerMentioned: true,
+          answerText: 'florida gemini snap',
+          citedDomains: ['azcoatings.example'],
+          competitorOverlap: [],
+          groundingSources: [],
+          searchQueries: [],
+          location: 'florida',
+          createdAt: sharedCreatedAt,
+        }],
+      },
+      {
+        id: 'run_mi',
+        projectId: 'proj_history_only',
+        kind: 'answer-visibility',
+        status: 'completed',
+        trigger: 'manual',
+        startedAt: sharedCreatedAt,
+        finishedAt: sharedCreatedAt,
+        error: null,
+        createdAt: sharedCreatedAt,
+        snapshots: [{
+          id: 'snap_mi',
+          runId: 'run_mi',
+          queryId: 'kw_1',
+          query: 'polyurea roof coating',
+          provider: 'gemini',
+          model: 'gemini-3-flash',
+          citationState: 'not-cited',
+          answerMentioned: false,
+          answerText: 'michigan gemini snap',
+          citedDomains: [],
+          competitorOverlap: [],
+          groundingSources: [],
+          searchQueries: [],
+          location: 'michigan',
+          createdAt: sharedCreatedAt,
+        }],
+      },
+    ],
+    previousRunDetails: [],
+  }
+
+  const evidence = buildProjectCommandCenter(data).visibilityEvidence
+  const openaiRows = evidence.filter(e => e.provider === 'openai')
+  // History-only provider must not multiply across configured locations.
+  expect(openaiRows).toHaveLength(1)
+  expect(openaiRows[0]?.location).toBeNull()
+  // Gemini has a snap per location and should still emit two rows.
+  const geminiRows = evidence.filter(e => e.provider === 'gemini')
+  expect(geminiRows).toHaveLength(2)
 })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.26.0",
+  "version": "4.26.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/history.ts
+++ b/packages/api-routes/src/history.ts
@@ -216,6 +216,7 @@ export async function historyRoutes(app: FastifyInstance) {
           answerMentioned: snap.answerMentioned,
           visibilityState: snap.answerMentioned ? 'visible' : 'not-visible',
           visibilityTransition,
+          location: snap.location,
         }
       })
     }

--- a/packages/api-routes/src/runs.ts
+++ b/packages/api-routes/src/runs.ts
@@ -215,7 +215,7 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
       .select()
       .from(runs)
       .where(eq(runs.projectId, project.id))
-      .orderBy(desc(runs.createdAt))
+      .orderBy(desc(runs.createdAt), desc(runs.id))
       .limit(1)
       .get()
 

--- a/packages/api-routes/test/index.test.ts
+++ b/packages/api-routes/test/index.test.ts
@@ -699,6 +699,105 @@ describe('api-routes', () => {
     }))
   })
 
+  it('GET /api/v1/projects/:name/timeline?location=X returns only that location and exposes location on run entries', async () => {
+    const projectId = crypto.randomUUID()
+    const queryId = crypto.randomUUID()
+    const flRunId = crypto.randomUUID()
+    const miRunId = crypto.randomUUID()
+    const sharedCreatedAt = new Date(Date.now() + 60_000).toISOString()
+
+    db.insert(projects).values({
+      id: projectId,
+      name: 'timeline-location-project',
+      displayName: 'Timeline Location Project',
+      canonicalDomain: 'example.com',
+      country: 'US',
+      language: 'en',
+      providers: '[]',
+      createdAt: sharedCreatedAt,
+      updatedAt: sharedCreatedAt,
+    }).run()
+
+    db.insert(queries).values({
+      id: queryId,
+      projectId,
+      query: 'polyurea roof coating',
+      createdAt: sharedCreatedAt,
+    }).run()
+
+    db.insert(runs).values([
+      {
+        id: flRunId,
+        projectId,
+        kind: 'answer-visibility',
+        status: 'completed',
+        trigger: 'manual',
+        location: 'florida',
+        createdAt: sharedCreatedAt,
+        finishedAt: sharedCreatedAt,
+      },
+      {
+        id: miRunId,
+        projectId,
+        kind: 'answer-visibility',
+        status: 'completed',
+        trigger: 'manual',
+        location: 'michigan',
+        createdAt: sharedCreatedAt,
+        finishedAt: sharedCreatedAt,
+      },
+    ]).run()
+
+    db.insert(querySnapshots).values([
+      {
+        id: crypto.randomUUID(),
+        runId: flRunId,
+        queryId,
+        provider: 'gemini',
+        citationState: 'cited',
+        answerMentioned: true,
+        location: 'florida',
+        citedDomains: '["example.com"]',
+        competitorOverlap: '[]',
+        recommendedCompetitors: '[]',
+        rawResponse: '{}',
+        createdAt: sharedCreatedAt,
+      },
+      {
+        id: crypto.randomUUID(),
+        runId: miRunId,
+        queryId,
+        provider: 'gemini',
+        citationState: 'not-cited',
+        answerMentioned: false,
+        location: 'michigan',
+        citedDomains: '[]',
+        competitorOverlap: '[]',
+        recommendedCompetitors: '[]',
+        rawResponse: '{}',
+        createdAt: sharedCreatedAt,
+      },
+    ]).run()
+
+    const res = await app.inject({ method: 'GET', url: '/api/v1/projects/timeline-location-project/timeline?location=florida' })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.payload) as Array<{
+      runs: Array<{ runId: string; location?: string | null }>
+      providerRuns?: Record<string, Array<{ runId: string; location?: string | null }>>
+    }>
+
+    expect(body[0]?.runs).toHaveLength(1)
+    expect(body[0]?.runs[0]?.runId).toBe(flRunId)
+    expect(body[0]?.runs[0]?.location).toBe('florida')
+    // None of the run entries (top-level or per-provider) should carry the wrong location.
+    for (const entry of body) {
+      for (const r of entry.runs) expect(r.location).toBe('florida')
+      for (const arr of Object.values(entry.providerRuns ?? {})) {
+        for (const r of arr) expect(r.location).toBe('florida')
+      }
+    }
+  })
+
   it('GET /api/v1/projects/:name/snapshots/diff includes visibility comparison fields', async () => {
     const projectId = crypto.randomUUID()
     const queryId = crypto.randomUUID()

--- a/packages/api-routes/test/run-latest.test.ts
+++ b/packages/api-routes/test/run-latest.test.ts
@@ -99,6 +99,69 @@ describe('GET /api/v1/projects/:name/runs/latest', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true })
   })
 
+  it('breaks ties deterministically when runs share the same createdAt (multi-location fan-out)', async () => {
+    const { app, db, tmpDir } = buildApp()
+    await app.ready()
+
+    const projectId = crypto.randomUUID()
+    // IDs deliberately set so that lexicographically-greater id wins the tiebreak,
+    // not whatever the DB happens to return first.
+    const runAId = '00000000-0000-0000-0000-000000000001'
+    const runBId = 'ffffffff-ffff-ffff-ffff-ffffffffffff'
+    const sharedCreatedAt = '2026-05-13T17:23:20.060Z'
+
+    db.insert(projects).values({
+      id: projectId,
+      name: 'azcoatings',
+      displayName: 'AZ Coatings',
+      canonicalDomain: 'azcoatings.example',
+      country: 'US',
+      language: 'en',
+      ownedDomains: '[]',
+      tags: '[]',
+      providers: '[]',
+      createdAt: '2026-05-10T00:00:00.000Z',
+      updatedAt: '2026-05-10T00:00:00.000Z',
+    }).run()
+    db.insert(runs).values([
+      {
+        id: runAId,
+        projectId,
+        kind: 'answer-visibility',
+        status: 'completed',
+        trigger: 'manual',
+        location: 'florida',
+        createdAt: sharedCreatedAt,
+        finishedAt: sharedCreatedAt,
+      },
+      {
+        id: runBId,
+        projectId,
+        kind: 'answer-visibility',
+        status: 'completed',
+        trigger: 'manual',
+        location: 'michigan',
+        createdAt: sharedCreatedAt,
+        finishedAt: sharedCreatedAt,
+      },
+    ]).run()
+
+    // The same call should yield the same run id every time — no
+    // insertion-order or storage-order influence.
+    const first = await app.inject({ method: 'GET', url: '/api/v1/projects/azcoatings/runs/latest' })
+    const second = await app.inject({ method: 'GET', url: '/api/v1/projects/azcoatings/runs/latest' })
+    expect(first.statusCode).toBe(200)
+    expect(second.statusCode).toBe(200)
+    const firstBody = JSON.parse(first.payload) as { run: { id: string } }
+    const secondBody = JSON.parse(second.payload) as { run: { id: string } }
+    expect(firstBody.run.id).toBe(secondBody.run.id)
+    // With desc(id) as tiebreak, the lexicographically-greater id wins.
+    expect(firstBody.run.id).toBe(runBId)
+
+    await app.close()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
   it('returns null when a project has no runs', async () => {
     const { app, db, tmpDir } = buildApp()
     await app.ready()

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.26.0",
+  "version": "4.26.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/commands/schedule.ts
+++ b/packages/canonry/src/commands/schedule.ts
@@ -89,10 +89,14 @@ export async function removeSchedule(project: string, format?: string, kind?: st
   console.log(`Schedule removed for "${project}" (kind: ${resolvedKind})`)
 }
 
-function printSchedule(s: ScheduleDto): void {
-  const label = s.preset ?? s.cronExpr
+export function printSchedule(s: ScheduleDto): void {
   console.log(`  Kind:      ${s.kind}`)
-  console.log(`  Schedule:  ${label}`)
+  // Only show the friendly preset name when set — without this guard, schedules
+  // configured via `--cron` print the cron expression twice (once on this line,
+  // once on the next).
+  if (s.preset) {
+    console.log(`  Preset:    ${s.preset}`)
+  }
   console.log(`  Cron:      ${s.cronExpr}`)
   console.log(`  Timezone:  ${s.timezone}`)
   console.log(`  Enabled:   ${s.enabled ? 'yes' : 'no'}`)

--- a/packages/canonry/test/schedule-print.test.ts
+++ b/packages/canonry/test/schedule-print.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type { ScheduleDto } from '@ainyc/canonry-contracts'
+import { printSchedule } from '../src/commands/schedule.js'
+
+describe('printSchedule (text-mode output)', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>
+  let lines: string[]
+
+  beforeEach(() => {
+    lines = []
+    logSpy = vi.spyOn(console, 'log').mockImplementation((msg: unknown) => {
+      lines.push(String(msg))
+    })
+  })
+
+  afterEach(() => {
+    logSpy.mockRestore()
+  })
+
+  function baseSchedule(overrides: Partial<ScheduleDto> = {}): ScheduleDto {
+    return {
+      id: 'sched_1',
+      projectId: 'proj_1',
+      kind: 'answer-visibility',
+      cronExpr: '*/15 * * * *',
+      preset: null,
+      timezone: 'UTC',
+      enabled: true,
+      providers: [],
+      sourceId: null,
+      lastRunAt: null,
+      nextRunAt: null,
+      createdAt: '2026-05-10T00:00:00.000Z',
+      updatedAt: '2026-05-10T00:00:00.000Z',
+      ...overrides,
+    }
+  }
+
+  it('does not duplicate the cron row when no preset is configured', () => {
+    // Regression: `--cron`-configured schedules previously printed the cron
+    // expression on both the "Schedule:" and "Cron:" rows. With no preset set,
+    // only the "Cron:" row should appear.
+    printSchedule(baseSchedule({ preset: null, cronExpr: '*/15 * * * *' }))
+
+    const cronOccurrences = lines.filter(l => l.includes('*/15 * * * *')).length
+    expect(cronOccurrences).toBe(1)
+    expect(lines.some(l => /^\s*Preset:/.test(l))).toBe(false)
+    expect(lines.some(l => l === '  Cron:      */15 * * * *')).toBe(true)
+  })
+
+  it('renders the preset row alongside the cron row when a preset is configured', () => {
+    printSchedule(baseSchedule({ preset: 'daily', cronExpr: '0 0 * * *' }))
+
+    expect(lines.some(l => l === '  Preset:    daily')).toBe(true)
+    expect(lines.some(l => l === '  Cron:      0 0 * * *')).toBe(true)
+    // The preset name and the cron expression must remain distinct.
+    expect(lines.filter(l => l.includes('daily'))).toHaveLength(1)
+    expect(lines.filter(l => l.includes('0 0 * * *'))).toHaveLength(1)
+  })
+
+  it('renders sourceId only for traffic-sync schedules', () => {
+    printSchedule(baseSchedule({ kind: 'traffic-sync', sourceId: 'src_abc' }))
+    expect(lines.some(l => l === '  Source:    src_abc')).toBe(true)
+  })
+
+  it('omits sourceId for answer-visibility schedules even when present', () => {
+    printSchedule(baseSchedule({ kind: 'answer-visibility', sourceId: 'src_abc' }))
+    expect(lines.some(l => l.startsWith('  Source:'))).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #477 — multi-location citation tracking now renders every configured location, not just whichever one the client-side latest-run resolver happened to pick first.

## Changes
- **`use-dashboard.ts` / `build-dashboard.ts`** — group same-timestamp completed answer-visibility runs, fetch run detail for the whole group, and emit evidence rows per (query × provider × location) so both Florida and Michigan survive the aggregate.
- **`ProjectPage.tsx`** — chips render from `model.project.locations` directly so a chip-less location is no longer hidden; `Compare` falls back to configured locations when evidence-only data fails the ≥2 threshold.
- **`api-routes/runs.ts`** — `/runs/latest` now orders by `createdAt DESC, id DESC` for a deterministic tiebreak across backup/restore.
- **`api-routes/history.ts`** — timeline run entries now expose `location` so callers can verify the `?location=X` filter the server already applied.
- **`canonry/commands/schedule.ts`** — drops the duplicate "Schedule:"/"Cron:" rows in `canonry schedule show` when only `--cron` is configured (separate user-reported CLI bug); "Schedule:" → "Preset:", only rendered when a preset is set.

## Test plan
- [x] New `build-dashboard` regression test covers the two-location fan-out scenario from the issue.
- [x] New `/runs/latest` tiebreak test asserts deterministic ordering across repeated calls with same `createdAt`.
- [x] New `/timeline?location=X` test asserts run entries carry the requested location.
- [x] New `printSchedule` unit tests cover cron-only, preset, and traffic-sync schedules.
- [x] Full workspace suite: 228 files / 2512 tests pass, `pnpm typecheck` + `pnpm lint` clean.