### PR TITLE
feat(wizard): inline provider key + inline run results; unify CLI next-steps

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -345,6 +345,17 @@ export function RootLayout() {
   // While loading or dashboard not yet available, use context data or null (no mock fallback)
   const safeDashboard = dashboard ?? contextDashboard?.dashboard ?? null
 
+  // First-run focus mode: hide the sidebar on /setup when the user has zero
+  // projects. The sidebar's nav items (Overview / Projects / Runs / Server
+  // traffic / Backlinks / Settings) point at surfaces that don't have any
+  // data yet — showing them adds visual noise + shrinks the wizard's
+  // available real estate. Once they create their first project the
+  // sidebar comes back automatically (intentional "you've made it into the
+  // app" moment).
+  const isFirstRunSetup = location.pathname === '/setup'
+    && safeDashboard !== null
+    && safeDashboard.portfolioOverview.projects.length === 0
+
   const selectedRun = runId && safeDashboard ? findRunById(safeDashboard, runId) : undefined
   const selectedEvidenceContext = evidenceId && safeDashboard ? findEvidenceById(safeDashboard, evidenceId) : undefined
 
@@ -373,12 +384,13 @@ export function RootLayout() {
   })()
 
   return (
-    <div className="app-shell">
+    <div className={`app-shell ${isFirstRunSetup ? 'app-shell-focus' : ''}`}>
       <a className="skip-link" href="#content">
         Skip to content
       </a>
 
       {/* ── Sidebar (desktop) ── */}
+      {!isFirstRunSetup && (
       <aside className="sidebar" aria-label="Primary navigation">
         <div className="sidebar-brand">
           <BrandLockup
@@ -505,6 +517,7 @@ export function RootLayout() {
           ))}
         </div>
       </aside>
+      )}
 
       {/* ── Main area ── */}
       <div className="main-area">

--- a/apps/web/src/pages/SetupPage.tsx
+++ b/apps/web/src/pages/SetupPage.tsx
@@ -647,7 +647,6 @@ export function SetupPage() {
                 </p>
                 <div className="rounded-md border border-zinc-800/60 bg-zinc-900/30 p-3 text-xs text-zinc-500">
                   <p>Status: <span className="text-zinc-300">{run?.status ?? 'queued'}</span></p>
-                  <p className="mt-1">Run ID: <span className="font-mono text-zinc-400">{launchedRunId}</span></p>
                 </div>
                 <div className="setup-nav">
                   <span />

--- a/apps/web/src/pages/SetupPage.tsx
+++ b/apps/web/src/pages/SetupPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
 import { Link } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
 
 import { Button } from '../components/ui/button.js'
 import { Card } from '../components/ui/card.js'
@@ -10,7 +11,9 @@ import {
   createProject,
   setQueries,
   setCompetitors,
+  fetchRunDetail,
   generateQueries as apiGenerateQueries,
+  updateProviderConfig,
 } from '../api.js'
 import { useTriggerRun } from '../queries/mutations.js'
 import { useDashboard } from '../queries/use-dashboard.js'
@@ -113,7 +116,31 @@ export function SetupPage() {
 
   const [runTriggered, setRunTriggered] = useState(false)
   const [runSaving, setRunSaving] = useState(false)
+  const [launchedRunId, setLaunchedRunId] = useState<string | null>(null)
   const triggerRunMutation = useTriggerRun()
+
+  // Poll the newly-triggered run so Step 5 can show results inline instead
+  // of the previous "queued — open project page" handoff. Refetches every
+  // 2s while the run is in flight, then stops once a terminal status
+  // (`completed`/`partial`/`failed`/`cancelled`) lands.
+  const launchedRun = useQuery({
+    queryKey: ['setup', 'launched-run', launchedRunId],
+    queryFn: () => fetchRunDetail(launchedRunId!),
+    enabled: !!launchedRunId,
+    refetchInterval: (q) => {
+      const status = q.state.data?.status
+      const terminal = status === 'completed' || status === 'partial' || status === 'failed' || status === 'cancelled'
+      return terminal ? false : 2000
+    },
+  })
+
+  // Inline provider key entry for Step 1. Replaces the prior "go to /settings"
+  // link that caused the wizard's biggest drop-off: users left the wizard,
+  // entered the key, and often forgot to navigate back. Keeping the form
+  // here lets first-time users stay in flow through the whole 5-step setup.
+  const [geminiKey, setGeminiKey] = useState('')
+  const [geminiSaving, setGeminiSaving] = useState(false)
+  const [geminiError, setGeminiError] = useState<string | null>(null)
 
   const slug = projectName.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '')
   const parsedQueries = queriesText.split('\n').map(k => k.trim()).filter(Boolean)
@@ -206,15 +233,41 @@ export function SetupPage() {
     }
   }
 
