### PR TITLE
feat(backfill): add --dry-run to backfill insights

### DIFF
--- a/packages/canonry/src/cli-commands/backfill.ts
+++ b/packages/canonry/src/cli-commands/backfill.ts
@@ -33,19 +33,21 @@ export const BACKFILL_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['backfill', 'insights'],
-    usage: 'canonry backfill insights <project> [--from-run <id>] [--to-run <id>] [--since <date>] [--format json]',
+    usage: 'canonry backfill insights <project> [--from-run <id>] [--to-run <id>] [--since <date>] [--dry-run] [--format json]',
     options: {
       'from-run': stringOption(),
       'to-run': stringOption(),
       'since': stringOption(),
+      'dry-run': { type: 'boolean' },
     },
     run: async (input) => {
-      const usage = 'canonry backfill insights <project> [--from-run <id>] [--to-run <id>] [--since <date>] [--format json]'
+      const usage = 'canonry backfill insights <project> [--from-run <id>] [--to-run <id>] [--since <date>] [--dry-run] [--format json]'
       const project = requireProject(input, 'backfill insights', usage)
       await backfillInsightsCommand(project, {
         fromRun: getString(input.values, 'from-run'),
         toRun: getString(input.values, 'to-run'),
         since: getString(input.values, 'since'),
+        dryRun: input.values['dry-run'] === true,
         format: input.format,
       })
     },

