### PR TITLE
fix(wp-traffic-logger): use canonical canonry.ai in Plugin URI

### DIFF
--- a/packages/wordpress-traffic-logger-plugin/plugin/canonry-traffic-logger.php
+++ b/packages/wordpress-traffic-logger-plugin/plugin/canonry-traffic-logger.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Canonry Traffic Logger
- * Plugin URI:  https://canonry.dev
+ * Plugin URI:  https://canonry.ai
  * Description: Captures non-admin page-load events and exposes them via REST for the canonry traffic-ingestion pipeline. Hashes IPs per-site, no classification — server does that.
  * Version:     0.2.0
  * Requires PHP: 7.4


### PR DESCRIPTION
## Summary
- Plugin header URI in `packages/wordpress-traffic-logger-plugin/plugin/canonry-traffic-logger.php` pointed at the non-canonical `canonry.dev`; updated to `canonry.ai`.
- This is the WP-facing "Plugin URI" link shown on the Plugins admin screen — no behavior change.

## Test plan
- [x] Plugin still activates cleanly (no PHP parse errors).
- [x] `php test/run-tests.php` in `packages/wordpress-traffic-logger-plugin/` passes.