### PR TITLE
fix(runs): respect project idle lock for --all-locations fan-out

### DIFF
--- a/packages/api-routes/src/runs.ts
+++ b/packages/api-routes/src/runs.ts
@@ -1,5 +1,5 @@
 import crypto from 'node:crypto'
-import { eq, asc, desc, sql } from 'drizzle-orm'
+import { and, eq, asc, desc, or, sql } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import { runs, querySnapshots, queries, projects, parseJsonColumn } from '@ainyc/canonry-db'
 import type { LocationContext } from '@ainyc/canonry-contracts'
@@ -98,33 +98,56 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
       resolvedLocation = loc
     }
 
-    // Handle --all-locations: create one run per configured location
-    // Skip the idle-check here — each location gets its own run regardless of other active runs.
+    // Handle --all-locations: create one run per configured location.
+    //
+    // The fan-out is atomic with respect to the project-level idle lock:
+    // a single transaction checks for any active run and, only if none
+    // exists, inserts the per-location runs. Two concurrent --all-locations
+    // calls (manual + scheduled, two CLI shells, etc.) can no longer stack
+    // duplicate sweeps on the same project, double-billing provider calls
+    // and racing snapshots into the same window.
     if (body.allLocations) {
       if (projectLocations.length === 0) {
         throw validationError('No locations configured for this project')
       }
 
-      // Insert all run records first, then dispatch — bypassing queueRunIfProjectIdle
-      // which would block after the first run is inserted.
-      const newRuns: Array<{ runId: string; loc: LocationContext }> = []
-      for (const loc of projectLocations) {
-        const runId = crypto.randomUUID()
-        app.db.insert(runs).values({
-          id: runId,
-          projectId: project.id,
-          kind,
-          status: 'queued',
-          trigger,
-          location: loc.label,
-          queries: queriesColumn,
-          createdAt: now,
-        }).run()
-        newRuns.push({ runId, loc })
+      const result = app.db.transaction((tx) => {
+        const activeRun = tx
+          .select({ id: runs.id })
+          .from(runs)
+          .where(and(
+            eq(runs.projectId, project.id),
+            or(eq(runs.status, 'queued'), eq(runs.status, 'running')),
+          ))
+          .get()
+        if (activeRun) {
+          return { conflict: true as const }
+        }
+
+        const inserted: Array<{ runId: string; loc: LocationContext }> = []
+        for (const loc of projectLocations) {
+          const runId = crypto.randomUUID()
+          tx.insert(runs).values({
+            id: runId,
+            projectId: project.id,
+            kind,
+            status: 'queued',
+            trigger,
+            location: loc.label,
+            queries: queriesColumn,
+            createdAt: now,
+          }).run()
+          inserted.push({ runId, loc })
+        }
+        return { conflict: false as const, inserted }
+      })
+
+      if (result.conflict) {
+        throw runInProgress(project.name)
       }
 
       const results = []
-      for (const { runId, loc } of newRuns) {
+      for (const { runId, loc } of result.inserted) {
         writeAuditLog(app.db, {
           projectId: project.id,
           actor: 'api',

--- a/packages/api-routes/test/run-all-locations-idle-lock.test.ts
+++ b/packages/api-routes/test/run-all-locations-idle-lock.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, beforeEach, afterEach, expect } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import Fastify from 'fastify'
+import { and, eq, or } from 'drizzle-orm'
+import { createClient, migrate, runs } from '@ainyc/canonry-db'
+import { apiRoutes } from '../src/index.js'
+
+function buildApp() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-run-all-loc-test-'))
+  const dbPath = path.join(tmpDir, 'test.db')
+  const db = createClient(dbPath)
+  migrate(db)
+  const app = Fastify()
+  app.register(apiRoutes, { db, skipAuth: true })
+  return { app, db, tmpDir }
+}
+
+async function seedProjectWithLocations(app: ReturnType<typeof Fastify>) {
+  await app.inject({
+    method: 'PUT',
+    url: '/api/v1/projects/multi-loc',
+    payload: {
+      displayName: 'Multi-location',
+      canonicalDomain: 'multi-loc.example.com',
+      country: 'US',
+      language: 'en',
+      locations: [
+        { label: 'east', city: 'New York', region: 'NY', country: 'US' },
+        { label: 'west', city: 'San Francisco', region: 'CA', country: 'US' },
+        { label: 'south', city: 'Austin', region: 'TX', country: 'US' },
+      ],
+    },
+  })
+}
+
+describe('POST /api/v1/projects/:name/runs with allLocations respects the idle lock', () => {
+  let app: ReturnType<typeof Fastify>
+  let db: ReturnType<typeof createClient>
+  let tmpDir: string
+
+  beforeEach(async () => {
+    const ctx = buildApp()
+    app = ctx.app
+    db = ctx.db
+    tmpDir = ctx.tmpDir
+    await app.ready()
+    await seedProjectWithLocations(app)
+  })
+
+  afterEach(async () => {
+    await app.close()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function projectIdFor(name: string): string {
+    // Pull from the runs table after a sweep, or from the API. Simplest: read
+    // the project row directly via the same DB the route plugin uses.
+    const row = db
+      .select({ projectId: runs.projectId })
+      .from(runs)
+      .all()
+    if (row.length > 0) return row[0]!.projectId
+    // Fallback: synthesize a UUID; the test will fail before using this when
+    // setup is correct.
+    return name
+  }
+
+  it('returns 409 RUN_IN_PROGRESS when a queued run already exists for the project', async () => {
+    // First, kick off a single-location run to learn the project_id (read
+    // via runs.projectId since the projects route doesn't return the UUID).
+    const seedRes = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/multi-loc/runs',
+      payload: { location: 'east' },
+    })
+    expect(seedRes.statusCode).toBe(201)
+    const projectId = projectIdFor('multi-loc')
+
+    // The seed run is still queued — leave it that way to simulate the
+    // "another sweep is already going" condition. Now try allLocations.
+    const allLocRes = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/multi-loc/runs',
+      payload: { allLocations: true },
+    })
+
+    expect(allLocRes.statusCode).toBe(409)
+    const body = JSON.parse(allLocRes.payload) as { error: { code: string } }
+    expect(body.error.code).toBe('RUN_IN_PROGRESS')
+
+    // Critically: no new run rows were inserted. Only the seed run exists.
+    const allRunsAfter = db
+      .select()
+      .from(runs)
+      .where(eq(runs.projectId, projectId))
+      .all()
+    expect(allRunsAfter).toHaveLength(1)
+  })
+
+  it('returns 409 when a running run is already in flight', async () => {
+    // Seed a project row by triggering a run we then promote to "running".
+    const seedRes = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/multi-loc/runs',
+      payload: { location: 'east' },
+    })
+    expect(seedRes.statusCode).toBe(201)
+    const seedBody = JSON.parse(seedRes.payload) as { id: string }
+    db.update(runs).set({ status: 'running' }).where(eq(runs.id, seedBody.id)).run()
+    const projectId = projectIdFor('multi-loc')
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/multi-loc/runs',
+      payload: { allLocations: true },
+    })
+
+    expect(res.statusCode).toBe(409)
+    const allRunsAfter = db
+      .select()
+      .from(runs)
+      .where(
+        and(
+          eq(runs.projectId, projectId),
+          or(eq(runs.status, 'queued'), eq(runs.status, 'running')),
+        ),
+      )
+      .all()
+    expect(allRunsAfter).toHaveLength(1) // only the original running run
+    expect(allRunsAfter[0]!.id).toBe(seedBody.id)
+  })
+
+  it('succeeds with 207 and creates one run per location when project is idle', async () => {
+    // Sanity: with no active runs, allLocations still fans out as before.
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/multi-loc/runs',
+      payload: { allLocations: true },
+    })
+    expect(res.statusCode).toBe(207)
+    const body = JSON.parse(res.payload) as unknown[]
+    expect(body).toHaveLength(3)
+    const projectId = projectIdFor('multi-loc')
+    const queued = db
+      .select()
+      .from(runs)
+      .where(
+        and(
+          eq(runs.projectId, projectId),
+          or(eq(runs.status, 'queued'), eq(runs.status, 'running')),
+        ),
+      )
+      .all()
+    expect(queued).toHaveLength(3)
+  })
+
+  it('a second allLocations call while the first is in-flight is rejected (no double-fan-out)', async () => {
+    // First call fans out 3 runs (idle precondition satisfied).
+    const first = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/multi-loc/runs',
+      payload: { allLocations: true },
+    })
+    expect(first.statusCode).toBe(207)
+    const projectId = projectIdFor('multi-loc')
+
+    // Second call must see "active run(s) on this project" and refuse.
+    // Pre-fix, the route bypassed the idle check entirely and inserted
+    // another 3 runs on top of the existing 3 — concurrent provider calls,
+    // double billing, racing snapshots.
+    const second = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/multi-loc/runs',
+      payload: { allLocations: true },
+    })
+    expect(second.statusCode).toBe(409)
+
+    // Still exactly 3 active runs — no duplication.
+    const queued = db
+      .select()
+      .from(runs)
+      .where(
+        and(
+          eq(runs.projectId, projectId),
+          or(eq(runs.status, 'queued'), eq(runs.status, 'running')),
+        ),
+      )
+      .all()
+    expect(queued).toHaveLength(3)
+  })
+})


