### PR TITLE
feat(dashboard): paired AEO performance hero + movement banner + plain tooltips

### DIFF
--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -11,7 +11,6 @@ import { CitationBadge } from '../components/shared/CitationBadge.js'
 import { InfoTooltip } from '../components/shared/InfoTooltip.js'
 import { ProviderBadge } from '../components/shared/ProviderBadge.js'
 import { RunRow } from '../components/shared/RunRow.js'
-import { ScoreGauge } from '../components/shared/ScoreGauge.js'
 import { ToneBadge } from '../components/shared/ToneBadge.js'
 import { EvidenceTable } from '../components/project/EvidenceTable.js'
 import { CompetitorTable } from '../components/project/CompetitorTable.js'
@@ -1528,43 +1527,73 @@ export function ProjectPage({
 
       {tab === 'overview' ? (
         <>
-          {/* At-a-glance metrics */}
-          <section className="gauge-row">
-            <ScoreGauge
-              value={model.mentionSummary.value}
-              label={model.mentionSummary.label}
-              delta={model.mentionSummary.delta}
-              tone={model.mentionSummary.tone}
-              description={model.mentionSummary.description}
-              tooltip={model.mentionSummary.tooltip}
-              isNumeric={isNumericScore(model.mentionSummary.value)}
-              progress={model.mentionSummary.progress}
-              providerCoverage={model.mentionSummary.providerCoverage}
-            />
-            <div className="metric-card">
-              <p className="metric-card-eyebrow">
-                {model.visibilitySummary.label}
-                <InfoTooltip text={model.visibilitySummary.tooltip ?? 'Percentage of tracked queries where your domain is cited in the AI answer source list.'} />
-              </p>
-              <p className="metric-card-big-value">
-                <span className="text-zinc-50">{model.visibilitySummary.value}</span>
-                {isNumericScore(model.visibilitySummary.value) ? <span className="text-zinc-600">%</span> : null}
-              </p>
-              <div className="metric-card-bar">
-                <div
-                  className={`metric-card-bar-fill progress-fill-${model.visibilitySummary.tone}`}
-                  style={{ width: model.visibilitySummary.progress !== undefined ? `${Math.min(Math.max(model.visibilitySummary.progress, 0), 100)}%` : '0%' }}
-                />
-              </div>
-              <p className="metric-card-detail">{model.visibilitySummary.delta}</p>
-              <p className="metric-card-sub">
-                {model.visibilitySummary.description}
-              </p>
+          {/* Hero: paired AEO performance (Mention + Citation, same shape) */}
+          <section className="aeo-hero">
+            <p className="aeo-hero-title">AEO performance</p>
+            <div className="aeo-hero-rows">
+              {([
+                { key: 'mention', label: 'Mentioned', tooltip: 'Your domain or company name was in the answer returned by the LLM.', summary: model.mentionSummary },
+                { key: 'citation', label: 'Cited', tooltip: 'An LLM used a page on your domain as a source for its answer.', summary: model.visibilitySummary },
+              ] as const).map(row => (
+                <div key={row.key} className="aeo-hero-row">
+                  <div className="aeo-hero-row-label">
+                    <span>{row.label}</span>
+                    <InfoTooltip text={row.tooltip} />
+                  </div>
+                  <div className="aeo-hero-row-value">
+                    <span className="text-zinc-50">{row.summary.value}</span>
+                    {isNumericScore(row.summary.value) ? <span className="text-zinc-600">%</span> : null}
+                  </div>
+                  <div className="aeo-hero-row-bar">
+                    <div
+                      className={`metric-card-bar-fill progress-fill-${row.summary.tone}`}
+                      style={{ width: row.summary.progress !== undefined ? `${Math.min(Math.max(row.summary.progress, 0), 100)}%` : '0%' }}
+                    />
+                  </div>
+                  <div className="aeo-hero-row-detail">{row.summary.delta}</div>
+                </div>
+              ))}
             </div>
+            {model.providerScores.length > 0 && (
+              <p className="aeo-hero-context">
+                Across {model.providerScores.length} {model.providerScores.length === 1 ? 'provider' : 'providers'}.
+              </p>
+            )}
+          </section>
+
+          {/* Movement banner — what changed since last run */}
+          <section className="movement-banner">
+            <span className="movement-banner-label">Since last run</span>
+            {model.movementSummary.hasPreviousRun ? (
+              <>
+                <span className={model.movementSummary.gained > 0 ? 'text-emerald-400 font-medium' : 'text-zinc-500'}>
+                  +{model.movementSummary.gained} gained
+                </span>
+                <span className="text-zinc-700 mx-1">·</span>
+                <span className={model.movementSummary.lost > 0 ? 'text-rose-400 font-medium' : 'text-zinc-500'}>
+                  −{model.movementSummary.lost} lost
+                </span>
+                <span className="text-zinc-600 ml-2">
+                  {model.movementSummary.gained === 0 && model.movementSummary.lost === 0
+                    ? '· no changes'
+                    : model.movementSummary.gained > model.movementSummary.lost
+                      ? '· improving'
+                      : model.movementSummary.lost > model.movementSummary.gained
+                        ? '· declining'
+                        : ''}
+                </span>
+              </>
+            ) : (
+              <span className="text-zinc-500">First run — no comparison yet</span>
+            )}
+          </section>
+
+          {/* Secondary: technical health */}
+          <section className="metric-grid">
             <div className="metric-card">
               <p className="metric-card-eyebrow">
                 Gap Queries
-                <InfoTooltip text="Tracked queries where competitors are cited in the latest completed visibility run but your domain is not." />
+                <InfoTooltip text="Queries where competitors got cited but you didn't." />
               </p>
               <p className="metric-card-big-value">
                 <span className="text-zinc-50">{model.gapQueries.value}</span>
@@ -1577,14 +1606,11 @@ export function ProjectPage({
                 />
               </div>
               <p className="metric-card-detail">{model.gapQueries.delta}</p>
-              <p className="metric-card-sub">
-                {model.gapQueries.description}
-              </p>
             </div>
             <div className="metric-card">
               <p className="metric-card-eyebrow">
                 Index Coverage
-                <InfoTooltip text="Percentage of inspected URLs that are currently indexed. Google Search Console is preferred when available, otherwise Bing Webmaster Tools is used." />
+                <InfoTooltip text="Percentage of your tracked URLs that Google or Bing has indexed." />
               </p>
               <p className="metric-card-big-value">
                 <span className="text-zinc-50">{model.indexCoverage.value}</span>
@@ -1597,37 +1623,6 @@ export function ProjectPage({
                 />
               </div>
               <p className="metric-card-detail">{model.indexCoverage.delta}</p>
-              <p className="metric-card-sub">
-                {model.indexCoverage.description}
-              </p>
-            </div>
-            <div className="metric-card">
-              <p className="metric-card-eyebrow">
-                Since Last Run
-                <InfoTooltip text="Query-level citation changes compared to the previous completed run." />
-              </p>
-              {model.movementSummary.hasPreviousRun ? (
-                <div className="metric-card-movement">
-                  <span className={model.movementSummary.gained > 0 ? 'text-emerald-400' : 'text-zinc-500'}>
-                    +{model.movementSummary.gained} gained
-                  </span>
-                  <span className="text-zinc-600 mx-1.5">·</span>
-                  <span className={model.movementSummary.lost > 0 ? 'text-rose-400' : 'text-zinc-500'}>
-                    −{model.movementSummary.lost} lost
-                  </span>
-                </div>
-              ) : (
-                <p className="metric-card-movement text-zinc-500">First run — no comparison yet</p>
-              )}
-              <p className="metric-card-sub mt-auto">
-                {model.movementSummary.gained === 0 && model.movementSummary.lost === 0 && model.movementSummary.hasPreviousRun
-                  ? 'No changes since last run'
-                  : model.movementSummary.gained > model.movementSummary.lost
-                    ? 'Visibility improving'
-                    : model.movementSummary.lost > model.movementSummary.gained
-                      ? 'Visibility declining'
-                      : ''}
-              </p>
             </div>
           </section>
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -503,6 +503,61 @@
     @apply mt-2.5 text-center text-[11px] leading-[1.45] text-zinc-500 w-full;
   }
 
+  /* ── AEO performance hero (paired Mention + Citation) ── */
+
+  .aeo-hero {
+    @apply rounded-xl border border-zinc-800/60 bg-zinc-900/30 px-5 py-5;
+  }
+
+  .aeo-hero-title {
+    @apply text-[10px] font-medium uppercase tracking-[0.12em] text-zinc-500 mb-3;
+  }
+
+  .aeo-hero-rows {
+    @apply space-y-3;
+  }
+
+  .aeo-hero-row {
+    @apply grid items-center gap-x-4;
+    grid-template-columns: 100px 90px 1fr auto;
+  }
+
+  .aeo-hero-row-label {
+    @apply text-sm font-medium text-zinc-200 flex items-center gap-1;
+  }
+
+  .aeo-hero-row-value {
+    @apply text-2xl font-bold tracking-tight tabular-nums;
+  }
+
+  .aeo-hero-row-bar {
+    @apply h-1.5 w-full rounded-full bg-zinc-800 overflow-hidden;
+  }
+
+  .aeo-hero-row-detail {
+    @apply text-[11px] text-zinc-500 tabular-nums;
+  }
+
+  .aeo-hero-context {
+    @apply text-[11px] text-zinc-600 mt-4;
+  }
+
+  /* ── Movement banner (Since Last Run) ── */
+
+  .movement-banner {
+    @apply rounded-lg border border-zinc-800/40 bg-zinc-900/20 px-4 py-2 text-xs flex items-center gap-2;
+  }
+
+  .movement-banner-label {
+    @apply text-[10px] font-medium uppercase tracking-[0.12em] text-zinc-500 mr-1;
+  }
+
+  /* ── Secondary metric grid (Gap Queries + Index Coverage) ── */
+
+  .metric-grid {
+    @apply grid gap-3 sm:grid-cols-2;
+  }
+
   /* ── Metric cards (non-gauge) ── */
 
   .metric-card {

--- a/packages/intelligence/src/mention-coverage.ts
+++ b/packages/intelligence/src/mention-coverage.ts
@@ -36,7 +36,7 @@ export function buildMentionCoverage(
   snapshots: readonly MentionCoverageSnapshot[],
   options: MentionCoverageOptions,
 ): ScoreSummaryDto {
-  const tooltip = 'Percentage of tracked queries where the AI answer text mentions your brand or domain. A query counts as mentioned if any configured provider includes your name in its answer body.'
+  const tooltip = 'Your domain or company name was in the answer returned by the LLM.'
 
   if (snapshots.length === 0) {
     return {

--- a/packages/intelligence/src/visibility-score.ts
+++ b/packages/intelligence/src/visibility-score.ts
@@ -36,7 +36,7 @@ export function buildVisibilityScore(
   snapshots: readonly VisibilityScoreSnapshot[],
   options: VisibilityScoreOptions,
 ): ScoreSummaryDto {
-  const tooltip = 'Percentage of tracked queries where your domain is cited by at least one AI answer engine. A query counts as cited if any configured provider includes your site in its response.'
+  const tooltip = 'An LLM used a page on your domain as a source for its answer.'
 
   if (snapshots.length === 0) {
     return {


### PR DESCRIPTION
## Why
Operator feedback on the post-#523 dashboard surfaced three problems:

1. **Visual asymmetry.** Mention Coverage rendered as a radial gauge while Citation Coverage and the other three tiles used a big-number-with-bar pattern. The eye has to retune for the outlier.
2. **Too dense.** Five tiles in the top row + each tile carrying a long prose description meant the at-a-glance area required reading, not scanning.
3. **Tooltips were technical prose.** They needed to be in plain English.

## What

### Hero card: "AEO performance"
Mention and Citation as two identical rows inside one card. Both signals visible at a glance, visually paired:

\`\`\`
AEO PERFORMANCE
  Mentioned ⓘ   45%  ━━━━━━━━━━━  5 of 11 queries mentioned
  Cited     ⓘ   45%  ━━━━━━━━━━━  5 of 11 queries cited

Across 4 providers.
\`\`\`

### Movement banner
A single thin line replacing the full "Since Last Run" tile:
\`\`\`
SINCE LAST RUN  +0 gained · −1 lost · declining
\`\`\`

### Secondary grid
Gap Queries + Index Coverage in a 2-column grid below. Prose descriptions dropped from each (delta line carries the meaning).

### Tooltips — verbatim per the request
- **Mentioned**: "Your domain or company name was in the answer returned by the LLM."
- **Cited**: "An LLM used a page on your domain as a source for its answer."
- **Gap Queries**: "Queries where competitors got cited but you didn't."
- **Index Coverage**: "Percentage of your tracked URLs that Google or Bing has indexed."

## Test plan
- [x] Typecheck clean
- [x] \`pnpm vitest run --project web --project intelligence --project api-routes\` — 1332/1332 pass
- [x] SPA bundle build confirms new strings present (AEO performance, aeo-hero, the plain tooltips)
- [x] \`ScoreGauge\` import removed from ProjectPage; component still exported for any future use

## Note
The radial \`ScoreGauge\` component is no longer rendered anywhere on the project overview. Left in the codebase in case a future surface wants it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)