### PR TITLE
fix(serve): require explicit home arg to getMissingUserSkillsNudge so the no-home test passes

### DIFF
--- a/packages/canonry/src/commands/serve.ts
+++ b/packages/canonry/src/commands/serve.ts
@@ -100,7 +100,7 @@ export async function serveCommand(format: CliFormat = 'text'): Promise<void> {
     } else {
       console.log(`\nCanonry server running at ${url}`)
       console.log('Press Ctrl+C to stop.\n')
-      const nudge = getMissingUserSkillsNudge()
+      const nudge = getMissingUserSkillsNudge(process.env.HOME)
       if (nudge) process.stderr.write(`${nudge.message}\n`)
     }
 

--- a/packages/canonry/src/commands/skills.ts
+++ b/packages/canonry/src/commands/skills.ts
@@ -331,7 +331,7 @@ export interface UserSkillsNudge {
  *
  * Caller is expected to print the message to stderr; this helper does no I/O.
  */
-export function getMissingUserSkillsNudge(home: string | undefined = process.env.HOME): UserSkillsNudge | null {
+export function getMissingUserSkillsNudge(home: string | null | undefined): UserSkillsNudge | null {
   if (!home) return null
   const skillsBase = path.join(home, '.claude', 'skills')
   const installed: BundledSkillName[] = []


### PR DESCRIPTION
## Why CI is red

Default-parameter trap in \`getMissingUserSkillsNudge\`:

\`\`\`typescript
// Before
export function getMissingUserSkillsNudge(
  home: string | undefined = process.env.HOME,
): UserSkillsNudge | null { ... }
\`\`\`

When the test invokes \`getMissingUserSkillsNudge(undefined)\`, the default kicks in and \`process.env.HOME\` is substituted. On a CI runner HOME is set but \`~/.claude/skills/\` is empty, so the function returns a real nudge — and the assertion \`toBeNull()\` fails.

The bug shipped in #531 and has been failing CI on main since then; local runs only pass because we already have \`~/.claude/skills/canonry\` + \`~/.claude/skills/aero\` installed locally.

## Fix

Drop the default. The caller (\`serve.ts\`) now passes \`process.env.HOME\` explicitly. The test's \`undefined\` argument now honors the no-home branch the docstring claims.

Two-line change.

## Test plan

- [x] \`pnpm vitest run --project canonry skills-install\` — 24/24 pass
- [x] \`pnpm typecheck && pnpm lint\` clean
- [x] Same behavior in production: \`serve.ts\` passes \`process.env.HOME\` which is always set on a real boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)