### PR TITLE
feat(integration-vercel): add Vercel request-logs traffic adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.29.1",
+  "version": "4.30.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.29.1",
+  "version": "4.30.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/contracts/src/traffic.ts
+++ b/packages/contracts/src/traffic.ts
@@ -103,6 +103,23 @@ export const wordpressTrafficSourceConfigSchema = z.object({
 })
 export type WordpressTrafficSourceConfig = z.infer<typeof wordpressTrafficSourceConfigSchema>
 
+export const vercelTrafficEnvironmentSchema = z.enum(['production', 'preview'])
+export type VercelTrafficEnvironment = z.infer<typeof vercelTrafficEnvironmentSchema>
+export const VercelTrafficEnvironments = vercelTrafficEnvironmentSchema.enum
+
+/**
+ * Persisted in `traffic_sources.configJson` for `sourceType = 'vercel'`.
+ * The Vercel API token lives in `~/.canonry/config.yaml`, never here.
+ */
+export const vercelTrafficSourceConfigSchema = z.object({
+  /** Vercel project id (e.g. `prj_...`). */
+  projectId: z.string().min(1),
+  /** Vercel team / owner id (e.g. `team_...`). */
+  teamId: z.string().min(1),
+  environment: vercelTrafficEnvironmentSchema,
+})
+export type VercelTrafficSourceConfig = z.infer<typeof vercelTrafficSourceConfigSchema>
+
 export const trafficSourceDtoSchema = z.object({
   id: z.string(),
   projectId: z.string(),
@@ -137,6 +154,19 @@ export const trafficConnectWordpressRequestSchema = z.object({
   displayName: z.string().min(1).optional(),
 })
 export type TrafficConnectWordpressRequest = z.infer<typeof trafficConnectWordpressRequestSchema>
+
+export const trafficConnectVercelRequestSchema = z.object({
+  /** Vercel project id (e.g. `prj_...`) — from the Vercel dashboard or `.vercel/project.json`. */
+  projectId: z.string().min(1),
+  /** Vercel team / owner id (e.g. `team_...`). */
+  teamId: z.string().min(1),
+  /** Vercel API token (personal access token). Stored in `~/.canonry/config.yaml`, never the DB. */
+  token: z.string().min(1),
+  /** Which deployment environment's request logs to pull. Default: `production`. */
+  environment: vercelTrafficEnvironmentSchema.optional(),
+  displayName: z.string().min(1).optional(),
+})
+export type TrafficConnectVercelRequest = z.infer<typeof trafficConnectVercelRequestSchema>
 
 export const trafficSyncResponseSchema = z.object({
   sourceId: z.string(),

--- a/packages/contracts/test/traffic.test.ts
+++ b/packages/contracts/test/traffic.test.ts
@@ -4,7 +4,9 @@ import {
   TrafficEvidenceKinds,
   TrafficSourceTypes,
   normalizedTrafficRequestSchema,
+  trafficConnectVercelRequestSchema,
   trafficConnectWordpressRequestSchema,
+  vercelTrafficSourceConfigSchema,
   wordpressTrafficSourceConfigSchema,
 } from '../src/traffic.js'
 
@@ -97,6 +99,73 @@ describe('trafficConnectWordpressRequestSchema', () => {
       baseUrl: 'https://example.com',
       username: 'canonry-bot',
       applicationPassword: '',
+    })).toThrow()
+  })
+})
+
+describe('vercelTrafficSourceConfigSchema', () => {
+  it('accepts a valid Vercel traffic source config', () => {
+    const parsed = vercelTrafficSourceConfigSchema.parse({
+      projectId: 'prj_abc123',
+      teamId: 'team_xyz789',
+      environment: 'production',
+    })
+    expect(parsed.projectId).toBe('prj_abc123')
+    expect(parsed.teamId).toBe('team_xyz789')
+    expect(parsed.environment).toBe('production')
+  })
+
+  it('rejects an unknown environment', () => {
+    expect(() => vercelTrafficSourceConfigSchema.parse({
+      projectId: 'prj_abc123',
+      teamId: 'team_xyz789',
+      environment: 'staging',
+    })).toThrow()
+  })
+
+  it('rejects an empty projectId or teamId', () => {
+    expect(() => vercelTrafficSourceConfigSchema.parse({
+      projectId: '',
+      teamId: 'team_xyz789',
+      environment: 'production',
+    })).toThrow()
+    expect(() => vercelTrafficSourceConfigSchema.parse({
+      projectId: 'prj_abc123',
+      teamId: '',
+      environment: 'production',
+    })).toThrow()
+  })
+})
+
+describe('trafficConnectVercelRequestSchema', () => {
+  it('accepts a connect request with all fields', () => {
+    const parsed = trafficConnectVercelRequestSchema.parse({
+      projectId: 'prj_abc123',
+      teamId: 'team_xyz789',
+      token: 'vcp_secret',
+      environment: 'preview',
+      displayName: 'Example Vercel',
+    })
+    expect(parsed.token).toBe('vcp_secret')
+    expect(parsed.environment).toBe('preview')
+    expect(parsed.displayName).toBe('Example Vercel')
+  })
+
+  it('allows omitting environment and displayName', () => {
+    const parsed = trafficConnectVercelRequestSchema.parse({
+      projectId: 'prj_abc123',
+      teamId: 'team_xyz789',
+      token: 'vcp_secret',
+    })
+    expect(parsed.environment).toBeUndefined()
+    expect(parsed.displayName).toBeUndefined()
+  })
+
+  it('rejects an empty token', () => {
+    expect(() => trafficConnectVercelRequestSchema.parse({
+      projectId: 'prj_abc123',
+      teamId: 'team_xyz789',
+      token: '',
     })).toThrow()
   })
 })

