### PR TITLE
fix(intelligence): skip orphan snapshots in buildRunData

### DIFF
--- a/packages/canonry/src/intelligence-service.ts
+++ b/packages/canonry/src/intelligence-service.ts
@@ -489,6 +489,10 @@ export class IntelligenceService {
     const rows = this.db
       .select({
         query: queries.query,
+        // Denormalized query text persisted by v58 — the fallback when the
+        // joined queries.query has been hard-deleted (or the query_id was
+        // nulled by the v58 dangling-FK cleanup).
+        queryText: querySnapshots.queryText,
         provider: querySnapshots.provider,
         citationState: querySnapshots.citationState,
         citedDomains: querySnapshots.citedDomains,
@@ -500,11 +504,21 @@ export class IntelligenceService {
       .where(eq(querySnapshots.runId, runId))
       .all()
 
-    const snapshots: Snapshot[] = rows.map(r => {
+    const snapshots: Snapshot[] = []
+    for (const r of rows) {
+      // Recover query identity in priority order: live join → denormalized
+      // text. If both are missing this snapshot has no identity to surface,
+      // and feeding it to the detectors would produce phantom insights —
+      // every orphan in the same run collapses to a single ("", provider,
+      // location) detector key, fabricating regressions/gains on a synthetic
+      // empty query. Skip it.
+      const resolvedQuery = r.query ?? r.queryText ?? null
+      if (!resolvedQuery) continue
+
       const domains = parseJsonColumn<string[]>(r.citedDomains, [])
       const competitors = parseJsonColumn<string[]>(r.competitorOverlap, [])
-      return {
-        query: r.query ?? '',
+      snapshots.push({
+        query: resolvedQuery,
         provider: r.provider,
         cited: r.citationState === CitationStates.cited,
         citationUrl: domains[0] ?? undefined,
@@ -519,8 +533,8 @@ export class IntelligenceService {
         // sources). Cause analysis uses it to name the displacing source
         // when no tracked competitor appears in the response.
         citedDomains: domains,
-      }
-    })
+      })
+    }
 
     return { runId, projectId, completedAt, location, snapshots }
   }

--- a/packages/canonry/test/intelligence-service.test.ts
+++ b/packages/canonry/test/intelligence-service.test.ts
@@ -555,4 +555,125 @@ describe('IntelligenceService', () => {
       expect(result!.regressions[0]!.previousRunId).toBe(flMid)
     })
   })
+
+  // Regression suite for the orphan-snapshot insight noise observed after
+  // backfilling azcoatings on 2026-05-16: 459 snapshots with `query_id`
+  // nulled by the v58 dangling-FK cleanup all collapsed to a single
+  // ("", "gemini", null) detector key, generating 28 phantom regressions
+  // + 3 phantom gains + 1 phantom first-citation on a single run.
+  describe('orphan snapshots (query_id NULL and query_text NULL)', () => {
+    function seedOrphanSnapshot(
+      db: ReturnType<typeof createClient>,
+      runId: string,
+      provider: string,
+      citationState: string,
+    ): void {
+      db.insert(querySnapshots).values({
+        id: crypto.randomUUID(),
+        runId,
+        queryId: null, // dangling — the v58 LEFT JOIN backfill nulled it
+        queryText: null, // never had a denormalized fallback either
+        provider,
+        model: 'test-model',
+        citationState,
+        citedDomains: '[]',
+        competitorOverlap: '[]',
+        createdAt: new Date().toISOString(),
+      }).run()
+    }
+
+    it('does not generate regression insights for orphan snapshots', () => {
+      const { db } = createTempDb('intel-orphan-regression-')
+      const projectId = seedProject(db)
+      const queryId = seedQuery(db, projectId, 'real query')
+
+      const run1 = seedRun(db, projectId, 'completed', '2026-04-01T00:00:00Z')
+      const run2 = seedRun(db, projectId, 'completed', '2026-04-02T00:00:00Z')
+
+      // Run 1: orphan cited + real-query cited
+      seedOrphanSnapshot(db, run1, 'gemini', 'cited')
+      seedSnapshot(db, run1, queryId, 'gemini', 'cited', { citedDomains: ['example.com'] })
+
+      // Run 2: orphan NOT cited + real-query cited (only the orphan would
+      // produce a phantom "regression"; the real-query is steady)
+      seedOrphanSnapshot(db, run2, 'gemini', 'not-cited')
+      seedSnapshot(db, run2, queryId, 'gemini', 'cited', { citedDomains: ['example.com'] })
+
+      const service = new IntelligenceService(db)
+      const result = service.analyzeAndPersist(run2, projectId)
+
+      expect(result).not.toBeNull()
+      // Pre-fix: result.regressions had the orphan as `{ query: '', provider: 'gemini' }`.
+      expect(result!.regressions).toHaveLength(0)
+
+      // Persisted insights table also has no empty-query rows.
+      const persistedEmpty = db.select().from(insights)
+        .all()
+        .filter(i => i.runId === run2 && (i.query === null || i.query === ''))
+      expect(persistedEmpty).toHaveLength(0)
+    })
+
+    it('does not generate gain insights for orphan snapshots', () => {
+      const { db } = createTempDb('intel-orphan-gain-')
+      const projectId = seedProject(db)
+      const queryId = seedQuery(db, projectId, 'real query')
+
+      const run1 = seedRun(db, projectId, 'completed', '2026-04-01T00:00:00Z')
+      const run2 = seedRun(db, projectId, 'completed', '2026-04-02T00:00:00Z')
+
+      // Run 1: orphan not cited
+      seedOrphanSnapshot(db, run1, 'gemini', 'not-cited')
+      seedSnapshot(db, run1, queryId, 'gemini', 'cited', { citedDomains: ['example.com'] })
+
+      // Run 2: orphan now cited — this would produce a phantom "gain" pre-fix
+      seedOrphanSnapshot(db, run2, 'gemini', 'cited')
+      seedSnapshot(db, run2, queryId, 'gemini', 'cited', { citedDomains: ['example.com'] })
+
+      const service = new IntelligenceService(db)
+      const result = service.analyzeAndPersist(run2, projectId)
+
+      expect(result).not.toBeNull()
+      expect(result!.gains).toHaveLength(0)
+    })
+
+    it('uses query_text as a fallback when queries.query is unavailable', () => {
+      // The v58 migration also backfilled `query_text` on snapshots whose
+      // queries row still existed at migration time. If a query is later
+      // hard-deleted (or its row vanishes for any reason), the joined
+      // queries.query goes null but query_text survives. The analyzer should
+      // recover the query identity from query_text rather than treating the
+      // snapshot as an orphan.
+      const { db } = createTempDb('intel-querytext-fallback-')
+      const projectId = seedProject(db)
+
+      const run1 = seedRun(db, projectId, 'completed', '2026-04-01T00:00:00Z')
+      const run2 = seedRun(db, projectId, 'completed', '2026-04-02T00:00:00Z')
+
+      // Pre-existing snapshots with query_text populated but query_id NULL
+      // (the queries row was deleted post-snapshot-write, post-v58).
+      function insertWithQueryText(runId: string, citationState: string) {
+        db.insert(querySnapshots).values({
+          id: crypto.randomUUID(),
+          runId,
+          queryId: null,
+          queryText: 'recovered query text',
+          provider: 'gemini',
+          model: 'test-model',
+          citationState,
+          citedDomains: citationState === 'cited' ? '["example.com"]' : '[]',
+          competitorOverlap: '[]',
+          createdAt: new Date().toISOString(),
+        }).run()
+      }
+      insertWithQueryText(run1, 'cited')
+      insertWithQueryText(run2, 'not-cited')
+
+      const service = new IntelligenceService(db)
+      const result = service.analyzeAndPersist(run2, projectId)
+
+      expect(result).not.toBeNull()
+      expect(result!.regressions).toHaveLength(1)
+      expect(result!.regressions[0]!.query).toBe('recovered query text')
+    })
+  })
 })


