### PR TITLE
feat(cli): add cnry alias for the canonry command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 - Watch AI engines crawl and refer traffic via [server-log ingestion](skills/canonry/references/server-side-traffic.md) — Cloud Run logs and the WordPress Traffic Logger plugin today
 - Diagnose against real traffic with built-in [GSC](docs/google-search-console-setup.md), [GA4](docs/google-analytics-setup.md), and [Bing Webmaster](docs/bing-webmaster-setup.md)
 - Execute fixes via [WordPress](docs/wordpress-setup.md), JSON-LD schema, and indexing submissions
-- Manage many clients declaratively — config-as-code YAML + `canonry apply`
+- Manage many clients declaratively — config-as-code YAML + `cnry apply`
 - Schedule recurring visibility checks AND traffic syncs, with webhook alerts on regressions
-- Generate client-ready HTML reports — `canonry report <project>`
+- Generate client-ready HTML reports — `cnry report <project>`
 - Drive from your own agent via the [67-tool MCP adapter](docs/mcp.md) or webhooks
 - Or use **Aero** — Canonry's built-in agent that wakes up after every run
 
@@ -22,28 +22,30 @@ Every dashboard view has a matching CLI command and API endpoint. The CLI is the
 
 ```bash
 npm install -g @ainyc/canonry
-canonry init
-canonry serve
+cnry init
+cnry serve
 ```
