### PR TITLE
fix: filter Cloud Run traffic by canonical domain

### DIFF
--- a/packages/api-routes/src/traffic.ts
+++ b/packages/api-routes/src/traffic.ts
@@ -1074,6 +1074,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
           pageSize,
           maxPages,
           firstSync: isFirstSync,
+          requestUrlSubstrings: [project.canonicalDomain],
         })
         allEvents = page.events
       } catch (e) {
@@ -1550,6 +1551,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
           // dedupedEvents anyway.
           firstSync: false,
           orderBy: 'timestamp asc',
+          requestUrlSubstrings: [project.canonicalDomain],
         })
         return page.events
       }


### PR DESCRIPTION
## Problem
Cloud Run traffic sync pulls all logs from the service revision, regardless of domain. When a single Cloud Run service hosts multiple domains (e.g. `ainyc.ai` + `canonry.ai` behind one `openclaw-nyc` revision), all traffic ends up in whichever project connects first.

## Fix
Add `requestUrlSubstrings: [project.canonicalDomain]` to both the regular sync and backfill pull calls. This tells the Cloud Run log filter to only match entries whose `httpRequest.requestUrl` contains the project's canonical domain.

## Changes
- `packages/api-routes/src/traffic.ts`: Add domain filter to `pullEvents` options in sync and backfill paths (2 lines)