### PR TITLE
fix(report): four polish + signal-to-noise improvements (positions, action copy, regression causes, discovery dedup)

### DIFF
--- a/packages/api-routes/src/report.ts
+++ b/packages/api-routes/src/report.ts
@@ -1307,7 +1307,15 @@ function buildReportActionPlan(input: ReportActionPlanInput): ReportActionPlanIt
 
   for (const [index, opportunity] of input.contentOpportunities.slice(0, 2).entries()) {
     const verb = contentActionVerb(opportunity.action)
-    const target = opportunity.ourBestPage?.url ?? `a new page for "${opportunity.query}"`
+    const bestPageUrl = opportunity.ourBestPage?.url
+    // Treat "/" the same as "no best page" for action copy. Pointing the
+    // operator at the homepage as the place to "Update" or "Create" reads
+    // as nonsense ("Create / so it directly answers…"). The homepage is
+    // the best slug match by default but is rarely the topical page the
+    // analyst should edit. Keep the URL in the evidence so the analyst
+    // still sees what canonry matched against — just don't bake it into
+    // the sentence.
+    const hasUsablePage = !!bestPageUrl && bestPageUrl !== '/' && bestPageUrl.trim() !== ''
     const evidence = [
       `Opportunity score ${Math.round(opportunity.score)} with ${opportunity.actionConfidence} confidence`,
       `Demand source: ${opportunity.demandSource}`,
@@ -1316,20 +1324,31 @@ function buildReportActionPlan(input: ReportActionPlanInput): ReportActionPlanIt
       evidence.push(`${opportunity.winningCompetitor.domain} is the current winning cited source`)
     }
     if (opportunity.ourBestPage) {
-      evidence.push(`Best matching owned page: ${opportunity.ourBestPage.url}`)
+      if (bestPageUrl === '/') {
+        evidence.push('No topical page yet — homepage is the closest slug match')
+      } else {
+        evidence.push(`Best matching owned page: ${bestPageUrl}`)
+      }
     } else {
       evidence.push('No matching owned page was found')
     }
 
+    // `create` action means "this slot needs new dedicated content" even
+    // when ourBestPage exists (a poor-ranking page IS the trigger for the
+    // create classification — see content-classifier.ts). For create
+    // actions, always say "a new page for …" rather than telling the
+    // operator to edit the bad page. Other verbs (Expand, Refresh, Add
+    // schema to) target the existing page.
+    const targetIsExistingPage = opportunity.action !== 'create' && hasUsablePage
     actions.push({
       audience: 'both',
       priority: 20 + index,
       horizon: opportunity.actionConfidence === 'high' ? 'short-term' : 'medium-term',
       category: 'content',
       title: `${verb} content for "${opportunity.query}"`,
-      action: opportunity.ourBestPage
-        ? `${verb} ${target} so it directly answers the tracked query and cites the strongest supporting evidence.`
-        : `${verb} ${target} that directly answers the query and earns citations from AI answer engines.`,
+      action: targetIsExistingPage
+        ? `${verb} the existing page so it directly answers the tracked query and cites the strongest supporting evidence.`
+        : `${verb} a new page for "${opportunity.query}" that directly answers the query and earns citations from AI answer engines.`,
       why: opportunity.drivers.length > 0
         ? opportunity.drivers
         : ['Canonry ranked this as a content opportunity from search-demand and citation evidence.'],

--- a/packages/canonry/src/discovery-run.ts
+++ b/packages/canonry/src/discovery-run.ts
@@ -1,5 +1,5 @@
 import crypto from 'node:crypto'
-import { eq } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import type { DatabaseClient } from '@ainyc/canonry-db'
 import {
   competitors,
@@ -474,33 +474,51 @@ function writeDiscoveryInsight(
     totalProbes,
   })
 
-  db.insert(insights).values({
-    id: crypto.randomUUID(),
-    projectId: input.projectId,
-    runId: input.runId,
-    type: 'discovery.basket-divergence',
-    severity,
-    title,
-    // query/provider fields don't fit the visibility-snapshot model for a
-    // session-level insight. Use the session marker so the
-    // (query, provider) index stays distinct across sessions; PR 5 will
-    // formalize a session-scoped insight subtype.
-    query: `discovery:${input.sessionId}`,
-    provider: input.seedProvider,
-    recommendation: JSON.stringify({
-      action: 'review-discovered-basket',
-      summary: `Run \`canonry discover show ${input.sessionId} --format json\` to inspect the per-query breakdown, then \`canonry discover promote <project> ${input.sessionId}\` to merge cited + aspirational findings into the project.`,
-      bucketCounts: buckets,
-      topCompetitors,
-    }),
-    cause: JSON.stringify({
-      sessionId: input.sessionId,
-      totalProbes,
-      seedProvider: input.seedProvider,
-    }),
-    dismissed: false,
-    createdAt: new Date().toISOString(),
-  }).run()
+  // Dismiss prior basket-divergence insights for this project before
+  // writing the new one. The insight is session-level — every discovery
+  // run produces one. Without this dedup, every session leaves a fresh
+  // insight in the active list AND keeps the older ones around, drowning
+  // the analyst's view (12 stale entries after 12 sessions, as observed
+  // on azcoatings May 2026). The newest session's findings supersede the
+  // older ones by definition, so auto-dismiss is the right semantic.
+  db.transaction((tx) => {
+    tx.update(insights)
+      .set({ dismissed: true })
+      .where(and(
+        eq(insights.projectId, input.projectId),
+        eq(insights.type, 'discovery.basket-divergence'),
+        eq(insights.dismissed, false),
+      ))
+      .run()
+
+    tx.insert(insights).values({
+      id: crypto.randomUUID(),
+      projectId: input.projectId,
+      runId: input.runId,
+      type: 'discovery.basket-divergence',
+      severity,
+      title,
+      // query/provider fields don't fit the visibility-snapshot model for
+      // a session-level insight. Use the session marker so the
+      // (query, provider) index stays distinct across sessions; PR 5 will
+      // formalize a session-scoped insight subtype.
+      query: `discovery:${input.sessionId}`,
+      provider: input.seedProvider,
+      recommendation: JSON.stringify({
+        action: 'review-discovered-basket',
+        summary: `Run \`canonry discover show ${input.sessionId} --format json\` to inspect the per-query breakdown, then \`canonry discover promote <project> ${input.sessionId}\` to merge cited + aspirational findings into the project.`,
+        bucketCounts: buckets,
+        topCompetitors,
+      }),
+      cause: JSON.stringify({
+        sessionId: input.sessionId,
+        totalProbes,
+        seedProvider: input.seedProvider,
+      }),
+      dismissed: false,
+      createdAt: new Date().toISOString(),
+    }).run()
+  })
 }
 
 function buildDiscoveryInsightTitle(input: {

--- a/packages/canonry/src/intelligence-service.ts
+++ b/packages/canonry/src/intelligence-service.ts
@@ -466,6 +466,10 @@ export class IntelligenceService {
         cited: r.citationState === CitationStates.cited,
         citationUrl: domains[0] ?? undefined,
         competitorDomains: competitors,
+        // citedDomains is the FULL set (tracked competitors + third-party
+        // sources). Cause analysis uses it to name the displacing source
+        // when no tracked competitor appears in the response.
+        citedDomains: domains,
       }
     })
 

--- a/packages/canonry/test/discovery-run.test.ts
+++ b/packages/canonry/test/discovery-run.test.ts
@@ -166,6 +166,72 @@ describe('executeDiscoveryRun', () => {
     expect(recommendation.topCompetitors.some(c => c.domain === 'aurora-solar.com')).toBe(true)
   })
 
+  it('dismisses prior basket-divergence insights for the project when a new session writes one', async () => {
+    // Without dedup, the session-level basket-divergence insight accumulates
+    // — every discovery run leaves a fresh insight active and the older
+    // ones stick around. azcoatings May 2026 had 12 active entries from
+    // 12 sessions, all flagging the same aggregate. The newest session's
+    // findings supersede the prior ones by definition, so auto-dismiss
+    // is the right semantic.
+    const { db, projectId, sessionId, runId } = setup()
+
+    // Plant a stale basket-divergence insight from a (notional) earlier
+    // session, and an unrelated regression insight that must NOT be
+    // touched by the dedup.
+    const stalePriorId = crypto.randomUUID()
+    db.insert(insights).values({
+      id: stalePriorId,
+      projectId,
+      runId,
+      type: 'discovery.basket-divergence',
+      severity: 'medium',
+      title: 'Older divergence (notional prior session)',
+      query: 'discovery:older-session',
+      provider: 'gemini-test',
+      recommendation: JSON.stringify({}),
+      cause: JSON.stringify({}),
+      dismissed: false,
+      createdAt: new Date(Date.now() - 60_000).toISOString(),
+    }).run()
+    const unrelatedRegressionId = crypto.randomUUID()
+    db.insert(insights).values({
+      id: unrelatedRegressionId,
+      projectId,
+      runId,
+      type: 'regression',
+      severity: 'high',
+      title: 'Unrelated regression',
+      query: 'some query',
+      provider: 'openai',
+      recommendation: JSON.stringify({}),
+      cause: JSON.stringify({}),
+      dismissed: false,
+      createdAt: new Date(Date.now() - 60_000).toISOString(),
+    }).run()
+
+    await executeDiscoveryRun({
+      db,
+      registry: new ProviderRegistry(),
+      runId,
+      sessionId,
+      projectId,
+      icpDescription: 'AEO test',
+      deps: buildDeps({ probeBuckets: ['cited', 'aspirational'] }),
+    })
+
+    const all = db.select().from(insights).all()
+    const stalePrior = all.find(i => i.id === stalePriorId)!
+    const unrelated = all.find(i => i.id === unrelatedRegressionId)!
+    expect(stalePrior.dismissed).toBe(true) // dismissed by the new session
+    expect(unrelated.dismissed).toBe(false) // untouched — different type
+
+    const activeDivergence = all.filter(
+      i => i.type === 'discovery.basket-divergence' && !i.dismissed,
+    )
+    expect(activeDivergence).toHaveLength(1)
+    expect(activeDivergence[0]!.query).toBe(`discovery:${sessionId}`)
+  })
+
   it('marks the run failed and writes session.error when the orchestrator throws', async () => {
     const { db, projectId, sessionId, runId } = setup()
 

--- a/packages/intelligence/src/causes.ts
+++ b/packages/intelligence/src/causes.ts
@@ -2,16 +2,22 @@ import type { Regression, Snapshot, CauseAnalysis } from './types.js'
 
 export function analyzeCause(regression: Regression, currentSnapshots: Snapshot[]): CauseAnalysis {
   // A regression means our domain was cited previously but is NOT cited now.
-  // Find the matching post-regression snapshot — the one where we lost the
-  // citation. That's where displacing sources live.
-  const matchingSnap = currentSnapshots.find(
+  // Look across ALL matching post-regression snapshots — multi-location
+  // projects produce one snapshot per (query, provider, location), and the
+  // intelligence-service select doesn't pin an order, so a `.find()` that
+  // stops at the first match can pick a third-party-only snapshot and
+  // miss a sibling snapshot that has the tracked competitor. Scan the
+  // full set and prefer the strongest signal explicitly.
+  const matchingSnaps = currentSnapshots.filter(
     s => s.query === regression.query && s.provider === regression.provider && !s.cited,
   )
 
   // Tracked competitor displacement — strongest signal (the operator
-  // already cares about this domain).
-  if (matchingSnap?.competitorDomains?.length) {
-    const competitor = matchingSnap.competitorDomains[0]!
+  // already cares about this domain). Wins over third-party even if a
+  // third-party-only snapshot happens to come first in the array.
+  const withCompetitor = matchingSnaps.find(s => s.competitorDomains?.length)
+  if (withCompetitor) {
+    const competitor = withCompetitor.competitorDomains![0]!
     return {
       cause: 'competitor_gain',
       competitorDomain: competitor,
@@ -19,12 +25,14 @@ export function analyzeCause(regression: Regression, currentSnapshots: Snapshot[
     }
   }
 
-  // Third-party displacement — no tracked competitor in the response, but
-  // the engine is grounding on somebody else (publisher, gov site, an
-  // unrelated brand). Naming them is far more actionable than the old
-  // "audit yourself, position unknown" recommendation that fired here.
-  if (matchingSnap?.citedDomains?.length) {
-    const top = matchingSnap.citedDomains.slice(0, 3)
+  // Third-party displacement — no tracked competitor in any matching
+  // snapshot, but the engine is grounding on somebody else (publisher,
+  // gov site, an unrelated brand). Naming them is far more actionable
+  // than the old "audit yourself, position unknown" recommendation that
+  // fired here.
+  const withCited = matchingSnaps.find(s => s.citedDomains?.length)
+  if (withCited) {
+    const top = withCited.citedDomains!.slice(0, 3)
     return {
       cause: 'third_party_displacement',
       details: `${regression.provider} now grounds on ${top.join(', ')} for "${regression.query}" — none are tracked competitors.`,

--- a/packages/intelligence/src/causes.ts
+++ b/packages/intelligence/src/causes.ts
@@ -2,22 +2,32 @@ import type { Regression, Snapshot, CauseAnalysis } from './types.js'
 
 export function analyzeCause(regression: Regression, currentSnapshots: Snapshot[]): CauseAnalysis {
   // A regression means our domain was cited previously but is NOT cited now.
-  // Look for the current snapshot where we lost citation and check if a
-  // competitor domain appeared in that same query+provider response.
-  const currentSnap = currentSnapshots.find(
-    s =>
-      s.query === regression.query &&
-      s.provider === regression.provider &&
-      !s.cited &&
-      s.competitorDomains && s.competitorDomains.length > 0
+  // Find the matching post-regression snapshot — the one where we lost the
+  // citation. That's where displacing sources live.
+  const matchingSnap = currentSnapshots.find(
+    s => s.query === regression.query && s.provider === regression.provider && !s.cited,
   )
 
-  if (currentSnap) {
-    const competitor = currentSnap.competitorDomains![0]!
+  // Tracked competitor displacement — strongest signal (the operator
+  // already cares about this domain).
+  if (matchingSnap?.competitorDomains?.length) {
+    const competitor = matchingSnap.competitorDomains[0]!
     return {
       cause: 'competitor_gain',
       competitorDomain: competitor,
       details: `Competitor ${competitor} now cited for "${regression.query}" on ${regression.provider}`,
+    }
+  }
+
+  // Third-party displacement — no tracked competitor in the response, but
+  // the engine is grounding on somebody else (publisher, gov site, an
+  // unrelated brand). Naming them is far more actionable than the old
+  // "audit yourself, position unknown" recommendation that fired here.
+  if (matchingSnap?.citedDomains?.length) {
+    const top = matchingSnap.citedDomains.slice(0, 3)
+    return {
+      cause: 'third_party_displacement',
+      details: `${regression.provider} now grounds on ${top.join(', ')} for "${regression.query}" — none are tracked competitors.`,
     }
   }
 

--- a/packages/intelligence/src/content-scorer.ts
+++ b/packages/intelligence/src/content-scorer.ts
@@ -128,10 +128,16 @@ function buildDrivers(input: ScorerInput): string[] {
     drivers.push('no existing page')
   }
 
-  if (input.position !== null && input.position > 30) {
-    drivers.push(`page ranks #${input.position} (effectively invisible)`)
-  } else if (input.position !== null && input.position > 10) {
-    drivers.push(`page ranks #${input.position}`)
+  if (input.position !== null) {
+    // GSC positions are averaged across impressions, so float values are
+    // legitimate — but `#59.666666666666664` reads as a debug artifact in
+    // client-facing copy. Round to integer for display.
+    const positionDisplay = Math.round(input.position)
+    if (input.position > 30) {
+      drivers.push(`page ranks #${positionDisplay} (effectively invisible)`)
+    } else if (input.position > 10) {
+      drivers.push(`page ranks #${positionDisplay}`)
+    }
   }
 
   if (input.action === 'add-schema') {

--- a/packages/intelligence/src/types.ts
+++ b/packages/intelligence/src/types.ts
@@ -12,6 +12,14 @@ export interface Snapshot {
    * tracked rival on the same (query, provider) pair.
    */
   competitorDomains?: readonly string[]
+  /**
+   * Every domain the engine actually cited for this (query, provider) —
+   * tracked competitors + third-party sources (publishers, gov sites,
+   * unrelated brands). Used by cause analysis to name a displacing source
+   * even when no tracked competitor appears, turning "audit yourself" into
+   * "audit who's winning."
+   */
+  citedDomains?: readonly string[]
 }
 
 export interface RunData {
@@ -52,7 +60,16 @@ export interface HealthTrend {
   delta: number
 }
 
-export type SuspectedCause = 'competitor_gain' | 'competitor_loss' | 'indexing_loss' | 'content_change' | 'unknown'
+export type SuspectedCause =
+  | 'competitor_gain'
+  | 'competitor_loss'
+  | 'indexing_loss'
+  | 'content_change'
+  /** Engine cites third-party sources (publishers, gov sites, unrelated
+   * brands) but no tracked competitor — points the analyst at the actual
+   * displacing domains rather than at an opaque self-audit. */
+  | 'third_party_displacement'
+  | 'unknown'
 
 export interface CauseAnalysis {
   cause: SuspectedCause

--- a/packages/intelligence/test/causes.test.ts
+++ b/packages/intelligence/test/causes.test.ts
@@ -29,7 +29,7 @@ describe('analyzeCause', () => {
     expect(result.details).toContain('chatgpt')
   })
 
-  it('returns unknown when no competitor domain is present', () => {
+  it('returns unknown when no competitor or third-party domain is present', () => {
     const reg = makeRegression()
     const snapshots: Snapshot[] = [
       { query: 'roof repair phoenix', provider: 'chatgpt', cited: false },
@@ -38,6 +38,69 @@ describe('analyzeCause', () => {
     const result = analyzeCause(reg, snapshots)
     expect(result.cause).toBe('unknown')
     expect(result.competitorDomain).toBeUndefined()
+  })
+
+  it('identifies third_party_displacement when no tracked competitor is in the snapshot but the engine cited other domains', () => {
+    // The May 2026 azcoatings case: openai stopped citing the project for
+    // "polyurea roof coating michigan" and grounded on michigan.gov + gaf.com
+    // instead. Neither was in the configured competitor list, so the old
+    // detector returned `cause: unknown` and the recommendation was the
+    // useless "audit yourself, position unknown."
+    const reg = makeRegression()
+    const snapshots: Snapshot[] = [
+      {
+        query: 'roof repair phoenix',
+        provider: 'chatgpt',
+        cited: false,
+        competitorDomains: [],
+        citedDomains: ['phoenix.gov', 'angi.com', 'somebody-else.com'],
+      },
+    ]
+
+    const result = analyzeCause(reg, snapshots)
+    expect(result.cause).toBe('third_party_displacement')
+    expect(result.competitorDomain).toBeUndefined()
+    expect(result.details).toContain('phoenix.gov')
+    expect(result.details).toContain('angi.com')
+    expect(result.details).toContain('roof repair phoenix')
+    expect(result.details).toContain('chatgpt')
+  })
+
+  it('prefers competitor_gain over third_party_displacement when both are present', () => {
+    const reg = makeRegression()
+    const snapshots: Snapshot[] = [
+      {
+        query: 'roof repair phoenix',
+        provider: 'chatgpt',
+        cited: false,
+        competitorDomains: ['rival.com'],
+        citedDomains: ['rival.com', 'phoenix.gov'],
+      },
+    ]
+
+    const result = analyzeCause(reg, snapshots)
+    expect(result.cause).toBe('competitor_gain')
+    expect(result.competitorDomain).toBe('rival.com')
+  })
+
+  it('caps third_party_displacement detail at the top 3 displacing domains', () => {
+    const reg = makeRegression()
+    const snapshots: Snapshot[] = [
+      {
+        query: 'roof repair phoenix',
+        provider: 'chatgpt',
+        cited: false,
+        citedDomains: ['a.com', 'b.com', 'c.com', 'd.com', 'e.com'],
+      },
+    ]
+
+    const result = analyzeCause(reg, snapshots)
+    expect(result.cause).toBe('third_party_displacement')
+    expect(result.details).toContain('a.com')
+    expect(result.details).toContain('b.com')
+    expect(result.details).toContain('c.com')
+    expect(result.details).not.toContain('d.com')
+    expect(result.details).not.toContain('e.com')
   })
 
   it('returns unknown when snapshots array is empty', () => {

--- a/packages/intelligence/test/causes.test.ts
+++ b/packages/intelligence/test/causes.test.ts
@@ -83,6 +83,37 @@ describe('analyzeCause', () => {
     expect(result.competitorDomain).toBe('rival.com')
   })
 
+  it('prefers competitor_gain even when a third-party-only snapshot comes first (multi-location order independence)', () => {
+    // Multi-location projects produce one snapshot per (query, provider,
+    // location); the intelligence-service select doesn't pin an order, so
+    // a `find()` that stops at the first match could pick a third-party-only
+    // snapshot and miss a sibling snapshot that has the tracked competitor.
+    // Regression guard for that pitfall — analyzeCause must scan all
+    // matching snapshots and prefer the tracked-competitor signal.
+    const reg = makeRegression()
+    const snapshots: Snapshot[] = [
+      // Third-party-only snapshot — listed FIRST.
+      {
+        query: 'roof repair phoenix',
+        provider: 'chatgpt',
+        cited: false,
+        citedDomains: ['phoenix.gov'],
+      },
+      // Tracked competitor on the SECOND snapshot — must still win.
+      {
+        query: 'roof repair phoenix',
+        provider: 'chatgpt',
+        cited: false,
+        competitorDomains: ['rival.com'],
+        citedDomains: ['rival.com'],
+      },
+    ]
+
+    const result = analyzeCause(reg, snapshots)
+    expect(result.cause).toBe('competitor_gain')
+    expect(result.competitorDomain).toBe('rival.com')
+  })
+
   it('caps third_party_displacement detail at the top 3 displacing domains', () => {
     const reg = makeRegression()
     const snapshots: Snapshot[] = [


### PR DESCRIPTION
## Summary

Four focused fixes to the audit findings from a real-data read of the report and intelligence surfaces on `azcoatings` and `demand-iq` — the same projects the May 2026 incident hit. None of these change DTO shapes; all are renderer / detector / writer-side improvements.

## What's in

### 1. Round position numbers in content-scorer drivers (`a271aac`)

`page ranks #59.666666666666664 (effectively invisible)` was bubbling all the way through to clientSummary `why` lines and HTML report copy. GSC's `avg_position` is impression-weighted so floats are legitimate — but raw 16-digit decimals read as debug artifacts to clients. Rounds at the driver-string level; the underlying `gscAvgPosition` DTO field is unchanged so consumers can format as they want.

### 2. Cleaner content-action copy when the best-match page is the homepage or a poor-ranking match (`d1ba1cc`)

The action plan builder was producing `Create / so it directly answers the tracked query…` (when `ourBestPage.url === '/'`) and `Create /blog/fcc-closes-the-multi-party-lead-gen-loophole-why-solar-and-home-improvement-contractors-are-shifting-to-branded-lead-generation so it…` (for long URLs). Two changes:

- `create` actions always read as "a new page for `<query>`" — matching the classification semantics. `content-classifier.ts` treats `not cited + position > 30 → CREATE`, so a bad page IS the trigger for create, not the fix.
- Non-create actions (Expand / Refresh / Add schema to) say "the existing page" rather than embedding the URL inline. The URL stays in the evidence list. `/` is treated as "no usable page" so homepage matches don't produce nonsense copy.

### 3. Name displacing third-party domains in regression causes (`6202b7c`)

The `analyzeCause` detector only fired `competitor_gain` when a *tracked* competitor showed up in the post-regression snapshot. When the engine grounded on publishers, gov sites, or unrelated brands instead — the common case for small/regional businesses whose competitive surface isn't fully mapped — the cause came back `unknown` and the regression recommendation collapsed to the useless `"audit <your domain> — page was previously cited at position unknown"`. The May 2026 azcoatings regression for `polyurea roof coating michigan` on openai is the canonical example: gaf.com and michigan.gov displaced the site; neither was a tracked competitor.

New `third_party_displacement` cause names the top 3 displacing domains. Turns "audit yourself" into "audit who's winning." `competitor_gain` keeps priority when both apply.

### 4. Dismiss prior basket-divergence insights when a new discovery session fires (`edc0cf8`)

`discovery.basket-divergence` is a session-level insight — every discovery run produces one. Without dedup, every session leaves a fresh insight active AND keeps the older ones around. azcoatings May 2026 had 12 of these in the active list from 12 sessions, all flagging the same aggregate fact and drowning the per-query signal. The newest session's findings supersede the prior ones by definition, so auto-dismiss is the right semantic. Wraps the insert in a transaction that first marks every active basket-divergence insight for the project as dismissed, then writes the new one.

## Out of scope (deferred)

- **`aiReferrals: null` section copy** — the HTML renderer already handles null gracefully (`renderEmpty('No AI referral traffic detected yet.')`). The empty state is acceptable; tightening the copy or wiring GA4 fully is a separate concern.
- **Pinned / featured action** — adding an `isPinned` flag to the top action-plan item needs coordinated HTML + SPA + tests changes (per the `Report parity (Critical)` rule), so it belongs in its own PR.

## Test plan

- [x] `pnpm run typecheck` — clean across the workspace
- [x] `pnpm -r run lint` — clean
- [x] `pnpm run test` — 235 / 236 files pass; the 1 failure is the pre-existing `sqlite3 CLI not found` env issue in `schedules-migration.test.ts` (unrelated; same as recent merged PRs)
- [x] New tests: `analyzeCause` third-party-displacement path + cap-at-3 + competitor-preferred-over-third-party (`packages/intelligence/test/causes.test.ts`); discovery dedup with unrelated-insight guard (`packages/canonry/test/discovery-run.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)