### PR TITLE
fix(intelligence): scope transition detection to same-location chronology

### DIFF
--- a/packages/canonry/src/intelligence-service.ts
+++ b/packages/canonry/src/intelligence-service.ts
@@ -51,25 +51,46 @@ export class IntelligenceService {
     }
 
     // 2. Build RunData for the current run
-    const currentRun = this.buildRunData(runId, projectId, currentRunRecord.finishedAt ?? currentRunRecord.createdAt)
+    const currentRun = this.buildRunData(
+      runId,
+      projectId,
+      currentRunRecord.finishedAt ?? currentRunRecord.createdAt,
+      currentRunRecord.location ?? null,
+    )
 
     if (currentRun.snapshots.length === 0) {
       log.info('intelligence.skip', { runId, reason: 'no snapshots' })
       return null
     }
 
-    // 3. Build RunData for previous run + history window (oldest → newest, ending at current)
+    // 3. Build RunData for previous run + history window (oldest → newest, ending at current).
+    //
+    // Multi-location fan-out: a single sweep produces one run per configured
+    // location. We must compare each run against the previous run *at the
+    // same location* — comparing Michigan to its sibling Florida arm would
+    // treat the geo difference as a regression/gain. Filter the ordered
+    // window to same-location entries, treating null/undefined as one
+    // bucket (locationless runs share a chronology).
     const orderedRecent = [...recentRuns].reverse()
-    const currentIdx = orderedRecent.findIndex(r => r.id === runId)
-    const previousRunRecord = currentIdx > 0 ? orderedRecent[currentIdx - 1]! : null
+    const currentLocation = currentRunRecord.location ?? null
+    const sameLocationOrdered = orderedRecent.filter(r => (r.location ?? null) === currentLocation)
+    const currentLocIdx = sameLocationOrdered.findIndex(r => r.id === runId)
+    const previousRunRecord = currentLocIdx > 0 ? sameLocationOrdered[currentLocIdx - 1]! : null
     const previousRun = previousRunRecord
-      ? this.buildRunData(previousRunRecord.id, projectId, previousRunRecord.finishedAt ?? previousRunRecord.createdAt)
+      ? this.buildRunData(
+        previousRunRecord.id,
+        projectId,
+        previousRunRecord.finishedAt ?? previousRunRecord.createdAt,
+        previousRunRecord.location ?? null,
+      )
       : null
 
     const trackedCompetitors = this.loadTrackedCompetitors(projectId)
