### PR TITLE
chore(cli): route ApiClient agent methods through generated SDK + ban raw fetch

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -242,4 +242,33 @@ export default tseslint.config(
       }],
     },
   },
+  {
+    // Analog of the apps/web SDK enforcement, for the CLI. Every CLI / job
+    // runner / server-internal call into the canonry API must go through
+    // `ApiClient` (which delegates to the generated SDK via `invoke()`),
+    // not raw `fetch()`. The only legitimate raw fetches are inside
+    // `client.ts` itself: the `/health` probe (bootstrap check that lives
+    // outside `/api/v1`) and the SSE `streamPost()` (the SDK can't
+    // represent text/event-stream cleanly). Both are bounded by file.
+    files: ['packages/canonry/src/**/*.ts'],
+    ignores: [
+      // `ApiClient`'s `/health` probe + SSE prompt stream.
+      'packages/canonry/src/client.ts',
+      // External HTTP — not the canonry API:
+      // - daemon.ts probes localhost `/health` for serve-readiness
+      // - sitemap-parser.ts fetches the user's own sitemap.xml URL
+      // - telemetry.ts POSTs to the public telemetry collector
+      // - update-check.ts polls npm dist-tags
+      'packages/canonry/src/commands/daemon.ts',
+      'packages/canonry/src/sitemap-parser.ts',
+      'packages/canonry/src/telemetry.ts',
+      'packages/canonry/src/update-check.ts',
+    ],
+    rules: {
+      'no-restricted-syntax': ['error', {
+        selector: "CallExpression[callee.name='fetch']",
+        message: 'Use the generated `@ainyc/canonry-api-client` SDK via `ApiClient` / `createApiClient()` (which routes through `invoke()` for tracing, CliError mapping, and the base-path probe) instead of raw `fetch()`. If you genuinely need raw `fetch()` for an external (non-canonry) HTTP call, add the file to the `ignores` list in `eslint.config.js` with a one-line comment naming the external service.',
+      }],
+    },
+  },
 )

--- a/packages/canonry/AGENTS.md
+++ b/packages/canonry/AGENTS.md
@@ -79,7 +79,7 @@ The publishable npm package (`@ainyc/canonry`). Bundles the CLI, local Fastify s
    ```
 3. The CLI dispatches based on `path` matching argv.
 
-### ApiClient usage
+### ApiClient usage (Critical)
 
 **Always use `createApiClient()`** — never instantiate `ApiClient` directly:
 
@@ -92,6 +92,22 @@ function getClient() {
 ```
 
 All `ApiClient` methods must return typed DTOs from `@ainyc/canonry-contracts`. Never cast responses with `as Record<string, unknown>`.
+
+**Every `ApiClient` method delegates to the generated SDK via `invoke()`.** Adding a new method is:
+
+```typescript
+import { getApiV1ProjectsByNameMyNewThing } from '@ainyc/canonry-api-client'
+
+async myNewThing(name: string): Promise<MyNewDto> {
+  return this.invoke<MyNewDto>(() =>
+    getApiV1ProjectsByNameMyNewThing({ client: this.heyClient, path: { name } }),
+  )
+}
+```
+
+`invoke()` handles base-path probing, CliError mapping, structured-error envelopes, and the `CANONRY_TRACE=1` request log. **Do not call `fetch()` directly** — ESLint blocks it in `packages/canonry/src/**` except in a handful of files that legitimately hit external HTTP (`telemetry.ts` → telemetry collector, `update-check.ts` → npm registry, `sitemap-parser.ts` → user sitemap, `commands/daemon.ts` → localhost health probe). If you need raw `fetch()` for a NEW external service, add the file to the `ignores` list in `eslint.config.js` with a one-line comment naming the service.
+
+The legacy `request<T>()` raw-fetch wrapper was removed in v4.51; if you find any reference to it, replace with an SDK call through `invoke()`.
 
 ### MCP adapter
 

