### PR TITLE
ci: split validate into parallel jobs + cache tsbuildinfo

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,14 @@
+name: Setup canonry
+description: Install pnpm, Node, and project dependencies. Assumes the repo is already checked out.
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v4
+      with:
+        version: 10.28.2
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 22
+        cache: pnpm
+    - run: pnpm install --frozen-lockfile
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - '.github/workflows/ci.yml'
+      - '.github/actions/setup/action.yml'
       - '.dockerignore'
       - 'Dockerfile'
       - 'docker/**'
@@ -23,6 +24,7 @@ on:
     # without waiting until rebase-to-main.
     paths:
       - '.github/workflows/ci.yml'
+      - '.github/actions/setup/action.yml'
       - '.dockerignore'
       - 'Dockerfile'
       - 'docker/**'
@@ -37,27 +39,68 @@ on:
       - 'AGENTS.md'
 
 jobs:
-  validate:
+  typecheck:
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: ./.github/actions/setup
+      - name: Restore TypeScript incremental cache
+        uses: actions/cache@v4
         with:
-          version: 10.28.2
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
+          path: '**/*.tsbuildinfo'
+          key: tsbuildinfo-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.run_id }}
+          restore-keys: |
+            tsbuildinfo-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+            tsbuildinfo-${{ runner.os }}-
+      - run: pnpm run typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: pnpm run test
+
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
       - run: bash scripts/check-docs.sh
         name: Check documentation coverage (AGENTS.md per package)
-      - run: pnpm run typecheck
-      - run: pnpm run test
       - run: pnpm run lint
+
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
       - run: pnpm -r run build
         name: Build all packages (catches missing deps, bundler errors)
+
+  validate:
+    runs-on: ubuntu-latest
+    needs: [typecheck, test, lint, build]
+    if: always()
+    steps:
+      - name: Verify all validate jobs succeeded
+        run: |
+          if [ "${{ needs.typecheck.result }}" != "success" ] || \
+             [ "${{ needs.test.result }}" != "success" ] || \
+             [ "${{ needs.lint.result }}" != "success" ] || \
+             [ "${{ needs.build.result }}" != "success" ]; then
+            echo "One or more validate jobs failed"
+            exit 1
+          fi
+          echo "All validate jobs passed"
 
   docker-build:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ coverage/
 dist/
 .tmp/
 .zed
+*.tsbuildinfo
 # Web SPA build output (built by build-web.ts)
 packages/canonry/assets/web/
 # Build-time copies of skills from repo root (copied by copy-agent-assets.ts)

--- a/packages/canonry/tsup.config.ts
+++ b/packages/canonry/tsup.config.ts
@@ -11,7 +11,14 @@ export default defineConfig({
   platform: 'node',
   splitting: true,
   clean: true,
-  dts: { entry: { index: 'src/index.ts' } },
+  dts: {
+    entry: { index: 'src/index.ts' },
+    // tsup's DTS step invokes tsc internally; `incremental` inherited from
+    // tsconfig.base.json triggers TS5074 here because there's no emit target
+    // and no tsBuildInfoFile in this path. Force it off — typecheck still
+    // benefits from incremental via the standalone `tsc --noEmit` script.
+    compilerOptions: { incremental: false },
+  },
   // Real npm deps — keep as external (installed by end user)
   external: [
     'better-sqlite3',

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,6 +11,7 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "verbatimModuleSyntax": true,
-    "types": ["node"]
+    "types": ["node"],
+    "incremental": true
   }
 }


### PR DESCRIPTION
## Summary

- Splits the single sequential `validate` job (typecheck → test → lint → build, ~3:33 wall-clock on `ubuntu-latest`) into four parallel jobs, gated by a small `validate` summary job that preserves the existing branch-protection check name.
- Adds `.github/actions/setup` composite action so the four jobs don't duplicate pnpm + Node + install boilerplate.
- Enables TypeScript `incremental: true` in `tsconfig.base.json` and caches `**/*.tsbuildinfo` in the typecheck job (keyed off `pnpm-lock.yaml` + `github.run_id`, with restore-keys for fallback). Local typecheck dropped 10.1s → 4.3s warm.
- Expected CI wall-clock: ~2:20 cold cache (down from 3:33), with `test` (~1:43) as the new floor.

## Test plan

- [ ] First CI run on this PR succeeds and shows four parallel `typecheck` / `test` / `lint` / `build` jobs + a green `validate` summary
- [ ] Second CI run on this PR (after a no-op push) shows a tsbuildinfo cache hit and a faster `typecheck` step
- [ ] `docker-build` job still green and independent of the validate fan-out