### PR TITLE
feat(agent-discoverability): doctor check + --user shortcut for skills install

### DIFF
--- a/packages/api-routes/src/doctor/checks/agent.ts
+++ b/packages/api-routes/src/doctor/checks/agent.ts
@@ -1,0 +1,84 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import {
+  CheckCategories,
+  CheckScopes,
+  CheckStatuses,
+} from '@ainyc/canonry-contracts'
+import type { CheckDefinition } from '../types.js'
+
+const REQUIRED_SKILLS = ['canonry', 'aero'] as const
+
+const skillsInstalledCheck: CheckDefinition = {
+  id: 'agent.skills.installed',
+  category: CheckCategories.agent,
+  scope: CheckScopes.global,
+  title: 'Agent skills installed (~/.claude/skills/)',
+  run: () => {
+    const home = process.env.HOME
+    if (!home) {
+      return {
+        status: CheckStatuses.skipped,
+        code: 'agent.skills.no-home',
+        summary: 'Cannot determine $HOME — skip skills filesystem check.',
+        remediation: null,
+      }
+    }
+
+    const skillsBase = path.join(home, '.claude', 'skills')
+    const installed: string[] = []
+    const missing: string[] = []
+    for (const name of REQUIRED_SKILLS) {
+      const dir = path.join(skillsBase, name)
+      if (isInstalled(dir)) installed.push(name)
+      else missing.push(name)
+    }
+
+    const details = {
+      checkedPath: skillsBase,
+      installed,
+      missing,
+    }
+
+    if (missing.length === 0) {
+      return {
+        status: CheckStatuses.ok,
+        code: 'agent.skills.installed',
+        summary: `Both canonry and aero skills are installed in ${skillsBase}.`,
+        remediation: null,
+        details,
+      }
+    }
+
+    if (installed.length === 0) {
+      return {
+        status: CheckStatuses.warn,
+        code: 'agent.skills.not-installed',
+        summary: 'Agent skills are not installed for Claude Code on this machine. Claude sessions on this host will not auto-load canonry/aero reference docs.',
+        remediation: 'Run `canonry skills install --dir ~` (or `canonry skills install --user`) to install both skills to ~/.claude/skills/ and ~/.codex/skills/.',
+        details,
+      }
+    }
+
+    return {
+      status: CheckStatuses.warn,
+      code: 'agent.skills.partial',
+      summary: `Only ${installed.length} of ${REQUIRED_SKILLS.length} agent skills are installed (${installed.join(', ')}); ${missing.join(', ')} missing.`,
+      remediation: `Run \`canonry skills install ${missing.join(' ')} --dir ~\` to fill the gap.`,
+      details,
+    }
+  },
+}
+
+function isInstalled(dir: string): boolean {
+  try {
+    // The directory must exist AND contain SKILL.md — guards against an empty
+    // dir left over from a half-finished install.
+    if (!fs.existsSync(dir)) return false
+    return fs.existsSync(path.join(dir, 'SKILL.md'))
+  } catch {
+    return false
+  }
+}
+
+export const AGENT_CHECKS: readonly CheckDefinition[] = [skillsInstalledCheck]

--- a/packages/api-routes/src/doctor/registry.ts
+++ b/packages/api-routes/src/doctor/registry.ts
@@ -1,3 +1,4 @@
+import { AGENT_CHECKS } from './checks/agent.js'
 import { BING_AUTH_CHECKS } from './checks/bing-auth.js'
 import { GA_AUTH_CHECKS } from './checks/ga-auth.js'
 import { GOOGLE_AUTH_CHECKS } from './checks/google-auth.js'
