### PR TITLE
refactor(db): migrate remaining tables to native SQLite column modes

### DIFF
--- a/packages/api-routes/src/bing.ts
+++ b/packages/api-routes/src/bing.ts
@@ -286,9 +286,9 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
     let snapshotRunId: string | null = null
 
     for (const [, row] of latestByUrl) {
-      if (row.inIndex === 1) {
+      if (row.inIndex === true) {
         indexedUrls.push(row)
-      } else if (row.inIndex === 0) {
+      } else if (row.inIndex === false) {
         notIndexedUrls.push(row)
       } else {
         unknownUrls.push(row)
@@ -308,7 +308,7 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
       id: r.id,
       url: r.url,
       httpCode: r.httpCode,
-      inIndex: r.inIndex === 1 ? true : r.inIndex === 0 ? false : null,
+      inIndex: r.inIndex,
       lastCrawledDate: r.lastCrawledDate,
       inIndexDate: r.inIndexDate,
       inspectedAt: r.inspectedAt,
@@ -404,7 +404,7 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
       id: r.id,
       url: r.url,
       httpCode: r.httpCode,
-      inIndex: r.inIndex === 1 ? true : r.inIndex === 0 ? false : null,
+      inIndex: r.inIndex,
       lastCrawledDate: r.lastCrawledDate,
       inIndexDate: r.inIndexDate,
       inspectedAt: r.inspectedAt,
@@ -504,7 +504,7 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
         projectId: project.id,
         url,
         httpCode,
-        inIndex: derivedInIndex === true ? 1 : derivedInIndex === false ? 0 : null,
+        inIndex: derivedInIndex,
         lastCrawledDate,
         inIndexDate,
         inspectedAt: now,
@@ -612,7 +612,7 @@ export async function bingRoutes(app: FastifyInstance, opts: BingRoutesOptions) 
 
       const unindexedUrls: string[] = []
       for (const [url, row] of latestByUrl) {
-        if (row.inIndex === 0 || row.inIndex === null) {
+        if (row.inIndex === false || row.inIndex === null) {
           unindexedUrls.push(url)
         }
       }

--- a/packages/api-routes/src/composites.ts
+++ b/packages/api-routes/src/composites.ts
@@ -830,8 +830,8 @@ function mapInsightRow(r: typeof insights.$inferSelect): InsightDto {
     title: r.title,
     query: r.query,
     provider: r.provider,
-    recommendation: parseJsonColumn<InsightDto['recommendation']>(r.recommendation, undefined),
-    cause: parseJsonColumn<InsightDto['cause']>(r.cause, undefined),
+    recommendation: r.recommendation ?? undefined,
+    cause: r.cause ?? undefined,
     dismissed: r.dismissed,
     createdAt: r.createdAt,
   }
@@ -845,7 +845,7 @@ function mapHealthRow(r: typeof healthSnapshots.$inferSelect): HealthSnapshotDto
     overallCitedRate: Number(r.overallCitedRate),
     totalPairs: r.totalPairs,
     citedPairs: r.citedPairs,
-    providerBreakdown: parseJsonColumn<HealthSnapshotDto['providerBreakdown']>(r.providerBreakdown, {}),
+    providerBreakdown: r.providerBreakdown,
     createdAt: r.createdAt,
     status: 'ready',
   }
@@ -926,8 +926,8 @@ function buildSnapshotHit(
 
 function buildInsightHit(row: typeof insights.$inferSelect, searchTerm: string): ProjectSearchInsightHitDto {
   const lower = searchTerm.toLowerCase()
-  const recommendation = row.recommendation ?? ''
-  const cause = row.cause ?? ''
+  const recommendation = row.recommendation ? `${row.recommendation.action}${row.recommendation.target ? ` ${row.recommendation.target}` : ''} ${row.recommendation.reason}` : ''
+  const cause = row.cause ? `${row.cause.cause}${row.cause.competitorDomain ? ` ${row.cause.competitorDomain}` : ''}${row.cause.details ? ` ${row.cause.details}` : ''}` : ''
   let matchedField: InsightMatchedField
   let snippet: string
   if (row.title.toLowerCase().includes(lower)) {

--- a/packages/api-routes/src/discovery/orchestrate.ts
+++ b/packages/api-routes/src/discovery/orchestrate.ts
@@ -305,7 +305,7 @@ export async function executeDiscovery(opts: ExecuteDiscoveryOptions): Promise<E
       query,
       bucket,
       citationState: probe.citationState,
-      citedDomains: JSON.stringify(probe.citedDomains),
+      citedDomains: probe.citedDomains,
       rawResponse: JSON.stringify(probe.rawResponse),
       createdAt: new Date().toISOString(),
     }).run()
@@ -331,7 +331,7 @@ export async function executeDiscovery(opts: ExecuteDiscoveryOptions): Promise<E
       citedCount: buckets.cited,
       aspirationalCount: buckets.aspirational,
       wastedCount: buckets['wasted-surface'],
-      competitorMap: JSON.stringify(competitorMap),
+      competitorMap,
       finishedAt: new Date().toISOString(),
     })
     .where(eq(discoverySessions.id, opts.sessionId))

--- a/packages/api-routes/src/discovery/routes.ts
+++ b/packages/api-routes/src/discovery/routes.ts
@@ -169,7 +169,7 @@ export async function discoveryRoutes(app: FastifyInstance, opts: DiscoveryRoute
         status: DiscoverySessionStatuses.queued,
         icpDescription,
         dedupThreshold: parsed.data.dedupThreshold,
-        competitorMap: '[]',
+        competitorMap: [],
         createdAt: now,
       }).run()
 
@@ -518,23 +518,21 @@ function serializeProbe(row: typeof discoveryProbes.$inferSelect): DiscoveryProb
     query: row.query,
     bucket: bucketParsed?.success ? bucketParsed.data : null,
     citationState: stateParsed.success ? stateParsed.data : 'not-cited',
-    citedDomains: parseJsonColumn<string[]>(row.citedDomains, []),
+    citedDomains: row.citedDomains,
     createdAt: row.createdAt,
   }
 }
 
 /**
- * Parse a `discovery_sessions.competitor_map` JSON column into normalized
- * entries. `parseJsonColumn` does not apply Zod defaults, so a competitor map
- * persisted before classification existed has entries without
- * `competitorType` — normalize those to `unknown` here so every consumer sees
- * a well-formed `DiscoveryCompetitorMapEntry`.
+ * Normalize a `discovery_sessions.competitor_map` value. Drizzle JSON-mode
+ * deserializes the column for us, but a competitor map persisted before
+ * classification existed has entries without `competitorType` — normalize
+ * those to `unknown` here so every consumer sees a well-formed
+ * `DiscoveryCompetitorMapEntry`.
  */
