### PR TITLE
feat(gsc): drive performance chart from daily aggregate endpoint

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,4 +1,4 @@
-import type { ErrorCode, GroundingSource, ProjectOverviewDto, ScheduleDto, NotificationDto, GscCoverageSummaryDto, GscCoverageSnapshotDto, IndexingRequestResultDto, MetricsWindow, GA4AiReferralHistoryEntry, GA4SessionHistoryEntry, GA4SocialReferralHistoryEntry, InsightDto, HealthSnapshotDto, ProjectReportDto, ReportAudience, RunKind, RunStatus, RunTrigger, RunErrorDto, CitationState, CitationVisibilityResponse, ComputedTransition, BacklinkSummaryDto, BacklinkDomainDto, BacklinkListResponse, BacklinkHistoryEntry, BacklinksInstallStatusDto, BacklinksInstallResultDto, CcAvailableRelease, CcCachedRelease, CcReleaseSyncDto, TrafficSourceDto, TrafficSourceDetailDto, TrafficSourceListResponse, TrafficStatusResponse, TrafficEventsResponse, TrafficConnectCloudRunRequest, TrafficConnectWordpressRequest, TrafficConnectVercelRequest, TrafficSyncResponse, DiscoveryRunRequest, DiscoverySessionDto, DiscoverySessionDetailDto, DiscoveryPromotePreview, DiscoveryPromoteRequest, DiscoveryPromoteResult } from '@ainyc/canonry-contracts'
+import type { ErrorCode, GroundingSource, ProjectOverviewDto, ScheduleDto, NotificationDto, GscCoverageSummaryDto, GscCoverageSnapshotDto, GscPerformanceDailyDto, IndexingRequestResultDto, MetricsWindow, GA4AiReferralHistoryEntry, GA4SessionHistoryEntry, GA4SocialReferralHistoryEntry, InsightDto, HealthSnapshotDto, ProjectReportDto, ReportAudience, RunKind, RunStatus, RunTrigger, RunErrorDto, CitationState, CitationVisibilityResponse, ComputedTransition, BacklinkSummaryDto, BacklinkDomainDto, BacklinkListResponse, BacklinkHistoryEntry, BacklinksInstallStatusDto, BacklinksInstallResultDto, CcAvailableRelease, CcCachedRelease, CcReleaseSyncDto, TrafficSourceDto, TrafficSourceDetailDto, TrafficSourceListResponse, TrafficStatusResponse, TrafficEventsResponse, TrafficConnectCloudRunRequest, TrafficConnectWordpressRequest, TrafficConnectVercelRequest, TrafficSyncResponse, DiscoveryRunRequest, DiscoverySessionDto, DiscoverySessionDetailDto, DiscoveryPromotePreview, DiscoveryPromoteRequest, DiscoveryPromoteResult } from '@ainyc/canonry-contracts'
 export type { ProjectOverviewDto }
 export type { BacklinkSummaryDto, BacklinkDomainDto, BacklinkListResponse, BacklinkHistoryEntry, BacklinksInstallStatusDto, BacklinksInstallResultDto, CcAvailableRelease, CcCachedRelease, CcReleaseSyncDto }
 export type { TrafficSourceDto, TrafficSourceDetailDto, TrafficSourceListResponse, TrafficStatusResponse, TrafficEventsResponse, TrafficConnectCloudRunRequest, TrafficConnectWordpressRequest, TrafficConnectVercelRequest, TrafficSyncResponse }