### PR DESCRIPTION
## Summary
- The `--all-locations` branch of `POST /projects/:name/runs` explicitly bypassed `queueRunIfProjectIdle`. The comment in the code said *"each location gets its own run regardless of other active runs."* In practice, two concurrent fan-outs (manual + scheduled, two CLI shells, race between `RunCoordinator` and a human trigger) could each insert N location runs on top of an already-queued sweep — racing snapshots into the same window and double-billing provider calls.
- Wrap the fan-out in a single transaction that checks for any queued or running run on the project and only inserts the per-location rows if none exists. On conflict, throw `runInProgress` (409) — matching the single-location path's behavior.
- Audit-log writes and `onRunCreated` callbacks fire after the transaction commits (consistent with the existing single-location flow).

## Test plan
- [x] `pnpm vitest run --project api-routes run-all-locations-idle-lock` — 4/4 pass
  - `returns 409 RUN_IN_PROGRESS when a queued run already exists for the project`
  - `returns 409 when a running run is already in flight`
  - `succeeds with 207 and creates one run per location when project is idle`
  - `a second allLocations call while the first is in-flight is rejected (no double-fan-out)`
- [x] Full `--project api-routes` suite: 727/727 pass (includes the prior `persists scope on every per-location run when combined with allLocations` test from PR #480)
- [x] Typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)