### PR TITLE
feat(backfill): add --since flag to scope insight backfills by date

### DIFF
--- a/packages/canonry/src/cli-commands/backfill.ts
+++ b/packages/canonry/src/cli-commands/backfill.ts
@@ -33,17 +33,19 @@ export const BACKFILL_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['backfill', 'insights'],
-    usage: 'canonry backfill insights <project> [--from-run <id>] [--to-run <id>] [--format json]',
+    usage: 'canonry backfill insights <project> [--from-run <id>] [--to-run <id>] [--since <date>] [--format json]',
     options: {
       'from-run': stringOption(),
       'to-run': stringOption(),
+      'since': stringOption(),
     },
     run: async (input) => {
-      const usage = 'canonry backfill insights <project> [--from-run <id>] [--to-run <id>] [--format json]'
+      const usage = 'canonry backfill insights <project> [--from-run <id>] [--to-run <id>] [--since <date>] [--format json]'
       const project = requireProject(input, 'backfill insights', usage)
       await backfillInsightsCommand(project, {
         fromRun: getString(input.values, 'from-run'),
         toRun: getString(input.values, 'to-run'),
+        since: getString(input.values, 'since'),
         format: input.format,
       })
     },

--- a/packages/canonry/src/commands/backfill.ts
+++ b/packages/canonry/src/commands/backfill.ts
@@ -651,7 +651,7 @@ function readStoredGroundingSources(rawResponse: string | null): GroundingSource
 
 export async function backfillInsightsCommand(
   project: string,
-  opts?: { fromRun?: string; toRun?: string; format?: CliFormat },
+  opts?: { fromRun?: string; toRun?: string; since?: string; format?: CliFormat },
 ): Promise<void> {
   // Lazy-load the intelligence graph so `backfill answer-visibility` can run and be
   // tested without pulling in the optional insights dependency chain.
@@ -664,12 +664,14 @@ export async function backfillInsightsCommand(
   const isJson = opts?.format === 'json'
 
   if (!isJson) {
-    process.stderr.write(`Backfilling insights for "${project}"...\n`)
+    const scope = opts?.since ? ` (since ${opts.since})` : ''
+    process.stderr.write(`Backfilling insights for "${project}"${scope}...\n`)
   }
 
   const result = service.backfill(project, {
     fromRunId: opts?.fromRun,
     toRunId: opts?.toRun,
+    since: opts?.since,
   }, (info) => {
     if (!isJson) {
       process.stderr.write(`  [${info.index}/${info.total}] ${info.runId} — ${info.insights} insights\n`)

--- a/packages/canonry/src/intelligence-service.ts
+++ b/packages/canonry/src/intelligence-service.ts
@@ -183,10 +183,19 @@ export class IntelligenceService {
   /**
    * Backfill intelligence for all completed/partial runs of a project.
    * Processes runs in chronological order so each run compares against its predecessor.
+   *
+   * Scoping options:
+   *   - `fromRunId` / `toRunId`: bound the target range by exact run ID.
+   *   - `since`: bound the target range by `finishedAt >= <date>`. Accepts
+   *     any string that `Date.parse` understands (ISO 8601, `YYYY-MM-DD`,
+   *     etc.). Runs before the cutoff are *not* re-processed but stay
+   *     available for predecessor lookup, so transition detection at the
+   *     boundary stays correct. Composes with `fromRunId` / `toRunId` —
+   *     all three filters intersect.
    */
   backfill(
     projectName: string,
-    opts?: { fromRunId?: string; toRunId?: string },
+    opts?: { fromRunId?: string; toRunId?: string; since?: string },
     onProgress?: (info: { runId: string; index: number; total: number; insights: number }) => void,
   ): { processed: number; skipped: number; totalInsights: number } {
     const project = this.db
@@ -196,6 +205,15 @@ export class IntelligenceService {
       .get()
     if (!project) {
       throw new Error(`Project "${projectName}" not found`)
+    }
+
+    let sinceTimestamp: number | null = null
+    if (opts?.since !== undefined) {
+      const parsed = Date.parse(opts.since)
+      if (Number.isNaN(parsed)) {
+        throw new Error(`Invalid --since value "${opts.since}": expected a parseable date (ISO 8601 or YYYY-MM-DD)`)
+      }
+      sinceTimestamp = parsed
     }
 
     const allRuns = this.db
@@ -224,7 +242,17 @@ export class IntelligenceService {
       endIdx = idx + 1
     }
 
-    const targetRuns = allRuns.slice(startIdx, endIdx)
+    let targetRuns = allRuns.slice(startIdx, endIdx)
+    // Apply --since on top of the range slice. We filter target runs only —
+    // `allRuns` is intentionally still the full chronology so the predecessor
+    // lookup inside the loop can walk back across the cutoff.
+    if (sinceTimestamp !== null) {
+      targetRuns = targetRuns.filter(r => {
+        const ts = r.finishedAt ?? r.createdAt
+        const t = Date.parse(ts)
+        return !Number.isNaN(t) && t >= sinceTimestamp
+      })
+    }
     let processed = 0
     let skipped = 0
     let totalInsights = 0

--- a/packages/canonry/test/intelligence-service.test.ts
+++ b/packages/canonry/test/intelligence-service.test.ts
@@ -319,6 +319,87 @@ describe('IntelligenceService', () => {
       expect(healthRows[0]!.runId).toBe(run2)
     })
 
+    it('respects --since by scoping processed runs to finishedAt >= the cutoff', () => {
+      // Use case: after a code change that affects insight generation, you
+      // want to re-process recent runs only — not walk the entire ~900-run
+      // history of a long-lived project. The predecessor lookup still pulls
+      // from the full history so transitions remain correct at the boundary.
+      const { db } = createTempDb('intel-backfill-since-')
+      const projectId = seedProject(db)
+      const queryId = seedQuery(db, projectId, 'test query')
+
+      const run1 = seedRun(db, projectId, 'completed', '2024-01-01T00:00:00Z')
+      seedSnapshot(db, run1, queryId, 'gemini', 'cited', { citedDomains: ['example.com'] })
+
+      const run2 = seedRun(db, projectId, 'completed', '2024-02-01T00:00:00Z')
+      seedSnapshot(db, run2, queryId, 'gemini', 'not-cited')
+
+      const run3 = seedRun(db, projectId, 'completed', '2024-03-01T00:00:00Z')
+      seedSnapshot(db, run3, queryId, 'gemini', 'cited', { citedDomains: ['example.com'] })
+
+      const service = new IntelligenceService(db)
+      const result = service.backfill('test-project', { since: '2024-02-15T00:00:00Z' })
+
+      // run1 and run2 are before the cutoff → not re-processed
+      // run3 is after → processed, with run2 (from full history) as predecessor
+      expect(result.processed).toBe(1)
+      const healthRows = db.select().from(healthSnapshots).all()
+      expect(healthRows).toHaveLength(1)
+      expect(healthRows[0]!.runId).toBe(run3)
+
+      // The transition (run2 not-cited → run3 cited) must still be detected
+      // as a gain — proves the predecessor lookup walked back past the cutoff.
+      const gainInsights = db.select().from(insights).all().filter(i => i.type === 'gain')
+      expect(gainInsights.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('--since accepts a YYYY-MM-DD date and treats it as midnight UTC', () => {
+      const { db } = createTempDb('intel-backfill-since-date-')
+      const projectId = seedProject(db)
+      const queryId = seedQuery(db, projectId, 'test query')
+
+      const run1 = seedRun(db, projectId, 'completed', '2024-01-15T00:00:00Z')
+      seedSnapshot(db, run1, queryId, 'gemini', 'cited', { citedDomains: ['example.com'] })
+
+      const run2 = seedRun(db, projectId, 'completed', '2024-02-15T00:00:00Z')
+      seedSnapshot(db, run2, queryId, 'gemini', 'not-cited')
+
+      const service = new IntelligenceService(db)
+      const result = service.backfill('test-project', { since: '2024-02-01' })
+
+      // run1 (Jan 15) is before; run2 (Feb 15) is after the Feb 1 cutoff.
+      expect(result.processed).toBe(1)
+    })
+
+    it('throws a clear error when --since is not parseable as a date', () => {
+      const { db } = createTempDb('intel-backfill-bad-since-')
+      seedProject(db)
+      const service = new IntelligenceService(db)
+      expect(() => service.backfill('test-project', { since: 'not-a-date' })).toThrow(/since.*date/i)
+    })
+
+    it('--since combines with --to-run to bound the upper edge', () => {
+      const { db } = createTempDb('intel-backfill-since-toRun-')
+      const projectId = seedProject(db)
+      const queryId = seedQuery(db, projectId, 'test query')
+
+      const run1 = seedRun(db, projectId, 'completed', '2024-01-01T00:00:00Z')
+      seedSnapshot(db, run1, queryId, 'gemini', 'cited', { citedDomains: ['example.com'] })
+      const run2 = seedRun(db, projectId, 'completed', '2024-02-01T00:00:00Z')
+      seedSnapshot(db, run2, queryId, 'gemini', 'not-cited')
+      const run3 = seedRun(db, projectId, 'completed', '2024-03-01T00:00:00Z')
+      seedSnapshot(db, run3, queryId, 'gemini', 'cited', { citedDomains: ['example.com'] })
+
+      const service = new IntelligenceService(db)
+      const result = service.backfill('test-project', {
+        since: '2024-01-15T00:00:00Z',
+        toRunId: run2,
+      })
+
+      // Window [since=Jan15, to=run2(Feb1)] → only run2 qualifies.
+      expect(result.processed).toBe(1)
+    })
+
     it('throws for unknown project', () => {
       const { db } = createTempDb('intel-backfill-404-')
       const service = new IntelligenceService(db)


### PR DESCRIPTION
## Summary
After deploying an analyzer change, you often want to re-process only the recent runs that the change affects — not walk the entire 800+ run history of a long-lived project (azcoatings has 869). The existing \`--from-run\` / \`--to-run\` flags require knowing UUIDs.

Add \`--since\` accepting any \`Date.parse\`-able string (ISO 8601, \`YYYY-MM-DD\`, etc.). Composes with \`--from-run\` / \`--to-run\` — all three filters intersect.

**Predecessor lookup stays correct at the cutoff boundary**: the inner loop walks the full chronology, so \`backfill --since 2024-02-15\` on a project with a 2024-02-01 run still compares the first post-cutoff run against the pre-cutoff predecessor for transition detection.

## Usage
\`\`\`bash
# Re-process anything from the last week
canonry backfill insights azcoatings --since 2026-05-09

# Combine with --to-run for a bounded window
canonry backfill insights azcoatings --since 2026-05-09 --to-run abc123

# ISO 8601 timestamp works too
canonry backfill insights azcoatings --since 2026-05-09T00:00:00Z
\`\`\`

## Test plan
- [x] \`pnpm vitest run --project canonry intelligence-service.test\` — 23/23 pass (19 existing + 4 new)
- [x] \`respects --since by scoping processed runs to finishedAt >= the cutoff\` — confirms predecessor lookup still walks the full history
- [x] \`--since accepts a YYYY-MM-DD date and treats it as midnight UTC\` — confirms the friendlier date form
- [x] \`throws a clear error when --since is not parseable as a date\` — confirms friendly failure mode
- [x] \`--since combines with --to-run to bound the upper edge\` — confirms compositionality
- [x] Full suite (canonry + intelligence + api-routes): 1858/1858 pass
- [x] Typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)