### PR TITLE
feat(web): add WordPress connect drawer to the Server traffic page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Agent-first AEO operating platform. Open source. Self-hosted.**
 
 - Track citations across Gemini, ChatGPT, Claude, Perplexity, and local LLMs
-- Watch AI engines crawl and refer traffic via [server-log ingestion](skills/canonry-setup/references/server-side-traffic.md) — Cloud Run today, more sources coming
+- Watch AI engines crawl and refer traffic via [server-log ingestion](skills/canonry-setup/references/server-side-traffic.md) — Cloud Run logs and the WordPress Traffic Logger plugin today
 - Diagnose against real traffic with built-in [GSC](docs/google-search-console-setup.md), [GA4](docs/google-analytics-setup.md), and [Bing Webmaster](docs/bing-webmaster-setup.md)
 - Execute fixes via [WordPress](docs/wordpress-setup.md), JSON-LD schema, and indexing submissions
 - Manage many clients declaratively — config-as-code YAML + `canonry apply`
@@ -66,7 +66,7 @@ Configure during `canonry init`, in the dashboard `/settings`, or as env vars.
 | **Architecture & data model** | [docs/architecture.md](docs/architecture.md) · [docs/data-model.md](docs/data-model.md) |
 | **Aero — built-in agent** | [skills/aero/SKILL.md](skills/aero/SKILL.md) |
 | **MCP — Claude Desktop / Cursor / Codex** | [docs/mcp.md](docs/mcp.md) |
-| **Integrations** | [GSC](docs/google-search-console-setup.md) · [GA4](docs/google-analytics-setup.md) · [Bing](docs/bing-webmaster-setup.md) · [WordPress](docs/wordpress-setup.md) · [Server-side traffic (Cloud Run logs)](skills/canonry-setup/references/server-side-traffic.md) |
+| **Integrations** | [GSC](docs/google-search-console-setup.md) · [GA4](docs/google-analytics-setup.md) · [Bing](docs/bing-webmaster-setup.md) · [WordPress](docs/wordpress-setup.md) · [Server-side traffic (Cloud Run + WordPress logs)](skills/canonry-setup/references/server-side-traffic.md) |
 | **Deployment** — Docker, Railway, Render, systemd, Tailscale | [docs/deployment.md](docs/deployment.md) |
 | **API** — 118+ endpoints | `GET /api/v1/openapi.json` (no auth) |
 | **Skills bundle** for Claude Code / Codex | `canonry skills install` ([details](skills/canonry-setup/SKILL.md)) |

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,7 +1,7 @@
-import type { ErrorCode, GroundingSource, ProjectOverviewDto, ScheduleDto, NotificationDto, GscCoverageSummaryDto, GscCoverageSnapshotDto, IndexingRequestResultDto, MetricsWindow, GA4AiReferralHistoryEntry, GA4SessionHistoryEntry, GA4SocialReferralHistoryEntry, InsightDto, HealthSnapshotDto, ProjectReportDto, ReportAudience, RunKind, RunStatus, RunTrigger, RunErrorDto, CitationState, CitationVisibilityResponse, ComputedTransition, BacklinkSummaryDto, BacklinkDomainDto, BacklinkListResponse, BacklinkHistoryEntry, BacklinksInstallStatusDto, BacklinksInstallResultDto, CcAvailableRelease, CcCachedRelease, CcReleaseSyncDto, TrafficSourceDto, TrafficSourceDetailDto, TrafficSourceListResponse, TrafficStatusResponse, TrafficEventsResponse, TrafficConnectCloudRunRequest, TrafficSyncResponse, DiscoveryRunRequest, DiscoverySessionDto, DiscoverySessionDetailDto, DiscoveryPromotePreview, DiscoveryPromoteRequest, DiscoveryPromoteResult } from '@ainyc/canonry-contracts'
+import type { ErrorCode, GroundingSource, ProjectOverviewDto, ScheduleDto, NotificationDto, GscCoverageSummaryDto, GscCoverageSnapshotDto, IndexingRequestResultDto, MetricsWindow, GA4AiReferralHistoryEntry, GA4SessionHistoryEntry, GA4SocialReferralHistoryEntry, InsightDto, HealthSnapshotDto, ProjectReportDto, ReportAudience, RunKind, RunStatus, RunTrigger, RunErrorDto, CitationState, CitationVisibilityResponse, ComputedTransition, BacklinkSummaryDto, BacklinkDomainDto, BacklinkListResponse, BacklinkHistoryEntry, BacklinksInstallStatusDto, BacklinksInstallResultDto, CcAvailableRelease, CcCachedRelease, CcReleaseSyncDto, TrafficSourceDto, TrafficSourceDetailDto, TrafficSourceListResponse, TrafficStatusResponse, TrafficEventsResponse, TrafficConnectCloudRunRequest, TrafficConnectWordpressRequest, TrafficSyncResponse, DiscoveryRunRequest, DiscoverySessionDto, DiscoverySessionDetailDto, DiscoveryPromotePreview, DiscoveryPromoteRequest, DiscoveryPromoteResult } from '@ainyc/canonry-contracts'
 export type { ProjectOverviewDto }
 export type { BacklinkSummaryDto, BacklinkDomainDto, BacklinkListResponse, BacklinkHistoryEntry, BacklinksInstallStatusDto, BacklinksInstallResultDto, CcAvailableRelease, CcCachedRelease, CcReleaseSyncDto }