@@ -747,6 +747,18 @@ export function fetchGscPerformance(
   if (params?.offset !== undefined && params.offset > 0) qs.set('offset', String(params.offset))
   const query = qs.toString() ? `?${qs.toString()}` : ''
   return apiFetch(`/projects/${encodeURIComponent(project)}/google/gsc/performance${query}`)
+}
+
+export function fetchGscPerformanceDaily(
+  project: string,
+  params?: { startDate?: string; endDate?: string; window?: MetricsWindow },
+): Promise<GscPerformanceDailyDto> {
+  const qs = new URLSearchParams()
+  if (params?.startDate) qs.set('startDate', params.startDate)
+  if (params?.endDate) qs.set('endDate', params.endDate)
+  if (params?.window && params.window !== 'all' && !params.startDate) qs.set('window', params.window)
+  const query = qs.toString() ? `?${qs.toString()}` : ''
+  return apiFetch(`/projects/${encodeURIComponent(project)}/google/gsc/performance/daily${query}`)
 }
 
 export function inspectGscUrl(project: string, url: string): Promise<ApiGscInspection> {

--- a/apps/web/src/components/project/GscSection.tsx
+++ b/apps/web/src/components/project/GscSection.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import { useQueryClient } from '@tanstack/react-query'
-import type { MetricsWindow } from '@ainyc/canonry-contracts'
+import type { GscPerformanceDailyDto, MetricsWindow } from '@ainyc/canonry-contracts'
 
 import { Button } from '../ui/button.js'
 import { Card } from '../ui/card.js'
@@ -16,6 +16,7 @@ import {
   googleDisconnect,
   saveGoogleProperty,
   fetchGscPerformance,
+  fetchGscPerformanceDaily,
   inspectGscUrl,
   fetchGscInspections,
   fetchGscDeindexed,
@@ -55,6 +56,7 @@ export function GscSection({
   const [connections, setConnections] = useState<ApiGoogleConnection[]>([])
   const [properties, setProperties] = useState<ApiGoogleProperty[]>([])
   const [performance, setPerformance] = useState<ApiGscPerformanceRow[]>([])
+  const [performanceDaily, setPerformanceDaily] = useState<GscPerformanceDailyDto | null>(null)
   const [inspections, setInspections] = useState<ApiGscInspection[]>([])
   const [deindexed, setDeindexed] = useState<ApiGscDeindexedRow[]>([])
   const [inspectionResult, setInspectionResult] = useState<ApiGscInspection | null>(null)
@@ -199,6 +201,28 @@ export function GscSection({
       setError(err instanceof Error ? err.message : 'Failed to load GSC performance data')
     } finally {
       setLoadingPerformance(false)
+    }
+  }
+
+  async function loadPerformanceDaily() {
+    try {
+      const filters = {
+        startDate: performanceFilters.startDate,
+        endDate: performanceFilters.endDate,
+        window: gscWindow,
+      }
+      const data = await queryClient.fetchQuery({
+        queryKey: queryKeys.gsc.performanceDaily(projectName, filters),
+        queryFn: () => fetchGscPerformanceDaily(projectName, {
+          startDate: performanceFilters.startDate || undefined,
+          endDate: performanceFilters.endDate || undefined,
+          window: gscWindow,
+        }),
+        staleTime: GSC_STALE_MS,
+      })
+      setPerformanceDaily(data)
+    } catch {
+      setPerformanceDaily(null)
     }
   }
 
@@ -379,6 +403,7 @@ export function GscSection({
       await Promise.all([
         loadProperties(currentConn),
         loadPerformanceRows(),
+        loadPerformanceDaily(),
         loadInspectionHistory(),
         loadCoverage(),
       ])
@@ -396,6 +421,7 @@ export function GscSection({
   useEffect(() => {
     setPerformanceOffset(0)
     void loadPerformanceRows(0)
+    void loadPerformanceDaily()
   }, [gscWindow])
 
   // Refetch when sort toggles between "off" and "on" so the fetched row set
@@ -529,22 +555,6 @@ export function GscSection({
         <div>
           <p className="eyebrow eyebrow-soft">Search Console</p>
           <h2>Google Search Console</h2>
-        </div>
-        <div className="flex gap-1">
-          {GSC_WINDOWS.map(w => (
-            <button
-              key={w}
-              type="button"
-              className={`px-3 py-1 text-xs rounded-full border transition-colors ${
-                gscWindow === w
-                  ? 'bg-zinc-700 border-zinc-600 text-zinc-50'
-                  : 'border-zinc-800 text-zinc-400 hover:border-zinc-700 hover:text-zinc-300'
-              }`}
-              onClick={() => setGscWindow(w)}
-            >
-              {w === 'all' ? 'All' : w}
-            </button>
-          ))}
         </div>
       </div>
 
@@ -981,29 +991,38 @@ export function GscSection({
                     <p className="eyebrow eyebrow-soft">Performance</p>
                     <h3>Search performance</h3>
                   </div>
-                  <Button type="button" variant="outline" size="sm" disabled={loadingPerformance} onClick={() => { setPerformanceOffset(0); void loadPerformanceRows(0) }}>
-                    {loadingPerformance ? 'Loading\u2026' : 'Apply filters'}
-                  </Button>
+                  <div className="flex items-center gap-2">
+                    <div className="flex gap-1" role="tablist" aria-label="Performance window">
+                      {GSC_WINDOWS.map(w => (
+                        <button
+                          key={w}
+                          type="button"
+                          role="tab"
+                          aria-selected={gscWindow === w}
+                          className={`px-2.5 py-1 text-xs rounded-full border transition-colors ${
+                            gscWindow === w
+                              ? 'bg-zinc-700 border-zinc-600 text-zinc-50'
+                              : 'border-zinc-800 text-zinc-400 hover:border-zinc-700 hover:text-zinc-300'
+                          }`}
+                          onClick={() => setGscWindow(w)}
+                        >
+                          {w === 'all' ? 'All' : w}
+                        </button>
+                      ))}
+                    </div>
+                    <Button type="button" variant="outline" size="sm" disabled={loadingPerformance} onClick={() => { setPerformanceOffset(0); void loadPerformanceRows(0); void loadPerformanceDaily() }}>
+                      {loadingPerformance ? 'Loading\u2026' : 'Apply filters'}
+                    </Button>
+                  </div>
                 </div>
 
-                {/* Clicks + Impressions bar chart */}
-                {performance.length > 0 && (() => {
-                  const byDate = new Map<string, { clicks: number; impressions: number }>()
-                  for (const row of performance) {
-                    const existing = byDate.get(row.date)
-                    if (existing) {
-                      existing.clicks += row.clicks
-                      existing.impressions += row.impressions
-                    } else {
-                      byDate.set(row.date, { clicks: row.clicks, impressions: row.impressions })
-                    }
-                  }
-                  const sorted = [...byDate.entries()].sort(([a], [b]) => a.localeCompare(b))
-                  if (sorted.length === 0) return null
-                  const maxImpressions = Math.max(...sorted.map(([, d]) => d.impressions), 1)
-                  const totalClicks = sorted.reduce((sum, [, d]) => sum + d.clicks, 0)
-                  const totalImpressions = sorted.reduce((sum, [, d]) => sum + d.impressions, 0)
-                  const avgCtr = totalImpressions > 0 ? ((totalClicks / totalImpressions) * 100).toFixed(1) : '0.0'
+                {/* Clicks + Impressions bar chart — driven by the daily aggregate
+                    endpoint so it reflects the full window, not the current page. */}
+                {performanceDaily && performanceDaily.daily.length > 0 && (() => {
+                  const sorted = performanceDaily.daily
+                  const maxImpressions = Math.max(...sorted.map((d) => d.impressions), 1)
+                  const { clicks: totalClicks, impressions: totalImpressions, ctr: totalCtr } = performanceDaily.totals
+                  const avgCtr = (totalCtr * 100).toFixed(1)
 
                   const w = 700
                   const h = 220
@@ -1053,13 +1072,13 @@ export function GscSection({
                             )
                           })}
                           {/* Bars */}
-                          {sorted.map(([date, d], i) => {
+                          {sorted.map((d, i) => {
                             const cx = pad.left + barGroupW * i + barGroupW / 2
                             const impressionH = (d.impressions / ceilVal) * plotH
                             const clickH = (d.clicks / ceilVal) * plotH
                             return (
-                              <g key={date}>
-                                <title>{`${date}\nClicks: ${d.clicks}\nImpressions: ${d.impressions}\nCTR: ${d.impressions > 0 ? ((d.clicks / d.impressions) * 100).toFixed(1) : 0}%`}</title>
+                              <g key={d.date}>
+                                <title>{`${d.date}\nClicks: ${d.clicks}\nImpressions: ${d.impressions}\nCTR: ${(d.ctr * 100).toFixed(1)}%`}</title>
                                 <rect
                                   x={cx - barW - barGap / 2}
                                   y={pad.top + plotH - impressionH}
@@ -1089,7 +1108,7 @@ export function GscSection({
                               const cx = pad.left + barGroupW * idx + barGroupW / 2
                               return (
                                 <text key={`xl-${idx}`} x={cx} y={h - 8} textAnchor="middle" fill="#71717a" fontSize="10" fontFamily="inherit">
-                                  {sorted[idx]![0].slice(5)}
+                                  {sorted[idx]!.date.slice(5)}
                                 </text>
                               )
                             })

--- a/apps/web/src/queries/query-keys.ts
+++ b/apps/web/src/queries/query-keys.ts
@@ -17,6 +17,7 @@ export const queryKeys = {
     connections: (project: string) => ['gsc', project, 'connections'] as const,
     properties: (project: string) => ['gsc', project, 'properties'] as const,
     performance: (project: string, filters?: Record<string, string>) => ['gsc', project, 'performance', filters] as const,
+    performanceDaily: (project: string, filters?: Record<string, string>) => ['gsc', project, 'performance-daily', filters] as const,
     inspections: (project: string, url?: string) => ['gsc', project, 'inspections', url] as const,
     deindexed: (project: string) => ['gsc', project, 'deindexed'] as const,
     coverage: (project: string) => ['gsc', project, 'coverage'] as const,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.40.0",
+  "version": "4.41.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/google.ts
+++ b/packages/api-routes/src/google.ts
@@ -450,6 +450,55 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
     }))
   })
 
+  // GET /projects/:name/google/gsc/performance/daily
+  // Returns one row per date with clicks + impressions summed across every
+  // (query, page, country, device) tuple in the window, plus window totals.
+  // The chart and headline metrics in the dashboard render from this — never
+  // recomputed from the paged /performance rows, which only cover one page.
+  app.get<{
+    Params: { name: string }
+    Querystring: { startDate?: string; endDate?: string; window?: string }
+  }>('/projects/:name/google/gsc/performance/daily', async (request) => {
+    const project = resolveProject(app.db, request.params.name)
+    const { startDate, endDate } = request.query
+    const cutoffDate = !startDate ? windowCutoff(parseWindow(request.query.window))?.slice(0, 10) ?? null : null
+
+    const conditions = [eq(gscSearchData.projectId, project.id)]
+    if (startDate) conditions.push(sql`${gscSearchData.date} >= ${startDate}`)
+    else if (cutoffDate) conditions.push(sql`${gscSearchData.date} >= ${cutoffDate}`)
+    if (endDate) conditions.push(sql`${gscSearchData.date} <= ${endDate}`)
+
+    const rows = app.db
+      .select({
+        date: gscSearchData.date,
+        clicks: sql<number>`COALESCE(SUM(${gscSearchData.clicks}), 0)`,
+        impressions: sql<number>`COALESCE(SUM(${gscSearchData.impressions}), 0)`,
+      })
+      .from(gscSearchData)
+      .where(and(...conditions))
+      .groupBy(gscSearchData.date)
+      .orderBy(gscSearchData.date)
+      .all()
+
+    const daily = rows.map((r) => ({
+      date: r.date,
+      clicks: r.clicks,
+      impressions: r.impressions,
+      ctr: r.impressions > 0 ? r.clicks / r.impressions : 0,
+    }))
+    const totalClicks = daily.reduce((sum, d) => sum + d.clicks, 0)
+    const totalImpressions = daily.reduce((sum, d) => sum + d.impressions, 0)
+    return {
+      totals: {
+        clicks: totalClicks,
+        impressions: totalImpressions,
+        ctr: totalImpressions > 0 ? totalClicks / totalImpressions : 0,
+        days: daily.length,
+      },
+      daily,
+    }
+  })
+
   // POST /projects/:name/google/gsc/inspect
   app.post<{
     Params: { name: string }

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -1456,6 +1456,22 @@ const routeCatalog: OpenApiOperation[] = [
     },
   },
   {
+    method: 'get',
+    path: '/api/v1/projects/{name}/google/gsc/performance/daily',
+    summary: 'Get GSC performance aggregated by day with window totals',
+    tags: ['google'],
+    parameters: [
+      nameParameter,
+      { name: 'startDate', in: 'query', description: 'Filter by start date.', schema: stringSchema },
+      { name: 'endDate', in: 'query', description: 'Filter by end date.', schema: stringSchema },
+      analyticsWindowParameter,
+    ],
+    responses: {
+      200: { description: 'Daily aggregate (date → clicks/impressions/ctr) plus window totals.' },
+      404: { description: 'Project not found.' },
+    },
+  },
+  {
     method: 'post',
     path: '/api/v1/projects/{name}/google/gsc/inspect',
     summary: 'Inspect a URL through Google Search Console',

--- a/packages/api-routes/test/google.test.ts
+++ b/packages/api-routes/test/google.test.ts
@@ -1341,3 +1341,160 @@ describe('googleRoutes: GET /projects/:name/google/gsc/performance offset pagina
     expect(garbageRows.map(r => r.date)).toEqual(['2026-01-06', '2026-01-05'])
   })
 })
+
+describe('googleRoutes: GET /projects/:name/google/gsc/performance/daily', () => {
+  let context: ReturnType<typeof buildApp>
+  let projectId: string
+
+  beforeEach(async () => {
+    context = buildApp({ googleClientId: 'cid', googleClientSecret: 'csec' })
+    await context.app.ready()
+    projectId = crypto.randomUUID()
+    const now = '2026-01-01T00:00:00.000Z'
+    context.db.insert(projects).values({
+      id: projectId,
+      name: 'perf',
+      displayName: 'Perf',
+      canonicalDomain: 'perf.example.com',
+      country: 'US',
+      language: 'en',
+      createdAt: now,
+      updatedAt: now,
+    }).run()
+    const syncRunId = crypto.randomUUID()
+    context.db.insert(runs).values({
+      id: syncRunId,
+      projectId,
+      kind: 'gsc-sync',
+      status: 'completed',
+      trigger: 'manual',
+      createdAt: now,
+    }).run()
+    // Seed multiple (query, page) tuples per day so the daily endpoint has
+    // something real to aggregate. Two days, three tuples each.
+    const seed = [
+      { date: '2026-01-05', query: 'a', page: '/a', clicks: 2, impressions: 100 },
+      { date: '2026-01-05', query: 'b', page: '/b', clicks: 3, impressions: 200 },
+      { date: '2026-01-05', query: 'c', page: '/c', clicks: 5, impressions: 50 },
+      { date: '2026-01-06', query: 'a', page: '/a', clicks: 4, impressions: 200 },
+      { date: '2026-01-06', query: 'b', page: '/b', clicks: 1, impressions: 100 },
+      { date: '2026-01-06', query: 'c', page: '/c', clicks: 5, impressions: 700 },
+    ]
+    for (const row of seed) {
+      context.db.insert(gscSearchData).values({
+        id: crypto.randomUUID(),
+        projectId,
+        syncRunId,
+        date: row.date,
+        query: row.query,
+        page: row.page,
+        country: 'usa',
+        device: 'DESKTOP',
+        impressions: row.impressions,
+        clicks: row.clicks,
+        ctr: row.impressions > 0 ? String(row.clicks / row.impressions) : '0',
+        position: '5',
+        createdAt: now,
+      }).run()
+    }
+  })
+
+  afterEach(async () => {
+    await context.app.close()
+    fs.rmSync(context.tmpDir, { recursive: true, force: true })
+  })
+
+  it('sums clicks + impressions per date and computes CTR from the sums (not an average of row CTRs)', async () => {
+    const res = await context.app.inject({
+      method: 'GET',
+      url: '/projects/perf/google/gsc/performance/daily',
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as { totals: { clicks: number; impressions: number; ctr: number; days: number }; daily: Array<{ date: string; clicks: number; impressions: number; ctr: number }> }
+
+    // Daily rows ordered by date asc
+    expect(body.daily.map(d => d.date)).toEqual(['2026-01-05', '2026-01-06'])
+
+    // 2026-01-05: 2+3+5=10 clicks, 100+200+50=350 impressions, CTR = 10/350
+    expect(body.daily[0]).toEqual({ date: '2026-01-05', clicks: 10, impressions: 350, ctr: 10 / 350 })
+    // 2026-01-06: 4+1+5=10 clicks, 200+100+700=1000 impressions, CTR = 10/1000 = 0.01
+    expect(body.daily[1]).toEqual({ date: '2026-01-06', clicks: 10, impressions: 1000, ctr: 0.01 })
+
+    // Window totals: aggregate of all rows, NOT averaged from per-day CTRs
+    // Total clicks 20, total impressions 1350, ctr = 20/1350 (not (10/350 + 10/1000) / 2)
+    expect(body.totals).toEqual({ clicks: 20, impressions: 1350, ctr: 20 / 1350, days: 2 })
+    // Sanity: averaged per-day CTR would be ~0.019, the bug we're protecting against
+    expect(body.totals.ctr).not.toBeCloseTo((10 / 350 + 10 / 1000) / 2, 5)
+  })
+
+  it('filters by the window param using windowCutoff', async () => {
+    // Add a stale row from before the 7d cutoff
+    const oldDate = new Date()
+    oldDate.setDate(oldDate.getDate() - 30)
+    context.db.insert(gscSearchData).values({
+      id: crypto.randomUUID(),
+      projectId,
+      syncRunId: context.db.select({ id: runs.id }).from(runs).all()[0]!.id,
+      date: oldDate.toISOString().slice(0, 10),
+      query: 'stale',
+      page: '/stale',
+      country: 'usa',
+      device: 'DESKTOP',
+      impressions: 999_999,
+      clicks: 999,
+      ctr: '0.001',
+      position: '50',
+      createdAt: '2025-12-01T00:00:00.000Z',
+    }).run()
+
+    // Add a fresh row that should pass the 7d cutoff
+    const freshDate = new Date().toISOString().slice(0, 10)
+    context.db.insert(gscSearchData).values({
+      id: crypto.randomUUID(),
+      projectId,
+      syncRunId: context.db.select({ id: runs.id }).from(runs).all()[0]!.id,
+      date: freshDate,
+      query: 'fresh',
+      page: '/fresh',
+      country: 'usa',
+      device: 'DESKTOP',
+      impressions: 50,
+      clicks: 5,
+      ctr: '0.1',
+      position: '3',
+      createdAt: '2026-05-15T00:00:00.000Z',
+    }).run()
+
+    const res = await context.app.inject({
+      method: 'GET',
+      url: '/projects/perf/google/gsc/performance/daily?window=7d',
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as { totals: { clicks: number; days: number }; daily: Array<{ date: string; clicks: number }> }
+
+    // Only the fresh row should be in the window; the stale row and the 2026-01-* seeds are excluded
+    expect(body.daily.map(d => d.date)).toEqual([freshDate])
+    expect(body.totals.clicks).toBe(5)
+    expect(body.totals.days).toBe(1)
+  })
+
+  it('returns zero totals and empty daily array when no rows match the window', async () => {
+    const res = await context.app.inject({
+      method: 'GET',
+      url: '/projects/perf/google/gsc/performance/daily?startDate=2030-01-01',
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({
+      totals: { clicks: 0, impressions: 0, ctr: 0, days: 0 },
+      daily: [],
+    })
+  })
+
+  it('returns 404 for an unknown project', async () => {
+    const res = await context.app.inject({
+      method: 'GET',
+      url: '/projects/nope/google/gsc/performance/daily',
+    })
+    expect(res.statusCode).toBe(404)
+  })
+})

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.40.0",
+  "version": "4.41.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/cli-commands/google.ts
+++ b/packages/canonry/src/cli-commands/google.ts
@@ -10,6 +10,7 @@ import {
   googleInspections,
   googleListSitemaps,
   googlePerformance,
+  googlePerformanceDaily,
   googleProperties,
   googleRefresh,
   googleRequestIndexing,
@@ -158,6 +159,24 @@ export const GOOGLE_CLI_COMMANDS: readonly CliCommandSpec[] = [
     },
   },
   {
+    path: ['google', 'performance-daily'],
+    usage: 'canonry google performance-daily <project> [--window 7d|30d|90d|all] [--start <YYYY-MM-DD>] [--end <YYYY-MM-DD>] [--format json]',
+    options: {
+      window: stringOption(),
+      start: stringOption(),
+      end: stringOption(),
+    },
+    run: async (input) => {
+      const project = requireProject(input, 'google.performance-daily', 'canonry google performance-daily <project> [--window 7d|30d|90d|all] [--start <YYYY-MM-DD>] [--end <YYYY-MM-DD>] [--format json]')
+      await googlePerformanceDaily(project, {
+        window: getString(input.values, 'window'),
+        startDate: getString(input.values, 'start'),
+        endDate: getString(input.values, 'end'),
+        format: input.format,
+      })
+    },
+  },
+  {
     path: ['google', 'inspect'],
     usage: 'canonry google inspect <project> <url> [--format json]',
     run: async (input) => {
@@ -286,12 +305,12 @@ export const GOOGLE_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['google'],
-    usage: 'canonry google <connect|disconnect|status|properties|set-property|set-sitemap|list-sitemaps|discover-sitemaps|sync|performance|inspect|inspect-sitemap|coverage|coverage-history|inspections|deindexed|request-indexing|refresh> <project> [args]',
+    usage: 'canonry google <connect|disconnect|status|properties|set-property|set-sitemap|list-sitemaps|discover-sitemaps|sync|performance|performance-daily|inspect|inspect-sitemap|coverage|coverage-history|inspections|deindexed|request-indexing|refresh> <project> [args]',
     run: async (input) => {
       unknownSubcommand(input.positionals[0], {
         command: 'google',
-        usage: 'canonry google <connect|disconnect|status|properties|set-property|set-sitemap|list-sitemaps|discover-sitemaps|sync|performance|inspect|inspect-sitemap|coverage|coverage-history|inspections|deindexed|request-indexing|refresh> <project> [args]',
-        available: ['connect', 'disconnect', 'status', 'properties', 'set-property', 'set-sitemap', 'list-sitemaps', 'discover-sitemaps', 'sync', 'performance', 'inspect', 'inspect-sitemap', 'coverage', 'coverage-history', 'inspections', 'deindexed', 'request-indexing', 'refresh'],
+        usage: 'canonry google <connect|disconnect|status|properties|set-property|set-sitemap|list-sitemaps|discover-sitemaps|sync|performance|performance-daily|inspect|inspect-sitemap|coverage|coverage-history|inspections|deindexed|request-indexing|refresh> <project> [args]',
+        available: ['connect', 'disconnect', 'status', 'properties', 'set-property', 'set-sitemap', 'list-sitemaps', 'discover-sitemaps', 'sync', 'performance', 'performance-daily', 'inspect', 'inspect-sitemap', 'coverage', 'coverage-history', 'inspections', 'deindexed', 'request-indexing', 'refresh'],
       })
     },
   },

--- a/packages/canonry/src/client.ts
+++ b/packages/canonry/src/client.ts
@@ -40,6 +40,7 @@ import type {
   AuditLogEntry,
   GoogleConnectionDto,
   GscSearchDataDto,
+  GscPerformanceDailyDto,
   GscUrlInspectionDto,
   GscCoverageSummaryDto,
   GscCoverageSnapshotDto,
@@ -680,6 +681,11 @@ export class ApiClient {
   async gscPerformance(project: string, params?: Record<string, string>): Promise<GscSearchDataDto[]> {
     const qs = params ? '?' + new URLSearchParams(params).toString() : ''
     return this.request<GscSearchDataDto[]>('GET', `/projects/${encodeURIComponent(project)}/google/gsc/performance${qs}`)
+  }
+
+  async gscPerformanceDaily(project: string, params?: Record<string, string>): Promise<GscPerformanceDailyDto> {
+    const qs = params ? '?' + new URLSearchParams(params).toString() : ''
+    return this.request<GscPerformanceDailyDto>('GET', `/projects/${encodeURIComponent(project)}/google/gsc/performance/daily${qs}`)
   }
 
   async gscInspect(project: string, url: string): Promise<GscUrlInspectionDto> {

--- a/packages/canonry/src/commands/google.ts
+++ b/packages/canonry/src/commands/google.ts
@@ -235,6 +235,45 @@ export async function googleSync(project: string, opts: {
   }
 }
 
+export async function googlePerformanceDaily(project: string, opts: {
+  window?: string
+  startDate?: string
+  endDate?: string
+  format?: string
+}): Promise<void> {
+  const client = getClient()
+  const params: Record<string, string> = {}
+  if (opts.window) params.window = opts.window
+  if (opts.startDate) params.startDate = opts.startDate
+  if (opts.endDate) params.endDate = opts.endDate
+
+  const data = await client.gscPerformanceDaily(project, Object.keys(params).length > 0 ? params : undefined)
+
+  if (opts.format === 'json') {
+    console.log(JSON.stringify(data, null, 2))
+    return
+  }
+
+  if (data.daily.length === 0) {
+    console.log('No GSC data found in this window. Run "canonry google sync" first.')
+    return
+  }
+
+  const { clicks, impressions, ctr, days } = data.totals
+  console.log(`GSC daily summary (${days} day${days === 1 ? '' : 's'}):\n`)
+  console.log(`  Clicks:      ${clicks.toLocaleString()}`)
+  console.log(`  Impressions: ${impressions.toLocaleString()}`)
+  console.log(`  CTR:         ${(ctr * 100).toFixed(2)}%`)
+  console.log()
+  console.log(`  ${'DATE'.padEnd(12)}${'CLICKS'.padStart(10)}${'IMPR'.padStart(12)}${'CTR'.padStart(10)}`)
+  console.log(`  ${'─'.repeat(12)}${'─'.repeat(10)}${'─'.repeat(12)}${'─'.repeat(10)}`)
+  for (const row of data.daily) {
+    console.log(
+      `  ${row.date.padEnd(12)}${row.clicks.toLocaleString().padStart(10)}${row.impressions.toLocaleString().padStart(12)}${(row.ctr * 100).toFixed(2).padStart(9)}%`,
+    )
+  }
+}
+
 export async function googlePerformance(project: string, opts: {
   days?: number
   keyword?: string

--- a/packages/canonry/src/mcp/openapi-classification.ts
+++ b/packages/canonry/src/mcp/openapi-classification.ts
@@ -75,6 +75,7 @@ export const MCP_OPENAPI_OPERATION_CLASSIFICATIONS = {
   'PUT /api/v1/projects/{name}/google/connections/{type}/sitemap': 'deferred',
   'POST /api/v1/projects/{name}/google/gsc/sync': 'deferred',
   'GET /api/v1/projects/{name}/google/gsc/performance': 'included',
+  'GET /api/v1/projects/{name}/google/gsc/performance/daily': 'included',
   'POST /api/v1/projects/{name}/google/gsc/inspect': 'deferred',
   'GET /api/v1/projects/{name}/google/gsc/inspections': 'included',
   'GET /api/v1/projects/{name}/google/gsc/deindexed': 'included',

--- a/packages/canonry/src/mcp/tool-registry.ts
+++ b/packages/canonry/src/mcp/tool-registry.ts
@@ -134,6 +134,13 @@ const gscPerformanceInputSchema = z.object({
   window: analyticsWindowSchema.optional(),
 })
 
+const gscPerformanceDailyInputSchema = z.object({
+  project: projectNameSchema,
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+  window: analyticsWindowSchema.optional(),
+})
+
 const gscInspectionsInputSchema = z.object({
   project: projectNameSchema,
   url: z.string().optional(),
@@ -714,6 +721,17 @@ export const canonryMcpTools = [
     annotations: readAnnotations(),
     openApiOperations: ['GET /api/v1/projects/{name}/google/gsc/performance'],
     handler: (client, input) => client.gscPerformance(input.project, compactStringParams(input, ['startDate', 'endDate', 'query', 'page', 'limit', 'window'])),
+  }),
+  defineTool({
+    name: 'canonry_gsc_performance_daily',
+    title: 'Get GSC daily performance summary',
+    description: 'Get GSC search performance aggregated by date with window totals (clicks, impressions, CTR). Use this for charts and headline metrics — never recompute by summing the paged canonry_gsc_performance rows, which only cover one page.',
+    access: 'read',
+    tier: 'gsc',
+    inputSchema: gscPerformanceDailyInputSchema,
+    annotations: readAnnotations(),
+    openApiOperations: ['GET /api/v1/projects/{name}/google/gsc/performance/daily'],
+    handler: (client, input) => client.gscPerformanceDaily(input.project, compactStringParams(input, ['startDate', 'endDate', 'window'])),
   }),
   defineTool({
     name: 'canonry_gsc_inspections',

--- a/packages/canonry/test/mcp-registry.test.ts
+++ b/packages/canonry/test/mcp-registry.test.ts
@@ -48,6 +48,7 @@ const expectedToolNames = [
   'canonry_settings_get',
   'canonry_google_connections_list',
   'canonry_gsc_performance',
+  'canonry_gsc_performance_daily',
   'canonry_gsc_inspections',
   'canonry_gsc_deindexed',
   'canonry_gsc_coverage',
@@ -103,8 +104,8 @@ const expectedToolNames = [
 
 describe('MCP tool registry', () => {
   it('ships the curated v1 surface', () => {
-    expect(CANONRY_MCP_TOOL_COUNT).toBe(83)
-    expect(CANONRY_MCP_READ_TOOL_COUNT).toBe(54)
+    expect(CANONRY_MCP_TOOL_COUNT).toBe(84)
+    expect(CANONRY_MCP_READ_TOOL_COUNT).toBe(55)
     expect(canonryMcpTools.map(tool => tool.name)).toEqual(expectedToolNames)
     const readNames = canonryMcpTools.filter(tool => tool.access === 'read').map(tool => tool.name)
     expect(getCanonryMcpTools('read-only').map(tool => tool.name)).toEqual(readNames)
@@ -142,7 +143,7 @@ describe('MCP tool registry', () => {
     }
     expect(counts.get('monitoring')).toBe(16)
     expect(counts.get('setup')).toBe(23)
-    expect(counts.get('gsc')).toBe(7)
+    expect(counts.get('gsc')).toBe(8)
     expect(counts.get('ga')).toBe(8)
     expect(counts.get('traffic')).toBe(9)
     expect(counts.get('agent')).toBe(5)
@@ -477,6 +478,7 @@ const handlerCases: HandlerCase[] = [
   { tool: 'canonry_settings_get', input: {}, methods: ['getSettings'] },
   { tool: 'canonry_google_connections_list', input: projectInput, methods: ['googleConnections'] },
   { tool: 'canonry_gsc_performance', input: { project: 'acme', window: '30d' }, methods: ['gscPerformance'] },
+  { tool: 'canonry_gsc_performance_daily', input: { project: 'acme', window: '30d' }, methods: ['gscPerformanceDaily'] },
   { tool: 'canonry_gsc_inspections', input: { project: 'acme', limit: 5 }, methods: ['gscInspections'] },
   { tool: 'canonry_gsc_deindexed', input: projectInput, methods: ['gscDeindexed'] },
   { tool: 'canonry_gsc_coverage', input: projectInput, methods: ['gscCoverage'] },

--- a/packages/canonry/test/mcp-stdio.test.ts
+++ b/packages/canonry/test/mcp-stdio.test.ts
@@ -171,8 +171,8 @@ describe('canonry-mcp stdio', () => {
     await client.connect(transport)
 
     const list = await client.listTools()
-    // 83 API tools + 2 meta-tools (canonry_help, canonry_load_toolkit).
-    expect(list.tools).toHaveLength(85)
+    // 84 API tools + 2 meta-tools (canonry_help, canonry_load_toolkit).
+    expect(list.tools).toHaveLength(86)
     const names = list.tools.map(tool => tool.name)
     expect(names).toContain('canonry_insights_list')
     expect(names).toContain('canonry_project_overview')

--- a/packages/contracts/src/google.ts
+++ b/packages/contracts/src/google.ts
@@ -28,6 +28,25 @@ export const gscSearchDataDtoSchema = z.object({
 })
 export type GscSearchDataDto = z.infer<typeof gscSearchDataDtoSchema>
 
+export const gscPerformanceDailyPointSchema = z.object({
+  date: z.string(),
+  clicks: z.number(),
+  impressions: z.number(),
+  ctr: z.number(),
+})
+export type GscPerformanceDailyPoint = z.infer<typeof gscPerformanceDailyPointSchema>
+
+export const gscPerformanceDailyDtoSchema = z.object({
+  totals: z.object({
+    clicks: z.number(),
+    impressions: z.number(),
+    ctr: z.number(),
+    days: z.number(),
+  }),
+  daily: z.array(gscPerformanceDailyPointSchema),
+})
+export type GscPerformanceDailyDto = z.infer<typeof gscPerformanceDailyDtoSchema>
+
 export const gscUrlInspectionDtoSchema = z.object({
   id: z.string(),
   url: z.string(),


### PR DESCRIPTION
## Summary
- Adds `GET /projects/:name/google/gsc/performance/daily` returning per-date clicks/impressions/CTR plus window totals.
- Switches the GSC dashboard chart and headline numbers to this aggregate so totals reflect the full window instead of just the current paged response.
- CTR is computed from summed clicks/impressions (not averaged from per-row CTRs); a test pins this against the common averaging bug.
- Ships the matching CLI (`canonry google performance-daily`), MCP tool (`canonry_gsc_performance_daily`), OpenAPI entry, contracts, and tests; version bumped to 4.41.0.

## Test plan
- [ ] `pnpm test` (api-routes daily endpoint suite, MCP registry/stdio counts)
- [ ] `canonry google performance-daily <project> --window 30d` renders aligned table; `--format json` returns `{ totals, daily }`
- [ ] Dashboard GSC tab: chart and Clicks/Impressions/CTR header reflect the full selected window, not the current page