-    const history = orderedRecent
-      .slice(0, currentIdx + 1)
-      .map(r => r.id === runId ? currentRun : this.buildRunData(r.id, projectId, r.finishedAt ?? r.createdAt))
+    const history = sameLocationOrdered
+      .slice(0, currentLocIdx + 1)
+      .map(r => r.id === runId
+        ? currentRun
+        : this.buildRunData(r.id, projectId, r.finishedAt ?? r.createdAt, r.location ?? null))
 
     // 4. Run analysis — skip transition detection on first run (no baseline to compare)
     if (!previousRun) {
@@ -114,25 +135,35 @@ export class IntelligenceService {
    * Used by backfill where we control the run ordering.
    */
   analyzeRunWithPrevious(
-    runRecord: { id: string; projectId: string; finishedAt: string | null; createdAt: string },
-    previousRunRecord: { id: string; projectId: string; finishedAt: string | null; createdAt: string } | null,
-    historyRecords?: readonly { id: string; projectId: string; finishedAt: string | null; createdAt: string }[],
+    runRecord: { id: string; projectId: string; finishedAt: string | null; createdAt: string; location?: string | null },
+    previousRunRecord: { id: string; projectId: string; finishedAt: string | null; createdAt: string; location?: string | null } | null,
+    historyRecords?: readonly { id: string; projectId: string; finishedAt: string | null; createdAt: string; location?: string | null }[],
   ): AnalysisResult | null {
-    const currentRun = this.buildRunData(runRecord.id, runRecord.projectId, runRecord.finishedAt ?? runRecord.createdAt)
+    const currentRun = this.buildRunData(
+      runRecord.id,
+      runRecord.projectId,
+      runRecord.finishedAt ?? runRecord.createdAt,
+      runRecord.location ?? null,
+    )
 
     if (currentRun.snapshots.length === 0) {
       return null
     }
 
     const previousRun = previousRunRecord
-      ? this.buildRunData(previousRunRecord.id, previousRunRecord.projectId, previousRunRecord.finishedAt ?? previousRunRecord.createdAt)
+      ? this.buildRunData(
+        previousRunRecord.id,
+        previousRunRecord.projectId,
+        previousRunRecord.finishedAt ?? previousRunRecord.createdAt,
+        previousRunRecord.location ?? null,
+      )
       : null
 
     const trackedCompetitors = this.loadTrackedCompetitors(runRecord.projectId)
     const history = (historyRecords ?? [])
       .map(r => r.id === runRecord.id
         ? currentRun
-        : this.buildRunData(r.id, r.projectId, r.finishedAt ?? r.createdAt))
+        : this.buildRunData(r.id, r.projectId, r.finishedAt ?? r.createdAt, r.location ?? null))
 
     // Skip transition detection on first run (no baseline to compare)
     if (!previousRun) {
@@ -200,12 +231,18 @@ export class IntelligenceService {
 
     for (let i = 0; i < targetRuns.length; i++) {
       const run = targetRuns[i]!
-      // Previous run is the one before this in the full list (not just the target slice)
-      const globalIdx = allRuns.indexOf(run)
-      const previousRun = globalIdx > 0 ? allRuns[globalIdx - 1]! : null
-      // History window for persistent-gap: last HISTORY_WINDOW_RUNS entries up to and including this run.
-      const historyStart = Math.max(0, globalIdx - (HISTORY_WINDOW_RUNS - 1))
-      const historyRecords = allRuns.slice(historyStart, globalIdx + 1)
+      // Pick the previous run *at the same location* — backfill of a
+      // multi-location project must not compare sibling fan-out arms as if
+      // they were a temporal sequence (Michigan→Florida is not a transition).
+      // Locationless runs share a chronology (treated as one bucket).
+      const runLocation = run.location ?? null
+      const sameLocationRuns = allRuns.filter(r => (r.location ?? null) === runLocation)
+      const sameLocIdx = sameLocationRuns.indexOf(run)
+      const previousRun = sameLocIdx > 0 ? sameLocationRuns[sameLocIdx - 1]! : null
+      // History window for persistent-gap: last HISTORY_WINDOW_RUNS entries
+      // at the same location up to and including this run.
+      const historyStart = Math.max(0, sameLocIdx - (HISTORY_WINDOW_RUNS - 1))
+      const historyRecords = sameLocationRuns.slice(historyStart, sameLocIdx + 1)
 
       const result = this.analyzeRunWithPrevious(run, previousRun, historyRecords)
 
@@ -443,7 +480,12 @@ export class IntelligenceService {
     })
   }
 
-  private buildRunData(runId: string, projectId: string, completedAt: string): RunData {
+  private buildRunData(
+    runId: string,
+    projectId: string,
+    completedAt: string,
+    location: string | null = null,
+  ): RunData {
     const rows = this.db
       .select({
         query: queries.query,
@@ -451,6 +493,7 @@ export class IntelligenceService {
         citationState: querySnapshots.citationState,
         citedDomains: querySnapshots.citedDomains,
         competitorOverlap: querySnapshots.competitorOverlap,
+        snapshotLocation: querySnapshots.location,
       })
       .from(querySnapshots)
       .leftJoin(queries, eq(querySnapshots.queryId, queries.id))
@@ -465,6 +508,12 @@ export class IntelligenceService {
         provider: r.provider,
         cited: r.citationState === CitationStates.cited,
         citationUrl: domains[0] ?? undefined,
+        // Snapshots carry their own location for downstream detectors. In
+        // practice every snapshot in a single runId shares the run's
+        // location; the per-row column is the same value duplicated, but
+        // we read it from the snapshot row so a stale runs.location can't
+        // mask snapshot truth.
+        location: r.snapshotLocation ?? location ?? null,
         competitorDomains: competitors,
         // citedDomains is the FULL set (tracked competitors + third-party
         // sources). Cause analysis uses it to name the displacing source
@@ -473,6 +522,6 @@ export class IntelligenceService {
       }
     })
 
-    return { runId, projectId, completedAt, snapshots }
+    return { runId, projectId, completedAt, location, snapshots }
   }
 }

--- a/packages/canonry/test/intelligence-service.test.ts
+++ b/packages/canonry/test/intelligence-service.test.ts
@@ -424,4 +424,135 @@ describe('IntelligenceService', () => {
       expect(typeof result!.health.overallCitedRate).toBe('number')
     })
   })
+
+  // Regression suite for the multi-location grouping bug: `analyzeAndPersist`
+  // used to pick the immediately-prior run by finishedAt regardless of
+  // location, so two siblings of the same fan-out (Florida cited / Michigan
+  // not-cited) were compared as if they were sequential runs at one location
+  // — flagging false regressions and false gains on every multi-location
+  // sweep. The fix matches previous run by location.
+  describe('multi-location previous-run selection', () => {
+    function seedTwoLocationProject(db: ReturnType<typeof createClient>): { projectId: string; queryId: string } {
+      const now = new Date().toISOString()
+      const projectId = crypto.randomUUID()
+      db.insert(projects).values({
+        id: projectId,
+        name: 'multi-loc',
+        displayName: 'Multi-Location',
+        canonicalDomain: 'example.com',
+        country: 'US',
+        language: 'en',
+        providers: '["gemini"]',
+        locations: JSON.stringify([
+          { label: 'florida',  city: 'Orlando', region: 'Florida',  country: 'US' },
+          { label: 'michigan', city: 'Detroit', region: 'Michigan', country: 'US' },
+        ]),
+        createdAt: now,
+        updatedAt: now,
+      }).run()
+      const queryId = seedQuery(db, projectId, 'polyurea roof coating')
+      return { projectId, queryId }
+    }
+
+    function insertFanOutRun(
+      db: ReturnType<typeof createClient>,
+      projectId: string,
+      location: string,
+      finishedAt: string,
+    ): string {
+      const runId = crypto.randomUUID()
+      db.insert(runs).values({
+        id: runId,
+        projectId,
+        kind: 'answer-visibility',
+        status: 'completed',
+        trigger: 'manual',
+        location,
+        createdAt: finishedAt,
+        finishedAt,
+      }).run()
+      return runId
+    }
+
+    it('does not flag a regression when the immediately-prior run is a different location', () => {
+      // Pre-fix: Michigan-latest (not cited) would be compared to Florida-mid
+      // (cited) — flagging "regression". Post-fix: compared to Michigan-mid
+      // (also not cited) → no regression.
+      const { db } = createTempDb('intel-multi-loc-regression-')
+      const { projectId, queryId } = seedTwoLocationProject(db)
+
+      const flMid       = insertFanOutRun(db, projectId, 'florida',  '2026-05-11T00:00:00Z')
+      const miMid       = insertFanOutRun(db, projectId, 'michigan', '2026-05-11T00:00:00Z')
+      const flLatest    = insertFanOutRun(db, projectId, 'florida',  '2026-05-13T00:00:00Z')
+      const miLatest    = insertFanOutRun(db, projectId, 'michigan', '2026-05-13T00:00:00Z')
+
+      seedSnapshot(db, flMid,       queryId, 'gemini', 'cited',     { citedDomains: ['example.com'] })
+      seedSnapshot(db, miMid,       queryId, 'gemini', 'not-cited')
+      seedSnapshot(db, flLatest,    queryId, 'gemini', 'cited',     { citedDomains: ['example.com'] })
+      seedSnapshot(db, miLatest,    queryId, 'gemini', 'not-cited')
+
+      const service = new IntelligenceService(db)
+      const result = service.analyzeAndPersist(miLatest, projectId)
+
+      expect(result).not.toBeNull()
+      // No transitions — Michigan was not cited last time either.
+      expect(result!.regressions).toEqual([])
+      expect(result!.gains).toEqual([])
+
+      // And no regression insight persisted to the DB.
+      const persistedRegressions = db.select().from(insights)
+        .all()
+        .filter(i => i.runId === miLatest && i.type === 'regression')
+      expect(persistedRegressions).toHaveLength(0)
+    })
+
+    it('does not flag a phantom gain on the opposite case (Michigan→Florida)', () => {
+      // Symmetric coverage. Florida-latest cited compared against Michigan-mid
+      // not-cited would have looked like a "gain" pre-fix.
+      const { db } = createTempDb('intel-multi-loc-gain-')
+      const { projectId, queryId } = seedTwoLocationProject(db)
+
+      const flMid    = insertFanOutRun(db, projectId, 'florida',  '2026-05-11T00:00:00Z')
+      const miMid    = insertFanOutRun(db, projectId, 'michigan', '2026-05-11T00:00:00Z')
+      const flLatest = insertFanOutRun(db, projectId, 'florida',  '2026-05-13T00:00:00Z')
+      const miLatest = insertFanOutRun(db, projectId, 'michigan', '2026-05-13T00:00:00Z')
+
+      seedSnapshot(db, flMid,    queryId, 'gemini', 'cited',     { citedDomains: ['example.com'] })
+      seedSnapshot(db, miMid,    queryId, 'gemini', 'not-cited')
+      seedSnapshot(db, flLatest, queryId, 'gemini', 'cited',     { citedDomains: ['example.com'] })
+      seedSnapshot(db, miLatest, queryId, 'gemini', 'not-cited')
+
+      const service = new IntelligenceService(db)
+      const result = service.analyzeAndPersist(flLatest, projectId)
+
+      expect(result).not.toBeNull()
+      // Florida was always cited — no gain.
+      expect(result!.gains).toEqual([])
+      expect(result!.regressions).toEqual([])
+    })
+
+    it('detects a real regression when the previous SAME-location run was cited', () => {
+      // Genuine signal we must preserve: Florida cited at mid, not cited at
+      // latest, and Michigan steady in between. The Michigan run between
+      // them must not mask the Florida regression.
+      const { db } = createTempDb('intel-multi-loc-real-regression-')
+      const { projectId, queryId } = seedTwoLocationProject(db)
+
+      const flMid    = insertFanOutRun(db, projectId, 'florida',  '2026-05-11T00:00:00Z')
+      const miMid    = insertFanOutRun(db, projectId, 'michigan', '2026-05-11T00:00:00Z')
+      const flLatest = insertFanOutRun(db, projectId, 'florida',  '2026-05-13T00:00:00Z')
+
+      seedSnapshot(db, flMid,    queryId, 'gemini', 'cited',     { citedDomains: ['example.com'] })
+      seedSnapshot(db, miMid,    queryId, 'gemini', 'not-cited')
+      seedSnapshot(db, flLatest, queryId, 'gemini', 'not-cited')
+
+      const service = new IntelligenceService(db)
+      const result = service.analyzeAndPersist(flLatest, projectId)
+
+      expect(result).not.toBeNull()
+      expect(result!.regressions).toHaveLength(1)
+      expect(result!.regressions[0]!.query).toBe('polyurea roof coating')
+      expect(result!.regressions[0]!.previousRunId).toBe(flMid)
+    })
+  })
 })

