### PR TITLE
fix(db): preserve audit log on project delete

### DIFF
--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1188,6 +1188,48 @@ export const MIGRATION_VERSIONS: ReadonlyArray<MigrationVersion> = [
       `ALTER TABLE projects ADD COLUMN aliases TEXT NOT NULL DEFAULT '[]'`,
     ],
   },
+  {
+    version: 60,
+    name: 'audit-log-preserve-on-project-delete',
+    // The legacy `audit_log.project_id` FK was `ON DELETE CASCADE`, so any
+    // `DELETE /projects/:name` call cascade-wiped every audit row for that
+    // project — including the `project.deleted` row the route handler had
+    // just written in the same path. The deletion erased the only record
+    // that the deletion happened, defeating the entire purpose of the
+    // audit log.
+    //
+    // Fix: rebuild `audit_log` with `project_id` as `ON DELETE SET NULL`.
+    // Existing rows survive verbatim; future deletions detach audit rows
+    // from the project (project_id=NULL) instead of erasing them. SQLite
+    // can't change FK behavior in place — same canonical table-rebuild
+    // pattern v58 used for `query_snapshots`.
+    statements: [
+      `CREATE TABLE IF NOT EXISTS audit_log_v60 (
+         id           TEXT PRIMARY KEY,
+         project_id   TEXT REFERENCES projects(id) ON DELETE SET NULL,
+         actor        TEXT NOT NULL,
+         action       TEXT NOT NULL,
+         entity_type  TEXT NOT NULL,
+         entity_id    TEXT,
+         diff         TEXT,
+         created_at   TEXT NOT NULL
+       )`,
+      // LEFT JOIN guard mirrors v58: if a pre-existing row carries a
+      // dangling project_id (from a pre-FK era or a write with
+      // PRAGMA foreign_keys=OFF), the join nulls it out rather than
+      // failing the migration on the new FK validation.
+      `INSERT INTO audit_log_v60 (
+         id, project_id, actor, action, entity_type, entity_id, diff, created_at
+       )
+       SELECT a.id, p.id, a.actor, a.action, a.entity_type, a.entity_id, a.diff, a.created_at
+       FROM audit_log a
+       LEFT JOIN projects p ON p.id = a.project_id`,
+      `DROP TABLE audit_log`,
+      `ALTER TABLE audit_log_v60 RENAME TO audit_log`,
+      `CREATE INDEX IF NOT EXISTS idx_audit_log_project ON audit_log(project_id)`,
+      `CREATE INDEX IF NOT EXISTS idx_audit_log_created ON audit_log(created_at)`,
+    ],
+  },
 ]
 
 /**

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -97,7 +97,12 @@ export const querySnapshots = sqliteTable('query_snapshots', {
 
 export const auditLog = sqliteTable('audit_log', {
   id: text('id').primaryKey(),
-  projectId: text('project_id').references(() => projects.id, { onDelete: 'cascade' }),
+  // SET NULL (not CASCADE) so deleting a project preserves its audit trail.
+  // The DELETE /projects route writes a "project.deleted" row immediately
+  // before the delete — a CASCADE here would wipe that record before any
+  // reader could see it (the deletion would erase the only evidence it
+  // happened). Detached rows surface in audit queries with project_id=NULL.
+  projectId: text('project_id').references(() => projects.id, { onDelete: 'set null' }),
   actor: text('actor').notNull(),
   action: text('action').notNull(),
   entityType: text('entity_type').notNull(),

--- a/packages/db/test/audit-log-preserve.test.ts
+++ b/packages/db/test/audit-log-preserve.test.ts
@@ -1,0 +1,139 @@
+import { test, expect, onTestFinished } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import { eq, sql } from 'drizzle-orm'
+import {
+  auditLog,
+  createClient,
+  migrate,
+  projects,
+} from '../src/index.js'
+
+function freshDb() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-audit-preserve-'))
+  const dbPath = path.join(tmpDir, 'test.db')
+  const db = createClient(dbPath)
+  migrate(db)
+  onTestFinished(() => fs.rmSync(tmpDir, { recursive: true, force: true }))
+  return db
+}
+
+function seedProject(db: ReturnType<typeof createClient>) {
+  const now = new Date().toISOString()
+  const projectId = crypto.randomUUID()
+  db.insert(projects).values({
+    id: projectId,
+    name: 'test-project',
+    displayName: 'Test',
+    canonicalDomain: 'example.com',
+    country: 'US',
+    language: 'en',
+    createdAt: now,
+    updatedAt: now,
+  }).run()
+  return { projectId, now }
+}
+
+test('deleting a project keeps its audit log rows (project_id=NULL)', () => {
+  const db = freshDb()
+  const { projectId, now } = seedProject(db)
+
+  const auditId = crypto.randomUUID()
+  db.insert(auditLog).values({
+    id: auditId,
+    projectId,
+    actor: 'api',
+    action: 'project.created',
+    entityType: 'project',
+    entityId: projectId,
+    createdAt: now,
+  }).run()
+
+  db.delete(projects).where(eq(projects.id, projectId)).run()
+
+  const after = db.select().from(auditLog).where(eq(auditLog.id, auditId)).all()
+  expect(after).toHaveLength(1)
+  expect(after[0]!.projectId).toBeNull()
+  expect(after[0]!.action).toBe('project.created')
+  expect(after[0]!.entityId).toBe(projectId)
+})
+
+test('project.deleted audit row survives the project DELETE that triggered it', () => {
+  // The bug fixed by this change: the DELETE /projects/:name handler writes
+  // an audit row with action="project.deleted" and entityId=<projectId>,
+  // then deletes the project. Pre-fix, the FK cascade wipes that audit row
+  // before any reader can observe it — the deletion erases the only record
+  // that the deletion happened.
+  const db = freshDb()
+  const { projectId, now } = seedProject(db)
+
+  const auditId = crypto.randomUUID()
+  db.transaction((tx) => {
+    tx.insert(auditLog).values({
+      id: auditId,
+      projectId,
+      actor: 'api',
+      action: 'project.deleted',
+      entityType: 'project',
+      entityId: projectId,
+      createdAt: now,
+    }).run()
+    tx.delete(projects).where(eq(projects.id, projectId)).run()
+  })
+
+  const after = db.select().from(auditLog).where(eq(auditLog.id, auditId)).all()
+  expect(after).toHaveLength(1)
+  expect(after[0]!.action).toBe('project.deleted')
+  expect(after[0]!.entityId).toBe(projectId)
+  expect(after[0]!.projectId).toBeNull()
+})
+
+test('schema declares audit_log.project_id with ON DELETE SET NULL', () => {
+  // Guard: a future migration that re-creates the table can't silently
+  // re-introduce the cascade without failing the suite.
+  const db = freshDb()
+  const fks = db.all<{ table: string; from: string; to: string; on_delete: string }>(
+    sql`PRAGMA foreign_key_list(audit_log)`,
+  )
+  const projectFk = fks.find(fk => fk.from === 'project_id')
+  expect(projectFk).toBeDefined()
+  expect(projectFk!.table).toBe('projects')
+  expect(projectFk!.on_delete).toBe('SET NULL')
+
+  const cols = db.all<{ name: string; notnull: number }>(
+    sql`PRAGMA table_info(audit_log)`,
+  )
+  const projectIdCol = cols.find(c => c.name === 'project_id')
+  expect(projectIdCol).toBeDefined()
+  expect(projectIdCol!.notnull).toBe(0) // nullable
+})
+
+test('migration is idempotent — re-running v60 leaves data untouched', () => {
+  // Same belt-and-suspenders pattern as the v58 dangling-ref test: force a
+  // re-run by clearing the tracker row, and confirm an existing detached
+  // (project_id=NULL) audit row survives the rebuild intact.
+  const db = freshDb()
+  const { projectId, now } = seedProject(db)
+
+  const auditId = crypto.randomUUID()
+  db.insert(auditLog).values({
+    id: auditId,
+    projectId,
+    actor: 'api',
+    action: 'project.created',
+    entityType: 'project',
+    entityId: projectId,
+    createdAt: now,
+  }).run()
+  db.delete(projects).where(eq(projects.id, projectId)).run()
+
+  db.run(sql`DELETE FROM _migrations WHERE version >= 60`)
+  expect(() => migrate(db)).not.toThrow()
+
+  const rows = db.select().from(auditLog).all()
+  expect(rows).toHaveLength(1)
+  expect(rows[0]!.id).toBe(auditId)
+  expect(rows[0]!.projectId).toBeNull()
+})


### PR DESCRIPTION
## Summary
- The `DELETE /projects/:name` handler writes a `project.deleted` audit row, then deletes the project. `audit_log.project_id` was `ON DELETE CASCADE`, so the cascade wiped the audit row in the same statement — the deletion erased its own evidence.
- Rebuild `audit_log` with `project_id` as `ON DELETE SET NULL` via migration v60. Future deletions detach audit rows from the project (`project_id=NULL`) instead of erasing them; existing rows survive verbatim.
- Same table-rebuild template v58 used for `query_snapshots`, including the `LEFT JOIN` guard against pre-existing dangling-FK rows (pre-FK era or `PRAGMA foreign_keys=OFF` writes).

## Test plan
- [x] `pnpm vitest run --project db audit-log-preserve` — 4/4 pass
- [x] `deleting a project keeps its audit log rows (project_id=NULL)` — the original bug
- [x] `project.deleted audit row survives the project DELETE that triggered it` — the exact route-handler flow
- [x] `schema declares audit_log.project_id with ON DELETE SET NULL` — PRAGMA guard against future regressions
- [x] `migration is idempotent — re-running v60 leaves data untouched` — replay-safety
- [x] Full `--project db` suite: 73 pass, 2 pre-existing failures in `schedules-migration.test.ts` unrelated to this change
- [x] `pnpm --filter @ainyc/canonry-db typecheck` clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)