+  const handleSaveGeminiKey = async () => {
+    const key = geminiKey.trim()
+    if (!key) return
+    setGeminiSaving(true)
+    setGeminiError(null)
+    try {
+      await updateProviderConfig('gemini', { apiKey: key })
+      addToast({
+        title: 'Gemini configured',
+        detail: 'Provider is ready — continuing setup.',
+        tone: 'positive',
+        dedupeKey: 'setup:gemini:configured',
+        dedupeMode: 'drop',
+      })
+      setGeminiKey('')
+      // Refetch dashboard so the health-check row flips to "Ready" and the
+      // "Continue" button at the bottom of Step 1 becomes enabled.
+      await refetch()
+    } catch (err) {
+      setGeminiError(err instanceof Error ? err.message : 'Failed to save Gemini key')
+    } finally {
+      setGeminiSaving(false)
+    }
+  }
+
   const handleLaunchRun = async () => {
     if (!createdProjectName) return
     setRunSaving(true)
     try {
-      await triggerRunMutation.mutateAsync({
+      const run = await triggerRunMutation.mutateAsync({
         projectName: createdProjectName,
         projectLabel: displayName || projectName || createdProjectName,
         sourceAction: 'setup-launch',
       })
+      setLaunchedRunId(run.id)
       setRunTriggered(true)
       void refetch()
     } catch {
@@ -245,12 +298,46 @@ export function SetupPage() {
                     <p className="run-row-title">{check.label}</p>
                     <p className="supporting-copy">{check.detail}</p>
                     {check.id === 'provider' && check.state !== 'ready' && (
-                      <Link
-                        to="/settings"
-                        className="text-emerald-400 hover:text-emerald-300 text-sm mt-1 underline underline-offset-2 cursor-pointer"
-                      >
-                        Configure providers
-                      </Link>
+                      <div className="mt-3 rounded-md border border-zinc-800/60 bg-zinc-900/40 p-3 space-y-2">
+                        <p className="text-xs text-zinc-400">
+                          Paste a Gemini key to enable visibility checks (free at{' '}
+                          <a
+                            href="https://aistudio.google.com/apikey"
+                            target="_blank"
+                            rel="noreferrer"
+                            className="text-emerald-400 hover:text-emerald-300 underline underline-offset-2"
+                          >
+                            aistudio.google.com
+                          </a>
+                          ).
+                        </p>
+                        <div className="flex items-center gap-2">
+                          <input
+                            type="password"
+                            value={geminiKey}
+                            onChange={(e) => setGeminiKey(e.target.value)}
+                            placeholder="AI... (paste here)"
+                            className="flex-1 rounded-md border border-zinc-800 bg-zinc-950 px-2.5 py-1.5 text-sm text-zinc-100 placeholder:text-zinc-600 focus:border-zinc-600 focus:outline-none font-mono"
+                            disabled={geminiSaving}
+                          />
+                          <Button
+                            type="button"
+                            size="sm"
+                            disabled={geminiSaving || !geminiKey.trim()}
+                            onClick={handleSaveGeminiKey}
+                          >
+                            {geminiSaving ? 'Saving...' : 'Save'}
+                          </Button>
+                        </div>
+                        {geminiError && <p className="text-xs text-rose-400">{geminiError}</p>}
+                        <p className="text-[11px] text-zinc-600">
+                          Other providers (OpenAI, Claude, Perplexity) configurable later via{' '}
+                          <Link to="/settings" className="text-zinc-500 hover:text-zinc-300 underline underline-offset-2">
+                            /settings
+                          </Link>
+                          .
+                        </p>
+                      </div>
                     )}
                   </div>
                   <ToneBadge
@@ -501,7 +588,22 @@ export function SetupPage() {
           </Card>
         )
 
-      case 4:
+      case 4: {
+        const run = launchedRun.data
+        const terminal = run?.status === 'completed' || run?.status === 'partial' || run?.status === 'failed' || run?.status === 'cancelled'
+        const snapshots = run?.snapshots ?? []
+        const cited = snapshots.filter(s => s.citationState === 'cited').length
+        const mentioned = snapshots.filter(s => s.answerMentioned === true).length
+        const totalQueries = new Set(snapshots.map(s => s.query).filter((q): q is string => !!q)).size
+
+        const stepBadge = !runTriggered
+          ? null
+          : terminal && (run?.status === 'completed' || run?.status === 'partial')
+            ? <ToneBadge tone="positive">Complete</ToneBadge>
+            : terminal
+              ? <ToneBadge tone="negative">Failed</ToneBadge>
+              : <ToneBadge tone="caution">Running</ToneBadge>
+
         return (
           <Card className="surface-card step-card">
             <div className="section-head">
@@ -509,19 +611,9 @@ export function SetupPage() {
                 <p className="eyebrow eyebrow-soft">Step 5 of 5</p>
                 <h2>Launch first run</h2>
               </div>
-              {runTriggered ? <ToneBadge tone="positive">Queued</ToneBadge> : null}
+              {stepBadge}
             </div>
-            {runTriggered ? (
-              <div className="compact-stack">
-                <p className="text-zinc-300">Visibility sweep has been queued. View progress on the project page.</p>
-                <div className="setup-nav">
-                  <span />
-                  <Button type="button" onClick={() => navigate({ to: createdProjectId ? `/projects/${createdProjectId}` : '/' })}>
-                    Open project
-                  </Button>
-                </div>
-              </div>
-            ) : (
+            {!runTriggered ? (
               <div className="compact-stack">
                 <p className="supporting-copy">
                   Everything is configured. Launch an answer-visibility sweep to start tracking citations for <span className="text-zinc-100 font-medium">{createdProjectName}</span>.
@@ -533,9 +625,69 @@ export function SetupPage() {
                   </Button>
                 </div>
               </div>
+            ) : !terminal ? (
+              <div className="compact-stack">
+                <p className="text-zinc-300">
+                  Sweep running — typically 30-60s. Polling every 2s…
+                </p>
+                <div className="rounded-md border border-zinc-800/60 bg-zinc-900/30 p-3 text-xs text-zinc-500">
+                  <p>Status: <span className="text-zinc-300">{run?.status ?? 'queued'}</span></p>
+                  <p className="mt-1">Run ID: <span className="font-mono text-zinc-400">{launchedRunId}</span></p>
+                </div>
+                <div className="setup-nav">
+                  <span />
+                  <Button type="button" variant="outline" onClick={() => navigate({ to: createdProjectId ? `/projects/${createdProjectId}` : '/' })}>
+                    Watch on project page
+                  </Button>
+                </div>
+              </div>
+            ) : run?.status === 'failed' ? (
+              <div className="compact-stack">
+                <p className="text-rose-400">Sweep failed. Inspect the run on the project page for the provider error and retry from there.</p>
+                <div className="setup-nav">
+                  <span />
+                  <Button type="button" onClick={() => navigate({ to: createdProjectId ? `/projects/${createdProjectId}` : '/' })}>
+                    Open project
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <div className="compact-stack">
+                <p className="text-zinc-300">
+                  Sweep complete. Your first answer-visibility snapshot for{' '}
+                  <span className="text-zinc-100 font-medium">{createdProjectName}</span>:
+                </p>
+                <div className="grid grid-cols-3 gap-2 mt-1">
+                  <div className="rounded-md border border-zinc-800/60 bg-zinc-900/30 p-3">
+                    <p className="text-[10px] uppercase tracking-wide text-zinc-500">Mentioned</p>
+                    <p className="text-2xl font-bold tabular-nums text-zinc-50 mt-1">{mentioned}<span className="text-zinc-600 text-lg"> / {totalQueries}</span></p>
+                    <p className="text-[11px] text-zinc-500 mt-0.5">queries with brand in answer</p>
+                  </div>
+                  <div className="rounded-md border border-zinc-800/60 bg-zinc-900/30 p-3">
+                    <p className="text-[10px] uppercase tracking-wide text-zinc-500">Cited</p>
+                    <p className="text-2xl font-bold tabular-nums text-zinc-50 mt-1">{cited}<span className="text-zinc-600 text-lg"> / {totalQueries}</span></p>
+                    <p className="text-[11px] text-zinc-500 mt-0.5">queries with domain in sources</p>
+                  </div>
+                  <div className="rounded-md border border-zinc-800/60 bg-zinc-900/30 p-3">
+                    <p className="text-[10px] uppercase tracking-wide text-zinc-500">Snapshots</p>
+                    <p className="text-2xl font-bold tabular-nums text-zinc-50 mt-1">{snapshots.length}</p>
+                    <p className="text-[11px] text-zinc-500 mt-0.5">total (query × provider)</p>
+                  </div>
+                </div>
+                <p className="text-[11px] text-zinc-500 mt-1">
+                  Full evidence, per-provider breakdown, and suggested next queries on the project dashboard.
+                </p>
+                <div className="setup-nav">
+                  <span />
+                  <Button type="button" onClick={() => navigate({ to: createdProjectId ? `/projects/${createdProjectId}` : '/' })}>
+                    Open project dashboard →
+                  </Button>
+                </div>
+              </div>
             )}
           </Card>
         )
+      }
 
       default:
         return null

--- a/apps/web/src/pages/SetupPage.tsx
+++ b/apps/web/src/pages/SetupPage.tsx
@@ -123,15 +123,25 @@ export function SetupPage() {
   // of the previous "queued — open project page" handoff. Refetches every
   // 2s while the run is in flight, then stops once a terminal status
   // (`completed`/`partial`/`failed`/`cancelled`) lands.
+  //
+  // `refetchIntervalInBackground: true` is load-bearing: without it,
+  // react-query v5 silently suppresses interval refetches whenever the
+  // tab loses focus (real user alt-tabbing during the 30-60s sweep, or
+  // any headless test environment). Symptom was: server completes the
+  // run, dashboard surfaces the result toast, but the wizard's Step 5
+  // card stays "Running" forever. Diagnosed via a remote PR walkthrough
+  // where the failure toast fired on the dashboard while the wizard
+  // card remained amber.
   const launchedRun = useQuery({
     queryKey: ['setup', 'launched-run', launchedRunId],
     queryFn: () => fetchRunDetail(launchedRunId!),
     enabled: !!launchedRunId,
-    refetchInterval: (q) => {
-      const status = q.state.data?.status
+    refetchInterval: ({ state }) => {
+      const status = state.data?.status
       const terminal = status === 'completed' || status === 'partial' || status === 'failed' || status === 'cancelled'
       return terminal ? false : 2000
     },
+    refetchIntervalInBackground: true,
   })
 
   // Inline provider key entry for Step 1. Replaces the prior "go to /settings"
@@ -169,7 +179,12 @@ export function SetupPage() {
         dedupeKey: `project:create:${project.name}`,
         dedupeMode: 'drop',
       })
-      void refetch()
+      // Await the dashboard refetch before advancing the step so the new
+      // project's row is in cache by the time Step 2's "Created" badge
+      // and Step 3's createdProjectName-dependent render run. Prior
+      // `void refetch()` raced with `setStep`, occasionally leaving the
+      // step indicator at 2 while the card content reverted to step 1.
+      await refetch()
       setStep(2)
     } catch (err) {
       setProjectError(err instanceof Error ? err.message : 'Failed to create project')
@@ -187,7 +202,7 @@ export function SetupPage() {
     try {
       await setQueries(createdProjectName, queries)
       setQueriesSaved(true)
-      void refetch()
+      await refetch()
       setStep(3)
     } catch (err) {
       setQueriesError(err instanceof Error ? err.message : 'Failed to save queries')
@@ -224,7 +239,7 @@ export function SetupPage() {
     try {
       await setCompetitors(createdProjectName, competitors)
       setCompetitorsSaved(true)
-      void refetch()
+      await refetch()
       setStep(4)
     } catch (err) {
       setCompetitorsError(err instanceof Error ? err.message : 'Failed to save competitors')
@@ -269,7 +284,7 @@ export function SetupPage() {
       })
       setLaunchedRunId(run.id)
       setRunTriggered(true)
-      void refetch()
+      await refetch()
     } catch {
       // Mutation hook surfaces the toast and error state.
     } finally {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -281,6 +281,14 @@
     @apply flex min-h-screen flex-1 flex-col lg:pl-56;
   }
 
+  /* First-run focus mode (sidebar hidden) — drop the 224px sidebar gutter
+     so the wizard centers across the full viewport instead of being
+     offset right. Applied via the `app-shell-focus` modifier set by
+     App.tsx when the user is on /setup with zero projects. */
+  .app-shell-focus .main-area {
+    @apply lg:pl-0;
+  }
+
   .topbar {
     @apply sticky top-0 z-20 flex items-center justify-between gap-4 border-b border-zinc-800/60 bg-zinc-950/95 px-4 py-2.5 backdrop-blur-sm md:px-6;
   }
@@ -936,7 +944,11 @@
   /* ── Setup wizard ── */
 
   .setup-wizard {
-    @apply max-w-xl;
+    /* Was max-w-xl (576px). On a 1400px+ viewport the card looked stranded
+       in empty space — the step indicator above is full page-container
+       width, so the card looked disconnected. 3xl (768px) gives form
+       fields room to breathe without sprawling on big monitors. */
+    @apply max-w-3xl;
   }
 
   .setup-steps {

--- a/apps/web/test/setup-launched-run-polling.test.tsx
+++ b/apps/web/test/setup-launched-run-polling.test.tsx
@@ -132,25 +132,49 @@ describe('SetupPage launched-run polling', () => {
     expect(fetcher.mock.calls.length).toBe(callsAtTerminal)
   })
 
-  it('keeps polling even when the document is not focused (regression for #554)', async () => {
-    // Reproduce the original bug: simulate the tab losing focus by stubbing
-    // document.hasFocus to return false. With the prior config
-    // (refetchIntervalInBackground default-false), polling would silently
-    // suppress. With the fix, polling continues regardless of focus.
-    const hasFocusSpy = vi.spyOn(document, 'hasFocus').mockReturnValue(false)
+  it('keeps polling even when the document visibilityState is "hidden" (regression for #554)', async () => {
+    // Reproduce the original bug: react-query v5's FocusManager checks
+    // `document.visibilityState === 'visible'` to gate background refetches.
+    // With `refetchIntervalInBackground: false` (the v5 default), polling
+    // silently suppresses whenever visibility flips to 'hidden' — exactly
+    // the case the remote walkthrough hit (the headless test environment
+    // and any real user alt-tabbing during the 30-60s sweep).
+    //
+    // This test overrides `document.visibilityState` and notifies the
+    // FocusManager via the `visibilitychange` event. With the fix
+    // (`refetchIntervalInBackground: true`), polling continues.
+    const originalDescriptor = Object.getOwnPropertyDescriptor(Document.prototype, 'visibilityState')
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'hidden',
+    })
+    document.dispatchEvent(new Event('visibilitychange'))
 
-    fetcher.mockResolvedValue(makeRunDetail('running'))
+    try {
+      fetcher.mockResolvedValue(makeRunDetail('running'))
 
-    render(
-      <QueryClientProvider client={queryClient}>
-        <Probe runId="run_test" />
-      </QueryClientProvider>,
-    )
+      render(
+        <QueryClientProvider client={queryClient}>
+          <Probe runId="run_test" />
+        </QueryClientProvider>,
+      )
 
-    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1))
-    await vi.advanceTimersByTimeAsync(4500)
-    expect(fetcher.mock.calls.length).toBeGreaterThanOrEqual(3)
+      await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1))
 
-    hasFocusSpy.mockRestore()
+      // Advance 4.5s. With the fix in place we expect ≥3 calls
+      // (initial + 2s + 4s polls). Without the fix this assertion would
+      // fail because the visibility-hidden focus manager suppresses
+      // background refetches.
+      await vi.advanceTimersByTimeAsync(4500)
+      expect(fetcher.mock.calls.length).toBeGreaterThanOrEqual(3)
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(Document.prototype, 'visibilityState', originalDescriptor)
+      } else {
+        // jsdom didn't define it on prototype; clear the instance override
+        delete (document as unknown as { visibilityState?: unknown }).visibilityState
+      }
+      document.dispatchEvent(new Event('visibilitychange'))
+    }
   })
 })

--- a/apps/web/test/setup-launched-run-polling.test.tsx
+++ b/apps/web/test/setup-launched-run-polling.test.tsx
@@ -1,0 +1,156 @@
+// Regression test for PR #554's Step 5 inline-results polling.
+//
+// The bug: `refetchInterval` callback worked, but `refetchIntervalInBackground`
+// defaulted to `false` in react-query v5 — meaning the moment the tab lost
+// focus (real user alt-tabbing during the 30-60s sweep, or any headless test
+// environment), polling silently suppressed and the wizard stayed on the
+// "Running" badge forever even though the server had already completed.
+//
+// This test exercises the polling helper in isolation against a mocked
+// `fetchRunDetail` to prove:
+//   1. The query polls on the 2s interval while status is non-terminal.
+//   2. Polling stops the moment a terminal status (`completed`/`failed`/...)
+//      lands.
+//   3. Polling does NOT silently suppress when the tab is not focused
+//      (the original bug).
+
+import { render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query'
+import type { ApiRunDetail } from '../src/api.js'
+
+// Standalone copy of the SetupPage.tsx launchedRun config. Importing the
+// full SetupPage pulls in too much state for a focused test; mirroring the
+// config here lets us assert the exact pattern without spinning up the
+// whole wizard.
+function useLaunchedRunPoll(runId: string | null, fetcher: (id: string) => Promise<ApiRunDetail>) {
+  return useQuery({
+    queryKey: ['setup', 'launched-run', runId],
+    queryFn: () => fetcher(runId!),
+    enabled: !!runId,
+    refetchInterval: ({ state }) => {
+      const status = state.data?.status
+      const terminal = status === 'completed' || status === 'partial' || status === 'failed' || status === 'cancelled'
+      return terminal ? false : 2000
+    },
+    refetchIntervalInBackground: true,
+  })
+}
+
+function makeRunDetail(status: ApiRunDetail['status']): ApiRunDetail {
+  return {
+    id: 'run_test',
+    projectId: 'p_test',
+    kind: 'answer-visibility',
+    status,
+    trigger: 'manual',
+    location: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    startedAt: '2026-01-01T00:00:00.000Z',
+    finishedAt: status === 'completed' || status === 'failed' || status === 'partial' || status === 'cancelled'
+      ? '2026-01-01T00:00:30.000Z'
+      : null,
+    error: null,
+    snapshots: [],
+  }
+}
+
+let queryClient: QueryClient
+let fetcher: ReturnType<typeof vi.fn>
+
+function Probe({ runId }: { runId: string | null }) {
+  const q = useLaunchedRunPoll(runId, fetcher)
+  return <div data-testid="status">{q.data?.status ?? 'no-data'}</div>
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0 } },
+  })
+  fetcher = vi.fn()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  queryClient.clear()
+})
+
+describe('SetupPage launched-run polling', () => {
+  it('does not fetch while runId is null', async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Probe runId={null} />
+      </QueryClientProvider>,
+    )
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(fetcher).not.toHaveBeenCalled()
+  })
+
+  it('polls every 2s while the run is still running', async () => {
+    // Server keeps returning 'running' — wizard should keep polling.
+    fetcher.mockResolvedValue(makeRunDetail('running'))
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Probe runId="run_test" />
+      </QueryClientProvider>,
+    )
+
+    // Wait for the initial fetch to resolve.
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1))
+
+    // Advance ~4.5s — expect 2 more polls at 2s + 4s.
+    await vi.advanceTimersByTimeAsync(4500)
+    expect(fetcher.mock.calls.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('stops polling the moment a terminal status lands', async () => {
+    // First call returns running, second returns failed.
+    fetcher
+      .mockResolvedValueOnce(makeRunDetail('running'))
+      .mockResolvedValueOnce(makeRunDetail('failed'))
+      .mockResolvedValue(makeRunDetail('failed'))
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Probe runId="run_test" />
+      </QueryClientProvider>,
+    )
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1))
+
+    // First poll cycle — picks up failed.
+    await vi.advanceTimersByTimeAsync(2100)
+    await waitFor(() => expect(fetcher.mock.calls.length).toBeGreaterThanOrEqual(2))
+
+    const callsAtTerminal = fetcher.mock.calls.length
+
+    // Now wait another 10s — no additional polls should fire because
+    // refetchInterval returned false.
+    await vi.advanceTimersByTimeAsync(10000)
+    expect(fetcher.mock.calls.length).toBe(callsAtTerminal)
+  })
+
+  it('keeps polling even when the document is not focused (regression for #554)', async () => {
+    // Reproduce the original bug: simulate the tab losing focus by stubbing
+    // document.hasFocus to return false. With the prior config
+    // (refetchIntervalInBackground default-false), polling would silently
+    // suppress. With the fix, polling continues regardless of focus.
+    const hasFocusSpy = vi.spyOn(document, 'hasFocus').mockReturnValue(false)
+
+    fetcher.mockResolvedValue(makeRunDetail('running'))
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Probe runId="run_test" />
+      </QueryClientProvider>,
+    )
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1))
+    await vi.advanceTimersByTimeAsync(4500)
+    expect(fetcher.mock.calls.length).toBeGreaterThanOrEqual(3)
+
+    hasFocusSpy.mockRestore()
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.45.0",
+  "version": "4.46.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.45.0",
+  "version": "4.46.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/commands/init.ts
+++ b/packages/canonry/src/commands/init.ts
@@ -409,21 +409,31 @@ export async function initCommand(opts?: InitOptions): Promise<ResolvedAgentLLM 
  * Concrete next-step instructions printed after `canonry init`. Listed in
  * the order the user should follow — analytics on the install funnel show a
  * large "silent bounce" cohort that runs init and never runs another command,