--- a/packages/integration-vercel/AGENTS.md
+++ b/packages/integration-vercel/AGENTS.md
@@ -1,0 +1,71 @@
+# integration-vercel
+
+## Purpose
+
+Vercel traffic integration — pulls request logs from Vercel's internal
+`request-logs` endpoint (`https://vercel.com/api/logs/request-logs`, the same
+endpoint the `vercel` CLI rides) and normalizes them into provider-neutral
+`NormalizedTrafficRequest` events for the traffic ingestion pipeline.
+
+Unlike the `vercel logs --json` CLI surface, this endpoint exposes
+`clientUserAgent`, `requestReferer`, and `requestSearchParams` natively — so
+Canonry can classify AI crawlers and AI referrals from a pure outbound pull,
+with **no in-app instrumentation** required on the user's Vercel project.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `src/client.ts` | `listVercelTrafficEvents` — page-paginated `request-logs` pull, `VercelLogsApiError` |
+| `src/normalize.ts` | `normalizeVercelLogRow` — converts a raw `request-logs` row into a `NormalizedTrafficRequest` |
+| `src/types.ts` | Adapter option/response shapes (`VercelRequestLogRow`, `ListVercelTrafficEventsOptions`, `VercelTrafficEventsPage`) |
+| `src/index.ts` | Re-exports public API |
+
+## Patterns
+
+- **Bearer-token auth.** The caller supplies a Vercel API token (personal
+  access token). This package does not own the token — credentials live in
+  `~/.canonry/config.yaml` under `vercelTraffic.connections` and are supplied
+  per call by the consumer (API route / sync orchestrator).
+- **Pull-only, page-paginated.** `listVercelTrafficEvents` accepts a
+  `startDate`/`endDate` window plus `maxPages`; the endpoint paginates by
+  `page` and reports `hasMoreRows`. No push, no SaaS relay. Incremental syncs
+  advance the time window (the `lastSyncedAt` timestamp is the cursor), not a
+  page token.
+- **Internal endpoint, defensively read.** `request-logs` is not the
+  documented `api.vercel.com` REST API — it is the endpoint the official CLI
+  uses. Every field read is optional and tolerated-missing; never assume a
+  field is present.
+- **`statusCode` fallback.** Vercel's top-level `statusCode` is sometimes `0`
+  (populated lazily). `normalizeVercelLogRow` falls back to the last real HTTP
+  status in the merged `events[]` timeline.
+- **No classification.** This package only pulls + normalizes. UA-pattern and
+  AI-referer detection happen in `packages/integration-traffic` alongside
+  Cloud Run and WordPress events, so the classifier rule set evolves in one
+  place.
+- **No client IP.** The endpoint does not expose a client IP, so `remoteIp` is
+  always `null` and Vercel events stay `claimed_unverified` in the classifier.
+- **Provider-neutral output.** Every adapter in the traffic stack emits the
+  same `NormalizedTrafficRequest` shape from `@ainyc/canonry-contracts`. Do not
+  leak Vercel-specific types past the package boundary.
+
+## Common Mistakes
+
+- **Storing the API token in this package.** Credentials live in
+  `~/.canonry/config.yaml` and are supplied per call.
+- **Trusting top-level `statusCode`.** It is `0` on freshly-logged rows — use
+  `normalizeVercelLogRow`'s `events[]` fallback.
+- **Adding UA/referer classification here.** All classification lives in
+  `packages/integration-traffic` so every adapter shares one rule set.
+- **Treating `request-logs` as a stable contract.** It is undocumented —
+  validate the response shape and fail loudly on drift rather than silently
+  emitting empty rollups.
+
+## See Also
+
+- `packages/contracts/src/traffic.ts` — `NormalizedTrafficRequest`,
+  `vercelTrafficSourceConfigSchema`, `trafficConnectVercelRequestSchema`
+- `packages/integration-traffic/` — provider-neutral classifier + hourly rollup
+- `packages/integration-cloud-run/` / `packages/integration-wordpress-traffic/`
+  — sibling pull adapters; mirror this file layout
+- `plans/server-side-ai-traffic-ingestion.md` — overall traffic plan