### PR DESCRIPTION
## Summary
When \`buildRunData\` LEFT JOINs \`query_snapshots\` with \`queries\`, any snapshot whose \`query_id\` had been nulled by the v58 dangling-FK cleanup returned \`r.query = null\` from the join. The previous code fell back to empty string, and the detector keys then collapsed every orphan in a single run to one shared \`("", provider, location)\` tuple — fabricating regressions / gains on a synthetic empty query.

**Observed in production** after backfilling azcoatings on 2026-05-16: 459 orphan snapshots produced **28 phantom regressions, 3 phantom gains, and 1 phantom first-citation** insight in a single run, all with empty title and query.

## Fix
- Pull \`querySnapshots.queryText\` (the v58 denormalized column) into the SELECT.
- Resolve query identity in priority: live join → denormalized text.
- If both are absent the snapshot has no surface in the dashboard; skip it before constructing the \`Snapshot[]\` array so the detectors never see it.

The next backfill on a project with v58 orphans will produce the same clean insight set the one-shot cleanup did, but structurally enforced.

## Test plan
- [x] \`pnpm vitest run --project canonry intelligence-service.test\` — 19/19 pass (16 existing + 3 new)
- [x] New regression tests:
  - \`does not generate regression insights for orphan snapshots\` — the bug surfaced in prod
  - \`does not generate gain insights for orphan snapshots\` — symmetric
  - \`uses query_text as a fallback when queries.query is unavailable\` — graceful degradation
- [x] Full suite: 2426/2426 pass (2 pre-existing schedules-migration failures unrelated)
- [x] Typecheck + lint clean

## Deploy + cleanup
- Re-run \`canonry backfill insights <project>\` on any project that had a backfill since the v58 migration. Idempotent — \`persistResult\` wipes prior insights per runId and re-inserts.
- Already-deployed manual cleanup of 32 noise insights for \`azcoatings\` will not regenerate after this fix lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)