+
+The CLI installs as `cnry` (short form) and `canonry` — the two are interchangeable.
 
 Open [http://localhost:4100/setup](http://localhost:4100/setup). A guided wizard walks you through provider keys, project setup, queries, and your first visibility check.
 
 Prefer the terminal?
 
 ```bash
-canonry project create my-site --domain example.com
-canonry query add my-site "your first query" "second query"
-canonry run my-site --wait
-canonry evidence my-site
-canonry insights my-site
+cnry project create my-site --domain example.com
+cnry query add my-site "your first query" "second query"
+cnry run my-site --wait
+cnry evidence my-site
+cnry insights my-site
 ```
 
 ## If you get stuck
 
 | Problem | Fix |
 |---------|-----|
-| No provider key configured | Grab a free [Gemini key](https://aistudio.google.com/apikey), set `GEMINI_API_KEY`, restart `canonry serve`. |
-| No results after a run | Visibility checks are async — check the Runs tab or use `canonry run <project> --wait`. |
+| No provider key configured | Grab a free [Gemini key](https://aistudio.google.com/apikey), set `GEMINI_API_KEY`, restart `cnry serve`. |
+| No results after a run | Visibility checks are async — check the Runs tab or use `cnry run <project> --wait`. |
 | Not sure what queries to test | The setup wizard auto-generates them by analyzing your site. |
 | `npm install` fails on `node-gyp` | Install build tools for `better-sqlite3` ([guide](https://github.com/WiseLibs/better-sqlite3/blob/master/docs/troubleshooting.md)). |
 
@@ -57,7 +59,7 @@ canonry insights my-site
 | Perplexity | [perplexity.ai/settings/api](https://www.perplexity.ai/settings/api) | `PERPLEXITY_API_KEY` |
 | Local LLMs | Any OpenAI-compatible endpoint | `LOCAL_LLM_URL` |
 
-Configure during `canonry init`, in the dashboard `/settings`, or as env vars.
+Configure during `cnry init`, in the dashboard `/settings`, or as env vars.
 
 ## Documentation
 
@@ -69,7 +71,7 @@ Configure during `canonry init`, in the dashboard `/settings`, or as env vars.
 | **Integrations** | [GSC](docs/google-search-console-setup.md) · [GA4](docs/google-analytics-setup.md) · [Bing](docs/bing-webmaster-setup.md) · [WordPress](docs/wordpress-setup.md) · [Server-side traffic (Cloud Run + WordPress logs)](skills/canonry/references/server-side-traffic.md) |
 | **Deployment** — Docker, Railway, Render, systemd, Tailscale | [docs/deployment.md](docs/deployment.md) |
 | **API** — 118+ endpoints | `GET /api/v1/openapi.json` (no auth) |
-| **Skills bundle** for Claude Code / Codex | `canonry skills install` ([details](skills/canonry/SKILL.md)) |
+| **Skills bundle** for Claude Code / Codex | `cnry skills install` ([details](skills/canonry/SKILL.md)) |
 | **Roadmap & ADRs** | [docs/roadmap.md](docs/roadmap.md) · [docs/adr/](docs/adr/) |
 | **All docs** | [docs/README.md](docs/README.md) |
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.29.1",
+  "version": "4.30.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.29.1",
+  "version": "4.30.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",
@@ -15,6 +15,7 @@
   },
   "bin": {
     "canonry": "./bin/canonry.mjs",
+    "cnry": "./bin/canonry.mjs",
     "canonry-mcp": "./bin/canonry-mcp.mjs"
   },
   "exports": {

--- a/packages/canonry/src/cli.ts
+++ b/packages/canonry/src/cli.ts
@@ -7,9 +7,9 @@ import { dispatchRegisteredCommand } from './cli-dispatch.js'
 import { REGISTERED_CLI_COMMANDS } from './cli-commands.js'
 
 const USAGE = `
-canonry — AEO monitoring CLI
+cnry — AEO monitoring CLI   ('canonry' also works)
 
-Usage:  canonry <command> [options]
+Usage:  cnry <command> [options]
 
 Setup:
   init                  Initialize config and database
@@ -57,7 +57,7 @@ Global options:
   --help, -h            Show help (use with any command group)
   --version, -v         Show version
 
-Run 'canonry <command> --help' for details on a specific command.
+Run 'cnry <command> --help' for details on a specific command.
 `.trim()
 
 import { createRequire } from 'node:module'
@@ -131,11 +131,11 @@ export async function runCli(args = process.argv.slice(2)): Promise<number> {
     if (await dispatchRegisteredCommand(args, format, REGISTERED_CLI_COMMANDS)) {
       return 0
     }
-    throw usageError(`Error: unknown command: ${command}\nRun "canonry --help" for usage.`, {
+    throw usageError(`Error: unknown command: ${command}\nRun "cnry --help" for usage.`, {
       message: `unknown command: ${command}`,
       details: {
         command,
-        usage: 'canonry --help',
+        usage: 'cnry --help',
       },
     })
   } catch (err: unknown) {

--- a/packages/canonry/test/bin-alias.test.ts
+++ b/packages/canonry/test/bin-alias.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { createRequire } from 'node:module'
+
+const _require = createRequire(import.meta.url)
+const pkg = _require('../package.json') as { bin: Record<string, string> }
+
+describe('cnry bin alias', () => {
+  it('exposes both canonry and cnry pointing at the same CLI shim', () => {
+    expect(pkg.bin.canonry).toBe('./bin/canonry.mjs')
+    expect(pkg.bin.cnry).toBe('./bin/canonry.mjs')
+    // cnry is an alias, not a separate entrypoint — it must resolve to the same shim.
+    expect(pkg.bin.cnry).toBe(pkg.bin.canonry)
+  })
+
+  it('leaves the canonry-mcp bin under its full name', () => {
+    expect(pkg.bin['canonry-mcp']).toBe('./bin/canonry-mcp.mjs')
+    expect(pkg.bin['cnry-mcp']).toBeUndefined()
+  })
+})

--- a/packages/canonry/test/cli-operator-contract.test.ts
+++ b/packages/canonry/test/cli-operator-contract.test.ts
@@ -987,6 +987,6 @@ describe('operator CLI contract', () => {
     expect(parsed.error.code).toBe('CLI_USAGE_ERROR')
     expect(parsed.error.message).toBe('unknown command: does-not-exist')
     expect(parsed.error.details.command).toBe('does-not-exist')
-    expect(parsed.error.details.usage).toBe('canonry --help')
+    expect(parsed.error.details.usage).toBe('cnry --help')
   })
 })

--- a/skills/aero/SKILL.md
+++ b/skills/aero/SKILL.md
@@ -9,12 +9,12 @@ repository: https://github.com/AINYC/aero
 # Aero Orchestration Skill
 
 You coordinate across two tools to deliver comprehensive AEO monitoring:
-- **canonry** — the source of truth for project state (runs, snapshots, timelines, insights, audit log, **GA4 traffic + AI/social referrals**). Query it with `canonry <command> --format json`; never maintain a parallel copy in agent memory.
+- **canonry** — the source of truth for project state (runs, snapshots, timelines, insights, audit log, **GA4 traffic + AI/social referrals**). Query it with `cnry <command> --format json` (the CLI is also installed as `canonry` — the two are interchangeable); never maintain a parallel copy in agent memory.
 - **aeo-audit** — on-demand site analysis and fix generation.
 
 Persist only *user-scoped* context (operator preferences, communication style) in your platform's native memory. Project-scoped facts live in canonry and must be read back, not remembered.
 
-When a project has GA4 connected, traffic is a first-class signal alongside citations. Use `canonry ga traffic` / `canonry ga attribution --trend` for the current snapshot, `canonry ga ai-referral-history` and `canonry ga social-referral-history` for daily series. Reads query a local DB synced by `canonry ga sync` — confirm `canonry ga status` shows a recent `lastSyncedAt` before quoting numbers; if stale, re-sync first. Full command reference and return shapes live in the co-installed `canonry/references/canonry-cli.md` (look for the "Google Analytics 4" section).
+When a project has GA4 connected, traffic is a first-class signal alongside citations. Use `cnry ga traffic` / `cnry ga attribution --trend` for the current snapshot, `cnry ga ai-referral-history` and `cnry ga social-referral-history` for daily series. Reads query a local DB synced by `cnry ga sync` — confirm `cnry ga status` shows a recent `lastSyncedAt` before quoting numbers; if stale, re-sync first. Full command reference and return shapes live in the co-installed `canonry/references/canonry-cli.md` (look for the "Google Analytics 4" section).
 
 ## Judgment Rules
 

--- a/skills/aero/references/aeo-discovery.md
+++ b/skills/aero/references/aeo-discovery.md
@@ -24,7 +24,7 @@ Plus a competitor map: every non-canonical domain that shows up in probe citatio
 The operator runs:
 
 ```bash
-canonry discover run <project> --icp "..." --wait
+cnry discover run <project> --icp "..." --wait
 ```
 
 Or the MCP equivalent: `canonry_discover_run_start` with `{ project, request: { icpDescription, dedupThreshold?, maxProbes? } }`. The endpoint returns `{ runId, sessionId, status: "running" }` immediately and finishes the work in the background. Poll `canonry_discover_session_get` until `status` is `completed` or `failed`.
@@ -45,7 +45,7 @@ Per session: ~$1 at the default probe budget (100 queries × 1 Gemini grounded c
 Things to call out without being asked:
 
 - **High wasted-surface ratio** (≥ 40% of probes, or > cited count at ≥ 20%) → the project is missing from its own competitive space. The auto-written `discovery.basket-divergence` insight flags this as `high` severity.
-- **Recurring new competitor domains** in `competitorMap` that aren't already in the project's tracked competitor list → `canonry discover promote` adopts domains with at least 2 hits automatically alongside the queries; or add them à la carte with `canonry competitor add <project> <domain>`.
+- **Recurring new competitor domains** in `competitorMap` that aren't already in the project's tracked competitor list → `cnry discover promote` adopts domains with at least 2 hits automatically alongside the queries; or add them à la carte with `cnry competitor add <project> <domain>`.
 - **Aspirational greenfield** queries with no tracked competitor and no canonical cite → low-friction content opportunities.
 
 ## Promoting a session into the tracked basket
@@ -53,7 +53,7 @@ Things to call out without being asked:
 Once a session is `completed`, preview first unless the operator has already approved the write:
 
 ```bash
-canonry discover promote preview <project> <session-id>
+cnry discover promote preview <project> <session-id>
 ```
 
 Or the MCP equivalent: `canonry_discover_promote_preview` with `{ project, sessionId }`.
@@ -68,10 +68,10 @@ The preview returns every bucket so you can explain the tradeoff:
 Promote with one of these paths:
 
 ```bash
-canonry discover promote <project> <session-id>                          # cited + aspirational buckets + recurring competitor domains
-canonry discover promote <project> <session-id> --bucket aspirational    # scope to a bucket subset (repeatable / comma-separated)
-canonry discover promote <project> <session-id> --bucket wasted-surface  # explicitly track off-ICP competitor gaps
-canonry discover promote <project> <session-id> --no-competitors         # queries only, skip the competitor merge
+cnry discover promote <project> <session-id>                          # cited + aspirational buckets + recurring competitor domains
+cnry discover promote <project> <session-id> --bucket aspirational    # scope to a bucket subset (repeatable / comma-separated)
+cnry discover promote <project> <session-id> --bucket wasted-surface  # explicitly track off-ICP competitor gaps
+cnry discover promote <project> <session-id> --no-competitors         # queries only, skip the competitor merge
 ```
 
 Or the MCP equivalent:
@@ -107,7 +107,7 @@ Respond with:
 1. A one-line headline naming the dominant bucket.
 2. The top 2-3 wasted-surface queries (call `canonry_discover_session_get` to fetch them — don't guess).
 3. The top 1-2 recurring new competitor domains worth tracking, ignoring one-hit domains unless the operator asks for the full long tail.
-4. A single recommended next step. Examples: "preview and promote cited + aspirational findings (`canonry discover promote preview`, then `canonry discover promote`)", "the wasted-surface set warrants a content plan around X before tracking", "the aspirational set is greenfield — pick the 3 with highest commercial intent and write content".
+4. A single recommended next step. Examples: "preview and promote cited + aspirational findings (`cnry discover promote preview`, then `cnry discover promote`)", "the wasted-surface set warrants a content plan around X before tracking", "the aspirational set is greenfield — pick the 3 with highest commercial intent and write content".
 
 Do not recommend "promote everything" as the default. The safe path is: inspect session detail, preview promotion candidates, then promote the default cited + aspirational set. Escalate `wasted-surface` to tracking only when the operator deliberately chooses that tradeoff.
 
@@ -120,7 +120,7 @@ Keep it tight. The operator wakes to a short, decision-ready summary, not a full
 
 ## Failure modes
 
-- **Gemini not configured** → orchestrator throws early; `runs.status='failed'` with `Gemini provider is not configured.` Surface as "configure Gemini before running discovery" — link to `canonry init` or `~/.canonry/config.yaml`.
+- **Gemini not configured** → orchestrator throws early; `runs.status='failed'` with `Gemini provider is not configured.` Surface as "configure Gemini before running discovery" — link to `cnry init` or `~/.canonry/config.yaml`.
 - **Vertex-only Gemini** → embeddings step throws (Vertex embeddings deferred). Same surface, "use a Gemini API key for now."
 - **ICP missing** → route returns 400 with `VALIDATION_ERROR`. Ask the operator for the ICP description in plain language.
 - **Seed collapse (hyperlocal/niche businesses)** → 40 raw seeds collapse to 1-2 canonical queries after embedding+clustering, even at low dedup thresholds. This happens when Gemini generates seed queries that all live in the same semantic pocket (e.g. all variants of "boutique hotel Venice Beach"). The embedding model sees them as near-identical, so clustering produces one representative.
@@ -130,7 +130,7 @@ Keep it tight. The operator wakes to a short, decision-ready summary, not a full
   **Remediation:** break the ICP into 3-5 distinct purchase-intent angles and run one session per angle via `--icp-angle`:
 
   ```bash
-  canonry discover run <project> \
+  cnry discover run <project> \
     --icp-angle "romantic anniversary stay in Venice Beach" \
     --icp-angle "best rooftop bars and dining hotels LA" \
     --icp-angle "walkable Venice Beach hotels near Abbot Kinney" \

--- a/skills/aero/references/memory-patterns.md
+++ b/skills/aero/references/memory-patterns.md
@@ -22,12 +22,12 @@ Aero ships with a built-in durable notes store — the `canonry_memory_set`, `ca
 Prefer Aero's read tools (`canonry_project_overview`, `canonry_health_latest`, `canonry_timeline_get`, `canonry_insights_list`, `canonry_queries_list`, `canonry_competitors_list`, `canonry_run_get`) over shelling out, but the CLI exists for operators too:
 
 ```bash
-canonry status <project> --format json
-canonry health <project> --format json
-canonry timeline <project> --since <YYYY-MM-DD> --format json
-canonry insights <project> --format json
-canonry evidence <project> --format json
-canonry audit <project> --format json
+cnry status <project> --format json
+cnry health <project> --format json
+cnry timeline <project> --since <YYYY-MM-DD> --format json
+cnry insights <project> --format json
+cnry evidence <project> --format json
+cnry audit <project> --format json
 ```
 
 If the data you need isn't reachable with a single read tool or CLI call, that's a bug in canonry's API surface — file it rather than working around it in memory.
@@ -47,9 +47,9 @@ Derived interpretations (trend summaries, correlations between events) are cheap
 **CLI parity.** Operators can manage memory without talking to you:
 
 ```bash
-canonry agent memory list <project> --format json
-canonry agent memory set <project> --key <k> --value <v>
-canonry agent memory forget <project> --key <k>
+cnry agent memory list <project> --format json
+cnry agent memory set <project> --key <k> --value <v>
+cnry agent memory forget <project> --key <k>
 ```
 
 ## Good remember candidates

--- a/skills/aero/references/orchestration.md
+++ b/skills/aero/references/orchestration.md
@@ -10,7 +10,7 @@ description: Workflow recipes — baseline, regression response, weekly review, 
 Trigger: First sweep completes for a new project
 
 Steps:
-1. `canonry evidence <project> --format json` → get initial citation data
+1. `cnry evidence <project> --format json` → get initial citation data
 2. Compute baseline: cited rate, provider breakdown, top/bottom queries
 3. `npx @ainyc/aeo-audit "<domain>" --format json` → site readiness score
 4. Identify top 3 gaps (uncited queries with fixable site issues)
@@ -22,9 +22,9 @@ Steps:
 Trigger: Comparison shows decline or webhook fires regression.detected
 
 Steps:
-1. `canonry evidence <project> --format json` → current state
-2. `canonry history <project>` → trend for affected query
-3. Check indexing: `canonry google coverage <project>` → is the page still indexed?
+1. `cnry evidence <project> --format json` → current state
+2. `cnry history <project>` → trend for affected query
+3. Check indexing: `cnry google coverage <project>` → is the page still indexed?
 4. Check competitor: did a competitor gain the citation we lost?
 5. Audit the page: `npx @ainyc/aeo-audit "<page-url>" --format json`
 6. Diagnose cause: indexing issue / content issue / competitive displacement
@@ -37,7 +37,7 @@ Steps:
 Trigger: Scheduled (weekly, or on-demand)
 
 Steps:
-1. `canonry evidence <project> --format json` → current metrics
+1. `cnry evidence <project> --format json` → current metrics
 2. Compare to baseline/prior week from memory
 3. Compute deltas: citations gained, lost, stable
 4. Flag any new regressions not yet addressed
@@ -49,7 +49,7 @@ Steps:
 Trigger: User asks "why aren't we cited for X?" or multiple uncited queries detected
 
 Steps:
-1. `canonry evidence <project>` → confirm uncited
+1. `cnry evidence <project>` → confirm uncited
 2. Check if a relevant page exists on the domain
 3. If no page: recommend content creation (topic, target queries)
 4. If page exists: `npx @ainyc/aeo-audit "<page-url>"` → diagnose why uncited

--- a/skills/aero/references/reporting.md
+++ b/skills/aero/references/reporting.md
@@ -10,9 +10,9 @@ description: Weekly and monthly report templates with metric tables, regression/
 When a client asks for a "current state" or "AEO report" without a specific custom narrative, prefer the bundled report instead of hand-rolling sections:
 
 ```bash
-canonry report <project>                          # writes canonry-report-<project>-YYYY-MM-DD.html in cwd
-canonry report <project> --output dist/aeo.html   # custom path
-canonry report <project> --format json            # raw payload, useful for narrating in chat
+cnry report <project>                          # writes canonry-report-<project>-YYYY-MM-DD.html in cwd
+cnry report <project> --output dist/aeo.html   # custom path
+cnry report <project> --format json            # raw payload, useful for narrating in chat
 ```
 
 The HTML is self-contained (inline CSS + SVG charts, no network dependencies) and covers: executive summary, per-query × per-provider citation matrix, competitor landscape, AI citation sources, GSC + GA4 performance, social and AI referrals, indexing health, citations trend, prioritized insights, and recommended next steps. Same payload is available via `GET /api/v1/projects/<name>/report` and the `canonry_report` MCP tool — use `--format json` when you want to summarize specific numbers in a thread instead of attaching the file.

--- a/skills/canonry/SKILL.md
+++ b/skills/canonry/SKILL.md
@@ -36,6 +36,8 @@ Agent-first open-source AEO (Answer Engine Optimization) operating platform. Tra
 
 **Website:** [ainyc.ai](https://ainyc.ai) | **Docs:** [github.com/AINYC/canonry](https://github.com/AINYC/canonry)
 
+**CLI:** invoke as `cnry` (short form) or `canonry` — both ship with the npm package and are interchangeable. Examples in this skill use `cnry`.
+
 ## When to Use
 
 - Tracking query citations across AI providers
@@ -56,11 +58,11 @@ Agent-first open-source AEO (Answer Engine Optimization) operating platform. Tra
 
 A canonry engagement follows the same loop regardless of project size:
 
-1. **Diagnose** — Run a baseline sweep (`canonry run <project> --wait`) and a technical audit (`npx @ainyc/aeo-audit@latest <url> --format json`). See `references/aeo-analysis.md` for interpretation.
+1. **Diagnose** — Run a baseline sweep (`cnry run <project> --wait`) and a technical audit (`npx @ainyc/aeo-audit@latest <url> --format json`). See `references/aeo-analysis.md` for interpretation.
 2. **Prioritize** — Triage by impact: indexing gaps → schema gaps → content gaps → query strategy. Branded-term losses are urgent.
 3. **Execute** — Apply fixes via the canonry CLI or platform integrations. See `references/canonry-cli.md` for the full command catalog and `references/wordpress-integration.md` for the WordPress workflow.
 4. **Monitor** — Re-run sweeps weekly. Correlate visibility shifts with deployments and competitor moves.
-5. **Report** — Lead with data, not interpretation: "Lost `<query>` on Gemini between <date> and <date> — two competitors moved in. Here's what to fix." For a one-command client-facing summary, run `canonry report <project>` to generate a self-contained HTML bundle (executive summary, citation scorecard, competitor landscape, GSC + GA4 performance, insights). Same payload is available via `--format json` and the `canonry_report` MCP tool.
+5. **Report** — Lead with data, not interpretation: "Lost `<query>` on Gemini between <date> and <date> — two competitors moved in. Here's what to fix." For a one-command client-facing summary, run `cnry report <project>` to generate a self-contained HTML bundle (executive summary, citation scorecard, competitor landscape, GSC + GA4 performance, insights). Same payload is available via `--format json` and the `canonry_report` MCP tool.
 
 ## Common Starting Points
 
@@ -70,7 +72,7 @@ A canonry engagement follows the same loop regardless of project size:
 
 ## Google Analytics 4
 
-GA4 is a first-class signal alongside citation tracking. Connect once with `canonry ga connect <project> --property-id <id> --key-file <path>`; `canonry ga sync` then pulls daily landing-page traffic, AI-referral sessions across 10 known providers (chatgpt, perplexity, claude, gemini, openai, anthropic, copilot, phind, you.com, meta.ai), and social referrals split into Organic vs Paid via GA4's `channelGroup` — and persists everything into four DB tables (`gaTrafficSnapshots`, `gaAiReferrals`, `gaSocialReferrals`, `gaTrafficSummaries`). All read commands query that local store, so they are fast and quotaless once a sync has run. AI referrals are tracked across three GA4 attribution dimensions (session source / first-user source / manual UTM) and joined to landing pages, so you can see which page each AI provider sent traffic to. Use `canonry ga traffic` for the current snapshot, `canonry ga attribution --trend` for a unified channel-share overview with biggest-mover deltas, and `canonry ga ai-referral-history` / `canonry ga social-referral-history` for daily series. See `references/canonry-cli.md` for the full command catalog and return-shape details.
+GA4 is a first-class signal alongside citation tracking. Connect once with `cnry ga connect <project> --property-id <id> --key-file <path>`; `cnry ga sync` then pulls daily landing-page traffic, AI-referral sessions across 10 known providers (chatgpt, perplexity, claude, gemini, openai, anthropic, copilot, phind, you.com, meta.ai), and social referrals split into Organic vs Paid via GA4's `channelGroup` — and persists everything into four DB tables (`gaTrafficSnapshots`, `gaAiReferrals`, `gaSocialReferrals`, `gaTrafficSummaries`). All read commands query that local store, so they are fast and quotaless once a sync has run. AI referrals are tracked across three GA4 attribution dimensions (session source / first-user source / manual UTM) and joined to landing pages, so you can see which page each AI provider sent traffic to. Use `cnry ga traffic` for the current snapshot, `cnry ga attribution --trend` for a unified channel-share overview with biggest-mover deltas, and `cnry ga ai-referral-history` / `cnry ga social-referral-history` for daily series. See `references/canonry-cli.md` for the full command catalog and return-shape details.
 
 ## Boundaries & Safety
 

--- a/skills/canonry/references/aeo-analysis.md
+++ b/skills/canonry/references/aeo-analysis.md
@@ -57,7 +57,7 @@ Shows which source categories AI models cite for your queries. Helps identify:
 ### Step 1: Check indexing first
 Not cited ≠ bad content. Often the page isn't indexed yet.
 ```bash
-canonry google coverage <project>
+cnry google coverage <project>
 ```
 If key pages are "unknown to Google," submit them before drawing conclusions.
 
@@ -70,28 +70,28 @@ For competitive queries, if others are cited and the client isn't:
 - Do they have stronger schema/structured data?
 - Are they more established in the index?
 
-Run `canonry evidence <project> --format json` and check `competitorOverlap` in snapshots.
+Run `cnry evidence <project> --format json` and check `competitorOverlap` in snapshots.
 
 ### Step 4: Check across providers
 Gemini, OpenAI, Claude, and Perplexity may behave differently. One citing a domain while another doesn't is normal — each has its own knowledge base and update schedule.
 
 ### Step 5: Check analytics trends
 ```bash
-canonry analytics <project> --feature gaps --window 30d
+cnry analytics <project> --feature gaps --window 30d
 ```
 Look for patterns: are gaps growing or shrinking? Are new competitors appearing?
 
 ### Step 6: Check GA4 traffic for impact
 A lost citation isn't always a lost user. Before declaring a regression real, confirm whether AI-referral traffic actually fell on the same window:
 ```bash
-canonry ga status <project>                          # confirm lastSyncedAt is recent; re-sync if stale
-canonry ga ai-referral-history <project> --format json
+cnry ga status <project>                          # confirm lastSyncedAt is recent; re-sync if stale
+cnry ga ai-referral-history <project> --format json
                                                       # daily {date, source, medium, attribution, sessions, users}
-canonry ga attribution <project> --trend             # 7d/30d direction per channel + biggest mover
+cnry ga attribution <project> --trend             # 7d/30d direction per channel + biggest mover
 ```
 Read the result against the citation loss window:
 - **AI sessions flat or up** → the citation loss may be sweep-side noise (provider variance, query refresh). Track for one more cycle before alarming the client.
-- **AI sessions dropped on the same date** → real outage; escalate. Cross-reference `aiReferrals[]` from `canonry ga traffic` to identify which provider lost traffic.
+- **AI sessions dropped on the same date** → real outage; escalate. Cross-reference `aiReferrals[]` from `cnry ga traffic` to identify which provider lost traffic.
 - **Organic dropped but AI held** → the citation loss is masking a separate indexing issue. Re-run Step 1.
 
 GA4 also covers the inverse case: a *gain* on `attribution --trend` for the AI channel that isn't reflected in citation count usually means a provider expanded an existing citation's exposure (more queries triggering it) — a quiet win worth flagging in the next report.
@@ -106,14 +106,14 @@ GA4 also covers the inverse case: a *gain* on `attribution --trend` for the AI c
 - Did a competitor page launch?
 - Did the page get deindexed or go down?
 - Did the model update?
-- Check `canonry google deindexed <project>` for index losses
+- Check `cnry google deindexed <project>` for index losses
 
 **Fluctuation** (cited in some runs, not others) — normal for competitive queries. Track trend over 5+ runs before drawing conclusions. AI answers are non-deterministic.
 
 ## What to Recommend
 
 ### Low overall citation (< 50%)
-1. Audit indexing — `canonry google coverage <project>`
+1. Audit indexing — `cnry google coverage <project>`
 2. Submit unindexed pages to Google Indexing API
 3. Submit sitemap to Bing WMT + send IndexNow batch
 4. Check core pages for schema (LocalBusiness / Organization / FAQPage)

--- a/skills/canonry/references/canonry-cli.md
+++ b/skills/canonry/references/canonry-cli.md
@@ -1,15 +1,17 @@
 # Canonry CLI Reference
 
+The CLI is invoked as `cnry` (short form) or `canonry` — both ship with the `@ainyc/canonry` npm package and behave identically. This reference uses `cnry`.
+
 ## Server Management
 
 ```bash
-canonry init                                      # interactive setup
-canonry bootstrap                                 # non-interactive setup from env vars
-canonry start                                     # start daemon
-canonry stop                                      # stop daemon
-canonry serve                                     # foreground mode
-canonry serve --host 0.0.0.0 --port 4100
-canonry --version
+cnry init                                      # interactive setup
+cnry bootstrap                                 # non-interactive setup from env vars
+cnry start                                     # start daemon
+cnry stop                                      # stop daemon
+cnry serve                                     # foreground mode
+cnry serve --host 0.0.0.0 --port 4100
+cnry --version
 ```
 
 Production managed by PM2:
@@ -22,12 +24,12 @@ pm2 restart canonry
 ## Project Management
 
 ```bash
-canonry project list                              # list all projects
-canonry project create <name> --domain <url> --country US --language en
-canonry project show <name>                       # project detail
-canonry project update <name>                     # update project settings
-canonry project delete <name>                     # delete a project
-canonry status <project>                          # citation summary + domain info
+cnry project list                              # list all projects
+cnry project create <name> --domain <url> --country US --language en
+cnry project show <name>                       # project detail
+cnry project update <name>                     # update project settings
+cnry project delete <name>                     # delete a project
+cnry status <project>                          # citation summary + domain info
 ```
 
 ### Locations
@@ -35,32 +37,32 @@ canonry status <project>                          # citation summary + domain in
 Projects support multi-region location context for geographically-aware sweeps:
 
 ```bash
-canonry project add-location <name> --label "NYC" --city "New York" --region NY --country US
-canonry project locations <name>                  # list configured locations
-canonry project set-default-location <name> <label>
-canonry project remove-location <name> <label>
+cnry project add-location <name> --label "NYC" --city "New York" --region NY --country US
+cnry project locations <name>                  # list configured locations
+cnry project set-default-location <name> <label>
+cnry project remove-location <name> <label>
 ```
 
 ## Sweeps
 
 ```bash
-canonry snapshot "Acme Corp" --domain acme.example.com      # one-shot sales snapshot
-canonry snapshot "Acme Corp" --domain acme.example.com --md          # save markdown report
-canonry snapshot "Acme Corp" --domain acme.example.com --output report.md  # custom path
-canonry snapshot "Acme Corp" --domain acme.example.com --pdf         # save PDF report
-canonry snapshot "Acme Corp" --domain acme.example.com --format json
+cnry snapshot "Acme Corp" --domain acme.example.com      # one-shot sales snapshot
+cnry snapshot "Acme Corp" --domain acme.example.com --md          # save markdown report
+cnry snapshot "Acme Corp" --domain acme.example.com --output report.md  # custom path
+cnry snapshot "Acme Corp" --domain acme.example.com --pdf         # save PDF report
+cnry snapshot "Acme Corp" --domain acme.example.com --format json
 
-canonry run <project>                             # sweep all configured providers
-canonry run <project> --provider gemini           # single provider only
-canonry run <project> --query "alpha" --query "beta"  # scope sweep to a subset of tracked queries (repeatable)
-canonry run <project> --wait                      # block until complete
-canonry run <project> --location <label>          # run with specific location context
-canonry run <project> --all-locations             # run for every configured location
-canonry run <project> --no-location               # explicitly skip location context
-canonry run --all --wait                          # all projects
-canonry run cancel <project> [run-id]             # force-cancel stuck runs
-canonry runs <project> --limit 10                 # list recent runs
-canonry run show <id>                             # show run details
+cnry run <project>                             # sweep all configured providers
+cnry run <project> --provider gemini           # single provider only
+cnry run <project> --query "alpha" --query "beta"  # scope sweep to a subset of tracked queries (repeatable)
+cnry run <project> --wait                      # block until complete
+cnry run <project> --location <label>          # run with specific location context
+cnry run <project> --all-locations             # run for every configured location
+cnry run <project> --no-location               # explicitly skip location context
+cnry run --all --wait                          # all projects
+cnry run cancel <project> [run-id]             # force-cancel stuck runs
+cnry runs <project> --limit 10                 # list recent runs
+cnry run show <id>                             # show run details
 ```
 
 Run statuses: `queued` → `running` → `completed` / `failed` / `partial`
@@ -72,12 +74,12 @@ Run statuses: `queued` → `running` → `completed` / `failed` / `partial`
 ## Citation Data
 
 ```bash
-canonry evidence <project>                        # per-query cited/not-cited
-canonry evidence <project> --format json          # JSON output
-canonry history <project>                         # audit trail
-canonry export <project> --include-results        # export as YAML
-canonry backfill answer-visibility                # recompute answer visibility from stored answers
-canonry backfill answer-visibility --project <name> --format json
+cnry evidence <project>                        # per-query cited/not-cited
+cnry evidence <project> --format json          # JSON output
+cnry history <project>                         # audit trail
+cnry export <project> --include-results        # export as YAML
+cnry backfill answer-visibility                # recompute answer visibility from stored answers
+cnry backfill answer-visibility --project <name> --format json
 ```
 
 Output shows:
@@ -88,9 +90,9 @@ Output shows:
 ## Reports
 
 ```bash
-canonry report <project>                          # write canonry-report-<project>-YYYY-MM-DD.html
-canonry report <project> --output dist/aeo.html   # custom path
-canonry report <project> --format json            # raw report payload to stdout
+cnry report <project>                          # write canonry-report-<project>-YYYY-MM-DD.html
+cnry report <project> --output dist/aeo.html   # custom path
+cnry report <project> --format json            # raw report payload to stdout
 ```
 
 One-command client-facing AEO report. Bundles the latest visibility sweep, competitor landscape, AI citation sources, GSC + GA4 performance, social and AI referrals, indexing health, citations trend, prioritized insights, and recommended next steps into a self-contained HTML file (inline CSS + SVG charts, no network dependencies). Backed by `GET /api/v1/projects/<name>/report` and the `canonry_report` MCP tool.
@@ -106,56 +108,56 @@ Behavior to know when narrating numbers from the report:
 ## Analytics
 
 ```bash
-canonry analytics <project>                       # default analytics view
-canonry analytics <project> --feature metrics     # citation rate trends
-canonry analytics <project> --feature gaps        # brand gap analysis (cited/gap/uncited)
-canonry analytics <project> --feature sources     # source breakdown by category
-canonry analytics <project> --window 7d           # time window: 7d, 30d, 90d, all
+cnry analytics <project>                       # default analytics view
+cnry analytics <project> --feature metrics     # citation rate trends
+cnry analytics <project> --feature gaps        # brand gap analysis (cited/gap/uncited)
+cnry analytics <project> --feature sources     # source breakdown by category
+cnry analytics <project> --window 7d           # time window: 7d, 30d, 90d, all
 ```
 
 ## Intelligence
 
 ```bash
-canonry insights <project>                        # list active insights (regressions, gains, opportunities)
-canonry insights <project> --dismissed            # include dismissed insights
-canonry insights <project> --format json          # JSON output
-canonry insights dismiss <project> <id>           # dismiss an insight
-canonry health <project>                          # latest citation health snapshot
-canonry health <project> --history                # health trend over time
-canonry health <project> --history --limit 10     # limit history entries
-canonry health <project> --format json            # JSON output
-canonry backfill insights <project>              # backfill insights for all completed runs
-canonry backfill insights <project> --from-run <id> --to-run <id>  # backfill a range
+cnry insights <project>                        # list active insights (regressions, gains, opportunities)
+cnry insights <project> --dismissed            # include dismissed insights
+cnry insights <project> --format json          # JSON output
+cnry insights dismiss <project> <id>           # dismiss an insight
+cnry health <project>                          # latest citation health snapshot
+cnry health <project> --history                # health trend over time
+cnry health <project> --history --limit 10     # limit history entries
+cnry health <project> --format json            # JSON output
+cnry backfill insights <project>              # backfill insights for all completed runs
+cnry backfill insights <project> --from-run <id> --to-run <id>  # backfill a range
 ```
 
 ## Queries & Competitors
 
 ```bash
-canonry query add <project> "phrase one" "phrase two"
-canonry query remove <project> "phrase"
-canonry query list <project>
-canonry query import <project> queries.txt
-canonry query generate <project> --provider gemini --count 10 --save
+cnry query add <project> "phrase one" "phrase two"
+cnry query remove <project> "phrase"
+cnry query list <project>
+cnry query import <project> queries.txt
+cnry query generate <project> --provider gemini --count 10 --save
 
-canonry competitor add <project> competitor1.com competitor2.com
-canonry competitor list <project>
+cnry competitor add <project> competitor1.com competitor2.com
+cnry competitor list <project>
 ```
 
 ## Scheduling & Notifications
 
 ```bash
-canonry schedule set <project> --preset daily     # or: weekly, twice-daily, daily@09
-canonry schedule set <project> --cron "0 9 * * *" --timezone America/New_York
-canonry schedule show <project>
-canonry schedule enable <project>
-canonry schedule disable <project>
-canonry schedule remove <project>
+cnry schedule set <project> --preset daily     # or: weekly, twice-daily, daily@09
+cnry schedule set <project> --cron "0 9 * * *" --timezone America/New_York
+cnry schedule show <project>
+cnry schedule enable <project>
+cnry schedule disable <project>
+cnry schedule remove <project>
 
-canonry notify add <project> --webhook <url> --events citation.lost,citation.gained
-canonry notify events                             # list all available event types
-canonry notify list <project>
-canonry notify remove <project> <id>
-canonry notify test <project> <id>
+cnry notify add <project> --webhook <url> --events citation.lost,citation.gained
+cnry notify events                             # list all available event types
+cnry notify list <project>
+cnry notify remove <project> <id>
+cnry notify test <project> <id>
 ```
 
 Available events: `citation.lost`, `citation.gained`, `run.completed`, `run.failed`, `insight.critical`, `insight.high`
@@ -165,11 +167,11 @@ Available events: `citation.lost`, `citation.gained`, `run.completed`, `run.fail
 ## Provider Settings & Quotas
 
 ```bash
-canonry settings                                  # show config: providers, apiUrl, db path
-canonry settings --format json
-canonry settings provider gemini --api-key <KEY> --model gemini-2.5-flash
-canonry settings provider openai --max-per-day 1000 --max-per-minute 20
-canonry settings provider perplexity --api-key <KEY>
+cnry settings                                  # show config: providers, apiUrl, db path
+cnry settings --format json
+cnry settings provider gemini --api-key <KEY> --model gemini-2.5-flash
+cnry settings provider openai --max-per-day 1000 --max-per-minute 20
+cnry settings provider perplexity --api-key <KEY>
 ```
 
 Quota flags: `--max-concurrent`, `--max-per-minute`, `--max-per-day`
@@ -197,46 +199,46 @@ When Vertex AI is configured, no `GEMINI_API_KEY` is required. The provider uses
 ## Google Search Console
 
 ```bash
-canonry google connect <project>                          # initiate OAuth flow
-canonry google disconnect <project>                       # disconnect GSC
-canonry google status <project>                           # connection status
-canonry google properties <project>                       # list available properties
-canonry google set-property <project> <url>               # set GSC property URL
-canonry google set-sitemap <project> <url>                # set sitemap URL
-canonry google list-sitemaps <project>                    # list submitted sitemaps
-canonry google discover-sitemaps <project> --wait         # auto-discover and inspect
+cnry google connect <project>                          # initiate OAuth flow
+cnry google disconnect <project>                       # disconnect GSC
+cnry google status <project>                           # connection status
+cnry google properties <project>                       # list available properties
+cnry google set-property <project> <url>               # set GSC property URL
+cnry google set-sitemap <project> <url>                # set sitemap URL
+cnry google list-sitemaps <project>                    # list submitted sitemaps
+cnry google discover-sitemaps <project> --wait         # auto-discover and inspect
 
-canonry google sync <project>                             # sync GSC data
-canonry google sync <project> --days 30 --full --wait     # full sync with wait
+cnry google sync <project>                             # sync GSC data
+cnry google sync <project> --days 30 --full --wait     # full sync with wait
 
-canonry google coverage <project>                         # index coverage summary
-canonry google refresh <project>                         # force-fetch fresh GSC coverage data
-canonry google performance <project>                      # search performance data
-canonry google performance <project> --days 30 --keyword "term" --page "/url"
+cnry google coverage <project>                         # index coverage summary
+cnry google refresh <project>                         # force-fetch fresh GSC coverage data
+cnry google performance <project>                      # search performance data
+cnry google performance <project> --days 30 --keyword "term" --page "/url"
 
-canonry google inspect <project> <url>                    # inspect specific URL
-canonry google inspect-sitemap <project> --wait           # bulk inspect all sitemap URLs
-canonry google inspections <project>                      # inspection history
-canonry google inspections <project> --url <url>          # filter by URL
-canonry google deindexed <project>                        # pages that lost indexing
+cnry google inspect <project> <url>                    # inspect specific URL
+cnry google inspect-sitemap <project> --wait           # bulk inspect all sitemap URLs
+cnry google inspections <project>                      # inspection history
+cnry google inspections <project> --url <url>          # filter by URL
+cnry google deindexed <project>                        # pages that lost indexing
 
-canonry google request-indexing <project> <url>           # push URL to Google
-canonry google request-indexing <project> --all-unindexed # push all unknown pages
+cnry google request-indexing <project> <url>           # push URL to Google
+cnry google request-indexing <project> --all-unindexed # push all unknown pages
 ```
 
 ## Discovery (Tracked-Basket Expansion)
 
 ```bash
-canonry discover run <project> --icp "..." --wait --format json    # full pipeline: seed → embed → cluster → probe → bucket
-canonry discover run <project> --icp "..." --dedup-threshold 0.85  # tune cosine threshold (default 0.85)
-canonry discover run <project> --icp "..." --max-probes 100         # per-session probe budget (default 100, hard cap 500)
-canonry discover run <project> --icp-angle "angle 1" --icp-angle "angle 2" --wait  # multi-angle: one session per ICP angle, useful for hyperlocal/niche businesses
+cnry discover run <project> --icp "..." --wait --format json    # full pipeline: seed → embed → cluster → probe → bucket
+cnry discover run <project> --icp "..." --dedup-threshold 0.85  # tune cosine threshold (default 0.85)
+cnry discover run <project> --icp "..." --max-probes 100         # per-session probe budget (default 100, hard cap 500)
+cnry discover run <project> --icp-angle "angle 1" --icp-angle "angle 2" --wait  # multi-angle: one session per ICP angle, useful for hyperlocal/niche businesses
 
-canonry discover list <project>                                     # newest-first session list
-canonry discover show <project> <session-id>                        # per-query probe rows + buckets
-canonry discover promote preview <project> <session-id>             # preview bucketed candidates + recurring suggested competitors (read-only)
-canonry discover promote <project> <session-id>                     # adopt cited + aspirational queries + recurring competitors
-canonry discover promote <project> <session-id> --bucket aspirational --no-competitors   # scope to a bucket subset / skip competitor merge
+cnry discover list <project>                                     # newest-first session list
+cnry discover show <project> <session-id>                        # per-query probe rows + buckets
+cnry discover promote preview <project> <session-id>             # preview bucketed candidates + recurring suggested competitors (read-only)
+cnry discover promote <project> <session-id>                     # adopt cited + aspirational queries + recurring competitors
+cnry discover promote <project> <session-id> --bucket aspirational --no-competitors   # scope to a bucket subset / skip competitor merge
 ```
 
 Discovery requires Gemini configured (API key today; Vertex-mode embeddings are deferred). The pipeline writes a `discovery_sessions` row, a `runs` row (kind `aeo-discover-probe`), and one `discovery.basket-divergence` insight when the session completes. Aero wakes unprompted with the bucket-count payload so the operator can act without polling. `discover promote` defaults to cited + aspirational queries and recurring competitor domains; include `--bucket wasted-surface` explicitly for off-ICP competitor gaps. Promotion is add-only and idempotent — queries/domains already tracked are reported as skipped, never inserted twice — and only works on `completed` sessions; promoted rows carry `provenance="discovery:<sessionId>"`.
@@ -244,45 +246,45 @@ Discovery requires Gemini configured (API key today; Vertex-mode embeddings are 
 ## Bing Webmaster Tools
 
 ```bash
-canonry bing connect <project> --api-key <key>   # connect Bing WMT
-canonry bing disconnect <project>                # disconnect
-canonry bing status <project>                    # connection status
-canonry bing sites <project>                     # list verified sites
-canonry bing set-site <project> <url>            # set active site URL
-canonry bing coverage <project>                  # URL coverage data
-canonry bing refresh <project>                  # force-fetch fresh Bing coverage data
-canonry bing inspect <project> <url>             # inspect specific URL
-canonry bing inspect-sitemap <project>           # discover sitemap URLs and inspect each via Bing
-canonry bing inspect-sitemap <project> --sitemap-url <url> --wait  # explicit sitemap, wait for run
-canonry bing inspections <project>               # inspection history
-canonry bing request-indexing <project> <url>    # submit URL for indexing
-canonry bing request-indexing <project> --all-unindexed  # submit all unindexed
-canonry bing performance <project>               # search performance data
+cnry bing connect <project> --api-key <key>   # connect Bing WMT
+cnry bing disconnect <project>                # disconnect
+cnry bing status <project>                    # connection status
+cnry bing sites <project>                     # list verified sites
+cnry bing set-site <project> <url>            # set active site URL
+cnry bing coverage <project>                  # URL coverage data
+cnry bing refresh <project>                  # force-fetch fresh Bing coverage data
+cnry bing inspect <project> <url>             # inspect specific URL
+cnry bing inspect-sitemap <project>           # discover sitemap URLs and inspect each via Bing
+cnry bing inspect-sitemap <project> --sitemap-url <url> --wait  # explicit sitemap, wait for run
+cnry bing inspections <project>               # inspection history
+cnry bing request-indexing <project> <url>    # submit URL for indexing
+cnry bing request-indexing <project> --all-unindexed  # submit all unindexed
+cnry bing performance <project>               # search performance data
 ```
 
 ## WordPress Integration
 
 ```bash
-canonry wordpress connect <project> --url <url> --user <user>   # connect (prompts for app password)
-canonry wordpress disconnect <project>                          # disconnect
-canonry wordpress status <project>                              # connection status
-canonry wordpress pages <project> [--live|--staging]            # list pages
-canonry wordpress page <project> <slug>                         # show page detail
-canonry wordpress create-page <project> --title <t> --slug <s> --content <c>  # create page
-canonry wordpress update-page <project> <slug> --content <c>   # update page
-canonry wordpress set-meta <project> <slug> --title <t>        # set SEO meta (single page)
-canonry wordpress set-meta <project> --from <file>              # bulk set SEO meta from JSON
-canonry wordpress schema <project> <slug>                       # read page JSON-LD
-canonry wordpress schema deploy <project> --profile <file>      # deploy schema from profile
-canonry wordpress schema status <project>                       # schema status per page
-canonry wordpress set-schema <project> <slug>                   # manual schema handoff
-canonry wordpress audit <project>                               # audit pages for SEO issues
-canonry wordpress diff <project> <slug>                         # compare live vs staging
-canonry wordpress staging status <project>                      # staging config status
-canonry wordpress staging push <project>                        # manual staging push handoff
-canonry wordpress llms-txt <project>                            # read /llms.txt
-canonry wordpress set-llms-txt <project>                        # manual llms.txt handoff
-canonry wordpress onboard <project> --url <url> --user <user>  # full onboarding workflow
+cnry wordpress connect <project> --url <url> --user <user>   # connect (prompts for app password)
+cnry wordpress disconnect <project>                          # disconnect
+cnry wordpress status <project>                              # connection status
+cnry wordpress pages <project> [--live|--staging]            # list pages
+cnry wordpress page <project> <slug>                         # show page detail
+cnry wordpress create-page <project> --title <t> --slug <s> --content <c>  # create page
+cnry wordpress update-page <project> <slug> --content <c>   # update page
+cnry wordpress set-meta <project> <slug> --title <t>        # set SEO meta (single page)
+cnry wordpress set-meta <project> --from <file>              # bulk set SEO meta from JSON
+cnry wordpress schema <project> <slug>                       # read page JSON-LD
+cnry wordpress schema deploy <project> --profile <file>      # deploy schema from profile
+cnry wordpress schema status <project>                       # schema status per page
+cnry wordpress set-schema <project> <slug>                   # manual schema handoff
+cnry wordpress audit <project>                               # audit pages for SEO issues
+cnry wordpress diff <project> <slug>                         # compare live vs staging
+cnry wordpress staging status <project>                      # staging config status
+cnry wordpress staging push <project>                        # manual staging push handoff
+cnry wordpress llms-txt <project>                            # read /llms.txt
+cnry wordpress set-llms-txt <project>                        # manual llms.txt handoff
+cnry wordpress onboard <project> --url <url> --user <user>  # full onboarding workflow
 ```
 
 **Onboard** runs: connect → audit → set-meta → schema deploy → Google submit → Bing submit. Use `--skip-schema` or `--skip-submit` to skip steps. `--profile <file>` provides business data and page-to-schema mapping for schema deployment.
@@ -292,31 +294,31 @@ canonry wordpress onboard <project> --url <url> --user <user>  # full onboarding
 GA4 integration uses service account authentication (no OAuth). The service account must have Viewer access on the GA4 property. `ga sync` writes to four DB tables (`gaTrafficSnapshots`, `gaAiReferrals`, `gaSocialReferrals`, `gaTrafficSummaries`); every subsequent read command queries the local store rather than re-fetching from GA4, so reads are fast and quotaless. AI-referral rows are tracked across 10 known providers (chatgpt, perplexity, claude, gemini, openai, anthropic, copilot, phind, you.com, meta.ai), three GA4 attribution dimensions (`session` / `first_user` / `manual_utm`), and joined to landing pages. Social referrals are split Organic vs Paid via GA4's `sessionDefaultChannelGroup`. All commands support `--format json`.
 
 ```bash
-canonry ga connect <project> --property-id <id> --key-file ./sa-key.json
+cnry ga connect <project> --property-id <id> --key-file ./sa-key.json
                                                   # connect via service account (auth method = service_account)
-canonry ga disconnect <project>                  # disconnect; deletes all synced rows for the project
-canonry ga status <project>                      # connected, propertyId, authMethod, lastSyncedAt
-canonry ga sync <project> [--days 30] [--only traffic|ai|social]
+cnry ga disconnect <project>                  # disconnect; deletes all synced rows for the project
+cnry ga status <project>                      # connected, propertyId, authMethod, lastSyncedAt
+cnry ga sync <project> [--days 30] [--only traffic|ai|social]
                                                   # refresh from GA4 → DB; --only restricts which slice is replaced
                                                   # returns: synced, rowCount, aiReferralCount, socialReferralCount,
                                                   #          syncedComponents, syncedAt
-canonry ga traffic <project>                     # current-period rollup; returns: totalSessions,
+cnry ga traffic <project>                     # current-period rollup; returns: totalSessions,
                                                   # totalOrganicSessions/totalDirectSessions/totalUsers,
                                                   # organicSharePct/aiSharePct/socialSharePct/directSharePct,
                                                   # topPages[], aiReferrals[], aiReferralLandingPages[],
                                                   # aiSessionsDeduped, aiUsersBySession, socialReferrals[]
-canonry ga attribution <project> [--trend]       # unified channel breakdown (organic / ai / social / direct
+cnry ga attribution <project> [--trend]       # unified channel breakdown (organic / ai / social / direct
                                                   # sessions + raw and display share %s); --trend adds 7d/30d
                                                   # direction per channel + biggest mover
-canonry ga ai-referral-history <project>         # daily array of {date, source, medium, attribution,
+cnry ga ai-referral-history <project>         # daily array of {date, source, medium, attribution,
                                                   # sessions, users}; one row per (day × source × dimension)
-canonry ga social-referral-history <project>     # daily array of {date, source, medium, channel,
+cnry ga social-referral-history <project>     # daily array of {date, source, medium, channel,
                                                   # sessions, users}; channel ∈ {Organic Social, Paid Social}
-canonry ga social-referral-summary <project> [--trend]
+cnry ga social-referral-summary <project> [--trend]
                                                   # one-line social rollup: socialSessions, socialUsers,
                                                   # socialSharePct, topSources[]; --trend adds 7d/30d direction
-canonry ga session-history <project>             # daily totals: {date, sessions, organicSessions, users}
-canonry ga coverage <project>                    # per-page overlay: {landingPage, sessions,
+cnry ga session-history <project>             # daily totals: {date, sessions, organicSessions, users}
+cnry ga coverage <project>                    # per-page overlay: {landingPage, sessions,
                                                   # organicSessions, users}
 ```
 
@@ -324,20 +326,20 @@ Every read command queries persisted DB rows, so a stale `lastSyncedAt` means th
 
 ## Backlinks (Common Crawl)
 
-Workspace-level Common Crawl release sync + per-project backlink extraction. Requires DuckDB; install once with `canonry backlinks install`. Releases are downloaded once per workspace and reused across all projects.
+Workspace-level Common Crawl release sync + per-project backlink extraction. Requires DuckDB; install once with `cnry backlinks install`. Releases are downloaded once per workspace and reused across all projects.
 
 ```bash
-canonry backlinks install                         # install bundled DuckDB binary
-canonry backlinks doctor                          # show install + plugin status
-canonry backlinks status                          # latest workspace release sync
-canonry backlinks releases                        # list cached releases on disk
-canonry backlinks sync --release <id>             # download + query a release (workspace-wide)
-canonry backlinks sync --release <id> --wait      # block until ready/failed
-canonry backlinks list <project>                  # top linking domains for the project
-canonry backlinks list <project> --limit 100 --release <id>
-canonry backlinks extract <project>               # re-extract this project against the latest ready release
-canonry backlinks extract <project> --release <id> --wait
-canonry backlinks cache prune --release <id>      # delete cached release files from disk
+cnry backlinks install                         # install bundled DuckDB binary
+cnry backlinks doctor                          # show install + plugin status
+cnry backlinks status                          # latest workspace release sync
+cnry backlinks releases                        # list cached releases on disk
+cnry backlinks sync --release <id>             # download + query a release (workspace-wide)
+cnry backlinks sync --release <id> --wait      # block until ready/failed
+cnry backlinks list <project>                  # top linking domains for the project
+cnry backlinks list <project> --limit 100 --release <id>
+cnry backlinks extract <project>               # re-extract this project against the latest ready release
+cnry backlinks extract <project> --release <id> --wait
+cnry backlinks cache prune --release <id>      # delete cached release files from disk
 ```
 
 All commands support `--format json`. A release sync has statuses `queued` → `downloading` → `querying` → `ready` / `failed`. Per-project extract runs use the standard run statuses (`queued` → `running` → `completed` / `failed`). Projects with the `autoExtractBacklinks` setting enabled get an extract run enqueued automatically when a release sync transitions to `ready`.
@@ -347,10 +349,10 @@ All commands support `--format json`. A release sync has statuses `queued` → `
 The CDP (Chrome DevTools Protocol) provider enables browser-based queries against AI chat interfaces (e.g., ChatGPT). This gives more accurate results than API-based providers for some use cases.
 
 ```bash
-canonry cdp connect --host localhost --port 9222  # connect to Chrome CDP
-canonry cdp status                                # show connection status
-canonry cdp targets                               # list available targets (ChatGPT, etc.)
-canonry cdp screenshot <query> --targets chatgpt  # screenshot a query result
+cnry cdp connect --host localhost --port 9222  # connect to Chrome CDP
+cnry cdp status                                # show connection status
+cnry cdp targets                               # list available targets (ChatGPT, etc.)
+cnry cdp screenshot <query> --targets chatgpt  # screenshot a query result
 ```
 
 **Requires:** Chrome running with `--remote-debugging-port=9222`
@@ -358,18 +360,18 @@ canonry cdp screenshot <query> --targets chatgpt  # screenshot a query result
 ## Telemetry
 
 ```bash
-canonry telemetry status                          # show telemetry status
-canonry telemetry enable                          # enable anonymous telemetry
-canonry telemetry disable                         # disable telemetry
+cnry telemetry status                          # show telemetry status
+cnry telemetry enable                          # enable anonymous telemetry
+cnry telemetry disable                         # disable telemetry
 ```
 
 ## Config as Code
 
 ```bash
-canonry apply project.yaml                        # apply declarative config
-canonry apply file1.yaml file2.yaml               # multiple files
-canonry export <project> --include-results > project.yaml
-canonry sitemap inspect <project>
+cnry apply project.yaml                        # apply declarative config
+cnry apply file1.yaml file2.yaml               # multiple files
+cnry export <project> --include-results > project.yaml
+cnry sitemap inspect <project>
 ```
 
 ## Agent
@@ -382,21 +384,21 @@ drive Canonry from Claude Code / Codex / a custom agent.
 
 ```bash
 # One-shot turn — Aero picks its own tools, streams events to stdout.
-canonry agent ask <project> "<prompt>"
-canonry agent ask <project> "<prompt>" --format json      # JSON event stream
+cnry agent ask <project> "<prompt>"
+cnry agent ask <project> "<prompt>" --format json      # JSON event stream
 
 # Select a specific provider / model (otherwise auto-detected from config).
-canonry agent ask <project> "<prompt>" --provider anthropic --model claude-opus-4-7
-canonry agent ask <project> "<prompt>" --provider zai      --model glm-5.1
-canonry agent ask <project> "<prompt>" --provider openai
-canonry agent ask <project> "<prompt>" --provider google
+cnry agent ask <project> "<prompt>" --provider anthropic --model claude-opus-4-7
+cnry agent ask <project> "<prompt>" --provider zai      --model glm-5.1
+cnry agent ask <project> "<prompt>" --provider openai
+cnry agent ask <project> "<prompt>" --provider google
 
 # Restrict the tool surface. Default is --scope all (full 13-tool surface:
 # 7 read + 6 write). --scope read-only exposes only the 7 read tools and
 # is what the dashboard bar uses by default so pasted "Copy as CLI"
 # commands can't enable writes the UI turn couldn't perform.
-canonry agent ask <project> "<prompt>" --scope read-only
-canonry agent ask <project> "<prompt>" --scope all
+cnry agent ask <project> "<prompt>" --scope read-only
+cnry agent ask <project> "<prompt>" --scope all
 ```
 
 **Provider detection order** when `--provider` is omitted: `anthropic` →
@@ -404,7 +406,7 @@ canonry agent ask <project> "<prompt>" --scope all
 (from `~/.canonry/config.yaml` providers block, or the matching env var
 `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` / `ZAI_API_KEY`).
 
-Conversations **persist per project** — `canonry agent ask` continues the
+Conversations **persist per project** — `cnry agent ask` continues the
 same rolling thread each invocation. Reset with `DELETE /api/v1/projects/<name>/agent/transcript`
 or via the dashboard bar's reset button.
 
@@ -412,10 +414,10 @@ or via the dashboard bar's reset button.
 
 ```bash
 # Wire an external agent webhook to a project
-canonry agent attach <project> --url <webhook-url>        # register webhook subscription
-canonry agent attach <project> --url <url> --format json  # JSON output
-canonry agent detach <project>                            # remove the agent webhook
-canonry agent detach <project> --format json              # JSON output
+cnry agent attach <project> --url <webhook-url>        # register webhook subscription
+cnry agent attach <project> --url <url> --format json  # JSON output
+cnry agent detach <project>                            # remove the agent webhook
+cnry agent detach <project> --format json              # JSON output
 ```
 
 **Agent webhooks** fire on `run.completed`, `insight.critical`, `insight.high`, and `citation.gained`. The attach/detach pair is idempotent per project (one agent webhook per project, matched by source tag).

--- a/skills/canonry/references/indexing.md
+++ b/skills/canonry/references/indexing.md
@@ -14,7 +14,7 @@ Getting pages indexed fast is high-leverage AEO work. Unindexed pages are invisi
 
 ### Check coverage
 ```bash
-canonry google coverage <project>
+cnry google coverage <project>
 ```
 
 Statuses to act on:
@@ -24,43 +24,43 @@ Statuses to act on:
 
 ### Sync GSC data
 ```bash
-canonry google sync <project>                    # incremental sync
-canonry google sync <project> --full --wait      # full re-sync
+cnry google sync <project>                    # incremental sync
+cnry google sync <project> --full --wait      # full re-sync
 ```
 
 ### Check search performance
 ```bash
-canonry google performance <project>                        # default 28 days
-canonry google performance <project> --days 90 --keyword "term"
+cnry google performance <project>                        # default 28 days
+cnry google performance <project> --days 90 --keyword "term"
 ```
 
 ### Discover and inspect sitemaps
 ```bash
-canonry google discover-sitemaps <project> --wait   # auto-discover sitemaps and queue inspection
-canonry google list-sitemaps <project>               # list submitted sitemaps
-canonry google inspect-sitemap <project> --wait      # bulk inspect all sitemap URLs
+cnry google discover-sitemaps <project> --wait   # auto-discover sitemaps and queue inspection
+cnry google list-sitemaps <project>               # list submitted sitemaps
+cnry google inspect-sitemap <project> --wait      # bulk inspect all sitemap URLs
 ```
 
 ### Inspect individual URLs
 ```bash
-canonry google inspect <project> <url>              # inspect specific URL
-canonry google inspections <project>                # inspection history
-canonry google inspections <project> --url <url>    # filter by URL
-canonry google deindexed <project>                  # pages that lost indexing
+cnry google inspect <project> <url>              # inspect specific URL
+cnry google inspections <project>                # inspection history
+cnry google inspections <project> --url <url>    # filter by URL
+cnry google deindexed <project>                  # pages that lost indexing
 ```
 
 ### Submit URLs to Google Indexing API
 ```bash
 # Single URL
-canonry google request-indexing <project> <url>
+cnry google request-indexing <project> <url>
 
 # All unindexed at once
-canonry google request-indexing <project> --all-unindexed
+cnry google request-indexing <project> --all-unindexed
 ```
 
 **Requirements:**
 - "Web Search Indexing API" enabled in the GCP project
-- OAuth connection set up in canonry (`canonry settings` shows Google connection)
+- OAuth connection set up in canonry (`cnry settings` shows Google connection)
 - Officially intended for JobPosting/BroadcastEvent schema; in practice Google processes all URLs
 
 **After submitting:** Check coverage again after 48h. Once indexed, run a sweep — pages must be indexed before citation is possible.
@@ -71,37 +71,37 @@ canonry google request-indexing <project> --all-unindexed
 
 ### One-time setup
 ```bash
-canonry bing connect <project> --api-key <key>
-canonry bing set-site <project> https://example.com/
+cnry bing connect <project> --api-key <key>
+cnry bing set-site <project> https://example.com/
 ```
 
 Get API key from: https://www.bing.com/webmasters/ → Settings → API Access
 
 ### Check connection and coverage
 ```bash
-canonry bing status <project>
-canonry bing coverage <project>
-canonry bing performance <project>
+cnry bing status <project>
+cnry bing coverage <project>
+cnry bing performance <project>
 ```
 
 ### Inspect URLs
 ```bash
-canonry bing inspect <project> <url>
-canonry bing inspections <project>
+cnry bing inspect <project> <url>
+cnry bing inspections <project>
 ```
 
 ### Inspect every URL in your sitemap
 ```bash
-canonry bing inspect-sitemap <project>                       # default https://<domain>/sitemap.xml
-canonry bing inspect-sitemap <project> --sitemap-url <url>   # explicit sitemap or sitemap index
-canonry bing inspect-sitemap <project> --wait                # block until the run finishes
+cnry bing inspect-sitemap <project>                       # default https://<domain>/sitemap.xml
+cnry bing inspect-sitemap <project> --sitemap-url <url>   # explicit sitemap or sitemap index
+cnry bing inspect-sitemap <project> --wait                # block until the run finishes
 ```
 Bing has no native sitemap inspection API — this command fetches the sitemap, diffs against the tracked URL set, then calls `GetUrlInfo` for each discovered URL so coverage reflects the full sitemap rather than only previously inspected pages.
 
 ### Submit URLs for indexing
 ```bash
-canonry bing request-indexing <project> <url>
-canonry bing request-indexing <project> --all-unindexed
+cnry bing request-indexing <project> <url>
+cnry bing request-indexing <project> --all-unindexed
 ```
 
 ### Submit sitemap (manual, one-time)
@@ -143,20 +143,20 @@ Expected response: `202 Accepted`
 |---|---|
 | Get pages into ChatGPT / Perplexity / Claude | Google Indexing API |
 | Get pages into Copilot / Bing AI | IndexNow + Bing WMT |
-| Audit what Google currently knows | `canonry google coverage <project>` |
-| Audit what Bing currently knows | `canonry bing coverage <project>` |
+| Audit what Google currently knows | `cnry google coverage <project>` |
+| Audit what Bing currently knows | `cnry bing coverage <project>` |
 | Fast crawl of new/updated pages on Bing | IndexNow batch submit |
-| Ongoing Google crawl health | `canonry google sync` + `canonry google performance` |
-| Ongoing Bing crawl health | Bing WMT sitemap + `canonry bing performance` |
-| Find deindexed pages | `canonry google deindexed <project>` |
+| Ongoing Google crawl health | `cnry google sync` + `cnry google performance` |
+| Ongoing Bing crawl health | Bing WMT sitemap + `cnry bing performance` |
+| Find deindexed pages | `cnry google deindexed <project>` |
 
 ---
 
 ## General Workflow for New Client Pages
 
-1. `canonry google coverage <project>` — identify unindexed pages
-2. `canonry google request-indexing <project> --all-unindexed` — push to Google
-3. `canonry bing request-indexing <project> --all-unindexed` — push to Bing
+1. `cnry google coverage <project>` — identify unindexed pages
+2. `cnry google request-indexing <project> --all-unindexed` — push to Google
+3. `cnry bing request-indexing <project> --all-unindexed` — push to Bing
 4. Submit sitemap to Bing WMT (manual, one-time per site)
 5. Send IndexNow batch for key URLs
 6. Re-check coverage after 48h

--- a/skills/canonry/references/server-side-traffic.md
+++ b/skills/canonry/references/server-side-traffic.md
@@ -45,13 +45,13 @@ Future adapters slot in by implementing the same contract.
 # 1. Create a service account in the Cloud project that hosts the Cloud Run
 #    service. Grant it `roles/logging.viewer`. Download the JSON key.
 
-# 2. Connect from canonry CLI:
-canonry traffic connect cloud-run <project> \
+# 2. Connect from cnry CLI:
+cnry traffic connect cloud-run <project> \
   --gcp-project <gcp-project-id> \
   --service-account-key <path/to/key.json>
 
 # 3. (Optional) narrow to a specific service or location:
-canonry traffic connect cloud-run <project> \
+cnry traffic connect cloud-run <project> \
   --gcp-project <id> \
   --service-account-key <path> \
   --service my-service-name \
@@ -59,7 +59,7 @@ canonry traffic connect cloud-run <project> \
 ```
 
 Credentials are stored in `~/.canonry/config.yaml` (not the DB). The
-canonical key lives only on the host that runs `canonry serve`. The
+canonical key lives only on the host that runs `cnry serve`. The
 sync flow does NOT echo the private key back in any response.
 
 ## Connecting a WordPress source
@@ -82,8 +82,8 @@ exposes a paginated REST endpoint protected by an Application Password.
 #    7–365 days; default is 90. The page also shows the current event
 #    count and the oldest event timestamp.
 
-# 4. Connect from canonry CLI:
-canonry traffic connect wordpress <project> \
+# 4. Connect from cnry CLI:
+cnry traffic connect wordpress <project> \
   --url https://example.com \
   --username admin \
   --app-password "xxxx xxxx xxxx xxxx xxxx xxxx"
@@ -109,10 +109,10 @@ window change it in `Settings → Canonry Traffic Logger`.
 ```bash
 # Manual sync — defaults to a 30-day lookback on the first run; subsequent
 # runs are clamped forward to lastSyncedAt to avoid re-pulling.
-canonry traffic sync <project> --source <id>
+cnry traffic sync <project> --source <id>
 
 # Override the lookback window (minutes):
-canonry traffic sync <project> --source <id> --since-minutes 4320  # 3 days
+cnry traffic sync <project> --source <id> --since-minutes 4320  # 3 days
 ```
 
 Cross-sync dedupe via the `last_event_ids` ring buffer means re-running a
@@ -123,14 +123,14 @@ hits. Safe to schedule (see "Scheduling" below) or trigger from CI.
 
 ```bash
 # All sources with last-24h totals + latest sync run (single-call):
-canonry traffic status <project> --format json
+cnry traffic status <project> --format json
 
 # Just the source list:
-canonry traffic sources <project> --format json
+cnry traffic sources <project> --format json
 
 # Windowed events (defaults to last 24h):
-canonry traffic events <project> --kind crawler --limit 200 --format json
-canonry traffic events <project> --kind ai-referral --since 2026-04-01 --until 2026-04-30
+cnry traffic events <project> --kind crawler --limit 200 --format json
+cnry traffic events <project> --kind ai-referral --since 2026-04-01 --until 2026-04-30
 ```
 
 The `traffic status` composite returns the same per-source detail
@@ -144,8 +144,8 @@ MCP `canonry_traffic_status` tool.
 |---|---|
 | Project dashboard `/projects/:name/activity` | Live source table + 24h totals + GA4 referrals (combined view) |
 | Top-level `/traffic` route | Cross-project source admin (connect, sync, archive) |
-| `canonry report <project>` (HTML + SPA) | "AI Visibility — Server-Side" section, ranked above Indexing Health |
-| `canonry doctor --project <name>` | `traffic.source.connected`, `recent-data`, `credentials`, `scopes` checks |
+| `cnry report <project>` (HTML + SPA) | "AI Visibility — Server-Side" section, ranked above Indexing Health |
+| `cnry doctor --project <name>` | `traffic.source.connected`, `recent-data`, `credentials`, `scopes` checks |
 | MCP toolkit `traffic` | Tools: `canonry_traffic_status`, `_sources_list`, `_source_get`, `_events`, `_connect_cloud_run`, `_sync` |
 
 ## Doctor signals
@@ -154,15 +154,15 @@ The doctor checks are adapter-agnostic. When they fail or warn:
 
 | Check | Code | What to do |
 |---|---|---|
-| `traffic.source.connected` | `traffic.source.none` | No source — `canonry traffic connect cloud-run …` |
+| `traffic.source.connected` | `traffic.source.none` | No source — `cnry traffic connect cloud-run …` |
 | `traffic.source.connected` | `traffic.source.all-errored` | Re-connect the source. The check's `details.lastError` shows the underlying reason. |
-| `traffic.source.recent-data` | `traffic.recent-data.stale` | Last sync was >7d ago. Run `canonry traffic sync …` or schedule a recurring sync. |
-| `traffic.source.recent-data` | `traffic.recent-data.empty` | Source connected but no data in 30d. Verify config and credentials with `canonry traffic sources <project>`. |
+| `traffic.source.recent-data` | `traffic.recent-data.stale` | Last sync was >7d ago. Run `cnry traffic sync …` or schedule a recurring sync. |
+| `traffic.source.recent-data` | `traffic.recent-data.empty` | Source connected but no data in 30d. Verify config and credentials with `cnry traffic sources <project>`. |
 | `traffic.source.credentials` | `traffic.credentials.resolve-failed` | Service-account key in `~/.canonry/config.yaml` is invalid or expired. Re-connect. |
 
 ## Scheduling
 
-`canonry schedule` supports `--kind traffic-sync`. Recurring syncs are
+`cnry schedule` supports `--kind traffic-sync`. Recurring syncs are
 safe because of the `last_event_ids` cross-sync dedupe ring buffer
 described above. Recommended cadence:
 

--- a/skills/canonry/references/wordpress-integration.md
+++ b/skills/canonry/references/wordpress-integration.md
@@ -6,16 +6,16 @@ Canonry integrates with WordPress through the core REST API plus Application Pas
 
 - Read and write page content, titles, slugs, and status
 - Audit pages for `noindex`, missing SEO title, missing meta description, missing schema, and thin content
-- Compare live vs staging for a page with `canonry wordpress diff`
+- Compare live vs staging for a page with `cnry wordpress diff`
 - Update SEO meta when the site exposes writable REST meta fields
 
 ## What Stays Manual
 
 Canonry generates payloads and instructions for these workflows, but it does not apply them remotely:
 
-- `canonry wordpress set-schema`
-- `canonry wordpress set-llms-txt`
-- `canonry wordpress staging push`
+- `cnry wordpress set-schema`
+- `cnry wordpress set-llms-txt`
+- `cnry wordpress staging push`
 
 Expect those commands to return:
 
@@ -39,13 +39,13 @@ Env-sensitive commands accept `--live` or `--staging`. If neither is provided, c
 ## Typical Workflow
 
 ```bash
-canonry wordpress connect mysite --url https://example.com --user admin --staging-url https://staging.example.com --default-env staging
-canonry wordpress pages mysite --staging
-canonry wordpress page mysite pricing --staging
-canonry wordpress set-meta mysite pricing --title "SEO title" --description "Meta description" --staging
-canonry wordpress audit mysite --staging
-canonry wordpress diff mysite pricing
-canonry wordpress staging push mysite
+cnry wordpress connect mysite --url https://example.com --user admin --staging-url https://staging.example.com --default-env staging
+cnry wordpress pages mysite --staging
+cnry wordpress page mysite pricing --staging
+cnry wordpress set-meta mysite pricing --title "SEO title" --description "Meta description" --staging
+cnry wordpress audit mysite --staging
+cnry wordpress diff mysite pricing
+cnry wordpress staging push mysite
 ```
 
 ## Important Constraints


### PR DESCRIPTION
## Summary
Adds `cnry` as a second bin entry pointing at the same CLI shim as `canonry`, so the published `@ainyc/canonry` package installs both interchangeable commands. The `--help` banner, unknown-command error, README, and both bundled skills (canonry + aero) now lead with `cnry` and note the alias, while package names, file paths, MCP tool names, and product-name prose stay `canonry`. Adds `bin-alias.test.ts` asserting both bins resolve to the same shim, and bumps the version 4.29.1 → 4.30.0.

## Test plan
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` all pass (2574 tests green locally)
- [x] `npm i -g @ainyc/canonry`, then confirm both `cnry --version` and `canonry --version` work