-export type { TrafficSourceDto, TrafficSourceDetailDto, TrafficSourceListResponse, TrafficStatusResponse, TrafficEventsResponse, TrafficConnectCloudRunRequest, TrafficSyncResponse }
+export type { TrafficSourceDto, TrafficSourceDetailDto, TrafficSourceListResponse, TrafficStatusResponse, TrafficEventsResponse, TrafficConnectCloudRunRequest, TrafficConnectWordpressRequest, TrafficSyncResponse }
 export type { DiscoveryRunRequest, DiscoverySessionDto, DiscoverySessionDetailDto, DiscoveryPromotePreview, DiscoveryPromoteRequest, DiscoveryPromoteResult }
 
 export type { GroundingSource }
@@ -1269,6 +1269,16 @@ export function connectServerTrafficCloudRun(
   body: TrafficConnectCloudRunRequest,
 ): Promise<TrafficSourceDto> {
   return apiFetch(`/projects/${encodeURIComponent(project)}/traffic/connect/cloud-run`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+export function connectServerTrafficWordpress(
+  project: string,
+  body: TrafficConnectWordpressRequest,
+): Promise<TrafficSourceDto> {
+  return apiFetch(`/projects/${encodeURIComponent(project)}/traffic/connect/wordpress`, {
     method: 'POST',
     body: JSON.stringify(body),
   })

--- a/apps/web/src/components/project/ActivitySection.tsx
+++ b/apps/web/src/components/project/ActivitySection.tsx
@@ -118,7 +118,7 @@ function ServerActivityPanel({ projectName }: { projectName: string }) {
           <div className="text-sm text-zinc-400">
             No server traffic source connected yet.{' '}
             <Link to="/traffic" className="text-blue-400 hover:underline">
-              Connect a Cloud Run source
+              Connect a WordPress or Cloud Run source
             </Link>{' '}
             to surface bot crawls and AI referrals straight from server logs.
           </div>

--- a/apps/web/src/components/server-traffic/ConnectWordpressDrawer.tsx
+++ b/apps/web/src/components/server-traffic/ConnectWordpressDrawer.tsx
@@ -1,0 +1,193 @@
+import { useState } from 'react'
+
+import { ApiError } from '../../api.js'
+import { useConnectServerTrafficWordpress } from '../../queries/server-traffic.js'
+import { Button } from '../ui/button.js'
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '../ui/sheet.js'
+
+export function ConnectWordpressDrawer({
+  open,
+  onOpenChange,
+  projectName,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  projectName: string
+}) {
+  const [baseUrl, setBaseUrl] = useState('')
+  const [username, setUsername] = useState('')
+  const [applicationPassword, setApplicationPassword] = useState('')
+  const [displayName, setDisplayName] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  const connect = useConnectServerTrafficWordpress(projectName || null)
+
+  const reset = () => {
+    setBaseUrl('')
+    setUsername('')
+    setApplicationPassword('')
+    setDisplayName('')
+    setError(null)
+    setSuccess(null)
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setSuccess(null)
+    if (!baseUrl.trim()) {
+      setError('WordPress site URL is required.')
+      return
+    }
+    if (!username.trim()) {
+      setError('Username is required.')
+      return
+    }
+    if (!applicationPassword.trim()) {
+      setError('Application Password is required.')
+      return
+    }
+    try {
+      const result = await connect.mutateAsync({
+        baseUrl: baseUrl.trim(),
+        username: username.trim(),
+        applicationPassword: applicationPassword.trim(),
+        displayName: displayName.trim() || undefined,
+      })
+      setApplicationPassword('')
+      setSuccess(`Connected ${result.displayName}.`)
+    } catch (e) {
+      const message = e instanceof ApiError ? e.message : e instanceof Error ? e.message : String(e)
+      setError(message)
+    }
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={(next) => {
+      onOpenChange(next)
+      if (!next) reset()
+    }}>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>Connect WordPress traffic source</SheetTitle>
+          <SheetDescription>
+            Pulls request events from the Canonry Traffic Logger plugin. The Application Password is stored in <code>~/.canonry/config.yaml</code> on the server and never echoed back to the dashboard.
+          </SheetDescription>
+        </SheetHeader>
+
+        <form onSubmit={handleSubmit} className="mt-6 flex flex-col gap-5 overflow-y-auto pr-1">
+          <Field
+            label="Project"
+            description="Canonry project this source attaches to."
+          >
+            <input
+              type="text"
+              value={projectName}
+              disabled
+              className="w-full rounded border border-zinc-700 bg-zinc-900/50 px-2 py-1.5 text-sm text-zinc-300"
+            />
+          </Field>
+
+          <Field
+            label="WordPress site URL"
+            description="Base URL of the site running the Canonry Traffic Logger plugin."
+            required
+          >
+            <input
+              type="url"
+              value={baseUrl}
+              onChange={(e) => setBaseUrl(e.target.value)}
+              required
+              autoComplete="url"
+              placeholder="https://example.com"
+              className="w-full rounded border border-zinc-700 bg-transparent px-2 py-1.5 text-sm text-zinc-200 placeholder-zinc-600 focus:border-zinc-500 focus:outline-none"
+            />
+          </Field>
+
+          <Field
+            label="Username"
+            description="WordPress user that owns the Application Password."
+            required
+          >
+            <input
+              type="text"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              required
+              autoComplete="username"
+              className="w-full rounded border border-zinc-700 bg-transparent px-2 py-1.5 text-sm text-zinc-200 placeholder-zinc-600 focus:border-zinc-500 focus:outline-none"
+            />
+          </Field>
+
+          <Field
+            label="Application Password"
+            description="Create one in wp-admin under Users -> Profile -> Application Passwords."
+            required
+          >
+            <input
+              type="password"
+              value={applicationPassword}
+              onChange={(e) => setApplicationPassword(e.target.value)}
+              required
+              autoComplete="new-password"
+              className="w-full rounded border border-zinc-700 bg-transparent px-2 py-1.5 text-sm text-zinc-200 placeholder-zinc-600 focus:border-zinc-500 focus:outline-none"
+            />
+          </Field>
+
+          <Field
+            label="Display name (optional)"
+            description="Friendly label shown in the dashboard. Defaults to the WordPress host."
+          >
+            <input
+              type="text"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              autoComplete="off"
+              className="w-full rounded border border-zinc-700 bg-transparent px-2 py-1.5 text-sm text-zinc-200 placeholder-zinc-600 focus:border-zinc-500 focus:outline-none"
+            />
+          </Field>
+
+          {error ? (
+            <p className="rounded-md border border-rose-800/50 bg-rose-950/30 px-3 py-2 text-xs text-rose-200">{error}</p>
+          ) : null}
+          {success ? (
+            <p className="rounded-md border border-emerald-800/50 bg-emerald-950/30 px-3 py-2 text-xs text-emerald-200">{success}</p>
+          ) : null}
+
+          <div className="mt-2 flex items-center justify-end gap-2 border-t border-zinc-800/60 pt-4">
+            <Button type="button" variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
+              Close
+            </Button>
+            <Button type="submit" disabled={connect.isPending} size="sm">
+              {connect.isPending ? 'Connecting...' : 'Connect'}
+            </Button>
+          </div>
+        </form>
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+function Field({
+  label,
+  description,
+  required,
+  children,
+}: {
+  label: string
+  description: string
+  required?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="text-xs font-medium text-zinc-200">
+        {label}
+        {required ? <span className="ml-1 text-rose-400">*</span> : null}
+      </span>
+      {children}
+      <span className="text-[11px] text-zinc-500">{description}</span>
+    </label>
+  )
+}

--- a/apps/web/src/pages/TrafficPage.tsx
+++ b/apps/web/src/pages/TrafficPage.tsx
@@ -10,6 +10,7 @@ import { Button } from '../components/ui/button.js'
 import { Card } from '../components/ui/card.js'
 import { ToneBadge } from '../components/shared/ToneBadge.js'
 import { ConnectCloudRunDrawer } from '../components/server-traffic/ConnectCloudRunDrawer.js'
+import { ConnectWordpressDrawer } from '../components/server-traffic/ConnectWordpressDrawer.js'
 import { queryKeys } from '../queries/query-keys.js'
 import {
   toneFromTrafficSourceStatus,
@@ -36,7 +37,8 @@ function formatCompact(n: number): string {
 
 export function TrafficPage() {
   const [selectedProject, setSelectedProject] = useState<string>('')
-  const [connectOpen, setConnectOpen] = useState(false)
+  const [cloudRunConnectOpen, setCloudRunConnectOpen] = useState(false)
+  const [wordpressConnectOpen, setWordpressConnectOpen] = useState(false)
 
   const projectsQuery = useQuery({
     queryKey: queryKeys.projects.all,
@@ -58,19 +60,31 @@ export function TrafficPage() {
         <div className="page-header-left">
           <h1 className="page-title">Server traffic</h1>
           <p className="page-subtitle">
-            Crawler hits and AI-referral sessions pulled directly from server logs (Cloud Run, etc.). Independent of GA — useful when you need server-side evidence that GPTBot or ChatGPT-User actually hit a page.
+            Crawler hits and AI-referral sessions pulled directly from Cloud Run logs or the WordPress Traffic Logger plugin. Independent of GA — useful when you need server-side evidence that GPTBot or ChatGPT-User actually hit a page.
           </p>
         </div>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={() => setConnectOpen(true)}
-          disabled={!activeProject}
-        >
-          <Plus className="size-3.5" />
-          Connect Cloud Run
-        </Button>
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setWordpressConnectOpen(true)}
+            disabled={!activeProject}
+          >
+            <Plus className="size-3.5" />
+            Connect WordPress
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setCloudRunConnectOpen(true)}
+            disabled={!activeProject}
+          >
+            <Plus className="size-3.5" />
+            Connect Cloud Run
+          </Button>
+        </div>
       </div>
 
       <section>
@@ -95,9 +109,13 @@ export function TrafficPage() {
         ) : sources.length === 0 ? (
           <Card className="p-8 text-center">
             <p className="text-sm text-zinc-300">No traffic sources connected for {activeProject}.</p>
-            <p className="mt-1 text-xs text-zinc-500">Connect a Cloud Run service to start ingesting crawler hits and AI-referral sessions from server logs.</p>
-            <div className="mt-4">
-              <Button type="button" variant="outline" size="sm" onClick={() => setConnectOpen(true)}>
+            <p className="mt-1 text-xs text-zinc-500">Connect a WordPress site or Cloud Run service to start ingesting crawler hits and AI-referral sessions from server logs.</p>
+            <div className="mt-4 flex flex-wrap items-center justify-center gap-2">
+              <Button type="button" variant="outline" size="sm" onClick={() => setWordpressConnectOpen(true)}>
+                <Plus className="size-3.5" />
+                Connect WordPress
+              </Button>
+              <Button type="button" variant="outline" size="sm" onClick={() => setCloudRunConnectOpen(true)}>
                 <Plus className="size-3.5" />
                 Connect Cloud Run
               </Button>
@@ -109,8 +127,13 @@ export function TrafficPage() {
       </section>
 
       <ConnectCloudRunDrawer
-        open={connectOpen}
-        onOpenChange={setConnectOpen}
+        open={cloudRunConnectOpen}
+        onOpenChange={setCloudRunConnectOpen}
+        projectName={activeProject}
+      />
+      <ConnectWordpressDrawer
+        open={wordpressConnectOpen}
+        onOpenChange={setWordpressConnectOpen}
         projectName={activeProject}
       />
     </div>
@@ -119,8 +142,7 @@ export function TrafficPage() {
 
 function SourcesTable({ projectName, sources }: { projectName: string; sources: TrafficSourceDto[] }) {
   // UI/CLI parity: this view shows last-24h totals + latest run, the same shape `canonry traffic status`
-  // returns. Rather than denormalize the totals onto the list endpoint, fan out to /traffic/sources/:id —
-  // v1 caps a project at one active Cloud Run source so the fan-out is bounded.
+  // returns. Rather than denormalize the totals onto the list endpoint, fan out to /traffic/sources/:id.
   const detailQueries = useQueries({
     queries: sources.map((source) => ({
       queryKey: queryKeys.serverTraffic.sourceDetail(projectName, source.id),

--- a/apps/web/src/queries/server-traffic.ts
+++ b/apps/web/src/queries/server-traffic.ts
@@ -5,6 +5,7 @@ import { TrafficSourceStatuses } from '@ainyc/canonry-contracts'
 
 import {
   connectServerTrafficCloudRun,
+  connectServerTrafficWordpress,
   fetchServerTrafficEvents,
   fetchServerTrafficSource,
   fetchServerTrafficSources,
@@ -16,6 +17,7 @@ import {
   type ApiTrafficStatus,
   type ApiTrafficSyncResult,
   type TrafficConnectCloudRunRequest,
+  type TrafficConnectWordpressRequest,
 } from '../api.js'
 import type { MetricTone } from '../view-models.js'
 import { TRAFFIC_STALE_MS } from './query-client.js'
@@ -105,6 +107,20 @@ export function useConnectServerTrafficCloudRun(project: string | null) {
     mutationFn: (request: TrafficConnectCloudRunRequest) => {
       if (!project) throw new Error('Project is required to connect a Cloud Run source')
       return connectServerTrafficCloudRun(project, request)
+    },
+    onSuccess: () => {
+      if (!project) return
+      void queryClient.invalidateQueries({ queryKey: queryKeys.serverTraffic.project(project) })
+    },
+  })
+}
+
+export function useConnectServerTrafficWordpress(project: string | null) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (request: TrafficConnectWordpressRequest) => {
+      if (!project) throw new Error('Project is required to connect a WordPress source')
+      return connectServerTrafficWordpress(project, request)
     },
     onSuccess: () => {
       if (!project) return

--- a/apps/web/test/api-fetch-headers.test.ts
+++ b/apps/web/test/api-fetch-headers.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, onTestFinished, describe } from 'vitest'
 
-import { installBacklinks, triggerGscSync } from '../src/api.js'
+import { connectServerTrafficWordpress, installBacklinks, triggerGscSync } from '../src/api.js'
 
 function mockFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
   const realFetch = globalThis.fetch
@@ -57,5 +57,46 @@ describe('apiFetch Content-Type header', () => {
     expect(observed?.method).toBe('POST')
     expect(observed?.body).toBeDefined()
     expect(headerFromInit(observed, 'Content-Type')).toBe('application/json')
+  })
+
+  test('posts WordPress traffic connects to the adapter-specific endpoint', async () => {
+    let observedUrl = ''
+    let observed: RequestInit | undefined
+    const restore = mockFetch((url, init) => {
+      observedUrl = url
+      observed = init
+      return jsonResponse({
+        id: 'source-1',
+        projectId: 'project-1',
+        sourceType: 'wordpress',
+        displayName: 'WordPress - example.com',
+        status: 'connected',
+        lastSyncedAt: null,
+        lastCursor: null,
+        lastError: null,
+        archivedAt: null,
+        config: { baseUrl: 'https://example.com', username: 'admin' },
+        createdAt: '2026-05-14T00:00:00.000Z',
+        updatedAt: '2026-05-14T00:00:00.000Z',
+      })
+    })
+    onTestFinished(restore)
+
+    await connectServerTrafficWordpress('demo project', {
+      baseUrl: 'https://example.com',
+      username: 'admin',
+      applicationPassword: 'xxxx xxxx',
+      displayName: 'WP logs',
+    })
+
+    expect(observedUrl).toBe('/api/v1/projects/demo%20project/traffic/connect/wordpress')
+    expect(observed?.method).toBe('POST')
+    expect(headerFromInit(observed, 'Content-Type')).toBe('application/json')
+    expect(JSON.parse(String(observed?.body))).toEqual({
+      baseUrl: 'https://example.com',
+      username: 'admin',
+      applicationPassword: 'xxxx xxxx',
+      displayName: 'WP logs',
+    })
   })
 })

--- a/apps/web/test/app.test.tsx
+++ b/apps/web/test/app.test.tsx
@@ -79,6 +79,14 @@ test('settings route renders provider state, quota summary, and service health',
   expect(html).toMatch(/Gemini/)
 })
 
+test('traffic route offers Cloud Run and WordPress server-log connections', async () => {
+  const html = await renderApp('/traffic')
+
+  expect(html).toMatch(/Server traffic/)
+  expect(html).toMatch(/Connect WordPress/)
+  expect(html).toMatch(/Connect Cloud Run/)
+})
+
 test('settings route renders the Google Search Console OAuth configuration card', async () => {
   const html = await renderApp('/settings')
 

--- a/docs/wordpress-setup.md
+++ b/docs/wordpress-setup.md
@@ -5,7 +5,7 @@ Canonry integrates with WordPress through the core REST API using **Application 
 - **Automated via REST:** page reads and writes, title/slug/content updates, page audits, staging-vs-live diffs, and SEO meta updates when the site exposes writable REST meta fields.
 - **Manual-assist only:** `llms.txt`, schema injection, and WP STAGING push-to-live. Canonry generates the content and next steps, but it does not click wp-admin buttons or write arbitrary files on the server.
 
-There is currently **no WordPress web UI** in canonry. Use the CLI or API.
+Content operations are CLI/API-first. The dashboard can connect a WordPress server-log traffic source under `/traffic`, but page/content automation remains on the CLI and API.
 
 ---
 

--- a/skills/canonry-setup/SKILL.md
+++ b/skills/canonry-setup/SKILL.md
@@ -88,7 +88,7 @@ GA4 is a first-class signal alongside citation tracking. Connect once with `cano
 | `references/aeo-analysis.md` | Interpreting sweep output, diagnosing regressions, planning content fixes |
 | `references/indexing.md` | Submitting URLs, checking GSC/Bing coverage, fixing indexing gaps |
 | `references/wordpress-integration.md` | Connecting to WordPress, editing pages, pushing staging → live |
-| `references/server-side-traffic.md` | Wiring server-log evidence (Cloud Run today; WordPress / others later) for AI Visibility — Server-Side. Connect, sync, manage sources, troubleshoot. |
+| `references/server-side-traffic.md` | Wiring server-log evidence (Cloud Run + WordPress adapters; more planned) for AI Visibility — Server-Side. Connect, sync, manage sources, troubleshoot. |
 
 ---
 


### PR DESCRIPTION
## Summary
- The WordPress server-log traffic adapter already shipped on the CLI, API, and MCP surfaces — this adds the missing dashboard UI to connect one.
- The `/traffic` page now offers both **Connect WordPress** and **Connect Cloud Run**, backed by a new `ConnectWordpressDrawer`, a `connectServerTrafficWordpress` API client function, and a `useConnectServerTrafficWordpress` mutation hook.
- README, `docs/wordpress-setup.md`, and the `canonry-setup` skill TOC are updated to reflect WordPress as a shipped server-log source alongside Cloud Run.

## Test plan
- [ ] `pnpm --filter @ainyc/canonry-web test` — covers the new WordPress connect endpoint test and the `/traffic` route render test
- [ ] Manually open `/traffic`, click **Connect WordPress**, confirm the drawer validates required fields and posts to `/traffic/connect/wordpress`