### PR TITLE
fix(report): rename SOV column to 'Citation share'

### DIFF
--- a/apps/web/src/pages/ReportPage.tsx
+++ b/apps/web/src/pages/ReportPage.tsx
@@ -1271,7 +1271,7 @@ function CompetitorLandscapeSection({ report }: { report: ProjectReportDto }) {
                 <th>Pressure</th>
                 <th>Citations</th>
                 <th>Mentions</th>
-                <th>SOV</th>
+                <th title="Citation share — % of cited-source slots that went to this competitor across tracked queries. Distinct from Mention Share (head-to-head answer-text mentions); see the hero gauge.">Citation share</th>
                 <th>Cited queries</th>
               </tr>
             </thead>

--- a/packages/api-routes/src/report-renderer.ts
+++ b/packages/api-routes/src/report-renderer.ts
@@ -1437,7 +1437,7 @@ function renderCompetitorLandscape(report: ProjectReportDto): string {
 
   const table = competitors.length > 0
     ? `<table class="report-table">
-        <thead><tr><th>Domain</th><th>Pressure</th><th>Citations</th><th class="numeric">Mentions</th><th class="numeric">SOV</th><th>Cited queries</th></tr></thead>
+        <thead><tr><th>Domain</th><th>Pressure</th><th>Citations</th><th class="numeric">Mentions</th><th class="numeric" title="Citation share — % of cited-source slots that went to this competitor across tracked queries. Distinct from Mention Share.">Citation share</th><th>Cited queries</th></tr></thead>
         <tbody>${rows}</tbody>
       </table>`
     : renderEmpty('No competitors configured.')

--- a/packages/api-routes/test/report-renderer.test.ts
+++ b/packages/api-routes/test/report-renderer.test.ts
@@ -968,12 +968,14 @@ describe('renderReportHtml', () => {
     expect(stepsBlock).toContain('No outstanding actions.')
   })
 
-  test('renders SOV % column in competitor landscape', () => {
+  test('renders the "Citation share" column header (renamed from "SOV") in competitor landscape', () => {
     const report = richReport()
     report.competitorLandscape.competitors[0]!.sharePct = 75
     report.competitorLandscape.competitors[1]!.sharePct = 25
     const html = renderReportHtml(report)
     const landscape = html.split('id="competitor-landscape"')[1]?.split('</section>')[0] ?? ''
+    expect(landscape).toContain('Citation share')
+    expect(landscape).not.toContain('>SOV<')
     expect(landscape).toContain('75%')
     expect(landscape).toContain('25%')
   })

--- a/packages/contracts/src/report.ts
+++ b/packages/contracts/src/report.ts
@@ -156,10 +156,11 @@ export interface CompetitorRow {
   /** Distinct queries on which this competitor was cited. */
   citedQueries: string[]
   /**
-   * Share of voice 0..100. Numerator = this competitor's `citationCount`.
+   * Citation share 0..100. Numerator = this competitor's `citationCount`.
    * Denominator = sum of `citationCount` across all competitors plus the
    * project's own `projectCitationCount`. Equals 0 when there are no cited
-   * slots in the snapshot.
+   * slots in the snapshot. Distinct from the project-level Mention Share
+   * gauge — that one is brand-in-answer-text, this one is domain-in-source-list.
    */
   sharePct: number
   /**
@@ -188,10 +189,11 @@ export interface MentionRow {
   /** Distinct queries on which this competitor was mentioned. */
   mentionedQueries: string[]
   /**
-   * Share of voice 0..100. Numerator = this competitor's `mentionCount`.
+   * Mention share 0..100. Numerator = this competitor's `mentionCount`.
    * Denominator = sum of `mentionCount` across all competitors plus the
    * project's own `projectMentionCount`. Equals 0 when no snapshot had any
-   * mention.
+   * mention. Per-competitor split of the same head-to-head measure the
+   * project's hero `MentionShareDto` gauge headlines.
    */
   sharePct: number
 }


### PR DESCRIPTION
**Stacked on top of #545.** From the #544 (Mention Share) code review — vocabulary cleanup.

## Summary

The report's per-competitor "SOV" column measures `sharePct` = % of cited-source slots that went to each competitor. That's **domain-in-source-list** share. Now that the project-level hero gauge is "Mention Share" (**brand-in-answer-text** share), the same "SOV" label means two different things in the product. Rename the column to **Citation share** in both renderers, with a tooltip explaining the distinction. Same math, same data — just an honest label.

## Changes

- `apps/web/src/pages/ReportPage.tsx` — column header `SOV` → `Citation share` (+ tooltip)
- `packages/api-routes/src/report-renderer.ts` — same change in the HTML report (per the "Report parity" critical rule, both renderers move together)
- `packages/contracts/src/report.ts` — JSDoc on `CompetitorRow.sharePct` and `MentionRow.sharePct` clarified to point at each lane's distinct definition
- `packages/api-routes/test/report-renderer.test.ts` — asserts the new header is present and the old `>SOV<` literal is gone

No behavior change. No version bump (under 100 lines, per the repo's versioning rule).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm vitest run --project api-routes` — 753 passing
- [x] `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)