### PR TITLE
feat(cli): make --dry-run a global flag with explicit opt-in per command

### DIFF
--- a/packages/canonry/src/cli-commands/backfill.ts
+++ b/packages/canonry/src/cli-commands/backfill.ts
@@ -38,8 +38,8 @@ export const BACKFILL_CLI_COMMANDS: readonly CliCommandSpec[] = [
       'from-run': stringOption(),
       'to-run': stringOption(),
       'since': stringOption(),
-      'dry-run': { type: 'boolean' },
     },
+    supportsDryRun: true,
     run: async (input) => {
       const usage = 'canonry backfill insights <project> [--from-run <id>] [--to-run <id>] [--since <date>] [--dry-run] [--format json]'
       const project = requireProject(input, 'backfill insights', usage)
@@ -47,7 +47,7 @@ export const BACKFILL_CLI_COMMANDS: readonly CliCommandSpec[] = [
         fromRun: getString(input.values, 'from-run'),
         toRun: getString(input.values, 'to-run'),
         since: getString(input.values, 'since'),
-        dryRun: input.values['dry-run'] === true,
+        dryRun: input.dryRun,
         format: input.format,
       })
     },

--- a/packages/canonry/src/cli-dispatch.ts
+++ b/packages/canonry/src/cli-dispatch.ts
@@ -10,6 +10,13 @@ export type CliCommandInput = {
   positionals: string[]
   values: CliValues
   format: CliFormat
+  /**
+   * True when the user passed `--dry-run`. Only set to `true` for commands
+   * that opt in via `CliCommandSpec.supportsDryRun`; for commands that don't,
+   * passing `--dry-run` raises a usage error before `run` is invoked, so a
+   * command author who reads `input.dryRun` can trust it.
+   */
+  dryRun: boolean
 }
 
 export type CliCommandSpec = {
@@ -17,6 +24,13 @@ export type CliCommandSpec = {
   usage: string
   options?: ParseArgsOptionsConfig
   allowPositionals?: boolean
+  /**
+   * Whether `--dry-run` is meaningful for this command. The dispatcher rejects
+   * `--dry-run` on commands that don't opt in, so agents can rely on the
+   * preview semantics actually being implemented (rather than silently
+   * ignored, which would risk writes when the agent thought it was previewing).
+   */
+  supportsDryRun?: boolean
   run: (input: CliCommandInput) => Promise<void>
 }
 
@@ -29,18 +43,14 @@ function matchesPath(args: readonly string[], path: readonly string[]): boolean 
   return path.every((segment, index) => args[index] === segment)
 }
 
