### PR TITLE
feat(runs): add probe trigger — operator/agent test runs excluded from aggregates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ canonry competitor add <project> <domain>...
 canonry competitor remove <project> <domain>...
 canonry run <project>
 canonry run <project> --provider gemini          # single-provider run
+canonry run <project> --probe --provider openai --query "..."  # operator/agent test run — writes a snapshot for inspection but is EXCLUDED from dashboard, analytics, intelligence, and notifications
 canonry status <project>
 canonry apply <file...>                          # multi-doc YAML + multiple files
 canonry export <project>
@@ -281,7 +282,7 @@ if (answerMentioned) mentioned++
 |----------|------|--------|
 | `RunKinds` | `RunKind` | `RunKinds['answer-visibility']`, `RunKinds['gsc-sync']`, etc. |
 | `RunStatuses` | `RunStatus` | `RunStatuses.completed`, `RunStatuses.failed`, etc. |
-| `RunTriggers` | `RunTrigger` | `RunTriggers.manual`, `RunTriggers.scheduled`, etc. |
+| `RunTriggers` | `RunTrigger` | `RunTriggers.manual`, `RunTriggers.scheduled`, `RunTriggers.probe`, etc. |
 | `CitationStates` | `CitationState` | `CitationStates.cited`, `CitationStates['not-cited']` |
 | `VisibilityStates` | `VisibilityState` | `VisibilityStates.visible`, `VisibilityStates['not-visible']` |
 | `ComputedTransitions` | `ComputedTransition` | `ComputedTransitions.lost`, `ComputedTransitions.emerging`, etc. |
@@ -718,6 +719,30 @@ All endpoints under `/api/v1/`. Auth via `Authorization: Bearer cnry_...`. Key e
 - `GET /api/v1/openapi.json` — OpenAPI spec (no auth)
 
 See OpenAPI spec at `/api/v1/openapi.json` for the complete API surface.
+
+## Probe runs (Critical)
+
+A **probe run** (`runs.trigger = 'probe'`, `RunTriggers.probe`) is an operator/agent test run that writes a snapshot so the operator can inspect provider behavior — but it MUST NOT influence the dashboard, analytics, intelligence, report, or notifications. Examples: verifying a provider migration still works; agent-initiated regression checks after a code change.
+
+Triggered via `canonry run <project> --probe ...` or `POST /api/v1/projects/:name/runs` with `{ "trigger": "probe", ... }`.
+
+### Rules for new code
+
+1. **Read-aggregate endpoints MUST exclude probes.** Every Drizzle query that does `from(runs).where(eq(runs.projectId, ...))` for dashboard / analytics / report / timeline / intelligence purposes MUST AND-in `notProbeRun()` from `packages/api-routes/src/helpers.ts`. The test that catches regressions is `packages/api-routes/test/probe-exclusion.test.ts` — add a case when you ship a new aggregate endpoint.
+
+2. **Per-run detail endpoints INCLUDE probes.** Endpoints that take a `runId` from the caller (`GET /runs/:id`, screenshot, browser-diff, GSC inspect lookups) MUST work for probe runs — the operator needs to inspect the snapshot they just created.
+
+3. **Operator-facing list endpoints INCLUDE probes.** `GET /runs` and `GET /projects/:name/runs` show probes alongside real runs so operators can find their tests. The dashboard's TanStack Query consumer (`apps/web/src/queries/use-dashboard.ts`) filters probes client-side after fetching the unfiltered list.
+
+4. **`RunCoordinator` short-circuits probes.** `packages/canonry/src/run-coordinator.ts` returns early without running intelligence, firing webhooks, or waking Aero when `runRow.trigger === 'probe'`. Don't add new post-run subscribers that skip this check.
+
+5. **Operator triggers only.** `runTriggerRequestSchema` only accepts `manual` or `probe` from external callers. `scheduled`, `config-apply`, `backfill` are server-set based on the call site.
+
+### Checklist when adding a new run-aggregate endpoint
+
+- [ ] Drizzle query AND-in `notProbeRun()` from `helpers.ts`
+- [ ] Add a case to `probe-exclusion.test.ts` asserting the endpoint reads from the real run, not the probe
+- [ ] If the endpoint pages through historical runs (insights / health / report), confirm the recent-runs window also excludes probes
 
 ## Base Path Awareness (Critical)
 

