### PR TITLE
fix(discovery): consolidate in-flight discover-run requests for the same ICP (#498)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.33.0",
+  "version": "4.33.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/discovery/routes.ts
+++ b/packages/api-routes/src/discovery/routes.ts
@@ -1,5 +1,5 @@
 import crypto from 'node:crypto'
-import { eq, desc } from 'drizzle-orm'
+import { and, desc, eq, gte, inArray } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import {
   competitors,
@@ -67,6 +67,21 @@ export interface DiscoveryRoutesOptions {
   onDiscoveryRunRequested?: OnDiscoveryRunRequested
 }
 
+/**
+ * Upper bound on the age of an in-flight discovery session that the route
+ * will consolidate onto. Rows in `queued`/`seeding`/`probing` older than
+ * this are presumed abandoned — the canonry-side handler was killed
+ * (process restart, OOM, SIGKILL) before its catch block in `discovery-run`
+ * could call `markSessionFailed`, leaving the row stuck. Without this guard
+ * every subsequent `discover run` for the same (project, ICP) would
+ * consolidate onto the zombie and never produce results. 2 hours is well
+ * above the orchestrator's realistic max runtime (~90 min for 500 probes at
+ * ~10s/probe + seed + classify), so a slow-but-still-running orchestrator
+ * is never falsely abandoned. The stale row itself is left untouched so an
+ * operator can inspect it via `canonry discover list`.
+ */
+const MAX_INFLIGHT_DISCOVERY_AGE_MS = 2 * 60 * 60 * 1000
+
 export async function discoveryRoutes(app: FastifyInstance, opts: DiscoveryRoutesOptions) {
   // POST /projects/:name/discover/run — kick off a discovery session
   app.post<{
@@ -109,10 +124,44 @@ export async function discoveryRoutes(app: FastifyInstance, opts: DiscoveryRoute
     }
 
     const now = new Date().toISOString()
-    const sessionId = crypto.randomUUID()
-    const runId = crypto.randomUUID()
 
-    app.db.transaction((tx) => {
+    // The lookup + insert run inside one transaction so two concurrent
+    // discover-run requests for the same ICP can't both miss the dedup check
+    // and start parallel sessions. SQLite serializes writers via the WAL —
+    // the second request blocks on the lock, then observes the first
+    // request's row and returns its IDs. Issue #498.
+    const ageFloorIso = new Date(Date.now() - MAX_INFLIGHT_DISCOVERY_AGE_MS).toISOString()
+    const decision = app.db.transaction((tx) => {
+      // `gte(createdAt, ageFloorIso)` keeps zombie rows from being reused.
+      // `orderBy desc` makes the choice deterministic when both a stale row
+      // and a fresh row exist for the same (project, ICP) — we always
+      // consolidate onto the newest match.
+      const existing = tx
+        .select({ id: discoverySessions.id, runId: discoverySessions.runId })
+        .from(discoverySessions)
+        .where(and(
+          eq(discoverySessions.projectId, project.id),
+          eq(discoverySessions.icpDescription, icpDescription),
+          inArray(discoverySessions.status, [
+            DiscoverySessionStatuses.queued,
+            DiscoverySessionStatuses.seeding,
+            DiscoverySessionStatuses.probing,
+          ]),
+          gte(discoverySessions.createdAt, ageFloorIso),
+        ))
+        .orderBy(desc(discoverySessions.createdAt))
+        .get()
+
+      // An in-flight session without a runId would be a legacy row from before
+      // the route always wrote one — treat it as not-reusable so the caller
+      // gets a real, kickoffable session.
+      if (existing && existing.runId) {
+        return { reused: true as const, sessionId: existing.id, runId: existing.runId }
+      }
+
+      const sessionId = crypto.randomUUID()
+      const runId = crypto.randomUUID()
+
       tx.insert(discoverySessions).values({
         id: sessionId,
         projectId: project.id,
@@ -140,11 +189,26 @@ export async function discoveryRoutes(app: FastifyInstance, opts: DiscoveryRoute
         entityType: 'discovery_session',
         entityId: sessionId,
       })
+
+      return { reused: false as const, sessionId, runId }
     })
 
+    if (decision.reused) {
+      // Nothing was inserted; do not fire the orchestrator callback again.
+      // The caller's `dedupThreshold` / `maxProbes` are intentionally
+      // dropped — the in-flight session was already started with its own
+      // config and changing it mid-flight would silently corrupt the run.
+      return reply.status(200).send({
+        runId: decision.runId,
+        sessionId: decision.sessionId,
+        status: 'running',
+        consolidated: true,
+      })
+    }
+
     opts.onDiscoveryRunRequested({
-      runId,
-      sessionId,
+      runId: decision.runId,
+      sessionId: decision.sessionId,
       projectId: project.id,
       icpDescription,
       dedupThreshold: parsed.data.dedupThreshold,
@@ -152,7 +216,12 @@ export async function discoveryRoutes(app: FastifyInstance, opts: DiscoveryRoute
       locations,
     })
 
-    return reply.status(201).send({ runId, sessionId, status: 'running' })
+    return reply.status(201).send({
+      runId: decision.runId,
+      sessionId: decision.sessionId,
+      status: 'running',
+      consolidated: false,
+    })
   })
 
   // GET /projects/:name/discover/sessions — list sessions for a project

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -2969,7 +2969,7 @@ const routeCatalog: OpenApiOperation[] = [
     path: '/api/v1/projects/{name}/discover/run',
     summary: 'Start a tracked-basket discovery session',
     description:
-      'Kicks off a discovery session for the project. The pipeline: ICP description → Gemini grounded seed prompt → embed + cluster (cosine ≥ 0.85 by default) → pick canonical representatives → probe each canonical via Gemini grounding → classify into cited / aspirational / wasted-surface → aggregate competitor map. Returns immediately with `{ runId, sessionId, status: "running" }`; the actual work runs in the background. Poll `GET /projects/{name}/discover/sessions/{id}` until `status` is `completed` or `failed`.',
+      'Kicks off a discovery session for the project. The pipeline: ICP description → Gemini grounded seed prompt → embed + cluster (cosine ≥ 0.85 by default) → pick canonical representatives → probe each canonical via Gemini grounding → classify into cited / aspirational / wasted-surface → aggregate competitor map. Returns immediately with `{ runId, sessionId, status: "running", consolidated }`; the actual work runs in the background. Poll `GET /projects/{name}/discover/sessions/{id}` until `status` is `completed` or `failed`. Concurrent/duplicate requests for the same (project, ICP) are consolidated onto a single in-flight session: the response carries `consolidated: true` and `200 OK` instead of `201`, and the request\'s `dedupThreshold` / `maxProbes` are ignored (the in-flight session keeps its original config).',
     tags: ['discovery'],
     parameters: [nameParameter],
     requestBody: {
@@ -2993,7 +2993,8 @@ const routeCatalog: OpenApiOperation[] = [
       },
     },
     responses: {
-      201: { description: 'Discovery session enqueued; returns { runId, sessionId, status }.' },
+      200: { description: 'An in-flight session with the same project + ICP was reused; returns { runId, sessionId, status, consolidated: true }. The request\'s dedupThreshold / maxProbes are ignored.' },
+      201: { description: 'New discovery session enqueued; returns { runId, sessionId, status, consolidated: false }.' },
       400: { description: 'Missing or invalid ICP / parameters.' },
       404: { description: 'Project not found.' },
     },

--- a/packages/api-routes/test/discovery.test.ts
+++ b/packages/api-routes/test/discovery.test.ts
@@ -744,6 +744,261 @@ describe('discovery routes', () => {
     expect(db.select().from(runs).all()).toHaveLength(0)
   })
 
+  it('POST /discover/run reuses an in-flight session with the same ICP (no new rows, no callback)', async () => {
+    // The fragmentation bug in issue #498: back-to-back `canonry discover run`
+    // commands today fire a fresh Gemini seed each time. Consolidation keeps
+    // the in-flight session and tells the caller the existing IDs.
+    const calls: Array<{ runId: string; sessionId: string; projectId: string; icp: string }> = []
+    const { app, db, tmpDir } = buildAppWithRoutes(calls)
+    cleanups.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }))
+    seedProject(db)
+
+    const first = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/demand-iq/discover/run',
+      payload: { icpDescription: 'industrial coatings' },
+    })
+    expect(first.statusCode).toBe(201)
+    const firstBody = first.json() as { runId: string; sessionId: string; consolidated?: boolean }
+    expect(firstBody.consolidated).toBeFalsy()
+
+    // Simulate the orchestrator picking up the session — the row is now in a
+    // non-terminal status, exactly when a second invocation would race in.
+    db.update(discoverySessions).set({ status: 'probing' }).run()
+
+    const second = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/demand-iq/discover/run',
+      payload: { icpDescription: 'industrial coatings' },
+    })
+    expect(second.statusCode).toBe(200)
+    const secondBody = second.json() as {
+      runId: string
+      sessionId: string
+      status: string
+      consolidated: boolean
+    }
+    expect(secondBody.consolidated).toBe(true)
+    expect(secondBody.sessionId).toBe(firstBody.sessionId)
+    expect(secondBody.runId).toBe(firstBody.runId)
+
+    // The expensive seed/probe pipeline must not be re-kicked.
+    expect(calls).toHaveLength(1)
+    expect(db.select().from(discoverySessions).all()).toHaveLength(1)
+    expect(db.select().from(runs).all()).toHaveLength(1)
+  })
+
+  it('POST /discover/run reuses a queued session (status check covers the pre-orchestrator window)', async () => {
+    const calls: Array<{ runId: string; sessionId: string }> = []
+    const { app, db, tmpDir } = buildAppWithRoutes(calls as never)
+    cleanups.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }))
+    seedProject(db)
+
+    const first = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/demand-iq/discover/run',
+      payload: { icpDescription: 'industrial coatings' },
+    })
+    const firstBody = first.json() as { sessionId: string }
+
+    // Sit it in `queued` — the orchestrator hasn't started yet. A second POST
+    // racing in here must still consolidate.
+    expect(db.select().from(discoverySessions).get()!.status).toBe('queued')
+
+    const second = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/demand-iq/discover/run',
+      payload: { icpDescription: 'industrial coatings' },
+    })
+    const secondBody = second.json() as { sessionId: string; consolidated: boolean }
+    expect(secondBody.consolidated).toBe(true)
+    expect(secondBody.sessionId).toBe(firstBody.sessionId)
+    expect(calls).toHaveLength(1)
+  })
+
+  it('POST /discover/run does NOT consolidate a completed session — that path is for seed-reuse, not consolidation', async () => {
+    const calls: Array<{ sessionId: string }> = []
+    const { app, db, tmpDir } = buildAppWithRoutes(calls as never)
+    cleanups.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }))
+    const { projectId } = seedProject(db)
+
+    db.insert(discoverySessions).values({
+      id: 'old_completed',
+      projectId,
+      status: 'completed',
+      icpDescription: 'industrial coatings',
+      competitorMap: '[]',
+      createdAt: new Date().toISOString(),
+    }).run()
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/demand-iq/discover/run',
+      payload: { icpDescription: 'industrial coatings' },
+    })
+    expect(response.statusCode).toBe(201)
+    const body = response.json() as { sessionId: string; consolidated?: boolean }
+    expect(body.consolidated).toBeFalsy()
+    expect(body.sessionId).not.toBe('old_completed')
+    expect(calls).toHaveLength(1)
+    expect(db.select().from(discoverySessions).all()).toHaveLength(2)
+  })
+
+  it('POST /discover/run does NOT consolidate a failed session', async () => {
+    const calls: Array<{ sessionId: string }> = []
+    const { app, db, tmpDir } = buildAppWithRoutes(calls as never)
+    cleanups.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }))
+    const { projectId } = seedProject(db)
+
+    db.insert(discoverySessions).values({
+      id: 'old_failed',
+      projectId,
+      status: 'failed',
+      icpDescription: 'industrial coatings',
+      competitorMap: '[]',
+      error: 'gemini quota',
+      createdAt: new Date().toISOString(),
+    }).run()
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/demand-iq/discover/run',
+      payload: { icpDescription: 'industrial coatings' },
+    })
+    expect(response.statusCode).toBe(201)
+    expect((response.json() as { consolidated?: boolean }).consolidated).toBeFalsy()
+    expect(calls).toHaveLength(1)
+  })
+
+  it('POST /discover/run creates a new session when the ICP differs from the in-flight one', async () => {
+    const calls: Array<{ icp: string }> = []
+    const { app, db, tmpDir } = buildAppWithRoutes(calls as never)
+    cleanups.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }))
+    seedProject(db)
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/demand-iq/discover/run',
+      payload: { icpDescription: 'industrial coatings' },
+    })
+    db.update(discoverySessions).set({ status: 'probing' }).run()
+
+    const second = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/demand-iq/discover/run',
+      payload: { icpDescription: 'aerospace coatings' },
+    })
+    expect(second.statusCode).toBe(201)
+    expect((second.json() as { consolidated?: boolean }).consolidated).toBeFalsy()
+    expect(calls).toHaveLength(2)
+    expect(db.select().from(discoverySessions).all()).toHaveLength(2)
+  })
+
+  it('POST /discover/run consolidates when the second call only differs by surrounding whitespace', async () => {
+    // The route already trims; the consolidation key must use the same
+    // normalized form so an operator who adds a stray space in a follow-up
+    // command doesn't start a duplicate sweep.
+    const calls: Array<{ icp: string }> = []
+    const { app, db, tmpDir } = buildAppWithRoutes(calls as never)
+    cleanups.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }))
+    seedProject(db)
+
+    const first = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/demand-iq/discover/run',
+      payload: { icpDescription: 'industrial coatings' },
+    })
+    const firstBody = first.json() as { sessionId: string }
+    db.update(discoverySessions).set({ status: 'probing' }).run()
+
+    const second = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/demand-iq/discover/run',
+      payload: { icpDescription: '  industrial coatings  ' },
+    })
+    const secondBody = second.json() as { sessionId: string; consolidated: boolean }
+    expect(secondBody.consolidated).toBe(true)
+    expect(secondBody.sessionId).toBe(firstBody.sessionId)
+    expect(calls).toHaveLength(1)
+  })
+
+  it('POST /discover/run consolidates when both calls fall back to project.icpDescription', async () => {
+    const calls: Array<{ icp: string }> = []
+    const { app, db, tmpDir } = buildAppWithRoutes(calls as never)
+    cleanups.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }))
+    seedProject(db, { icpDescription: 'industrial coatings' })
+
+    const first = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/demand-iq/discover/run',
+      payload: {},
+    })
+    const firstBody = first.json() as { sessionId: string }
+    db.update(discoverySessions).set({ status: 'probing' }).run()
+
+    const second = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/demand-iq/discover/run',
+      payload: {},
+    })
+    const secondBody = second.json() as { sessionId: string; consolidated: boolean }
+    expect(secondBody.consolidated).toBe(true)
+    expect(secondBody.sessionId).toBe(firstBody.sessionId)
+    expect(calls).toHaveLength(1)
+  })
+
+  it('POST /discover/run does NOT consolidate onto a zombie session past the staleness threshold', async () => {
+    // If the canonry-side handler is killed mid-run before its catch block
+    // can call markSessionFailed, the row gets stuck in seeding/probing
+    // forever. Without an age guard every subsequent discover-run for the
+    // same (project, ICP) would consolidate onto that zombie and never
+    // complete. We pick an age comfortably past the 2-hour threshold so
+    // this test doesn't flake if the constant nudges later.
+    const calls: Array<{ sessionId: string }> = []
+    const { app, db, tmpDir } = buildAppWithRoutes(calls as never)
+    cleanups.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }))
+    const { projectId } = seedProject(db)
+
+    const longAgoIso = new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString()
+    db.insert(discoverySessions).values({
+      id: 'zombie_session',
+      projectId,
+      runId: 'zombie_run',
+      status: 'probing',
+      icpDescription: 'industrial coatings',
+      competitorMap: '[]',
+      createdAt: longAgoIso,
+    }).run()
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/demand-iq/discover/run',
+      payload: { icpDescription: 'industrial coatings' },
+    })
+    expect(response.statusCode).toBe(201)
+    const body = response.json() as { sessionId: string; consolidated: boolean }
+    expect(body.consolidated).toBe(false)
+    expect(body.sessionId).not.toBe('zombie_session')
+    expect(calls).toHaveLength(1)
+    // Stale row is left in place for an operator to inspect — we only
+    // refuse to consolidate onto it; the new session is the second row.
+    expect(db.select().from(discoverySessions).all()).toHaveLength(2)
+
+    // A follow-up call now consolidates onto the fresh session (orderBy
+    // desc + age guard pick the newest non-stale row), not the zombie.
+    const followUp = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/demand-iq/discover/run',
+      payload: { icpDescription: 'industrial coatings' },
+    })
+    expect(followUp.statusCode).toBe(200)
+    const followUpBody = followUp.json() as { sessionId: string; consolidated: boolean }
+    expect(followUpBody.consolidated).toBe(true)
+    expect(followUpBody.sessionId).toBe(body.sessionId)
+    expect(followUpBody.sessionId).not.toBe('zombie_session')
+    expect(calls).toHaveLength(1)
+  })
+
   it('GET /discover/sessions returns sessions newest-first', async () => {
     const { app, db, tmpDir } = buildAppWithRoutes([])
     cleanups.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }))

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.33.0",
+  "version": "4.33.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/client.ts
+++ b/packages/canonry/src/client.ts
@@ -158,6 +158,13 @@ export interface DiscoveryRunStartResponse {
   runId: string
   sessionId: string
   status: 'running'
+  /**
+   * True when the request landed on an already-in-flight session for the same
+   * project + ICP. Returned IDs point at the existing session; no new
+   * orchestrator run was kicked off and the caller's `dedupThreshold` /
+   * `maxProbes` were ignored. Issue #498.
+   */
+  consolidated: boolean
 }
 
 /**

--- a/packages/canonry/src/commands/discover.ts
+++ b/packages/canonry/src/commands/discover.ts
@@ -112,10 +112,20 @@ export async function discoverRun(project: string, opts: DiscoverRunOptions): Pr
     }
     for (const { angle, start } of runs) {
       if (angle) console.log(`[${angle}]`)
-      console.log(`Discovery run started: ${start.runId}`)
-      console.log(`  Session: ${start.sessionId}`)
-      console.log(`  Status:  ${start.status}`)
-      console.log(`  Tail:    canonry discover show ${project} ${start.sessionId}`)
+      // The headline must tell the operator whether a fresh sweep started or
+      // whether the route latched onto an in-flight one — otherwise the
+      // expensive Gemini seed call looks identical from the CLI. Issue #498.
+      if (start.consolidated) {
+        console.log(`Reusing in-flight discovery session: ${start.sessionId}`)
+        console.log(`  Run:     ${start.runId}`)
+        console.log(`  Status:  ${start.status}`)
+        console.log(`  Tail:    canonry discover show ${project} ${start.sessionId}`)
+      } else {
+        console.log(`Discovery run started: ${start.runId}`)
+        console.log(`  Session: ${start.sessionId}`)
+        console.log(`  Status:  ${start.status}`)
+        console.log(`  Tail:    canonry discover show ${project} ${start.sessionId}`)
+      }
       if (runs.length > 1) console.log()
     }
     return

--- a/packages/canonry/test/discover-commands.test.ts
+++ b/packages/canonry/test/discover-commands.test.ts
@@ -339,6 +339,63 @@ describe('discover CLI commands', () => {
     // The 400 short-circuits before any session row is written.
     expect(db.select().from(discoverySessions).all()).toHaveLength(0)
   })
+
+  it('discover run --format json carries consolidated=true when an in-flight session is reused (issue #498)', async () => {
+    // Seed a session that looks in-flight — the route should latch on rather
+    // than starting a second seed/probe sweep.
+    const existingSessionId = crypto.randomUUID()
+    const existingRunId = crypto.randomUUID()
+    db.insert(discoverySessions).values({
+      id: existingSessionId,
+      projectId,
+      runId: existingRunId,
+      status: 'probing',
+      icpDescription: 'in-flight icp',
+      competitorMap: '[]',
+      createdAt: new Date().toISOString(),
+    }).run()
+
+    const result = await invokeCli([
+      'discover', 'run', 'demand-iq',
+      '--icp', 'in-flight icp',
+      '--format', 'json',
+    ])
+    expect(result.exitCode).toBeUndefined()
+
+    const json = parseJsonOutput(result.stdout) as DiscoveryRunStartResponse
+    expect(json.consolidated).toBe(true)
+    expect(json.sessionId).toBe(existingSessionId)
+    expect(json.runId).toBe(existingRunId)
+
+    // No new session row was created — the bug the issue calls out is the
+    // explosion of micro-sessions, so the contract here is "exactly one row".
+    expect(db.select().from(discoverySessions).all()).toHaveLength(1)
+  })
+
+  it('discover run prints a "Reusing in-flight session" line when the response is consolidated', async () => {
+    const existingSessionId = crypto.randomUUID()
+    const existingRunId = crypto.randomUUID()
+    db.insert(discoverySessions).values({
+      id: existingSessionId,
+      projectId,
+      runId: existingRunId,
+      status: 'probing',
+      icpDescription: 'in-flight icp',
+      competitorMap: '[]',
+      createdAt: new Date().toISOString(),
+    }).run()
+
+    const result = await invokeCli([
+      'discover', 'run', 'demand-iq',
+      '--icp', 'in-flight icp',
+    ])
+    expect(result.exitCode).toBeUndefined()
+    // The operator sees clearly that no fresh sweep started — "Discovery run
+    // started" would mislead them into thinking they paid for another seed.
+    expect(result.stdout).toContain('Reusing in-flight discovery session')
+    expect(result.stdout).toContain(existingSessionId)
+    expect(result.stdout).not.toContain('Discovery run started')
+  })
 })
 
 describe('resolveIcpAngles', () => {


### PR DESCRIPTION
## Summary

- Back-to-back `canonry discover run` calls for the same `(project, ICP)` no longer fire fresh Gemini seed/probe pipelines — `POST /discover/run` now looks up an in-flight session inside the insert transaction and returns `200 { consolidated: true, runId, sessionId }` pointing at the existing row when one is found.
- An age guard (`MAX_INFLIGHT_DISCOVERY_AGE_MS = 2h`) prevents consolidation onto zombies stuck in `seeding`/`probing` after a process crash; the route falls through and starts a fresh session, leaving the stale row for an operator to inspect.
- The CLI prints "Reusing in-flight discovery session …" on the consolidated path so an operator can tell a reuse from a fresh sweep; `DiscoveryRunStartResponse` carries the new `consolidated: boolean`, and the OpenAPI spec documents the 200 response and the new field.

## Test plan

- [ ] `pnpm typecheck` clean
- [ ] `pnpm lint` clean
- [ ] api-routes + canonry vitest suites pass (1398/1398 locally), including new tests covering: in-flight reuse, queued-state reuse, completed/failed sessions are NOT reused, different ICPs create separate sessions, whitespace/project-default ICP normalization consolidates, and the zombie staleness guard
- [ ] `canonry discover run <project> --icp "..."` shows "Discovery run started" on the first call and "Reusing in-flight discovery session" on a follow-up before the sweep completes