### PR TITLE
fix(cli): UI/CLI parity for Mention + Mention share + suggested queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.43.0",
+  "version": "4.44.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.43.0",
+  "version": "4.44.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/commands/overview.ts
+++ b/packages/canonry/src/commands/overview.ts
@@ -1,4 +1,4 @@
-import type { ProjectOverviewDto, ScoreSummaryDto } from '@ainyc/canonry-contracts'
+import type { MentionShareDto, ProjectOverviewDto, ScoreSummaryDto } from '@ainyc/canonry-contracts'
 import { createApiClient } from '../client.js'
 
 export interface ShowOverviewOpts {
@@ -22,7 +22,10 @@ export async function showOverview(project: string, opts: ShowOverviewOpts): Pro
   renderHuman(overview)
 }
 
-function renderHuman(overview: ProjectOverviewDto): void {
+/** Exported so unit tests can capture stdout shape without spinning up the
+ *  real client. Format change is contract-y enough that agents parsing it
+ *  via grep need protection. */
+export function renderHuman(overview: ProjectOverviewDto): void {
   const {
     project: meta,
     latestRun,
@@ -37,6 +40,7 @@ function renderHuman(overview: ProjectOverviewDto): void {
     providerScores,
     attentionItems,
     runHistory,
+    suggestedQueries,
     dateRangeLabel,
     contextLabel,
   } = overview
@@ -54,7 +58,13 @@ function renderHuman(overview: ProjectOverviewDto): void {
   }
 
   console.log('\nScores:')
+  // Order matches the dashboard hero (Mention → Cited → Mention share)
+  // so an operator alt-tabbing between SPA and CLI sees the same lineup.
+  printScore('Mention          ', scores.mention)
   printScore('Visibility       ', scores.visibility)
+  printScore('Mention share    ', scores.mentionShare)
+  printMentionShareBreakdown(scores.mentionShare)
+  printScore('Mention gaps     ', scores.mentionGaps)
   printScore('Gap queries      ', scores.gapQueries)
   printScore('Index coverage   ', scores.indexCoverage)
   printScore('Competitor press.', scores.competitorPressure)
@@ -120,12 +130,43 @@ function renderHuman(overview: ProjectOverviewDto): void {
       console.log(`    ${point.createdAt.slice(0, 10)} ${String(point.citationRate).padStart(3)}% ${bar}`)
     }
   }
+
+  if (suggestedQueries.rows.length > 0) {
+    const moreLabel = suggestedQueries.totalCandidates > suggestedQueries.rows.length
+      ? ` (showing ${suggestedQueries.rows.length} of ${suggestedQueries.totalCandidates})`
+      : ''
+    console.log(`\n  Suggested queries to track${moreLabel}:`)
+    for (const s of suggestedQueries.rows) {
+      console.log(`    + ${s.query}`)
+      console.log(`        ${s.reason}`)
+    }
+    console.log(`    (add via: canonry query add ${meta.name} "<query>")`)
+  }
 }
 
 function printScore(prefix: string, score: ScoreSummaryDto): void {
   const tone = `[${score.tone}]`.padEnd(11)
   const value = score.value.padEnd(8)
   console.log(`  ${prefix} ${tone} ${value} ${score.delta}`)
+}
+
+/** Per-competitor split of Mention Share — the same data the dashboard
+ *  hero renders inline beneath the gauge. Top 3 competitors keeps the CLI
+ *  output tight; the full breakdown is in the `--format json` payload. */
+function printMentionShareBreakdown(mentionShare: MentionShareDto): void {
+  const { breakdown } = mentionShare
+  if (breakdown.perCompetitor.length === 0) return
+  const total = breakdown.projectMentionSnapshots + breakdown.competitorMentionSnapshots
+  if (total === 0) return
+  const youPct = ((breakdown.projectMentionSnapshots / total) * 100).toFixed(1)
+  console.log(`      you${' '.repeat(28)} ${breakdown.projectMentionSnapshots} mentions (${youPct}% of combined)`)
+  for (const row of breakdown.perCompetitor.slice(0, 3)) {
+    const pct = ((row.mentionSnapshots / total) * 100).toFixed(1)
+    console.log(`      ${row.domain.padEnd(30)} ${row.mentionSnapshots} mentions (${pct}% of combined)`)
+  }
+  if (breakdown.perCompetitor.length > 3) {
+    console.log(`      + ${breakdown.perCompetitor.length - 3} more competitor${breakdown.perCompetitor.length - 3 === 1 ? '' : 's'} (--format json for full breakdown)`)
+  }
 }
 
 function pct(value: number): string {

--- a/packages/canonry/test/overview-command.test.ts
+++ b/packages/canonry/test/overview-command.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ProjectOverviewDto } from '@ainyc/canonry-contracts'
+import { renderHuman } from '../src/commands/overview.js'
+
+function makeOverview(overrides: Partial<ProjectOverviewDto> = {}): ProjectOverviewDto {
+  return {
+    project: {
+      id: 'p-1',
+      name: 'demo',
+      displayName: 'Demo',
+      canonicalDomain: 'demo.example.com',
+      ownedDomains: [],
+      aliases: [],
+      country: 'US',
+      language: 'en',
+      tags: [],
+      labels: {},
+      locations: [],
+      defaultLocation: null,
+      autoExtractBacklinks: false,
+      configSource: 'manual',
+      configRevision: null,
+      createdAt: '2026-05-01T00:00:00.000Z',
+      updatedAt: '2026-05-01T00:00:00.000Z',
+    },
+    latestRun: { run: null, totalRuns: 0 },
+    health: null,
+    topInsights: [],
+    queryCounts: { totalQueries: 0, citedQueries: 0, notCitedQueries: 0, citedRate: 0 },
+    providers: [],
+    transitions: { since: null, gained: 0, lost: 0, emerging: 0 },
+    scores: {
+      mention: { label: 'Mention Coverage', value: '75', delta: '6 of 8 queries mentioned', tone: 'positive', description: '', trend: [], progress: 75 },
+      visibility: { label: 'Citation Coverage', value: '50', delta: '4 of 8 queries cited', tone: 'caution', description: '', trend: [], progress: 50 },
+      mentionShare: {
+        label: 'Mention Share',
+        value: '60',
+        delta: '6 of 10 brand mentions',
+        tone: 'positive',
+        description: '',
+        trend: [],
+        progress: 60,
+        breakdown: {
+          projectMentionSnapshots: 6,
+          competitorMentionSnapshots: 4,
+          perCompetitor: [
+            { domain: 'rival-a.com', mentionSnapshots: 3, shareOfCompetitiveTotal: 75 },
+            { domain: 'rival-b.com', mentionSnapshots: 1, shareOfCompetitiveTotal: 25 },
+          ],
+          snapshotsWithAnswerText: 8,
+          snapshotsTotal: 10,
+        },
+      },
+      gapQueries: { label: 'Citation Gaps', value: '2', delta: '2 of 8 queries at risk', tone: 'caution', description: '', trend: [] },
+      mentionGaps: { label: 'Mention Gaps', value: '1', delta: '1 of 8 queries at risk', tone: 'caution', description: '', trend: [] },
+      indexCoverage: { label: 'Index Coverage', value: 'No data', delta: '', tone: 'neutral', description: '', trend: [] },
+      competitorPressure: { label: 'Competitor Pressure', value: 'None', delta: '', tone: 'neutral', description: '', trend: [] },
+      runStatus: { label: 'Run Status', value: 'Healthy', delta: '', tone: 'positive', description: '', trend: [] },
+    },
+    movementSummary: { gained: 0, lost: 0, tone: 'neutral', hasPreviousRun: false },
+    competitors: [],
+    providerScores: [],
+    attentionItems: [],
+    runHistory: [],
+    suggestedQueries: { rows: [], totalCandidates: 0, skippedAlreadyTracked: 0 },
+    dateRangeLabel: 'All time',
+    contextLabel: 'US / EN',
+    ...overrides,
+  }
+}
+
+function captureOutput(fn: () => void): string {
+  const lines: string[] = []
+  const spy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    lines.push(args.map(String).join(' '))
+  })
+  try {
+    fn()
+  } finally {
+    spy.mockRestore()
+  }
+  return lines.join('\n')
+}
+
+describe('canonry overview — human output', () => {
+  let output = ''
+
+  beforeEach(() => {
+    output = ''
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders Mention, Citation, and Mention Share scores in the hero order', () => {
+    output = captureOutput(() => renderHuman(makeOverview()))
+    // The dashboard hero shows Mention → Cited → Mention share. CLI must match.
+    const mentionIdx = output.indexOf('Mention   ')
+    const visibilityIdx = output.indexOf('Visibility ')
+    const mentionShareIdx = output.indexOf('Mention share')
+    expect(mentionIdx).toBeGreaterThan(-1)
+    expect(visibilityIdx).toBeGreaterThan(mentionIdx)
+    expect(mentionShareIdx).toBeGreaterThan(visibilityIdx)
+    expect(output).toContain('6 of 8 queries mentioned')
+    expect(output).toContain('6 of 10 brand mentions')
+  })
+
+  it('breakdown shows project and competitor mention counts with combined-total %', () => {
+    output = captureOutput(() => renderHuman(makeOverview()))
+    // Project: 6 of 10 combined = 60.0% (matches headline value 60)
+    expect(output).toMatch(/you[^\n]*6 mentions \(60\.0% of combined\)/)
+    // Top competitor: rival-a 3 of 10 = 30.0%
+    expect(output).toMatch(/rival-a\.com[^\n]*3 mentions \(30\.0% of combined\)/)
+    // Second competitor: rival-b 1 of 10 = 10.0%
+    expect(output).toMatch(/rival-b\.com[^\n]*1 mentions \(10\.0% of combined\)/)
+  })
+
+  it('omits Mention Share breakdown when no competitors are mentioned', () => {
+    const overview = makeOverview()
+    overview.scores.mentionShare = {
+      ...overview.scores.mentionShare,
+      value: 'Add competitors',
+      tone: 'neutral',
+      breakdown: {
+        projectMentionSnapshots: 0,
+        competitorMentionSnapshots: 0,
+        perCompetitor: [],
+        snapshotsWithAnswerText: 0,
+        snapshotsTotal: 0,
+      },
+    }
+    output = captureOutput(() => renderHuman(overview))
+    expect(output).toContain('Mention share')
+    expect(output).toContain('Add competitors')
+    expect(output).not.toContain('mentions (')
+  })
+
+  it('caps Mention Share breakdown at top-3 competitors with a "+N more" line', () => {
+    const overview = makeOverview()
+    overview.scores.mentionShare.breakdown.perCompetitor = [
+      { domain: 'a.com', mentionSnapshots: 10, shareOfCompetitiveTotal: 33 },
+      { domain: 'b.com', mentionSnapshots: 9, shareOfCompetitiveTotal: 30 },
+      { domain: 'c.com', mentionSnapshots: 8, shareOfCompetitiveTotal: 27 },
+      { domain: 'd.com', mentionSnapshots: 3, shareOfCompetitiveTotal: 10 },
+    ]
+    overview.scores.mentionShare.breakdown.competitorMentionSnapshots = 30
+    overview.scores.mentionShare.breakdown.projectMentionSnapshots = 6
+    output = captureOutput(() => renderHuman(overview))
+    expect(output).toContain('a.com')
+    expect(output).toContain('b.com')
+    expect(output).toContain('c.com')
+    expect(output).not.toContain('d.com')
+    expect(output).toContain('+ 1 more competitor')
+  })
+
+  it('renders the suggested-queries panel when GSC suggestions are available', () => {
+    const overview = makeOverview({
+      suggestedQueries: {
+        rows: [
+          { query: 'best aeo tool', impressions: 1800, clicks: 30, avgPosition: 12, reason: '1.8K impressions · ranks #12' },
+          { query: 'how to track ai citations', impressions: 400, clicks: 5, avgPosition: 22, reason: '400 impressions · ranks #22' },
+        ],
+        totalCandidates: 5,
+        skippedAlreadyTracked: 8,
+      },
+    })
+    output = captureOutput(() => renderHuman(overview))
+    expect(output).toContain('Suggested queries to track')
+    expect(output).toContain('showing 2 of 5')
+    expect(output).toContain('+ best aeo tool')
+    expect(output).toContain('1.8K impressions · ranks #12')
+    expect(output).toContain('canonry query add demo')
+  })
+
+  it('omits suggested-queries panel when no GSC suggestions exist', () => {
+    output = captureOutput(() => renderHuman(makeOverview()))
+    expect(output).not.toContain('Suggested queries')
+  })
+
+  it('shows all 8 scores (no SoV — that field is gone)', () => {
+    output = captureOutput(() => renderHuman(makeOverview()))
+    expect(output).toContain('Mention   ')
+    expect(output).toContain('Visibility')
+    expect(output).toContain('Mention share')
+    expect(output).toContain('Mention gaps')
+    expect(output).toContain('Gap queries')
+    expect(output).toContain('Index coverage')
+    expect(output).toContain('Competitor press.')
+    expect(output).toContain('Run status')
+    expect(output).not.toMatch(/Share of [Vv]oice/)
+  })
+})


