### PR TITLE
fix(web): project rename now propagates without a manual refresh

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -468,7 +468,7 @@ export function RootLayout() {
                     activeProps={{ className: 'sidebar-project sidebar-project-active' }}
                   >
                     <span className={`sidebar-dot sidebar-dot-${visibilityTone}`} />
-                    <span>{projectVm.project.name}</span>
+                    <span>{projectVm.project.displayName || projectVm.project.name}</span>
                   </Link>
                 )
               })}

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -1220,6 +1220,7 @@ export function ProjectPage({
   const { projectId } = useParams({ from: '/projects/$projectId' })
   const navigate = useNavigate()
   const { dashboard, isLoading, refetch } = useDashboard()
+  const queryClient = useQueryClient()
 
   if (!dashboard || isLoading) {
     return (
@@ -1523,7 +1524,12 @@ export function ProjectPage({
 
   async function handleUpdateProject(pName: string, updates: { displayName?: string; canonicalDomain?: string; ownedDomains?: string[]; aliases?: string[]; country?: string; language?: string; locations?: Array<{ label: string; city: string; region: string; country: string; timezone?: string }>; defaultLocation?: string | null }) {
     await apiUpdateProject(pName, updates)
-    void refetch()
+    // Invalidate the whole 'projects' branch (prefix match) so every consumer
+    // — sidebar, project page, per-project detail queries — refetches the new
+    // displayName before the user sees the next render. `refetch()` alone only
+    // covers the top-level lists; detail queries were keyed on run IDs and
+    // would silently hold the stale project object.
+    await queryClient.invalidateQueries({ queryKey: queryKeys.projects.all })
   }
 
   const isNumericScore = (value: string) => !Number.isNaN(Number.parseInt(value, 10))


### PR DESCRIPTION
## Two bugs

You changed the display name in Settings and (1) had to refresh manually, and (2) the sidebar kept showing the old name even after the refresh.

### 1. Sidebar reads the wrong field

\`App.tsx:471\` rendered \`{projectVm.project.name}\` — that's the immutable URL slug (\`ainyc\`), not the editable \`displayName\` (\`Canonry.ai\`). So no matter how many times you refreshed, the sidebar showed the slug.

### 2. \`handleUpdateProject\` is fire-and-forget

\`\`\`typescript
// Before
await apiUpdateProject(pName, updates)
void refetch()
\`\`\`

\`void refetch()\` doesn't wait. The function returns, the user sees the page render, and the dashboard cache is still stale. Worse: \`refetch()\` from \`useDashboard\` only covers the top-level \`projects.all\` / \`runs.all\` / \`settings\` queries. The **per-project detail queries** (keyed on run IDs) still held the cached project object, so even after refetch the rebuilt dashboard kept the old displayName.

## Fix

- Sidebar reads \`displayName || name\`
- Replace \`refetch()\` with \`await queryClient.invalidateQueries({ queryKey: queryKeys.projects.all })\`. React Query does prefix matching on query keys, so this invalidates every \`['projects', ...]\` entry — top-level list, per-project detail, queries, competitors, timeline — and every consumer refetches before the next render

Two-file change. \`pnpm typecheck && pnpm vitest run --project web && pnpm lint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)