--- a/packages/canonry/src/commands/backfill.ts
+++ b/packages/canonry/src/commands/backfill.ts
@@ -651,7 +651,7 @@ function readStoredGroundingSources(rawResponse: string | null): GroundingSource
 
 export async function backfillInsightsCommand(
   project: string,
-  opts?: { fromRun?: string; toRun?: string; since?: string; format?: CliFormat },
+  opts?: { fromRun?: string; toRun?: string; since?: string; dryRun?: boolean; format?: CliFormat },
 ): Promise<void> {
   // Lazy-load the intelligence graph so `backfill answer-visibility` can run and be
   // tested without pulling in the optional insights dependency chain.
@@ -662,27 +662,34 @@ export async function backfillInsightsCommand(
 
   const service = new IntelligenceService(db)
   const isJson = opts?.format === 'json'
+  const isDryRun = opts?.dryRun === true
 
   if (!isJson) {
     const scope = opts?.since ? ` (since ${opts.since})` : ''
-    process.stderr.write(`Backfilling insights for "${project}"${scope}...\n`)
+    const mode = isDryRun ? ' [DRY RUN — no writes]' : ''
+    process.stderr.write(`Backfilling insights for "${project}"${scope}${mode}...\n`)
   }
 
   const result = service.backfill(project, {
     fromRunId: opts?.fromRun,
     toRunId: opts?.toRun,
     since: opts?.since,
+    dryRun: isDryRun,
   }, (info) => {
     if (!isJson) {
       process.stderr.write(`  [${info.index}/${info.total}] ${info.runId} — ${info.insights} insights\n`)
     }
   })
 
-  const output = {
+  const output: Record<string, unknown> = {
     project,
     processed: result.processed,
     skipped: result.skipped,
     totalInsights: result.totalInsights,
+  }
+  if (result.dryRun) {
+    output.dryRun = true
+    output.delta = result.delta
   }
 
   if (isJson) {
@@ -690,10 +697,14 @@ export async function backfillInsightsCommand(
     return
   }
 
-  console.log(`\nBackfill complete.`)
+  console.log(`\nBackfill ${isDryRun ? 'preview' : 'complete'}.`)
   console.log(`  Processed: ${result.processed}`)
   console.log(`  Skipped:   ${result.skipped}`)
   console.log(`  Insights:  ${result.totalInsights}`)
+  if (result.delta) {
+    console.log(`  Delta:     -${result.delta.wouldDelete} existing  +${result.delta.wouldCreate} new  (net ${result.delta.netChange >= 0 ? '+' : ''}${result.delta.netChange})`)
+    console.log(`             No DB writes performed. Re-run without --dry-run to apply.`)
+  }
 }
 
 type ReparsedProviderSnapshot = {

--- a/packages/canonry/src/intelligence-service.ts
+++ b/packages/canonry/src/intelligence-service.ts
@@ -133,11 +133,17 @@ export class IntelligenceService {
   /**
    * Analyze a single run given an explicit previous run (or null for first run).
    * Used by backfill where we control the run ordering.
+   *
+   * `dryRun: true` skips the DB write — `persistResult` is not called and
+   * dismissed flags / health rows are untouched. Callers receive the same
+   * AnalysisResult they would have, suitable for previewing what a write
+   * would have produced.
    */
   analyzeRunWithPrevious(
     runRecord: { id: string; projectId: string; finishedAt: string | null; createdAt: string; location?: string | null },
     previousRunRecord: { id: string; projectId: string; finishedAt: string | null; createdAt: string; location?: string | null } | null,
     historyRecords?: readonly { id: string; projectId: string; finishedAt: string | null; createdAt: string; location?: string | null }[],
+    opts?: { dryRun?: boolean },
   ): AnalysisResult | null {
     const currentRun = this.buildRunData(
       runRecord.id,
@@ -168,14 +174,15 @@ export class IntelligenceService {
     // Skip transition detection on first run (no baseline to compare)
     if (!previousRun) {
       const result = analyzeRuns(currentRun, currentRun, { trackedCompetitors, history })
-      this.persistResult(this.emptyAnalysisResult(result), runRecord.id, runRecord.projectId)
+      const emptyResult = this.emptyAnalysisResult(result)
+      if (!opts?.dryRun) this.persistResult(emptyResult, runRecord.id, runRecord.projectId)
       return result
     }
 
     const result = analyzeRuns(currentRun, previousRun, { trackedCompetitors, history })
 
     const tieredResult = this.tierResult(result, runRecord.id, runRecord.projectId)
-    this.persistResult(tieredResult, runRecord.id, runRecord.projectId)
+    if (!opts?.dryRun) this.persistResult(tieredResult, runRecord.id, runRecord.projectId)
 
     return tieredResult
   }
@@ -192,12 +199,26 @@ export class IntelligenceService {
    *     available for predecessor lookup, so transition detection at the
    *     boundary stays correct. Composes with `fromRunId` / `toRunId` —
    *     all three filters intersect.
+   *   - `dryRun`: compute the analysis without writing. The return value
+   *     includes a `delta` describing what would change (rows to delete vs
+   *     create per run + aggregate). DB is left untouched.
    */
   backfill(
     projectName: string,
-    opts?: { fromRunId?: string; toRunId?: string; since?: string },
+    opts?: { fromRunId?: string; toRunId?: string; since?: string; dryRun?: boolean },
     onProgress?: (info: { runId: string; index: number; total: number; insights: number }) => void,
-  ): { processed: number; skipped: number; totalInsights: number } {
+  ): {
+    processed: number
+    skipped: number
+    totalInsights: number
+    dryRun?: boolean
+    delta?: {
+      wouldDelete: number
+      wouldCreate: number
+      netChange: number
+      perRun: Array<{ runId: string; existingInsights: number; newInsights: number }>
+    }
+  } {
     const project = this.db
       .select()
       .from(projects)
@@ -256,6 +277,28 @@ export class IntelligenceService {
     let processed = 0
     let skipped = 0
     let totalInsights = 0
+    const isDryRun = opts?.dryRun === true
+    const perRunDelta: Array<{ runId: string; existingInsights: number; newInsights: number }> = []
+    let wouldDeleteTotal = 0
+
+    // Dry-run delta calc: count the existing insights for every targeted run
+    // so we can report "what gets wiped" alongside "what gets written". A
+    // real backfill would delete these inside persistResult before re-inserting.
+    const existingByRunId = new Map<string, number>()
+    if (isDryRun && targetRuns.length > 0) {
+      const rows = this.db
+        .select({ runId: insights.runId })
+        .from(insights)
+        .where(inArray(insights.runId, targetRuns.map(r => r.id)))
+        .all()
+      for (const r of rows) {
+        // insights.run_id is nullable in the schema (FK SET NULL post-cascade),
+        // but rows whose run_id is null can't have been written by a backfill
+        // for any run in targetRuns, so skip them.
+        if (r.runId == null) continue
+        existingByRunId.set(r.runId, (existingByRunId.get(r.runId) ?? 0) + 1)
+      }
+    }
 
     for (let i = 0; i < targetRuns.length; i++) {
       const run = targetRuns[i]!
@@ -272,11 +315,16 @@ export class IntelligenceService {
       const historyStart = Math.max(0, sameLocIdx - (HISTORY_WINDOW_RUNS - 1))
       const historyRecords = sameLocationRuns.slice(historyStart, sameLocIdx + 1)
 
-      const result = this.analyzeRunWithPrevious(run, previousRun, historyRecords)
+      const result = this.analyzeRunWithPrevious(run, previousRun, historyRecords, { dryRun: isDryRun })
 
       if (result) {
         processed++
         totalInsights += result.insights.length
+        if (isDryRun) {
+          const existing = existingByRunId.get(run.id) ?? 0
+          wouldDeleteTotal += existing
+          perRunDelta.push({ runId: run.id, existingInsights: existing, newInsights: result.insights.length })
+        }
         onProgress?.({ runId: run.id, index: i + 1, total: targetRuns.length, insights: result.insights.length })
       } else {
         skipped++
@@ -284,6 +332,20 @@ export class IntelligenceService {
       }
     }
 
+    if (isDryRun) {
+      return {
+        processed,
+        skipped,
+        totalInsights,
+        dryRun: true,
+        delta: {
+          wouldDelete: wouldDeleteTotal,
+          wouldCreate: totalInsights,
+          netChange: totalInsights - wouldDeleteTotal,
+          perRun: perRunDelta,
+        },
+      }
+    }
     return { processed, skipped, totalInsights }
   }
 

--- a/packages/canonry/test/intelligence-service.test.ts
+++ b/packages/canonry/test/intelligence-service.test.ts
@@ -295,6 +295,80 @@ describe('IntelligenceService', () => {
       expect(healthRows).toHaveLength(3)
     })
 
+    it('--dry-run does not write insights or health snapshots, returns delta', () => {
+      // First we let a real backfill establish baseline insight rows. Then a
+      // dry-run pass with mutated data should: (a) leave the DB untouched,
+      // (b) return a delta describing what *would* change.
+      const { db } = createTempDb('intel-backfill-dryrun-')
+      const projectId = seedProject(db)
+      const queryId = seedQuery(db, projectId, 'test query')
+
+      const run1 = seedRun(db, projectId, 'completed', '2024-01-01T00:00:00Z')
+      seedSnapshot(db, run1, queryId, 'gemini', 'cited', { citedDomains: ['example.com'] })
+      const run2 = seedRun(db, projectId, 'completed', '2024-02-01T00:00:00Z')
+      seedSnapshot(db, run2, queryId, 'gemini', 'not-cited')
+
+      const service = new IntelligenceService(db)
+      // Real backfill — populates insights + health.
+      service.backfill('test-project')
+
+      const insightsBefore = db.select().from(insights).all()
+      const healthBefore = db.select().from(healthSnapshots).all()
+      expect(insightsBefore.length).toBeGreaterThan(0)
+      expect(healthBefore.length).toBeGreaterThan(0)
+
+      // Dry-run pass — must not touch the DB.
+      const result = service.backfill('test-project', { dryRun: true })
+
+      const insightsAfter = db.select().from(insights).all()
+      const healthAfter = db.select().from(healthSnapshots).all()
+      expect(insightsAfter.map(i => i.id).sort()).toEqual(insightsBefore.map(i => i.id).sort())
+      expect(healthAfter.map(h => h.id).sort()).toEqual(healthBefore.map(h => h.id).sort())
+
+      // Result reports the would-be deltas so an operator can preview impact.
+      expect(result.dryRun).toBe(true)
+      expect(result.delta).toBeDefined()
+      expect(result.delta!.wouldDelete).toBe(insightsBefore.length)
+      expect(result.delta!.wouldCreate).toBe(result.totalInsights)
+      expect(result.delta!.netChange).toBe(result.totalInsights - insightsBefore.length)
+    })
+
+    it('--dry-run report includes per-run delta entries an agent can scan', () => {
+      const { db } = createTempDb('intel-backfill-dryrun-perrun-')
+      const projectId = seedProject(db)
+      const queryId = seedQuery(db, projectId, 'test query')
+
+      const run1 = seedRun(db, projectId, 'completed', '2024-01-01T00:00:00Z')
+      seedSnapshot(db, run1, queryId, 'gemini', 'cited', { citedDomains: ['example.com'] })
+      const run2 = seedRun(db, projectId, 'completed', '2024-02-01T00:00:00Z')
+      seedSnapshot(db, run2, queryId, 'gemini', 'not-cited')
+
+      const service = new IntelligenceService(db)
+      service.backfill('test-project') // populate baseline
+
+      const result = service.backfill('test-project', { dryRun: true })
+      expect(result.delta!.perRun).toBeDefined()
+      expect(result.delta!.perRun!.length).toBeGreaterThan(0)
+      for (const entry of result.delta!.perRun!) {
+        expect(entry).toHaveProperty('runId')
+        expect(entry).toHaveProperty('existingInsights')
+        expect(entry).toHaveProperty('newInsights')
+      }
+    })
+
+    it('non-dry-run result omits the dryRun + delta fields (backwards compat)', () => {
+      const { db } = createTempDb('intel-backfill-normal-')
+      const projectId = seedProject(db)
+      const queryId = seedQuery(db, projectId, 'test query')
+      const run1 = seedRun(db, projectId, 'completed', '2024-01-01T00:00:00Z')
+      seedSnapshot(db, run1, queryId, 'gemini', 'cited', { citedDomains: ['example.com'] })
+
+      const service = new IntelligenceService(db)
+      const result = service.backfill('test-project')
+      expect(result.dryRun).toBeUndefined()
+      expect(result.delta).toBeUndefined()
+    })
+
     it('respects --from-run and --to-run range', () => {
       const { db } = createTempDb('intel-backfill-range-')
       const projectId = seedProject(db)


### PR DESCRIPTION
## Summary
Before this PR, \`canonry backfill insights <project>\` was a fully destructive operation with no preview affordance. Real-world consequence: during the multi-location regression fix (PR #516), running the backfill on azcoatings silently generated 32 phantom orphan-snapshot insights that had to be cleaned up *post-write* with raw SQL instead of caught before.

Add \`--dry-run\` so operators (and agents) can preview impact before applying:

\`\`\`bash
canonry backfill insights azcoatings --dry-run
# Output:
# Backfill preview. Processed: 8 | Skipped: 861 | Insights: 70
# Delta: -86 existing  +70 new  (net -16)
# No DB writes performed. Re-run without --dry-run to apply.
\`\`\`

For agents:
\`\`\`bash
canonry backfill insights azcoatings --dry-run --format json
\`\`\`
returns:
\`\`\`json
{
  "project": "azcoatings",
  "processed": 8,
  "skipped": 861,
  "totalInsights": 70,
  "dryRun": true,
  "delta": {
    "wouldDelete": 86,
    "wouldCreate": 70,
    "netChange": -16,
    "perRun": [
      { "runId": "abc-123", "existingInsights": 11, "newInsights": 8 },
      ...
    ]
  }
}
\`\`\`

## Implementation
- \`IntelligenceService.backfill\` accepts \`opts.dryRun: boolean\`. When true, it pre-queries existing insight counts per targeted run, calls \`analyzeRunWithPrevious\` with \`{ dryRun: true }\` (which short-circuits \`persistResult\`), and aggregates the deltas.
- \`analyzeRunWithPrevious\` gains a fourth optional argument \`{ dryRun?: boolean }\`. Backwards compatible — existing callers (run coordinator, post-run analysis) pass nothing and get the same behavior.
- CLI flag \`--dry-run\` plumbed through \`backfillInsightsCommand\`.

## Test plan
- [x] \`pnpm vitest run --project canonry intelligence-service.test\` — 28/28 pass (25 existing + 3 new)
  - \`--dry-run does not write insights or health snapshots, returns delta\` — DB unchanged after dry-run
  - \`--dry-run report includes per-run delta entries an agent can scan\` — \`delta.perRun[]\` populated with runId/existingInsights/newInsights
  - \`non-dry-run result omits the dryRun + delta fields (backwards compat)\`
- [x] Wider suite (canonry + intelligence + api-routes): 1875/1875 pass
- [x] Typecheck + lint clean

## Follow-ups
Other destructive commands (\`canonry project delete\`, \`canonry apply\`, \`canonry query replace\`, \`canonry backfill answer-mentions\`) want the same pattern. Each is its own focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)