--- a/apps/web/src/queries/use-dashboard.ts
+++ b/apps/web/src/queries/use-dashboard.ts
@@ -56,7 +56,15 @@ export function useDashboard(initialDashboard?: DashboardVm | null) {
     queries: projects.map((project) => {
       const projectRuns = allRuns.filter(r => r.projectId === project.id)
       const completedRuns = projectRuns
-        .filter(r => (r.status === 'completed' || r.status === 'partial') && r.kind === 'answer-visibility')
+        .filter(r =>
+          (r.status === 'completed' || r.status === 'partial')
+          && r.kind === 'answer-visibility'
+          // Probe runs are operator/agent test runs — they write a
+          // snapshot for inspection but must never displace a real sweep
+          // on the dashboard. /runs (the operator-facing list endpoint)
+          // intentionally includes probes, so the dashboard has to filter
+          // them out client-side.
+          && r.trigger !== 'probe')
         .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
 
       // Multi-location sweeps fan out into one run per location with an identical

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -533,7 +533,7 @@ export type LatestProjectRunDto = {
         projectId: string;
         kind: 'answer-visibility' | 'site-audit' | 'gsc-sync' | 'inspect-sitemap' | 'ga-sync' | 'bing-inspect' | 'bing-inspect-sitemap' | 'backlink-extract' | 'traffic-sync' | 'aeo-discover-seed' | 'aeo-discover-probe';
         status: 'queued' | 'running' | 'completed' | 'partial' | 'failed' | 'cancelled';
-        trigger: 'manual' | 'scheduled' | 'config-apply' | 'backfill';
+        trigger: 'manual' | 'scheduled' | 'config-apply' | 'backfill' | 'probe';
         location?: string;
         queries?: Array<string>;
         startedAt?: string;
@@ -638,7 +638,7 @@ export type RunDetailDto = {
     projectId: string;
     kind: 'answer-visibility' | 'site-audit' | 'gsc-sync' | 'inspect-sitemap' | 'ga-sync' | 'bing-inspect' | 'bing-inspect-sitemap' | 'backlink-extract' | 'traffic-sync' | 'aeo-discover-seed' | 'aeo-discover-probe';
     status: 'queued' | 'running' | 'completed' | 'partial' | 'failed' | 'cancelled';
-    trigger: 'manual' | 'scheduled' | 'config-apply' | 'backfill';
+    trigger: 'manual' | 'scheduled' | 'config-apply' | 'backfill' | 'probe';
     location?: string;
     queries?: Array<string>;
     startedAt?: string;
@@ -685,7 +685,7 @@ export type RunDto = {
     projectId: string;
     kind: 'answer-visibility' | 'site-audit' | 'gsc-sync' | 'inspect-sitemap' | 'ga-sync' | 'bing-inspect' | 'bing-inspect-sitemap' | 'backlink-extract' | 'traffic-sync' | 'aeo-discover-seed' | 'aeo-discover-probe';
     status: 'queued' | 'running' | 'completed' | 'partial' | 'failed' | 'cancelled';
-    trigger: 'manual' | 'scheduled' | 'config-apply' | 'backfill';
+    trigger: 'manual' | 'scheduled' | 'config-apply' | 'backfill' | 'probe';
     location?: string;
     queries?: Array<string>;
     startedAt?: string;

--- a/packages/api-routes/AGENTS.md
+++ b/packages/api-routes/AGENTS.md
@@ -9,7 +9,7 @@ Shared Fastify route plugins used by both the local server (`packages/canonry`) 
 | File | Role |
 |------|------|
 | `src/index.ts` | Plugin entry point, global error handler, `ApiRoutesOptions` interface |
-| `src/helpers.ts` | `resolveProject()`, `writeAuditLog()`, `incrementUsage()` |
+| `src/helpers.ts` | `resolveProject()`, `writeAuditLog()`, `incrementUsage()`, `notProbeRun()` (Drizzle predicate every dashboard/analytics/report/timeline/intelligence read MUST AND-in to exclude probe runs — see root AGENTS.md "Probe runs" section) |
 | `src/projects.ts` | Project CRUD routes (largest route file) |
 | `src/runs.ts` | Run trigger, status, and list routes |
 | `src/auth.ts` | Auth plugin — API key and session validation |

--- a/packages/api-routes/src/analytics.ts
+++ b/packages/api-routes/src/analytics.ts
@@ -1,4 +1,4 @@
-import { eq, desc, inArray } from 'drizzle-orm'
+import { and, eq, desc, inArray } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import { filterTrackedSnapshots, groupRunsByCreatedAt, pickGroupRepresentative, querySnapshots, runs, queries, parseJsonColumn } from '@ainyc/canonry-db'
 import { AI_PROVIDER_INFRA_DOMAINS, categorizeSource, categoryLabel, CitationStates, parseWindow, windowCutoff } from '@ainyc/canonry-contracts'
@@ -7,7 +7,7 @@ import type {
   TimeBucket, TrendDirection, GapQuery, GapCategory,
   SourceCategory, SourceCategoryCount, ProviderMetric, QueryChangeEvent,
 } from '@ainyc/canonry-contracts'
-import { resolveProject, resolveSnapshotAnswerMentioned } from './helpers.js'
+import { notProbeRun, resolveProject, resolveSnapshotAnswerMentioned } from './helpers.js'
 
 export async function analyticsRoutes(app: FastifyInstance) {
   // GET /projects/:name/analytics/metrics — citation rate trends
@@ -23,7 +23,7 @@ export async function analyticsRoutes(app: FastifyInstance) {
     const projectRuns = app.db
       .select()
       .from(runs)
-      .where(eq(runs.projectId, project.id))
+      .where(and(eq(runs.projectId, project.id), notProbeRun()))
       .orderBy(runs.createdAt)
       .all()
       .filter(r => r.status === 'completed' || r.status === 'partial')
@@ -118,7 +118,7 @@ export async function analyticsRoutes(app: FastifyInstance) {
     const completedRuns = app.db
       .select()
       .from(runs)
-      .where(eq(runs.projectId, project.id))
+      .where(and(eq(runs.projectId, project.id), notProbeRun()))
       .orderBy(desc(runs.createdAt), desc(runs.id))
       .all()
       .filter(r => r.status === 'completed' || r.status === 'partial')
@@ -134,7 +134,7 @@ export async function analyticsRoutes(app: FastifyInstance) {
     const windowRuns = app.db
       .select()
       .from(runs)
-      .where(eq(runs.projectId, project.id))
+      .where(and(eq(runs.projectId, project.id), notProbeRun()))
       .orderBy(runs.createdAt)
       .all()
       .filter(r => r.status === 'completed' || r.status === 'partial')
@@ -306,7 +306,7 @@ export async function analyticsRoutes(app: FastifyInstance) {
     const windowRuns = app.db
       .select()
       .from(runs)
-      .where(eq(runs.projectId, project.id))
+      .where(and(eq(runs.projectId, project.id), notProbeRun()))
       .orderBy(desc(runs.createdAt), desc(runs.id))
       .all()
       .filter(r => r.status === 'completed' || r.status === 'partial')

--- a/packages/api-routes/src/citations.ts
+++ b/packages/api-routes/src/citations.ts
@@ -1,4 +1,4 @@
-import { eq, inArray } from 'drizzle-orm'
+import { and, eq, inArray } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import { competitors, queries, querySnapshots, runs, parseJsonColumn } from '@ainyc/canonry-db'
 import {
@@ -11,7 +11,7 @@ import {
   type CompetitorGapRow,
   type CitationState,
 } from '@ainyc/canonry-contracts'
-import { resolveProject } from './helpers.js'
+import { notProbeRun, resolveProject } from './helpers.js'
 
 interface SnapshotRow {
   id: string
@@ -49,7 +49,7 @@ export async function citationRoutes(app: FastifyInstance) {
     const projectRuns = app.db
       .select({ id: runs.id, createdAt: runs.createdAt })
       .from(runs)
-      .where(eq(runs.projectId, project.id))
+      .where(and(eq(runs.projectId, project.id), notProbeRun()))
       .all()
 
     if (projectRuns.length === 0) {

--- a/packages/api-routes/src/composites.ts
+++ b/packages/api-routes/src/composites.ts
@@ -66,7 +66,7 @@ import {
   providerKey,
   type SuggestedQueryGscRow,
 } from '@ainyc/canonry-intelligence'
-import { resolveProject } from './helpers.js'
+import { notProbeRun, resolveProject } from './helpers.js'
 
 const TOP_INSIGHT_LIMIT = 5
 const SEARCH_HIT_HARD_LIMIT = 50
@@ -112,7 +112,7 @@ export async function compositeRoutes(app: FastifyInstance) {
     const allRunsRaw = app.db
       .select()
       .from(runs)
-      .where(eq(runs.projectId, project.id))
+      .where(and(eq(runs.projectId, project.id), notProbeRun()))
       .orderBy(desc(runs.createdAt), desc(runs.id))
       .all()
     const allRuns = allRunsRaw.filter(r => runMatchesFilters(r, filterLocation, sinceIso))

--- a/packages/api-routes/src/content-data.ts
+++ b/packages/api-routes/src/content-data.ts
@@ -39,6 +39,7 @@ import {
   type LocationContext,
   type ProviderName,
 } from '@ainyc/canonry-contracts'
+import { notProbeRun } from './helpers.js'
 
 const RECENT_RUNS_WINDOW = 5
 
@@ -235,6 +236,9 @@ function listRecentAnswerVisibilityRunIds(
         // snapshots; including them risks pointing latestRunId at a run with
         // no usable evidence.
         inArray(runs.status, [RunStatuses.completed, RunStatuses.partial]),
+        // Probe runs are operator/agent test runs; they must not poison the
+        // recent-runs window the content engine uses to recommend actions.
+        notProbeRun(),
       ),
     )
     .orderBy(desc(runs.createdAt))

--- a/packages/api-routes/src/helpers.ts
+++ b/packages/api-routes/src/helpers.ts
@@ -1,17 +1,35 @@
 import crypto from 'node:crypto'
-import { eq, sql } from 'drizzle-orm'
+import { eq, ne, sql, type SQL } from 'drizzle-orm'
 import type { DatabaseClient } from '@ainyc/canonry-db'
-import { projects, auditLog, usageCounters, parseJsonColumn } from '@ainyc/canonry-db'
+import { projects, runs, auditLog, usageCounters, parseJsonColumn } from '@ainyc/canonry-db'
 import {
   extractAnswerMentions,
   effectiveBrandNames,
   effectiveDomains,
   mentionStateFromAnswerMentioned,
   notFound,
+  RunTriggers,
   visibilityStateFromAnswerMentioned,
   type MentionState,
   type VisibilityState,
 } from '@ainyc/canonry-contracts'
+
+/**
+ * Drizzle predicate that excludes probe runs (`trigger='probe'`).
+ *
+ * Probe runs are operator/agent test runs that write snapshots so the
+ * operator can inspect provider behavior, but they must NEVER influence
+ * dashboard / analytics / report / timeline aggregates. Every read-aggregate
+ * query that touches `runs` MUST AND-in this predicate. See
+ * `packages/api-routes/test/probe-exclusion.test.ts` for the surface map.
+ *
+ * INCLUDE probes in: per-run detail endpoints (caller passes the runId),
+ * delete-preview cascade counts (must show true blast radius), the operator
+ * run-list view (`GET /projects/:name/runs`).
+ */
+export function notProbeRun(): SQL {
+  return ne(runs.trigger, RunTriggers.probe)
+}
 
 export function resolveProject(db: DatabaseClient, name: string) {
   const project = db.select().from(projects).where(eq(projects.name, name)).get()

--- a/packages/api-routes/src/history.ts
+++ b/packages/api-routes/src/history.ts
@@ -1,8 +1,8 @@
-import { eq, desc, inArray } from 'drizzle-orm'
+import { and, eq, desc, inArray } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import { auditLog, querySnapshots, runs, queries, parseJsonColumn } from '@ainyc/canonry-db'
 import { CitationStates, validationError } from '@ainyc/canonry-contracts'
-import { resolveProject, resolveSnapshotAnswerMentioned, resolveSnapshotMentionState, resolveSnapshotVisibilityState } from './helpers.js'
+import { notProbeRun, resolveProject, resolveSnapshotAnswerMentioned, resolveSnapshotMentionState, resolveSnapshotVisibilityState } from './helpers.js'
 import { redactNotificationDiff } from './notification-redaction.js'
 
 export async function historyRoutes(app: FastifyInstance) {
@@ -45,7 +45,7 @@ export async function historyRoutes(app: FastifyInstance) {
     const projectRuns = app.db
       .select({ id: runs.id })
       .from(runs)
-      .where(eq(runs.projectId, project.id))
+      .where(and(eq(runs.projectId, project.id), notProbeRun()))
       .all()
 
     if (projectRuns.length === 0) {
@@ -123,7 +123,7 @@ export async function historyRoutes(app: FastifyInstance) {
     const projectRuns = app.db
       .select()
       .from(runs)
-      .where(eq(runs.projectId, project.id))
+      .where(and(eq(runs.projectId, project.id), notProbeRun()))
       .orderBy(runs.createdAt)
       .all()
 

--- a/packages/api-routes/src/intelligence.ts
+++ b/packages/api-routes/src/intelligence.ts
@@ -2,7 +2,7 @@ import { eq, desc, and, inArray } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import { groupRunsByCreatedAt, insights, healthSnapshots, parseJsonColumn, runs } from '@ainyc/canonry-db'
 import { notFound, RunKinds, RunStatuses, type InsightDto, type HealthSnapshotDto } from '@ainyc/canonry-contracts'
-import { resolveProject } from './helpers.js'
+import { notProbeRun, resolveProject } from './helpers.js'
 
 function emptyHealthSnapshot(projectId: string): HealthSnapshotDto {
   return {
@@ -198,6 +198,9 @@ export async function intelligenceRoutes(app: FastifyInstance) {
         eq(runs.projectId, project.id),
         eq(runs.kind, RunKinds['answer-visibility']),
         inArray(runs.status, [RunStatuses.completed, RunStatuses.partial]),
+        // Health-latest is the dashboard headline; probe runs must not
+        // displace the most recent real visibility sweep.
+        notProbeRun(),
       ))
       .orderBy(desc(runs.createdAt), desc(runs.id))
       .all()

--- a/packages/api-routes/src/report.ts
+++ b/packages/api-routes/src/report.ts
@@ -62,7 +62,7 @@ import {
   mapOpportunitiesToNextSteps,
   smoothedRunDelta,
 } from '@ainyc/canonry-intelligence'
-import { resolveProject } from './helpers.js'
+import { notProbeRun, resolveProject } from './helpers.js'
 import { renderReportHtml } from './report-renderer.js'
 import {
   extractGroundingSources,
@@ -971,7 +971,7 @@ function buildCitationsTrend(
   const visibilityRuns = db
     .select()
     .from(runs)
-    .where(and(eq(runs.projectId, projectId), eq(runs.kind, RunKinds['answer-visibility'])))
+    .where(and(eq(runs.projectId, projectId), eq(runs.kind, RunKinds['answer-visibility']), notProbeRun()))
     .all()
     .filter(r => locationFilter === undefined || (r.location ?? null) === locationFilter)
 
@@ -1053,6 +1053,7 @@ function buildInsightList(
         eq(runs.projectId, projectId),
         eq(runs.kind, RunKinds['answer-visibility']),
         or(eq(runs.status, RunStatuses.completed), eq(runs.status, RunStatuses.partial)),
+        notProbeRun(),
       ),
     )
     .orderBy(desc(runs.createdAt))
@@ -1797,7 +1798,7 @@ function buildProjectReport(db: DatabaseClient, projectName: string): ProjectRep
   const allRuns = db
     .select()
     .from(runs)
-    .where(eq(runs.projectId, project.id))
+    .where(and(eq(runs.projectId, project.id), notProbeRun()))
     .orderBy(desc(runs.createdAt), desc(runs.id))
     .all()
 

--- a/packages/api-routes/test/probe-exclusion.test.ts
+++ b/packages/api-routes/test/probe-exclusion.test.ts
@@ -1,0 +1,302 @@
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import Fastify from 'fastify'
+import { eq } from 'drizzle-orm'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  createClient,
+  migrate,
+  projects,
+  queries as queriesTable,
+  competitors,
+  runs,
+  querySnapshots,
+} from '@ainyc/canonry-db'
+import { apiRoutes } from '../src/index.js'
+
+/**
+ * Probe runs (`runs.trigger = 'probe'`) write snapshots so an operator can
+ * inspect what a provider returned, but they must NEVER influence
+ * dashboard / analytics / report / timeline aggregates. The aggregates
+ * read directly from `runs` + `query_snapshots`, so the filter has to live
+ * at the query layer.
+ *
+ * This file is the single chokepoint for that invariant: it seeds one
+ * project with two runs — a `manual` (real) run that cites the brand and
+ * a `probe` run that intentionally does NOT cite the brand — and verifies
+ * every aggregate endpoint surfaces only the real run.
+ *
+ * If you add a new read-aggregate endpoint that reads from `runs`, add a
+ * case to this file. The map in the original PR (.probe-exclusion-map.txt)
+ * enumerates the surface.
+ */
+
+interface Ctx {
+  app: ReturnType<typeof Fastify>
+  db: ReturnType<typeof createClient>
+  tmpDir: string
+  projectId: string
+  queryId: string
+  realRunId: string
+  probeRunId: string
+}
+
+function buildCtx(): Ctx {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-probe-excl-'))
+  const db = createClient(path.join(tmpDir, 'test.db'))
+  migrate(db)
+  const app = Fastify()
+  app.register(apiRoutes, { db, skipAuth: true })
+
+  const now = new Date()
+  const realCreatedAt = new Date(now.getTime() - 60_000).toISOString() // 1 min ago
+  const probeCreatedAt = now.toISOString() // newer than the real run
+
+  const projectId = crypto.randomUUID()
+  db.insert(projects).values({
+    id: projectId,
+    name: 'probe-excl',
+    displayName: 'Probe Exclusion',
+    canonicalDomain: 'real-brand.example.com',
+    country: 'US',
+    language: 'en',
+    providers: JSON.stringify(['openai']),
+    locations: '[]',
+    createdAt: realCreatedAt,
+    updatedAt: realCreatedAt,
+  }).run()
+
+  const queryId = crypto.randomUUID()
+  db.insert(queriesTable).values({
+    id: queryId,
+    projectId,
+    query: 'best AEO platform',
+    createdAt: realCreatedAt,
+  }).run()
+
+  db.insert(competitors).values({
+    id: crypto.randomUUID(),
+    projectId,
+    domain: 'competitor.example.com',
+    createdAt: realCreatedAt,
+  }).run()
+
+  // Real run — cites the brand. Should appear in every aggregate.
+  const realRunId = crypto.randomUUID()
+  db.insert(runs).values({
+    id: realRunId,
+    projectId,
+    kind: 'answer-visibility',
+    status: 'completed',
+    trigger: 'manual',
+    createdAt: realCreatedAt,
+    finishedAt: realCreatedAt,
+  }).run()
+  db.insert(querySnapshots).values({
+    id: crypto.randomUUID(),
+    runId: realRunId,
+    queryId,
+    provider: 'openai',
+    citationState: 'cited',
+    answerMentioned: true,
+    citedDomains: JSON.stringify(['real-brand.example.com']),
+    competitorOverlap: JSON.stringify([]),
+    recommendedCompetitors: '[]',
+    answerText: 'real-brand.example.com is the canonical AEO platform.',
+    createdAt: realCreatedAt,
+  }).run()
+
+  // Probe run — intentionally NOT cited. Newer than the real run, so any
+  // endpoint that picks "latest" without filtering would (incorrectly) show
+  // not-cited.
+  const probeRunId = crypto.randomUUID()
+  db.insert(runs).values({
+    id: probeRunId,
+    projectId,
+    kind: 'answer-visibility',
+    status: 'completed',
+    trigger: 'probe',
+    createdAt: probeCreatedAt,
+    finishedAt: probeCreatedAt,
+  }).run()
+  db.insert(querySnapshots).values({
+    id: crypto.randomUUID(),
+    runId: probeRunId,
+    queryId,
+    provider: 'openai',
+    citationState: 'not-cited',
+    answerMentioned: false,
+    citedDomains: JSON.stringify(['competitor.example.com']),
+    competitorOverlap: JSON.stringify(['competitor.example.com']),
+    recommendedCompetitors: '[]',
+    answerText: 'Do you mean an AEO platform in the US? (probe clarifier)',
+    createdAt: probeCreatedAt,
+  }).run()
+
+  return { app, db, tmpDir, projectId, queryId, realRunId, probeRunId }
+}
+
+let ctx: Ctx
+
+beforeEach(() => { ctx = buildCtx() })
+afterEach(async () => {
+  await ctx.app.close()
+  fs.rmSync(ctx.tmpDir, { recursive: true, force: true })
+})
+
+async function get<T>(path: string): Promise<{ status: number; body: T }> {
+  const res = await ctx.app.inject({ method: 'GET', url: path })
+  return { status: res.statusCode, body: res.json() as T }
+}
+
+// ============================================================================
+// Aggregates that MUST exclude probes
+// ============================================================================
+
+describe('probe runs are excluded from dashboard / analytics aggregates', () => {
+  it('citations/visibility reads the real run, not the newer probe', async () => {
+    const { body } = await get<{
+      summary: { latestRunId: string | null; queriesCitedAndMentioned: number; totalQueries: number }
+    }>(`/api/v1/projects/probe-excl/citations/visibility`)
+    // If the probe leaked, latestRunId would point at the probe run (it's newer)
+    // and queriesCitedAndMentioned would be 0 (probe is not-cited).
+    expect(body.summary.latestRunId).toBe(ctx.realRunId)
+    expect(body.summary.queriesCitedAndMentioned).toBe(1)
+    expect(body.summary.totalQueries).toBe(1)
+  })
+
+  it('overview composite returns the real run as latest answer-visibility run', async () => {
+    const { body } = await get<{ latestRun: { run: { id: string } | null } | null }>(
+      `/api/v1/projects/probe-excl/overview`,
+    )
+    // latestRun.run is the absolute-latest run of any kind. We only have
+    // answer-visibility runs here, so the real run should win — not the probe.
+    expect(body.latestRun?.run?.id).toBe(ctx.realRunId)
+  })
+
+  it('analytics/metrics overall rate reflects the real run only (probe excluded from totals)', async () => {
+    const { body } = await get<{ overall: { citationRate: number; cited: number; total: number } }>(
+      `/api/v1/projects/probe-excl/analytics/metrics`,
+    )
+    // Real run: 1 cited snapshot out of 1. Probe (if leaked): 1 not-cited
+    // snapshot out of 1, dropping the rate from 1.0 to 0.5.
+    expect(body.overall.total).toBe(1)
+    expect(body.overall.cited).toBe(1)
+    expect(body.overall.citationRate).toBe(1)
+  })
+
+  it('analytics/gaps anchors to the real run (cited), not the probe (not-cited)', async () => {
+    const { body } = await get<{
+      runId: string | null
+      cited: Array<{ query: string }>
+      uncited: Array<{ query: string }>
+    }>(`/api/v1/projects/probe-excl/analytics/gaps`)
+    // Gap analysis anchors to the latest answer-visibility run. If the probe
+    // leaked, runId would point at the probe and the query would be uncited.
+    expect(body.runId).toBe(ctx.realRunId)
+    expect(body.cited.map(q => q.query)).toContain('best AEO platform')
+    expect(body.uncited.map(q => q.query)).not.toContain('best AEO platform')
+  })
+
+  it('analytics/sources anchors to the real run (cites brand domain)', async () => {
+    const { body } = await get<{ runId: string | null; overall: Array<{ url?: string; domain?: string }> }>(
+      `/api/v1/projects/probe-excl/analytics/sources`,
+    )
+    // If the probe leaked, runId would point at the probe whose only grounding
+    // source is competitor.example.com, not the brand domain.
+    expect(body.runId).toBe(ctx.realRunId)
+  })
+
+  it('snapshots list excludes probe snapshots', async () => {
+    const { body } = await get<{ snapshots: { runId: string }[] }>(
+      `/api/v1/projects/probe-excl/snapshots`,
+    )
+    const runIds = new Set(body.snapshots.map(s => s.runId))
+    expect(runIds.has(ctx.realRunId)).toBe(true)
+    expect(runIds.has(ctx.probeRunId)).toBe(false)
+  })
+
+  it('timeline does not include the probe run', async () => {
+    const { body } = await get<Array<{ query: string; runs: { runId: string }[] }>>(
+      `/api/v1/projects/probe-excl/timeline`,
+    )
+    const allRunIds = new Set(body.flatMap(q => q.runs.map(r => r.runId)))
+    expect(allRunIds.has(ctx.realRunId)).toBe(true)
+    expect(allRunIds.has(ctx.probeRunId)).toBe(false)
+  })
+
+  it('report citations trend does not include the probe', async () => {
+    const { body } = await get<{ citationsTrend: { points: Array<{ runId: string }> } }>(
+      `/api/v1/projects/probe-excl/report`,
+    )
+    const trendRunIds = new Set((body.citationsTrend?.points ?? []).map(p => p.runId))
+    expect(trendRunIds.has(ctx.probeRunId)).toBe(false)
+  })
+
+  it('content/targets pulls recent answer-visibility runs without the probe', async () => {
+    // Probes must not poison the orchestrator input that drives the
+    // content-engine recommendations.
+    const res = await ctx.app.inject({ method: 'GET', url: `/api/v1/projects/probe-excl/content/targets` })
+    expect(res.statusCode).toBe(200)
+    // No specific assertion on shape — the test exists to catch regression where
+    // the probe snapshot poisons the orchestrator input and crashes the route
+    // (or shifts recommendations). If it returns 200, the filter held.
+    const body = res.json() as { targets?: unknown[] }
+    expect(body.targets === undefined || Array.isArray(body.targets)).toBe(true)
+  })
+})
+
+// ============================================================================
+// Things that MUST still include probes (so operators can audit their tests)
+// ============================================================================
+
+describe('probe runs remain queryable for operators', () => {
+  it('GET /runs/:id returns a probe by id (per-run inspector)', async () => {
+    const { status, body } = await get<{ id: string; trigger: string }>(
+      `/api/v1/runs/${ctx.probeRunId}`,
+    )
+    expect(status).toBe(200)
+    expect(body.id).toBe(ctx.probeRunId)
+    expect(body.trigger).toBe('probe')
+  })
+
+  it('GET /projects/:name/runs lists probes alongside real runs (operator visibility)', async () => {
+    const { body } = await get<{ id: string; trigger: string }[]>(
+      `/api/v1/projects/probe-excl/runs`,
+    )
+    const triggers = new Set(body.map(r => r.trigger))
+    expect(triggers.has('manual')).toBe(true)
+    expect(triggers.has('probe')).toBe(true)
+  })
+})
+
+describe("POST /projects/:name/runs accepts trigger='probe' end-to-end", () => {
+  it('persists the run row with trigger=probe', async () => {
+    const res = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/projects/probe-excl/runs`,
+      payload: { trigger: 'probe', queries: ['best AEO platform'], noLocation: true },
+    })
+    expect([200, 201]).toContain(res.statusCode)
+    const body = res.json() as { id?: string; trigger?: string } | Array<{ id: string; trigger: string }>
+    // Single-location runs return a single object; fan-out returns an array.
+    const created = Array.isArray(body) ? body[0]! : body
+    expect(created.trigger).toBe('probe')
+
+    // Confirm the DB row really has trigger='probe' — schema enum + handler
+    // path both validated end-to-end.
+    const runRow = ctx.db.select().from(runs).where(eq(runs.id, created.id!)).get()
+    expect(runRow?.trigger).toBe('probe')
+  })
+
+  it("rejects unknown trigger values (e.g. 'scheduled' from external callers)", async () => {
+    const res = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/projects/probe-excl/runs`,
+      payload: { trigger: 'scheduled', noLocation: true },
+    })
+    expect(res.statusCode).toBe(400)
+  })
+})

--- a/packages/canonry/src/cli-commands/run.ts
+++ b/packages/canonry/src/cli-commands/run.ts
@@ -26,7 +26,7 @@ export const RUN_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['run'],
-    usage: 'canonry run <project|--all> [--provider <name>] [--query <q>...] [--location <label>] [--all-locations] [--no-location] [--wait] [--format json]',
+    usage: 'canonry run <project|--all> [--provider <name>] [--query <q>...] [--location <label>] [--all-locations] [--no-location] [--probe] [--wait] [--format json]',
     options: {
       provider: stringOption(),
       query: multiStringOption(),
@@ -35,6 +35,11 @@ export const RUN_CLI_COMMANDS: readonly CliCommandSpec[] = [
       location: stringOption(),
       'all-locations': { type: 'boolean', default: false },
       'no-location': { type: 'boolean', default: false },
+      // Probe runs are operator/agent test runs — they write a snapshot
+      // for inspection but are excluded from dashboard / analytics /
+      // intelligence / notifications. Use when you want to verify a
+      // provider works without polluting the project's metrics.
+      probe: { type: 'boolean', default: false },
     },
     run: async (input) => {
       if (getBoolean(input.values, 'all')) {
@@ -80,6 +85,7 @@ export const RUN_CLI_COMMANDS: readonly CliCommandSpec[] = [
         location: getString(input.values, 'location'),
         allLocations: getBoolean(input.values, 'all-locations'),
         noLocation: getBoolean(input.values, 'no-location'),
+        probe: getBoolean(input.values, 'probe'),
         format: input.format,
       })
     },

--- a/packages/canonry/src/commands/run.ts
+++ b/packages/canonry/src/commands/run.ts
@@ -8,7 +8,7 @@ function getClient() {
 
 const TERMINAL_STATUSES = new Set(['completed', 'partial', 'failed', 'cancelled'])
 
-export async function triggerRun(project: string, opts?: { provider?: string; queries?: string[]; wait?: boolean; format?: string; location?: string; allLocations?: boolean; noLocation?: boolean }): Promise<void> {
+export async function triggerRun(project: string, opts?: { provider?: string; queries?: string[]; wait?: boolean; format?: string; location?: string; allLocations?: boolean; noLocation?: boolean; probe?: boolean }): Promise<void> {
   const client = getClient()
   const body: Record<string, unknown> = {}
   if (opts?.provider) {
@@ -28,6 +28,9 @@ export async function triggerRun(project: string, opts?: { provider?: string; qu
   }
   if (opts?.noLocation) {
     body.noLocation = true
+  }
+  if (opts?.probe) {
+    body.trigger = 'probe'
   }
   const response = await client.triggerRun(project, body)
 

--- a/packages/canonry/src/intelligence-service.ts
+++ b/packages/canonry/src/intelligence-service.ts
@@ -1,9 +1,9 @@
-import { eq, desc, asc, and, or, inArray } from 'drizzle-orm'
+import { eq, desc, asc, and, ne, or, inArray } from 'drizzle-orm'
 import type { DatabaseClient } from '@ainyc/canonry-db'
 import { competitors, groupRunsByCreatedAt, gscSearchData, healthSnapshots, insights, parseJsonColumn, projects, queries, querySnapshots, runs } from '@ainyc/canonry-db'
 import { analyzeRuns, classifyRegressionSeverity, PERSISTENT_GAP_THRESHOLD } from '@ainyc/canonry-intelligence'
 import type { RunData, Snapshot, AnalysisResult, Insight } from '@ainyc/canonry-intelligence'
-import { CitationStates, RunKinds } from '@ainyc/canonry-contracts'
+import { CitationStates, RunKinds, RunTriggers } from '@ainyc/canonry-contracts'
 import crypto from 'node:crypto'
 import { createLogger } from './logger.js'
 
@@ -33,6 +33,11 @@ export class IntelligenceService {
         and(
           eq(runs.projectId, projectId),
           or(eq(runs.status, 'completed'), eq(runs.status, 'partial')),
+          // Defensive: RunCoordinator already skips probes before this is
+          // called, but if a future call site invokes analyzeAndPersist
+          // directly for a probe, probes still must not pollute the
+          // intelligence window.
+          ne(runs.trigger, RunTriggers.probe),
         ),
       )
       .orderBy(desc(runs.finishedAt), desc(runs.createdAt))
@@ -244,6 +249,8 @@ export class IntelligenceService {
         and(
           eq(runs.projectId, project.id),
           or(eq(runs.status, 'completed'), eq(runs.status, 'partial')),
+          // Backfill must not replay probe runs as if they were real sweeps.
+          ne(runs.trigger, RunTriggers.probe),
         ),
       )
       .orderBy(asc(runs.finishedAt))
@@ -502,6 +509,8 @@ export class IntelligenceService {
           eq(runs.projectId, projectId),
           eq(runs.kind, RunKinds['answer-visibility']),
           or(eq(runs.status, 'completed'), eq(runs.status, 'partial')),
+          // Defensive — see top of file.
+          ne(runs.trigger, RunTriggers.probe),
         ),
       )
       .orderBy(desc(runs.createdAt), desc(runs.id))

--- a/packages/canonry/src/run-coordinator.ts
+++ b/packages/canonry/src/run-coordinator.ts
@@ -3,6 +3,7 @@ import type { DatabaseClient } from '@ainyc/canonry-db'
 import { discoverySessions, runs, parseJsonColumn } from '@ainyc/canonry-db'
 import {
   RunKinds,
+  RunTriggers,
   type DiscoveryCompetitorMapEntry,
   type RunKind,
 } from '@ainyc/canonry-contracts'
@@ -66,6 +67,17 @@ export class RunCoordinator {
   async onRunCompleted(runId: string, projectId: string): Promise<void> {
     const runRow = this.db.select().from(runs).where(eq(runs.id, runId)).get()
     const kind = (runRow?.kind ?? RunKinds['answer-visibility']) as RunKind
+
+    // Probe runs are operator/agent test runs — they write snapshots so the
+    // operator can inspect what the provider returned, but they must not
+    // displace real data: no intelligence analysis, no notifier webhooks,
+    // no Aero wake-up. Skip the entire post-run pipeline. The dashboard +
+    // analytics endpoints filter trigger='probe' separately so the snapshots
+    // never feed aggregations either.
+    if (runRow?.trigger === RunTriggers.probe) {
+      log.info('probe.skip-side-effects', { runId, projectId, kind })
+      return
+    }
 
     let insightCount = 0
     let criticalOrHigh = 0

--- a/packages/canonry/test/cli-run-contract.test.ts
+++ b/packages/canonry/test/cli-run-contract.test.ts
@@ -232,6 +232,30 @@ describe('run lifecycle CLI contract', () => {
     expect(parsed.error.message).toContain('--query cannot be combined with --all')
   })
 
+  it("--probe flag persists the run with trigger='probe' (operator/agent test runs)", async () => {
+    // Probe runs are operator/agent tests — they write a snapshot so the
+    // operator can inspect provider behavior, but they must never poison
+    // the dashboard / analytics / report aggregates. The filter lives in
+    // RunCoordinator + read endpoints; here we just verify the CLI flag
+    // gets the trigger value all the way through to the DB.
+    await client.appendQueries('test-proj', ['probe-query'])
+
+    const result = await invokeCli([
+      'run', 'test-proj',
+      '--probe',
+      '--query', 'probe-query',
+      '--no-location',
+      '--format', 'json',
+    ])
+
+    expect(result.exitCode).toBe(undefined)
+    const parsed = JSON.parse(result.stdout) as { id: string; trigger: string }
+    expect(parsed.trigger).toBe('probe')
+
+    const row = db.select().from(runs).where(eq(runs.id, parsed.id)).get()
+    expect(row?.trigger).toBe('probe')
+  })
+
   it('prints a JSON usage error for runs <project> --limit with a non-integer value', async () => {
     const result = await invokeCli(['runs', 'test-proj', '--limit', 'bogus', '--format', 'json'])
 

--- a/packages/canonry/test/mcp-registry.test.ts
+++ b/packages/canonry/test/mcp-registry.test.ts
@@ -170,7 +170,12 @@ describe('MCP tool registry', () => {
 
     const runTriggerRequest = schemaProperty(inputSchemaFor('canonry_run_trigger'), 'request')
     expect(schemaProperty(runTriggerRequest, 'kind')).toMatchObject({ const: 'answer-visibility' })
-    expect(schemaProperty(runTriggerRequest, 'trigger')).toMatchObject({ const: 'manual' })
+    // Operator-supplied triggers: 'manual' (default) or 'probe' (test runs
+    // excluded from dashboard / analytics — see root AGENTS.md "Probe runs").
+    expect(schemaProperty(runTriggerRequest, 'trigger')).toMatchObject({
+      type: 'string',
+      enum: ['manual', 'probe'],
+    })
     expect(runTriggerRequest.required ?? []).not.toContain('kind')
     expect(runTriggerRequest.required ?? []).not.toContain('trigger')
 

--- a/packages/canonry/test/run-coordinator.test.ts
+++ b/packages/canonry/test/run-coordinator.test.ts
@@ -174,6 +174,135 @@ describe('RunCoordinator', () => {
     expect(callOrder).toEqual(['intelligence', 'notifier'])
   })
 
+  describe("trigger='probe' runs skip downstream side-effects", () => {
+    // A probe is an operator/agent test run — meant to verify wire-level
+    // behavior (e.g. "did the OpenAI provider migration still work?")
+    // without polluting the dashboard, generating insights, firing webhooks,
+    // or waking Aero. The snapshot data is still written so the operator
+    // can inspect what the provider returned. RunCoordinator is the chokepoint
+    // for those side-effects, so the skip lives here.
+
+    function seedProbeRun(db: ReturnType<typeof createTempDb>['db']) {
+      const now = new Date().toISOString()
+      const projectId = crypto.randomUUID()
+      db.insert(projects).values({
+        id: projectId,
+        name: 'probe-test',
+        displayName: 'Probe Test',
+        canonicalDomain: 'example.com',
+        country: 'US',
+        language: 'en',
+        providers: '["gemini"]',
+        createdAt: now,
+        updatedAt: now,
+      }).run()
+
+      const queryId = crypto.randomUUID()
+      db.insert(queries).values({
+        id: queryId,
+        projectId,
+        query: 'probe query',
+        createdAt: now,
+      }).run()
+
+      const runId = crypto.randomUUID()
+      db.insert(runs).values({
+        id: runId,
+        projectId,
+        kind: 'answer-visibility',
+        status: 'completed',
+        trigger: 'probe',
+        createdAt: now,
+        finishedAt: now,
+      }).run()
+
+      db.insert(querySnapshots).values({
+        id: crypto.randomUUID(),
+        runId,
+        queryId,
+        provider: 'gemini',
+        model: 'test-model',
+        citationState: 'cited',
+        citedDomains: '["example.com"]',
+        competitorOverlap: '[]',
+        createdAt: now,
+      }).run()
+
+      return { projectId, runId }
+    }
+
+    it('does NOT run intelligence analysis (no health snapshots, no insights)', async () => {
+      const { db } = createTempDb('coord-probe-intel-')
+      const { projectId, runId } = seedProbeRun(db)
+
+      const notifier = createMockNotifier()
+      const service = new IntelligenceService(db)
+      const intelSpy = vi.spyOn(service, 'analyzeAndPersist')
+
+      const coordinator = new RunCoordinator(db, notifier as Notifier, service)
+      await coordinator.onRunCompleted(runId, projectId)
+
+      expect(intelSpy).not.toHaveBeenCalled()
+      const healthRows = db.select().from(healthSnapshots).all()
+      expect(healthRows).toHaveLength(0)
+    })
+
+    it('does NOT call the notifier (webhooks stay quiet)', async () => {
+      const { db } = createTempDb('coord-probe-notify-')
+      const { projectId, runId } = seedProbeRun(db)
+
+      const notifier = createMockNotifier()
+      const service = new IntelligenceService(db)
+      const coordinator = new RunCoordinator(db, notifier as Notifier, service)
+
+      await coordinator.onRunCompleted(runId, projectId)
+
+      expect(notifier.onRunCompleted).not.toHaveBeenCalled()
+    })
+
+    it('does NOT wake Aero', async () => {
+      const { db } = createTempDb('coord-probe-aero-')
+      const { projectId, runId } = seedProbeRun(db)
+
+      const notifier = createMockNotifier()
+      const service = new IntelligenceService(db)
+      const aeroSpy = vi.fn(async () => {})
+
+      const coordinator = new RunCoordinator(db, notifier as Notifier, service, undefined, aeroSpy)
+      await coordinator.onRunCompleted(runId, projectId)
+
+      expect(aeroSpy).not.toHaveBeenCalled()
+    })
+
+    it('still resolves cleanly (no thrown errors) — probes are silent successes', async () => {
+      const { db } = createTempDb('coord-probe-clean-')
+      const { projectId, runId } = seedProbeRun(db)
+
+      const notifier = createMockNotifier()
+      const service = new IntelligenceService(db)
+      const coordinator = new RunCoordinator(db, notifier as Notifier, service)
+
+      await expect(coordinator.onRunCompleted(runId, projectId)).resolves.toBeUndefined()
+    })
+
+    it("regression guard: non-probe runs (trigger='manual') still trigger intelligence + notifier", async () => {
+      // Make sure the probe skip doesn't accidentally widen and silence
+      // real runs. This is the symmetric "happy path" assertion.
+      const { db } = createTempDb('coord-probe-regression-')
+      const { projectId, runId } = seedFixture(db) // trigger defaults to 'manual'
+
+      const notifier = createMockNotifier()
+      const service = new IntelligenceService(db)
+      const intelSpy = vi.spyOn(service, 'analyzeAndPersist')
+
+      const coordinator = new RunCoordinator(db, notifier as Notifier, service)
+      await coordinator.onRunCompleted(runId, projectId)
+
+      expect(intelSpy).toHaveBeenCalled()
+      expect(notifier.onRunCompleted).toHaveBeenCalled()
+    })
+  })
+
   it('discovery aero context resolves the session by runId, not by "latest non-queued"', async () => {
     // Regression: two discovery sessions on the same project must be
     // disambiguated by runId. Picking the most recent non-queued session

--- a/packages/contracts/src/run.ts
+++ b/packages/contracts/src/run.ts
@@ -21,7 +21,23 @@ export const runKindSchema = z.enum([
 export type RunKind = z.infer<typeof runKindSchema>
 export const RunKinds = runKindSchema.enum
 
-export const runTriggerSchema = z.enum(['manual', 'scheduled', 'config-apply', 'backfill'])
+/**
+ * What caused this run to be created.
+ *
+ * - `manual`        operator-initiated full sweep (CLI `canonry run` or the
+ *                   dashboard "Run now" button) — feeds dashboard + analytics
+ * - `scheduled`     fired by the cron scheduler — feeds dashboard + analytics
+ * - `config-apply`  triggered by `canonry apply` after a queries/competitors
+ *                   change — feeds dashboard + analytics
+ * - `backfill`      historical recomputation (CLI `canonry backfill`) — does
+ *                   not displace the latest "live" run on the dashboard
+ * - `probe`         operator/agent test run that exercises a query × provider
+ *                   slice to verify behavior (e.g. "did the OpenAI provider
+ *                   migration still work?"). Probes do NOT feed dashboard,
+ *                   analytics, intelligence, or notifications. They remain
+ *                   queryable for audit but never displace a real sweep.
+ */
+export const runTriggerSchema = z.enum(['manual', 'scheduled', 'config-apply', 'backfill', 'probe'])
 export type RunTrigger = z.infer<typeof runTriggerSchema>
 export const RunTriggers = runTriggerSchema.enum
 
@@ -57,9 +73,16 @@ export const mentionTransitionSchema = z.enum(['new', 'mentioned', 'lost', 'emer
 export type MentionTransition = z.infer<typeof mentionTransitionSchema>
 export const MentionTransitions = mentionTransitionSchema.enum
 
+/**
+ * Operator-supplied triggers on POST /runs. The other RunTrigger values
+ * (`scheduled`, `config-apply`, `backfill`) are set server-side based on
+ * the call site and aren't accepted from external callers.
+ */
+const operatorTriggerSchema = z.enum([RunTriggers.manual, RunTriggers.probe])
+
 export const runTriggerRequestSchema = z.object({
   kind: z.literal(RunKinds['answer-visibility']).optional(),
-  trigger: z.literal(RunTriggers.manual).optional(),
+  trigger: operatorTriggerSchema.optional(),
   providers: z.array(providerNameSchema).optional(),
   queries: z.array(z.string().min(1)).min(1).optional(),
   location: z.string().min(1).optional(),

--- a/packages/contracts/test/run-trigger-schema.test.ts
+++ b/packages/contracts/test/run-trigger-schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { runDtoSchema, runTriggerRequestSchema } from '../src/run.js'
+import { runDtoSchema, runTriggerRequestSchema, runTriggerSchema, RunTriggers } from '../src/run.js'
 
 describe('runDtoSchema.queries', () => {
   it('parses a run row with a queries array', () => {
@@ -73,5 +73,49 @@ describe('runTriggerRequestSchema.queries', () => {
       allLocations: true,
     })
     expect(result.success).toBe(true)
+  })
+})
+
+describe("runTriggerSchema: 'probe' as a first-class trigger", () => {
+  // Probe runs are operator/agent test runs that exercise a (queries × providers)
+  // slice without affecting the dashboard, analytics, or notifications. They
+  // share the answer-visibility code path but are excluded from aggregations.
+  it("accepts 'probe' as a valid trigger value", () => {
+    expect(runTriggerSchema.safeParse('probe').success).toBe(true)
+  })
+
+  it("exposes RunTriggers.probe = 'probe'", () => {
+    expect(RunTriggers.probe).toBe('probe')
+  })
+
+  it("runDtoSchema parses a row with trigger='probe'", () => {
+    const result = runDtoSchema.parse({
+      id: 'run_1',
+      projectId: 'proj_1',
+      kind: 'answer-visibility',
+      status: 'completed',
+      trigger: 'probe',
+      createdAt: '2026-05-17T02:28:00.000Z',
+    })
+    expect(result.trigger).toBe('probe')
+  })
+
+  it("runTriggerRequestSchema accepts trigger='probe' from API/CLI callers", () => {
+    const result = runTriggerRequestSchema.safeParse({ trigger: 'probe' })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.trigger).toBe('probe')
+    }
+  })
+
+  it("runTriggerRequestSchema still accepts trigger='manual' (no regression)", () => {
+    const result = runTriggerRequestSchema.safeParse({ trigger: 'manual' })
+    expect(result.success).toBe(true)
+  })
+
+  it('runTriggerRequestSchema rejects unknown trigger values', () => {
+    const result = runTriggerRequestSchema.safeParse({ trigger: 'scheduled' })
+    // Only manual/probe are operator-supplied; 'scheduled'/'config-apply'/'backfill' are server-set
+    expect(result.success).toBe(false)
   })
 })


### PR DESCRIPTION
## Why

Yesterday an agent triggered two manual `--query --provider openai` test runs on a production project to verify a recent OpenAI provider migration. Each wrote one snapshot; the dashboard's "latest answer-visibility run" headline picked them up — collapsing 44-snapshot daily sweeps into a single 1-snapshot probe and showing 0% mention coverage. The dashboard wasn't wrong (it always shows the latest run); the data shape was. A probe shouldn't be the thing the dashboard shows.

## What

New `RunTriggers.probe` value. Probe runs:
- **Write snapshots** so the operator can inspect what the provider returned
- **Skip intelligence, notifier webhooks, and Aero wake-up** (`RunCoordinator` short-circuits)
- **Are excluded from every dashboard / analytics / report / timeline aggregate** via `notProbeRun()` Drizzle predicate applied to 14 endpoints
- **Stay queryable** through per-run detail endpoints and the operator-facing list (`GET /runs`, `GET /projects/:name/runs`)
- **CLI**: `canonry run <project> --probe ...`

## Test plan (TDD throughout)

- [x] **Contracts** (5 tests) — schema accepts 'probe', `RunTriggers.probe` constant, runDtoSchema parses probe rows, runTriggerRequestSchema accepts 'probe' + rejects server-set triggers
- [x] **RunCoordinator** (5 tests) — probes skip intelligence (no health snapshots), skip notifier, skip Aero; regression guard that non-probe runs still hit all three subscribers
- [x] **api-routes** (`probe-exclusion.test.ts`, 13 tests) — one chokepoint integration suite: seeds a project with a real run + newer probe run, hits every dashboard/analytics/report/timeline endpoint, asserts the real run wins. Symmetric assertions that per-run detail + operator list endpoints still show probes. Includes end-to-end POST /runs with `trigger='probe'`.
- [x] **CLI** — `canonry run --probe` persists `trigger='probe'` to the DB end-to-end through a live Fastify server
- [x] **MCP** — schema generation asserts MCP exposes `trigger` as enum `['manual', 'probe']`
- [x] `pnpm typecheck` — clean across all 26 projects
- [x] `pnpm test` — 2948 / 2950 passing (the 2 failures are pre-existing `sqlite3 CLI not found` in `db/test/schedules-migration.test.ts`, deferred per project memory)
- [ ] CI green

## Notable design decisions

| Question | Choice | Rationale |
|---|---|---|
| Trigger or kind? | Trigger | Probes are still answer-visibility kind — same code path, same snapshot model |
| Aggregate filtering | Shared `notProbeRun()` helper in `helpers.ts` | One chokepoint; ~14 routes import it; one test file (`probe-exclusion.test.ts`) covers them all |
| Per-run detail endpoints | INCLUDE probes | Caller passes runId; operator needs to inspect the snapshot they just created |
| Operator list endpoints (`/runs`) | INCLUDE probes; dashboard filters client-side | Operators can audit their tests; dashboard's `use-dashboard.ts` excludes probes after fetching |
| Intelligence side-effects | SKIP for probes | Insights from a 1-snapshot test are noise; webhooks shouldn't fire for a verification run |

## Follow-up (not in this PR)

After this lands, reclassify the two May-17 ainyc runs (`0719ea6e...`, `cae71507...`) from `trigger='manual'` to `trigger='probe'` via one-off SQL. The runs caught a real regression (OpenAI returning clarifying questions instead of substantive answers); reclassifying preserves them as audit and unblocks the dashboard.

## Docs

- Root `AGENTS.md` gets a "Probe runs (Critical)" section with the rules + checklist for new aggregate endpoints
- `packages/api-routes/AGENTS.md` flags `notProbeRun()` as a required predicate
- CLI help string updated to mention `--probe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)