### PR TITLE
fix(google): refuse silent fallback to insecure default state secret

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -30,6 +30,7 @@ export function buildApp(env: PlatformEnv) {
       version: '0.1.0',
     },
     providerSummary,
+    googleStateSecret: env.googleStateSecret,
   })
 
   registerHealthRoutes(app, env)

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -25,6 +25,7 @@ test('buildApp registers health and API routes', async () => {
     DATABASE_URL: dbPath,
     API_PORT: '3000',
     WORKER_PORT: '3001',
+    GOOGLE_STATE_SECRET: 'test-only-google-state-secret-32b',
   })
   const app = buildApp(env)
 

--- a/packages/api-routes/src/google.ts
+++ b/packages/api-routes/src/google.ts
@@ -117,7 +117,37 @@ async function getValidToken(
 }
 
 export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptions) {
-  const stateSecret = opts.googleStateSecret ?? 'insecure-default-secret'
+  // State signing is the only thing keeping an attacker from forging an OAuth
+  // callback that lands a connection on an account they control — there is no
+  // safe "default" secret. Three states:
+  //
+  //   - undefined: operator hasn't wired Google at all. Skip route
+  //     registration with a warning; Google endpoints respond 404, no attack
+  //     surface. Cloud (apps/api) inherits this when GOOGLE_STATE_SECRET is
+  //     unset — secure default.
+  //
+  //   - empty string OR the legacy literal 'insecure-default-secret': active
+  //     misconfiguration. Throw at registration so the operator catches it at
+  //     boot.
+  //
+  //   - any other value: register normally.
+  if (opts.googleStateSecret === undefined) {
+    app.log.warn(
+      'googleStateSecret is not configured — Google OAuth routes will not be registered. Set GOOGLE_STATE_SECRET to enable Google integrations.',
+    )
+    return
+  }
+  if (opts.googleStateSecret === '') {
+    throw new Error(
+      'googleStateSecret is empty. Set a non-empty secret (e.g. `openssl rand -hex 32`) via the GOOGLE_STATE_SECRET environment variable.',
+    )
+  }
+  if (opts.googleStateSecret === 'insecure-default-secret') {
+    throw new Error(
+      'googleStateSecret is set to the legacy insecure default. Generate a real secret (e.g. `openssl rand -hex 32`) and set GOOGLE_STATE_SECRET.',
+    )
+  }
+  const stateSecret = opts.googleStateSecret
 
   function getAuthConfig() {
     return opts.getGoogleAuthConfig?.() ?? {}

--- a/packages/api-routes/test/google-state-secret.test.ts
+++ b/packages/api-routes/test/google-state-secret.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import Fastify from 'fastify'
+import { createClient, migrate } from '@ainyc/canonry-db'
+import { AppError } from '@ainyc/canonry-contracts'
+import { googleRoutes } from '../src/google.js'
+
+function makeApp() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'google-no-secret-test-'))
+  const dbPath = path.join(tmpDir, 'test.db')
+  const db = createClient(dbPath)
+  migrate(db)
+
+  const app = Fastify()
+  app.decorate('db', db)
+  app.setErrorHandler((error, _request, reply) => {
+    if (error instanceof AppError) {
+      return reply.status(error.statusCode).send(error.toJSON())
+    }
+    throw error
+  })
+  return { app, db, tmpDir }
+}
+
+const baseStore = {
+  listConnections: () => [],
+  getConnection: () => undefined,
+  upsertConnection: (connection: Parameters<typeof baseStore.upsertConnection>[0]) => connection,
+  updateConnection: () => undefined,
+  deleteConnection: () => false,
+} as const
+
+describe('googleRoutes refuses to register without a configured state secret', () => {
+  it('skips registration when googleStateSecret is undefined (no Google routes mounted)', async () => {
+    const { app, tmpDir } = makeApp()
+    app.register(googleRoutes, {
+      getGoogleAuthConfig: () => ({ clientId: 'id', clientSecret: 'secret' }),
+      googleConnectionStore: baseStore,
+      // googleStateSecret deliberately omitted — pre-fix this silently
+      // fell back to the literal string 'insecure-default-secret'. Now the
+      // plugin no-ops so the OAuth attack surface vanishes; the routes
+      // simply 404. Operators see the warning in logs.
+    })
+
+    await app.ready()
+    // Probe a representative Google route — it must 404 because the plugin
+    // refused to register itself.
+    const res = await app.inject({
+      method: 'POST',
+      url: '/projects/my-project/google/connect',
+      payload: { type: 'gsc' },
+    })
+    expect(res.statusCode).toBe(404)
+
+    await app.close()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('throws at app.ready() when googleStateSecret is an empty string', async () => {
+    // Empty string is an active misconfiguration (e.g. GOOGLE_STATE_SECRET=""
+    // in env). Surface it loudly at boot rather than silently treating it as
+    // "not configured".
+    const { app, tmpDir } = makeApp()
+    app.register(googleRoutes, {
+      getGoogleAuthConfig: () => ({ clientId: 'id', clientSecret: 'secret' }),
+      googleConnectionStore: baseStore,
+      googleStateSecret: '',
+    })
+
+    await expect(app.ready()).rejects.toThrow(/empty|state secret|GOOGLE_STATE_SECRET/i)
+
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('rejects the literal insecure default value (defense in depth)', async () => {
+    // Even if someone copy-pastes the historical fallback into config, the
+    // plugin refuses to honor it.
+    const { app, tmpDir } = makeApp()
+    app.register(googleRoutes, {
+      getGoogleAuthConfig: () => ({ clientId: 'id', clientSecret: 'secret' }),
+      googleConnectionStore: baseStore,
+      googleStateSecret: 'insecure-default-secret',
+    })
+
+    await expect(app.ready()).rejects.toThrow(/insecure|state secret|GOOGLE_STATE_SECRET/i)
+
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('registers successfully when a real secret is provided', async () => {
+    const { app, tmpDir } = makeApp()
+    app.register(googleRoutes, {
+      getGoogleAuthConfig: () => ({ clientId: 'id', clientSecret: 'secret' }),
+      googleConnectionStore: baseStore,
+      googleStateSecret: 'a-real-32-byte-hex-secret-here-1234',
+    })
+
+    await expect(app.ready()).resolves.toBeDefined()
+    await app.close()
+
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+})

--- a/packages/api-routes/test/openapi-contract.test.ts
+++ b/packages/api-routes/test/openapi-contract.test.ts
@@ -26,7 +26,10 @@ function buildObservedApp(opts: Partial<Omit<ApiRoutesOptions, 'db'>> = {}): Rou
       observedRoutes.push({ method: String(method), url: route.url })
     }
   })
-  app.register(apiRoutes, { db, skipAuth: true, ...opts })
+  // Google routes register only when a state secret is configured; this
+  // contract test enumerates every public path including Google's, so seed
+  // a dummy secret to keep that surface mounted under test.
+  app.register(apiRoutes, { db, skipAuth: true, googleStateSecret: 'test-only-google-state-secret-32b', ...opts })
 
   return { app, observedRoutes, tmpDir }
 }

--- a/packages/api-routes/test/security.test.ts
+++ b/packages/api-routes/test/security.test.ts
@@ -15,7 +15,10 @@ function buildApp(opts: Partial<Omit<ApiRoutesOptions, 'db'>> = {}) {
   migrate(db)
 
   const app = Fastify()
-  app.register(apiRoutes, { db, skipAuth: false, ...opts })
+  // Google routes register only when a state secret is configured; the
+  // public-route exception test below covers /google/callback, so seed a
+  // dummy secret to keep that surface mounted under test.
+  app.register(apiRoutes, { db, skipAuth: false, googleStateSecret: 'test-only-google-state-secret-32b', ...opts })
 
   return { app, db, tmpDir }
 }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -36,6 +36,10 @@ const envSchema = z.object({
   PERPLEXITY_MAX_CONCURRENCY: z.coerce.number().int().positive().default(2),
   PERPLEXITY_MAX_REQUESTS_PER_MINUTE: z.coerce.number().int().positive().default(10),
   PERPLEXITY_MAX_REQUESTS_PER_DAY: z.coerce.number().int().positive().default(1000),
+  // Secret for HMAC-signing Google OAuth state parameters. Required for
+  // cloud deployments that mount googleRoutes; the plugin refuses to register
+  // without it (see packages/api-routes/src/google.ts).
+  GOOGLE_STATE_SECRET: z.string().optional(),
 })
 
 export interface ProviderEnvConfig {
@@ -76,6 +80,13 @@ export interface PlatformEnv {
   webPort: number
   basePath: string
   bootstrapSecret: string
+  /**
+   * Required for cloud deployments that expose Google OAuth routes. Sourced
+   * from `GOOGLE_STATE_SECRET`. Undefined when unset — the api-routes plugin
+   * will refuse to register googleRoutes in that case, which is the secure
+   * default.
+   */
+  googleStateSecret?: string
   providers: {
     gemini?: ProviderEnvConfig
     openai?: ProviderEnvConfig
@@ -169,6 +180,7 @@ export function getPlatformEnv(source: NodeJS.ProcessEnv): PlatformEnv {
     webPort: parsed.WEB_PORT,
     basePath: parsed.CANONRY_BASE_PATH,
     bootstrapSecret: parsed.BOOTSTRAP_SECRET,
+    googleStateSecret: parsed.GOOGLE_STATE_SECRET,
     providers,
   }
 }


### PR DESCRIPTION
## Summary
- `googleRoutes` silently fell back to the literal string `'insecure-default-secret'` when `opts.googleStateSecret` was unset. An attacker who guessed that fixed value — trivial since it lived in source — could forge OAuth state and complete a Google connection as themselves.
- Replaces the silent fallback with explicit handling:
  - `undefined`: skip route registration entirely with a logged warning (Google features 404 — no attack surface). Cloud deployments inherit this safely when `GOOGLE_STATE_SECRET` is unset.
  - `''` (empty string): throw at boot — active misconfiguration.
  - `'insecure-default-secret'` literal: throw at boot — defense in depth against copy-paste of the legacy fallback.
  - any other value: register normally.
- Wires `GOOGLE_STATE_SECRET` through `PlatformEnv` and `apps/api` so the cloud entrypoint forwards it explicitly.

## Test plan
- [x] `pnpm vitest run --project api-routes --project api --project config` — 737/737 pass
- [x] New `google-state-secret.test.ts`:
  - `skips registration when googleStateSecret is undefined (no Google routes mounted)` — secure default
  - `throws at app.ready() when googleStateSecret is an empty string`
  - `rejects the literal insecure default value (defense in depth)`
  - `registers successfully when a real secret is provided`
- [x] Existing test harnesses that exercise Google routes (`openapi-contract.test.ts`, `security.test.ts`, `apps/api/test/app.test.ts`) now pass an explicit test-only secret
- [x] Typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)