- * so the goal is to make the next action unambiguous and immediate (project
- * → query → run).
+ * so the goal is to make the next action unambiguous and immediate.
+ *
+ * The dashboard wizard (`canonry serve` → `http://localhost:4100/setup`) is
+ * the recommended primary path: it covers project creation, query basket,
+ * competitors, and the first sweep with results inline — 5 guided steps with
+ * health checks, no flag-juggling. The CLI sequence is listed as the
+ * alternative for operators who prefer scripts or non-interactive automation.
  */
 function buildNextSteps(): string[] {
   return [
-    '1. Create a project for the domain you want to track:',
-    '     canonry project create my-site --domain example.com --country US --language en',
+    '1. Start the dashboard and open the setup wizard:',
+    '     canonry serve',
+    '     → http://localhost:4100/setup',
     '',
-    '2. Add the questions your customers ask AI assistants:',
-    '     canonry query add my-site "best <category> for <use case>"',
+    '   The wizard walks through project → queries → competitors → first sweep',
+    '   in 5 guided steps and shows your first results inline.',
     '',
-    '3. Run your first sweep:',
-    '     canonry run my-site',
+    'Prefer the terminal? The same flow as CLI commands:',
     '',
-    'Tip: "canonry doctor" verifies your setup. "canonry serve" opens the dashboard.',
+    '  a. canonry project create my-site --domain example.com --country US --language en',
+    '  b. canonry query add my-site "best <category> for <use case>"',
+    '  c. canonry run my-site --wait',
+    '  d. canonry overview my-site',
+    '',
+    'Tip: "canonry doctor" verifies your setup before you start.',
   ]
 }
 


