### PR TITLE
fix(bing): doctor check uses wrong field name — always reports unverified

### DIFF
--- a/packages/api-routes/src/bing.ts
+++ b/packages/api-routes/src/bing.ts
@@ -165,7 +165,7 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
       connected: true,
       domain: project.canonicalDomain,
       siteUrl: existing?.siteUrl ?? null,
-      availableSites: sites.map((s) => ({ url: s.Url, verified: s.Verified ?? false })),
+      availableSites: sites.map((s) => ({ url: s.Url, verified: s.IsVerified ?? false })),
     }
   })
 
@@ -214,7 +214,7 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
     const conn = requireConnection(store, project.canonicalDomain)
 
     const sites = await getSites(conn.apiKey)
-    return { sites: sites.map((s) => ({ url: s.Url, verified: s.Verified ?? false })) }
+    return { sites: sites.map((s) => ({ url: s.Url, verified: s.IsVerified ?? false })) }
   })
 
   // POST /projects/:name/bing/set-site

--- a/packages/api-routes/src/doctor/checks/bing-auth.ts
+++ b/packages/api-routes/src/doctor/checks/bing-auth.ts
@@ -132,7 +132,7 @@ export const BING_AUTH_CHECKS: readonly CheckDefinition[] = [
           }
         }
 
