### PR TITLE
feat(serve): nudge operators when ~/.claude/skills/ is missing canonry/aero

### DIFF
--- a/packages/canonry/src/commands/serve.ts
+++ b/packages/canonry/src/commands/serve.ts
@@ -4,6 +4,7 @@ import { createServer } from '../server.js'
 import { trackEvent, setTelemetrySource } from '../telemetry.js'
 import { CliError, type CliFormat } from '../cli-error.js'
 import { backfillAiReferralPaths, backfillNormalizedPaths } from './backfill.js'
+import { getMissingUserSkillsNudge } from './skills.js'
 
 /**
  * Precedence: `CANONRY_PORT` env var (also set by `--port`) > config.yaml `port:` > 4100.
@@ -99,6 +100,8 @@ export async function serveCommand(format: CliFormat = 'text'): Promise<void> {
     } else {
       console.log(`\nCanonry server running at ${url}`)
       console.log('Press Ctrl+C to stop.\n')
+      const nudge = getMissingUserSkillsNudge()
+      if (nudge) process.stderr.write(`${nudge.message}\n`)
     }
 
     // Switch the source for the rest of this process — every event emitted

--- a/packages/canonry/src/commands/skills.ts
+++ b/packages/canonry/src/commands/skills.ts
@@ -314,6 +314,54 @@ export function emitInstallSummary(summary: SkillsInstallSummary, format?: strin
   console.log(summary.message)
 }
 
+export interface UserSkillsNudge {
+  /** One-line message safe to print to stderr at `canonry serve` boot. */
+  message: string
+  /** Skills missing from `~/.claude/skills/`. */
+  missing: BundledSkillName[]
+  /** Skills already installed there. */
+  installed: BundledSkillName[]
+}
+
+/**
+ * Mirrors the `agent.skills.installed` doctor check but returns a nudge
+ * payload instead of a check result. Returns null when:
+ *   - both skills are installed (nothing to nudge about), or
+ *   - $HOME is not set (cannot tell — silent rather than wrong).
+ *
+ * Caller is expected to print the message to stderr; this helper does no I/O.
+ */
+export function getMissingUserSkillsNudge(home: string | undefined = process.env.HOME): UserSkillsNudge | null {
+  if (!home) return null
+  const skillsBase = path.join(home, '.claude', 'skills')
+  const installed: BundledSkillName[] = []
+  const missing: BundledSkillName[] = []
+  for (const name of BUNDLED_SKILL_NAMES) {
+    const skillFile = path.join(skillsBase, name, 'SKILL.md')
+    if (existsSafe(skillFile)) installed.push(name)
+    else missing.push(name)
+  }
+
+  if (missing.length === 0) return null
+
+  const fix = missing.length === BUNDLED_SKILL_NAMES.length
+    ? 'canonry skills install --user'
+    : `canonry skills install ${missing.join(' ')} --user`
+  return {
+    message: `Tip: ${missing.join(' + ')} skill${missing.length === 1 ? '' : 's'} not installed in ~/.claude/skills/. Run \`${fix}\` so Claude/Codex sessions on this host auto-load the canonry reference docs.`,
+    missing,
+    installed,
+  }
+}
+
+function existsSafe(p: string): boolean {
+  try {
+    return fs.existsSync(p)
+  } catch {
+    return false
+  }
+}
+
 export function parseSkillsClient(value: string | undefined): SkillsClient {
   if (!value) return SkillsClients.all
   const parsed = skillsClientSchema.safeParse(value)

--- a/packages/canonry/test/skills-install.test.ts
+++ b/packages/canonry/test/skills-install.test.ts
@@ -7,6 +7,7 @@ import {
   BUNDLED_SKILL_NAMES,
   emitInstallSummary,
   getBundledSkills,
+  getMissingUserSkillsNudge,
   installSkills,
   listSkills,
   parseSkillsClient,
@@ -260,5 +261,50 @@ describe('installSkills --user shortcut', () => {
     } finally {
       fs.rmSync(decoy, { recursive: true, force: true })
     }
+  })
+})
+
+describe('getMissingUserSkillsNudge', () => {
+  let homeDir: string
+
+  beforeEach(() => {
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-skills-nudge-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(homeDir, { recursive: true, force: true })
+  })
+
+  function seedSkill(name: string): void {
+    const dir = path.join(homeDir, '.claude', 'skills', name)
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(path.join(dir, 'SKILL.md'), '---\nname: x\ndescription: y\n---\n', 'utf-8')
+  }
+
+  it('returns null when both bundled skills are installed', () => {
+    for (const name of BUNDLED_SKILL_NAMES) seedSkill(name)
+    expect(getMissingUserSkillsNudge(homeDir)).toBeNull()
+  })
+
+  it('returns a nudge listing every missing skill when none are installed', () => {
+    const nudge = getMissingUserSkillsNudge(homeDir)
+    expect(nudge).not.toBeNull()
+    expect(nudge!.missing.sort()).toEqual([...BUNDLED_SKILL_NAMES].sort())
+    expect(nudge!.installed).toEqual([])
+    expect(nudge!.message).toContain('canonry skills install --user')
+    expect(nudge!.message).toContain('~/.claude/skills/')
+  })
+
+  it('returns a tailored nudge that names only the missing skill when one is installed', () => {
+    seedSkill('canonry')
+    const nudge = getMissingUserSkillsNudge(homeDir)
+    expect(nudge).not.toBeNull()
+    expect(nudge!.installed).toEqual(['canonry'])
+    expect(nudge!.missing).toEqual(['aero'])
+    expect(nudge!.message).toContain('canonry skills install aero --user')
+  })
+
+  it('returns null when $HOME is undefined (can\'t safely tell)', () => {
+    expect(getMissingUserSkillsNudge(undefined)).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

PR #525 added a doctor check (\`agent.skills.installed\`) that flags missing user-level skill installs in \`~/.claude/skills/\`. But operators starting \`canonry serve\` on a fresh host rarely run doctor first — they discover the skills system only when they wonder why their Claude session can't recall canonry commands.

This adds a one-line stderr nudge at \`canonry serve\` boot when either bundled skill (\`canonry\` or \`aero\`) is missing:

\`\`\`
Tip: aero skill not installed in ~/.claude/skills/. Run \`canonry skills install aero --user\` so Claude/Codex sessions on this host auto-load the canonry reference docs.
\`\`\`

- New helper \`getMissingUserSkillsNudge(home?)\` — pure, no I/O side effects, returns null when both skills are installed or \`$HOME\` is unset (silent rather than wrong)
- \`serveCommand\` writes the message to **stderr** in text mode so it doesn't pollute stdout or interfere with JSON mode
- Tailored message: names the specific missing skill(s) and emits the exact \`canonry skills install [skill] --user\` command

## Test plan

- [x] \`getMissingUserSkillsNudge\` returns null when both skills present, full nudge when neither, tailored nudge when one is present, null when \$HOME is undefined
- [x] \`pnpm vitest run --project canonry --project api-routes\` — 1502/1502 pass
- [x] \`pnpm typecheck && pnpm lint\` clean

## Why nudge vs hard fail

The doctor check is the right place for a structured pass/warn/fail signal. The boot nudge is just discoverability — it points the operator at a 30-second fix without blocking. If the operator already ran skills install (or doesn't want it), the nudge silently disappears next boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)