### PR TITLE
feat: notify when a newer canonry version is published

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -267,6 +267,44 @@ export function RootLayout() {
 
   // ── UI state ──
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
+  // Per-version dismiss for the update pill. Read once on mount; updates only
+  // when the user clicks ×. When a newer version ships, the dismissed value
+  // no longer matches `updateAvailable.latest`, so the pill reappears.
+  const [dismissedUpdateVersion, setDismissedUpdateVersion] = useState<string | null>(() => {
+    if (typeof window === 'undefined') return null
+    try {
+      return window.localStorage.getItem('canonry:dismissedUpdateVersion')
+    } catch {
+      return null
+    }
+  })
+  // Dev affordance: `?force-update=<version>` synthesizes a fake
+  // updateAvailable payload so the bubble can be previewed in `pnpm dev:web`
+  // without editing package.json or waiting on npm. Example:
+  //   http://localhost:5173/?force-update=99.0.0
+  // Read once on mount.
+  const [forceUpdateVersion] = useState<string | null>(() => {
+    if (typeof window === 'undefined') return null
+    return new URLSearchParams(window.location.search).get('force-update')
+  })
+  const updateAvailable = forceUpdateVersion
+    ? {
+        current: healthSnapshot.apiStatus.version ?? '0.0.0',
+        latest: forceUpdateVersion,
+        url: 'https://www.npmjs.com/package/@ainyc/canonry',
+        upgradeCommand: 'npm install -g @ainyc/canonry',
+      }
+    : healthSnapshot.apiStatus.updateAvailable
+  const showUpdatePill = updateAvailable && updateAvailable.latest !== dismissedUpdateVersion
+  const dismissUpdatePill = () => {
+    if (!updateAvailable) return
+    try {
+      window.localStorage.setItem('canonry:dismissedUpdateVersion', updateAvailable.latest)
+    } catch {
+      // best-effort — Safari private mode etc.
+    }
+    setDismissedUpdateVersion(updateAvailable.latest)
+  }
 
   // ── Run detail for drawer ──
   const runDetailQuery = useRunDetail(runId)
@@ -343,7 +381,11 @@ export function RootLayout() {
       {/* ── Sidebar (desktop) ── */}
       <aside className="sidebar" aria-label="Primary navigation">
         <div className="sidebar-brand">
-          <BrandLockup version={healthSnapshot.apiStatus.version} />
+          <BrandLockup
+            version={healthSnapshot.apiStatus.version}
+            updateAvailable={showUpdatePill ? updateAvailable : null}
+            onDismissUpdate={dismissUpdatePill}
+          />
         </div>
 
         <nav className="sidebar-nav">

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1344,7 +1344,24 @@ export function fetchCitationVisibility(project: string): Promise<CitationVisibi
 
 // ── Health ──────────────────────────────────────────────────────────────────
 
-import type { ServiceStatus } from './view-models.js'
+import type { ServiceStatus, UpdateAvailable } from './view-models.js'
+
+function parseUpdateAvailable(value: unknown): UpdateAvailable | undefined {
+  if (!value || typeof value !== 'object') return undefined
+  const v = value as Record<string, unknown>
+  if (
+    typeof v.current !== 'string' ||
+    typeof v.latest !== 'string' ||
+    typeof v.url !== 'string' ||
+    typeof v.upgradeCommand !== 'string'
+  ) return undefined
+  return {
+    current: v.current,
+    latest: v.latest,
+    url: v.url,
+    upgradeCommand: v.upgradeCommand,
+  }
+}
 
 export async function fetchServiceStatus(path: string, label: string): Promise<ServiceStatus> {
   const requestPath = publicPath(path)
@@ -1366,6 +1383,7 @@ export async function fetchServiceStatus(path: string, label: string): Promise<S
     const databaseConfigured =
       typeof payload.databaseUrlConfigured === 'boolean' ? payload.databaseUrlConfigured : undefined
     const lastHeartbeatAt = typeof payload.lastHeartbeatAt === 'string' ? payload.lastHeartbeatAt : undefined
+    const updateAvailable = parseUpdateAvailable(payload.updateAvailable)
     const detail = [
       version,
       databaseConfigured === false ? 'database not configured' : 'database configured',
@@ -1381,6 +1399,7 @@ export async function fetchServiceStatus(path: string, label: string): Promise<S
       version,
       databaseConfigured,
       lastHeartbeatAt,
+      ...(updateAvailable ? { updateAvailable } : {}),
     }
   } catch (error) {
     return {

--- a/apps/web/src/components/shared/BrandLockup.tsx
+++ b/apps/web/src/components/shared/BrandLockup.tsx
@@ -1,23 +1,100 @@
+import { useState } from 'react'
 import { Link } from '@tanstack/react-router'
+import { ArrowRight, X } from 'lucide-react'
+import type { UpdateAvailable } from '../../view-models.js'
 
 interface BrandLockupProps {
   compact?: boolean
   version?: string
+  updateAvailable?: UpdateAvailable | null
+  onDismissUpdate?: () => void
 }
 
-export function BrandLockup({ compact = false, version }: BrandLockupProps) {
+const BUBBLE_EXIT_MS = 220
+
+export function BrandLockup({ compact = false, version, updateAvailable, onDismissUpdate }: BrandLockupProps) {
   const showVersion = !compact && version && version !== 'unknown'
+  // Local closing state so we can play the exit animation before the parent
+  // unmounts the bubble. Without this the bubble vanishes the instant React
+  // re-renders with updateAvailable=null.
+  const [closing, setClosing] = useState(false)
+  // Bubble only renders in the sidebar (non-compact) layout — the topbar
+  // mobile lockup has no room for it.
+  const showBubble = !compact && updateAvailable && onDismissUpdate
+
+  const handleDismiss = () => {
+    setClosing(true)
+    window.setTimeout(() => {
+      onDismissUpdate?.()
+      // Reset so a future updateAvailable (next version released) animates in fresh.
+      setClosing(false)
+    }, BUBBLE_EXIT_MS)
+  }
+
+  // Compact lockup (mobile topbar) keeps the original simple Link structure —
+  // no bubble support, no nested clickables to worry about.
+  if (compact) {
+    return (
+      <Link
+        to="/"
+        className="brand-lockup brand-lockup-compact"
+        aria-label="Canonry home"
+      >
+        <img className="brand-icon" src="./favicon.svg" alt="" aria-hidden="true" />
+        <span className="brand-copy">
+          <span className="brand-mark">Canonry</span>
+        </span>
+      </Link>
+    )
+  }
+
+  // Sidebar layout: split the Link so the version slot can host interactive
+  // elements (the bubble's npm link + dismiss button) without nesting <a>/<button>
+  // inside another <a>. The bird image and the "Canonry" wordmark are both
+  // separate Links to home — accessible to keyboard users either way.
   return (
-    <Link
-      to="/"
-      className={`brand-lockup ${compact ? 'brand-lockup-compact' : ''}`}
-      aria-label="Canonry home"
-    >
-      <img className="brand-icon" src="./favicon.svg" alt="" aria-hidden="true" />
-      <span className="brand-copy">
-        <span className="brand-mark">Canonry</span>
-        {showVersion ? <span className="brand-version">v{version}</span> : null}
-      </span>
-    </Link>
+    <div className="brand-lockup brand-lockup-wrapper">
+      <Link
+        to="/"
+        className="brand-icon-link"
+        aria-label="Canonry home"
+        tabIndex={-1}
+      >
+        <img className="brand-icon" src="./favicon.svg" alt="" aria-hidden="true" />
+      </Link>
+      <div className="brand-copy">
+        <Link to="/" className="brand-mark">Canonry</Link>
+        {showBubble ? (
+          <span
+            className={`brand-update-bubble ${closing ? 'brand-update-bubble-closing' : ''}`}
+            role="status"
+            aria-live="polite"
+          >
+            <a
+              className="brand-update-bubble-link"
+              href={updateAvailable.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              title={`Open release: ${updateAvailable.upgradeCommand}`}
+              aria-label={`New version v${updateAvailable.latest} available — open release page`}
+            >
+              <span className="brand-update-bubble-from">v{updateAvailable.current}</span>
+              <ArrowRight className="brand-update-bubble-arrow size-3" aria-hidden="true" />
+              <span className="brand-update-bubble-to">v{updateAvailable.latest}</span>
+            </a>
+            <button
+              type="button"
+              className="brand-update-bubble-dismiss"
+              onClick={handleDismiss}
+              aria-label={`Dismiss update notification for v${updateAvailable.latest}`}
+            >
+              <X className="size-3" aria-hidden="true" />
+            </button>
+          </span>
+        ) : showVersion ? (
+          <span className="brand-version">v{version}</span>
+        ) : null}
+      </div>
+    </div>
   )
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -96,7 +96,7 @@
   }
 
   .brand-mark {
-    @apply text-[15px] font-semibold leading-none tracking-[-0.02em] text-zinc-100;
+    @apply text-[15px] font-semibold leading-none tracking-[-0.02em] text-zinc-100 no-underline;
   }
 
   .brand-lockup-compact .brand-mark {
@@ -105,6 +105,124 @@
 
   .brand-version {
     @apply mt-0.5 font-mono text-[11px] tracking-tight text-zinc-500;
+  }
+
+  /* ── Update bubble ── */
+  /*
+   * Inline speech bubble that REPLACES the static "v4.35.0" label below
+   * "Canonry" when a new canonry version is available. Compact horizontal
+   * pill showing the current → latest transition; click opens npm, × dismisses
+   * (per-version, persisted to localStorage). Tail on the bubble's left side
+   * points at the bird mascot. The bird plays a one-shot chirp animation when
+   * the bubble appears.
+   */
+  .brand-lockup-wrapper {
+    @apply inline-flex items-center gap-3;
+  }
+
+  .brand-icon-link {
+    @apply block shrink-0 outline-none focus-visible:ring-2 focus-visible:ring-amber-400/60 rounded-full;
+  }
+
+  .brand-update-bubble {
+    @apply relative mt-2 inline-flex w-max items-center gap-1 rounded-full border border-amber-500/30 bg-amber-500/10 py-0.5 pl-2 pr-1 font-mono text-[11px] leading-none text-amber-100 transition;
+    box-shadow:
+      0 8px 20px -10px rgba(245, 158, 11, 0.4),
+      inset 0 0 0 1px rgba(245, 158, 11, 0.06);
+    transform-origin: 0 50%;
+    /* Delayed so the bird "speaks" first, then the bubble appears as the chirp. */
+    animation: brand-bubble-pop 540ms cubic-bezier(0.34, 1.56, 0.64, 1) 100ms both;
+  }
+
+  .brand-update-bubble:hover {
+    @apply border-amber-500/45 bg-amber-500/15;
+  }
+
+  .brand-update-bubble-link {
+    @apply inline-flex items-center gap-1 rounded-full text-amber-100 no-underline outline-none;
+  }
+
+  .brand-update-bubble-link:focus-visible {
+    @apply ring-2 ring-amber-400/60;
+  }
+
+  .brand-update-bubble-closing {
+    animation: brand-bubble-out 220ms cubic-bezier(0.4, 0, 1, 1) forwards;
+  }
+
+  .brand-update-bubble-from {
+    @apply text-amber-200/55;
+  }
+
+  .brand-update-bubble-arrow {
+    @apply shrink-0 text-amber-400/70;
+  }
+
+  .brand-update-bubble:hover .brand-update-bubble-arrow {
+    @apply text-amber-300;
+  }
+
+  .brand-update-bubble-to {
+    @apply font-medium text-amber-100;
+  }
+
+  .brand-update-bubble:hover .brand-update-bubble-to {
+    @apply text-amber-50;
+  }
+
+  .brand-update-bubble-dismiss {
+    @apply ml-0.5 flex shrink-0 items-center justify-center rounded-full p-0.5 text-amber-300/70 transition;
+    @apply hover:bg-amber-500/20 hover:text-amber-100;
+    @apply focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-amber-300;
+  }
+
+  /* Bird chirps just before the bubble appears. Origin near the bird's
+   * feet so the rotation reads as a head tilt rather than a spin. */
+  .brand-lockup-wrapper:has(.brand-update-bubble) .brand-icon {
+    animation: brand-bird-talk 1.4s cubic-bezier(0.45, 0.05, 0.55, 0.95) 0ms both;
+    transform-origin: 50% 80%;
+  }
+
+  @keyframes brand-bubble-pop {
+    0% {
+      opacity: 0;
+      transform: scale(0.4) translateY(-6px);
+    }
+    55% {
+      opacity: 1;
+      transform: scale(1.08) translateY(0);
+    }
+    75% {
+      transform: scale(0.97);
+    }
+    100% {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
+  @keyframes brand-bird-talk {
+    0%   { transform: translateY(0) rotate(0deg); }
+    12%  { transform: translateY(-2px) rotate(-6deg) scale(1.04); }
+    24%  { transform: translateY(1px) rotate(3deg) scale(0.98); }
+    38%  { transform: translateY(-1px) rotate(-3deg); }
+    52%  { transform: translateY(0) rotate(2deg); }
+    68%  { transform: translateY(-1px) rotate(-1deg); }
+    100% { transform: translateY(0) rotate(0deg); }
+  }
+
+  @keyframes brand-bubble-out {
+    0%   { opacity: 1; transform: scale(1); }
+    100% { opacity: 0; transform: scale(0.6) translateY(-4px); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .brand-update-bubble {
+      animation: none;
+    }
+    .brand-lockup-wrapper:has(.brand-update-bubble) .brand-icon {
+      animation: none;
+    }
   }
 
   .sidebar-nav {

--- a/apps/web/src/view-models.ts
+++ b/apps/web/src/view-models.ts
@@ -14,6 +14,14 @@ export interface ServiceStatus {
   lastHeartbeatAt?: string
   statusCode?: number
   hint?: string
+  updateAvailable?: UpdateAvailable
+}
+
+export interface UpdateAvailable {
+  current: string
+  latest: string
+  url: string
+  upgradeCommand: string
 }
 
 export interface HealthSnapshot {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.34.0",
+  "version": "4.35.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.34.0",
+  "version": "4.35.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/cli.ts
+++ b/packages/canonry/src/cli.ts
@@ -5,6 +5,7 @@ import { buildSetupState } from './setup-state.js'
 import { CliError, EXIT_SYSTEM_ERROR, EXIT_USER_ERROR, printCliError, usageError } from './cli-error.js'
 import { dispatchRegisteredCommand } from './cli-dispatch.js'
 import { REGISTERED_CLI_COMMANDS } from './cli-commands.js'
+import { checkLatestVersionForCli } from './update-check.js'
 
 const USAGE = `
 cnry — AEO monitoring CLI   ('canonry' also works)
@@ -124,6 +125,20 @@ export async function runCli(args = process.argv.slice(2)): Promise<number> {
     trackEvent('cli.command', {
       command: resolvedCommand,
       ...(setupState ? { setup_state: setupState } : {}),
+    })
+  }
+
+  // Surface a new-version banner before the command runs. Opt-outs and the
+  // 24h cache live in `update-check.ts`; this stays a no-op when the
+  // registry is unreachable, the user is offline, or no upgrade is
+  // available. Banner goes to stderr so it never pollutes `--format json`.
+  if (!isHelpRequest && command !== 'telemetry') {
+    void checkLatestVersionForCli().then((update) => {
+      if (!update) return
+      process.stderr.write(
+        `\n→ canonry ${update.latest} is available (you have ${update.current}).\n` +
+        `  Upgrade: ${update.upgradeCommand}\n\n`,
+      )
     })
   }
 

--- a/packages/canonry/src/config.ts
+++ b/packages/canonry/src/config.ts
@@ -186,6 +186,11 @@ export interface CanonryConfig {
   // Last canonry CLI version observed by this install — used to fire a
   // single `cli.upgraded` event when the running binary version changes.
   lastSeenVersion?: string
+  // Update-check opt-out — `false` disables the daily npm-registry probe.
+  updateCheck?: boolean
+  // Set by the CLI's daily npm-registry probe; cached for TTL gating.
+  lastUpdateCheckAt?: string
+  lastKnownLatestVersion?: string
   // Agent layer configuration (reserved — native loop TBD)
   agent?: AgentConfigEntry
 }

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -57,6 +57,7 @@ import {
   upsertWordpressConnection,
 } from './wordpress-config.js'
 import { isTelemetryEnabled, getOrCreateAnonymousId, trackEvent } from './telemetry.js'
+import { checkLatestVersionForServer } from './update-check.js'
 import { JobRunner } from './job-runner.js'
 import { executeGscSync } from './gsc-sync.js'
 import { executeInspectSitemap } from './gsc-inspect-sitemap.js'
@@ -1404,16 +1405,31 @@ export async function createServer(opts: {
 
   // Health endpoint — registered at both /health and <basePath>health when base path is set,
   // so load-balancer probes work regardless of whether the proxy strips the prefix.
-  const healthHandler = async () => ({
-    status: 'ok',
-    service: 'canonry',
-    version: PKG_VERSION,
-    ...(basePath ? { basePath: basePath.replace(/\/$/, '') } : {}),
-  })
+  // `updateAvailable` is read from an in-memory TTL cache and is non-blocking:
+  // the registry probe runs in the background (stale-while-revalidate), so
+  // /health responds in microseconds and never exceeds k8s probe budgets.
+  // Opt-out via CANONRY_DISABLE_UPDATE_CHECK=1, DO_NOT_TRACK=1, CI, or
+  // updateCheck: false in config.
+  const healthHandler = () => {
+    const update = checkLatestVersionForServer()
+    return {
+      status: 'ok',
+      service: 'canonry',
+      version: PKG_VERSION,
+      ...(basePath ? { basePath: basePath.replace(/\/$/, '') } : {}),
+      ...(update ? { updateAvailable: update } : {}),
+    }
+  }
   app.get('/health', healthHandler)
   if (basePath) {
     app.get(`${basePath}health`, healthHandler)
   }
+
+  // Warm the update-check cache on boot so the first /health response after a
+  // restart already includes `updateAvailable` (assuming the npm round-trip
+  // completes before the dashboard's first poll, which it almost always does).
+  // Fire-and-forget — boot does not wait on this.
+  checkLatestVersionForServer()
 
   // Start scheduler after setup
   scheduler.start()

--- a/packages/canonry/src/update-check.ts
+++ b/packages/canonry/src/update-check.ts
@@ -1,0 +1,258 @@
+import { createRequire } from 'node:module'
+import { configExists, loadConfigRaw, saveConfigPatch } from './config.js'
+
+const _require = createRequire(import.meta.url)
+const { version: PKG_VERSION } = _require('../package.json') as { version: string }
+
+const PKG_NAME = '@ainyc/canonry'
+const NPM_DIST_TAGS_URL = `https://registry.npmjs.org/-/package/${PKG_NAME}/dist-tags`
+const NPM_PACKAGE_URL = `https://www.npmjs.com/package/${PKG_NAME}`
+const FETCH_TIMEOUT_MS = 1_500
+
+export interface UpdateAvailable {
+  current: string
+  latest: string
+  url: string
+  upgradeCommand: string
+}
+
+/**
+ * Opt-out gate. Mirrors telemetry's opt-out pattern so users get one mental
+ * model for "no outbound calls": env var > config flag.
+ *
+ * Order: CANONRY_DISABLE_UPDATE_CHECK=1 > DO_NOT_TRACK=1 > CI > config.updateCheck === false
+ */
+export function isUpdateCheckEnabled(): boolean {
+  if (process.env.CANONRY_DISABLE_UPDATE_CHECK === '1') return false
+  if (process.env.DO_NOT_TRACK === '1') return false
+  if (process.env.CI) return false
+
+  if (!configExists()) return true
+
+  try {
+    const raw = loadConfigRaw()
+    return raw?.updateCheck !== false
+  } catch {
+    return true
+  }
+}
+
+/**
+ * Compare two semver-shaped strings ("major.minor.patch" with optional
+ * pre-release / build metadata which we ignore). Returns 1 if a > b,
+ * -1 if a < b, 0 if equal. Anything we can't parse compares as equal so
+ * we never falsely advertise an "upgrade" from a malformed registry response.
+ */
+export function compareSemver(a: string, b: string): number {
+  const parse = (v: string): [number, number, number] | null => {
+    const core = v.split(/[-+]/)[0]
+    if (!core) return null
+    const parts = core.split('.')
+    if (parts.length < 3) return null
+    const nums: number[] = []
+    for (let i = 0; i < 3; i++) {
+      const n = Number(parts[i])
+      if (!Number.isInteger(n) || n < 0) return null
+      nums.push(n)
+    }
+    return [nums[0]!, nums[1]!, nums[2]!]
+  }
+
+  const pa = parse(a)
+  const pb = parse(b)
+  if (!pa || !pb) return 0
+
+  for (let i = 0; i < 3; i++) {
+    if (pa[i]! > pb[i]!) return 1
+    if (pa[i]! < pb[i]!) return -1
+  }
+  return 0
+}
+
+/**
+ * Fetch the latest published version from the npm registry's dist-tags
+ * endpoint. Lightweight (returns just `{ latest, ... }`), no auth, no
+ * rate limit for normal usage. Returns null on any failure — callers
+ * must never block on this.
+ */
+export async function fetchLatestVersion(opts?: { timeoutMs?: number }): Promise<string | null> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), opts?.timeoutMs ?? FETCH_TIMEOUT_MS)
+  timeout.unref()
+
+  try {
+    const res = await fetch(NPM_DIST_TAGS_URL, {
+      signal: controller.signal,
+      headers: { accept: 'application/json' },
+    })
+    if (!res.ok) return null
+    const data = (await res.json()) as { latest?: unknown }
+    if (typeof data.latest !== 'string') return null
+    return data.latest
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+/**
+ * Returns the running CLI/server's package version. Single source of truth so
+ * callers don't each re-import `package.json`.
+ */
+export function getCurrentVersion(): string {
+  return PKG_VERSION
+}
+
+/**
+ * Build an `UpdateAvailable` payload if `latest` is strictly newer than
+ * `current`. Returns null when no upgrade is available or inputs are
+ * malformed.
+ */
+export function buildUpdateAvailable(current: string, latest: string): UpdateAvailable | null {
+  if (compareSemver(latest, current) <= 0) return null
+  return {
+    current,
+    latest,
+    url: NPM_PACKAGE_URL,
+    upgradeCommand: `npm install -g ${PKG_NAME}`,
+  }
+}
+
+/**
+ * CLI-side check with on-disk TTL cache. Hits the npm registry at most once
+ * per `ttlHours` (default 24). Returns `null` when disabled, cached as
+ * up-to-date, or the registry call failed.
+ *
+ * Persists `lastUpdateCheckAt` (ISO timestamp) and `lastKnownLatestVersion`
+ * to `~/.canonry/config.yaml`. The cached version is also returned (without
+ * a fresh fetch) for in-cache windows so the banner stays consistent
+ * between invocations.
+ */
+export async function checkLatestVersionForCli(opts?: {
+  ttlHours?: number
+  now?: () => Date
+}): Promise<UpdateAvailable | null> {
+  if (!isUpdateCheckEnabled()) return null
+  if (!configExists()) return null
+
+  const now = opts?.now ? opts.now() : new Date()
+  const ttlMs = (opts?.ttlHours ?? 24) * 60 * 60 * 1000
+
+  let raw
+  try {
+    raw = loadConfigRaw()
+  } catch {
+    return null
+  }
+  if (!raw) return null
+
+  const lastCheckedAt = raw.lastUpdateCheckAt ? Date.parse(raw.lastUpdateCheckAt) : NaN
+  const cachedLatest = typeof raw.lastKnownLatestVersion === 'string' ? raw.lastKnownLatestVersion : undefined
+
+  if (Number.isFinite(lastCheckedAt) && now.getTime() - lastCheckedAt < ttlMs) {
+    if (!cachedLatest) return null
+    return buildUpdateAvailable(PKG_VERSION, cachedLatest)
+  }
+
+  const latest = await fetchLatestVersion()
+  if (!latest) {
+    // Refresh `lastUpdateCheckAt` even on failure so we don't hammer the
+    // registry from a long-running process. Re-tries on the next interval.
+    try {
+      saveConfigPatch({ lastUpdateCheckAt: now.toISOString() })
+    } catch {
+      // best-effort
+    }
+    return null
+  }
+
+  try {
+    saveConfigPatch({
+      lastUpdateCheckAt: now.toISOString(),
+      lastKnownLatestVersion: latest,
+    })
+  } catch {
+    // best-effort
+  }
+
+  return buildUpdateAvailable(PKG_VERSION, latest)
+}
+
+interface MemoryCacheEntry {
+  fetchedAt: number
+  latest: string | null
+}
+
+let memoryCache: MemoryCacheEntry | null = null
+let inFlight: Promise<void> | null = null
+
+/**
+ * For tests — flush any in-flight refresh, then wipe the in-memory cache used
+ * by `checkLatestVersionForServer`. Async because pending refreshes may still
+ * be writing to `memoryCache` and would otherwise pollute the next test.
+ */
+export async function resetServerUpdateCheckCache(): Promise<void> {
+  if (inFlight) await inFlight
+  memoryCache = null
+  inFlight = null
+}
+
+/**
+ * For tests — await the currently in-flight refresh (if any). Resolves
+ * immediately when no refresh is running.
+ */
+export function awaitPendingServerRefresh(): Promise<void> {
+  return inFlight ?? Promise.resolve()
+}
+
+function startBackgroundRefresh(getNow: () => number): void {
+  if (inFlight) return
+  inFlight = (async () => {
+    try {
+      const latest = await fetchLatestVersion()
+      memoryCache = { fetchedAt: getNow(), latest }
+    } catch {
+      // fetchLatestVersion already swallows errors and returns null, but be
+      // defensive — still mark the cache as fetched so we don't immediately
+      // re-queue another attempt on the next call.
+      memoryCache = { fetchedAt: getNow(), latest: null }
+    } finally {
+      inFlight = null
+    }
+  })()
+}
+
+/**
+ * Server-side check used by the `/health` endpoint. Synchronous and
+ * non-blocking — never awaits a network call, so it cannot exceed
+ * load-balancer / Kubernetes probe budgets:
+ *
+ *   - Cold cache (server boot): returns `null` immediately, kicks off a
+ *     background fetch. The next call (after the npm round-trip completes)
+ *     will see the cached result. /health responses include `updateAvailable`
+ *     once the cache warms up, typically within a second of boot.
+ *   - Stale cache (>= TTL old): returns the cached value immediately, kicks
+ *     off a background refresh. Subsequent calls see the new value.
+ *   - Fresh cache: returns the cached value immediately, no I/O.
+ *
+ * Concurrent refresh attempts are deduplicated via an in-flight promise, so
+ * a burst of /health probes during cold boot triggers a single npm call.
+ */
+export function checkLatestVersionForServer(opts?: {
+  ttlMs?: number
+  now?: () => number
+}): UpdateAvailable | null {
+  if (!isUpdateCheckEnabled()) return null
+
+  const getNow = opts?.now ?? Date.now
+  const ttl = opts?.ttlMs ?? 60 * 60 * 1000
+  const now = getNow()
+
+  if (!memoryCache || now - memoryCache.fetchedAt >= ttl) {
+    startBackgroundRefresh(getNow)
+  }
+
+  if (!memoryCache || !memoryCache.latest) return null
+  return buildUpdateAvailable(PKG_VERSION, memoryCache.latest)
+}

--- a/packages/canonry/test/update-check.test.ts
+++ b/packages/canonry/test/update-check.test.ts
@@ -1,0 +1,466 @@
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest'
+import os from 'node:os'
+import fs from 'node:fs'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import { fileURLToPath } from 'node:url'
+
+const tmpDir = path.join(os.tmpdir(), `canonry-update-check-test-${crypto.randomUUID()}`)
+const PKG_JSON_PATH = fileURLToPath(new URL('../package.json', import.meta.url))
+
+function restoreEnvVar(name: string, original: string | undefined) {
+  if (original === undefined) {
+    delete process.env[name]
+  } else {
+    process.env[name] = original
+  }
+}
+
+function makeConfig(overrides?: Record<string, unknown>) {
+  return {
+    apiUrl: 'http://localhost:4100',
+    database: 'test.db',
+    apiKey: 'cnry_test',
+    ...overrides,
+  }
+}
+
+describe('update-check', () => {
+  let savedEnvVars: Record<string, string | undefined>
+  const envVarsToSave = [
+    'CANONRY_CONFIG_DIR',
+    'CANONRY_DISABLE_UPDATE_CHECK',
+    'DO_NOT_TRACK',
+    'CI',
+  ]
+  let savedFetch: typeof fetch
+
+  beforeEach(() => {
+    savedEnvVars = {}
+    for (const name of envVarsToSave) {
+      savedEnvVars[name] = process.env[name]
+    }
+    const testDir = path.join(tmpDir, crypto.randomUUID())
+    fs.mkdirSync(testDir, { recursive: true })
+    process.env.CANONRY_CONFIG_DIR = testDir
+    delete process.env.CANONRY_DISABLE_UPDATE_CHECK
+    delete process.env.DO_NOT_TRACK
+    delete process.env.CI
+    savedFetch = globalThis.fetch
+  })
+
+  afterEach(() => {
+    for (const name of envVarsToSave) {
+      restoreEnvVar(name, savedEnvVars[name])
+    }
+    globalThis.fetch = savedFetch
+    vi.restoreAllMocks()
+  })
+
+  // ── compareSemver ───────────────────────────────────────────────────
+
+  describe('compareSemver', () => {
+    it('returns 1 when a is greater than b', async () => {
+      const { compareSemver } = await import('../src/update-check.js')
+      expect(compareSemver('4.35.0', '4.34.0')).toBe(1)
+      expect(compareSemver('5.0.0', '4.99.99')).toBe(1)
+      expect(compareSemver('4.34.1', '4.34.0')).toBe(1)
+    })
+
+    it('returns -1 when a is less than b', async () => {
+      const { compareSemver } = await import('../src/update-check.js')
+      expect(compareSemver('4.34.0', '4.35.0')).toBe(-1)
+    })
+
+    it('returns 0 for equal versions', async () => {
+      const { compareSemver } = await import('../src/update-check.js')
+      expect(compareSemver('4.34.0', '4.34.0')).toBe(0)
+    })
+
+    it('ignores pre-release and build metadata', async () => {
+      const { compareSemver } = await import('../src/update-check.js')
+      expect(compareSemver('4.34.0-rc1', '4.34.0')).toBe(0)
+      expect(compareSemver('4.34.0+build.1', '4.34.0')).toBe(0)
+    })
+
+    it('returns 0 for malformed input so we never falsely advertise an upgrade', async () => {
+      const { compareSemver } = await import('../src/update-check.js')
+      expect(compareSemver('not-a-version', '4.34.0')).toBe(0)
+      expect(compareSemver('4.34', '4.34.0')).toBe(0)
+      expect(compareSemver('', '4.34.0')).toBe(0)
+    })
+  })
+
+  // ── buildUpdateAvailable ────────────────────────────────────────────
+
+  describe('buildUpdateAvailable', () => {
+    it('returns a payload when latest is strictly newer than current', async () => {
+      const { buildUpdateAvailable } = await import('../src/update-check.js')
+      const out = buildUpdateAvailable('4.34.0', '4.35.0')
+      expect(out).toEqual({
+        current: '4.34.0',
+        latest: '4.35.0',
+        url: 'https://www.npmjs.com/package/@ainyc/canonry',
+        upgradeCommand: 'npm install -g @ainyc/canonry',
+      })
+    })
+
+    it('returns null when versions are equal', async () => {
+      const { buildUpdateAvailable } = await import('../src/update-check.js')
+      expect(buildUpdateAvailable('4.34.0', '4.34.0')).toBe(null)
+    })
+
+    it('returns null when latest is older than current', async () => {
+      const { buildUpdateAvailable } = await import('../src/update-check.js')
+      expect(buildUpdateAvailable('4.35.0', '4.34.0')).toBe(null)
+    })
+  })
+
+  // ── isUpdateCheckEnabled ────────────────────────────────────────────
+
+  describe('isUpdateCheckEnabled', () => {
+    it('returns true by default (no config, no env vars)', async () => {
+      const { isUpdateCheckEnabled } = await import('../src/update-check.js')
+      expect(isUpdateCheckEnabled()).toBe(true)
+    })
+
+    it('returns false when CANONRY_DISABLE_UPDATE_CHECK=1', async () => {
+      process.env.CANONRY_DISABLE_UPDATE_CHECK = '1'
+      const { isUpdateCheckEnabled } = await import('../src/update-check.js')
+      expect(isUpdateCheckEnabled()).toBe(false)
+    })
+
+    it('returns false when DO_NOT_TRACK=1 (shared opt-out)', async () => {
+      process.env.DO_NOT_TRACK = '1'
+      const { isUpdateCheckEnabled } = await import('../src/update-check.js')
+      expect(isUpdateCheckEnabled()).toBe(false)
+    })
+
+    it('returns false in CI', async () => {
+      process.env.CI = 'true'
+      const { isUpdateCheckEnabled } = await import('../src/update-check.js')
+      expect(isUpdateCheckEnabled()).toBe(false)
+    })
+
+    it('returns false when config has updateCheck: false', async () => {
+      const { saveConfig } = await import('../src/config.js')
+      saveConfig(makeConfig({ updateCheck: false }))
+      const { isUpdateCheckEnabled } = await import('../src/update-check.js')
+      expect(isUpdateCheckEnabled()).toBe(false)
+    })
+
+    it('returns true when config has updateCheck: true', async () => {
+      const { saveConfig } = await import('../src/config.js')
+      saveConfig(makeConfig({ updateCheck: true }))
+      const { isUpdateCheckEnabled } = await import('../src/update-check.js')
+      expect(isUpdateCheckEnabled()).toBe(true)
+    })
+
+    it('env var CANONRY_DISABLE_UPDATE_CHECK overrides config updateCheck: true', async () => {
+      const { saveConfig } = await import('../src/config.js')
+      saveConfig(makeConfig({ updateCheck: true }))
+      process.env.CANONRY_DISABLE_UPDATE_CHECK = '1'
+      const { isUpdateCheckEnabled } = await import('../src/update-check.js')
+      expect(isUpdateCheckEnabled()).toBe(false)
+    })
+  })
+
+  // ── fetchLatestVersion ──────────────────────────────────────────────
+
+  describe('fetchLatestVersion', () => {
+    it('returns the latest string from a successful npm response', async () => {
+      globalThis.fetch = vi.fn(async () => new Response(
+        JSON.stringify({ latest: '4.35.0', next: '5.0.0-rc.1' }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )) as unknown as typeof fetch
+
+      const { fetchLatestVersion } = await import('../src/update-check.js')
+      expect(await fetchLatestVersion()).toBe('4.35.0')
+    })
+
+    it('returns null on non-2xx response', async () => {
+      globalThis.fetch = vi.fn(async () => new Response('Not Found', { status: 404 })) as unknown as typeof fetch
+      const { fetchLatestVersion } = await import('../src/update-check.js')
+      expect(await fetchLatestVersion()).toBe(null)
+    })
+
+    it('returns null on network failure (caller must never throw)', async () => {
+      globalThis.fetch = vi.fn(async () => { throw new Error('network down') }) as unknown as typeof fetch
+      const { fetchLatestVersion } = await import('../src/update-check.js')
+      expect(await fetchLatestVersion()).toBe(null)
+    })
+
+    it('returns null when payload is missing latest', async () => {
+      globalThis.fetch = vi.fn(async () => new Response(
+        JSON.stringify({ next: '5.0.0' }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )) as unknown as typeof fetch
+      const { fetchLatestVersion } = await import('../src/update-check.js')
+      expect(await fetchLatestVersion()).toBe(null)
+    })
+
+    it('returns null when latest is not a string', async () => {
+      globalThis.fetch = vi.fn(async () => new Response(
+        JSON.stringify({ latest: 42 }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )) as unknown as typeof fetch
+      const { fetchLatestVersion } = await import('../src/update-check.js')
+      expect(await fetchLatestVersion()).toBe(null)
+    })
+  })
+
+  // ── checkLatestVersionForCli ────────────────────────────────────────
+
+  describe('checkLatestVersionForCli', () => {
+    function currentVersion(): string {
+      const pkg = JSON.parse(fs.readFileSync(PKG_JSON_PATH, 'utf-8')) as { version: string }
+      return pkg.version
+    }
+
+    it('returns null when disabled by env var', async () => {
+      process.env.CANONRY_DISABLE_UPDATE_CHECK = '1'
+      const fetchSpy = vi.fn() as unknown as typeof fetch
+      globalThis.fetch = fetchSpy
+
+      const { saveConfig } = await import('../src/config.js')
+      saveConfig(makeConfig())
+
+      const { checkLatestVersionForCli } = await import('../src/update-check.js')
+      expect(await checkLatestVersionForCli()).toBe(null)
+      expect(fetchSpy).not.toHaveBeenCalled()
+    })
+
+    it('returns null when no config exists (avoids hitting npm before init)', async () => {
+      const fetchSpy = vi.fn() as unknown as typeof fetch
+      globalThis.fetch = fetchSpy
+      const { checkLatestVersionForCli } = await import('../src/update-check.js')
+      expect(await checkLatestVersionForCli()).toBe(null)
+      expect(fetchSpy).not.toHaveBeenCalled()
+    })
+
+    it('hits npm on first call, persists cache, returns upgrade payload', async () => {
+      globalThis.fetch = vi.fn(async () => new Response(
+        JSON.stringify({ latest: '999.0.0' }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )) as unknown as typeof fetch
+
+      const { saveConfig, loadConfig } = await import('../src/config.js')
+      saveConfig(makeConfig())
+
+      const { checkLatestVersionForCli } = await import('../src/update-check.js')
+      const out = await checkLatestVersionForCli({ now: () => new Date('2026-05-15T00:00:00Z') })
+      expect(out).not.toBe(null)
+      expect(out!.latest).toBe('999.0.0')
+      expect(out!.current).toBe(currentVersion())
+
+      const config = loadConfig()
+      expect(config.lastUpdateCheckAt).toBe('2026-05-15T00:00:00.000Z')
+      expect(config.lastKnownLatestVersion).toBe('999.0.0')
+    })
+
+    it('skips npm call inside the TTL window and returns cached comparison', async () => {
+      const fetchSpy = vi.fn() as unknown as typeof fetch
+      globalThis.fetch = fetchSpy
+
+      const { saveConfig } = await import('../src/config.js')
+      saveConfig(makeConfig({
+        lastUpdateCheckAt: '2026-05-15T00:00:00.000Z',
+        lastKnownLatestVersion: '999.0.0',
+      }))
+
+      const { checkLatestVersionForCli } = await import('../src/update-check.js')
+      const out = await checkLatestVersionForCli({
+        now: () => new Date('2026-05-15T01:00:00Z'),  // 1h after cache
+      })
+      expect(out).not.toBe(null)
+      expect(out!.latest).toBe('999.0.0')
+      expect(fetchSpy).not.toHaveBeenCalled()
+    })
+
+    it('re-checks npm after the TTL window expires', async () => {
+      const fetchSpy = vi.fn(async () => new Response(
+        JSON.stringify({ latest: '999.0.1' }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )) as unknown as typeof fetch
+      globalThis.fetch = fetchSpy
+
+      const { saveConfig } = await import('../src/config.js')
+      saveConfig(makeConfig({
+        lastUpdateCheckAt: '2026-05-14T00:00:00.000Z',
+        lastKnownLatestVersion: '999.0.0',
+      }))
+
+      const { checkLatestVersionForCli } = await import('../src/update-check.js')
+      const out = await checkLatestVersionForCli({
+        now: () => new Date('2026-05-15T01:00:00Z'),  // 25h after cache
+      })
+      expect(out).not.toBe(null)
+      expect(out!.latest).toBe('999.0.1')
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('returns null (no banner) when latest equals current', async () => {
+      globalThis.fetch = vi.fn(async () => new Response(
+        JSON.stringify({ latest: currentVersion() }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )) as unknown as typeof fetch
+
+      const { saveConfig } = await import('../src/config.js')
+      saveConfig(makeConfig())
+
+      const { checkLatestVersionForCli } = await import('../src/update-check.js')
+      expect(await checkLatestVersionForCli()).toBe(null)
+    })
+
+    it('still refreshes lastUpdateCheckAt on network failure so we don\'t hammer npm', async () => {
+      globalThis.fetch = vi.fn(async () => { throw new Error('offline') }) as unknown as typeof fetch
+
+      const { saveConfig, loadConfig } = await import('../src/config.js')
+      saveConfig(makeConfig())
+
+      const { checkLatestVersionForCli } = await import('../src/update-check.js')
+      const out = await checkLatestVersionForCli({ now: () => new Date('2026-05-15T00:00:00Z') })
+      expect(out).toBe(null)
+
+      const config = loadConfig()
+      expect(config.lastUpdateCheckAt).toBe('2026-05-15T00:00:00.000Z')
+      expect(config.lastKnownLatestVersion).toBeUndefined()
+    })
+  })
+
+  // ── checkLatestVersionForServer (synchronous, non-blocking) ─────────
+
+  describe('checkLatestVersionForServer', () => {
+    it('returns null when disabled and does not call fetch', async () => {
+      process.env.CANONRY_DISABLE_UPDATE_CHECK = '1'
+      const fetchSpy = vi.fn() as unknown as typeof fetch
+      globalThis.fetch = fetchSpy
+
+      const { checkLatestVersionForServer, resetServerUpdateCheckCache } = await import('../src/update-check.js')
+      await resetServerUpdateCheckCache()
+      expect(checkLatestVersionForServer()).toBe(null)
+      expect(fetchSpy).not.toHaveBeenCalled()
+    })
+
+    it('never awaits the npm round-trip — returns synchronously even when fetch takes seconds', async () => {
+      // Critical for /health probe budgets: the function must return
+      // immediately even when the upstream registry is slow or hung.
+      let fetchResolve: (r: Response) => void = () => {}
+      const fetchSpy = vi.fn(() => new Promise<Response>((resolve) => {
+        fetchResolve = resolve
+      })) as unknown as typeof fetch
+      globalThis.fetch = fetchSpy
+
+      const { checkLatestVersionForServer, resetServerUpdateCheckCache, awaitPendingServerRefresh } = await import('../src/update-check.js')
+      await resetServerUpdateCheckCache()
+
+      const t0 = Date.now()
+      const out = checkLatestVersionForServer()
+      const elapsedMs = Date.now() - t0
+
+      // Cold cache → null, but the call returned (synchronously) in well under
+      // any conceivable LB/k8s probe budget — even a 100ms threshold is
+      // generous for what is effectively a Map lookup.
+      expect(out).toBe(null)
+      expect(elapsedMs).toBeLessThan(50)
+      expect(fetchSpy).toHaveBeenCalledTimes(1) // background refresh kicked off
+
+      // Resolve the pending fetch so the test cleanup awaits a settled cache.
+      fetchResolve(new Response(
+        JSON.stringify({ latest: '999.0.0' }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ))
+      await awaitPendingServerRefresh()
+    })
+
+    it('cold cache: returns null, kicks off background refresh, populates on next call', async () => {
+      const fetchSpy = vi.fn(async () => new Response(
+        JSON.stringify({ latest: '999.0.0' }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )) as unknown as typeof fetch
+      globalThis.fetch = fetchSpy
+
+      const { checkLatestVersionForServer, resetServerUpdateCheckCache, awaitPendingServerRefresh } = await import('../src/update-check.js')
+      await resetServerUpdateCheckCache()
+
+      // First call: cache empty → null, refresh starts in background
+      expect(checkLatestVersionForServer({ now: () => 1_000_000 })).toBe(null)
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+
+      // Wait for the background refresh to finish writing the cache.
+      await awaitPendingServerRefresh()
+
+      // Second call: cache warm → cached payload
+      const out = checkLatestVersionForServer({ now: () => 1_000_000 + 1_000 })
+      expect(out?.latest).toBe('999.0.0')
+      expect(fetchSpy).toHaveBeenCalledTimes(1) // no second fetch
+    })
+
+    it('deduplicates concurrent refresh attempts across a burst of /health probes', async () => {
+      const fetchSpy = vi.fn(async () => new Response(
+        JSON.stringify({ latest: '999.0.0' }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )) as unknown as typeof fetch
+      globalThis.fetch = fetchSpy
+
+      const { checkLatestVersionForServer, resetServerUpdateCheckCache, awaitPendingServerRefresh } = await import('../src/update-check.js')
+      await resetServerUpdateCheckCache()
+
+      // Simulate ten cold-cache probes arriving simultaneously.
+      for (let i = 0; i < 10; i++) {
+        expect(checkLatestVersionForServer({ now: () => 1_000_000 })).toBe(null)
+      }
+      await awaitPendingServerRefresh()
+
+      // Only one outbound npm call despite ten concurrent probes.
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('stale cache: returns the previous value immediately, refreshes in background', async () => {
+      let nextLatest = '999.0.0'
+      const fetchSpy = vi.fn(async () => new Response(
+        JSON.stringify({ latest: nextLatest }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )) as unknown as typeof fetch
+      globalThis.fetch = fetchSpy
+
+      const { checkLatestVersionForServer, resetServerUpdateCheckCache, awaitPendingServerRefresh } = await import('../src/update-check.js')
+      await resetServerUpdateCheckCache()
+
+      // Seed the cache.
+      checkLatestVersionForServer({ ttlMs: 60_000, now: () => 1_000_000 })
+      await awaitPendingServerRefresh()
+      expect(checkLatestVersionForServer({ ttlMs: 60_000, now: () => 1_000_000 + 1_000 })?.latest).toBe('999.0.0')
+
+      // Bump upstream version and advance past TTL.
+      nextLatest = '999.0.1'
+      // Stale call → returns the OLD value immediately, kicks off refresh.
+      expect(checkLatestVersionForServer({ ttlMs: 60_000, now: () => 1_000_000 + 60_001 })?.latest).toBe('999.0.0')
+      expect(fetchSpy).toHaveBeenCalledTimes(2) // refresh started
+
+      // After the background refresh completes, the cache holds the new value.
+      await awaitPendingServerRefresh()
+      expect(checkLatestVersionForServer({ ttlMs: 60_000, now: () => 1_000_000 + 60_002 })?.latest).toBe('999.0.1')
+    })
+
+    it('returns null without firing a refresh when the cached latest equals the current version', async () => {
+      // Seed the cache with the running version — a fresh-cache hit should
+      // return null (no banner) and skip the npm call.
+      const fetchSpy = vi.fn(async () => new Response(
+        JSON.stringify({ latest: '0.0.1' }), // older than current → no banner
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )) as unknown as typeof fetch
+      globalThis.fetch = fetchSpy
+
+      const { checkLatestVersionForServer, resetServerUpdateCheckCache, awaitPendingServerRefresh } = await import('../src/update-check.js')
+      await resetServerUpdateCheckCache()
+
+      checkLatestVersionForServer({ now: () => 1_000_000 })
+      await awaitPendingServerRefresh()
+
+      // Cache is fresh (within TTL) and the latest is older than current.
+      expect(checkLatestVersionForServer({ now: () => 1_000_000 + 1_000 })).toBe(null)
+      expect(fetchSpy).toHaveBeenCalledTimes(1) // no extra calls
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a daily npm-registry probe (`packages/canonry/src/update-check.ts`) with on-disk TTL cache for the CLI and a stale-while-revalidate in-memory cache for the server. Opt-outs: `CANONRY_DISABLE_UPDATE_CHECK`, `DO_NOT_TRACK`, `CI`, or `updateCheck: false` in `~/.canonry/config.yaml`.
- Surfaces the upgrade hint in three places: a stderr banner before every CLI command, an `updateAvailable` field on `GET /health`, and an animated, per-version-dismissible bubble next to the brand mark in the sidebar.
- Bumps `4.34.0` → `4.35.0` in both `package.json` files; ships with full unit coverage in `packages/canonry/test/update-check.test.ts`.

## Test plan
- [ ] `pnpm test` (new `update-check.test.ts` covers semver, opt-outs, CLI TTL cache, server stale-while-revalidate, dedup of concurrent probes)
- [ ] `pnpm typecheck && pnpm lint`
- [ ] Manually: `?force-update=99.0.0` query string shows the sidebar bubble; clicking × persists per-version dismiss in localStorage
- [ ] Manually: hit `/health` and confirm `updateAvailable` appears once the cache warms