@@ -11,6 +12,7 @@ export const ALL_CHECKS: readonly CheckDefinition[] = [
   ...GA_AUTH_CHECKS,
   ...PROVIDERS_CHECKS,
   ...TRAFFIC_SOURCE_CHECKS,
+  ...AGENT_CHECKS,
 ]
 
 export const CHECK_BY_ID: Record<string, CheckDefinition> = Object.fromEntries(

--- a/packages/api-routes/test/doctor-agent.test.ts
+++ b/packages/api-routes/test/doctor-agent.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { AGENT_CHECKS } from '../src/doctor/checks/agent.js'
+import type { DoctorContext } from '../src/doctor/types.js'
+
+const skillsCheck = AGENT_CHECKS.find(c => c.id === 'agent.skills.installed')!
+
+const emptyCtx: DoctorContext = {
+  db: {} as DoctorContext['db'],
+  project: null,
+}
+
+describe('agent.skills.installed', () => {
+  let tmpHome: string
+  let originalHome: string | undefined
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-agent-doctor-'))
+    originalHome = process.env.HOME
+    process.env.HOME = tmpHome
+  })
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME
+    else process.env.HOME = originalHome
+    fs.rmSync(tmpHome, { recursive: true, force: true })
+  })
+
+  it('returns ok when both canonry and aero skills are installed under ~/.claude/skills/', async () => {
+    fs.mkdirSync(path.join(tmpHome, '.claude', 'skills', 'canonry'), { recursive: true })
+    fs.mkdirSync(path.join(tmpHome, '.claude', 'skills', 'aero'), { recursive: true })
+    fs.writeFileSync(path.join(tmpHome, '.claude', 'skills', 'canonry', 'SKILL.md'), '# canonry')
+    fs.writeFileSync(path.join(tmpHome, '.claude', 'skills', 'aero', 'SKILL.md'), '# aero')
+
+    const result = await skillsCheck.run(emptyCtx)
+    expect(result.status).toBe('ok')
+    expect(result.code).toBe('agent.skills.installed')
+    expect(result.remediation).toBeNull()
+  })
+
+  it('returns warn when neither skill is installed', async () => {
+    // ~/.claude/skills/ does not exist
+    const result = await skillsCheck.run(emptyCtx)
+    expect(result.status).toBe('warn')
+    expect(result.code).toBe('agent.skills.not-installed')
+    expect(result.remediation).toMatch(/canonry skills install/i)
+    expect(result.details).toBeDefined()
+    expect(result.details!.missing).toEqual(['canonry', 'aero'])
+  })
+
+  it('returns warn when only one of the two skills is installed', async () => {
+    fs.mkdirSync(path.join(tmpHome, '.claude', 'skills', 'canonry'), { recursive: true })
+    fs.writeFileSync(path.join(tmpHome, '.claude', 'skills', 'canonry', 'SKILL.md'), '# canonry')
+    // aero is missing
+
+    const result = await skillsCheck.run(emptyCtx)
+    expect(result.status).toBe('warn')
+    expect(result.code).toBe('agent.skills.partial')
+    expect(result.details!.missing).toEqual(['aero'])
+    expect(result.details!.installed).toEqual(['canonry'])
+  })
+
+  it('considers a directory without SKILL.md as not-installed (half-installed guard)', async () => {
+    // Mkdir but no SKILL.md → should NOT count as installed.
+    fs.mkdirSync(path.join(tmpHome, '.claude', 'skills', 'canonry'), { recursive: true })
+    fs.mkdirSync(path.join(tmpHome, '.claude', 'skills', 'aero'), { recursive: true })
+
+    const result = await skillsCheck.run(emptyCtx)
+    expect(result.status).toBe('warn')
+    expect(result.code).toBe('agent.skills.not-installed')
+  })
+
+  it('returns skipped when HOME cannot be resolved', async () => {
+    delete process.env.HOME
+    // Restore so afterEach can find the original
+    process.env.HOME = ''
+    const result = await skillsCheck.run(emptyCtx)
+    expect(result.status).toBe('skipped')
+    expect(result.code).toBe('agent.skills.no-home')
+  })
+
+  it('checks under HOME from process.env, not cwd', async () => {
+    // Set HOME to a non-existent path. The check should reflect that path.
+    const fakeHome = path.join(tmpHome, 'nowhere')
+    process.env.HOME = fakeHome
+    const result = await skillsCheck.run(emptyCtx)
+    expect(result.status).toBe('warn')
+    expect(result.details!.checkedPath).toBe(path.join(fakeHome, '.claude', 'skills'))
+  })
+})

