### PR TITLE
fix(web): four UI nits from operator review

### DIFF
--- a/apps/web/src/components/project/EvidenceTable.tsx
+++ b/apps/web/src/components/project/EvidenceTable.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useMemo, useState } from 'react'
+import { Fragment, useMemo, useState } from 'react'
 import { ChevronRight } from 'lucide-react'
 import { CitationStates, brandLabelFromDomain } from '@ainyc/canonry-contracts'
 
@@ -108,19 +108,6 @@ export function EvidenceTable({
     return [...map.values()]
   }, [evidence, mode, compareLocations])
 
-  // Detailed mode is meant to show answer text; auto-expand the first three
-  // groups on first render so operators see the meat without clicking. Resets
-  // when groups change (mode toggle, project switch).
-  useEffect(() => {
-    if (density !== 'detailed') return
-    setExpandedRows(prev => {
-      if (prev.size > 0) return prev
-      const next = new Set<string>()
-      for (const g of groups.slice(0, 3)) next.add(g.key)
-      return next
-    })
-  }, [density, groups])
-
   const toggleRow = (key: string) => {
     setExpandedRows(prev => {
       const next = new Set(prev)
@@ -146,19 +133,6 @@ export function EvidenceTable({
           <button
             type="button"
             role="tab"
-            aria-selected={mode === 'citations'}
-            className={`px-2.5 py-1 text-xs font-medium rounded transition-colors ${
-              mode === 'citations'
-                ? 'bg-zinc-800 text-zinc-100'
-                : 'text-zinc-400 hover:text-zinc-200'
-            }`}
-            onClick={() => setMode('citations')}
-          >
-            Citations
-          </button>
-          <button
-            type="button"
-            role="tab"
             aria-selected={mode === 'mentions'}
             className={`px-2.5 py-1 text-xs font-medium rounded transition-colors ${
               mode === 'mentions'
@@ -168,6 +142,19 @@ export function EvidenceTable({
             onClick={() => setMode('mentions')}
           >
             Mentions
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'citations'}
+            className={`px-2.5 py-1 text-xs font-medium rounded transition-colors ${
+              mode === 'citations'
+                ? 'bg-zinc-800 text-zinc-100'
+                : 'text-zinc-400 hover:text-zinc-200'
+            }`}
+            onClick={() => setMode('citations')}
+          >
+            Citations
           </button>
         </div>
         <span className="text-[11px] text-zinc-500">

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -93,7 +93,9 @@ function BingSection({
   const [loading, setLoading] = useState(true)
   const [requestingIndexing, setRequestingIndexing] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [activeTab, setActiveTab] = useState<'coverage' | 'inspections' | 'performance'>('coverage')
+  // Performance is the default — it's the highest-signal view (per-query
+  // impressions, clicks, position) and mirrors how the GSC tab leads.
+  const [activeTab, setActiveTab] = useState<'performance' | 'coverage' | 'inspections'>('performance')
 
   useEffect(() => {
     void loadData()
@@ -392,10 +394,11 @@ function BingSection({
   }
 
   const tabs = [
-    { key: 'coverage' as const, label: 'Coverage' },
-    { key: 'inspections' as const, label: 'Inspections' },
-    { key: 'performance' as const, label: 'Performance' },
+    { key: 'performance' as const, label: 'Performance', eyebrow: 'Performance', title: 'Search performance' },
+    { key: 'coverage' as const, label: 'Coverage', eyebrow: 'Coverage', title: 'Index monitoring' },
+    { key: 'inspections' as const, label: 'Inspections', eyebrow: 'Inspection', title: 'URL inspection history' },
   ]
+  const activeTabMeta = tabs.find(t => t.key === activeTab) ?? tabs[0]!
 
   return (
     <div className="space-y-3">
@@ -438,8 +441,8 @@ function BingSection({
       <Card className="surface-card">
         <div className="section-head section-head-inline">
           <div>
-            <p className="eyebrow eyebrow-soft">Coverage</p>
-            <h3>Index monitoring</h3>
+            <p className="eyebrow eyebrow-soft">{activeTabMeta.eyebrow}</p>
+            <h3>{activeTabMeta.title}</h3>
           </div>
           <p className="text-xs text-zinc-500">
             {coverage?.lastInspectedAt ? `Last inspected ${formatTimestamp(coverage.lastInspectedAt)}` : 'No inspection history yet'}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -519,7 +519,10 @@
 
   .aeo-hero-row {
     @apply grid items-center gap-x-4;
-    grid-template-columns: 100px 90px 1fr auto;
+    /* First col widened from 100px so "Mention share" fits on one line —
+       previously wrapped and pushed the InfoTooltip icon to the right edge,
+       which made the tooltip bubble render far right of where readers expect. */
+    grid-template-columns: 130px 90px 1fr auto;
   }
 
   .aeo-hero-row-label {


### PR DESCRIPTION
Four small UI fixes from a live operator session, bundled because they're all hardening for the same surface.

## Changes

1. **Mention share tooltip rendered far right.** The hero label column was 100px which forced "Mention share" to wrap to two lines; the InfoTooltip icon then sat at the right edge of the column on line 2, and the tooltip portal centered on that position. Widen the label column to 130px so the label fits on one line.

2. **EvidenceTable auto-expanded first 3 rows.** The auto-expand-on-mount effect buried the rest of the basket below large answer blocks. Removed — all rows start collapsed; the "Expand all" button still works on demand.

3. **EvidenceTable "View by" toggle order.** Citations was first, Mentions second. Mentioned is the primary AEO signal now (hero gauge order + vocabulary rules), so Mentions leads.

4. **Bing tab default + order.** Defaulted to Coverage, which is index-status noise relative to the per-query Performance table. Promote Performance to first tab + default. Section header is now driven by the active tab so it stays accurate as the user switches panes.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm vitest run --project web` — 199 passing
- [x] `pnpm lint` — clean
- [x] Browser smoke: hover Mention share tooltip, confirm Evidence rows collapsed, confirm Mentions leads, confirm Bing opens to Performance

No version bump (under 100 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)