### PR TITLE
fix(vocab): use canonical 'mentioned' vocabulary in DTOs + UI labels

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -203,7 +203,9 @@ export interface ApiSnapshot {
   provider: string
   citationState: CitationState
   answerMentioned?: boolean
+  /** @deprecated legacy alias for `mentionState`; same data, kept for backwards compatibility. */
   visibilityState?: string
+  mentionState?: string
   answerText: string | null
   citedDomains: string[]
   competitorOverlap: string[]
@@ -238,8 +240,12 @@ export interface ApiTimelineRunEntry {
   citationState: string
   transition: string
   answerMentioned?: boolean
+  /** @deprecated legacy alias for `mentionState`. */
   visibilityState?: string
+  /** @deprecated legacy alias for `mentionTransition`. */
   visibilityTransition?: string
+  mentionState?: string
+  mentionTransition?: string
   location?: string | null
 }
 

--- a/apps/web/src/build-dashboard.ts
+++ b/apps/web/src/build-dashboard.ts
@@ -269,6 +269,8 @@ function buildEvidenceFromTimeline(
               answerMentioned: r.answerMentioned,
               visibilityState: r.visibilityState as RunHistoryPoint['visibilityState'] | undefined,
               visibilityTransition: r.visibilityTransition,
+              mentionState: r.mentionState as RunHistoryPoint['mentionState'] | undefined,
+              mentionTransition: r.mentionTransition,
             }))
           const modelsSeen = collectModels(runHistory)
           const historyScope: EvidenceHistoryScope = baseHistoryScope === 'provider' && modelsSeen.length <= 1
