### PR TITLE
docs(web): use Facebook/Meta as the alias example in help copy

### DIFF
--- a/apps/web/src/components/project/ProjectSettingsSection.tsx
+++ b/apps/web/src/components/project/ProjectSettingsSection.tsx
@@ -270,7 +270,7 @@ export function ProjectSettingsSection({
             <label className={labelClass}>Aliases</label>
             <p className="text-[11px] text-zinc-500 mb-1.5">
               Additional brand names checked against LLM answer text. Use for product names,
-              prior names, or DBAs (e.g. add "LlamaParse" if the project is "LlamaIndex").
+              prior names, or DBAs (e.g. add "Meta" as an alias to facebook.com).
             </p>
             <div className="flex flex-wrap gap-1.5 mb-2">
               {aliases.map((a) => (
@@ -284,7 +284,7 @@ export function ProjectSettingsSection({
               <input
                 className={`${inputClass} flex-1`}
                 type="text"
-                placeholder="LlamaParse"
+                placeholder="Facebook"
                 value={newAlias}
                 onChange={(e) => setNewAlias(e.target.value)}
                 onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), handleAddAlias())}

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -1446,7 +1446,7 @@ export function ProjectPage({
           <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
             <span className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wide text-zinc-500 mr-1">
               Also known as
-              <InfoTooltip text="Extra brand names checked against LLM answer text alongside the project name. Use for product names, prior names, or DBAs (e.g. add LlamaParse if the project is LlamaIndex). Changing these recomputes mentions on historical runs." />
+              <InfoTooltip text="Extra brand names checked against LLM answer text alongside the project name. Use for product names, prior names, or DBAs (e.g. add Meta as an alias to facebook.com). Changing these recomputes mentions on historical runs." />
             </span>
             {(model.project.aliases ?? []).map((a) => (
               <span key={a} className="inline-flex items-center gap-1 rounded-full border border-zinc-700/60 bg-zinc-800/40 px-2 py-0.5 text-xs text-zinc-300">


### PR DESCRIPTION
## Summary
- Replaced the LlamaParse/LlamaIndex example in the alias help text with the more universally recognized Facebook/Meta pairing.
- Rephrased the example as a direct instruction ("add Meta as an alias to facebook.com") so it maps onto the UI action.
- Touches the inline "+ ALIAS" tooltip on the project page and the matching description + input placeholder on the settings page.

## Test plan
- [ ] Open a project page and hover the "Also known as" info tooltip — verify the new copy renders.
- [ ] Open project Settings and confirm the aliases description and input placeholder show the new example.