--- a/packages/integration-vercel/CLAUDE.md
+++ b/packages/integration-vercel/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/integration-vercel/package.json
+++ b/packages/integration-vercel/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@ainyc/canonry-integration-vercel",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "license": "FSL-1.1-ALv2",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "types": "./src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "vitest run",
+    "lint": "eslint src/ test/"
+  },
+  "dependencies": {
+    "@ainyc/canonry-contracts": "workspace:*"
+  }
+}

--- a/packages/integration-vercel/src/client.ts
+++ b/packages/integration-vercel/src/client.ts
@@ -1,0 +1,136 @@
+import { normalizeVercelLogRow } from './normalize.js'
+import type {
+  ListVercelTrafficEventsOptions,
+  VercelRequestLogsResponseBody,
+  VercelTrafficEventsPage,
+} from './types.js'
+
+const VERCEL_REQUEST_LOGS_URL = 'https://vercel.com/api/logs/request-logs'
+const DEFAULT_ENVIRONMENT = 'production'
+const DEFAULT_MAX_PAGES = 1
+const DEFAULT_TIMEOUT_MS = 30_000
+
+export class VercelLogsApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly body?: string,
+  ) {
+    super(message)
+    this.name = 'VercelLogsApiError'
+  }
+}
+
+function trimRequired(name: string, value: string): string {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    throw new VercelLogsApiError(`${name} is required`, 400)
+  }
+  return trimmed
+}
+
+function normalizeMaxPages(maxPages: number | undefined): number {
+  if (maxPages === undefined) return DEFAULT_MAX_PAGES
+  if (!Number.isInteger(maxPages) || maxPages < 1) {
+    throw new VercelLogsApiError('maxPages must be a positive integer', 400)
+  }
+  return maxPages
+}
+
+function toEpochMs(label: string, value: number | string | Date): string {
+  const ms = value instanceof Date
+    ? value.getTime()
+    : typeof value === 'number'
+      ? value
+      : new Date(value).getTime()
+  if (!Number.isFinite(ms)) {
+    throw new VercelLogsApiError(`${label} must be a valid date`, 400)
+  }
+  return String(Math.trunc(ms))
+}
+
+async function readErrorBody(response: Response): Promise<string | undefined> {
+  const text = await response.text().catch(() => '')
+  if (!text) return undefined
+  return text.length <= 500 ? text : `${text.slice(0, 500)}... [truncated]`
+}
+
+/**
+ * Pull a page (or up to `maxPages` pages) of request logs from Vercel's
+ * internal `request-logs` endpoint — the same endpoint the `vercel` CLI rides
+ * — normalize each row into `NormalizedTrafficRequest`, and return the merged
+ * page plus the `hasMore` continuation signal.
+ *
+ * Pure pull adapter — no DB, no classification, no credential storage. The
+ * caller supplies the Vercel API token and bounds the time window.
+ */
+export async function listVercelTrafficEvents(
+  options: ListVercelTrafficEventsOptions,
+): Promise<VercelTrafficEventsPage> {
+  const token = trimRequired('token', options.token)
+  const projectId = trimRequired('projectId', options.projectId)
+  const teamId = trimRequired('teamId', options.teamId)
+  const environment = options.environment ?? DEFAULT_ENVIRONMENT
+  const startDate = toEpochMs('startDate', options.startDate)
+  const endDate = toEpochMs('endDate', options.endDate)
+  const maxPages = normalizeMaxPages(options.maxPages)
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+
+  let rawEntryCount = 0
+  let skippedEntryCount = 0
+  let hasMore = false
+  const events: VercelTrafficEventsPage['events'] = []
+
+  for (let page = 0; page < maxPages; page += 1) {
+    const url = new URL(VERCEL_REQUEST_LOGS_URL)
+    url.searchParams.set('projectId', projectId)
+    url.searchParams.set('ownerId', teamId)
+    url.searchParams.set('teamId', teamId)
+    url.searchParams.set('page', String(page))
+    url.searchParams.set('startDate', startDate)
+    url.searchParams.set('endDate', endDate)
+    url.searchParams.set('environment', environment)
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+      },
+      signal: AbortSignal.timeout(timeoutMs),
+    })
+
+    if (!response.ok) {
+      const body = await readErrorBody(response)
+      throw new VercelLogsApiError(
+        `Vercel request-logs endpoint returned HTTP ${response.status}`,
+        response.status,
+        body,
+      )
+    }
+
+    const body = (await response.json()) as VercelRequestLogsResponseBody
+    const rows = body.rows ?? []
+    rawEntryCount += rows.length
+
+    for (const row of rows) {
+      const event = normalizeVercelLogRow(row)
+      if (event) {
+        events.push(event)
+      } else {
+        skippedEntryCount += 1
+      }
+    }
+
+    hasMore = Boolean(body.hasMoreRows)
+    if (!hasMore) break
+  }
+
+  return {
+    events,
+    rawEntryCount,
+    skippedEntryCount,
+    hasMore,
+    endpoint: VERCEL_REQUEST_LOGS_URL,
+  }
+}

