### PR TITLE
fix(discovery): bucket seed prompt by search intent (#505)

### DIFF
--- a/packages/canonry/src/discovery-run.ts
+++ b/packages/canonry/src/discovery-run.ts
@@ -413,6 +413,7 @@ export function buildSeedPrompt(input: {
   locations?: readonly LocationContext[]
 }): string {
   const locationConstraint = buildLocationConstraint(input.locations ?? [])
+  const currentYear = new Date().getFullYear()
   return [
     'You are an AEO (Answer Engine Optimization) analyst expanding a tracked-query basket for a customer.',
     '',
@@ -423,7 +424,7 @@ export function buildSeedPrompt(input: {
     'Brainstorm queries a member of this ICP would type into an AI answer engine (Gemini, ChatGPT, Perplexity). Generate candidates across the five intent buckets below — these are SEMANTICALLY DISTINCT search intents, not stylistic variants. A query should fit one bucket cleanly. Diversity across buckets is the point: it keeps the list from collapsing into near-synonyms of a single intent.',
     '',
     ' 1. Informational — the searcher wants to understand a concept, market, or problem. Templates: "what is X", "how does X work", "X explained", "why X matters".',
-    ' 2. Commercial — the searcher is researching category leaders before a purchase. Templates: "best X for Y", "top X 2026", "leading X providers", "X for [use case]".',
+    ` 2. Commercial — the searcher is researching category leaders before a purchase. Templates: "best X for Y", "top X ${currentYear}", "leading X providers", "X for [use case]".`,
     ' 3. Navigational — the searcher is looking for a specific brand, place, or directory. Templates: "X near me", "X reviews", "X website", "X directory".',
     ' 4. Comparative — the searcher is weighing named alternatives head-to-head. Templates: "X vs Y", "X or Y for Z", "alternatives to X".',
     ' 5. Transactional — the searcher is ready to act on a purchase or booking. Templates: "book X", "X pricing", "X discount code", "buy X online".',

--- a/packages/canonry/src/discovery-run.ts
+++ b/packages/canonry/src/discovery-run.ts
@@ -33,6 +33,17 @@ const log = createLogger('DiscoveryRun')
 
 const DEFAULT_SEED_COUNT = 30
 
+/**
+ * Per-intent-bucket quota the seed prompt requests. Multiplied by the five
+ * intent buckets (informational / commercial / navigational / comparative /
+ * transactional) it yields {@link DEFAULT_SEED_COUNT}. The bucket structure
+ * is what stops Gemini from collapsing the candidate list into 30+ near-
+ * synonyms of a single intent (issue #505) — semantically distinct intents
+ * cluster apart at the dedup threshold, producing multiple representatives
+ * and therefore multiple probes per session.
+ */
+const QUERIES_PER_INTENT_BUCKET = 6
+
 export interface ExecuteDiscoveryRunOptions {
   db: DatabaseClient
   registry: ProviderRegistry
@@ -409,14 +420,15 @@ export function buildSeedPrompt(input: {
     `ICP: ${input.icpDescription}`,
     ...(locationConstraint.length > 0 ? ['', ...locationConstraint] : []),
     '',
-    'Brainstorm a wide set of queries a member of this ICP would type into an AI answer engine (Gemini, ChatGPT, Perplexity) when they are about to make a decision in this space. Aim for 30+ candidates covering:',
-    ' - Comparison queries ("best X for Y")',
-    ' - Specific feature / capability queries',
-    ' - Pricing / vendor-shortlist queries',
-    ' - Workflow / how-to queries',
-    ' - Adjacent jobs-to-be-done queries',
+    'Brainstorm queries a member of this ICP would type into an AI answer engine (Gemini, ChatGPT, Perplexity). Generate candidates across the five intent buckets below — these are SEMANTICALLY DISTINCT search intents, not stylistic variants. A query should fit one bucket cleanly. Diversity across buckets is the point: it keeps the list from collapsing into near-synonyms of a single intent.',
     '',
-    'Return ONE query per line. Plain text only — no numbering, bullets, quotes, or commentary.',
+    ' 1. Informational — the searcher wants to understand a concept, market, or problem. Templates: "what is X", "how does X work", "X explained", "why X matters".',
+    ' 2. Commercial — the searcher is researching category leaders before a purchase. Templates: "best X for Y", "top X 2026", "leading X providers", "X for [use case]".',
+    ' 3. Navigational — the searcher is looking for a specific brand, place, or directory. Templates: "X near me", "X reviews", "X website", "X directory".',
+    ' 4. Comparative — the searcher is weighing named alternatives head-to-head. Templates: "X vs Y", "X or Y for Z", "alternatives to X".',
+    ' 5. Transactional — the searcher is ready to act on a purchase or booking. Templates: "book X", "X pricing", "X discount code", "buy X online".',
+    '',
+    `Generate EXACTLY ${QUERIES_PER_INTENT_BUCKET} queries per bucket — ${QUERIES_PER_INTENT_BUCKET * 5} total. Return ONE query per line. Plain text only — no numbering, bullets, quotes, bucket labels, or commentary.`,
   ].join('\n')
 }
 

--- a/packages/canonry/test/discovery-run.test.ts
+++ b/packages/canonry/test/discovery-run.test.ts
@@ -623,4 +623,13 @@ describe('buildSeedPrompt', () => {
     }
     expect(prompt).toContain('EXACTLY 6 queries per bucket — 30 total')
   })
+
+  it('uses the current year in the "top X <year>" commercial template (not a hardcoded year)', () => {
+    // The Commercial bucket template demonstrates a year-stamped query. It
+    // must always reflect the current year so discovered queries don't drift
+    // toward stale year tokens once the calendar rolls over.
+    const prompt = buildSeedPrompt({ project, icpDescription: 'spray foam installers' })
+    const currentYear = new Date().getFullYear()
+    expect(prompt).toContain(`"top X ${currentYear}"`)
+  })
 })

--- a/packages/canonry/test/discovery-run.test.ts
+++ b/packages/canonry/test/discovery-run.test.ts
@@ -566,13 +566,20 @@ describe('buildSeedPrompt', () => {
   const detroit: LocationContext = { label: 'michigan', city: 'Detroit', region: 'Michigan', country: 'US' }
   const miami: LocationContext = { label: 'florida', city: 'Miami', region: 'Florida', country: 'US' }
 
+  // Sentinels that anchor the bucketed-by-intent prompt structure introduced
+  // for issue #505. A seed run that lost any of these would regress back into
+  // the "30 near-synonyms of one intent" failure mode.
+  const INTENT_BUCKET_LABELS = ['Informational', 'Commercial', 'Navigational', 'Comparative', 'Transactional']
+  const PER_BUCKET_QUOTA_LINE = 'Generate EXACTLY 6 queries per bucket — 30 total'
+
   it('omits the location block entirely when no locations are given', () => {
     const prompt = buildSeedPrompt({ project, icpDescription: 'spray foam installers' })
     expect(prompt).toContain('Customer: AZ Coatings')
     expect(prompt).toContain('ICP: spray foam installers')
     expect(prompt).not.toMatch(/business serves/i)
-    // The standard brainstorm block is still present.
-    expect(prompt).toContain('Brainstorm a wide set of queries')
+    // The intent-bucket scaffold is still present.
+    for (const label of INTENT_BUCKET_LABELS) expect(prompt).toContain(label)
+    expect(prompt).toContain(PER_BUCKET_QUOTA_LINE)
   })
 
   it('injects a single-location constraint with no quota line', () => {
@@ -582,8 +589,12 @@ describe('buildSeedPrompt', () => {
       locations: [detroit],
     })
     expect(prompt).toContain('The business serves Detroit, Michigan, US')
-    expect(prompt).not.toMatch(/at least/i)
-    expect(prompt).toContain('Brainstorm a wide set of queries')
+    // No PER-LOCATION quota line — single-location prompts skip the per-area
+    // quota and only inject the relevance rule. The per-bucket quota line is
+    // unrelated and must still be present.
+    expect(prompt).not.toMatch(/at least \d+ queries for EACH/i)
+    for (const label of INTENT_BUCKET_LABELS) expect(prompt).toContain(label)
+    expect(prompt).toContain(PER_BUCKET_QUOTA_LINE)
   })
 
   it('injects a multi-location constraint with the per-area quota', () => {
@@ -596,6 +607,20 @@ describe('buildSeedPrompt', () => {
     expect(prompt).toContain(' - Detroit, Michigan, US')
     expect(prompt).toContain(' - Miami, Florida, US')
     expect(prompt).toContain('at least 15 queries for EACH')
-    expect(prompt).toContain('Brainstorm a wide set of queries')
+    for (const label of INTENT_BUCKET_LABELS) expect(prompt).toContain(label)
+    expect(prompt).toContain(PER_BUCKET_QUOTA_LINE)
+  })
+
+  it('asks for semantically distinct intents (issue #505 — bucketed-by-intent fix)', () => {
+    // Regression guard: every bucket label must appear, the prompt must call
+    // out that intents are semantically distinct (the prior prompt's vague
+    // categories let Gemini collapse 40 candidates into one cluster), and the
+    // total quota must reflect 6 × 5 = 30.
+    const prompt = buildSeedPrompt({ project, icpDescription: 'spray foam installers' })
+    expect(prompt).toMatch(/SEMANTICALLY DISTINCT/)
+    for (const label of INTENT_BUCKET_LABELS) {
+      expect(prompt).toMatch(new RegExp(`\\b${label}\\b`))
+    }
+    expect(prompt).toContain('EXACTLY 6 queries per bucket — 30 total')
   })
 })


### PR DESCRIPTION
## Summary

- Replaces the discovery seed prompt's loose "30+ candidates across five fuzzy categories" instruction with an explicit per-bucket quota across five semantically distinct search intents (informational / commercial / navigational / comparative / transactional), so Gemini stops collapsing the candidate list into near-synonyms of a single intent (issue #505).
- Distinct intents cluster apart at the dedup threshold, producing multiple representatives and therefore multiple probes per session.
- Adds regression-sentinel tests that anchor the bucket scaffold, the "SEMANTICALLY DISTINCT" framing, and the `EXACTLY 6 × 5 = 30` quota line.

## Test plan

- [ ] `pnpm -r run test --filter @ainyc/canonry` covers `buildSeedPrompt` (bucket labels, per-bucket quota line, no per-location quota for single-location prompts, multi-location quota still injected).
- [ ] Spot-check one live `canonry discover run` against a project to confirm Gemini returns queries spanning multiple intent buckets.