--- a/packages/canonry/src/client.ts
+++ b/packages/canonry/src/client.ts
@@ -89,6 +89,14 @@ import type {
 import {
   createClient as createHeyClient,
   type Client,
+  // Agent (canonry-local routes — included in SDK since codegen was set to
+  // `includeCanonryLocal: true` in v4.50.0; previously called via raw fetch).
+  deleteApiV1ProjectsByNameAgentMemory,
+  deleteApiV1ProjectsByNameAgentTranscript,
+  getApiV1ProjectsByNameAgentMemory,
+  getApiV1ProjectsByNameAgentProviders,
+  getApiV1ProjectsByNameAgentTranscript,
+  putApiV1ProjectsByNameAgentMemory,
   // Projects
   getApiV1Projects,
   getApiV1ProjectsByName,
@@ -528,116 +536,57 @@ export class ApiClient {
     return result.data as TData
   }
 
-  /**
-   * Raw HTTP call — used for the agent transcript / providers / memory routes,
-   * which are registered locally in `packages/canonry/src/agent/agent-routes.ts`
-   * and aren't (yet) emitted by the OpenAPI spec. Once they're in the spec we
-   * regen the client and migrate these to `invoke()` like every other method.
-   */
-  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
-    await this.probeBasePath()
-    const url = `${this.originUrl}/api/v1${path}`
-    const serializedBody = body != null ? JSON.stringify(body) : undefined
-    const headers: Record<string, string> = {
-      Authorization: `Bearer ${this.apiKey}`,
-      Accept: 'application/json',
-      ...(serializedBody != null ? { 'Content-Type': 'application/json' } : {}),
-    }
-
-    const traceEnabled = process.env.CANONRY_TRACE === '1'
-    const traceStart = traceEnabled ? Date.now() : 0
-
-    let res: Response
-    try {
-      res = await fetch(url, { method, headers, body: serializedBody })
-    } catch (err) {
-      if (traceEnabled) {
-        const durMs = Date.now() - traceStart
-        process.stderr.write(`[trace] ${method} ${url} → ERROR (${durMs}ms)\n`)
-      }
-      if (err instanceof CliError) throw err
-      const msg = err instanceof Error ? err.message : String(err)
-      if (msg.includes('fetch failed') || msg.includes('ECONNREFUSED') || msg.includes('connect ECONNREFUSED')) {
-        throw new CliError({
-          code: 'CONNECTION_ERROR',
-          message:
-            `Could not connect to canonry server at ${this.originUrl}. ` +
-            'Start it with "canonry serve" (or "canonry serve &" to run in background).',
-          exitCode: EXIT_SYSTEM_ERROR,
-        })
-      }
-      throw new CliError({ code: 'CONNECTION_ERROR', message: msg, exitCode: EXIT_SYSTEM_ERROR })
-    }
-
-    if (!res.ok) {
-      let errorBody: unknown
-      try {
-        errorBody = await res.json()
-      } catch {
-        errorBody = { error: { code: 'UNKNOWN', message: res.statusText } }
-      }
-      const errorObj =
-        errorBody &&
-        typeof errorBody === 'object' &&
-        'error' in errorBody &&
-        errorBody.error &&
-        typeof errorBody.error === 'object'
-          ? (errorBody.error as { code?: string; message?: string; details?: Record<string, unknown> })
-          : null
-      const msg = errorObj?.message ? String(errorObj.message) : `HTTP ${res.status}: ${res.statusText}`
-      const code = errorObj?.code ? String(errorObj.code) : 'API_ERROR'
-      const exitCode = res.status >= 500 ? EXIT_SYSTEM_ERROR : EXIT_USER_ERROR
-      throw new CliError({
-        code,
-        message: msg,
-        exitCode,
-        details: { ...(errorObj?.details ?? {}), httpStatus: res.status },
-      })
-    }
-
-    if (traceEnabled) {
-      const durMs = Date.now() - traceStart
-      process.stderr.write(`[trace] ${method} ${url} → ${res.status} (${durMs}ms)\n`)
-    }
-
-    if (res.status === 204) return undefined as T
-    return (await res.json()) as T
-  }
-
-  // ── Agent (routes not in OpenAPI spec — raw request<T>) ─────────────────
+  // ── Agent (canonry-local routes — SDK-typed since v4.50.0) ─────────────
+  //
+  // These endpoints live in `packages/canonry/src/agent/agent-routes.ts` and
+  // are registered through `apiRoutes.registerAuthenticatedRoutes`, not the
+  // shared `routeCatalog`. They appear in the OpenAPI spec only when the
+  // caller passes `includeCanonryLocal: true` to `buildOpenApiDocument` —
+  // which canonry's own server and the codegen both do, so they're in the
+  // generated SDK and we route them through `invoke()` like every other
+  // endpoint. The SSE `POST /agent/prompt` is intentionally not here — it
+  // stays on `streamPost()` below since the SDK can't represent SSE cleanly.
 
   async getAgentTranscript(project: string): Promise<AgentTranscriptDto> {
-    return this.request<AgentTranscriptDto>('GET', `/projects/${encodeURIComponent(project)}/agent/transcript`)
+    return this.invoke<AgentTranscriptDto>(() =>
+      getApiV1ProjectsByNameAgentTranscript({ client: this.heyClient, path: { name: project } }),
+    )
   }
 
   async resetAgentTranscript(project: string): Promise<void> {
-    await this.request<unknown>('DELETE', `/projects/${encodeURIComponent(project)}/agent/transcript`)
+    await this.invoke<unknown>(() =>
+      deleteApiV1ProjectsByNameAgentTranscript({ client: this.heyClient, path: { name: project } }),
+    )
   }
 
   async listAgentProviders(project: string): Promise<AgentProvidersResponse> {
-    return this.request<AgentProvidersResponse>('GET', `/projects/${encodeURIComponent(project)}/agent/providers`)
+    return this.invoke<AgentProvidersResponse>(() =>
+      getApiV1ProjectsByNameAgentProviders({ client: this.heyClient, path: { name: project } }),
+    )
   }
 
   async listAgentMemory(project: string): Promise<AgentMemoryListResponse> {
-    return this.request<AgentMemoryListResponse>('GET', `/projects/${encodeURIComponent(project)}/agent/memory`)
+    return this.invoke<AgentMemoryListResponse>(() =>
+      getApiV1ProjectsByNameAgentMemory({ client: this.heyClient, path: { name: project } }),
+    )
   }
 
   async setAgentMemory(
     project: string,
     body: AgentMemoryUpsertRequest,
   ): Promise<{ status: 'ok'; entry: AgentMemoryEntryDto }> {
-    return this.request<{ status: 'ok'; entry: AgentMemoryEntryDto }>(
-      'PUT',
-      `/projects/${encodeURIComponent(project)}/agent/memory`,
-      body,
+    return this.invoke<{ status: 'ok'; entry: AgentMemoryEntryDto }>(() =>
+      putApiV1ProjectsByNameAgentMemory({ client: this.heyClient, path: { name: project }, body }),
     )
   }
 
   async forgetAgentMemory(project: string, key: string): Promise<{ status: 'forgotten' | 'missing'; key: string }> {
-    return this.request<{ status: 'forgotten' | 'missing'; key: string }>(
-      'DELETE',
-      `/projects/${encodeURIComponent(project)}/agent/memory`,
-      { key },
+    return this.invoke<{ status: 'forgotten' | 'missing'; key: string }>(() =>
+      deleteApiV1ProjectsByNameAgentMemory({
+        client: this.heyClient,
+        path: { name: project },
+        body: { key },
+      }),
     )
   }
 


### PR DESCRIPTION
## Summary

Completes the spec-as-source-of-truth pipeline by collapsing the CLI's `ApiClient` onto the same generated SDK that the web already uses. The 6 hand-rolled agent methods (transcript / providers / memory) were the last holdouts on raw `fetch()` — they couldn't migrate before because the canonry-local agent routes weren't in the SDK. **PR #570 (v4.50.0) put them there** by flipping codegen to `includeCanonryLocal: true`; this PR closes the loop.

## What changes

- **6 methods migrated** to `invoke<T>(() => getApiV1...({client: this.heyClient, ...}))`:
  - `getAgentTranscript`, `resetAgentTranscript`
  - `listAgentProviders`
  - `listAgentMemory`, `setAgentMemory`, `forgetAgentMemory`
- **`request<T>()` wrapper deleted** (~80 LOC). No callers remain.
- **ESLint rule added** for `packages/canonry/src/**`: bans raw `fetch()` outside 5 explicitly-allowlisted files. Same shape as the existing `apps/web/src/**` rule from #570.
- **`packages/canonry/AGENTS.md`** rewrites the ApiClient section as Critical with the new pattern + raw-fetch policy.

## Allowlisted raw-`fetch` files (with reason)

| File | Why |
|---|---|
| `client.ts` | `probeBasePath()` (bootstrap health probe outside `/api/v1`) + `streamPost()` (SSE which the SDK can't represent cleanly) |
| `commands/daemon.ts` | localhost `/health` probe for serve-readiness |
| `sitemap-parser.ts` | fetches the user's sitemap.xml (external URL) |
| `telemetry.ts` | POSTs to the public telemetry collector |
| `update-check.ts` | npm dist-tags poll |

Adding a new external-HTTP file requires editing the ignores list with a comment naming the service — visible in PR review.

## Why this matters

Before: spec → SDK → web ✓, but CLI/MCP via separate hand-typed methods that called `this.request<T>()`. Two typed pipelines, two places to forget when adding an endpoint.

After: every `ApiClient` method delegates to the SDK. **One pipeline. One enforcement boundary.**

## Test plan

- [x] `pnpm typecheck` clean across 26 packages
- [x] `pnpm test` — 2950 pass; 2 pre-existing `sqlite3` CLI failures unrelated
- [x] `pnpm lint` — 0 errors (synthetic `fetch()` in non-allowlisted files triggers the rule with the expected guidance message)
- [x] No remaining `this.request<T>` references in the codebase
- [x] All 6 migrated methods consume the same SDK functions the web already uses (no shape drift)

## Follow-up potential

Could codegen the CLI ApiClient methods themselves from the spec (eliminate the dual definition entirely). Out of scope here — the current shape is now well-defined enough to template if we want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)