### PR TITLE
fix(webhooks): block loopback addresses by default

### DIFF
--- a/packages/api-routes/src/apply.ts
+++ b/packages/api-routes/src/apply.ts
@@ -15,9 +15,12 @@ export interface ApplyRoutesOptions {
   onGoogleConnectionPropertyUpdated?: (domain: string, connectionType: 'gsc' | 'ga4', propertyId: string) => void
   /** Valid provider names from registered adapters — used to reject unknown providers */
   validProviderNames?: string[]
+  /** Allow webhook URLs that resolve to loopback addresses. Defaults to false. */
+  allowLoopbackWebhooks?: boolean
 }
 
 export async function applyRoutes(app: FastifyInstance, opts?: ApplyRoutesOptions) {
+  const allowLoopback = opts?.allowLoopbackWebhooks === true
   // POST /apply — accept a canonry.yaml body (JSON-parsed version)
   app.post('/apply', async (request, reply) => {
     const parsed = projectConfigSchema.safeParse(request.body)
@@ -83,7 +86,7 @@ export async function applyRoutes(app: FastifyInstance, opts?: ApplyRoutesOption
     const hasNotifications = 'notifications' in rawSpec
     if (hasNotifications) {
       for (const notif of config.spec.notifications) {
-        const urlCheck = await resolveWebhookTarget(notif.url ?? '')
+        const urlCheck = await resolveWebhookTarget(notif.url ?? '', { allowLoopback })
         if (!urlCheck.ok) throw validationError(`Notification URL invalid: ${urlCheck.message}`)
       }
     }

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -28,7 +28,7 @@ import { telemetryRoutes } from './telemetry.js'
 import type { TelemetryRoutesOptions } from './telemetry.js'
 import { scheduleRoutes } from './schedules.js'
 import type { ScheduleRoutesOptions } from './schedules.js'
-import { notificationRoutes } from './notifications.js'
+import { notificationRoutes, type NotificationRoutesOptions } from './notifications.js'
 import { googleRoutes } from './google.js'
 import type { GoogleRoutesOptions } from './google.js'
 import { bingRoutes } from './bing.js'
@@ -165,6 +165,14 @@ export interface ApiRoutesOptions {
    * not bypass auth. Cloud deployments pass undefined.
    */
   registerAuthenticatedRoutes?: (scope: FastifyInstance) => Promise<void> | void
+  /**
+   * Allow webhook URLs that resolve to loopback addresses (127.0.0.0/8 and ::1).
+   * Defaults to false — loopback is blocked by default so a cloud deployment
+   * cannot be coerced into reaching its own host services (metadata proxies,
+   * Redis/Vault, sidecar admin endpoints). Local servers can opt in to preserve
+   * dev workflows that point webhooks at localhost.
+   */
+  allowLoopbackWebhooks?: boolean
 }
 
 export async function apiRoutes(app: FastifyInstance, opts: ApiRoutesOptions) {
@@ -239,6 +247,7 @@ export async function apiRoutes(app: FastifyInstance, opts: ApiRoutesOptions) {
       onProjectUpserted: opts.onProjectUpserted,
       onAliasesChanged: opts.onAliasesChanged,
       validProviderNames: opts.providerAdapters?.map(a => a.name),
+      allowLoopbackWebhooks: opts.allowLoopbackWebhooks,
       onGoogleConnectionPropertyUpdated: (domain, connectionType, propertyId) => {
         opts.googleConnectionStore?.updateConnection(domain, connectionType, {
           propertyId,
@@ -269,7 +278,9 @@ export async function apiRoutes(app: FastifyInstance, opts: ApiRoutesOptions) {
       onScheduleUpdated: opts.onScheduleUpdated,
       validProviderNames: opts.providerAdapters?.map(a => a.name),
     } satisfies ScheduleRoutesOptions)
-    await api.register(notificationRoutes)
+    await api.register(notificationRoutes, {
+      allowLoopbackWebhooks: opts.allowLoopbackWebhooks,
+    } satisfies NotificationRoutesOptions)
     await api.register(telemetryRoutes, {
       getTelemetryStatus: opts.getTelemetryStatus,
       setTelemetryEnabled: opts.setTelemetryEnabled,

--- a/packages/api-routes/src/notifications.ts
+++ b/packages/api-routes/src/notifications.ts
@@ -10,7 +10,13 @@ import { deliverWebhook, resolveWebhookTarget } from './webhooks.js'
 
 const VALID_EVENTS: NotificationEvent[] = ['citation.lost', 'citation.gained', 'run.completed', 'run.failed', 'insight.critical', 'insight.high']
 
-export async function notificationRoutes(app: FastifyInstance) {
+export interface NotificationRoutesOptions {
+  /** Allow webhook URLs that resolve to loopback addresses. Defaults to false. */
+  allowLoopbackWebhooks?: boolean
+}
+
+export async function notificationRoutes(app: FastifyInstance, opts: NotificationRoutesOptions = {}) {
+  const allowLoopback = opts.allowLoopbackWebhooks === true
   // GET /notifications/events — list valid notification event types
   app.get('/notifications/events', async (_request, reply) => {
     return reply.send(VALID_EVENTS)
@@ -27,7 +33,7 @@ export async function notificationRoutes(app: FastifyInstance) {
 
     if (channel !== 'webhook') throw validationError('Only "webhook" channel is supported')
 
-    const urlCheck = await resolveWebhookTarget(url ?? '')
+    const urlCheck = await resolveWebhookTarget(url ?? '', { allowLoopback })
     if (!urlCheck.ok) throw validationError(urlCheck.message)
 
     if (!events?.length) throw validationError('"events" must be a non-empty array')
@@ -110,7 +116,7 @@ export async function notificationRoutes(app: FastifyInstance) {
     const config = parseJsonColumn<{ url: string; events: string[] }>(notification.config, { url: '', events: [] })
 
     // Re-validate URL at delivery time (stored URLs may predate validation logic)
-    const urlCheck = await resolveWebhookTarget(config.url)
+    const urlCheck = await resolveWebhookTarget(config.url, { allowLoopback })
     if (!urlCheck.ok) throw validationError(`Stored webhook URL is invalid: ${urlCheck.message}`)
 
     const payload = {

--- a/packages/api-routes/src/webhooks.ts
+++ b/packages/api-routes/src/webhooks.ts
@@ -16,7 +16,21 @@ export type ResolveWebhookTargetResult =
   | { ok: true; target: SafeWebhookTarget }
   | { ok: false; message: string }
 
-export async function resolveWebhookTarget(raw: string): Promise<ResolveWebhookTargetResult> {
+export interface ResolveWebhookTargetOptions {
+  /**
+   * Allow loopback addresses (127.0.0.0/8 and ::1, including IPv4-mapped forms).
+   * Defaults to false — loopback is blocked by default so a cloud deployment
+   * cannot be coerced into reaching its own host services (metadata proxies,
+   * Redis/Vault, sidecar admin endpoints). Local servers can opt in to preserve
+   * dev workflows that point webhooks at localhost.
+   */
+  allowLoopback?: boolean
+}
+
+export async function resolveWebhookTarget(
+  raw: string,
+  options: ResolveWebhookTargetOptions = {},
+): Promise<ResolveWebhookTargetResult> {
   let parsed: URL
   try {
     parsed = new URL(raw)
@@ -42,7 +56,7 @@ export async function resolveWebhookTarget(raw: string): Promise<ResolveWebhookT
     return { ok: false, message: '"url" hostname could not be resolved' }
   }
 
-  const blocked = addresses.find((entry) => isBlockedAddress(entry.address))
+  const blocked = addresses.find((entry) => isBlockedAddress(entry.address, options))
   if (blocked) {
     return { ok: false, message: '"url" must not resolve to a private or loopback address' }
   }
@@ -141,32 +155,35 @@ async function resolveHostAddresses(hostname: string): Promise<Array<{ address: 
   }
 }
 
-function isBlockedAddress(address: string): boolean {
+function isBlockedAddress(address: string, options: ResolveWebhookTargetOptions): boolean {
   const normalized = stripIpv6Brackets(address).toLowerCase()
   const family = net.isIP(normalized)
 
   if (family === 4) {
-    return isBlockedIpv4(normalized)
+    return isBlockedIpv4(normalized, options)
   }
 
   if (family === 6) {
     const mappedIpv4 = extractMappedIpv4(normalized)
     if (mappedIpv4) {
-      return isBlockedIpv4(mappedIpv4)
+      return isBlockedIpv4(mappedIpv4, options)
     }
-    return isBlockedIpv6(normalized)
+    return isBlockedIpv6(normalized, options)
   }
 
   return true
 }
 
-function isBlockedIpv4(address: string): boolean {
+function isBlockedIpv4(address: string, options: ResolveWebhookTargetOptions): boolean {
   const octets = address.split('.').map(part => Number.parseInt(part, 10))
   if (octets.length !== 4 || octets.some(Number.isNaN)) {
     return true
   }
 
   const [first, second] = octets
+  if (first === 127 && !options.allowLoopback) {
+    return true
+  }
   return (
     first === 0 ||
     first === 10 ||
@@ -178,11 +195,13 @@ function isBlockedIpv4(address: string): boolean {
   )
 }
 
-function isBlockedIpv6(address: string): boolean {
+function isBlockedIpv6(address: string, options: ResolveWebhookTargetOptions): boolean {
   const normalized = address.split('%')[0]!.toLowerCase()
-  // Block unspecified (::) but allow loopback (::1)
   if (normalized === '::') {
     return true
+  }
+  if (normalized === '::1') {
+    return !options.allowLoopback
   }
 
   const firstHextetText = normalized.split(':')[0] ?? ''

--- a/packages/api-routes/test/webhooks.test.ts
+++ b/packages/api-routes/test/webhooks.test.ts
@@ -14,12 +14,25 @@ test('resolveWebhookTarget rejects private and unspecified literal addresses', a
   }
 })
 
-test('resolveWebhookTarget accepts loopback literal addresses', async () => {
+test('resolveWebhookTarget rejects loopback literal addresses by default', async () => {
+  for (const url of [
+    'http://127.0.0.1/hook',
+    'http://127.255.255.254/hook',
+    'http://[::1]/hook',
+    // IPv4-mapped IPv6 loopback
+    'http://[::ffff:127.0.0.1]/hook',
+  ]) {
+    const result = await resolveWebhookTarget(url)
+    expect(result.ok, `expected ${url} to be blocked`).toBe(false)
+  }
+})
+
+test('resolveWebhookTarget accepts loopback when allowLoopback is true', async () => {
   for (const [url, address] of [
     ['http://127.0.0.1/hook', '127.0.0.1'],
     ['http://[::1]/hook', '::1'],
   ] as const) {
-    const result = await resolveWebhookTarget(url)
+    const result = await resolveWebhookTarget(url, { allowLoopback: true })
     expect(result.ok).toBe(true)
     if (result.ok) {
       expect(result.target.address).toBe(address)

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -918,6 +918,12 @@ export async function createServer(opts: {
     skipAuth: false,
     sessionCookieName: SESSION_COOKIE_NAME,
     resolveSessionApiKeyId,
+    // Local canonry serve runs on the operator's machine, where pointing a
+    // webhook at localhost (Discord test container, Pipedream-mock dev server,
+    // etc.) is a legitimate workflow. Default to allowing it for the local
+    // installer; cloud deployments inherit the secure default of `false` by
+    // not passing this option. Override with CANONRY_ALLOW_LOOPBACK_WEBHOOKS=0.
+    allowLoopbackWebhooks: process.env.CANONRY_ALLOW_LOOPBACK_WEBHOOKS !== '0',
     // Local-only Aero agent routes. Registered here so they inherit api-routes'
     // auth plugin — bare `registerAgentRoutes(app, ...)` would skip auth.
     registerAuthenticatedRoutes: async (scope) => {


### PR DESCRIPTION
## Summary
- Webhook URLs that resolve to `127.0.0.0/8` or `::1` (including the IPv4-mapped form `::ffff:127.0.0.1`) were accepted by `resolveWebhookTarget`. Any cloud deployment exposing `POST /notifications` or `POST /apply` could be coerced into hitting its own host services (cloud-metadata proxies bound to localhost, sidecar admin endpoints, local Redis/Vault).
- Adds an `allowLoopback` option (default `false`) and threads it through `NotificationRoutesOptions` + `ApplyRoutesOptions` + `ApiRoutesOptions`.
- Cloud `apps/api` inherits the secure default. Local `canonry serve` opts in by default to preserve existing dev workflows (Discord test containers, Pipedream-mock dev servers), with `CANONRY_ALLOW_LOOPBACK_WEBHOOKS=0` as the off switch.

## Test plan
- [x] `pnpm vitest run --project api-routes` — 724/724 pass
- [x] Added `resolveWebhookTarget rejects loopback literal addresses by default` covering `127.0.0.1`, `127.255.255.254`, `::1`, `::ffff:127.0.0.1`
- [x] Repurposed the prior "accepts loopback" test to assert the new `allowLoopback: true` opt-in
- [x] Existing "rejects private and unspecified" + "accepts public" tests unchanged and still pass
- [x] `pnpm --filter @ainyc/canonry-api-routes typecheck` clean
- [x] `pnpm --filter @ainyc/canonry typecheck` clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)