### PR TITLE
fix(web): collapse GSC connection card to a one-line strip (reverts #539)

### DIFF
--- a/apps/web/src/components/project/GscSection.tsx
+++ b/apps/web/src/components/project/GscSection.tsx
@@ -525,6 +525,29 @@ export function GscSection({
 
   return (
     <section className="page-section-divider">
+      <div className="section-head section-head-inline">
+        <div>
+          <p className="eyebrow eyebrow-soft">Search Console</p>
+          <h2>Google Search Console</h2>
+        </div>
+        <div className="flex gap-1">
+          {GSC_WINDOWS.map(w => (
+            <button
+              key={w}
+              type="button"
+              className={`px-3 py-1 text-xs rounded-full border transition-colors ${
+                gscWindow === w
+                  ? 'bg-zinc-700 border-zinc-600 text-zinc-50'
+                  : 'border-zinc-800 text-zinc-400 hover:border-zinc-700 hover:text-zinc-300'
+              }`}
+              onClick={() => setGscWindow(w)}
+            >
+              {w === 'all' ? 'All' : w}
+            </button>
+          ))}
+        </div>
+      </div>
+
       {error && (
         <div className="mb-3 rounded-lg border border-rose-800/40 bg-rose-950/20 px-3 py-2 text-sm text-rose-300">
           {error}
@@ -970,29 +993,9 @@ export function GscSection({
                     <p className="eyebrow eyebrow-soft">Performance</p>
                     <h3>Search performance</h3>
                   </div>
-                  <div className="flex items-center gap-2">
-                    <div className="flex gap-1" role="tablist" aria-label="Performance window">
-                      {GSC_WINDOWS.map(w => (
-                        <button
-                          key={w}
-                          type="button"
-                          role="tab"
-                          aria-selected={gscWindow === w}
-                          className={`px-2.5 py-1 text-xs rounded-full border transition-colors ${
-                            gscWindow === w
-                              ? 'bg-zinc-700 border-zinc-600 text-zinc-50'
-                              : 'border-zinc-800 text-zinc-400 hover:border-zinc-700 hover:text-zinc-300'
-                          }`}
-                          onClick={() => setGscWindow(w)}
-                        >
-                          {w === 'all' ? 'All' : w}
-                        </button>
-                      ))}
-                    </div>
-                    <Button type="button" variant="outline" size="sm" disabled={loadingPerformance} onClick={() => { setPerformanceOffset(0); void loadPerformanceRows(0) }}>
-                      {loadingPerformance ? 'Loading\u2026' : 'Apply filters'}
-                    </Button>
-                  </div>
+                  <Button type="button" variant="outline" size="sm" disabled={loadingPerformance} onClick={() => { setPerformanceOffset(0); void loadPerformanceRows(0) }}>
+                    {loadingPerformance ? 'Loading\u2026' : 'Apply filters'}
+                  </Button>
                 </div>
 
                 {/* Clicks + Impressions bar chart */}

--- a/apps/web/src/components/project/GscSection.tsx
+++ b/apps/web/src/components/project/GscSection.tsx
@@ -565,47 +565,35 @@ export function GscSection({
         <p className="text-sm text-zinc-500">{'Loading\u2026'}</p>
       ) : (
         <div className="space-y-3">
-          <Card className="surface-card">
-            <div className="section-head section-head-inline">
-              <div>
-                <p className="eyebrow eyebrow-soft">Connection</p>
-                <h3>Domain authorization</h3>
-              </div>
-              <ToneBadge tone={gscConn ? 'positive' : googleConfigured ? 'caution' : 'negative'}>
-                {gscConn ? 'Connected' : googleConfigured ? 'Ready to connect' : 'App credentials missing'}
-              </ToneBadge>
+          {gscConn ? (
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 px-1 text-xs text-zinc-500">
+              <span className="flex items-center gap-1.5">
+                <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+                <span className="text-zinc-300">Authorized</span>
+              </span>
+              <span className="text-zinc-700">·</span>
+              <code className="text-zinc-400">{gscConn.domain}</code>
+              <span className="text-zinc-700">·</span>
+              <span>Last updated {formatTimestamp(gscConn.updatedAt)}</span>
+              <button
+                type="button"
+                className="ml-auto text-zinc-500 transition-colors hover:text-rose-400"
+                onClick={handleDisconnect}
+              >
+                Disconnect
+              </button>
             </div>
-            {gscConn ? (
-              <div className="mt-3 space-y-3">
-                <div className="rounded-lg border border-zinc-800/60 bg-zinc-900/30 px-4 py-3">
-                  <div className="flex items-center gap-3">
-                    <span className="h-2 w-2 rounded-full bg-emerald-500" />
-                    <span className="text-sm text-zinc-200">Authorized for this project domain</span>
-                    <span className="text-xs text-zinc-500">{gscConn.domain}</span>
-                    <button
-                      type="button"
-                      className="ml-auto text-xs text-zinc-500 hover:text-rose-400 transition-colors"
-                      onClick={handleDisconnect}
-                    >
-                      Disconnect
-                    </button>
-                  </div>
-                  <p className="mt-2 text-xs text-zinc-500">
-                    Canonry stores OAuth tokens per canonical domain. This project currently maps to <code>{gscConn.domain}</code>.
-                  </p>
+          ) : (
+            <Card className="surface-card">
+              <div className="section-head section-head-inline">
+                <div>
+                  <p className="eyebrow eyebrow-soft">Connection</p>
+                  <h3>Domain authorization</h3>
                 </div>
-                <div className="grid gap-3 lg:grid-cols-2">
-                  <div className="rounded-lg border border-zinc-800/60 bg-zinc-900/20 p-3">
-                    <p className="text-xs uppercase tracking-wide text-zinc-500">Selected property</p>
-                    <p className="mt-1 text-sm text-zinc-200">{gscConn.propertyId ?? 'No property selected yet'}</p>
-                  </div>
-                  <div className="rounded-lg border border-zinc-800/60 bg-zinc-900/20 p-3">
-                    <p className="text-xs uppercase tracking-wide text-zinc-500">Last auth update</p>
-                    <p className="mt-1 text-sm text-zinc-200">{formatTimestamp(gscConn.updatedAt)}</p>
-                  </div>
-                </div>
+                <ToneBadge tone={googleConfigured ? 'caution' : 'negative'}>
+                  {googleConfigured ? 'Ready to connect' : 'App credentials missing'}
+                </ToneBadge>
               </div>
-            ) : (
               <div className="mt-3 rounded-lg border border-zinc-800/60 bg-zinc-900/30 px-4 py-5">
                 <p className="text-sm text-zinc-300">
                   {googleConfigured
@@ -627,8 +615,8 @@ export function GscSection({
                   )}
                 </div>
               </div>
-            )}
-          </Card>
+            </Card>
+          )}
 
           {/* One-time sitemap prompt — shown when connected but no sitemap URL stored */}
           {gscConn && !gscConn.sitemapUrl && (


### PR DESCRIPTION
## Summary
- Reverts #539 — that PR removed the wrong header. The actual duplication was the inner *Connection / Domain authorization* card repeating info already shown in the parent *Search Engine Intelligence* tile (Connected status + selected property).
- Collapses the connected state to a single-line strip: `● Authorized · <domain> · Last updated <ts> · Disconnect`.
- Unconnected states keep the full card — that's the only OAuth gateway in the UI (`googleConnect('gsc')` has no other caller).

## Test plan
- [ ] Connected project: GSC tab shows only the slim strip with Disconnect, no duplicate property tile.
- [ ] Unconnected project with OAuth credentials configured: full card with "Connect Google Search Console" button still renders.
- [ ] Unconnected project without OAuth credentials: full card with "Open Settings" link still renders.
- [ ] Disconnect from the strip still works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)