### PR TITLE
chore: bump max backfill window to 90 days

### DIFF
--- a/packages/api-routes/src/traffic.ts
+++ b/packages/api-routes/src/traffic.ts
@@ -227,7 +227,7 @@ const MAX_TRACKED_EVENT_IDS = 1_000
 // one-shot operation; a busy site with ~30K events/30d still completes in well
 // under a minute.
 const DEFAULT_BACKFILL_DAYS = 30
-const MAX_BACKFILL_DAYS = 30
+const MAX_BACKFILL_DAYS = 90
 const BACKFILL_MAX_PAGES = 1_000
 const BACKFILL_SAMPLE_LIMIT = 500
 

--- a/packages/api-routes/test/traffic.test.ts
+++ b/packages/api-routes/test/traffic.test.ts
@@ -2108,7 +2108,7 @@ describe('POST /traffic/sources/:id/backfill', () => {
       expect(submitRes.statusCode).toBe(200)
       const submitted = JSON.parse(submitRes.payload)
       expect(submitted.daysRequested).toBe(365)
-      expect(submitted.daysApplied).toBe(30)
+      expect(submitted.daysApplied).toBe(90)
     } finally {
       await h.close()
     }
@@ -2544,7 +2544,7 @@ describe('POST /traffic/sources/:id/backfill — WordPress', () => {
       expect(submitRes.statusCode).toBe(200)
       const submitted = JSON.parse(submitRes.payload)
       expect(submitted.daysRequested).toBe(365)
-      expect(submitted.daysApplied).toBe(30)
+      expect(submitted.daysApplied).toBe(90)
     } finally {
       await h.close()
     }


### PR DESCRIPTION
Allows traffic backfill up to 90 days instead of 30.