--- a/packages/integration-vercel/src/index.ts
+++ b/packages/integration-vercel/src/index.ts
@@ -1,0 +1,3 @@
+export * from './client.js'
+export * from './normalize.js'
+export type * from './types.js'

--- a/packages/integration-vercel/src/normalize.ts
+++ b/packages/integration-vercel/src/normalize.ts
@@ -1,0 +1,106 @@
+import {
+  TrafficEventConfidences,
+  TrafficEvidenceKinds,
+  TrafficSourceTypes,
+  type NormalizedTrafficRequest,
+} from '@ainyc/canonry-contracts'
+import type { VercelRequestLogRow } from './types.js'
+
+function numberOrNull(value: number | undefined): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+  return value
+}
+
+/**
+ * Resolve the response status. Vercel's top-level `statusCode` is sometimes
+ * `0` (populated lazily / propagation lag), so fall back to the last real HTTP
+ * status in the merged `events[]` timeline — that reflects what the client
+ * actually received (proxy/static layer last, after middleware).
+ */
+function resolveStatus(row: VercelRequestLogRow): number | null {
+  if (typeof row.statusCode === 'number' && row.statusCode >= 100) {
+    return row.statusCode
+  }
+  const events = row.events ?? []
+  for (let i = events.length - 1; i >= 0; i -= 1) {
+    const status = events[i]?.httpStatus
+    if (typeof status === 'number' && status >= 100) return status
+  }
+  return null
+}
+
+function serializeSearchParams(params: Record<string, string> | undefined): string | null {
+  if (!params) return null
+  const entries = Object.entries(params).filter(
+    (entry): entry is [string, string] => typeof entry[1] === 'string',
+  )
+  if (entries.length === 0) return null
+  return new URLSearchParams(entries).toString()
+}
+
+function emptyToNull(value: string | undefined): string | null {
+  if (typeof value !== 'string' || value.trim() === '') return null
+  return value
+}
+
+function stringLabels(input: Record<string, string | undefined>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(input).filter(
+      (entry): entry is [string, string] => typeof entry[1] === 'string' && entry[1] !== '',
+    ),
+  )
+}
+
+/**
+ * Convert a raw `request-logs` row into a provider-neutral
+ * `NormalizedTrafficRequest`. Returns `null` for rows that lack the minimum
+ * evidence (path, timestamp, request id) needed downstream.
+ */
+export function normalizeVercelLogRow(row: VercelRequestLogRow): NormalizedTrafficRequest | null {
+  const path = row.requestPath
+  if (!path) return null
+  const observedAt = row.timestamp
+  if (!observedAt) return null
+  const requestId = row.requestId
+  if (!requestId) return null
+
+  const host = emptyToNull(row.domain)
+  const queryString = serializeSearchParams(row.requestSearchParams)
+  const requestUrl = host
+    ? `https://${host}${path}${queryString ? `?${queryString}` : ''}`
+    : null
+
+  return {
+    sourceType: TrafficSourceTypes.vercel,
+    evidenceKind: TrafficEvidenceKinds['raw-request'],
+    confidence: TrafficEventConfidences.observed,
+    eventId: `vercel:${observedAt}:${requestId}`,
+    observedAt,
+    method: row.requestMethod ?? null,
+    requestUrl,
+    host,
+    path,
+    queryString,
+    status: resolveStatus(row),
+    userAgent: emptyToNull(row.clientUserAgent),
+    // The request-logs endpoint does not expose a client IP; UA-only matches
+    // stay `claimed_unverified` in the classifier.
+    remoteIp: null,
+    referer: emptyToNull(row.requestReferer),
+    latencyMs: numberOrNull(row.requestDurationMs),
+    requestSizeBytes: null,
+    responseSizeBytes: null,
+    providerResource: {
+      type: 'vercel_deployment',
+      labels: stringLabels({
+        deploymentId: row.deploymentId,
+        environment: row.environment,
+        region: row.clientRegion,
+      }),
+    },
+    providerLabels: stringLabels({
+      branch: row.branch,
+      cache: row.cache,
+    }),
+  }
+}