-        if (!match.Verified) {
+        if (!match.IsVerified) {
           return {
             status: CheckStatuses.fail,
             code: 'bing.auth.site-not-verified',

--- a/packages/api-routes/test/doctor-bing-auth.test.ts
+++ b/packages/api-routes/test/doctor-bing-auth.test.ts
@@ -62,7 +62,7 @@ describe('bing.auth.connection', () => {
   const check = BING_AUTH_CHECKS.find(c => c.id === 'bing.auth.connection')!
 
   it('returns ok when API key is valid', async () => {
-    getSitesMock.mockResolvedValue([{ Url: 'https://example.com/', Verified: true }])
+    getSitesMock.mockResolvedValue([{ Url: 'https://example.com/', IsVerified: true }])
     const result = await check.run(ctx({}))
     expect(result.status).toBe('ok')
     expect(result.code).toBe('bing.auth.connected')
@@ -87,7 +87,7 @@ describe('bing.auth.site-access', () => {
   const check = BING_AUTH_CHECKS.find(c => c.id === 'bing.auth.site-access')!
 
   it('returns ok when site is verified and matches', async () => {
-    getSitesMock.mockResolvedValue([{ Url: 'https://example.com/', Verified: true }])
+    getSitesMock.mockResolvedValue([{ Url: 'https://example.com/', IsVerified: true }])
     const result = await check.run(ctx({}))
     expect(result.status).toBe('ok')
     expect(result.code).toBe('bing.auth.site-verified')
@@ -100,7 +100,7 @@ describe('bing.auth.site-access', () => {
   })
 
   it('returns site-not-found when site is missing from Bing list', async () => {
-    getSitesMock.mockResolvedValue([{ Url: 'https://other.com/', Verified: true }])
+    getSitesMock.mockResolvedValue([{ Url: 'https://other.com/', IsVerified: true }])
     const result = await check.run(ctx({}))
     expect(result.status).toBe('fail')
     expect(result.code).toBe('bing.auth.site-not-found')
@@ -111,7 +111,7 @@ describe('bing.auth.site-access', () => {
   })
 
   it('returns site-not-verified when site is in list but not verified', async () => {
-    getSitesMock.mockResolvedValue([{ Url: 'https://example.com/', Verified: false }])
+    getSitesMock.mockResolvedValue([{ Url: 'https://example.com/', IsVerified: false }])
     const result = await check.run(ctx({}))
     expect(result.status).toBe('fail')
     expect(result.code).toBe('bing.auth.site-not-verified')

--- a/packages/integration-bing/src/types.ts
+++ b/packages/integration-bing/src/types.ts
@@ -1,6 +1,13 @@
 export interface BingSite {
   Url: string
-  Verified?: boolean
+  /**
+   * Whether the site is verified in Bing Webmaster Tools (DNS / HTML file /
+   * Meta tag). Field name follows Bing's actual `GetUserSites` JSON payload
+   * exactly — historically this was modelled as `Verified` here, but the
+   * live API returns `IsVerified` and the `Verified` field was always
+   * undefined, which made every doctor "site-access" check fail.
+   */
+  IsVerified?: boolean
 }
 
 export interface BingUrlInfo {

--- a/packages/integration-bing/test/bing-client.test.ts
+++ b/packages/integration-bing/test/bing-client.test.ts
@@ -13,11 +13,28 @@ describe('getSites', () => {
     globalThis.fetch = originalFetch
   })
 
-  it('returns parsed site entries', async () => {
+  it('returns parsed site entries (matches Bing\'s real GetUserSites response shape — IsVerified, not Verified)', async () => {
+    // Fixture mirrors a real production response: `IsVerified`, plus the
+    // additional fields (`__type`, `AuthenticationCode`, `DnsVerificationCode`)
+    // Bing returns that we don't currently model. A prior version of this
+    // test asserted on `Verified` (without `Is`), which is a field Bing never
+    // populates — that masked the doctor `bing.auth.site-access` false-fail.
     const mockResponse = {
       d: [
-        { Url: 'https://example.com/', Verified: true },
-        { Url: 'https://test.com/', Verified: false },
+        {
+          __type: 'Site:#Microsoft.Bing.Webmaster.Api',
+          AuthenticationCode: '54561B14450AE9971F4BA160466A8B0F',
+          DnsVerificationCode: '08f0f0e100e910875e42a2ba79b2c6c2.example.com',
+          IsVerified: true,
+          Url: 'https://example.com/',
+        },
+        {
+          __type: 'Site:#Microsoft.Bing.Webmaster.Api',
+          AuthenticationCode: '54561B14450AE9971F4BA160466A8B0F',
+          DnsVerificationCode: '08f0f0e100e910875e42a2ba79b2c6c2.test.com',
+          IsVerified: false,
+          Url: 'https://test.com/',
+        },
       ],
     }
 
@@ -30,7 +47,9 @@ describe('getSites', () => {
     const sites = await getSites('test-key')
     expect(sites.length).toBe(2)
     expect(sites[0]!.Url).toBe('https://example.com/')
-    expect(sites[1]!.Verified).toBe(false)
+    expect(sites[0]!.IsVerified).toBe(true)
+    expect(sites[1]!.Url).toBe('https://test.com/')
+    expect(sites[1]!.IsVerified).toBe(false)
   })
 
   it('returns empty array when no sites', async () => {


### PR DESCRIPTION
## Root cause

`canonry doctor --project <name>` was reporting `[fail] bing.auth.site-access — registered but not verified` for every project, even when the underlying site **was** verified in Bing Webmaster Tools.

The integration's `BingSite` type modelled the verification flag as `Verified?: boolean`. But Bing's `GetUserSites` API actually returns **`IsVerified`** — so `match.Verified` was always `undefined`, the check's `if (!match.Verified)` always evaluated true, and every site was falsely flagged.

Verified against the live API:

```bash
curl https://ssl.bing.com/webmaster/api.svc/json/GetUserSites?apikey=…
{"d":[{
  "__type":"Site:#Microsoft.Bing.Webmaster.Api",
  "AuthenticationCode":"…",
  "DnsVerificationCode":"…",
  "IsVerified":true,
  "Url":"https://ainyc.ai/"
},…]}
```

## Why tests didn't catch this

Two layers of fixture rot:

1. **`integration-bing/test/bing-client.test.ts`** asserted on `Verified: false` against a fixture it built itself with `Verified: false`. The wrong type + wrong assertion matched each other and the test passed.

2. **`api-routes/test/doctor-bing-auth.test.ts`** stubbed `getSites` to return `[{ Url, Verified: true }]` and the check read `match.Verified` — passed. Live API returns `IsVerified` and the check reads `Verified` — fails. Test never saw the real shape.

## Fix

- Rename `BingSite.Verified` → `BingSite.IsVerified` with a JSDoc pinning the name to Bing's real payload so future-me doesn't "fix" it back.
- Update the doctor check + two API route call sites that map to our internal response shape.
- Rewrite both test fixtures to mirror a real Bing payload (including `__type`, `AuthenticationCode`, `DnsVerificationCode`).

## Verification

Re-deployed locally and re-ran `canonry doctor --project <name>` for all 5 projects:

```
ainyc          [ok] bing.auth.site-access — Site "https://ainyc.ai/" is verified and accessible.
demand-iq      [ok] bing.auth.site-access — Site "https://demand-iq.com/" is verified and accessible.
gjelina-hotel  [ok] bing.auth.site-access — Site "https://gjelinahotel.com/" is verified and accessible.
canonry.ai     [ok] bing.auth.site-access — Site "https://canonry.ai/" is verified and accessible.
azcoatings     [ok] bing.auth.site-access — Site "https://azcoatingsllc.com/" is verified and accessible.
```

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm vitest run` — 2885 passing (2 pre-existing sqlite3-binary failures unrelated)
- [x] `pnpm lint` — clean
- [x] Live doctor verification across all 5 production projects

No version bump (under 100 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)