### PR TITLE
feat(web): split evidence rows by location in compare mode

### DIFF
--- a/apps/web/src/components/project/EvidenceTable.tsx
+++ b/apps/web/src/components/project/EvidenceTable.tsx
@@ -77,28 +77,35 @@ function projectItemsForMode(items: CitationInsightVm[], mode: CoverageMode): Ci
 
 export function EvidenceTable({
   evidence,
+  compareLocations = false,
 }: {
   evidence: CitationInsightVm[]
+  compareLocations?: boolean
 }) {
   const { openEvidence } = useDrawer()
-  const [expandedPhrases, setExpandedPhrases] = useState<Set<string>>(new Set())
+  const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set())
   const [mode, setMode] = useState<CoverageMode>('citations')
 
   const groups = useMemo(() => {
     const projected = projectItemsForMode(evidence, mode)
-    const map = new Map<string, CitationInsightVm[]>()
+    type Group = { key: string; phrase: string; location: string | null; items: CitationInsightVm[] }
+    const map = new Map<string, Group>()
     for (const item of projected) {
-      const existing = map.get(item.query) ?? []
-      map.set(item.query, [...existing, item])
+      const phrase = item.query
+      const location = compareLocations ? (item.location ?? null) : null
+      const key = compareLocations ? JSON.stringify([phrase, location]) : phrase
+      const existing = map.get(key) ?? { key, phrase, location, items: [] }
+      existing.items.push(item)
+      map.set(key, existing)
     }
-    return [...map.entries()].map(([phrase, items]) => ({ phrase, items }))
-  }, [evidence, mode])
+    return [...map.values()]
+  }, [evidence, mode, compareLocations])
 
-  const togglePhrase = (phrase: string) => {
-    setExpandedPhrases(prev => {
+  const toggleRow = (key: string) => {
+    setExpandedRows(prev => {
       const next = new Set(prev)
-      if (next.has(phrase)) next.delete(phrase)
-      else next.add(phrase)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
       return next
     })
   }
@@ -162,8 +169,8 @@ export function EvidenceTable({
             </tr>
           </thead>
           <tbody>
-            {groups.map(({ phrase, items }) => {
-              const isExpanded = expandedPhrases.has(phrase)
+            {groups.map(({ key: groupKey, phrase, location, items }) => {
+              const isExpanded = expandedRows.has(groupKey)
               const states = items.map(i => i.citationState)
               const aggState: CitationState =
                 states.includes('cited') ? 'cited' :
@@ -176,10 +183,10 @@ export function EvidenceTable({
               const aggChangeLabel = describeChange(mergedHistory, mode)
 
               return (
-                <Fragment key={phrase}>
+                <Fragment key={groupKey}>
                   <tr
                     className="evidence-phrase-row cursor-pointer hover:bg-zinc-800/40"
-                    onClick={() => togglePhrase(phrase)}
+                    onClick={() => toggleRow(groupKey)}
                     aria-expanded={isExpanded}
                   >
                     <td>
@@ -191,6 +198,11 @@ export function EvidenceTable({
                     <td className="evidence-query-cell">
                       <div>
                         <span className="font-medium text-zinc-100">{phrase}</span>
+                        {compareLocations && (
+                          <span className="ml-2 text-[10px] uppercase tracking-wide text-zinc-500">
+                            {location ?? 'No location'}
+                          </span>
+                        )}
                         <div className="flex flex-wrap gap-1 mt-1">
                           {items.map(item => (
                             <ProviderBadge key={item.id} provider={item.provider} />

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -1657,6 +1657,7 @@ export function ProjectPage({
             )}
             <EvidenceTable
               evidence={filteredEvidence}
+              compareLocations={compareLocations}
             />
           </section>
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.26.1",
+  "version": "4.27.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.26.1",
+  "version": "4.27.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Summary
- Pass `compareLocations` from `ProjectPage` into `EvidenceTable` and key groups by `(phrase, location)` when on, so toggling the Compare chip now actually splits the table into one row per location with a small inline location label.
- Renames `expandedPhrases`/`togglePhrase` to `expandedRows`/`toggleRow` since the unit is no longer guaranteed to be a phrase.
- Bumps to 4.27.0.

## Test plan
- [ ] Open a project with multiple configured locations and an answer-visibility sweep; click Compare and confirm each (query, location) renders as its own row with the location label
- [ ] Toggle Compare off and confirm rows collapse back to one row per query
- [ ] Pick a single location chip and confirm Compare hides + behavior matches pre-change (single grouping by query)