--- a/packages/integration-vercel/src/types.ts
+++ b/packages/integration-vercel/src/types.ts
@@ -1,0 +1,72 @@
+import type { NormalizedTrafficRequest, VercelTrafficEnvironment } from '@ainyc/canonry-contracts'
+
+/**
+ * One entry in a request-log row's compute timeline (`events` / `proxyEvents`
+ * / `functionEvents`). Only the fields the normalizer reads are typed; Vercel
+ * returns many more.
+ */
+export interface VercelRequestLogEvent {
+  source?: string
+  httpStatus?: number
+  region?: string
+}
+
+/**
+ * A single row from `GET https://vercel.com/api/logs/request-logs`. This is
+ * the internal endpoint the `vercel` CLI rides; only the fields Canonry
+ * normalizes are typed here.
+ */
+export interface VercelRequestLogRow {
+  requestId?: string
+  timestamp?: string
+  deploymentId?: string
+  environment?: string
+  branch?: string
+  domain?: string
+  requestMethod?: string
+  requestPath?: string
+  /** Sometimes `0` — populated lazily by Vercel. Fall back to `events[]`. */
+  statusCode?: number
+  route?: string
+  cache?: string
+  clientUserAgent?: string
+  requestReferer?: string
+  requestSearchParams?: Record<string, string>
+  requestDurationMs?: number
+  clientRegion?: string
+  events?: VercelRequestLogEvent[]
+  proxyEvents?: VercelRequestLogEvent[]
+  functionEvents?: VercelRequestLogEvent[]
+}
+
+export interface VercelRequestLogsResponseBody {
+  rows?: VercelRequestLogRow[]
+  hasMoreRows?: boolean
+}
+
+export interface ListVercelTrafficEventsOptions {
+  /** Vercel API token (personal access token). Supplied per call — never stored in this package. */
+  token: string
+  /** Vercel project id (`prj_...`). */
+  projectId: string
+  /** Vercel team / owner id (`team_...`). */
+  teamId: string
+  /** Deployment environment to pull. Defaults to `production`. */
+  environment?: VercelTrafficEnvironment
+  /** Inclusive lower bound — epoch ms, ISO string, or Date. */
+  startDate: number | string | Date
+  /** Exclusive upper bound — epoch ms, ISO string, or Date. */
+  endDate: number | string | Date
+  /** Max pages to walk (the endpoint paginates by `page`). Defaults to 1. */
+  maxPages?: number
+  timeoutMs?: number
+}
+
+export interface VercelTrafficEventsPage {
+  events: NormalizedTrafficRequest[]
+  rawEntryCount: number
+  skippedEntryCount: number
+  /** True when the endpoint reported more rows than the page budget pulled. */
+  hasMore: boolean
+  endpoint: string
+}