--- a/packages/intelligence/src/gains.ts
+++ b/packages/intelligence/src/gains.ts
@@ -1,19 +1,30 @@
-import type { RunData, Gain } from './types.js'
+import type { RunData, Gain, Snapshot } from './types.js'
+
+/**
+ * See `regressions.ts` — same key composition keeps multi-location fan-out
+ * siblings on separate timelines.
+ */
+function snapshotKey(snap: Pick<Snapshot, 'query' | 'provider' | 'location'>): string {
+  const loc = snap.location ?? '__none__'
+  return JSON.stringify([snap.query, snap.provider, loc])
+}
 
 export function detectGains(currentRun: RunData, previousRun: RunData): Gain[] {
+  // See `regressions.ts` — bail if the caller fed a cross-location pair.
+  if ((currentRun.location ?? null) !== (previousRun.location ?? null)) {
+    return []
+  }
   const gains: Gain[] = []
 
-  // Build a set of previously cited pairs
   const previousCited = new Set<string>()
   for (const snap of previousRun.snapshots) {
     if (snap.cited) {
-      previousCited.add(`${snap.query}:${snap.provider}`)
+      previousCited.add(snapshotKey(snap))
     }
   }
 
-  // Find current snapshots that ARE cited but were NOT previously
   for (const snap of currentRun.snapshots) {
-    const key = `${snap.query}:${snap.provider}`
+    const key = snapshotKey(snap)
     if (snap.cited && !previousCited.has(key)) {
       gains.push({
         query: snap.query,

--- a/packages/intelligence/src/regressions.ts
+++ b/packages/intelligence/src/regressions.ts
@@ -1,22 +1,40 @@
-import type { RunData, Regression } from './types.js'
+import type { RunData, Regression, Snapshot } from './types.js'
+
+/**
+ * Key composition for transition detection. Location is included so two
+ * siblings of a multi-location fan-out (e.g. Florida snapshot in the previous
+ * run, Michigan snapshot in the current run, same query × provider) do not
+ * collapse into a single timeline. `null`/`undefined` location is normalized
+ * to a single sentinel so locationless runs match other locationless runs.
+ */
+function snapshotKey(snap: Pick<Snapshot, 'query' | 'provider' | 'location'>): string {
+  const loc = snap.location ?? '__none__'
+  return JSON.stringify([snap.query, snap.provider, loc])
+}
 
 export function detectRegressions(currentRun: RunData, previousRun: RunData): Regression[] {
+  // Defense-in-depth: comparing two RunDatas with different locations would
+  // treat sibling fan-out runs as a temporal sequence. The intelligence
+  // service is the authoritative source for "previous run at same location",
+  // but the pure detector also bails out if the caller feeds a mismatched
+  // pair — better to produce nothing than false transitions.
+  if ((currentRun.location ?? null) !== (previousRun.location ?? null)) {
+    return []
+  }
   const regressions: Regression[] = []
 
-  // Build a map of previous citations: key = "query:provider"
   const previousCited = new Map<string, { citationUrl?: string; position?: number }>()
   for (const snap of previousRun.snapshots) {
     if (snap.cited) {
-      previousCited.set(`${snap.query}:${snap.provider}`, {
+      previousCited.set(snapshotKey(snap), {
         citationUrl: snap.citationUrl,
         position: snap.position,
       })
     }
   }
 
-  // Find current snapshots that are NOT cited but WERE cited previously
   for (const snap of currentRun.snapshots) {
-    const key = `${snap.query}:${snap.provider}`
+    const key = snapshotKey(snap)
     if (!snap.cited && previousCited.has(key)) {
       const prev = previousCited.get(key)!
       regressions.push({

--- a/packages/intelligence/src/types.ts
+++ b/packages/intelligence/src/types.ts
@@ -6,6 +6,14 @@ export interface Snapshot {
   position?: number
   snippet?: string
   /**
+   * Location label this snapshot was produced at, or `undefined`/`null` for
+   * projects with no configured locations. Detectors that compute transitions
+   * include this in their dedup key so two siblings of a multi-location
+   * fan-out (Florida cited / Michigan not-cited) don't get treated as a
+   * sequential before/after pair.
+   */
+  location?: string | null
+  /**
    * All competitor domains observed in this snapshot's competitorOverlap.
    * Detectors that filter against the project's tracked-competitor set must
    * iterate this array — taking the first element drops every additional
@@ -26,6 +34,15 @@ export interface RunData {
   runId: string
   projectId: string
   completedAt: string
+  /**
+   * Location label this run targeted, or `null`/`undefined` for locationless
+   * runs (projects without configured locations, or the explicit "no
+   * location" flag). Snapshots in a RunData all share this location. The
+   * intelligence service is responsible for picking previousRun with a
+   * matching location; the detectors enforce the invariant via their key
+   * composition as defense-in-depth.
+   */
+  location?: string | null
   snapshots: Snapshot[]
 }
 

--- a/packages/intelligence/test/gains.test.ts
+++ b/packages/intelligence/test/gains.test.ts
@@ -165,4 +165,45 @@ describe('detectGains', () => {
     expect(result).toHaveLength(1)
     expect(result[0].query).toBe('k2')
   })
+
+  it('does not flag a gain when the previous and current runs are different locations', () => {
+    // Symmetric to the regression case: Florida (not cited) followed by
+    // Michigan (cited) is not a "gain" — those are two different chronologies.
+    // Defense-in-depth in the detector: bail when run-level location differs.
+    const prev = makeRun({
+      runId: 'run_001',
+      location: 'florida',
+      snapshots: [
+        { query: 'roofers', provider: 'gemini', cited: false, location: 'florida' },
+      ],
+    })
+    const curr = makeRun({
+      runId: 'run_002',
+      location: 'michigan',
+      snapshots: [
+        { query: 'roofers', provider: 'gemini', cited: true, location: 'michigan' },
+      ],
+    })
+
+    expect(detectGains(curr, prev)).toEqual([])
+  })
+
+  it('detects a gain when locations match across runs', () => {
+    const prev = makeRun({
+      runId: 'run_001',
+      location: 'michigan',
+      snapshots: [
+        { query: 'roofers', provider: 'gemini', cited: false, location: 'michigan' },
+      ],
+    })
+    const curr = makeRun({
+      runId: 'run_002',
+      location: 'michigan',
+      snapshots: [
+        { query: 'roofers', provider: 'gemini', cited: true, location: 'michigan' },
+      ],
+    })
+
+    expect(detectGains(curr, prev)).toHaveLength(1)
+  })
 })

--- a/packages/intelligence/test/regressions.test.ts
+++ b/packages/intelligence/test/regressions.test.ts
@@ -195,6 +195,93 @@ describe('detectRegressions', () => {
     }
   })
 
+  it('does not flag a regression when the previous and current runs are different locations', () => {
+    // Multi-location fan-out: an answer-visibility sweep produces one run per
+    // configured location. The intelligence service must compare each run
+    // against the previous run *at the same location* — comparing Michigan
+    // (cited) to Florida (not-cited) generates a phantom regression.
+    // Defense-in-depth lives in the pure detector: if the service feeds
+    // mismatched-location pairs, the detector bails out and produces nothing
+    // rather than reporting false transitions.
+    const prev = makeRun({
+      runId: 'run_001',
+      location: 'michigan',
+      snapshots: [
+        { query: 'roofers', provider: 'gemini', cited: true, location: 'michigan' },
+      ],
+    })
+    const curr = makeRun({
+      runId: 'run_002',
+      location: 'florida',
+      snapshots: [
+        { query: 'roofers', provider: 'gemini', cited: false, location: 'florida' },
+      ],
+    })
+
+    expect(detectRegressions(curr, prev)).toEqual([])
+  })
+
+  it('detects a regression when locations match across runs', () => {
+    // Same-location chronology — the legitimate signal we want to preserve.
+    const prev = makeRun({
+      runId: 'run_001',
+      location: 'michigan',
+      snapshots: [
+        { query: 'roofers', provider: 'gemini', cited: true, location: 'michigan' },
+      ],
+    })
+    const curr = makeRun({
+      runId: 'run_002',
+      location: 'michigan',
+      snapshots: [
+        { query: 'roofers', provider: 'gemini', cited: false, location: 'michigan' },
+      ],
+    })
+
+    const result = detectRegressions(curr, prev)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.query).toBe('roofers')
+  })
+
+  it('treats locationless snapshots as the same chronology', () => {
+    // Projects without configured locations have all snapshots with
+    // location=undefined/null. They form one continuous timeline.
+    const prev = makeRun({
+      runId: 'run_001',
+      snapshots: [
+        { query: 'roofers', provider: 'gemini', cited: true },
+      ],
+    })
+    const curr = makeRun({
+      runId: 'run_002',
+      snapshots: [
+        { query: 'roofers', provider: 'gemini', cited: false },
+      ],
+    })
+
+    expect(detectRegressions(curr, prev)).toHaveLength(1)
+  })
+
+  it('does not match a locationless snapshot against a labeled-location snapshot', () => {
+    // A project that adds its first location starts a new chronology — old
+    // locationless runs are not a baseline for the new labeled-location run.
+    const prev = makeRun({
+      runId: 'run_001',
+      snapshots: [
+        { query: 'roofers', provider: 'gemini', cited: true },
+      ],
+    })
+    const curr = makeRun({
+      runId: 'run_002',
+      location: 'michigan',
+      snapshots: [
+        { query: 'roofers', provider: 'gemini', cited: false, location: 'michigan' },
+      ],
+    })
+
+    expect(detectRegressions(curr, prev)).toEqual([])
+  })
+
   it('isolates regressions by provider — same query, different provider is independent', () => {
     const prev = makeRun({
       runId: 'run_001',


### PR DESCRIPTION
## Summary
- The intelligence service compared each finished run against the immediately-prior project run regardless of location. In a multi-location fan-out (Michigan + Florida per sweep), it would compare Michigan to its Florida sibling — flagging the geo difference as a regression or gain. Every multi-location sweep silently produced wrong-fact insights in the dashboard, report, Aero analyses, and notification webhooks.
- Three-part fix:
  1. \`Snapshot\` and \`RunData\` types carry a \`location\` field. \`buildRunData\` reads \`runs.location\` and \`query_snapshots.location\` and populates them.
  2. \`IntelligenceService.analyzeAndPersist\`, \`analyzeRunWithPrevious\`, and \`backfill\` pick the previous run from the same-location chronology. Locationless runs (\`null\`) share one bucket; labeled locations have their own. History window scopes to same-location too.
  3. \`detectRegressions\` and \`detectGains\` include location in their dedup key and bail out if \`currentRun.location !== previousRun.location\` — defense-in-depth.
- \`provider-pickups\`, \`competitor-changes\`, and \`persistent-gaps\` inherit the fix through the service's same-location history slice; their own defense-in-depth guards can be added as a follow-up.

## Test plan
- [x] \`pnpm vitest run --project intelligence regressions gains\` — 26/26 pass (21 existing + 5 new)
- [x] \`pnpm vitest run --project canonry intelligence-service.test\` — 16/16 pass (13 existing + 3 new)
- [x] New pure-detector tests:
  - regressions: no false-flag across locations, real regression preserved at same location, locationless chronology, locationless vs labeled mismatch
  - gains: symmetric coverage
- [x] New service-integration tests:
  - \`does not flag a regression when the immediately-prior run is a different location\`
  - \`does not flag a phantom gain on the opposite case (Michigan→Florida)\`
  - \`detects a real regression when the previous SAME-location run was cited\`
- [x] Full \`--project intelligence --project canonry --project api-routes\` run: 1816/1816 pass
- [x] Typecheck + lint clean

## Follow-ups (intentionally out of scope)
- \`provider-pickups\`, \`competitor-changes\`, \`persistent-gaps\`: add their own location guards as defense-in-depth (currently rely on the service feeding same-location inputs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)