### PR TITLE
feat(cli): add --dry-run to backfill answer-visibility and answer-mentions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.35.0",
+  "version": "4.36.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.35.0",
+  "version": "4.36.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/cli-commands/backfill.ts
+++ b/packages/canonry/src/cli-commands/backfill.ts
@@ -5,28 +5,32 @@ import { requireProject, getString, stringOption, unknownSubcommand } from '../c
 export const BACKFILL_CLI_COMMANDS: readonly CliCommandSpec[] = [
   {
     path: ['backfill', 'answer-visibility'],
-    usage: 'canonry backfill answer-visibility [--project <name>] [--format json]',
+    usage: 'canonry backfill answer-visibility [--project <name>] [--dry-run] [--format json]',
     options: {
       project: stringOption(),
     },
     allowPositionals: false,
+    supportsDryRun: true,
     run: async (input) => {
       await backfillAnswerVisibilityCommand({
         project: getString(input.values, 'project'),
+        dryRun: input.dryRun,
         format: input.format,
       })
     },
   },
   {
     path: ['backfill', 'answer-mentions'],
-    usage: 'canonry backfill answer-mentions [--project <name>] [--format json]',
+    usage: 'canonry backfill answer-mentions [--project <name>] [--dry-run] [--format json]',
     options: {
       project: stringOption(),
     },
     allowPositionals: false,
+    supportsDryRun: true,
     run: async (input) => {
       await backfillAnswerMentionsCommand({
         project: getString(input.values, 'project'),
+        dryRun: input.dryRun,
         format: input.format,
       })
     },

--- a/packages/canonry/src/commands/backfill.ts
+++ b/packages/canonry/src/commands/backfill.ts
@@ -19,6 +19,7 @@ const SNAPSHOT_BATCH_SIZE = 500
 
 export async function backfillAnswerVisibilityCommand(opts?: {
   project?: string
+  dryRun?: boolean
   format?: CliFormat
 }): Promise<void> {
   const config = loadConfig()
@@ -26,6 +27,7 @@ export async function backfillAnswerVisibilityCommand(opts?: {
   migrate(db)
 
   const projectFilter = opts?.project?.trim()
+  const isDryRun = opts?.dryRun === true
 
   const scopedProjects = projectFilter
     ? db.select().from(projects).where(eq(projects.name, projectFilter)).all()
@@ -33,6 +35,7 @@ export async function backfillAnswerVisibilityCommand(opts?: {
 
   let examined = 0
   let updated = 0
+  let wouldUpdate = 0
   let mentioned = 0
   let reparsed = 0
   let providerErrors = 0
@@ -167,21 +170,25 @@ export async function backfillAnswerVisibilityCommand(opts?: {
         }
 
         if (pendingUpdates.length > 0) {
-          db.transaction((tx) => {
-            for (const update of pendingUpdates) {
-              tx.update(querySnapshots)
-                .set(update.patch)
-                .where(eq(querySnapshots.id, update.id))
-                .run()
-            }
-          })
-          updated += pendingUpdates.length
+          if (isDryRun) {
+            wouldUpdate += pendingUpdates.length
+          } else {
+            db.transaction((tx) => {
+              for (const update of pendingUpdates) {
+                tx.update(querySnapshots)
+                  .set(update.patch)
+                  .where(eq(querySnapshots.id, update.id))
+                  .run()
+              }
+            })
+            updated += pendingUpdates.length
+          }
         }
       }
     }
   }
 
-  const result = {
+  const result: Record<string, unknown> = {
     project: projectFilter ?? null,
     projects: scopedProjects.length,
     examined,
@@ -190,22 +197,33 @@ export async function backfillAnswerVisibilityCommand(opts?: {
     reparsed,
     providerErrors,
   }
+  if (isDryRun) {
+    result.dryRun = true
+    result.wouldUpdate = wouldUpdate
+  }
 
   if (opts?.format === 'json') {
     console.log(JSON.stringify(result, null, 2))
     return
   }
 
-  console.log('Answer visibility backfill complete.\n')
+  console.log(`Answer visibility backfill ${isDryRun ? 'preview' : 'complete'}.\n`)
   if (projectFilter) {
     console.log(`  Project:  ${projectFilter}`)
   }
   console.log(`  Projects: ${scopedProjects.length}`)
-  console.log(`  Examined:  ${examined}`)
-  console.log(`  Updated:   ${updated}`)
-  console.log(`  Mentioned: ${mentioned}`)
-  console.log(`  Reparsed:  ${reparsed}`)
-  console.log(`  Errors:    ${providerErrors}`)
+  console.log(`  Examined:     ${examined}`)
+  if (isDryRun) {
+    console.log(`  Would update: ${wouldUpdate}`)
+  } else {
+    console.log(`  Updated:      ${updated}`)
+  }
+  console.log(`  Mentioned:    ${mentioned}`)
+  console.log(`  Reparsed:     ${reparsed}`)
+  console.log(`  Errors:       ${providerErrors}`)
+  if (isDryRun) {
+    console.log(`\nNo DB writes performed. Re-run without --dry-run to apply.`)
+  }
 }
 
 export interface NormalizedPathsBackfillResult {
@@ -448,6 +466,7 @@ export async function backfillAiReferralPathsCommand(opts?: {
 export interface ProjectAnswerMentionsBackfillResult {
   examined: number
   updated: number
+  wouldUpdate?: number
   mentioned: number
 }
 
@@ -463,7 +482,9 @@ export interface ProjectAnswerMentionsBackfillResult {
 export function backfillProjectAnswerMentions(
   db: DatabaseClient,
   projectId: string,
+  opts?: { dryRun?: boolean },
 ): ProjectAnswerMentionsBackfillResult {
+  const isDryRun = opts?.dryRun === true
   const project = db.select().from(projects).where(eq(projects.id, projectId)).get()
   if (!project) return { examined: 0, updated: 0, mentioned: 0 }
 
@@ -483,8 +504,11 @@ export function backfillProjectAnswerMentions(
 
   let examined = 0
   let updated = 0
+  let wouldUpdate = 0
   let mentioned = 0
-  if (runIds.length === 0) return { examined, updated, mentioned }
+  if (runIds.length === 0) {
+    return isDryRun ? { examined, updated, wouldUpdate, mentioned } : { examined, updated, mentioned }
+  }
 
   const projectDomains = effectiveDomains({
     canonicalDomain: project.canonicalDomain,
@@ -559,19 +583,23 @@ export function backfillProjectAnswerMentions(
     }
 
     if (pendingUpdates.length > 0) {
-      db.transaction((tx) => {
-        for (const update of pendingUpdates) {
-          tx.update(querySnapshots)
-            .set(update.patch)
-            .where(eq(querySnapshots.id, update.id))
-            .run()
-        }
-      })
-      updated += pendingUpdates.length
+      if (isDryRun) {
+        wouldUpdate += pendingUpdates.length
+      } else {
+        db.transaction((tx) => {
+          for (const update of pendingUpdates) {
+            tx.update(querySnapshots)
+              .set(update.patch)
+              .where(eq(querySnapshots.id, update.id))
+              .run()
+          }
+        })
+        updated += pendingUpdates.length
+      }
     }
   }
 
-  return { examined, updated, mentioned }
+  return isDryRun ? { examined, updated, wouldUpdate, mentioned } : { examined, updated, mentioned }
 }
 
 /**
@@ -588,6 +616,7 @@ export function backfillProjectAnswerMentions(
  */
 export async function backfillAnswerMentionsCommand(opts?: {
   project?: string
+  dryRun?: boolean
   format?: CliFormat
 }): Promise<void> {
   const config = loadConfig()
@@ -595,6 +624,7 @@ export async function backfillAnswerMentionsCommand(opts?: {
   migrate(db)
 
   const projectFilter = opts?.project?.trim()
+  const isDryRun = opts?.dryRun === true
 
   const scopedProjects = projectFilter
     ? db.select().from(projects).where(eq(projects.name, projectFilter)).all()
@@ -602,21 +632,27 @@ export async function backfillAnswerMentionsCommand(opts?: {
 
   let examined = 0
   let updated = 0
+  let wouldUpdate = 0
   let mentioned = 0
 
   for (const project of scopedProjects) {
-    const result = backfillProjectAnswerMentions(db, project.id)
+    const result = backfillProjectAnswerMentions(db, project.id, { dryRun: isDryRun })
     examined += result.examined
     updated += result.updated
+    wouldUpdate += result.wouldUpdate ?? 0
     mentioned += result.mentioned
   }
 
-  const result = {
+  const result: Record<string, unknown> = {
     project: projectFilter ?? null,
     projects: scopedProjects.length,
     examined,
     updated,
     mentioned,
+  }
+  if (isDryRun) {
+    result.dryRun = true
+    result.wouldUpdate = wouldUpdate
   }
 
   if (opts?.format === 'json') {
@@ -624,12 +660,19 @@ export async function backfillAnswerMentionsCommand(opts?: {
     return
   }
 
-  console.log('Answer mentions backfill complete.\n')
-  if (projectFilter) console.log(`  Project:   ${projectFilter}`)
-  console.log(`  Projects:  ${scopedProjects.length}`)
-  console.log(`  Examined:  ${examined}`)
-  console.log(`  Updated:   ${updated}`)
-  console.log(`  Mentioned: ${mentioned}`)
+  console.log(`Answer mentions backfill ${isDryRun ? 'preview' : 'complete'}.\n`)
+  if (projectFilter) console.log(`  Project:      ${projectFilter}`)
+  console.log(`  Projects:     ${scopedProjects.length}`)
+  console.log(`  Examined:     ${examined}`)
+  if (isDryRun) {
+    console.log(`  Would update: ${wouldUpdate}`)
+  } else {
+    console.log(`  Updated:      ${updated}`)
+  }
+  console.log(`  Mentioned:    ${mentioned}`)
+  if (isDryRun) {
+    console.log(`\nNo DB writes performed. Re-run without --dry-run to apply.`)
+  }
 }
 
 function readStoredGroundingSources(rawResponse: string | null): GroundingSource[] {

--- a/packages/canonry/test/backfill-answer-mentions.test.ts
+++ b/packages/canonry/test/backfill-answer-mentions.test.ts
@@ -352,4 +352,48 @@ describe('backfill answer-mentions', () => {
       .get()
     expect(JSON.parse(auditSnapshot!.competitorOverlap)).toEqual(['offers.roofle.com'])
   })
+
+  it('--dry-run reports would-update count without writing to the DB', async () => {
+    const { runId, queryId } = seedAnswerVisibilityRun({
+      projectName: 'dry-run-project',
+      competitorDomains: ['offers.roofle.com'],
+    })
+    const now = new Date().toISOString()
+
+    const snapshotId = crypto.randomUUID()
+    const originalCompetitorOverlap = '["offers.roofle.com"]'
+    db.insert(querySnapshots).values({
+      id: snapshotId,
+      runId,
+      queryId,
+      provider: 'openai',
+      model: 'gpt-5',
+      citationState: 'not-cited',
+      answerMentioned: false,
+      answerText: 'Energy Design Systems offers a white-label lead generation tool.',
+      citedDomains: '[]',
+      competitorOverlap: originalCompetitorOverlap,
+      recommendedCompetitors: '[]',
+      rawResponse: JSON.stringify({ groundingSources: [], searchQueries: [] }),
+      createdAt: now,
+    }).run()
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await backfillAnswerMentionsCommand({ project: 'dry-run-project', dryRun: true, format: 'json' })
+    const result = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0] ?? '{}'))
+
+    expect(result.dryRun).toBe(true)
+    expect(result.examined).toBe(1)
+    expect(result.updated).toBe(0)
+    expect(result.wouldUpdate).toBe(1)
+
+    // Snapshot must be untouched
+    const snapshot = db
+      .select()
+      .from(querySnapshots)
+      .where(eq(querySnapshots.id, snapshotId))
+      .get()
+    expect(snapshot!.competitorOverlap).toBe(originalCompetitorOverlap)
+  })
 })

--- a/packages/canonry/test/backfill-provider-data.test.ts
+++ b/packages/canonry/test/backfill-provider-data.test.ts
@@ -520,4 +520,65 @@ describe('backfill answer-visibility provider reparsing', () => {
     expect(auditSnapshots[0]?.citationState).toBe('not-cited')
     expect(auditSnapshots[0]?.rawResponse).toContain('should-not-change')
   })
+
+  it('--dry-run reports would-update counts without writing to the DB', async () => {
+    const projectId = crypto.randomUUID()
+    const runId = crypto.randomUUID()
+    const queryId = crypto.randomUUID()
+    const snapshotId = crypto.randomUUID()
+    const now = new Date().toISOString()
+    const projectName = 'dry-run-vis'
+
+    db.insert(projects).values({
+      id: projectId, name: projectName, displayName: 'Canonry',
+      canonicalDomain: 'canonry.ai', ownedDomains: '[]', country: 'US', language: 'en',
+      providers: '["openai"]', createdAt: now, updatedAt: now,
+    }).run()
+    db.insert(runs).values({
+      id: runId, projectId, kind: RunKinds['answer-visibility'],
+      status: 'completed', trigger: 'manual', createdAt: now,
+    }).run()
+    db.insert(queries).values({
+      id: queryId, projectId, query: 'canonry pricing', createdAt: now,
+    }).run()
+
+    // An OpenAI snapshot that needs an answerMentioned flip (currently false,
+    // text mentions canonry → would flip to true on a real backfill).
+    const originalRawResponse = JSON.stringify({
+      apiResponse: {
+        output: [
+          { type: 'message', content: [{ type: 'output_text', text: 'Canonry costs $99/mo.' }] },
+        ],
+      },
+    })
+    const originalCitationState = 'not-cited'
+    db.insert(querySnapshots).values({
+      id: snapshotId,
+      runId, queryId,
+      provider: 'openai', model: 'gpt-5',
+      citationState: originalCitationState, answerMentioned: false,
+      answerText: 'Canonry costs $99/mo.',
+      citedDomains: '[]', competitorOverlap: '[]', recommendedCompetitors: '[]',
+      rawResponse: originalRawResponse, createdAt: now,
+    }).run()
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    await backfillAnswerVisibilityCommand({ project: projectName, dryRun: true, format: 'json' })
+    const output = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0] ?? '{}'))
+
+    expect(output.dryRun).toBe(true)
+    expect(output.examined).toBe(1)
+    expect(output.updated).toBe(0)
+    expect(output.wouldUpdate).toBeGreaterThanOrEqual(1)
+
+    // Confirm the snapshot row is untouched
+    const snapshot = db
+      .select()
+      .from(querySnapshots)
+      .where(eq(querySnapshots.id, snapshotId))
+      .get()
+    expect(snapshot!.answerMentioned).toBe(false)
+    expect(snapshot!.citationState).toBe(originalCitationState)
+    expect(snapshot!.rawResponse).toBe(originalRawResponse)
+  })
 })


### PR DESCRIPTION
## Summary

Both `canonry backfill answer-visibility` and `canonry backfill answer-mentions` walk every answer-visibility snapshot in the project (or the whole DB) and rewrite up to 6 fields per row. On a multi-thousand snapshot history (azcoatings has ~460 snapshots; typical client has more) that's slow and not easy to undo. The new `--dry-run` reports examined / would-update / mentioned counts without touching the DB.

- `backfillAnswerVisibilityCommand` accepts `dryRun`: skips the per-batch transaction, bumps a `wouldUpdate` counter instead
- `backfillProjectAnswerMentions(db, projectId, { dryRun })` threads the flag through; aggregated by `backfillAnswerMentionsCommand`
- CLI specs opt into `supportsDryRun: true` (uses the global `--dry-run` shipped in #526)
- JSON output adds `{ dryRun: true, wouldUpdate: N }`; human output prints `Would update:` instead of `Updated:` and a `No DB writes performed` footer

This closes out the dry-run series for the destructive bulk-rewrite commands. Combined with #528 (project delete) and #529 (query replace), every meaningfully destructive `canonry` command now has a `--dry-run`.

## Test plan

- [x] New test: `backfill answer-mentions --dry-run` reports `dryRun: true`, `wouldUpdate: 1`, `updated: 0`, and the snapshot row is byte-identical after the call
- [x] New test: `backfill answer-visibility --dry-run` same invariants on a snapshot whose `answerMentioned` would flip
- [x] `pnpm vitest run --project canonry --project api-routes` — 1496/1496 pass
- [x] `pnpm typecheck && pnpm lint` clean

## Out of scope

`backfill normalized-paths` and `backfill ai-referral-paths` only fill in NULL values (idempotent, never overwrite), and run automatically on `canonry serve` startup. Lower priority for preview; can revisit if operators want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)