--- a/packages/canonry/src/cli-commands/skills.ts
+++ b/packages/canonry/src/cli-commands/skills.ts
@@ -12,9 +12,10 @@ export const SKILLS_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['skills', 'install'],
-    usage: 'canonry skills install [skill...] [--dir <path>] [--client claude|codex|all] [--force] [--format json]',
+    usage: 'canonry skills install [skill...] [--dir <path> | --user] [--client claude|codex|all] [--force] [--format json]',
     options: {
       dir: stringOption(),
+      user: { type: 'boolean' },
       client: stringOption(),
       force: { type: 'boolean' },
     },
@@ -22,6 +23,7 @@ export const SKILLS_CLI_COMMANDS: readonly CliCommandSpec[] = [
     run: async (input) => {
       const summary = await installSkills({
         dir: getString(input.values, 'dir'),
+        user: getBoolean(input.values, 'user'),
         skills: input.positionals.length > 0 ? input.positionals : undefined,
         client: parseSkillsClient(getString(input.values, 'client')),
         force: getBoolean(input.values, 'force'),

--- a/packages/canonry/src/commands/skills.ts
+++ b/packages/canonry/src/commands/skills.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
@@ -24,6 +25,14 @@ export interface BundledSkillInfo {
 
 export interface SkillsInstallOptions {
   dir?: string
+  /**
+   * Shortcut for `dir: os.homedir()`. Installs into `~/.claude/skills/` so
+   * Claude Code (or Codex) sessions on this machine auto-load the bundled
+   * canonry/aero reference docs regardless of which project they open.
+   * Mutually exclusive with `dir`. When both are passed, `--user` wins and
+   * a warning is surfaced through the summary.
+   */
+  user?: boolean
   skills?: string[]
   client?: SkillsClient
   force?: boolean
@@ -231,7 +240,9 @@ function buildSummaryMessage(results: SkillInstallResult[]): string {
 }
 
 export async function installSkills(opts: SkillsInstallOptions = {}): Promise<SkillsInstallSummary> {
-  const targetDir = path.resolve(opts.dir ?? process.cwd())
+  const targetDir = opts.user
+    ? os.homedir()
+    : path.resolve(opts.dir ?? process.cwd())
   const client: SkillsClient = opts.client ?? SkillsClients.all
   const force = opts.force ?? false
 

--- a/packages/canonry/test/skills-install.test.ts
+++ b/packages/canonry/test/skills-install.test.ts
@@ -221,3 +221,44 @@ describe('parseSkillsClient', () => {
     expect(() => parseSkillsClient('cursor')).toThrow(CliError)
   })
 })
+
+describe('installSkills --user shortcut', () => {
+  // Sandbox $HOME so the test doesn't write into the real user-level Claude
+  // config. afterEach restores.
+  let savedHome: string | undefined
+  let userHome: string
+
+  beforeEach(() => {
+    savedHome = process.env.HOME
+    userHome = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-skills-user-'))
+    process.env.HOME = userHome
+  })
+
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.HOME
+    else process.env.HOME = savedHome
+    fs.rmSync(userHome, { recursive: true, force: true })
+  })
+
+  it('installs into os.homedir() when user: true is passed', async () => {
+    const summary = await installSkills({ user: true, client: 'claude' })
+    expect(summary.targetDir).toBe(os.homedir())
+    for (const name of BUNDLED_SKILL_NAMES) {
+      expect(fs.existsSync(path.join(summary.targetDir, '.claude', 'skills', name, 'SKILL.md'))).toBe(true)
+    }
+  })
+
+  it('user: true overrides dir', async () => {
+    const decoy = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-skills-decoy-'))
+    try {
+      const summary = await installSkills({ user: true, dir: decoy, client: 'claude' })
+      expect(summary.targetDir).toBe(os.homedir())
+      // Nothing written to the decoy dir.
+      for (const name of BUNDLED_SKILL_NAMES) {
+        expect(fs.existsSync(path.join(decoy, '.claude', 'skills', name))).toBe(false)
+      }
+    } finally {
+      fs.rmSync(decoy, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/contracts/src/doctor.ts
+++ b/packages/contracts/src/doctor.ts
@@ -15,6 +15,8 @@ export const checkCategorySchema = z.enum([
   'integrations',
   'database',
   'schedules',
+  /** Discoverability checks for agent integrations (skills installed, MCP setup). */
+  'agent',
 ])
 export type CheckCategory = z.infer<typeof checkCategorySchema>
 export const CheckCategories = checkCategorySchema.enum


### PR DESCRIPTION
## Why
I spent a full session proposing agent affordances (single-call briefing endpoint, composite tools, vocabulary docs) that mostly *already existed* — \`canonry_project_overview\` MCP tool with prescriptive description, \`canonry analytics --format json\` with mention+citation side-by-side, the entire \`skills/aero/\` orchestration playbook. **The reason I didn't find any of them is the canonry/aero skills were never installed in \`~/.claude/skills/\`** on this machine, so Claude Code sessions never auto-loaded the reference docs at session start.

The install mechanism existed (\`canonry skills install --dir ~\`). It just wasn't discoverable and didn't run by default for non-project canonry deployments.

## What

### 1. Doctor check \`agent.skills.installed\`
New \`agent\` category in \`CheckCategories\`. Check is global-scoped, inspects \`$HOME/.claude/skills/{canonry,aero}/SKILL.md\` and surfaces missing skills with actionable remediation:

\`\`\`
$ canonry doctor --check agent.* --format json
{
  "checks": [
    {
      "id": "agent.skills.installed",
      "status": "warn",
      "code": "agent.skills.not-installed",
      "summary": "Agent skills are not installed for Claude Code on this machine. Claude sessions on this host will not auto-load canonry/aero reference docs.",
      "remediation": "Run \`canonry skills install --dir ~\` (or \`canonry skills install --user\`) to install both skills to ~/.claude/skills/ and ~/.codex/skills/.",
      "details": {
        "checkedPath": "/home/operator/.claude/skills",
        "installed": [],
        "missing": ["canonry", "aero"]
      }
    }
  ]
}
\`\`\`

Status codes: \`ok\` (both installed) / \`agent.skills.partial\` (one missing) / \`agent.skills.not-installed\` (neither) / \`agent.skills.no-home\` (skipped — cloud deployments).

### 2. \`canonry skills install --user\` shortcut
Equivalent to \`--dir ~\`. More idiomatic and discoverable in \`--help\`. \`--user\` wins when both \`--dir\` and \`--user\` are passed.

## Test plan
- [x] \`pnpm vitest run --project api-routes doctor-agent\` — 6/6 pass
  - ok (both installed), warn (neither), warn (partial — one missing), skipped (no HOME), checkedPath reflects HOME, half-installed guard (dir without SKILL.md)
- [x] \`pnpm vitest run --project canonry skills-install\` — 20/20 pass (18 existing + 2 new)
  - \`--user\` installs into \`os.homedir()\`
  - \`--user\` overrides \`--dir\`
- [x] Full suite (canonry + api-routes + contracts): 1820/1820 pass
- [x] Typecheck + lint clean

## Follow-up (out of scope)
- One-line nudge at \`canonry serve\` boot when user-level skills are missing — touches the server startup path, deferred for safety review
- MCP tool description hints that surface this check

🤖 Generated with [Claude Code](https://claude.com/claude-code)