-function parseCompetitorMap(json: string): DiscoveryCompetitorMapEntry[] {
-  const raw = parseJsonColumn<Array<Partial<DiscoveryCompetitorMapEntry> & { domain: string; hits: number }>>(
-    json,
-    [],
-  )
+function parseCompetitorMap(
+  raw: ReadonlyArray<Partial<DiscoveryCompetitorMapEntry> & { domain: string; hits: number }>,
+): DiscoveryCompetitorMapEntry[] {
   return raw.map(entry => ({
     domain: entry.domain,
     hits: entry.hits,

--- a/packages/api-routes/src/doctor/types.ts
+++ b/packages/api-routes/src/doctor/types.ts
@@ -20,7 +20,7 @@ export interface TrafficSourceProbe {
   status: string
   lastSyncedAt: string | null
   lastError: string | null
-  configJson: string
+  configJson: Record<string, unknown>
 }
 
 /**

--- a/packages/api-routes/src/google.ts
+++ b/packages/api-routes/src/google.ts
@@ -543,9 +543,9 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
       robotsTxtState: idx?.robotsTxtState ?? null,
       crawlTime: idx?.lastCrawlTime ?? null,
       lastCrawlResult: idx?.crawlResult ?? null,
-      isMobileFriendly: mob?.verdict === 'PASS' ? 1 : mob?.verdict === 'FAIL' ? 0 : null,
-      richResults: JSON.stringify(rich?.detectedItems?.map((d: { richResultType: string }) => d.richResultType) ?? []),
-      referringUrls: JSON.stringify(idx?.referringUrls ?? []),
+      isMobileFriendly: mob?.verdict === 'PASS' ? true : mob?.verdict === 'FAIL' ? false : null,
+      richResults: rich?.detectedItems?.map((d: { richResultType: string }) => d.richResultType) ?? [],
+      referringUrls: idx?.referringUrls ?? [],
       inspectedAt: now,
       createdAt: now,
     }).run()
@@ -596,9 +596,9 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
       robotsTxtState: r.robotsTxtState,
       crawlTime: r.crawlTime,
       lastCrawlResult: r.lastCrawlResult,
-      isMobileFriendly: r.isMobileFriendly === 1 ? true : r.isMobileFriendly === 0 ? false : null,
-      richResults: JSON.parse(r.richResults) as unknown,
-      referringUrls: JSON.parse(r.referringUrls) as unknown,
+      isMobileFriendly: r.isMobileFriendly,
+      richResults: r.richResults,
+      referringUrls: r.referringUrls,
       inspectedAt: r.inspectedAt,
     }))
   })
@@ -753,8 +753,8 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
       robotsTxtState: r.robotsTxtState,
       crawlTime: r.crawlTime,
       lastCrawlResult: r.lastCrawlResult,
-      isMobileFriendly: r.isMobileFriendly === 1 ? true : r.isMobileFriendly === 0 ? false : null,
-      richResults: JSON.parse(r.richResults) as unknown,
+      isMobileFriendly: r.isMobileFriendly,
+      richResults: r.richResults,
       inspectedAt: r.inspectedAt,
     })
 
@@ -816,7 +816,7 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
         date: r.date,
         indexed: r.indexed,
         notIndexed: r.notIndexed,
-        reasonBreakdown: JSON.parse(r.reasonBreakdown) as Record<string, number>,
+        reasonBreakdown: r.reasonBreakdown,
       }))
       .reverse()
   })

--- a/packages/api-routes/src/intelligence.ts
+++ b/packages/api-routes/src/intelligence.ts
@@ -1,6 +1,6 @@
 import { eq, desc, and, inArray } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
-import { groupRunsByCreatedAt, insights, healthSnapshots, parseJsonColumn, runs } from '@ainyc/canonry-db'
+import { groupRunsByCreatedAt, insights, healthSnapshots, runs } from '@ainyc/canonry-db'
 import { notFound, RunKinds, RunStatuses, type InsightDto, type HealthSnapshotDto } from '@ainyc/canonry-contracts'
 import { notProbeRun, resolveProject } from './helpers.js'
 
@@ -29,8 +29,8 @@ function mapInsightRow(r: typeof insights.$inferSelect): InsightDto {
     title: r.title,
     query: r.query,
     provider: r.provider,
-    recommendation: parseJsonColumn<InsightDto['recommendation']>(r.recommendation, undefined),
-    cause: parseJsonColumn<InsightDto['cause']>(r.cause, undefined),
+    recommendation: r.recommendation ?? undefined,
+    cause: r.cause ?? undefined,
     dismissed: r.dismissed,
     createdAt: r.createdAt,
   }
@@ -44,7 +44,7 @@ function mapHealthRow(r: typeof healthSnapshots.$inferSelect): HealthSnapshotDto
     overallCitedRate: Number(r.overallCitedRate),
     totalPairs: r.totalPairs,
     citedPairs: r.citedPairs,
-    providerBreakdown: parseJsonColumn<HealthSnapshotDto['providerBreakdown']>(r.providerBreakdown, {}),
+    providerBreakdown: r.providerBreakdown,
     createdAt: r.createdAt,
     status: 'ready',
   }
@@ -78,7 +78,7 @@ function aggregateHealthSnapshots(
     citedPairs += row.citedPairs
     if (row.createdAt > newestCreatedAt) newestCreatedAt = row.createdAt
     if (row.runId) runIds.push(row.runId)
-    const providerBreakdown = parseJsonColumn<HealthSnapshotDto['providerBreakdown']>(row.providerBreakdown, {})
+    const providerBreakdown = row.providerBreakdown
     for (const [provider, entry] of Object.entries(providerBreakdown)) {
       const existing = mergedProviders[provider] ?? { total: 0, cited: 0, citedRate: 0 }
       existing.total += entry.total

--- a/packages/api-routes/src/report.ts
+++ b/packages/api-routes/src/report.ts
@@ -1075,7 +1075,7 @@ function buildInsightList(
   const flat: Array<ReportInsight & { _sortRank: number }> = rows
     .filter(r => !r.dismissed)
     .map(r => {
-      const recommendation = parseJsonColumn<{ action?: string; target?: string; reason?: string } | null>(r.recommendation, null)
+      const recommendation = r.recommendation
       let recText: string | null = null
       if (recommendation) {
         const parts: string[] = []

--- a/packages/api-routes/src/traffic.ts
+++ b/packages/api-routes/src/traffic.ts
@@ -7,7 +7,6 @@ import {
   aiReferralEventsHourly,
   rawEventSamples,
   runs,
-  parseJsonColumn,
 } from '@ainyc/canonry-db'
 import {
   notFound,
@@ -232,7 +231,7 @@ const BACKFILL_MAX_PAGES = 1_000
 const BACKFILL_SAMPLE_LIMIT = 500
 
 function parseSourceConfig(row: typeof trafficSources.$inferSelect): Record<string, unknown> {
-  return parseJsonColumn<Record<string, unknown>>(row.configJson, {})
+  return row.configJson
 }
 
 function rowToDto(row: typeof trafficSources.$inferSelect): TrafficSourceDto {
@@ -483,10 +482,10 @@ async function runBackfillTask(options: RunBackfillTaskOptions): Promise<void> {
             pathNormalized: sample.pathNormalized,
             status: sample.status,
             refererHost,
-            classifierDetailsJson: JSON.stringify({
+            classifierDetailsJson: {
               crawler: sample.crawler,
               aiReferral: sample.aiReferral,
-            }),
+            },
             createdAt: finishedAt,
           })
           .run()
@@ -498,7 +497,7 @@ async function runBackfillTask(options: RunBackfillTaskOptions): Promise<void> {
           status: TrafficSourceStatuses.connected,
           lastSyncedAt: nextLastSyncedAt,
           lastError: null,
-          lastEventIds: JSON.stringify(newRingBuffer),
+          lastEventIds: newRingBuffer,
           updatedAt: finishedAt,
         })
         .where(eq(trafficSources.id, sourceRow.id))
@@ -602,7 +601,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
           displayName: fallbackName,
           status: TrafficSourceStatuses.connected,
           lastError: null,
-          configJson: JSON.stringify(config),
+          configJson: config,
           updatedAt: now,
         })
         .where(eq(trafficSources.id, activeSource.id))
@@ -626,7 +625,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
           lastCursor: null,
           lastError: null,
           archivedAt: null,
-          configJson: JSON.stringify(config),
+          configJson: config,
           createdAt: now,
           updatedAt: now,
         })
@@ -728,7 +727,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
           displayName: fallbackName,
           status: TrafficSourceStatuses.connected,
           lastError: null,
-          configJson: JSON.stringify(config),
+          configJson: config,
           updatedAt: now,
         })
         .where(eq(trafficSources.id, activeSource.id))
@@ -752,7 +751,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
           lastCursor: null,
           lastError: null,
           archivedAt: null,
-          configJson: JSON.stringify(config),
+          configJson: config,
           createdAt: now,
           updatedAt: now,
         })
@@ -861,7 +860,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
           displayName: fallbackName,
           status: TrafficSourceStatuses.connected,
           lastError: null,
-          configJson: JSON.stringify(config),
+          configJson: config,
           updatedAt: now,
         })
         .where(eq(trafficSources.id, activeSource.id))
@@ -885,7 +884,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
           lastCursor: null,
           lastError: null,
           archivedAt: null,
-          configJson: JSON.stringify(config),
+          configJson: config,
           createdAt: now,
           updatedAt: now,
         })
@@ -1231,7 +1230,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
       // observed in the previous successful sync. The lastSyncedAt clamp
       // narrows the fetch window, but events with timestamp == lastSyncedAt
       // (boundary second) can still appear in two consecutive pulls.
-      const previousIds = parseJsonColumn<string[]>(latestRow.lastEventIds, [])
+      const previousIds = latestRow.lastEventIds ?? []
       const seenEventIds = new Set(previousIds)
       const dedupedEvents = seenEventIds.size === 0
         ? allEvents
@@ -1364,10 +1363,10 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
             pathNormalized: sample.pathNormalized,
             status: sample.status,
             refererHost,
-            classifierDetailsJson: JSON.stringify({
+            classifierDetailsJson: {
               crawler: sample.crawler,
               aiReferral: sample.aiReferral,
-            }),
+            },
             createdAt: finishedAt,
           })
           .run()
@@ -1386,7 +1385,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
         // past them and they'd be lost.
         lastSyncedAt: windowEnd.toISOString(),
         lastError: null,
-        lastEventIds: JSON.stringify(nextEventIds),
+        lastEventIds: nextEventIds,
         updatedAt: finishedAt,
       }
       if (sourceRow.sourceType === TrafficSourceTypes.wordpress) {

--- a/packages/api-routes/test/auth-malformed.test.ts
+++ b/packages/api-routes/test/auth-malformed.test.ts
@@ -16,7 +16,7 @@ test('malformed Authorization headers return the structured AUTH_REQUIRED envelo
     name: 'test',
     keyHash: crypto.createHash('sha256').update('cnry_test').digest('hex'),
     keyPrefix: 'cnry_test',
-    scopes: '["*"]',
+    scopes: ['*'],
     createdAt: new Date().toISOString(),
   }).run()
 

--- a/packages/api-routes/test/composites.test.ts
+++ b/packages/api-routes/test/composites.test.ts
@@ -89,7 +89,7 @@ function seedProjectWithRuns() {
     overallCitedRate: '0.6667',
     totalPairs: 3,
     citedPairs: 2,
-    providerBreakdown: '{}',
+    providerBreakdown: {},
     createdAt: '2026-04-18T14:21:00.000Z',
   }).run()
   // Two insights, one dismissed
@@ -282,7 +282,7 @@ describe('GET /api/v1/projects/:name/overview', () => {
       date: '2026-04-18',
       indexed: 19,
       notIndexed: 1,
-      reasonBreakdown: '{}',
+      reasonBreakdown: {},
       createdAt: '2026-04-18T14:25:00.000Z',
     }).run()
     db.insert(gscUrlInspections).values([
@@ -310,7 +310,7 @@ describe('GET /api/v1/projects/:name/overview', () => {
       date: '2026-04-18',
       indexed: 6,
       notIndexed: 4,
-      reasonBreakdown: '{}',
+      reasonBreakdown: {},
       createdAt: '2026-04-18T14:25:00.000Z',
     }).run()
     await app.ready()

--- a/packages/api-routes/test/discovery.test.ts
+++ b/packages/api-routes/test/discovery.test.ts
@@ -11,7 +11,6 @@ import {
   discoveryProbes,
   discoverySessions,
   migrate,
-  parseJsonColumn,
   projects,
   queries,
   runs,
@@ -261,7 +260,7 @@ describe('executeDiscovery', () => {
       projectId,
       status: 'queued',
       icpDescription: 'solar contractors',
-      competitorMap: '[]',
+      competitorMap: [],
       createdAt: now,
     }).run()
     db.insert(runs).values({
@@ -348,7 +347,7 @@ describe('executeDiscovery', () => {
     expect(sessionRow.citedCount).toBe(1)
     expect(sessionRow.aspirationalCount).toBe(1)
     expect(sessionRow.wastedCount).toBe(2)
-    expect(parseJsonColumn(sessionRow.competitorMap, [])).toEqual([
+    expect(sessionRow.competitorMap).toEqual([
       { domain: 'aurora-solar.com', hits: 2, competitorType: 'direct-competitor' },
       { domain: 'enerflo.com', hits: 1, competitorType: 'direct-competitor' },
       { domain: 'random.com', hits: 1, competitorType: 'other' },
@@ -374,7 +373,7 @@ describe('executeDiscovery', () => {
       id: sessionId,
       projectId,
       status: 'queued',
-      competitorMap: '[]',
+      competitorMap: [],
       createdAt: now,
     }).run()
     db.insert(runs).values({
@@ -429,7 +428,7 @@ describe('executeDiscovery', () => {
       id: sessionId,
       projectId,
       status: 'queued',
-      competitorMap: '[]',
+      competitorMap: [],
       createdAt: now,
     }).run()
 
@@ -468,7 +467,7 @@ describe('executeDiscovery', () => {
       id: sessionId,
       projectId,
       status: 'queued',
-      competitorMap: '[]',
+      competitorMap: [],
       createdAt: now,
     }).run()
 
@@ -544,7 +543,7 @@ describe('executeDiscovery', () => {
       id: sessionWith,
       projectId,
       status: 'queued',
-      competitorMap: '[]',
+      competitorMap: [],
       createdAt: new Date().toISOString(),
     }).run()
     await executeDiscovery({
@@ -565,7 +564,7 @@ describe('executeDiscovery', () => {
       id: sessionWithout,
       projectId,
       status: 'queued',
-      competitorMap: '[]',
+      competitorMap: [],
       createdAt: new Date().toISOString(),
     }).run()
     await executeDiscovery({
@@ -827,7 +826,7 @@ describe('discovery routes', () => {
       projectId,
       status: 'completed',
       icpDescription: 'industrial coatings',
-      competitorMap: '[]',
+      competitorMap: [],
       createdAt: new Date().toISOString(),
     }).run()
 
@@ -855,7 +854,7 @@ describe('discovery routes', () => {
       projectId,
       status: 'failed',
       icpDescription: 'industrial coatings',
-      competitorMap: '[]',
+      competitorMap: [],
       error: 'gemini quota',
       createdAt: new Date().toISOString(),
     }).run()
@@ -966,7 +965,7 @@ describe('discovery routes', () => {
       runId: 'zombie_run',
       status: 'probing',
       icpDescription: 'industrial coatings',
-      competitorMap: '[]',
+      competitorMap: [],
       createdAt: longAgoIso,
     }).run()
 
@@ -1009,14 +1008,14 @@ describe('discovery routes', () => {
         id: 'older',
         projectId,
         status: 'completed',
-        competitorMap: '[]',
+        competitorMap: [],
         createdAt: '2026-05-01T00:00:00Z',
       },
       {
         id: 'newer',
         projectId,
         status: 'completed',
-        competitorMap: '[]',
+        competitorMap: [],
         createdAt: '2026-05-10T00:00:00Z',
       },
     ]).run()
@@ -1051,7 +1050,7 @@ describe('discovery routes', () => {
       id: 'sess_other',
       projectId: otherProjectId,
       status: 'completed',
-      competitorMap: '[]',
+      competitorMap: [],
       createdAt: new Date().toISOString(),
     }).run()
     // Use the wrong project to look up the session
@@ -1081,7 +1080,7 @@ describe('discovery routes', () => {
       citedCount: 1,
       aspirationalCount: 0,
       wastedCount: 1,
-      competitorMap: JSON.stringify([{ domain: 'aurora-solar.com', hits: 1 }]),
+      competitorMap: [{ domain: 'aurora-solar.com', hits: 1, competitorType: 'unknown' }],
       createdAt: new Date().toISOString(),
     }).run()
     db.insert(discoveryProbes).values([
@@ -1092,7 +1091,7 @@ describe('discovery routes', () => {
         query: 'best solar quoting',
         bucket: 'cited',
         citationState: 'cited',
-        citedDomains: JSON.stringify(['demand-iq.com']),
+        citedDomains: ['demand-iq.com'],
         rawResponse: '{}',
         createdAt: new Date().toISOString(),
       },
@@ -1103,7 +1102,7 @@ describe('discovery routes', () => {
         query: 'aurora alternatives',
         bucket: 'wasted-surface',
         citationState: 'not-cited',
-        citedDomains: JSON.stringify(['aurora-solar.com']),
+        citedDomains: ['aurora-solar.com'],
         rawResponse: '{}',
         createdAt: new Date().toISOString(),
       },
@@ -1133,13 +1132,13 @@ describe('discovery routes', () => {
       id: sessionId,
       projectId,
       status: 'completed',
-      competitorMap: JSON.stringify([
+      competitorMap: [
         { domain: 'aurora-solar.com', hits: 3, competitorType: 'direct-competitor' }, // already tracked
         { domain: 'enerflo.com', hits: 2, competitorType: 'direct-competitor' }, // already tracked
         { domain: 'expedia.com', hits: 3, competitorType: 'ota-aggregator' }, // new + recurring aggregator
         { domain: 'helioscope.com', hits: 2, competitorType: 'direct-competitor' }, // new + recurring
         { domain: 'oneoff.example', hits: 1, competitorType: 'direct-competitor' }, // new but too noisy to suggest
-      ]),
+      ],
       createdAt: new Date().toISOString(),
     }).run()
     db.insert(discoveryProbes).values([
@@ -1251,7 +1250,7 @@ describe('POST /discover/sessions/:id/promote', () => {
       id: sessionId,
       projectId,
       status: opts.status ?? 'completed',
-      competitorMap: JSON.stringify(competitorMap),
+      competitorMap,
       createdAt: now,
     }).run()
     for (const p of opts.probes ?? []) {
@@ -1262,7 +1261,7 @@ describe('POST /discover/sessions/:id/promote', () => {
         query: p.query,
         bucket: p.bucket,
         citationState: p.bucket === 'cited' ? 'cited' : 'not-cited',
-        citedDomains: '[]',
+        citedDomains: [],
         createdAt: now,
       }).run()
     }
@@ -1523,10 +1522,13 @@ describe('POST /discover/sessions/:id/promote', () => {
       id: sessionId,
       projectId,
       status: 'completed',
-      competitorMap: JSON.stringify([
+      // Legacy fixture: entries deliberately lack `competitorType` to exercise
+      // the unknown-normalization fallback. Cast bypasses the typed schema so
+      // we can land malformed JSON like an older row would have.
+      competitorMap: [
         { domain: 'helioscope.com', hits: 3 },
         { domain: 'solargraf.com', hits: 2 },
-      ]),
+      ] as DiscoveryCompetitorMapEntry[],
       createdAt: new Date().toISOString(),
     }).run()
 

--- a/packages/api-routes/test/doctor-traffic-source.test.ts
+++ b/packages/api-routes/test/doctor-traffic-source.test.ts
@@ -82,7 +82,7 @@ function insertTrafficSource(
     lastError: args.lastError ?? null,
     lastEventIds: null,
     archivedAt: args.status === 'archived' ? now : null,
-    configJson: '{}',
+    configJson: {},
     createdAt: now,
     updatedAt: now,
   }).run()

--- a/packages/api-routes/test/google.test.ts
+++ b/packages/api-routes/test/google.test.ts
@@ -557,7 +557,7 @@ describe('googleRoutes: GET /projects/:name/google/gsc/coverage/history', () => 
       date: '2025-01-01',
       indexed: 80,
       notIndexed: 20,
-      reasonBreakdown: JSON.stringify({ 'Crawled - currently not indexed': 15, 'Duplicate without user-selected canonical': 5 }),
+      reasonBreakdown: { 'Crawled - currently not indexed': 15, 'Duplicate without user-selected canonical': 5 },
       createdAt: now,
     }).run()
 
@@ -568,7 +568,7 @@ describe('googleRoutes: GET /projects/:name/google/gsc/coverage/history', () => 
       date: '2025-01-02',
       indexed: 85,
       notIndexed: 15,
-      reasonBreakdown: JSON.stringify({ 'Crawled - currently not indexed': 10, 'Duplicate without user-selected canonical': 5 }),
+      reasonBreakdown: { 'Crawled - currently not indexed': 10, 'Duplicate without user-selected canonical': 5 },
       createdAt: now,
     }).run()
 
@@ -709,7 +709,7 @@ describe('googleRoutes: coverage snapshot deduplication', () => {
       date: '2025-03-01',
       indexed: 50,
       notIndexed: 50,
-      reasonBreakdown: '{}',
+      reasonBreakdown: {},
       createdAt: now,
     }).run()
 
@@ -756,7 +756,7 @@ describe('googleRoutes: coverage snapshot deduplication', () => {
       date: '2025-03-01',
       indexed: 90,
       notIndexed: 10,
-      reasonBreakdown: '{}',
+      reasonBreakdown: {},
       createdAt: new Date().toISOString(),
     }).run()
 
@@ -876,7 +876,7 @@ describe('googleRoutes: GET /projects/:name/google/gsc/coverage', () => {
       date: '2026-05-04',
       indexed: 1,
       notIndexed: 0,
-      reasonBreakdown: '{}',
+      reasonBreakdown: {},
       createdAt: syncTime,
     }).run()
 
@@ -901,7 +901,7 @@ describe('googleRoutes: GET /projects/:name/google/gsc/coverage', () => {
       date: '2026-05-02',
       indexed: 1,
       notIndexed: 0,
-      reasonBreakdown: '{}',
+      reasonBreakdown: {},
       createdAt: earlierSync,
     }).run()
 
@@ -912,7 +912,7 @@ describe('googleRoutes: GET /projects/:name/google/gsc/coverage', () => {
       date: '2026-05-05',
       indexed: 1,
       notIndexed: 0,
-      reasonBreakdown: '{}',
+      reasonBreakdown: {},
       createdAt: latestSync,
     }).run()
 

--- a/packages/api-routes/test/health-latest.test.ts
+++ b/packages/api-routes/test/health-latest.test.ts
@@ -73,7 +73,7 @@ test('returns 200 with status:"ready" when a snapshot exists', async () => {
     overallCitedRate: 0.42,
     totalPairs: 10,
     citedPairs: 4,
-    providerBreakdown: JSON.stringify({ gemini: { citedRate: 0.5, cited: 5, total: 10 } }),
+    providerBreakdown: { gemini: { citedRate: 0.5, cited: 5, total: 10 } },
     createdAt: '2026-04-27T00:00:00Z',
   }).run()
   await ctx.app.ready()
@@ -119,7 +119,7 @@ test('aggregates healthSnapshots across the latest fan-out group when a multi-lo
       overallCitedRate: '0.6',
       totalPairs: 10,
       citedPairs: 6,
-      providerBreakdown: JSON.stringify({ gemini: { citedRate: 0.6, cited: 6, total: 10 } }),
+      providerBreakdown: { gemini: { citedRate: 0.6, cited: 6, total: 10 } },
       createdAt,
     },
     {
@@ -129,7 +129,7 @@ test('aggregates healthSnapshots across the latest fan-out group when a multi-lo
       overallCitedRate: '0.2',
       totalPairs: 10,
       citedPairs: 2,
-      providerBreakdown: JSON.stringify({ gemini: { citedRate: 0.2, cited: 2, total: 10 } }),
+      providerBreakdown: { gemini: { citedRate: 0.2, cited: 2, total: 10 } },
       createdAt,
     },
   ]).run()

--- a/packages/api-routes/test/report.test.ts
+++ b/packages/api-routes/test/report.test.ts
@@ -424,7 +424,7 @@ describe('GET /api/v1/projects/:name/report', () => {
       date: '2026-04-30',
       indexed: 2,
       notIndexed: 8,
-      reasonBreakdown: '{}',
+      reasonBreakdown: {},
       createdAt: new Date().toISOString(),
     }).run()
 
@@ -755,7 +755,7 @@ describe('GET /api/v1/projects/:name/report', () => {
       date: '2026-04-30',
       indexed: 80,
       notIndexed: 20,
-      reasonBreakdown: '{}',
+      reasonBreakdown: {},
       createdAt: new Date().toISOString(),
     }).run()
 
@@ -1027,7 +1027,7 @@ describe('GET /api/v1/projects/:name/report', () => {
         title: 'Lost citation on query',
         query: 'aeo platform',
         provider: 'gemini',
-        recommendation: JSON.stringify({ action: 'review-content', target: '/landing', reason: 'rival outranking' }),
+        recommendation: { action: 'review-content', target: '/landing', reason: 'rival outranking' },
         cause: null,
         dismissed: false,
         createdAt: '2026-04-30T00:00:00Z',
@@ -1512,7 +1512,7 @@ describe('serverActivity (AI visibility — server-side)', () => {
       lastError: null,
       lastEventIds: null,
       archivedAt: status === 'archived' ? now : null,
-      configJson: '{}',
+      configJson: {},
       createdAt: now,
       updatedAt: now,
     }).run()

--- a/packages/api-routes/test/schedules.test.ts
+++ b/packages/api-routes/test/schedules.test.ts
@@ -80,7 +80,7 @@ async function buildHarness(): Promise<Harness> {
     lastError: null,
     lastEventIds: null,
     archivedAt: null,
-    configJson: '{}',
+    configJson: {},
     createdAt: now,
     updatedAt: now,
   }).run()
@@ -95,7 +95,7 @@ async function buildHarness(): Promise<Harness> {
     lastError: null,
     lastEventIds: null,
     archivedAt: null,
-    configJson: '{}',
+    configJson: {},
     createdAt: now,
     updatedAt: now,
   }).run()

--- a/packages/api-routes/test/security.test.ts
+++ b/packages/api-routes/test/security.test.ts
@@ -29,7 +29,7 @@ function insertApiKey(db: ReturnType<typeof createClient>, rawKey = `cnry_${cryp
     name: 'test',
     keyHash: crypto.createHash('sha256').update(rawKey).digest('hex'),
     keyPrefix: rawKey.slice(0, 9),
-    scopes: '["*"]',
+    scopes: ['*'],
     createdAt: new Date().toISOString(),
   }).run()
 

--- a/packages/api-routes/test/traffic.test.ts
+++ b/packages/api-routes/test/traffic.test.ts
@@ -404,7 +404,7 @@ describe('POST /traffic/connect/cloud-run', () => {
     expect(second.statusCode).toBe(200)
     const sources = h.db.select().from(trafficSources).all()
     expect(sources.length).toBe(1)
-    const config = JSON.parse(sources[0].configJson) as Record<string, unknown>
+    const config = sources[0].configJson
     expect(config.gcpProjectId).toBe('new-project')
     expect(config.serviceName).toBe('new-svc')
   })
@@ -502,7 +502,7 @@ describe('POST /traffic/connect/wordpress', () => {
     expect(second.statusCode).toBe(200)
     const sources = h.db.select().from(trafficSources).all()
     expect(sources.length).toBe(1)
-    const config = JSON.parse(sources[0].configJson) as Record<string, unknown>
+    const config = sources[0].configJson
     expect(config.username).toBe('new-bot')
   })
 })
@@ -621,7 +621,7 @@ describe('POST /traffic/connect/vercel', () => {
     expect(second.statusCode).toBe(200)
     const sources = h.db.select().from(trafficSources).all()
     expect(sources.length).toBe(1)
-    const config = JSON.parse(sources[0].configJson) as Record<string, unknown>
+    const config = sources[0].configJson
     expect(config.projectId).toBe('prj_new')
     expect(config.teamId).toBe('team_new')
     // Credential record updated in place too.
@@ -661,7 +661,7 @@ describe('POST /traffic/sources/:id/sync — Vercel', () => {
         sourceType: TrafficSourceTypes.vercel,
         displayName: 'orphan vercel',
         status: TrafficSourceStatuses.connected,
-        configJson: JSON.stringify({ projectId: 'prj_abc', teamId: 'team_xyz', environment: 'production' }),
+        configJson: { projectId: 'prj_abc', teamId: 'team_xyz', environment: 'production' },
         createdAt: now,
         updatedAt: now,
       }).run()
@@ -1002,7 +1002,7 @@ describe('POST /traffic/sources/:id/backfill — Vercel', () => {
         sourceType: TrafficSourceTypes.vercel,
         displayName: 'orphan vercel',
         status: TrafficSourceStatuses.connected,
-        configJson: JSON.stringify({ projectId: 'prj_abc', teamId: 'team_xyz', environment: 'production' }),
+        configJson: { projectId: 'prj_abc', teamId: 'team_xyz', environment: 'production' },
         createdAt: now,
         updatedAt: now,
       }).run()
@@ -1046,7 +1046,7 @@ describe('POST /traffic/sources/:id/sync', () => {
         sourceType: TrafficSourceTypes['cloud-run'],
         displayName: 'orphan',
         status: TrafficSourceStatuses.connected,
-        configJson: '{"gcpProjectId":"orphan-project","authMode":"service-account"}',
+        configJson: { gcpProjectId: 'orphan-project', authMode: 'service-account' },
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
       }).run()
@@ -1355,7 +1355,7 @@ describe('POST /traffic/sources/:id/sync', () => {
 
       // The dup event ID should be persisted on the source row.
       const afterFirst = h.db.select().from(trafficSources).where(eq(trafficSources.id, sourceId)).all()
-      expect(JSON.parse(afterFirst[0].lastEventIds ?? '[]')).toContain('cloud-run:dup-1')
+      expect(afterFirst[0].lastEventIds ?? []).toContain('cloud-run:dup-1')
 
       // Push a new event into the harness's array — Cloud Logging's
       // bypass-time-filter mock will now return [dup, fresh]. The deduper
@@ -1424,7 +1424,7 @@ describe('POST /traffic/sources/:id/sync', () => {
       })
 
       const rows = h.db.select().from(trafficSources).where(eq(trafficSources.id, sourceId)).all()
-      const persisted: string[] = JSON.parse(rows[0].lastEventIds ?? '[]')
+      const persisted: string[] = rows[0].lastEventIds ?? []
       // Ring buffer must be bounded.
       expect(persisted.length).toBeLessThanOrEqual(1_000)
       expect(persisted.length).toBeGreaterThan(0)
@@ -1683,7 +1683,7 @@ describe('POST /traffic/sources/:id/sync — WordPress', () => {
         sourceType: TrafficSourceTypes.wordpress,
         displayName: 'orphan wp',
         status: TrafficSourceStatuses.connected,
-        configJson: JSON.stringify({ baseUrl: 'https://example.com', username: 'bot' }),
+        configJson: { baseUrl: 'https://example.com', username: 'bot' },
         createdAt: now,
         updatedAt: now,
       }).run()
@@ -2563,7 +2563,7 @@ describe('POST /traffic/sources/:id/backfill — WordPress', () => {
         sourceType: TrafficSourceTypes.wordpress,
         displayName: 'orphan wp',
         status: TrafficSourceStatuses.connected,
-        configJson: JSON.stringify({ baseUrl: 'https://example.com', username: 'bot' }),
+        configJson: { baseUrl: 'https://example.com', username: 'bot' },
         createdAt: now,
         updatedAt: now,
       }).run()
@@ -2709,7 +2709,7 @@ describe('GET /traffic/sources', () => {
         displayName: 'old',
         status: TrafficSourceStatuses.archived,
         archivedAt: now,
-        configJson: '{}',
+        configJson: {},
         createdAt: now,
         updatedAt: now,
       }).run()
@@ -2840,7 +2840,7 @@ describe('GET /traffic/sources/:id', () => {
         sourceType: TrafficSourceTypes['cloud-run'],
         displayName: 'second source',
         status: TrafficSourceStatuses.connected,
-        configJson: '{}',
+        configJson: {},
         createdAt: now,
         updatedAt: now,
       }).run()
@@ -2938,7 +2938,7 @@ describe('GET /traffic/status', () => {
         displayName: 'old',
         status: TrafficSourceStatuses.archived,
         archivedAt: now,
-        configJson: '{}',
+        configJson: {},
         createdAt: now,
         updatedAt: now,
       }).run()

--- a/packages/canonry/src/bing-inspect-sitemap.ts
+++ b/packages/canonry/src/bing-inspect-sitemap.ts
@@ -134,7 +134,7 @@ export async function executeBingInspectSitemap(
           projectId,
           url: pageUrl,
           httpCode,
-          inIndex: derivedInIndex === true ? 1 : derivedInIndex === false ? 0 : null,
+          inIndex: derivedInIndex,
           lastCrawledDate,
           inIndexDate,
           inspectedAt,
@@ -196,8 +196,8 @@ export async function executeBingInspectSitemap(
     let snapNotIndexed = 0
     let snapUnknown = 0
     for (const [, row] of latestByUrl) {
-      if (row.inIndex === 1) snapIndexed++
-      else if (row.inIndex === 0) snapNotIndexed++
+      if (row.inIndex === true) snapIndexed++
+      else if (row.inIndex === false) snapNotIndexed++
       else snapUnknown++
     }
 

--- a/packages/canonry/src/commands/bootstrap.ts
+++ b/packages/canonry/src/commands/bootstrap.ts
@@ -70,7 +70,7 @@ export async function bootstrapCommand(_opts?: { force?: boolean; format?: CliFo
       name: 'default',
       keyHash,
       keyPrefix,
-      scopes: '["*"]',
+      scopes: ['*'],
       createdAt: new Date().toISOString(),
     }).run()
   })

--- a/packages/canonry/src/commands/init.ts
+++ b/packages/canonry/src/commands/init.ts
@@ -259,7 +259,7 @@ export async function initCommand(opts?: InitOptions): Promise<ResolvedAgentLLM 
     name: 'default',
     keyHash,
     keyPrefix,
-    scopes: '["*"]',
+    scopes: ['*'],
     createdAt: new Date().toISOString(),
   }).run()
 

--- a/packages/canonry/src/discovery-run.ts
+++ b/packages/canonry/src/discovery-run.ts
@@ -517,17 +517,15 @@ function writeDiscoveryInsight(
       // formalize a session-scoped insight subtype.
       query: `discovery:${input.sessionId}`,
       provider: input.seedProvider,
-      recommendation: JSON.stringify({
+      recommendation: {
         action: 'review-discovered-basket',
-        summary: `Run \`canonry discover show ${input.sessionId} --format json\` to inspect the per-query breakdown, then \`canonry discover promote <project> ${input.sessionId}\` to merge cited + aspirational findings into the project.`,
-        bucketCounts: buckets,
-        topCompetitors,
-      }),
-      cause: JSON.stringify({
-        sessionId: input.sessionId,
-        totalProbes,
-        seedProvider: input.seedProvider,
-      }),
+        target: input.sessionId,
+        reason: `Run \`canonry discover show ${input.sessionId} --format json\` to inspect the per-query breakdown, then \`canonry discover promote <project> ${input.sessionId}\` to merge cited + aspirational findings into the project. Top competitors: ${topCompetitors.map(c => c.domain).join(', ') || 'none'} | Buckets: cited=${buckets.cited} aspirational=${buckets.aspirational} wasted=${buckets['wasted-surface']}`,
+      },
+      cause: {
+        cause: `Discovery session ${input.sessionId} probed ${totalProbes} representative queries via ${input.seedProvider}`,
+        details: `sessionId=${input.sessionId}, totalProbes=${totalProbes}, seedProvider=${input.seedProvider}`,
+      },
       dismissed: false,
       createdAt: new Date().toISOString(),
     }).run()

--- a/packages/canonry/src/gsc-inspect-sitemap.ts
+++ b/packages/canonry/src/gsc-inspect-sitemap.ts
@@ -99,9 +99,9 @@ export async function executeInspectSitemap(
           robotsTxtState: idx?.robotsTxtState ?? null,
           crawlTime: idx?.lastCrawlTime ?? null,
           lastCrawlResult: idx?.crawlResult ?? null,
-          isMobileFriendly: mob?.verdict === 'PASS' ? 1 : mob?.verdict === 'FAIL' ? 0 : null,
-          richResults: JSON.stringify(rich?.detectedItems?.map((d) => d.richResultType) ?? []),
-          referringUrls: JSON.stringify(idx?.referringUrls ?? []),
+          isMobileFriendly: mob?.verdict === 'PASS' ? true : mob?.verdict === 'FAIL' ? false : null,
+          richResults: rich?.detectedItems?.map((d) => d.richResultType) ?? [],
+          referringUrls: idx?.referringUrls ?? [],
           inspectedAt,
           createdAt: inspectedAt,
         }).run()
@@ -158,7 +158,7 @@ export async function executeInspectSitemap(
       date: snapshotDate,
       indexed: snapIndexed,
       notIndexed: snapNotIndexed,
-      reasonBreakdown: JSON.stringify(reasonCounts),
+      reasonBreakdown: reasonCounts,
       createdAt: new Date().toISOString(),
     }).run()
 

--- a/packages/canonry/src/gsc-sync.ts
+++ b/packages/canonry/src/gsc-sync.ts
@@ -168,9 +168,9 @@ export async function executeGscSync(
           robotsTxtState: idx?.robotsTxtState ?? null,
           crawlTime: idx?.lastCrawlTime ?? null,
           lastCrawlResult: idx?.crawlResult ?? null,
-          isMobileFriendly: mob?.verdict === 'PASS' ? 1 : mob?.verdict === 'FAIL' ? 0 : null,
-          richResults: JSON.stringify(rich?.detectedItems?.map((d) => d.richResultType) ?? []),
-          referringUrls: JSON.stringify(idx?.referringUrls ?? []),
+          isMobileFriendly: mob?.verdict === 'PASS' ? true : mob?.verdict === 'FAIL' ? false : null,
+          richResults: rich?.detectedItems?.map((d) => d.richResultType) ?? [],
+          referringUrls: idx?.referringUrls ?? [],
           inspectedAt,
           createdAt: inspectedAt,
         }).run()
@@ -219,7 +219,7 @@ export async function executeGscSync(
       date: snapshotDate,
       indexed: snapIndexed,
       notIndexed: snapNotIndexed,
-      reasonBreakdown: JSON.stringify(reasonCounts),
+      reasonBreakdown: reasonCounts,
       createdAt: new Date().toISOString(),
     }).run()
 

--- a/packages/canonry/src/intelligence-service.ts
+++ b/packages/canonry/src/intelligence-service.ts
@@ -413,8 +413,8 @@ export class IntelligenceService {
           title: insight.title,
           query: insight.query,
           provider: insight.provider,
-          recommendation: insight.recommendation ? JSON.stringify(insight.recommendation) : null,
-          cause: insight.cause ? JSON.stringify(insight.cause) : null,
+          recommendation: insight.recommendation ?? null,
+          cause: insight.cause ?? null,
           dismissed: wasDismissed,
           createdAt: insight.createdAt,
         }).run()
@@ -427,7 +427,7 @@ export class IntelligenceService {
         overallCitedRate: String(result.health.overallCitedRate),
         totalPairs: result.health.totalPairs,
         citedPairs: result.health.citedPairs,
-        providerBreakdown: JSON.stringify(result.health.providerBreakdown),
+        providerBreakdown: result.health.providerBreakdown,
         createdAt: now,
       }).run()
     })

--- a/packages/canonry/src/run-coordinator.ts
+++ b/packages/canonry/src/run-coordinator.ts
@@ -1,6 +1,6 @@
 import { eq } from 'drizzle-orm'
 import type { DatabaseClient } from '@ainyc/canonry-db'
-import { discoverySessions, runs, parseJsonColumn } from '@ainyc/canonry-db'
+import { discoverySessions, runs } from '@ainyc/canonry-db'
 import {
   RunKinds,
   RunTriggers,
@@ -156,9 +156,7 @@ export class RunCoordinator {
       .where(eq(discoverySessions.runId, runId))
       .get()
 
-    const competitorMap = session
-      ? parseJsonColumn<DiscoveryCompetitorMapEntry[]>(session.competitorMap, [])
-      : []
+    const competitorMap = session ? session.competitorMap : []
 
     return {
       kind: RunKinds['aeo-discover-probe'],

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -711,7 +711,7 @@ export async function createServer(opts: {
         name: 'default',
         keyHash,
         keyPrefix: prefix,
-        scopes: JSON.stringify(['*']),
+        scopes: ['*'],
         createdAt: new Date().toISOString(),
       }).run()
     }

--- a/packages/canonry/test/bing-inspect-sitemap.test.ts
+++ b/packages/canonry/test/bing-inspect-sitemap.test.ts
@@ -126,7 +126,7 @@ describe('executeBingInspectSitemap', () => {
       {
         id: crypto.randomUUID(), projectId,
         url: 'https://azcoatingsllc.com/',
-        httpCode: 200, inIndex: 1,
+        httpCode: 200, inIndex: true,
         lastCrawledDate: '2026-04-19T10:00:00Z', inIndexDate: null,
         inspectedAt: seededAt, syncRunId: null, createdAt: seededAt,
         documentSize: 5000, anchorCount: null, discoveryDate: null,
@@ -134,7 +134,7 @@ describe('executeBingInspectSitemap', () => {
       {
         id: crypto.randomUUID(), projectId,
         url: 'https://azcoatingsllc.com/about/',
-        httpCode: 200, inIndex: 1,
+        httpCode: 200, inIndex: true,
         lastCrawledDate: '2026-04-19T10:00:00Z', inIndexDate: null,
         inspectedAt: seededAt, syncRunId: null, createdAt: seededAt,
         documentSize: 3000, anchorCount: null, discoveryDate: null,
@@ -184,7 +184,7 @@ describe('executeBingInspectSitemap', () => {
     ])
     // Newly discovered URLs are now tracked + indexed
     for (const row of newInspections) {
-      expect(row.inIndex).toBe(1)
+      expect(row.inIndex).toBe(true)
     }
 
     // Coverage snapshot covers the full discovered set, not just the originally
@@ -301,7 +301,7 @@ describe('executeBingInspectSitemap', () => {
       .where(eq(bingUrlInspections.syncRunId, runId)).all()
     const blocked = inspections.find((r) => r.url.endsWith('/blocked'))
     const ok = inspections.find((r) => r.url.endsWith('/ok'))
-    expect(blocked?.inIndex).toBe(0)
-    expect(ok?.inIndex).toBe(1)
+    expect(blocked?.inIndex).toBe(false)
+    expect(ok?.inIndex).toBe(true)
   })
 })

--- a/packages/canonry/test/discover-commands.test.ts
+++ b/packages/canonry/test/discover-commands.test.ts
@@ -108,7 +108,7 @@ describe('discover CLI commands', () => {
       id: sessionId,
       projectId,
       status: opts.status ?? 'completed',
-      competitorMap: JSON.stringify(competitorMap),
+      competitorMap,
       createdAt: now,
     }).run()
     for (const p of opts.probes ?? []) {
@@ -119,7 +119,7 @@ describe('discover CLI commands', () => {
         query: p.query,
         bucket: p.bucket,
         citationState: p.bucket === 'cited' ? 'cited' : 'not-cited',
-        citedDomains: '[]',
+        citedDomains: [],
         createdAt: now,
       }).run()
     }
@@ -351,7 +351,7 @@ describe('discover CLI commands', () => {
       runId: existingRunId,
       status: 'probing',
       icpDescription: 'in-flight icp',
-      competitorMap: '[]',
+      competitorMap: [],
       createdAt: new Date().toISOString(),
     }).run()
 
@@ -381,7 +381,7 @@ describe('discover CLI commands', () => {
       runId: existingRunId,
       status: 'probing',
       icpDescription: 'in-flight icp',
-      competitorMap: '[]',
+      competitorMap: [],
       createdAt: new Date().toISOString(),
     }).run()
 

--- a/packages/canonry/test/discovery-run.test.ts
+++ b/packages/canonry/test/discovery-run.test.ts
@@ -10,7 +10,6 @@ import {
   discoverySessions,
   insights,
   migrate,
-  parseJsonColumn,
   projects,
   runs,
 } from '@ainyc/canonry-db'
@@ -137,7 +136,7 @@ describe('executeDiscoveryRun', () => {
     expect(sessionRow.aspirationalCount).toBe(1)
     expect(sessionRow.seedProvider).toBe('gemini-test')
     // The orchestrator's classification pass types every recurring cited domain.
-    expect(parseJsonColumn(sessionRow.competitorMap, [])).toEqual([
+    expect(sessionRow.competitorMap).toEqual([
       { domain: 'aurora-solar.com', hits: 2, competitorType: 'direct-competitor' },
       { domain: 'random.com', hits: 1, competitorType: 'other' },
     ])
@@ -161,9 +160,16 @@ describe('executeDiscoveryRun', () => {
     expect(insight.dismissed).toBe(false)
     // 50% wasted-surface → severity 'high'
     expect(insight.severity).toBe('high')
-    const recommendation = parseJsonColumn<{ bucketCounts: Record<string, number>; topCompetitors: Array<{ domain: string }> }>(insight.recommendation, { bucketCounts: {}, topCompetitors: [] })
-    expect(recommendation.bucketCounts).toEqual({ cited: 1, aspirational: 1, 'wasted-surface': 2 })
-    expect(recommendation.topCompetitors.some(c => c.domain === 'aurora-solar.com')).toBe(true)
+    const recommendation = insight.recommendation
+    expect(recommendation).not.toBeNull()
+    expect(recommendation!.action).toBe('review-discovered-basket')
+    expect(recommendation!.target).toBe(sessionId)
+    // reason text encodes both the bucket counts and the top competitors so
+    // operators see them inline in the insight body.
+    expect(recommendation!.reason).toContain('cited=1')
+    expect(recommendation!.reason).toContain('aspirational=1')
+    expect(recommendation!.reason).toContain('wasted=2')
+    expect(recommendation!.reason).toContain('aurora-solar.com')
   })
 
   it('dismisses prior basket-divergence insights for the project when a new session writes one', async () => {
@@ -188,8 +194,8 @@ describe('executeDiscoveryRun', () => {
       title: 'Older divergence (notional prior session)',
       query: 'discovery:older-session',
       provider: 'gemini-test',
-      recommendation: JSON.stringify({}),
-      cause: JSON.stringify({}),
+      recommendation: null,
+      cause: null,
       dismissed: false,
       createdAt: new Date(Date.now() - 60_000).toISOString(),
     }).run()
@@ -203,8 +209,8 @@ describe('executeDiscoveryRun', () => {
       title: 'Unrelated regression',
       query: 'some query',
       provider: 'openai',
-      recommendation: JSON.stringify({}),
-      cause: JSON.stringify({}),
+      recommendation: null,
+      cause: null,
       dismissed: false,
       createdAt: new Date(Date.now() - 60_000).toISOString(),
     }).run()

--- a/packages/canonry/test/index.test.ts
+++ b/packages/canonry/test/index.test.ts
@@ -229,7 +229,7 @@ describe('canonry', () => {
       name: 'test',
       keyHash,
       keyPrefix: rawKey.slice(0, 9),
-      scopes: '["*"]',
+      scopes: ['*'],
       createdAt: new Date().toISOString(),
     }).run()
 
@@ -269,7 +269,7 @@ describe('canonry', () => {
       name: 'test',
       keyHash,
       keyPrefix: rawKey.slice(0, 9),
-      scopes: '["*"]',
+      scopes: ['*'],
       createdAt: new Date().toISOString(),
     }).run()
 
@@ -404,7 +404,7 @@ describe('canonry', () => {
       name: 'test',
       keyHash,
       keyPrefix: rawKey.slice(0, 9),
-      scopes: '["*"]',
+      scopes: ['*'],
       createdAt: new Date().toISOString(),
     }).run()
 
@@ -470,7 +470,7 @@ describe('canonry', () => {
       name: 'test',
       keyHash,
       keyPrefix: rawKey.slice(0, 9),
-      scopes: '["*"]',
+      scopes: ['*'],
       createdAt: new Date().toISOString(),
     }).run()
 
@@ -715,7 +715,7 @@ describe('canonry', () => {
       name: 'test',
       keyHash,
       keyPrefix: rawKey.slice(0, 9),
-      scopes: '["*"]',
+      scopes: ['*'],
       createdAt: new Date().toISOString(),
     }).run()
 
@@ -769,7 +769,7 @@ describe('canonry', () => {
       name: 'test',
       keyHash,
       keyPrefix: rawKey.slice(0, 9),
-      scopes: '["*"]',
+      scopes: ['*'],
       createdAt: new Date().toISOString(),
     }).run()
 
@@ -869,7 +869,7 @@ describe('canonry', () => {
       name: 'test',
       keyHash,
       keyPrefix: rawKey.slice(0, 9),
-      scopes: '["*"]',
+      scopes: ['*'],
       createdAt: new Date().toISOString(),
     }).run()
 
@@ -906,7 +906,7 @@ describe('canonry', () => {
       name: 'test',
       keyHash,
       keyPrefix: rawKey.slice(0, 9),
-      scopes: '["*"]',
+      scopes: ['*'],
       createdAt: new Date().toISOString(),
     }).run()
 
@@ -947,7 +947,7 @@ describe('canonry', () => {
       name: 'test',
       keyHash,
       keyPrefix: rawKey.slice(0, 9),
-      scopes: '["*"]',
+      scopes: ['*'],
       createdAt: new Date().toISOString(),
     }).run()
 
@@ -992,7 +992,7 @@ describe('canonry', () => {
       name: 'test',
       keyHash,
       keyPrefix: rawKey.slice(0, 9),
-      scopes: '["*"]',
+      scopes: ['*'],
       createdAt: new Date().toISOString(),
     }).run()
 
@@ -1049,7 +1049,7 @@ describe('canonry', () => {
       name: 'test',
       keyHash,
       keyPrefix: rawKey.slice(0, 9),
-      scopes: '["*"]',
+      scopes: ['*'],
       createdAt: new Date().toISOString(),
     }).run()
 
@@ -1095,7 +1095,7 @@ describe('canonry', () => {
       name: 'test',
       keyHash,
       keyPrefix: rawKey.slice(0, 9),
-      scopes: '["*"]',
+      scopes: ['*'],
       createdAt: new Date().toISOString(),
     }).run()
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -17,6 +17,7 @@
     "lint": "eslint src/ test/"
   },
   "dependencies": {
+    "@ainyc/canonry-contracts": "workspace:*",
     "better-sqlite3": "^12.6.2",
     "drizzle-orm": "^0.45.1"
   },

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,3 +1,4 @@
+import type { DiscoveryCompetitorMapEntry } from '@ainyc/canonry-contracts'
 import { index, integer, primaryKey, real, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core'
 
 export const projects = sqliteTable('projects', {
@@ -119,7 +120,7 @@ export const apiKeys = sqliteTable('api_keys', {
   name: text('name').notNull(),
   keyHash: text('key_hash').notNull().unique(),
   keyPrefix: text('key_prefix').notNull(),
-  scopes: text('scopes').notNull().default('["*"]'),
+  scopes: text('scopes', { mode: 'json' }).$type<string[]>().notNull().default(['*']),
   createdAt: text('created_at').notNull(),
   lastUsedAt: text('last_used_at'),
   revokedAt: text('revoked_at'),
@@ -169,7 +170,7 @@ export const googleConnections = sqliteTable('google_connections', {
   connectionType: text('connection_type').notNull(),
   propertyId: text('property_id'),
   sitemapUrl: text('sitemap_url'),
-  scopes: text('scopes').notNull().default('[]'),
+  scopes: text('scopes', { mode: 'json' }).$type<string[]>().notNull().default([]),
   createdAt: text('created_at').notNull(),
   updatedAt: text('updated_at').notNull(),
 }, (table) => [
@@ -208,9 +209,9 @@ export const gscUrlInspections = sqliteTable('gsc_url_inspections', {
   robotsTxtState: text('robots_txt_state'),
   crawlTime: text('crawl_time'),
   lastCrawlResult: text('last_crawl_result'),
-  isMobileFriendly: integer('is_mobile_friendly'),
-  richResults: text('rich_results').notNull().default('[]'),
-  referringUrls: text('referring_urls').notNull().default('[]'),
+  isMobileFriendly: integer('is_mobile_friendly', { mode: 'boolean' }),
+  richResults: text('rich_results', { mode: 'json' }).$type<string[]>().notNull().default([]),
+  referringUrls: text('referring_urls', { mode: 'json' }).$type<string[]>().notNull().default([]),
   inspectedAt: text('inspected_at').notNull(),
   createdAt: text('created_at').notNull(),
 }, (table) => [
@@ -226,7 +227,7 @@ export const gscCoverageSnapshots = sqliteTable('gsc_coverage_snapshots', {
   date: text('date').notNull(),
   indexed: integer('indexed').notNull().default(0),
   notIndexed: integer('not_indexed').notNull().default(0),
-  reasonBreakdown: text('reason_breakdown').notNull().default('{}'),
+  reasonBreakdown: text('reason_breakdown', { mode: 'json' }).$type<Record<string, number>>().notNull().default({}),
   createdAt: text('created_at').notNull(),
 }, (table) => [
   index('idx_gsc_coverage_snap_project_date').on(table.projectId, table.date),
@@ -262,7 +263,7 @@ export const bingUrlInspections = sqliteTable('bing_url_inspections', {
   projectId: text('project_id').notNull().references(() => projects.id, { onDelete: 'cascade' }),
   url: text('url').notNull(),
   httpCode: integer('http_code'),
-  inIndex: integer('in_index'),
+  inIndex: integer('in_index', { mode: 'boolean' }),
   lastCrawledDate: text('last_crawled_date'),
   inIndexDate: text('in_index_date'),
   inspectedAt: text('inspected_at').notNull(),
@@ -440,8 +441,8 @@ export const insights = sqliteTable('insights', {
   title: text('title').notNull(),
   query: text('query').notNull(),
   provider: text('provider').notNull(),
-  recommendation: text('recommendation'),
-  cause: text('cause'),
+  recommendation: text('recommendation', { mode: 'json' }).$type<{ action: string; target?: string; reason: string }>(),
+  cause: text('cause', { mode: 'json' }).$type<{ cause: string; competitorDomain?: string; details?: string }>(),
   dismissed: integer('dismissed', { mode: 'boolean' }).notNull().default(false),
   createdAt: text('created_at').notNull(),
 }, (table) => [
@@ -458,7 +459,7 @@ export const healthSnapshots = sqliteTable('health_snapshots', {
   overallCitedRate: text('overall_cited_rate').notNull(),
   totalPairs: integer('total_pairs').notNull(),
   citedPairs: integer('cited_pairs').notNull(),
-  providerBreakdown: text('provider_breakdown').notNull().default('{}'),
+  providerBreakdown: text('provider_breakdown', { mode: 'json' }).$type<Record<string, { citedRate: number; cited: number; total: number }>>().notNull().default({}),
   createdAt: text('created_at').notNull(),
 }, (table) => [
   index('idx_health_snapshots_project').on(table.projectId),
@@ -591,9 +592,9 @@ export const trafficSources = sqliteTable('traffic_sources', {
   // observed in the most recent successful sync. Bounded ring buffer used to
   // dedupe across sync runs at the boundary timestamp where lastSyncedAt
   // clamping alone leaves a small overlap window.
-  lastEventIds: text('last_event_ids'),
+  lastEventIds: text('last_event_ids', { mode: 'json' }).$type<string[]>(),
   archivedAt: text('archived_at'),
-  configJson: text('config_json').notNull().default('{}'),
+  configJson: text('config_json', { mode: 'json' }).$type<Record<string, unknown>>().notNull().default({}),
   createdAt: text('created_at').notNull(),
   updatedAt: text('updated_at').notNull(),
 }, (table) => [
@@ -680,7 +681,7 @@ export const rawEventSamples = sqliteTable('raw_event_samples', {
   pathNormalized: text('path_normalized').notNull(),
   status: integer('status'),
   refererHost: text('referer_host'),
-  classifierDetailsJson: text('classifier_details_json').notNull().default('{}'),
+  classifierDetailsJson: text('classifier_details_json', { mode: 'json' }).$type<Record<string, unknown>>().notNull().default({}),
   createdAt: text('created_at').notNull(),
 }, (table) => [
   index('idx_raw_event_samples_project_ts').on(table.projectId, table.ts),
@@ -702,7 +703,7 @@ export const discoverySessions = sqliteTable('discovery_sessions', {
   citedCount: integer('cited_count'),
   aspirationalCount: integer('aspirational_count'),
   wastedCount: integer('wasted_count'),
-  competitorMap: text('competitor_map').notNull().default('[]'),
+  competitorMap: text('competitor_map', { mode: 'json' }).$type<DiscoveryCompetitorMapEntry[]>().notNull().default([]),
   error: text('error'),
   startedAt: text('started_at'),
   finishedAt: text('finished_at'),
@@ -719,7 +720,7 @@ export const discoveryProbes = sqliteTable('discovery_probes', {
   query: text('query').notNull(),
   bucket: text('bucket'),
   citationState: text('citation_state').notNull(),
-  citedDomains: text('cited_domains').notNull().default('[]'),
+  citedDomains: text('cited_domains', { mode: 'json' }).$type<string[]>().notNull().default([]),
   rawResponse: text('raw_response'),
   createdAt: text('created_at').notNull(),
 }, (table) => [

--- a/packages/db/test/discovery-migration.test.ts
+++ b/packages/db/test/discovery-migration.test.ts
@@ -6,7 +6,6 @@ import { sql } from 'drizzle-orm'
 import {
   createClient,
   migrate,
-  parseJsonColumn,
   projects,
   queries,
   competitors,
@@ -269,6 +268,6 @@ test('discovery_sessions.competitor_map default is an array, not an object (regr
 
   const [row] = db.select().from(discoverySessions).all()
   expect(row.status).toBe('queued')
-  expect(row.competitorMap).toBe('[]')
-  expect(parseJsonColumn(row.competitorMap, null)).toEqual([])
+  // Drizzle JSON-mode deserializes the stored '[]' default into a JS array.
+  expect(row.competitorMap).toEqual([])
 })

--- a/packages/db/test/index.test.ts
+++ b/packages/db/test/index.test.ts
@@ -381,10 +381,10 @@ test('migrate v43 backfills bing_url_inspections.in_index from stored crawl sign
 
   const rows = db.select().from(bingUrlInspections).all()
   const byId = Object.fromEntries(rows.map((row) => [row.id, row]))
-  expect(byId.insp_crawled_zero_size.inIndex).toBe(1)
-  expect(byId.insp_broken.inIndex).toBe(0)
-  expect(byId.insp_discovered.inIndex).toBe(0)
-  expect(byId.insp_demoted.inIndex).toBe(0)
+  expect(byId.insp_crawled_zero_size.inIndex).toBe(true)
+  expect(byId.insp_broken.inIndex).toBe(false)
+  expect(byId.insp_discovered.inIndex).toBe(false)
+  expect(byId.insp_demoted.inIndex).toBe(false)
 })
 
 test('migrate adds sync_run_id columns without reintroducing query_snapshots.default_location', () => {

--- a/packages/db/test/traffic-tables.test.ts
+++ b/packages/db/test/traffic-tables.test.ts
@@ -84,7 +84,7 @@ test('traffic_sources supports archived status with archived_at', () => {
     displayName: 'Old host',
     status: 'archived',
     archivedAt: now,
-    configJson: '{}',
+    configJson: {},
     createdAt: now,
     updatedAt: now,
   }).run()
@@ -108,7 +108,7 @@ test('crawler_events_hourly composite PK rejects duplicate inserts and accumulat
     sourceType: 'cloud-run',
     displayName: 'Cloud Run',
     status: 'connected',
-    configJson: '{}',
+    configJson: {},
     createdAt: now,
     updatedAt: now,
   }).run()
@@ -167,7 +167,7 @@ test('ai_referral_events_hourly stores hourly buckets keyed by product+source+ev
     sourceType: 'cloud-run',
     displayName: 'Cloud Run',
     status: 'connected',
-    configJson: '{}',
+    configJson: {},
     createdAt: now,
     updatedAt: now,
   }).run()
@@ -217,7 +217,7 @@ test('raw_event_samples stores debug samples without full IPs', () => {
     sourceType: 'cloud-run',
     displayName: 'Cloud Run',
     status: 'connected',
-    configJson: '{}',
+    configJson: {},
     createdAt: now,
     updatedAt: now,
   }).run()
@@ -256,7 +256,7 @@ test('traffic_sources cascade deletes all dependent rows when project is removed
     sourceType: 'cloud-run',
     displayName: 'Cloud Run',
     status: 'connected',
-    configJson: '{}',
+    configJson: {},
     createdAt: now,
     updatedAt: now,
   }).run()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,6 +362,9 @@ importers:
 
   packages/db:
     dependencies:
+      '@ainyc/canonry-contracts':
+        specifier: workspace:*
+        version: link:../contracts
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.6.2


### PR DESCRIPTION
## Summary

Wraps up the JSON/boolean column-mode migration. After this PR, every JSON/boolean column in the schema uses Drizzle's native mode except the two deliberate exceptions documented below.

Storage format unchanged. No DB migration needed.

Adds `@ainyc/canonry-contracts` as a db dep (matching PRs #573 / #575) to bring in `DiscoveryCompetitorMapEntry`.

## Schema changes

| Table | Column | After |
|-------|--------|-------|
| apiKeys | scopes | `text({mode:'json'}).\$type<string[]>()` |
| insights | recommendation | `text({mode:'json'}).\$type<{action; target?; reason}>()` |
| insights | cause | `text({mode:'json'}).\$type<{cause; competitorDomain?; details?}>()` |
| healthSnapshots | providerBreakdown | `text({mode:'json'}).\$type<Record<string,{citedRate;cited;total}>>()` |
| discoverySessions | competitorMap | `text({mode:'json'}).\$type<DiscoveryCompetitorMapEntry[]>()` |
| discoveryProbes | citedDomains | `text({mode:'json'}).\$type<string[]>()` |
| googleConnections | scopes | `text({mode:'json'}).\$type<string[]>()` |
| gscUrlInspections | isMobileFriendly | `integer({mode:'boolean'})` (nullable) |
| gscUrlInspections | richResults | `text({mode:'json'}).\$type<string[]>()` |
| gscUrlInspections | referringUrls | `text({mode:'json'}).\$type<string[]>()` |
| gscCoverageSnapshots | reasonBreakdown | `text({mode:'json'}).\$type<Record<string,number>>()` |
| bingUrlInspections | inIndex | `integer({mode:'boolean'})` (nullable) |
| trafficSources | lastEventIds | `text({mode:'json'}).\$type<string[]>()` (nullable) |
| trafficSources | configJson | `text({mode:'json'}).\$type<Record<string,unknown>>()` |
| rawEventSamples | classifierDetailsJson | `text({mode:'json'}).\$type<Record<string,unknown>>()` |

## Deliberately deferred (separate PR)

- **`agentSessions.messages`, `agentSessions.followUpQueue`** — store `AgentMessage[]` from `@mariozechner/pi-agent-core`. Migrating would require adding pi-agent-core as a db dep (large surface). Deferred until we decide whether to expose a local `AgentMessage` alias or accept the dep.
- **`runs.error`** — uses back-compat `parseRunError` / `serializeRunError` to handle four legacy storage shapes. Drizzle native mode would throw on the legacy formats.

## Latent bug fix surfaced by the migration

`packages/canonry/src/discovery-run.ts` was writing:

\`\`\`ts
recommendation: JSON.stringify({ action, summary, bucketCounts, topCompetitors }),
cause: JSON.stringify({ sessionId, totalProbes, seedProvider }),
\`\`\`

Neither shape matched the `InsightDto.recommendation` / `cause` schemas (`{action, target?, reason}` / `{cause, competitorDomain?, details?}`). The typed schema forced this into view. Reshape preserves the same information through the canonical fields. Test updated.

This is exactly the kind of drift PR #572's coverage test would now catch for the projects table — and what PR C (drizzle-zod) will eliminate by deriving DTOs directly from the schema.

## Call-site impact

35 files:
- 9 api-routes source files updated for the new typed reads/writes on insights, discovery, gsc, bing, traffic, and the doctor type.
- 9 canonry source files updated likewise.
- 17 test files migrated fixtures from `'[\"*\"]'` / `'{}'` literals to `['*']` / `{}` and dropped `JSON.parse` on reads.
- `composites.ts` `buildInsightHit` switched to reading the typed recommendation/cause objects directly and serializing the substring-search target rather than using a raw text column.

## Test plan

- [x] `pnpm -r typecheck` → 0 errors
- [x] `pnpm -r lint` → 0 errors
- [x] `npx vitest run --project api-routes --project canonry --project db --project contracts` → 1976/1978 pass
- [x] Pre-commit hook ran full repo lint + test + typecheck
- [x] The 2 test failures are the pre-existing `sqlite3` CLI shell-out in `packages/db/test/schedules-migration.test.ts`

## Series

- #572 — DB↔DTO coverage test
- #573 — projects table
- #574 — querySnapshots + runs
- #575 — schedules + notifications
- **This PR** — apiKeys, insights, healthSnapshots, discovery, googleConnections, gscUrlInspections, gscCoverageSnapshots, bingUrlInspections, trafficSources, rawEventSamples (15 columns across 10 tables)
- Next: **PR C** — adopt `drizzle-zod` so DTOs derive from the schema. The `formatX` bridge functions in `composites.ts` will collapse to one-line passthroughs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)