### PR TITLE
feat(cli): add --dry-run to project delete (+ /delete-preview API)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.35.0",
+  "version": "4.36.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -260,6 +260,18 @@ const routeCatalog: OpenApiOperation[] = [
     },
   },
   {
+    method: 'get',
+    path: '/api/v1/projects/{name}/delete-preview',
+    summary: 'Preview the cascade impact of deleting a project',
+    description: 'Read-only impact summary backing `canonry project delete --dry-run`. Returns counts of rows that would cascade-delete (queries, competitors, runs, snapshots, insights) and rows that would be detached (audit_log — `project_id` set to NULL).',
+    tags: ['projects'],
+    parameters: [nameParameter],
+    responses: {
+      200: { description: 'Preview of cascade impact.' },
+      404: { description: 'Project not found.' },
+    },
+  },
+  {
     method: 'post',
     path: '/api/v1/projects/{name}/locations',
     summary: 'Add a project location',

--- a/packages/api-routes/src/projects.ts
+++ b/packages/api-routes/src/projects.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto'
-import { eq } from 'drizzle-orm'
+import { eq, sql } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
-import { projects, queries, competitors, schedules, notifications, parseJsonColumn } from '@ainyc/canonry-db'
+import { projects, queries, competitors, schedules, notifications, runs, querySnapshots, insights, auditLog, parseJsonColumn } from '@ainyc/canonry-db'
 import {
   validationError,
   locationContextSchema,
@@ -186,6 +186,59 @@ export async function projectRoutes(app: FastifyInstance, opts: ProjectRoutesOpt
   app.get<{ Params: { name: string } }>('/projects/:name', async (request, reply) => {
     const project = resolveProject(app.db, request.params.name)
     return reply.send(formatProject(project))
+  })
+
+  app.get<{ Params: { name: string } }>('/projects/:name/delete-preview', async (request, reply) => {
+    const project = resolveProject(app.db, request.params.name)
+    const pid = project.id
+
+    const count = (n: number | undefined): number => n ?? 0
+    const queryCount = app.db
+      .select({ n: sql<number>`count(*)` })
+      .from(queries)
+      .where(eq(queries.projectId, pid))
+      .get()
+    const competitorCount = app.db
+      .select({ n: sql<number>`count(*)` })
+      .from(competitors)
+      .where(eq(competitors.projectId, pid))
+      .get()
+    const runCount = app.db
+      .select({ n: sql<number>`count(*)` })
+      .from(runs)
+      .where(eq(runs.projectId, pid))
+      .get()
+    // Snapshots have no projectId — count via the run join instead.
+    const snapshotCount = app.db
+      .select({ n: sql<number>`count(*)` })
+      .from(querySnapshots)
+      .innerJoin(runs, eq(querySnapshots.runId, runs.id))
+      .where(eq(runs.projectId, pid))
+      .get()
+    const insightCount = app.db
+      .select({ n: sql<number>`count(*)` })
+      .from(insights)
+      .where(eq(insights.projectId, pid))
+      .get()
+    const auditLogCount = app.db
+      .select({ n: sql<number>`count(*)` })
+      .from(auditLog)
+      .where(eq(auditLog.projectId, pid))
+      .get()
+
+    return reply.send({
+      project: { id: project.id, name: project.name },
+      cascadeRows: {
+        queries: count(queryCount?.n),
+        competitors: count(competitorCount?.n),
+        runs: count(runCount?.n),
+        snapshots: count(snapshotCount?.n),
+        insights: count(insightCount?.n),
+      },
+      detachedRows: {
+        auditLog: count(auditLogCount?.n),
+      },
+    })
   })
 
   // DELETE /projects/:name

--- a/packages/api-routes/test/projects-delete-preview.test.ts
+++ b/packages/api-routes/test/projects-delete-preview.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import crypto from 'node:crypto'
+import Fastify from 'fastify'
+import { createClient, migrate, projects, queries, competitors, runs, querySnapshots, insights, auditLog } from '@ainyc/canonry-db'
+import { apiRoutes } from '../src/index.js'
+
+const cleanups: Array<() => void> = []
+afterEach(() => {
+  for (const fn of cleanups.splice(0)) fn()
+})
+
+function buildApp() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'projects-delete-preview-'))
+  cleanups.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }))
+  const dbPath = path.join(tmpDir, 'test.db')
+  const db = createClient(dbPath)
+  migrate(db)
+  const app = Fastify()
+  app.register(apiRoutes, { db, skipAuth: true })
+  return { app, db }
+}
+
+function seedProject(db: ReturnType<typeof createClient>, name: string): string {
+  const projectId = crypto.randomUUID()
+  const now = new Date().toISOString()
+  db.insert(projects).values({
+    id: projectId,
+    name,
+    displayName: name,
+    canonicalDomain: `${name}.example`,
+    country: 'US',
+    language: 'en',
+    createdAt: now,
+    updatedAt: now,
+  }).run()
+  return projectId
+}
+
+describe('GET /projects/:name/delete-preview', () => {
+  it('returns zero counts for a project with nothing attached', async () => {
+    const { app, db } = buildApp()
+    seedProject(db, 'empty-project')
+    await app.ready()
+
+    const res = await app.inject({ method: 'GET', url: '/api/v1/projects/empty-project/delete-preview' })
+    expect(res.statusCode).toBe(200)
+
+    const body = res.json() as { project: { name: string }; cascadeRows: Record<string, number>; detachedRows: Record<string, number> }
+    expect(body.project.name).toBe('empty-project')
+    expect(body.cascadeRows.queries).toBe(0)
+    expect(body.cascadeRows.competitors).toBe(0)
+    expect(body.cascadeRows.runs).toBe(0)
+    expect(body.cascadeRows.snapshots).toBe(0)
+    expect(body.cascadeRows.insights).toBe(0)
+    expect(body.detachedRows.auditLog).toBe(0)
+  })
+
+  it('returns accurate cascade counts for a project with full data', async () => {
+    const { app, db } = buildApp()
+    const projectId = seedProject(db, 'full-project')
+    const now = new Date().toISOString()
+
+    // 3 queries
+    const queryIds = [1, 2, 3].map(() => crypto.randomUUID())
+    for (const id of queryIds) {
+      db.insert(queries).values({ id, projectId, query: `q-${id.slice(0, 6)}`, createdAt: now }).run()
+    }
+    // 2 competitors
+    for (const _ of [1, 2]) {
+      db.insert(competitors).values({ id: crypto.randomUUID(), projectId, domain: `c-${crypto.randomUUID().slice(0, 6)}.com`, createdAt: now }).run()
+    }
+    // 4 runs
+    const runIds = [1, 2, 3, 4].map(() => crypto.randomUUID())
+    for (const id of runIds) {
+      db.insert(runs).values({ id, projectId, kind: 'answer-visibility', status: 'completed', trigger: 'manual', createdAt: now, finishedAt: now }).run()
+    }
+    // 6 snapshots (across runs)
+    for (let i = 0; i < 6; i++) {
+      const runId = runIds[i % runIds.length]!
+      const queryId = queryIds[i % queryIds.length]!
+      db.insert(querySnapshots).values({
+        id: crypto.randomUUID(), runId, queryId, provider: 'gemini', citationState: 'cited',
+        citedDomains: '[]', competitorOverlap: '[]', recommendedCompetitors: '[]', createdAt: now,
+      }).run()
+    }
+    // 2 insights
+    for (const _ of [1, 2]) {
+      db.insert(insights).values({
+        id: crypto.randomUUID(), projectId, runId: runIds[0]!, type: 'gain', severity: 'low',
+        title: 't', query: 'q', provider: 'gemini', dismissed: false, createdAt: now,
+      }).run()
+    }
+    // 5 audit_log rows (these survive — SET NULL on cascade)
+    for (let i = 0; i < 5; i++) {
+      db.insert(auditLog).values({
+        id: crypto.randomUUID(), projectId, actor: 'api', action: `event-${i}`,
+        entityType: 'project', entityId: projectId, createdAt: now,
+      }).run()
+    }
+
+    await app.ready()
+    const res = await app.inject({ method: 'GET', url: '/api/v1/projects/full-project/delete-preview' })
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as { cascadeRows: Record<string, number>; detachedRows: Record<string, number> }
+
+    expect(body.cascadeRows.queries).toBe(3)
+    expect(body.cascadeRows.competitors).toBe(2)
+    expect(body.cascadeRows.runs).toBe(4)
+    expect(body.cascadeRows.snapshots).toBe(6)
+    expect(body.cascadeRows.insights).toBe(2)
+    expect(body.detachedRows.auditLog).toBe(5)
+  })
+
+  it('returns 404 for unknown project', async () => {
+    const { app } = buildApp()
+    await app.ready()
+    const res = await app.inject({ method: 'GET', url: '/api/v1/projects/missing/delete-preview' })
+    expect(res.statusCode).toBe(404)
+  })
+
+  it('preview does NOT actually delete anything', async () => {
+    const { app, db } = buildApp()
+    const projectId = seedProject(db, 'survives')
+    const now = new Date().toISOString()
+    db.insert(queries).values({ id: crypto.randomUUID(), projectId, query: 'q1', createdAt: now }).run()
+    await app.ready()
+
+    await app.inject({ method: 'GET', url: '/api/v1/projects/survives/delete-preview' })
+
+    // Project still exists, query row still exists
+    const projectRow = db.select().from(projects).all().find(p => p.name === 'survives')
+    expect(projectRow).toBeDefined()
+    const queryRow = db.select().from(queries).all().find(q => q.projectId === projectId)
+    expect(queryRow).toBeDefined()
+  })
+})

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.35.0",
+  "version": "4.36.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/cli-commands/project.ts
+++ b/packages/canonry/src/cli-commands/project.ts
@@ -104,10 +104,11 @@ export const PROJECT_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['project', 'delete'],
-    usage: 'canonry project delete <name> [--format json]',
+    usage: 'canonry project delete <name> [--dry-run] [--format json]',
+    supportsDryRun: true,
     run: async (input) => {
-      const name = requireProject(input, 'project.delete', 'canonry project delete <name> [--format json]')
-      await deleteProject(name, input.format)
+      const name = requireProject(input, 'project.delete', 'canonry project delete <name> [--dry-run] [--format json]')
+      await deleteProject(name, { dryRun: input.dryRun, format: input.format })
     },
   },
   {

--- a/packages/canonry/src/client.ts
+++ b/packages/canonry/src/client.ts
@@ -100,6 +100,20 @@ export interface SettingsDto {
 /** Apply response */
 export type ApplyResultDto = ProjectDto
 
+export interface ProjectDeletePreviewDto {
+  project: { id: string; name: string }
+  cascadeRows: {
+    queries: number
+    competitors: number
+    runs: number
+    snapshots: number
+    insights: number
+  }
+  detachedRows: {
+    auditLog: number
+  }
+}
+
 /** Telemetry status */
 export interface TelemetryDto {
   enabled: boolean
@@ -424,6 +438,10 @@ export class ApiClient {
 
   async deleteProject(name: string): Promise<void> {
     await this.request<void>('DELETE', `/projects/${encodeURIComponent(name)}`)
+  }
+
+  async previewProjectDelete(name: string): Promise<ProjectDeletePreviewDto> {
+    return this.request<ProjectDeletePreviewDto>('GET', `/projects/${encodeURIComponent(name)}/delete-preview`)
   }
 
   async putQueries(project: string, queries: string[]): Promise<void> {

--- a/packages/canonry/src/commands/project.ts
+++ b/packages/canonry/src/commands/project.ts
@@ -151,11 +151,34 @@ export async function updateProjectSettings(
   console.log(`Project updated: ${result.name}`)
 }
 
-export async function deleteProject(name: string, format?: string): Promise<void> {
+export async function deleteProject(name: string, opts?: { dryRun?: boolean; format?: string }): Promise<void> {
   const client = getClient()
+  const isJson = opts?.format === 'json'
+
+  if (opts?.dryRun) {
+    const preview = await client.previewProjectDelete(name)
+    if (isJson) {
+      console.log(JSON.stringify({ dryRun: true, ...preview }, null, 2))
+      return
+    }
+    const { cascadeRows: cr, detachedRows: dr } = preview
+    console.log(`Project delete preview for "${name}":`)
+    console.log(`  Cascade-deletes:`)
+    console.log(`    queries:      ${cr.queries}`)
+    console.log(`    competitors:  ${cr.competitors}`)
+    console.log(`    runs:         ${cr.runs}`)
+    console.log(`    snapshots:    ${cr.snapshots}`)
+    console.log(`    insights:     ${cr.insights}`)
+    console.log(`  Detached (project_id set to NULL):`)
+    console.log(`    audit_log:    ${dr.auditLog}`)
+    console.log(``)
+    console.log(`No DB writes performed. Re-run without --dry-run to delete.`)
+    return
+  }
+
   await client.deleteProject(name)
 
-  if (format === 'json') {
+  if (isJson) {
     console.log(JSON.stringify({ name, deleted: true }, null, 2))
     return
   }

--- a/packages/canonry/src/mcp/openapi-classification.ts
+++ b/packages/canonry/src/mcp/openapi-classification.ts
@@ -6,6 +6,7 @@ export const MCP_OPENAPI_OPERATION_CLASSIFICATIONS = {
   'GET /api/v1/projects': 'included',
   'GET /api/v1/projects/{name}': 'included',
   'DELETE /api/v1/projects/{name}': 'deferred',
+  'GET /api/v1/projects/{name}/delete-preview': 'included',
   'POST /api/v1/projects/{name}/locations': 'deferred',
   'GET /api/v1/projects/{name}/locations': 'deferred',
   'DELETE /api/v1/projects/{name}/locations/{label}': 'deferred',

--- a/packages/canonry/src/mcp/tool-registry.ts
+++ b/packages/canonry/src/mcp/tool-registry.ts
@@ -362,6 +362,17 @@ export const canonryMcpTools = [
     handler: (client, input) => client.getProject(input.project),
   }),
   defineTool({
+    name: 'canonry_project_delete_preview',
+    title: 'Preview project delete impact',
+    description: 'Returns the cascade impact of deleting a project — how many queries, competitors, runs, snapshots, and insights would be removed, plus how many audit_log rows would be detached (project_id set NULL). Read-only. Use this BEFORE invoking project delete on any project you didn\'t create yourself; the underlying delete is irreversible.',
+    access: 'read',
+    tier: 'setup',
+    inputSchema: projectInputSchema,
+    annotations: readAnnotations(),
+    openApiOperations: ['GET /api/v1/projects/{name}/delete-preview'],
+    handler: (client, input) => client.previewProjectDelete(input.project),
+  }),
+  defineTool({
     name: 'canonry_project_overview',
     title: 'Get project overview (composite)',
     description: 'One-call summary for "how is project X doing?" — bundles project info, latest run, top undismissed insights, latest health snapshot, query cited rate, per-provider breakdown, gained/lost/emerging vs the previous run, the five score gauges (visibility, gap queries, index coverage, competitor pressure, run status), per-(provider, model) scores, configured competitors with pressure labels, an attention queue of critical/high insights, and a recent-runs sparkline. Filterable by location and time window. Prefer this over fanning out to separate tools.',

--- a/packages/canonry/test/mcp-registry.test.ts
+++ b/packages/canonry/test/mcp-registry.test.ts
@@ -18,6 +18,7 @@ import { CANONRY_MCP_TIERS, CANONRY_MCP_TOOLKITS } from '../src/mcp/toolkits.js'
 const expectedToolNames = [
   'canonry_projects_list',
   'canonry_project_get',
+  'canonry_project_delete_preview',
   'canonry_project_overview',
   'canonry_report',
   'canonry_search',
@@ -101,8 +102,8 @@ const expectedToolNames = [
 
 describe('MCP tool registry', () => {
   it('ships the curated v1 surface', () => {
-    expect(CANONRY_MCP_TOOL_COUNT).toBe(81)
-    expect(CANONRY_MCP_READ_TOOL_COUNT).toBe(52)
+    expect(CANONRY_MCP_TOOL_COUNT).toBe(82)
+    expect(CANONRY_MCP_READ_TOOL_COUNT).toBe(53)
     expect(canonryMcpTools.map(tool => tool.name)).toEqual(expectedToolNames)
     const readNames = canonryMcpTools.filter(tool => tool.access === 'read').map(tool => tool.name)
     expect(getCanonryMcpTools('read-only').map(tool => tool.name)).toEqual(readNames)
@@ -139,7 +140,7 @@ describe('MCP tool registry', () => {
       counts.set(tool.tier, (counts.get(tool.tier) ?? 0) + 1)
     }
     expect(counts.get('monitoring')).toBe(16)
-    expect(counts.get('setup')).toBe(21)
+    expect(counts.get('setup')).toBe(22)
     expect(counts.get('gsc')).toBe(7)
     expect(counts.get('ga')).toBe(8)
     expect(counts.get('traffic')).toBe(9)

--- a/packages/canonry/test/mcp-stdio.test.ts
+++ b/packages/canonry/test/mcp-stdio.test.ts
@@ -171,8 +171,8 @@ describe('canonry-mcp stdio', () => {
     await client.connect(transport)
 
     const list = await client.listTools()
-    // 81 API tools + 2 meta-tools (canonry_help, canonry_load_toolkit).
-    expect(list.tools).toHaveLength(83)
+    // 82 API tools + 2 meta-tools (canonry_help, canonry_load_toolkit).
+    expect(list.tools).toHaveLength(84)
     const names = list.tools.map(tool => tool.name)
     expect(names).toContain('canonry_insights_list')
     expect(names).toContain('canonry_project_overview')


### PR DESCRIPTION
## Summary

Adds a read-only preview endpoint so `canonry project delete --dry-run` can show the blast radius before an operator (or agent) confirms a destructive call.

- **API:** `GET /api/v1/projects/{name}/delete-preview` returns
  - `cascadeRows`: counts of rows that would cascade-delete (queries, competitors, runs, snapshots, insights)
  - `detachedRows`: rows that would be detached — `audit_log` (`project_id` set to NULL post v60), so the audit history survives the project
- **Client / DTO:** `ApiClient.previewProjectDelete` + `ProjectDeletePreviewDto`
- **CLI:** `canonry project delete <name> --dry-run [--format json]` — opts into the global `--dry-run` infrastructure shipped in #526, prints cascade + detached counts and a "No DB writes performed" footer
- **MCP:** new `canonry_project_delete_preview` tool (setup tier, `access: 'read'`) so Aero and external agents can preview impact without holding the destructive write tool

Why: project delete is the single most destructive operation in canonry — it nukes every run, snapshot, and insight for a project. Agents that orchestrate cleanups need a way to confirm impact first; humans want it too.

## Test plan

- [x] `pnpm vitest run --project canonry --project api-routes` — 1498/1498 pass
- [x] New `projects-delete-preview.test.ts` covers empty project, full data (3 queries / 2 competitors / 4 runs / 6 snapshots / 2 insights / 5 audit-log rows), unknown-project 404, and "preview does NOT actually delete anything"
- [x] MCP coverage drift test updated (tool count 81→82, read count 52→53, setup toolkit 21→22) and `canonry_project_delete_preview` added to `expectedToolNames`
- [x] MCP stdio --eager test updated (84 tools total)
- [x] `pnpm typecheck && pnpm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)