### PR TITLE
fix(intelligence): use JSON-serialized key for insight grouping

### DIFF
--- a/packages/intelligence/src/insight-grouping.ts
+++ b/packages/intelligence/src/insight-grouping.ts
@@ -30,7 +30,12 @@ export interface GroupedInsight<T extends InsightLike = InsightLike> {
 
 /**
  * Group insights by an arbitrary key. Default key tuples on the natural
- * dedup dimensions: (query, provider, type).
+ * dedup dimensions: (query, provider, type), serialized via `JSON.stringify`
+ * so spaces inside a tracked query (e.g. "best polyurea roof coating") can't
+ * reshuffle the field boundaries and collide with a different (query,
+ * provider, type) tuple. A previous space-joined key produced the same
+ * string for {query:"a b", provider:"c"} and {query:"a", provider:"b c"},
+ * silently merging distinct insights.
  *
  * Group order is the order of first appearance in the input.
  * Within each group, instances are sorted oldest → newest by createdAt
@@ -38,7 +43,7 @@ export interface GroupedInsight<T extends InsightLike = InsightLike> {
  */
 export function groupInsights<T extends InsightLike>(
   insights: T[],
-  keyFn: (i: T) => string = (i) => `${i.query} ${i.provider} ${i.type}`,
+  keyFn: (i: T) => string = (i) => JSON.stringify([i.query, i.provider, i.type]),
 ): GroupedInsight<T>[] {
   const order: string[] = []
   const buckets = new Map<string, T[]>()

--- a/packages/intelligence/test/insight-grouping.test.ts
+++ b/packages/intelligence/test/insight-grouping.test.ts
@@ -75,4 +75,32 @@ describe('groupInsights', () => {
     expect(groups).toHaveLength(1)
     expect(groups[0]!.count).toBe(2)
   })
+
+  test('does not collide when field boundaries fall on whitespace', () => {
+    // Tracked queries almost always contain spaces ("HVAC lead generation",
+    // "best polyurea roof coating"). If the dedup key is built by joining
+    // (query, provider, type) with a space, two genuinely different inputs
+    // can produce the same key — and two distinct insights silently merge
+    // into a single row. The pair below produces identical concat strings
+    // under a space-joined key.
+    const insights = [
+      makeInsight({ query: 'HVAC lead', provider: 'openai', type: 'gain', createdAt: '2026-01-01T00:00:00Z', title: 'A' }),
+      makeInsight({ query: 'HVAC', provider: 'lead openai', type: 'gain', createdAt: '2026-01-01T00:00:00Z', title: 'B' }),
+    ]
+    const groups = groupInsights(insights)
+    expect(groups).toHaveLength(2)
+    const titles = groups.map(g => g.representative.title).sort()
+    expect(titles).toEqual(['A', 'B'])
+  })
+
+  test('does not collide when boundary tokens are reshuffled across fields', () => {
+    // Same total tokens, different field assignment. With a space-joined
+    // key, both produce "best HVAC openai gain" — distinct insights merge.
+    const insights = [
+      makeInsight({ query: 'best HVAC openai', provider: 'gain', type: 'gain', createdAt: '2026-01-01T00:00:00Z', title: 'A' }),
+      makeInsight({ query: 'best HVAC', provider: 'openai gain', type: 'gain', createdAt: '2026-01-01T00:00:00Z', title: 'B' }),
+    ]
+    const groups = groupInsights(insights)
+    expect(groups).toHaveLength(2)
+  })
 })


### PR DESCRIPTION
## Summary
- \`groupInsights\` built its dedup key by joining \`(query, provider, type)\` with a space. Tracked queries routinely contain spaces, so two genuinely different tuples could produce the same key — e.g. \`{query:"HVAC lead", provider:"openai"}\` and \`{query:"HVAC", provider:"lead openai"}\` both serialized to \`"HVAC lead openai gain"\`. Distinct insights silently merged into one row in the dashboard, report, and CLI list views.
- Switch the default key to \`JSON.stringify([query, provider, type])\` so field boundaries are unambiguous regardless of content. One-line behavior change; signature unchanged.

## Test plan
- [x] \`pnpm vitest run --project intelligence insight-grouping\` — 8/8 pass (6 existing + 2 new)
- [x] New regression tests:
  - \`does not collide when field boundaries fall on whitespace\` — covers the realistic \`HVAC lead\` × \`lead openai\` collision
  - \`does not collide when boundary tokens are reshuffled across fields\` — same-token-count collision proof
- [x] Full \`--project intelligence --project api-routes --project canonry\` run: 1809/1809 pass — consumers (\`report.ts\`, \`report-renderer.ts\`) use the default keyFn and inherit the fix automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)