### PR TITLE
chore(web): rename project Inbound tab to Backlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ cnry insights my-site
 |---------|-----|
 | No provider key configured | Grab a free [Gemini key](https://aistudio.google.com/apikey), set `GEMINI_API_KEY`, restart `cnry serve`. |
 | No results after a run | Visibility checks are async — check the Runs tab or use `cnry run <project> --wait`. |
-| Not sure what queries to test | The setup wizard auto-generates them by analyzing your site. |
+| Not sure what queries to test | Setup wizard auto-generates them; expand the basket later with `cnry discover run <project> --icp "..."` — see the [discovery methodology](skills/aero/references/aeo-discovery.md). |
 | `npm install` fails on `node-gyp` | Install build tools for `better-sqlite3` ([guide](https://github.com/WiseLibs/better-sqlite3/blob/master/docs/troubleshooting.md)). |
 
 ## Provider keys

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -69,7 +69,7 @@ import { useDrawer } from '../hooks/use-drawer.js'
 import { findProjectVm } from '../mock-data.js'
 import type { ProjectCommandCenterVm, RunHistoryPoint } from '../view-models.js'
 
-export type ProjectPageTab = 'overview' | 'search-console' | 'discovery' | 'report' | 'activity' | 'inbound' | 'settings'
+export type ProjectPageTab = 'overview' | 'search-console' | 'discovery' | 'report' | 'activity' | 'backlinks' | 'settings'
 
 type SearchConsoleWorkspace = 'google' | 'bing'
 
@@ -1538,7 +1538,7 @@ export function ProjectPage({
     { key: 'search-console', label: 'Search Engine Intelligence', href: `/projects/${model.project.id}/search-console` },
     { key: 'activity', label: 'Activity', href: `/projects/${model.project.id}/activity` },
     { key: 'report', label: 'Report', href: `/projects/${model.project.id}/report` },
-    { key: 'inbound', label: 'Inbound', href: `/projects/${model.project.id}/inbound` },
+    { key: 'backlinks', label: 'Backlinks', href: `/projects/${model.project.id}/backlinks` },
     { key: 'discovery', label: 'Discovery', href: `/projects/${model.project.id}/discovery` },
     { key: 'settings', label: 'Settings', href: `/projects/${model.project.id}/settings` },
   ]
@@ -2032,7 +2032,7 @@ export function ProjectPage({
         <DiscoverySection projectName={projectName} />
       ) : tab === 'activity' ? (
         <ActivitySection projectName={model.project.name} />
-      ) : tab === 'inbound' ? (
+      ) : tab === 'backlinks' ? (
         <BacklinksSection projectName={model.project.name} />
       ) : (
         <SearchConsoleSection projectName={model.project.name} />

--- a/apps/web/src/router/routes.tsx
+++ b/apps/web/src/router/routes.tsx
@@ -95,10 +95,10 @@ export const projectActivityRoute = createRoute({
   component: () => <ProjectPage tab="activity" />,
 })
 
-export const projectInboundRoute = createRoute({
+export const projectBacklinksRoute = createRoute({
   getParentRoute: () => projectLayoutRoute,
-  path: '/inbound',
-  component: () => <ProjectPage tab="inbound" />,
+  path: '/backlinks',
+  component: () => <ProjectPage tab="backlinks" />,
 })
 
 export const projectSettingsRoute = createRoute({
@@ -167,7 +167,7 @@ export const routeTree = rootRoute.addChildren([
     projectDiscoveryRoute,
     projectReportRoute,
     projectActivityRoute,
-    projectInboundRoute,
+    projectBacklinksRoute,
     projectSettingsRoute,
   ]),
   runsRoute,


### PR DESCRIPTION
## Summary
- Renames the project-scoped **Inbound** tab to **Backlinks** so the label, route (`/projects/:id/inbound` → `/projects/:id/backlinks`), type literal, and route export all match the top-level Backlinks nav and the existing in-tab eyebrow.
- README "If you get stuck" troubleshooting row about query selection now points at `cnry discover` and the [discovery methodology](skills/aero/references/aeo-discovery.md).

## Test plan
- [x] `pnpm --filter @ainyc/canonry-web typecheck` (clean locally)
- [ ] Visit `/projects/:id/backlinks` in the dashboard — tab loads `BacklinksSection`
- [x] Sidebar/tab label reads "Backlinks"; no stale `/inbound` link anywhere