--- a/packages/integration-vercel/test/vercel-client.test.ts
+++ b/packages/integration-vercel/test/vercel-client.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { VercelLogsApiError, listVercelTrafficEvents, normalizeVercelLogRow } from '../src/index.js'
+import type { VercelRequestLogRow } from '../src/index.js'
+
+// A serverless row where the top-level `statusCode` is 0 (Vercel populates it
+// lazily) — `status` must fall back to the last `events[].httpStatus`.
+const statusZeroRow: VercelRequestLogRow = {
+  requestId: 'xkhwp-1778784321070-22c8d2d3a690',
+  timestamp: '2026-05-14T18:45:21.070Z',
+  deploymentId: 'dpl_GN4o8XFnt6ZnfziroiCyCVpRir1E',
+  environment: 'production',
+  domain: 'project-5umza.vercel.app',
+  requestMethod: 'GET',
+  requestPath: '/api/no-log',
+  statusCode: 0,
+  branch: '',
+  cache: '',
+  clientUserAgent: 'ChatGPT-User/1.0',
+  requestSearchParams: { probe: 'nomw-chatgpt-1778784320' },
+  requestDurationMs: 0,
+  clientRegion: 'iad1',
+  requestReferer: 'https://chatgpt.com/',
+  proxyEvents: [],
+  functionEvents: [{ source: 'serverless', httpStatus: 200, region: 'iad1' }],
+  events: [{ source: 'serverless', httpStatus: 200, region: 'iad1' }],
+}
+
+// A static 404 with a valid top-level `statusCode`, an empty referer, and no
+// query params — empties must coerce to null.
+const favicon404Row: VercelRequestLogRow = {
+  requestId: '4ctc5-1778784026388-10219bcf8bec',
+  timestamp: '2026-05-14T18:40:26.388Z',
+  deploymentId: 'dpl_2Qik6u3MzrzHePJAWPDMk5pZCwic',
+  environment: 'production',
+  domain: 'project-5umza.vercel.app',
+  requestMethod: 'GET',
+  requestPath: '/favicon.png',
+  statusCode: 404,
+  clientUserAgent: 'vercel-favicon/1.0',
+  requestSearchParams: {},
+  requestDurationMs: 148,
+  clientRegion: 'sfo1',
+  requestReferer: '',
+  events: [
+    { source: 'edge-middleware', httpStatus: 200 },
+    { source: 'static', httpStatus: 404 },
+  ],
+}
+
+describe('normalizeVercelLogRow', () => {
+  it('maps a Vercel request-logs row into Canonry request evidence', () => {
+    expect(normalizeVercelLogRow(statusZeroRow)).toEqual({
+      sourceType: 'vercel',
+      evidenceKind: 'raw-request',
+      confidence: 'observed',
+      eventId: 'vercel:2026-05-14T18:45:21.070Z:xkhwp-1778784321070-22c8d2d3a690',
+      observedAt: '2026-05-14T18:45:21.070Z',
+      method: 'GET',
+      requestUrl: 'https://project-5umza.vercel.app/api/no-log?probe=nomw-chatgpt-1778784320',
+      host: 'project-5umza.vercel.app',
+      path: '/api/no-log',
+      queryString: 'probe=nomw-chatgpt-1778784320',
+      status: 200,
+      userAgent: 'ChatGPT-User/1.0',
+      remoteIp: null,
+      referer: 'https://chatgpt.com/',
+      latencyMs: 0,
+      requestSizeBytes: null,
+      responseSizeBytes: null,
+      providerResource: {
+        type: 'vercel_deployment',
+        labels: {
+          deploymentId: 'dpl_GN4o8XFnt6ZnfziroiCyCVpRir1E',
+          environment: 'production',
+          region: 'iad1',
+        },
+      },
+      providerLabels: {},
+    })
+  })
+
+  it('falls back to the last events[] httpStatus when top-level statusCode is 0', () => {
+    expect(normalizeVercelLogRow(statusZeroRow)?.status).toBe(200)
+  })
+
+  it('uses the top-level statusCode when it is a valid HTTP status', () => {
+    expect(normalizeVercelLogRow(favicon404Row)?.status).toBe(404)
+  })
+
+  it('coerces an empty referer and empty query params to null', () => {
+    const event = normalizeVercelLogRow(favicon404Row)
+    expect(event?.referer).toBeNull()
+    expect(event?.queryString).toBeNull()
+    expect(event?.requestUrl).toBe('https://project-5umza.vercel.app/favicon.png')
+  })
+
+  it('drops rows missing the request path, timestamp, or request id', () => {
+    expect(normalizeVercelLogRow({ ...statusZeroRow, requestPath: '' })).toBeNull()
+    expect(normalizeVercelLogRow({ ...statusZeroRow, timestamp: undefined })).toBeNull()
+    expect(normalizeVercelLogRow({ ...statusZeroRow, requestId: undefined })).toBeNull()
+  })
+})
+
+describe('listVercelTrafficEvents', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+  })
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  it('calls the request-logs endpoint with bearer auth + query params and paginates', async () => {
+    fetchSpy.mockImplementation(async (input: string | URL | Request) => {
+      const url = new URL(String(input))
+      const page = url.searchParams.get('page')
+      return new Response(
+        JSON.stringify({
+          rows: page === '0' ? [statusZeroRow] : [favicon404Row],
+          hasMoreRows: page === '0',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      )
+    })
+
+    const result = await listVercelTrafficEvents({
+      token: 'vcp_test',
+      projectId: 'prj_abc',
+      teamId: 'team_xyz',
+      startDate: '2026-05-14T18:00:00.000Z',
+      endDate: '2026-05-14T19:00:00.000Z',
+      maxPages: 3,
+    })
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+    const firstUrl = new URL(String(fetchSpy.mock.calls[0]![0]))
+    expect(firstUrl.origin + firstUrl.pathname).toBe('https://vercel.com/api/logs/request-logs')
+    expect(firstUrl.searchParams.get('projectId')).toBe('prj_abc')
+    expect(firstUrl.searchParams.get('teamId')).toBe('team_xyz')
+    expect(firstUrl.searchParams.get('ownerId')).toBe('team_xyz')
+    expect(firstUrl.searchParams.get('environment')).toBe('production')
+    expect(firstUrl.searchParams.get('page')).toBe('0')
+    expect(firstUrl.searchParams.get('startDate')).toBe(String(Date.parse('2026-05-14T18:00:00.000Z')))
+    expect(firstUrl.searchParams.get('endDate')).toBe(String(Date.parse('2026-05-14T19:00:00.000Z')))
+    expect(fetchSpy.mock.calls[0]![1]).toMatchObject({
+      method: 'GET',
+      headers: { Authorization: 'Bearer vcp_test' },
+    })
+    expect(new URL(String(fetchSpy.mock.calls[1]![0])).searchParams.get('page')).toBe('1')
+    expect(result.events.map((event) => event.path)).toEqual(['/api/no-log', '/favicon.png'])
+    expect(result.rawEntryCount).toBe(2)
+    expect(result.skippedEntryCount).toBe(0)
+    expect(result.hasMore).toBe(false)
+  })
+
+  it('stops paginating at maxPages even when more rows remain', async () => {
+    fetchSpy.mockImplementation(async () => new Response(
+      JSON.stringify({ rows: [statusZeroRow], hasMoreRows: true }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ))
+
+    const result = await listVercelTrafficEvents({
+      token: 'vcp_test',
+      projectId: 'prj_abc',
+      teamId: 'team_xyz',
+      startDate: 0,
+      endDate: 1,
+      maxPages: 2,
+    })
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+    expect(result.hasMore).toBe(true)
+  })
+
+  it('throws VercelLogsApiError with the HTTP status on a non-2xx response', async () => {
+    fetchSpy.mockImplementation(async () => new Response('forbidden', { status: 403 }))
+
+    const error = await listVercelTrafficEvents({
+      token: 'vcp_bad',
+      projectId: 'prj_abc',
+      teamId: 'team_xyz',
+      startDate: 0,
+      endDate: 1,
+    }).catch((err: unknown) => err)
+
+    expect(error).toBeInstanceOf(VercelLogsApiError)
+    expect((error as VercelLogsApiError).status).toBe(403)
+  })
+
+  it('counts rows that fail to normalize as skipped', async () => {
+    fetchSpy.mockImplementation(async () => new Response(
+      JSON.stringify({
+        rows: [statusZeroRow, { requestId: 'x', timestamp: '2026-01-01T00:00:00.000Z' }],
+        hasMoreRows: false,
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ))
+
+    const result = await listVercelTrafficEvents({
+      token: 'vcp_test',
+      projectId: 'prj_abc',
+      teamId: 'team_xyz',
+      startDate: 0,
+      endDate: 1,
+    })
+
+    expect(result.rawEntryCount).toBe(2)
+    expect(result.skippedEntryCount).toBe(1)
+    expect(result.events).toHaveLength(1)
+  })
+})

--- a/packages/integration-vercel/tsconfig.json
+++ b/packages/integration-vercel/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -407,6 +407,12 @@ importers:
         specifier: workspace:*
         version: link:../contracts
 
+  packages/integration-vercel:
+    dependencies:
+      '@ainyc/canonry-contracts':
+        specifier: workspace:*
+        version: link:../contracts
+
   packages/integration-wordpress:
     dependencies:
       '@ainyc/canonry-contracts':

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -36,6 +36,7 @@ const NODE_PACKAGES = [
   'integration-google',
   'integration-google-analytics',
   'integration-traffic',
+  'integration-vercel',
   'integration-wordpress',
   'integration-wordpress-traffic',
   'intelligence',


### PR DESCRIPTION
## Summary
- New `@ainyc/canonry-integration-vercel` package: a pure pull adapter over Vercel's internal `request-logs` endpoint that normalizes rows into provider-neutral `NormalizedTrafficRequest` events, with `VercelLogsApiError`, page-based pagination, and a `statusCode: 0` fallback to the `events[]` timeline.
- Unlike `vercel logs --json`, this endpoint exposes user-agent, referer, and query params natively, so AI crawler/referral classification needs no in-app instrumentation on the user's Vercel project.
- Adds `vercelTrafficSourceConfigSchema` and `trafficConnectVercelRequestSchema` (+ `vercelTrafficEnvironmentSchema`) to `packages/contracts`, registers the package in `vitest.config.ts`, and bumps the version to `4.30.0`.

## Test plan
- [x] `pnpm test` — contracts + integration-vercel suites pass (normalize mapping, status fallback, null coercion, dropped rows, pagination/`maxPages` cap, error path, skipped counts)
- [ ] `pnpm typecheck` and `pnpm lint` clean