### PR TITLE
fix(intelligence): log a warning when orphan snapshots are skipped

### DIFF
--- a/packages/canonry/src/intelligence-service.ts
+++ b/packages/canonry/src/intelligence-service.ts
@@ -505,6 +505,7 @@ export class IntelligenceService {
       .all()
 
     const snapshots: Snapshot[] = []
+    let orphanCount = 0
     for (const r of rows) {
       // Recover query identity in priority order: live join → denormalized
       // text. If both are missing this snapshot has no identity to surface,
@@ -513,7 +514,10 @@ export class IntelligenceService {
       // location) detector key, fabricating regressions/gains on a synthetic
       // empty query. Skip it.
       const resolvedQuery = r.query ?? r.queryText ?? null
-      if (!resolvedQuery) continue
+      if (!resolvedQuery) {
+        orphanCount++
+        continue
+      }
 
       const domains = parseJsonColumn<string[]>(r.citedDomains, [])
       const competitors = parseJsonColumn<string[]>(r.competitorOverlap, [])
@@ -534,6 +538,15 @@ export class IntelligenceService {
         // when no tracked competitor appears in the response.
         citedDomains: domains,
       })
+    }
+
+    // Surface the silent skip path. Healthy DBs emit zero orphan-skip
+    // warnings; a sudden non-zero count is a signal that a write path
+    // started accumulating dangling-FK rows again, or that v58-equivalent
+    // migration debt exists on the project. Without this log the skip is
+    // invisible to operators until a customer notices missing insights.
+    if (orphanCount > 0) {
+      log.warn('snapshot.orphan-skip', { runId, projectId, orphanCount })
     }
 
     return { runId, projectId, completedAt, location, snapshots }

--- a/packages/canonry/test/intelligence-service.test.ts
+++ b/packages/canonry/test/intelligence-service.test.ts
@@ -675,5 +675,78 @@ describe('IntelligenceService', () => {
       expect(result!.regressions).toHaveLength(1)
       expect(result!.regressions[0]!.query).toBe('recovered query text')
     })
+
+    it('logs a warning with the orphan count when orphan snapshots are skipped', async () => {
+      // The orphan-skip is silent in code, but loud in operator-facing logs
+      // so a healthy DB with sudden orphan accumulation surfaces in the
+      // JobRunner / canonry serve output instead of failing closed.
+      const vi = await import('vitest').then(m => m.vi)
+      const writes: string[] = []
+      const spy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
+        if (typeof chunk === 'string') writes.push(chunk)
+        else if (chunk instanceof Buffer) writes.push(chunk.toString('utf8'))
+        return true
+      }) as typeof process.stdout.write)
+
+      try {
+        const { db } = createTempDb('intel-orphan-log-')
+        const projectId = seedProject(db)
+        const queryId = seedQuery(db, projectId, 'real query')
+        const run1 = seedRun(db, projectId, 'completed', '2026-04-01T00:00:00Z')
+
+        seedSnapshot(db, run1, queryId, 'gemini', 'cited', { citedDomains: ['example.com'] })
+        // Three orphan snapshots in the same run.
+        for (let i = 0; i < 3; i++) {
+          db.insert(querySnapshots).values({
+            id: crypto.randomUUID(),
+            runId: run1,
+            queryId: null,
+            queryText: null,
+            provider: 'gemini',
+            model: 'test-model',
+            citationState: 'not-cited',
+            citedDomains: '[]',
+            competitorOverlap: '[]',
+            createdAt: new Date().toISOString(),
+          }).run()
+        }
+
+        const service = new IntelligenceService(db)
+        service.analyzeAndPersist(run1, projectId)
+
+        const warnLine = writes.find(w => w.includes('snapshot.orphan-skip'))
+        expect(warnLine).toBeDefined()
+        expect(warnLine).toContain('"orphanCount":3')
+        expect(warnLine).toContain('"warn"')
+      } finally {
+        spy.mockRestore()
+      }
+    })
+
+    it('does not emit the warning when no orphan snapshots are present', async () => {
+      const vi = await import('vitest').then(m => m.vi)
+      const writes: string[] = []
+      const spy = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
+        if (typeof chunk === 'string') writes.push(chunk)
+        else if (chunk instanceof Buffer) writes.push(chunk.toString('utf8'))
+        return true
+      }) as typeof process.stdout.write)
+
+      try {
+        const { db } = createTempDb('intel-orphan-quiet-')
+        const projectId = seedProject(db)
+        const queryId = seedQuery(db, projectId, 'real query')
+        const run1 = seedRun(db, projectId, 'completed', '2026-04-01T00:00:00Z')
+        seedSnapshot(db, run1, queryId, 'gemini', 'cited', { citedDomains: ['example.com'] })
+
+        const service = new IntelligenceService(db)
+        service.analyzeAndPersist(run1, projectId)
+
+        const warnLine = writes.find(w => w.includes('snapshot.orphan-skip'))
+        expect(warnLine).toBeUndefined()
+      } finally {
+        spy.mockRestore()
+      }
+    })
   })
 })


### PR DESCRIPTION
## Summary
PR #519 made \`buildRunData\` skip snapshots whose query identity couldn't be recovered. The skip is silent — if a future write path starts accumulating orphan snapshots, or if a project picks up v58-equivalent migration debt, the analyzer silently loses insights and nobody notices until a customer complains "where did my regressions go?"

Track orphan count in the loop, then \`log.warn('snapshot.orphan-skip', { runId, projectId, orphanCount })\` if non-zero. Healthy DBs emit zero warnings; sudden non-zero counts surface in \`canonry serve\` / JobRunner logs for operator triage.

## Test plan
- [x] \`pnpm vitest run --project canonry intelligence-service.test\` — 21/21 pass (19 existing + 2 new)
- [x] \`logs a warning with the orphan count when orphan snapshots are skipped\` — verifies log fires with correct count
- [x] \`does not emit the warning when no orphan snapshots are present\` — verifies healthy-path silence
- [x] Wider suite (canonry + intelligence + api-routes): 1856/1856 pass
- [x] Typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)