### PR DESCRIPTION
Three fixes from the onboarding audit. Two structural drop-offs in the wizard + one CLI/UI split-brain in next-steps.

## What changes

**Step 1 — provider key entry inline (was: link out to `/settings`)**
Previously: "Configure providers →" link sent users away from the wizard. Most never came back.
Now: small inline form for the Gemini key (the easiest free provider). Save → re-checks → "Continue" enables. Other providers still reachable via a `/settings` deep-link at the bottom for users who want them.

**Step 5 — inline run results (was: "Queued — Open project page")**
Previously: hit Launch → "queued" → button to a half-empty project page. Aha moment lost.
Now: triggerRun captures the runId, `useQuery` polls every 2s until terminal status, then renders three result tiles in the wizard:

| Mentioned | Cited | Snapshots |
|---|---|---|
| 3 / 5 | 1 / 5 | 9 |
| queries with brand in answer | queries with domain in sources | total (query × provider) |

Distinct UI states for running / failed / complete. "Open project dashboard →" only appears once there's data to look at.

**CLI `canonry init` next-steps — lead with the wizard**
Previously led with `canonry project create my-site --domain example.com --country US --language en` (4 flags to remember on day one). Now leads with `canonry serve` → `http://localhost:4100/setup` and lists CLI commands as the "prefer the terminal?" alternative. Closes the README ↔ init split-brain.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm vitest run --project web` — 199 passing
- [x] `pnpm lint` — clean
- [ ] **Live browser walkthrough on an isolated `CANONRY_CONFIG_DIR=/tmp/...` instance** — happening next, will report findings

Minor bump 4.45.0 → 4.46.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)