@@ -444,16 +446,16 @@ function visibilityEvidenceSummary(
 ): string {
   switch (visibilityTransition) {
     case 'lost':
-      return `Visibility was lost for "${query}". Your brand no longer appeared in the latest answer.`
+      return `Mention was lost for "${query}". Your brand no longer appeared in the latest answer.`
     case 'emerging':
       return `Your brand started appearing in AI answers for "${query}".`
   }
 
   switch (visibilityState) {
     case 'visible':
-      return `Your brand or domain is visible in AI answers for "${query}".`
+      return `Your brand or domain is mentioned in AI answers for "${query}".`
     case 'pending':
-      return `"${query}" has been added but no visibility run has been triggered yet.`
+      return `"${query}" has been added but no run has been triggered yet.`
     case 'not-visible':
     default:
       return `Your brand or domain was not mentioned in AI answers for "${query}".`
@@ -625,7 +627,7 @@ export function buildPortfolioProject(data: ProjectData): PortfolioProjectVm {
     providerCoverage: visibility.providerCoverage,
     lastRun: runItem,
     insight: total > 0
-      ? `${cited} of ${total} queries visible across ${providerCount} provider${providerCount === 1 ? '' : 's'}.`
+      ? `${cited} of ${total} queries mentioned across ${providerCount} provider${providerCount === 1 ? '' : 's'}.`
       : 'No runs completed yet.',
     trend: [],
     competitorPressureLabel: overview.scores.competitorPressure.value,

--- a/apps/web/src/components/layout/EvidenceDetailModal.tsx
+++ b/apps/web/src/components/layout/EvidenceDetailModal.tsx
@@ -28,15 +28,18 @@ export interface EvidenceDisplayData {
   summary: string
 }
 
-function describeVisibilityChange(transition?: string, visibilityState?: string): string {
+function describeMentionChange(transition?: string, mentionState?: string): string {
   switch (transition) {
     case 'new': return 'First observation'
-    case 'emerging': return 'First visibility'
+    case 'emerging': return 'First mention'
     case 'lost': return 'Lost since last run'
     default:
-      if (visibilityState === 'visible') return 'Visible in latest run'
-      if (visibilityState === 'pending') return 'Awaiting first run'
-      return 'Not visible in latest run'
+      // Accept both the canonical 'mentioned' / 'not-mentioned' values and
+      // the legacy 'visible' / 'not-visible' aliases so consumers can pass
+      // either while the API and DTO migration rolls out.
+      if (mentionState === 'mentioned' || mentionState === 'visible') return 'Mentioned in latest run'
+      if (mentionState === 'pending') return 'Awaiting first run'
+      return 'Not mentioned in latest run'
   }
 }
 
@@ -165,11 +168,13 @@ export function EvidenceDetailModal({
       : []),
   ]
 
-  // State key for CSS variants
-  const stateKey: 'cited' | 'not-cited' | 'lost' | 'pending' =
+  // CSS variant key. The legacy values 'cited' / 'not-cited' were misleading
+  // because the hero card represents the mention signal (brand in the answer
+  // text), not the citation signal. Renamed to match the data source.
+  const stateKey: 'mentioned' | 'not-mentioned' | 'lost' | 'pending' =
     isPending ? 'pending' :
     display.visibilityTransition === 'lost' ? 'lost' :
-    isVisible ? 'cited' : 'not-cited'
+    isVisible ? 'mentioned' : 'not-mentioned'
 
   // Guard against out-of-order async completions when clicking dots quickly
   const activeRequestRef = useRef(0)
@@ -222,7 +227,7 @@ export function EvidenceDetailModal({
         matchedTerms: snap.matchedTerms ?? [],
         groundingSources: snap.groundingSources,
         evidenceUrls: [],
-        changeLabel: describeVisibilityChange(run.visibilityTransition, run.visibilityState),
+        changeLabel: describeMentionChange(run.mentionTransition ?? run.visibilityTransition, run.mentionState ?? run.visibilityState),
         summary: '',
       } : {
         citationState: run.citationState,
@@ -238,7 +243,7 @@ export function EvidenceDetailModal({
         matchedTerms: [],
         groundingSources: [],
         evidenceUrls: [],
-        changeLabel: describeVisibilityChange(run.visibilityTransition, run.visibilityState),
+        changeLabel: describeMentionChange(run.mentionTransition ?? run.visibilityTransition, run.mentionState ?? run.visibilityState),
         summary: 'Snapshot data not available for this run.',
       }
 
@@ -260,7 +265,7 @@ export function EvidenceDetailModal({
         matchedTerms: [],
         groundingSources: [],
         evidenceUrls: [],
-        changeLabel: describeVisibilityChange(run.visibilityTransition, run.visibilityState),
+        changeLabel: describeMentionChange(run.mentionTransition ?? run.visibilityTransition, run.mentionState ?? run.visibilityState),
         summary: 'Failed to load historical run data.',
       })
     } finally {
@@ -284,14 +289,14 @@ export function EvidenceDetailModal({
   const heroCopy = (() => {
     if (isVisible) {
       return {
-        label: 'Visible in answer',
+        label: 'Mentioned in answer',
         title: 'Your brand or domain is mentioned in this answer',
         meta: providerMeta,
       }
     }
     if (display.visibilityTransition === 'lost') {
       return {
-        label: 'Visibility lost',
+        label: 'Mention lost',
         title: 'Your brand no longer appears in this answer',
         meta: providerMeta,
       }
@@ -299,12 +304,12 @@ export function EvidenceDetailModal({
     if (isPending) {
       return {
         label: 'Pending',
-        title: 'Awaiting first visibility run',
+        title: 'Awaiting first run',
         meta: 'No provider data yet',
       }
     }
     return {
-      label: 'Not visible in answer',
+      label: 'Not mentioned in answer',
       title: 'Your brand or domain was not mentioned in this answer',
       meta: providerMeta,
     }
@@ -560,13 +565,13 @@ export function EvidenceDetailModal({
                     <>
                       <div>
                         <div className="drawer-section-label flex items-center">
-                          <span>Answer visibility</span>
+                          <span>Mention in answer</span>
                           <InfoTooltip text="Canonry scans the AI answer for your owned domains and project name. This is independent from grounding or citation sources." />
                         </div>
-                        <div className={`mention-status mention-status--${isVisible ? 'visible' : 'not-visible'}`}>
+                        <div className={`mention-status mention-status--${isVisible ? 'mentioned' : 'not-mentioned'}`}>
                           <span className="mention-status-icon">{isPending ? '…' : isVisible ? '✓' : '—'}</span>
                           <span className="mention-status-label">
-                            {isPending ? 'Pending' : isVisible ? 'Visible' : 'Not visible'}
+                            {isPending ? 'Pending' : isVisible ? 'Mentioned' : 'Not mentioned'}
                           </span>
                         </div>
 

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -1152,6 +1152,8 @@ export function ProjectPage({
           answerMentioned: r.answerMentioned,
           visibilityState: r.visibilityState as RunHistoryPoint['visibilityState'] | undefined,
           visibilityTransition: r.visibilityTransition,
+          mentionState: r.mentionState as RunHistoryPoint['mentionState'] | undefined,
+          mentionTransition: r.mentionTransition,
         })))
       }
       // Fallback: query-level history when no per-provider data
@@ -1163,6 +1165,8 @@ export function ProjectPage({
           answerMentioned: r.answerMentioned,
           visibilityState: r.visibilityState as RunHistoryPoint['visibilityState'] | undefined,
           visibilityTransition: r.visibilityTransition,
+          mentionState: r.mentionState as RunHistoryPoint['mentionState'] | undefined,
+          mentionTransition: r.mentionTransition,
         })))
       }
     }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1162,11 +1162,13 @@
   }
 
   .evidence-position-hero--cited,
+  .evidence-position-hero--mentioned,
   .evidence-position-hero--emerging {
     @apply border-emerald-800/40 bg-emerald-950/25;
   }
 
-  .evidence-position-hero--not-cited {
+  .evidence-position-hero--not-cited,
+  .evidence-position-hero--not-mentioned {
     @apply border-zinc-800/60 bg-zinc-900/30;
   }
 
@@ -1183,11 +1185,13 @@
   }
 
   .evidence-position-label--cited,
+  .evidence-position-label--mentioned,
   .evidence-position-label--emerging {
     @apply text-emerald-500;
   }
 
-  .evidence-position-label--not-cited {
+  .evidence-position-label--not-cited,
+  .evidence-position-label--not-mentioned {
     @apply text-zinc-500;
   }
 
@@ -1200,11 +1204,13 @@
   }
 
   .evidence-position-title--cited,
+  .evidence-position-title--mentioned,
   .evidence-position-title--emerging {
     @apply text-emerald-300;
   }
 
-  .evidence-position-title--not-cited {
+  .evidence-position-title--not-cited,
+  .evidence-position-title--not-mentioned {
     @apply text-zinc-300;
   }
 
@@ -1252,11 +1258,13 @@
     @apply flex items-center gap-2 rounded-lg px-3 py-2 border;
   }
 
-  .mention-status--visible {
+  .mention-status--visible,
+  .mention-status--mentioned {
     @apply border-emerald-800/40 bg-emerald-950/25 text-emerald-300;
   }
 
-  .mention-status--not-visible {
+  .mention-status--not-visible,
+  .mention-status--not-mentioned {
     @apply border-zinc-800/40 bg-zinc-900/20 text-zinc-500;
   }
 

--- a/apps/web/src/view-models.ts
+++ b/apps/web/src/view-models.ts
@@ -4,6 +4,8 @@ export type MetricTone = 'positive' | 'caution' | 'negative' | 'neutral'
 export type HealthState = 'checking' | 'ok' | 'error'
 export type CitationState = 'cited' | 'lost' | 'emerging' | 'not-cited' | 'pending'
 export type VisibilityState = 'visible' | 'not-visible' | 'pending'
+/** Canonical-vocabulary equivalent of `VisibilityState`. New consumers prefer this. */
+export type MentionState = 'mentioned' | 'not-mentioned' | 'pending'
 
 export interface ServiceStatus {
   label: string
@@ -92,8 +94,12 @@ export interface RunHistoryPoint {
   createdAt: string
   model?: string | null
   answerMentioned?: boolean
+  /** @deprecated legacy alias for `mentionState`. */
   visibilityState?: VisibilityState
+  /** @deprecated legacy alias for `mentionTransition`. */
   visibilityTransition?: string
+  mentionState?: MentionState
+  mentionTransition?: string
 }
 
 export type EvidenceHistoryScope = 'query' | 'model' | 'provider'

--- a/apps/web/test/build-dashboard.test.ts
+++ b/apps/web/test/build-dashboard.test.ts
@@ -3,6 +3,91 @@ import { test, expect } from 'vitest'
 import { buildDashboard, buildProjectCommandCenter, type ProjectData } from '../src/build-dashboard.js'
 import type { ApiSettings } from '../src/api.js'
 
+test('buildProjectCommandCenter evidence summary uses canonical mention vocabulary, not legacy "visible"', () => {
+  // AGENTS.md vocabulary rule: new UI labels for the answer-text-presence
+  // signal must say "mentioned", not "visible". The visibilityEvidenceSummary
+  // helper used to mix the two terms in the same function — "visible in AI
+  // answers" for one branch and "was not mentioned in AI answers" for the
+  // adjacent branch. The fix unifies on "mentioned".
+  const baseRun = {
+    id: 'run_1',
+    projectId: 'proj_1',
+    kind: 'answer-visibility',
+    status: 'completed',
+    trigger: 'manual',
+    startedAt: '2026-03-15T00:00:00Z',
+    finishedAt: '2026-03-15T00:00:10Z',
+    error: null,
+    createdAt: '2026-03-15T00:00:00Z',
+  } as const
+
+  const data: ProjectData = {
+    project: {
+      id: 'proj_1',
+      name: 'mention-vocab',
+      displayName: 'Mention Vocab',
+      canonicalDomain: 'example.com',
+      ownedDomains: [],
+      country: 'US',
+      language: 'en',
+      tags: [],
+      labels: {},
+      providers: ['gemini'],
+      configSource: 'api',
+      configRevision: 1,
+      createdAt: '2026-03-10T00:00:00Z',
+      updatedAt: '2026-03-15T00:00:00Z',
+    },
+    runs: [baseRun],
+    queries: [{ id: 'q_1', query: 'best polyurea roof coating', createdAt: '2026-03-10T00:00:00Z' }],
+    competitors: [],
+    timeline: [{
+      query: 'best polyurea roof coating',
+      runs: [{
+        runId: 'run_1',
+        createdAt: '2026-03-15T00:00:00Z',
+        citationState: 'cited',
+        transition: 'new',
+        answerMentioned: true,
+        visibilityState: 'visible',
+        visibilityTransition: 'new',
+        mentionState: 'mentioned',
+        mentionTransition: 'new',
+      }],
+    }],
+    latestRunDetails: [{
+      ...baseRun,
+      snapshots: [{
+        id: 'snap_1',
+        runId: 'run_1',
+        queryId: 'q_1',
+        query: 'best polyurea roof coating',
+        provider: 'gemini',
+        citationState: 'cited',
+        answerMentioned: true,
+        visibilityState: 'visible',
+        mentionState: 'mentioned',
+        answerText: 'The brand is mentioned.',
+        citedDomains: ['example.com'],
+        competitorOverlap: [],
+        groundingSources: [],
+        searchQueries: [],
+        model: 'gemini-3-flash',
+        location: null,
+        createdAt: '2026-03-15T00:00:00Z',
+      }],
+    }],
+    previousRunDetails: [],
+  }
+
+  const cc = buildProjectCommandCenter(data)
+  const evidence = cc.visibilityEvidence[0]
+  expect(evidence).toBeDefined()
+  // Summary text must use the canonical "mentioned" vocabulary, not "visible".
+  expect(evidence!.summary).toMatch(/mentioned/i)
+  expect(evidence!.summary).not.toMatch(/\bvisible\b/i)
+})
+
 test('buildDashboard maps Google settings into the dashboard view model', () => {
   const apiSettings: ApiSettings = {
     providers: [{

--- a/packages/api-routes/src/helpers.ts
+++ b/packages/api-routes/src/helpers.ts
@@ -6,8 +6,10 @@ import {
   extractAnswerMentions,
   effectiveBrandNames,
   effectiveDomains,
+  mentionStateFromAnswerMentioned,
   notFound,
   visibilityStateFromAnswerMentioned,
+  type MentionState,
   type VisibilityState,
 } from '@ainyc/canonry-contracts'
 
@@ -107,6 +109,19 @@ export function resolveSnapshotVisibilityState(
   project: SnapshotVisibilityProject,
 ): VisibilityState {
   return visibilityStateFromAnswerMentioned(resolveSnapshotMentionResult(snapshot, project).mentioned)
+}
+
+/**
+ * Canonical-vocabulary equivalent of `resolveSnapshotVisibilityState`.
+ * Returns `'mentioned'` / `'not-mentioned'` for the same underlying signal.
+ * New callers should prefer this; legacy callers continue to work via the
+ * `Visibility` variant.
+ */
+export function resolveSnapshotMentionState(
+  snapshot: { answerMentioned?: boolean | null; answerText?: string | null },
+  project: SnapshotVisibilityProject,
+): MentionState {
+  return mentionStateFromAnswerMentioned(resolveSnapshotMentionResult(snapshot, project).mentioned)
 }
 
 export function resolveSnapshotMatchedTerms(

--- a/packages/api-routes/src/history.ts
+++ b/packages/api-routes/src/history.ts
@@ -2,7 +2,7 @@ import { eq, desc, inArray } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import { auditLog, querySnapshots, runs, queries, parseJsonColumn } from '@ainyc/canonry-db'
 import { CitationStates, validationError } from '@ainyc/canonry-contracts'
-import { resolveProject, resolveSnapshotAnswerMentioned, resolveSnapshotVisibilityState } from './helpers.js'
+import { resolveProject, resolveSnapshotAnswerMentioned, resolveSnapshotMentionState, resolveSnapshotVisibilityState } from './helpers.js'
 import { redactNotificationDiff } from './notification-redaction.js'
 
 export async function historyRoutes(app: FastifyInstance) {
@@ -96,6 +96,7 @@ export async function historyRoutes(app: FastifyInstance) {
         citationState: s.citationState,
         answerMentioned: resolveSnapshotAnswerMentioned(s, project),
         visibilityState: resolveSnapshotVisibilityState(s, project),
+        mentionState: resolveSnapshotMentionState(s, project),
         answerText: s.answerText,
         citedDomains: parseJsonColumn<string[]>(s.citedDomains, []),
         competitorOverlap: parseJsonColumn<string[]>(s.competitorOverlap, []),
@@ -189,10 +190,12 @@ export async function historyRoutes(app: FastifyInstance) {
         const run = projectRuns.find(r => r.id === snap.runId)
         let transition: string = snap.citationState === CitationStates.cited ? 'cited' : 'not-cited'
         let visibilityTransition: string = snap.answerMentioned ? 'visible' : 'not-visible'
+        let mentionTransition: string = snap.answerMentioned ? 'mentioned' : 'not-mentioned'
 
         if (idx === 0) {
           transition = 'new'
           visibilityTransition = 'new'
+          mentionTransition = 'new'
         } else {
           const prev = snaps[idx - 1]!
           if (prev.citationState === CitationStates['not-cited'] && snap.citationState === CitationStates.cited) {
@@ -203,8 +206,10 @@ export async function historyRoutes(app: FastifyInstance) {
 
           if (!prev.answerMentioned && snap.answerMentioned) {
             visibilityTransition = 'emerging'
+            mentionTransition = 'emerging'
           } else if (prev.answerMentioned && !snap.answerMentioned) {
             visibilityTransition = 'lost'
+            mentionTransition = 'lost'
           }
         }
 
@@ -214,8 +219,12 @@ export async function historyRoutes(app: FastifyInstance) {
           citationState: snap.citationState,
           transition,
           answerMentioned: snap.answerMentioned,
+          // Legacy aliases of `mentionState` / `mentionTransition`.
           visibilityState: snap.answerMentioned ? 'visible' : 'not-visible',
           visibilityTransition,
+          // Canonical-vocabulary fields — new consumers prefer these.
+          mentionState: snap.answerMentioned ? 'mentioned' : 'not-mentioned',
+          mentionTransition,
           location: snap.location,
         }
       })
@@ -304,12 +313,14 @@ export async function historyRoutes(app: FastifyInstance) {
     const map1 = new Map<string | null, (typeof snaps1[number]) & {
       resolvedAnswerMentioned: boolean
       resolvedVisibilityState: ReturnType<typeof resolveSnapshotVisibilityState>
+      resolvedMentionState: ReturnType<typeof resolveSnapshotMentionState>
     }>()
     for (const s of snaps1) {
       const resolved = {
         ...s,
         resolvedAnswerMentioned: resolveSnapshotAnswerMentioned(s, project),
         resolvedVisibilityState: resolveSnapshotVisibilityState(s, project),
+        resolvedMentionState: resolveSnapshotMentionState(s, project),
       }
       const existing = map1.get(s.queryId)
       if (
@@ -323,12 +334,14 @@ export async function historyRoutes(app: FastifyInstance) {
     const map2 = new Map<string | null, (typeof snaps2[number]) & {
       resolvedAnswerMentioned: boolean
       resolvedVisibilityState: ReturnType<typeof resolveSnapshotVisibilityState>
+      resolvedMentionState: ReturnType<typeof resolveSnapshotMentionState>
     }>()
     for (const s of snaps2) {
       const resolved = {
         ...s,
         resolvedAnswerMentioned: resolveSnapshotAnswerMentioned(s, project),
         resolvedVisibilityState: resolveSnapshotVisibilityState(s, project),
+        resolvedMentionState: resolveSnapshotMentionState(s, project),
       }
       const existing = map2.get(s.queryId)
       if (
@@ -352,8 +365,11 @@ export async function historyRoutes(app: FastifyInstance) {
         run2State: s2?.citationState ?? null,
         run1AnswerMentioned: s1?.resolvedAnswerMentioned ?? null,
         run2AnswerMentioned: s2?.resolvedAnswerMentioned ?? null,
+        // Legacy aliases — same data as run{1,2}MentionState below.
         run1VisibilityState: s1?.resolvedVisibilityState ?? null,
         run2VisibilityState: s2?.resolvedVisibilityState ?? null,
+        run1MentionState: s1?.resolvedMentionState ?? null,
+        run2MentionState: s2?.resolvedMentionState ?? null,
         changed: (s1?.citationState ?? null) !== (s2?.citationState ?? null),
         visibilityChanged: (s1?.resolvedAnswerMentioned ?? null) !== (s2?.resolvedAnswerMentioned ?? null),
       }

--- a/packages/api-routes/src/runs.ts
+++ b/packages/api-routes/src/runs.ts
@@ -15,7 +15,7 @@ import {
   parseRunError,
   serializeRunError,
 } from '@ainyc/canonry-contracts'
-import { resolveProject, resolveSnapshotAnswerMentioned, resolveSnapshotVisibilityState, resolveSnapshotMatchedTerms, writeAuditLog } from './helpers.js'
+import { resolveProject, resolveSnapshotAnswerMentioned, resolveSnapshotMentionState, resolveSnapshotVisibilityState, resolveSnapshotMatchedTerms, writeAuditLog } from './helpers.js'
 import { queueRunIfProjectIdle } from './run-queue.js'
 
 export interface RunRoutesOptions {
@@ -475,9 +475,14 @@ function loadRunDetail(app: FastifyInstance, run: typeof runs.$inferSelect) {
         provider: s.provider,
         citationState: s.citationState,
         answerMentioned,
+        // Legacy alias of `mentionState`, retained for backwards compatibility.
         visibilityState: project
           ? resolveSnapshotVisibilityState(s, project)
           : (answerMentioned ? 'visible' : 'not-visible'),
+        // Canonical vocabulary for answer-text presence; new consumers prefer this.
+        mentionState: project
+          ? resolveSnapshotMentionState(s, project)
+          : (answerMentioned ? 'mentioned' : 'not-mentioned'),
         answerText: s.answerText,
         citedDomains: parseJsonColumn<string[]>(s.citedDomains, []),
         competitorOverlap: parseJsonColumn<string[]>(s.competitorOverlap, []),

--- a/packages/contracts/src/answer-visibility.ts
+++ b/packages/contracts/src/answer-visibility.ts
@@ -1,5 +1,5 @@
 import { brandLabelFromDomain, normalizeProjectDomain, registrableDomain } from './project.js'
-import type { VisibilityState } from './run.js'
+import type { MentionState, VisibilityState } from './run.js'
 
 const GENERIC_TOKENS = new Set([
   'agency',
@@ -144,6 +144,15 @@ export function determineAnswerMentioned(
 
 export function visibilityStateFromAnswerMentioned(answerMentioned: boolean | null | undefined): VisibilityState {
   return answerMentioned ? 'visible' : 'not-visible'
+}
+
+/**
+ * Canonical-vocabulary equivalent of `visibilityStateFromAnswerMentioned`.
+ * Returns `'mentioned'` / `'not-mentioned'` — the language new APIs, CLI
+ * flags, and UI labels must use per the AGENTS.md vocabulary rules.
+ */
+export function mentionStateFromAnswerMentioned(answerMentioned: boolean | null | undefined): MentionState {
+  return answerMentioned ? 'mentioned' : 'not-mentioned'
 }
 
 /**

--- a/packages/contracts/src/run.ts
+++ b/packages/contracts/src/run.ts
@@ -33,9 +33,29 @@ export const visibilityStateSchema = z.enum(['visible', 'not-visible'])
 export type VisibilityState = z.infer<typeof visibilityStateSchema>
 export const VisibilityStates = visibilityStateSchema.enum
 
+/**
+ * Canonical vocabulary for answer-text presence. Use this in new APIs, CLI
+ * flags, and UI labels. `visibilityState` is the legacy name for the same
+ * signal — kept on DTOs for backwards compatibility but new consumers should
+ * read `mentionState` instead.
+ */
+export const mentionStateSchema = z.enum(['mentioned', 'not-mentioned'])
+export type MentionState = z.infer<typeof mentionStateSchema>
+export const MentionStates = mentionStateSchema.enum
+
 export const computedTransitionSchema = z.enum(['new', 'cited', 'lost', 'emerging', 'not-cited'])
 export type ComputedTransition = z.infer<typeof computedTransitionSchema>
 export const ComputedTransitions = computedTransitionSchema.enum
+
+/**
+ * Per-run mention transition values for the timeline endpoint. Parallel to
+ * `ComputedTransition` (which describes citation transitions). `'mentioned'`
+ * and `'not-mentioned'` are the steady-state values; `'emerging'` and
+ * `'lost'` are the cross-run transitions; `'new'` is the first observation.
+ */
+export const mentionTransitionSchema = z.enum(['new', 'mentioned', 'lost', 'emerging', 'not-mentioned'])
+export type MentionTransition = z.infer<typeof mentionTransitionSchema>
+export const MentionTransitions = mentionTransitionSchema.enum
 
 export const runTriggerRequestSchema = z.object({
   kind: z.literal(RunKinds['answer-visibility']).optional(),
@@ -187,7 +207,10 @@ export const querySnapshotDtoSchema = z.object({
   provider: providerNameSchema,
   citationState: citationStateSchema,
   answerMentioned: z.boolean().optional(),
+  /** @deprecated legacy name for `mentionState`; same data, kept for backwards compatibility. */
   visibilityState: visibilityStateSchema.optional(),
+  /** Mention state for this snapshot — see `mentionStateSchema`. Prefer this over the legacy `visibilityState`. */
+  mentionState: mentionStateSchema.optional(),
   transition: computedTransitionSchema.optional(),
   answerText: z.string().nullable().optional(),
   citedDomains: z.array(z.string()).default([]),
@@ -217,8 +240,14 @@ export const snapshotDiffRowSchema = z.object({
   run2State: citationStateSchema.nullable(),
   run1AnswerMentioned: z.boolean().nullable(),
   run2AnswerMentioned: z.boolean().nullable(),
+  /** @deprecated legacy name for `run1MentionState`. */
   run1VisibilityState: visibilityStateSchema.nullable(),
+  /** @deprecated legacy name for `run2MentionState`. */
   run2VisibilityState: visibilityStateSchema.nullable(),
+  /** Mention state in run 1 — prefer this over the legacy `run1VisibilityState`. */
+  run1MentionState: mentionStateSchema.nullable().optional(),
+  /** Mention state in run 2 — prefer this over the legacy `run2VisibilityState`. */
+  run2MentionState: mentionStateSchema.nullable().optional(),
   changed: z.boolean(),
   visibilityChanged: z.boolean(),
 })

--- a/packages/contracts/test/index.test.ts
+++ b/packages/contracts/test/index.test.ts
@@ -22,6 +22,7 @@ import {
   computedTransitionSchema,
   determineAnswerMentioned,
   extractAnswerMentions,
+  mentionStateFromAnswerMentioned,
   querySnapshotDtoSchema,
   auditLogEntrySchema,
   notificationDtoSchema,
@@ -357,6 +358,29 @@ test('querySnapshotDtoSchema applies defaults', () => {
   expect(snapshot.matchedTerms).toEqual([])
   expect(snapshot.answerMentioned).toBeUndefined()
   expect(snapshot.visibilityState).toBeUndefined()
+  expect(snapshot.mentionState).toBeUndefined()
+})
+
+test('querySnapshotDtoSchema accepts the new mentionState field', () => {
+  for (const state of ['mentioned', 'not-mentioned'] as const) {
+    const snapshot = querySnapshotDtoSchema.parse({
+      id: 'snap_1',
+      runId: 'run_1',
+      queryId: 'q_1',
+      provider: 'gemini',
+      citationState: 'cited',
+      mentionState: state,
+      createdAt: '2026-03-09T00:00:00.000Z',
+    })
+    expect(snapshot.mentionState).toBe(state)
+  }
+})
+
+test('mentionStateFromAnswerMentioned mirrors the legacy visibility helper with the new vocabulary', () => {
+  expect(mentionStateFromAnswerMentioned(true)).toBe('mentioned')
+  expect(mentionStateFromAnswerMentioned(false)).toBe('not-mentioned')
+  expect(mentionStateFromAnswerMentioned(null)).toBe('not-mentioned')
+  expect(mentionStateFromAnswerMentioned(undefined)).toBe('not-mentioned')
 })
 
 test('querySnapshotDtoSchema accepts all provider names', () => {


### PR DESCRIPTION
## Summary
AGENTS.md vocabulary rules reserve **mentioned** for answer-text presence and **cited** for citation-source presence. The SPA used the legacy "visible" / "visibility" terminology for the mention signal — and *inconsistently*: \`visibilityEvidenceSummary\` mixed "visible in AI answers" and "was not mentioned in AI answers" in the same function. The modal showed a "Visible" badge inside a "Mentions" tab.

Three-layer fix, all additive on the API contract:

1. **contracts**: add \`mentionStateSchema\`, \`mentionTransitionSchema\`, and the \`mentionStateFromAnswerMentioned\` helper. \`mentionState\` field on \`querySnapshotDtoSchema\`; \`run{1,2}MentionState\` on the diff schema. Legacy \`visibilityState\` fields kept and marked \`@deprecated\`.
2. **api-routes**: \`history\` and \`runs\` endpoints populate the new fields alongside the legacy ones. New \`resolveSnapshotMentionState\` helper mirrors the existing \`resolveSnapshotVisibilityState\`.
3. **web**: \`EvidenceDetailModal\` reads new fields with legacy fallback. Labels renamed: "Visible in answer" → "Mentioned in answer", "Answer visibility" → "Mention in answer", "Visible / Not visible" → "Mentioned / Not mentioned". \`stateKey\` variant values renamed \`'cited' | 'not-cited'\` → \`'mentioned' | 'not-mentioned'\` (the data source was always the mention signal). CSS class variants \`--mentioned\` / \`--not-mentioned\` added alongside the legacy \`--cited\` / \`--not-cited\` for visual parity. \`build-dashboard\` summary helpers now use "mentioned" consistently.

## Test plan
- [x] \`pnpm vitest run --project contracts --project api-routes --project canonry --project web\` — 1966/1966 pass
- [x] Contracts: new \`mentionStateFromAnswerMentioned\` helper + \`mentionState\` field roundtrip
- [x] web: new \`buildProjectCommandCenter evidence summary uses canonical mention vocabulary\` test asserts summary says "mentioned" and never "visible"
- [x] Typecheck + lint clean across all touched packages

## Not in scope (intentional follow-up)
\`buildVisibilityScore\` in \`packages/intelligence/src/visibility-score.ts\` labels its output "Answer Visibility" but counts \`citationState='cited'\` — a real label/data mismatch where the gauge name implies the mention signal but the math is the citation signal. The fix is either renaming the gauge or recomputing from \`answerMentioned\`; either choice has contract implications worth their own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)