### PR TITLE
Potential fix for code scanning alert no. 7: Server-side request forgery

### DIFF
--- a/packages/integration-google-analytics/src/ga4-client.ts
+++ b/packages/integration-google-analytics/src/ga4-client.ts
@@ -147,7 +147,9 @@ async function runReport(
   propertyId: string,
   request: GA4RunReportRequest,
 ): Promise<GA4RunReportResponse> {
-  const url = `${GA4_DATA_API_BASE}/properties/${propertyId}:runReport`
+  validatePropertyId(propertyId)
+  const safePropertyId = encodeURIComponent(propertyId)
+  const url = `${GA4_DATA_API_BASE}/properties/${safePropertyId}:runReport`
 
   const res = await fetch(url, {
     method: 'POST',


### PR DESCRIPTION
Potential fix for [https://github.com/AINYC/canonry/security/code-scanning/7](https://github.com/AINYC/canonry/security/code-scanning/7)

To fix this safely, enforce strict validation of `propertyId` at the point where the URL is built (`runReport`), and URL-encode the path segment before interpolation.

Best approach without changing functionality:
1. In `packages/integration-google-analytics/src/ga4-client.ts`, inside `runReport`, call existing `validatePropertyId(propertyId)` before constructing `url`.
2. Build a safe path segment with `encodeURIComponent(propertyId)` and use that in the URL template.
3. Keep all existing request logic unchanged.

This preserves expected GA4 behavior for valid property IDs while preventing malicious characters from altering path/query/fragment semantics.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
