### PR TITLE
chore: refresh post-Vercel copy in Activity panel + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Agent-first AEO operating platform. Open source. Self-hosted.**
 
 - Track citations across Gemini, ChatGPT, Claude, Perplexity, and local LLMs
-- Watch AI engines crawl and refer traffic via [server-log ingestion](skills/canonry/references/server-side-traffic.md) — Cloud Run logs and the WordPress Traffic Logger plugin today
+- Watch AI engines crawl and refer traffic via [server-log ingestion](skills/canonry/references/server-side-traffic.md) — Cloud Run, Vercel, and the WordPress Traffic Logger plugin today
 - Diagnose against real traffic with built-in [GSC](docs/google-search-console-setup.md), [GA4](docs/google-analytics-setup.md), and [Bing Webmaster](docs/bing-webmaster-setup.md)
 - Execute fixes via [WordPress](docs/wordpress-setup.md), JSON-LD schema, and indexing submissions
 - Manage many clients declaratively — config-as-code YAML + `cnry apply`
@@ -68,7 +68,7 @@ Configure during `cnry init`, in the dashboard `/settings`, or as env vars.
 | **Architecture & data model** | [docs/architecture.md](docs/architecture.md) · [docs/data-model.md](docs/data-model.md) |
 | **Aero — built-in agent** | [skills/aero/SKILL.md](skills/aero/SKILL.md) |
 | **MCP — Claude Desktop / Cursor / Codex** | [docs/mcp.md](docs/mcp.md) |
-| **Integrations** | [GSC](docs/google-search-console-setup.md) · [GA4](docs/google-analytics-setup.md) · [Bing](docs/bing-webmaster-setup.md) · [WordPress](docs/wordpress-setup.md) · [Server-side traffic (Cloud Run + WordPress logs)](skills/canonry/references/server-side-traffic.md) |
+| **Integrations** | [GSC](docs/google-search-console-setup.md) · [GA4](docs/google-analytics-setup.md) · [Bing](docs/bing-webmaster-setup.md) · [WordPress](docs/wordpress-setup.md) · [Server-side traffic (Cloud Run + Vercel + WordPress logs)](skills/canonry/references/server-side-traffic.md) |
 | **Deployment** — Docker, Railway, Render, systemd, Tailscale | [docs/deployment.md](docs/deployment.md) |
 | **API** — 118+ endpoints | `GET /api/v1/openapi.json` (no auth) |
 | **Skills bundle** for Claude Code / Codex | `cnry skills install` ([details](skills/canonry/SKILL.md)) |

--- a/apps/web/src/components/project/ActivitySection.tsx
+++ b/apps/web/src/components/project/ActivitySection.tsx
@@ -118,7 +118,7 @@ function ServerActivityPanel({ projectName }: { projectName: string }) {
           <div className="text-sm text-zinc-400">
             No server traffic source connected yet.{' '}
             <Link to="/traffic" className="text-blue-400 hover:underline">
-              Connect a WordPress or Cloud Run source
+              Connect a traffic source
             </Link>{' '}
             to surface bot crawls and AI referrals straight from server logs.
           </div>


### PR DESCRIPTION
## Summary
- \`apps/web/src/components/project/ActivitySection.tsx\` — empty-state link copy was \"Connect a WordPress or Cloud Run source\". #495 fixed the same wording on the Traffic page but missed this card, so the project Overview still hides Vercel from users. Replaced with generic \"Connect a traffic source\".
- \`README.md\` — the feature bullet about server-log ingestion still said \"Cloud Run logs and the WordPress Traffic Logger plugin today\", missing Vercel (#493). Updated to \"Cloud Run, Vercel, and the WordPress Traffic Logger plugin today\".
- One note left out of scope: \`skills/canonry/references/server-side-traffic.md\` (linked from the README bullet) only documents Cloud Run + WordPress connection flow — Vercel still needs its own section there. Happy to do as a follow-up.

## Test plan
- [x] \`pnpm test --project web\` (198 passed)
- [x] \`pnpm --filter canonry-web run typecheck\`
- [ ] Manual: load the project Overview empty state and reread the README bullet