-function withFormatOption(options?: ParseArgsOptionsConfig): ParseArgsOptionsConfig {
-  if (!options) {
-    return {
-      format: { type: 'string' },
-    }
-  }
-
-  if ('format' in options) return options
-  return {
-    ...options,
-    format: { type: 'string' },
-  }
+function withGlobalOptions(options?: ParseArgsOptionsConfig): ParseArgsOptionsConfig {
+  const base = options ? { ...options } : {}
+  if (!('format' in base)) base.format = { type: 'string' }
+  // --dry-run is always parsed so the dispatcher can validate its use against
+  // the spec's `supportsDryRun` flag. Commands that don't opt in get a usage
+  // error before `run` is called.
+  if (!('dry-run' in base)) base['dry-run'] = { type: 'boolean' }
+  return base
 }
 
 function toFormat(value: CliValue, fallbackFormat: CliFormat): CliFormat {
@@ -122,7 +132,7 @@ export async function dispatchRegisteredCommand(
   try {
     const parsed = parseArgs({
       args: remainingArgs,
-      options: withFormatOption(spec.options),
+      options: withGlobalOptions(spec.options),
       allowPositionals: spec.allowPositionals ?? true,
     })
     values = parsed.values as CliValues
@@ -138,10 +148,23 @@ export async function dispatchRegisteredCommand(
     })
   }
 
+  const dryRunRequested = values['dry-run'] === true
+  if (dryRunRequested && !spec.supportsDryRun) {
+    throw usageError(
+      `Command "${spec.path.join(' ')}" does not support --dry-run. Either drop the flag, or run a different command that supports preview mode (e.g. ` +
+      `\`canonry doctor\` for health checks, \`canonry status <project>\` for read-only state).`,
+      {
+        message: `Command "${spec.path.join(' ')}" does not support --dry-run`,
+        details: { command: commandId(spec), usage: spec.usage },
+      },
+    )
+  }
+
   await spec.run({
     positionals,
     values,
     format: toFormat(values.format, fallbackFormat),
+    dryRun: dryRunRequested,
   })
 
   return true

--- a/packages/canonry/test/cli-dispatch-dry-run.test.ts
+++ b/packages/canonry/test/cli-dispatch-dry-run.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest'
+import { dispatchRegisteredCommand, type CliCommandSpec } from '../src/cli-dispatch.js'
+import { CliError } from '../src/cli-error.js'
+
+describe('dispatchRegisteredCommand --dry-run global flag', () => {
+  it('passes dryRun=true to commands that opt in via supportsDryRun', async () => {
+    const run = vi.fn().mockResolvedValue(undefined)
+    const spec: CliCommandSpec = {
+      path: ['demo'],
+      usage: 'canonry demo [--dry-run]',
+      supportsDryRun: true,
+      run,
+    }
+
+    await dispatchRegisteredCommand(['demo', '--dry-run'], 'text', [spec])
+
+    expect(run).toHaveBeenCalledTimes(1)
+    expect(run.mock.calls[0]![0].dryRun).toBe(true)
+  })
+
+  it('passes dryRun=false to commands when flag is absent', async () => {
+    const run = vi.fn().mockResolvedValue(undefined)
+    const spec: CliCommandSpec = {
+      path: ['demo'],
+      usage: 'canonry demo',
+      supportsDryRun: true,
+      run,
+    }
+
+    await dispatchRegisteredCommand(['demo'], 'text', [spec])
+
+    expect(run.mock.calls[0]![0].dryRun).toBe(false)
+  })
+
+  it('rejects --dry-run on commands that do not opt in', async () => {
+    const run = vi.fn().mockResolvedValue(undefined)
+    const spec: CliCommandSpec = {
+      path: ['demo'],
+      usage: 'canonry demo',
+      // supportsDryRun omitted — defaults to false
+      run,
+    }
+
+    await expect(
+      dispatchRegisteredCommand(['demo', '--dry-run'], 'text', [spec]),
+    ).rejects.toThrow(CliError)
+
+    expect(run).not.toHaveBeenCalled()
+  })
+
+  it('rejection mentions the command and the supported alternatives', async () => {
+    const spec: CliCommandSpec = {
+      path: ['demo'],
+      usage: 'canonry demo',
+      run: vi.fn(),
+    }
+
+    try {
+      await dispatchRegisteredCommand(['demo', '--dry-run'], 'text', [spec])
+      throw new Error('expected rejection')
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError)
+      const message = (err as CliError).message
+      expect(message.toLowerCase()).toContain('--dry-run')
+      expect(message.toLowerCase()).toContain('does not support')
+    }
+  })
+
+  it('commands not opting in can still use other options without conflict', async () => {
+    const run = vi.fn().mockResolvedValue(undefined)
+    const spec: CliCommandSpec = {
+      path: ['demo'],
+      usage: 'canonry demo [--name <name>]',
+      options: { name: { type: 'string' } },
+      run,
+    }
+
+    await dispatchRegisteredCommand(['demo', '--name', 'foo'], 'text', [spec])
+
+    expect(run).toHaveBeenCalledTimes(1)
+    expect(run.mock.calls[0]![0].dryRun).toBe(false)
+    expect(run.mock.calls[0]![0].values.name).toBe('foo')
+  })
+
+  it('--dry-run combines with --format json on supporting commands', async () => {
+    const run = vi.fn().mockResolvedValue(undefined)
+    const spec: CliCommandSpec = {
+      path: ['demo'],
+      usage: 'canonry demo [--dry-run]',
+      supportsDryRun: true,
+      run,
+    }
+
+    await dispatchRegisteredCommand(['demo', '--dry-run', '--format', 'json'], 'text', [spec])
+
+    expect(run.mock.calls[0]![0].dryRun).toBe(true)
+    expect(run.mock.calls[0]![0].format).toBe('json')
+  })
+})


### PR DESCRIPTION
## Why
PR #524 added \`--dry-run\` to \`canonry backfill insights\` as a per-command option. Generalizing: \`--dry-run\` is a cross-cutting agent concern (every destructive write wants the same preview semantics), not a per-command one. Make it a top-level flag the dispatcher parses, with explicit opt-in on each command spec.

## Two safety properties for agents

1. **Discoverability.** Any agent that tries \`--dry-run\` on any command either gets preview semantics OR a clear error. Consistent surface across the whole CLI.
2. **Fail-safety.** If \`--dry-run\` is passed to a command that doesn't support preview, the dispatcher errors *before* \`run\` is invoked. Agents can't accidentally write when they meant to preview.

\`\`\`bash
$ canonry status azcoatings --dry-run
Error: Command "status" does not support --dry-run. Either drop the
flag, or run a different command that supports preview mode (e.g.
\`canonry doctor\` for health checks, \`canonry status <project>\` for
read-only state).
\`\`\`

## Infrastructure
- \`CliCommandInput\` gains \`dryRun: boolean\`
- \`CliCommandSpec\` gains optional \`supportsDryRun: boolean\` (defaults to false)
- \`withGlobalOptions\` wires both \`--format\` and \`--dry-run\` globally
- Dispatcher rejects \`--dry-run\` on non-opted commands with usage error

## Migrated
\`canonry backfill insights\` now reads \`input.dryRun\` instead of its custom \`--dry-run\` option. End-user behavior unchanged.

## Test plan
- [x] \`pnpm vitest run --project canonry cli-dispatch-dry-run\` — 6/6 pass (new file)
  - dryRun=true passed when supported
  - dryRun=false when flag absent
  - rejects --dry-run when not opted in
  - rejection message identifies the command
  - non-opted commands ignore unrelated options
  - --dry-run + --format json compose
- [x] Full suite (canonry + api-routes): 1494/1494 pass
- [x] Typecheck + lint clean

## Follow-up PRs
- \`--dry-run\` on \`project delete\` (with new \`/delete-preview\` API endpoint)
- \`--dry-run\` on \`query replace\` (with new \`/queries/replace-preview\` API endpoint)
- \`--dry-run\` on \`backfill answer-mentions\` / \`backfill answer-visibility\`
- \`--dry-run\` on \`canonry apply\` (declarative diff — most complex, deserves design)
- \`canonry serve\` boot nudge for missing user-level skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)