### PR TITLE
feat(discovery): add --icp-angle for multi-angle ICP discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,7 @@ canonry doctor --project <name> --check google.auth.* --format json   # filter b
 # Discovery — expand a tracked-query basket from an ICP description
 canonry discover run <project> --icp "..." [--wait] [--format json]
 canonry discover run <project> --dedup-threshold 0.85 --max-probes 100 --wait     # tune dedup / per-session probe budget (cap 500)
+canonry discover run <project> --icp-angle "angle 1" --icp-angle "angle 2" --wait  # multi-angle: one session per ICP angle, aggregates coverage across niches
 canonry discover list <project> [--limit 20] [--format json]
 canonry discover show <project> <session-id> [--format json]
 canonry discover probe <project> <session-id> [--format json]                       # alias of show (read-only) until a later PR splits phases

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.28.0",
+  "version": "4.29.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.28.0",
+  "version": "4.29.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/cli-commands/discover.ts
+++ b/packages/canonry/src/cli-commands/discover.ts
@@ -19,6 +19,8 @@ import {
   requireProject,
   stringOption,
 } from '../cli-command-helpers.js'
+
+export type { DiscoverRunOptions } from '../commands/discover.js'
 import { usageError } from '../cli-error.js'
 
 function parseFloatOption(values: Record<string, unknown>, key: string, usage: string): number | undefined {
@@ -70,22 +72,21 @@ export const DISCOVER_CLI_COMMANDS: readonly CliCommandSpec[] = [
   {
     path: ['discover', 'run'],
     usage:
-      'canonry discover run <project> [--icp "..."] [--dedup-threshold 0.85] [--max-probes 100] [--wait] [--format json]',
+      'canonry discover run <project> [--icp "..."] [--icp-angle "..."] [--dedup-threshold 0.85] [--max-probes 100] [--wait] [--format json]',
     options: {
       icp: stringOption(),
+      'icp-angle': multiStringOption(),
       'dedup-threshold': stringOption(),
       'max-probes': stringOption(),
       wait: { type: 'boolean', default: false },
     },
     run: async (input) => {
-      const project = requireProject(
-        input,
-        'discover.run',
-        'canonry discover run <project> [--icp "..."] [--wait] [--format json]',
-      )
-      const usage = 'canonry discover run <project> [--icp "..."] [--dedup-threshold 0.85] [--max-probes 100] [--wait] [--format json]'
+      const usage =
+        'canonry discover run <project> [--icp "..."] [--icp-angle "..."] [--dedup-threshold 0.85] [--max-probes 100] [--wait] [--format json]'
+      const project = requireProject(input, 'discover.run', usage)
       await discoverRun(project, {
         icp: getString(input.values, 'icp'),
+        icpAngles: getStringArray(input.values, 'icp-angle'),
         dedupThreshold: parseFloatOption(input.values, 'dedup-threshold', usage),
         maxProbes: parseIntegerOption(input, 'max-probes', {
           command: 'discover.run',
@@ -100,22 +101,21 @@ export const DISCOVER_CLI_COMMANDS: readonly CliCommandSpec[] = [
   {
     path: ['discover', 'seed'],
     usage:
-      'canonry discover seed <project> [--icp "..."] [--dedup-threshold 0.85] [--max-probes 100] [--wait] [--format json]',
+      'canonry discover seed <project> [--icp "..."] [--icp-angle "..."] [--dedup-threshold 0.85] [--max-probes 100] [--wait] [--format json]',
     options: {
       icp: stringOption(),
+      'icp-angle': multiStringOption(),
       'dedup-threshold': stringOption(),
       'max-probes': stringOption(),
       wait: { type: 'boolean', default: false },
     },
     run: async (input) => {
-      const project = requireProject(
-        input,
-        'discover.seed',
-        'canonry discover seed <project> [--icp "..."] [--wait] [--format json]',
-      )
-      const usage = 'canonry discover seed <project> [--icp "..."] [--dedup-threshold 0.85] [--max-probes 100] [--wait] [--format json]'
+      const usage =
+        'canonry discover seed <project> [--icp "..."] [--icp-angle "..."] [--dedup-threshold 0.85] [--max-probes 100] [--wait] [--format json]'
+      const project = requireProject(input, 'discover.seed', usage)
       await discoverSeed(project, {
         icp: getString(input.values, 'icp'),
+        icpAngles: getStringArray(input.values, 'icp-angle'),
         dedupThreshold: parseFloatOption(input.values, 'dedup-threshold', usage),
         maxProbes: parseIntegerOption(input, 'max-probes', {
           command: 'discover.seed',

--- a/packages/canonry/src/cli-commands/discover.ts
+++ b/packages/canonry/src/cli-commands/discover.ts
@@ -19,8 +19,6 @@ import {
   requireProject,
   stringOption,
 } from '../cli-command-helpers.js'
-
-export type { DiscoverRunOptions } from '../commands/discover.js'
 import { usageError } from '../cli-error.js'
 
 function parseFloatOption(values: Record<string, unknown>, key: string, usage: string): number | undefined {

--- a/packages/canonry/src/commands/discover.ts
+++ b/packages/canonry/src/commands/discover.ts
@@ -35,26 +35,75 @@ function buildRunBody(opts: DiscoverRunOptions, icpDescription?: string): Record
   return body
 }
 
-export function resolveIcpAngles(opts: DiscoverRunOptions): Array<string | undefined> {
-  if (opts.icpAngles && opts.icpAngles.length > 0) return opts.icpAngles
-  if (opts.icp) return [opts.icp]
-  return [undefined]
+export interface ResolvedIcpAngles {
+  /** One entry per discovery session to start. `undefined` lets the API fall back to the project-stored ICP. */
+  angles: Array<string | undefined>
+  /** True when `--icp-angle` supplied at least one non-empty value — drives array-vs-object JSON output. */
+  multiAngle: boolean
+}
+
+export function resolveIcpAngles(opts: DiscoverRunOptions): ResolvedIcpAngles {
+  const angles = (opts.icpAngles ?? []).map(a => a.trim()).filter(a => a.length > 0)
+  if (angles.length > 0) return { angles, multiAngle: true }
+  const icp = opts.icp?.trim()
+  if (icp) return { angles: [icp], multiAngle: false }
+  return { angles: [undefined], multiAngle: false }
+}
+
+export interface AngleSummary {
+  angleCount: number
+  totalProbes: number
+  totalCited: number
+  totalWasted: number
+  totalAspirational: number
+}
+
+type DiscoverySessionCounts = Pick<
+  DiscoverySessionDetailDto,
+  'probeCount' | 'citedCount' | 'wastedCount' | 'aspirationalCount'
+>
+
+export function summarizeAngles(sessions: readonly DiscoverySessionCounts[]): AngleSummary {
+  return {
+    angleCount: sessions.length,
+    totalProbes: sessions.reduce((sum, s) => sum + (s.probeCount ?? 0), 0),
+    totalCited: sessions.reduce((sum, s) => sum + (s.citedCount ?? 0), 0),
+    totalWasted: sessions.reduce((sum, s) => sum + (s.wastedCount ?? 0), 0),
+    totalAspirational: sessions.reduce((sum, s) => sum + (s.aspirationalCount ?? 0), 0),
+  }
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
 }
 
 export async function discoverRun(project: string, opts: DiscoverRunOptions): Promise<void> {
   const client = getClient()
-  const angles = resolveIcpAngles(opts)
+  const { angles, multiAngle } = resolveIcpAngles(opts)
 
   const runs: Array<{ angle: string | undefined; start: DiscoveryRunStartResponse }> = []
   for (const angle of angles) {
-    const body = buildRunBody(opts, angle)
-    const start = await client.triggerDiscoveryRun(project, body)
-    runs.push({ angle, start })
+    try {
+      const start = await client.triggerDiscoveryRun(project, buildRunBody(opts, angle))
+      runs.push({ angle, start })
+    } catch (err) {
+      // A trigger failure mid-loop leaves earlier sessions already running
+      // server-side — surface their IDs so the operator can recover them.
+      if (runs.length > 0) {
+        process.stderr.write(
+          `\nFailed to start ${angle ? `angle "${angle}"` : 'discovery run'}: ${errorMessage(err)}\n` +
+            `Sessions already started (recover with \`canonry discover show ${project} <id>\`):\n` +
+            runs.map(r => `  ${r.start.sessionId}`).join('\n') +
+            '\n',
+        )
+      }
+      throw err
+    }
   }
 
   if (!opts.wait) {
     if (opts.format === 'json') {
-      console.log(JSON.stringify(runs.length === 1 ? runs[0]!.start : runs.map(r => r.start), null, 2))
+      console.log(JSON.stringify(multiAngle ? runs.map(r => r.start) : runs[0]!.start, null, 2))
       return
     }
     for (const { angle, start } of runs) {
@@ -68,32 +117,63 @@ export async function discoverRun(project: string, opts: DiscoverRunOptions): Pr
     return
   }
 
-  const results = await Promise.all(
-    runs.map(r => pollSession(client, project, r.start.sessionId).then(session => ({ angle: r.angle, session }))),
+  // Poll every session even if some fail — one timeout must not discard the
+  // sessions that completed. Multiple sessions poll quietly under a single
+  // status line so their progress dots don't interleave on stderr.
+  const parallel = runs.length > 1
+  if (parallel) process.stderr.write(`Waiting for ${runs.length} discovery sessions...\n`)
+  const settled = await Promise.allSettled(
+    runs.map(r => pollSession(client, project, r.start.sessionId, parallel)),
   )
 
-  if (opts.format === 'json') {
-    console.log(JSON.stringify(results.length === 1 ? results[0]!.session : results.map(r => r.session), null, 2))
-    return
-  }
-
-  for (const { angle, session } of results) {
-    if (angle) console.log(`## ICP angle: ${angle}\n`)
-    printSessionDetail(session)
-    if (results.length > 1) console.log()
-  }
-
-  if (results.length > 1) {
-    const totalProbes = results.reduce((sum, r) => sum + (r.session.probeCount ?? 0), 0)
-    const totalCited = results.reduce((sum, r) => sum + (r.session.citedCount ?? 0), 0)
-    const totalWasted = results.reduce((sum, r) => sum + (r.session.wastedCount ?? 0), 0)
-    const totalAsp = results.reduce((sum, r) => sum + (r.session.aspirationalCount ?? 0), 0)
-    console.log(`── Summary across ${results.length} angle(s) ──`)
-    console.log(`  Probes: ${totalProbes}  Cited: ${totalCited}  Wasted: ${totalWasted}  Aspirational: ${totalAsp}`)
-    console.log('\n  Promote each session:')
-    for (const { session } of results) {
-      console.log(`    canonry discover promote ${project} ${session.id}`)
+  const results: Array<{ angle: string | undefined; session: DiscoverySessionDetailDto }> = []
+  const failures: Array<{ angle: string | undefined; sessionId: string; reason: unknown }> = []
+  settled.forEach((outcome, i) => {
+    const run = runs[i]!
+    if (outcome.status === 'fulfilled') {
+      results.push({ angle: run.angle, session: outcome.value })
+    } else {
+      failures.push({ angle: run.angle, sessionId: run.start.sessionId, reason: outcome.reason })
     }
+  })
+
+  if (results.length > 0) {
+    if (opts.format === 'json') {
+      console.log(JSON.stringify(multiAngle ? results.map(r => r.session) : results[0]!.session, null, 2))
+    } else {
+      for (const { angle, session } of results) {
+        if (angle) console.log(`## ICP angle: ${angle}\n`)
+        printSessionDetail(session)
+        if (results.length > 1) console.log()
+      }
+      if (results.length > 1) {
+        const summary = summarizeAngles(results.map(r => r.session))
+        console.log(`── Summary across ${summary.angleCount} angle(s) ──`)
+        console.log(
+          `  Probes: ${summary.totalProbes}  Cited: ${summary.totalCited}` +
+            `  Wasted: ${summary.totalWasted}  Aspirational: ${summary.totalAspirational}`,
+        )
+        console.log('\n  Promote each session:')
+        for (const { session } of results) {
+          console.log(`    canonry discover promote ${project} ${session.id}`)
+        }
+      }
+    }
+  }
+
+  if (failures.length > 0) {
+    // Single-angle (legacy) path: surface the original poll error untouched.
+    if (!multiAngle) throw failures[0]!.reason
+    for (const f of failures) {
+      process.stderr.write(
+        `Discovery session ${f.sessionId}${f.angle ? ` ("${f.angle}")` : ''} did not complete: ${errorMessage(f.reason)}\n`,
+      )
+    }
+    throw new CliError({
+      code: 'DISCOVERY_INCOMPLETE',
+      message: `${failures.length} of ${runs.length} discovery session(s) did not complete`,
+      details: { failed: failures.map(f => f.sessionId) },
+    })
   }
 }
 
@@ -246,8 +326,9 @@ async function pollSession(
   client: ApiClient,
   project: string,
   sessionId: string,
+  quiet = false,
 ): Promise<DiscoverySessionDetailDto> {
-  process.stderr.write(`Waiting for discovery session ${sessionId}`)
+  if (!quiet) process.stderr.write(`Waiting for discovery session ${sessionId}`)
   const deadline = Date.now() + POLL_TIMEOUT_MS
   for (;;) {
     await new Promise(r => setTimeout(r, POLL_INTERVAL_MS))
@@ -258,9 +339,9 @@ async function pollSession(
       })
     }
     const session = await client.getDiscoverySession(project, sessionId)
-    process.stderr.write('.')
+    if (!quiet) process.stderr.write('.')
     if (TERMINAL_DISCOVERY_STATUSES.has(session.status)) {
-      process.stderr.write('\n')
+      if (!quiet) process.stderr.write('\n')
       return session
     }
   }

--- a/packages/canonry/src/commands/discover.ts
+++ b/packages/canonry/src/commands/discover.ts
@@ -20,39 +20,81 @@ function getClient(): ApiClient {
 
 export interface DiscoverRunOptions {
   icp?: string
+  icpAngles?: string[]
   dedupThreshold?: number
   maxProbes?: number
   wait?: boolean
   format?: string
 }
 
-export async function discoverRun(project: string, opts: DiscoverRunOptions): Promise<void> {
-  const client = getClient()
+function buildRunBody(opts: DiscoverRunOptions, icpDescription?: string): Record<string, unknown> {
   const body: Record<string, unknown> = {}
-  if (opts.icp) body.icpDescription = opts.icp
+  if (icpDescription) body.icpDescription = icpDescription
   if (opts.dedupThreshold !== undefined) body.dedupThreshold = opts.dedupThreshold
   if (opts.maxProbes !== undefined) body.maxProbes = opts.maxProbes
+  return body
+}
 
-  const start: DiscoveryRunStartResponse = await client.triggerDiscoveryRun(project, body)
+export function resolveIcpAngles(opts: DiscoverRunOptions): Array<string | undefined> {
+  if (opts.icpAngles && opts.icpAngles.length > 0) return opts.icpAngles
+  if (opts.icp) return [opts.icp]
+  return [undefined]
+}
+
+export async function discoverRun(project: string, opts: DiscoverRunOptions): Promise<void> {
+  const client = getClient()
+  const angles = resolveIcpAngles(opts)
+
+  const runs: Array<{ angle: string | undefined; start: DiscoveryRunStartResponse }> = []
+  for (const angle of angles) {
+    const body = buildRunBody(opts, angle)
+    const start = await client.triggerDiscoveryRun(project, body)
+    runs.push({ angle, start })
+  }
 
   if (!opts.wait) {
     if (opts.format === 'json') {
-      console.log(JSON.stringify(start, null, 2))
+      console.log(JSON.stringify(runs.length === 1 ? runs[0]!.start : runs.map(r => r.start), null, 2))
       return
     }
-    console.log(`Discovery run started: ${start.runId}`)
-    console.log(`  Session: ${start.sessionId}`)
-    console.log(`  Status:  ${start.status}`)
-    console.log(`  Tail:    canonry discover show ${project} ${start.sessionId}`)
+    for (const { angle, start } of runs) {
+      if (angle) console.log(`[${angle}]`)
+      console.log(`Discovery run started: ${start.runId}`)
+      console.log(`  Session: ${start.sessionId}`)
+      console.log(`  Status:  ${start.status}`)
+      console.log(`  Tail:    canonry discover show ${project} ${start.sessionId}`)
+      if (runs.length > 1) console.log()
+    }
     return
   }
 
-  const final = await pollSession(client, project, start.sessionId)
+  const results = await Promise.all(
+    runs.map(r => pollSession(client, project, r.start.sessionId).then(session => ({ angle: r.angle, session }))),
+  )
+
   if (opts.format === 'json') {
-    console.log(JSON.stringify(final, null, 2))
+    console.log(JSON.stringify(results.length === 1 ? results[0]!.session : results.map(r => r.session), null, 2))
     return
   }
-  printSessionDetail(final)
+
+  for (const { angle, session } of results) {
+    if (angle) console.log(`## ICP angle: ${angle}\n`)
+    printSessionDetail(session)
+    if (results.length > 1) console.log()
+  }
+
+  if (results.length > 1) {
+    const totalProbes = results.reduce((sum, r) => sum + (r.session.probeCount ?? 0), 0)
+    const totalCited = results.reduce((sum, r) => sum + (r.session.citedCount ?? 0), 0)
+    const totalWasted = results.reduce((sum, r) => sum + (r.session.wastedCount ?? 0), 0)
+    const totalAsp = results.reduce((sum, r) => sum + (r.session.aspirationalCount ?? 0), 0)
+    console.log(`── Summary across ${results.length} angle(s) ──`)
+    console.log(`  Probes: ${totalProbes}  Cited: ${totalCited}  Wasted: ${totalWasted}  Aspirational: ${totalAsp}`)
+    console.log('\n  Promote each session:')
+    for (const { session } of results) {
+      console.log(`    canonry discover promote ${project} ${session.id}`)
+    }
+  }
 }
 
 export async function discoverSeed(project: string, opts: DiscoverRunOptions): Promise<void> {

--- a/packages/canonry/test/discover-commands.test.ts
+++ b/packages/canonry/test/discover-commands.test.ts
@@ -16,10 +16,11 @@ import {
 import type { DiscoveryPromoteResult } from '@ainyc/canonry-contracts'
 import { createServer } from '../src/server.js'
 import { ApiClient } from '../src/client.js'
-import { resolveIcpAngles } from '../src/commands/discover.js'
+import type { DiscoveryRunStartResponse } from '../src/client.js'
+import { resolveIcpAngles, summarizeAngles } from '../src/commands/discover.js'
 import { invokeCli, parseJsonOutput } from './cli-test-utils.js'
 
-describe('discover promote CLI command', () => {
+describe('discover CLI commands', () => {
   let tmpDir: string
   let origConfigDir: string | undefined
   let projectId: string
@@ -214,29 +215,138 @@ describe('discover promote CLI command', () => {
     expect(result.exitCode).toBe(1)
     expect(db.select().from(queries).all()).toHaveLength(0)
   })
+
+  it('discover run --icp-angle starts one session per angle and emits a JSON array', async () => {
+    const result = await invokeCli([
+      'discover', 'run', 'demand-iq',
+      '--icp-angle', 'angle one',
+      '--icp-angle', 'angle two',
+      '--format', 'json',
+    ])
+    expect(result.exitCode).toBeUndefined()
+
+    const json = parseJsonOutput(result.stdout) as DiscoveryRunStartResponse[]
+    expect(Array.isArray(json)).toBe(true)
+    expect(json).toHaveLength(2)
+    expect(new Set(json.map(r => r.sessionId)).size).toBe(2)
+
+    // Each angle is threaded into its own session body, not collapsed to one ICP.
+    const sessions = db.select().from(discoverySessions).all()
+    expect(sessions).toHaveLength(2)
+    expect(sessions.map(s => s.icpDescription).sort()).toEqual(['angle one', 'angle two'])
+  })
+
+  it('discover run with a single --icp emits a bare object (legacy shape preserved)', async () => {
+    const result = await invokeCli([
+      'discover', 'run', 'demand-iq',
+      '--icp', 'just one icp',
+      '--format', 'json',
+    ])
+    expect(result.exitCode).toBeUndefined()
+
+    const json = parseJsonOutput(result.stdout) as DiscoveryRunStartResponse
+    expect(Array.isArray(json)).toBe(false)
+    expect(typeof json.sessionId).toBe('string')
+
+    const sessions = db.select().from(discoverySessions).all()
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]!.icpDescription).toBe('just one icp')
+  })
 })
 
-describe('discover multi-angle ICP', () => {
-  it('returns [undefined] when neither icp nor icpAngles are set (fallback to project ICP)', () => {
-    expect(resolveIcpAngles({})).toEqual([undefined])
+describe('resolveIcpAngles', () => {
+  it('falls back to [undefined] when neither icp nor icpAngles are set', () => {
+    expect(resolveIcpAngles({})).toEqual({ angles: [undefined], multiAngle: false })
   })
 
-  it('returns [icp] when only icp is set', () => {
-    expect(resolveIcpAngles({ icp: 'single ICP' })).toEqual(['single ICP'])
+  it('returns the bare icp as a single non-multi angle', () => {
+    expect(resolveIcpAngles({ icp: 'single ICP' })).toEqual({ angles: ['single ICP'], multiAngle: false })
   })
 
-  it('returns icpAngles when set (takes priority over icp)', () => {
-    expect(resolveIcpAngles({ icp: 'ignored', icpAngles: ['angle a', 'angle b'] })).toEqual([
-      'angle a',
-      'angle b',
+  it('trims a bare icp and treats a whitespace-only icp as absent', () => {
+    expect(resolveIcpAngles({ icp: '  spaced ICP  ' })).toEqual({ angles: ['spaced ICP'], multiAngle: false })
+    expect(resolveIcpAngles({ icp: '   ' })).toEqual({ angles: [undefined], multiAngle: false })
+  })
+
+  it('uses icpAngles over icp and flags multiAngle', () => {
+    expect(resolveIcpAngles({ icp: 'ignored', icpAngles: ['angle a', 'angle b'] })).toEqual({
+      angles: ['angle a', 'angle b'],
+      multiAngle: true,
+    })
+  })
+
+  it('keeps multiAngle true even for a single icp-angle', () => {
+    expect(resolveIcpAngles({ icpAngles: ['solo'] })).toEqual({ angles: ['solo'], multiAngle: true })
+  })
+
+  it('trims and drops empty / whitespace-only angles', () => {
+    expect(resolveIcpAngles({ icpAngles: ['  kept  ', '', '   ', 'also kept'] })).toEqual({
+      angles: ['kept', 'also kept'],
+      multiAngle: true,
+    })
+  })
+
+  it('falls back to icp when every icp-angle is blank', () => {
+    expect(resolveIcpAngles({ icp: 'fallback', icpAngles: ['', '  '] })).toEqual({
+      angles: ['fallback'],
+      multiAngle: false,
+    })
+  })
+
+  it('falls back to [undefined] when icp-angles are all blank and no icp is given', () => {
+    expect(resolveIcpAngles({ icpAngles: ['', '   '] })).toEqual({ angles: [undefined], multiAngle: false })
+  })
+})
+
+describe('summarizeAngles', () => {
+  it('sums each bucket across sessions and counts angles', () => {
+    const summary = summarizeAngles([
+      { probeCount: 40, citedCount: 3, wastedCount: 5, aspirationalCount: 8 },
+      { probeCount: 38, citedCount: 1, wastedCount: 9, aspirationalCount: 4 },
+      { probeCount: 40, citedCount: 2, wastedCount: 0, aspirationalCount: 11 },
     ])
+    expect(summary).toEqual({
+      angleCount: 3,
+      totalProbes: 118,
+      totalCited: 6,
+      totalWasted: 14,
+      totalAspirational: 23,
+    })
   })
 
-  it('returns icpAngles even when icp is empty', () => {
-    expect(resolveIcpAngles({ icpAngles: ['only angle'] })).toEqual(['only angle'])
+  it('treats null / missing counts as zero', () => {
+    const summary = summarizeAngles([
+      { probeCount: 10, citedCount: null, wastedCount: 1, aspirationalCount: 2 },
+      { citedCount: 4, wastedCount: null, aspirationalCount: null },
+    ])
+    expect(summary).toEqual({
+      angleCount: 2,
+      totalProbes: 10,
+      totalCited: 4,
+      totalWasted: 1,
+      totalAspirational: 2,
+    })
   })
 
-  it('returns icpAngles as-is when provided as a single-item array', () => {
-    expect(resolveIcpAngles({ icpAngles: ['solo'] })).toEqual(['solo'])
+  it('returns all-zero totals for an empty session list', () => {
+    expect(summarizeAngles([])).toEqual({
+      angleCount: 0,
+      totalProbes: 0,
+      totalCited: 0,
+      totalWasted: 0,
+      totalAspirational: 0,
+    })
+  })
+
+  it('passes a single session through unchanged', () => {
+    expect(
+      summarizeAngles([{ probeCount: 40, citedCount: 7, wastedCount: 3, aspirationalCount: 12 }]),
+    ).toEqual({
+      angleCount: 1,
+      totalProbes: 40,
+      totalCited: 7,
+      totalWasted: 3,
+      totalAspirational: 12,
+    })
   })
 })

--- a/packages/canonry/test/discover-commands.test.ts
+++ b/packages/canonry/test/discover-commands.test.ts
@@ -16,6 +16,7 @@ import {
 import type { DiscoveryPromoteResult } from '@ainyc/canonry-contracts'
 import { createServer } from '../src/server.js'
 import { ApiClient } from '../src/client.js'
+import { resolveIcpAngles } from '../src/commands/discover.js'
 import { invokeCli, parseJsonOutput } from './cli-test-utils.js'
 
 describe('discover promote CLI command', () => {
@@ -212,5 +213,30 @@ describe('discover promote CLI command', () => {
     const result = await invokeCli(['discover', 'promote', 'demand-iq', sessionId])
     expect(result.exitCode).toBe(1)
     expect(db.select().from(queries).all()).toHaveLength(0)
+  })
+})
+
+describe('discover multi-angle ICP', () => {
+  it('returns [undefined] when neither icp nor icpAngles are set (fallback to project ICP)', () => {
+    expect(resolveIcpAngles({})).toEqual([undefined])
+  })
+
+  it('returns [icp] when only icp is set', () => {
+    expect(resolveIcpAngles({ icp: 'single ICP' })).toEqual(['single ICP'])
+  })
+
+  it('returns icpAngles when set (takes priority over icp)', () => {
+    expect(resolveIcpAngles({ icp: 'ignored', icpAngles: ['angle a', 'angle b'] })).toEqual([
+      'angle a',
+      'angle b',
+    ])
+  })
+
+  it('returns icpAngles even when icp is empty', () => {
+    expect(resolveIcpAngles({ icpAngles: ['only angle'] })).toEqual(['only angle'])
+  })
+
+  it('returns icpAngles as-is when provided as a single-item array', () => {
+    expect(resolveIcpAngles({ icpAngles: ['solo'] })).toEqual(['solo'])
   })
 })

--- a/skills/aero/references/aeo-discovery.md
+++ b/skills/aero/references/aeo-discovery.md
@@ -123,6 +123,22 @@ Keep it tight. The operator wakes to a short, decision-ready summary, not a full
 - **Gemini not configured** → orchestrator throws early; `runs.status='failed'` with `Gemini provider is not configured.` Surface as "configure Gemini before running discovery" — link to `canonry init` or `~/.canonry/config.yaml`.
 - **Vertex-only Gemini** → embeddings step throws (Vertex embeddings deferred). Same surface, "use a Gemini API key for now."
 - **ICP missing** → route returns 400 with `VALIDATION_ERROR`. Ask the operator for the ICP description in plain language.
+- **Seed collapse (hyperlocal/niche businesses)** → 40 raw seeds collapse to 1-2 canonical queries after embedding+clustering, even at low dedup thresholds. This happens when Gemini generates seed queries that all live in the same semantic pocket (e.g. all variants of "boutique hotel Venice Beach"). The embedding model sees them as near-identical, so clustering produces one representative.
+
+  **Diagnostic signal:** `seedCountRaw / seedCount > 10:1` (e.g. 40 raw → 1 selected).
+
+  **Remediation:** break the ICP into 3-5 distinct purchase-intent angles and run one session per angle via `--icp-angle`:
+
+  ```bash
+  canonry discover run <project> \
+    --icp-angle "romantic anniversary stay in Venice Beach" \
+    --icp-angle "best rooftop bars and dining hotels LA" \
+    --icp-angle "walkable Venice Beach hotels near Abbot Kinney" \
+    --icp-angle "design-forward boutique hotels for creative professionals" \
+    --wait
+  ```
+
+  Each angle generates its own 40-seed cluster independently, so aggregate coverage grows while per-session dedup stays clean. The `--wait` output prints a combined summary with per-session session IDs and a `promote` command for each. Promote the sessions individually after reviewing previews.
 
 ## Memory hygiene
 

--- a/skills/canonry-setup/references/canonry-cli.md
+++ b/skills/canonry-setup/references/canonry-cli.md
@@ -230,6 +230,7 @@ canonry google request-indexing <project> --all-unindexed # push all unknown pag
 canonry discover run <project> --icp "..." --wait --format json    # full pipeline: seed → embed → cluster → probe → bucket
 canonry discover run <project> --icp "..." --dedup-threshold 0.85  # tune cosine threshold (default 0.85)
 canonry discover run <project> --icp "..." --max-probes 100         # per-session probe budget (default 100, hard cap 500)
+canonry discover run <project> --icp-angle "angle 1" --icp-angle "angle 2" --wait  # multi-angle: one session per ICP angle, useful for hyperlocal/niche businesses
 
 canonry discover list <project>                                     # newest-first session list
 canonry discover show <project> <session-id>                        # per-query probe rows + buckets


### PR DESCRIPTION
## Problem

Gemini seed generation collapses 40 raw queries into 1-2 canonical queries for hyperlocal/niche businesses because all seeds live in the same semantic pocket. Lowering dedup threshold from 0.85 to 0.50 doesn't help — the embeddings cluster together regardless.

**Example** (gjelina-hotel discovery, three runs):
| Threshold | Raw Seeds | Surviving | Result |
|---|---|---|---|
| 0.85 | 40 | 1 | aspirational only |
| 0.70 | 40 | 1 | 1 cited |
| 0.50 | 40 | 1 | aspirational only |

## Solution

Add `--icp-angle` (repeatable) to `canonry discover run` and `canonry discover seed`:

```
canonry discover run gjelina-hotel \
  --icp-angle "romantic anniversary stay in Venice Beach" \
  --icp-angle "best rooftop bars and dining hotels LA" \
  --icp-angle "walkable Venice Beach hotels near Abbot Kinney" \
  --icp-angle "design-forward boutique hotels for creative professionals" \
  --wait
```

Each angle spawns an independent discovery session. Different seed contexts produce different embedding clusters, so aggregate coverage grows while per-session dedup stays clean.

**Output** with `--wait`:
- Per-angle session detail
- Combined summary (total probes, cited, wasted, aspirational)
- `canonry discover promote` command for each session

## Changes

### Code
- `packages/canonry/src/commands/discover.ts`: `DiscoverRunOptions.icpAngles`, `resolveIcpAngles()`, parallel multi-session loop with summary
- `packages/canonry/src/cli-commands/discover.ts`: `--icp-angle` as `multiStringOption()` on `discover run` and `discover seed`
- `packages/canonry/test/discover-commands.test.ts`: 5 unit tests for `resolveIcpAngles`

### Documentation
- `skills/aero/references/aeo-discovery.md`: new failure mode — seed collapse diagnostic and multi-angle remediation
- `skills/canonry-setup/references/canonry-cli.md`: `--icp-angle` usage
- `AGENTS.md`: discover section updated with multi-angle example

## Backward Compatibility

- `--icp` still works as single-angle mode
- Neither `--icp` nor `--icp-angle` provided: falls back to project-stored ICP (existing behavior)
- Single-angle output matches existing format exactly
- JSON output adapts: single object for 1 angle, array for N angles