### PR DESCRIPTION
**Stacked on top of #546.** From the #544 (Mention Share) code review — UI/CLI parity gap.

## Summary

`canonry overview` was rendering 5 score gauges (Visibility, Gap queries, Index coverage, Competitor pressure, Run status) — missing three dashboard-hero metrics: Mention, Mention Share, and Mention Gaps. AGENTS.md "UI/CLI parity" is listed as Critical and requires every UI-visible metric be retrievable via CLI in the same shape. This closes the gap.

## What the new output looks like

```
Scores:
  Mention           [positive]  75       6 of 8 queries mentioned
  Visibility        [caution]   50       4 of 8 queries cited
  Mention share     [positive]  60       6 of 10 brand mentions
      you                              6 mentions (60.0% of combined)
      rival-a.com                      3 mentions (30.0% of combined)
      rival-b.com                      1 mentions (10.0% of combined)
  Mention gaps      [caution]   1        1 of 8 queries at risk
  Gap queries       [caution]   2        2 of 8 queries at risk
  Index coverage    [neutral]   No data
  Competitor press. [neutral]   None
  Run status        [positive]  Healthy
```

Score order matches the dashboard hero (Mention → Cited → Mention share) so operators alt-tabbing between SPA and CLI see the same lineup. Top-3 competitor breakdown renders inline beneath Mention Share with combined-total %; full breakdown stays in `--format json` via `scores.mentionShare.breakdown.perCompetitor`.

Also surfaces the new Suggested Queries panel from the overview DTO (added in #545):

```
Suggested queries to track (showing 2 of 5):
  + best aeo tool
      1.8K impressions · ranks #12
  + how to track ai citations
      400 impressions · ranks #22
  (add via: canonry query add demo "<query>")
```

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm vitest run` — 2885 passing (2 pre-existing sqlite3-binary failures unrelated)
- [x] `pnpm lint` — clean
- [x] 7 new unit tests in `packages/canonry/test/overview-command.test.ts` covering score order, breakdown rendering, top-3 cap, "Add competitors" neutral state, suggested-queries panel, and no-SoV regression

## Note for reviewer

`renderHuman` is now exported from `commands/overview.ts` so the new test can capture stdout without spinning up a real client. Output format is contract-y enough (agents may grep it) that locking it down via test is warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)