### PR TITLE
feat(api-routes): adopt drizzle-zod — derive row schemas from the DB

### DIFF
--- a/packages/api-routes/AGENTS.md
+++ b/packages/api-routes/AGENTS.md
@@ -10,6 +10,7 @@ Shared Fastify route plugins used by both the local server (`packages/canonry`) 
 |------|------|
 | `src/index.ts` | Plugin entry point, global error handler, `ApiRoutesOptions` interface |
 | `src/helpers.ts` | `resolveProject()`, `writeAuditLog()`, `incrementUsage()`, `notProbeRun()` (Drizzle predicate every dashboard/analytics/report/timeline/intelligence read MUST AND-in to exclude probe runs — see root AGENTS.md "Probe runs" section) |
+| `src/db-derived-dtos.ts` | `drizzle-zod`-derived row schemas (`projectRowSchema`, `runRowSchema`, `scheduleRowSchema`, `notificationRowSchema`) for the migrated tables. Per-column refinements narrow JSON columns and enum text columns to the typed Zod shapes the DB writes. Use for runtime validation of rows read from these tables; the hand-rolled DTOs in `@ainyc/canonry-contracts` remain the SDK source (see the "Derived row schemas" section below). |
 | `src/projects.ts` | Project CRUD routes (largest route file) |
 | `src/runs.ts` | Run trigger, status, and list routes |
 | `src/auth.ts` | Auth plugin — API key and session validation |
@@ -117,6 +118,27 @@ incrementally.
 ### Event callbacks
 
 Routes fire lifecycle hooks via `opts` callbacks — `onRunCreated`, `onProviderUpdate`, `onScheduleUpdated`, `onProjectDeleted`. Fire these **after** the database transaction commits, not inside it.
+
+### Derived row schemas (drizzle-zod)
+
+`src/db-derived-dtos.ts` exports `*RowSchema` Zod validators generated from the Drizzle table definitions via `drizzle-zod`'s `createSelectSchema()`. Per-column refinements narrow:
+- JSON columns whose `$type<>` is a TypeScript-only hint (drizzle-zod can't introspect those — it produces a loose `ZodUnion` fallback; the refinement supplies the actual schema)
+- text columns whose values are an enum at the API layer (`configSource`, `runKind`, `runStatus`, etc.)
+
+Use them when you want runtime validation of a row at the DB → DTO seam:
+
+```typescript
+import { projectRowSchema } from './db-derived-dtos.js'
+
+// .parse(row) verifies the row matches the schema. Throws if the column
+// types drifted (e.g. configSource got a value not in the enum).
+const validated = projectRowSchema.parse(row)
+```
+
+Constraints:
+- The hand-rolled DTO schemas in `@ainyc/canonry-contracts` remain the OpenAPI / SDK source. Derived schemas are an internal validator, not a public type — they live in `api-routes` because `contracts` can't import from `db` (db already imports types from contracts for `$type<>`, so the reverse would cycle).
+- `db-derived-dtos.test.ts` asserts each derived schema's field set equals the table's column set, plus round-trip parse tests on representative rows. Adding a new column to a covered table fails the field-set test until the refinements + DTO are updated.
+- Only the migrated tables have derived schemas today (projects, runs, schedules, notifications). Add more by importing the table, listing refinements for any column whose Zod type the SQL type alone can't express, and extending the test's `ENTRIES` table.
 
 ## Common Mistakes
 

--- a/packages/api-routes/package.json
+++ b/packages/api-routes/package.json
@@ -30,6 +30,7 @@
     "@ainyc/canonry-integration-wordpress-traffic": "workspace:*",
     "@ainyc/canonry-intelligence": "workspace:*",
     "drizzle-orm": "^0.45.1",
+    "drizzle-zod": "^0.8.3",
     "fastify": "^5.4.0",
     "zod": "^4.3.6"
   }

--- a/packages/api-routes/src/db-derived-dtos.ts
+++ b/packages/api-routes/src/db-derived-dtos.ts
@@ -1,0 +1,114 @@
+/**
+ * DTO schemas derived from the Drizzle table definitions via `drizzle-zod`.
+ *
+ * The hand-rolled DTO schemas in `@ainyc/canonry-contracts` remain the
+ * canonical public surface — they're what generates the OpenAPI spec and
+ * the `@ainyc/canonry-api-client` SDK. The schemas below are an internal
+ * runtime-validator pair: for each migrated table, `createSelectSchema()`
+ * walks the Drizzle column types and produces a Zod schema, with per-column
+ * refinements applied where the SQL column type alone isn't expressive
+ * enough (enum narrowing on text columns, inner-shape typing on JSON
+ * columns whose `$type<>` is a TypeScript-only hint).
+ *
+ * Why a parallel "row schema" instead of just using the contracts DTO?
+ *
+ * 1. **Drift detection at the seam.** Routes that read from these tables
+ *    can `.parse(row)` through the derived schema before handing the
+ *    result to the consumer-facing DTO. If a future schema change drops
+ *    a refinement (e.g. forgetting to narrow `configSource` to its enum
+ *    after adding a new value), the parse fails loudly in tests rather
+ *    than silently mis-typing the SDK output.
+ *
+ * 2. **Field-name coverage.** `db-derived-dtos.test.ts` asserts that
+ *    `Object.keys(derivedSchema.shape) === Object.keys(getTableColumns(table))`
+ *    — a stronger version of `db-dto-coverage.test.ts` (which only checks
+ *    that DB columns appear in the hand-rolled DTO, not that the derived
+ *    schema is exhaustive).
+ *
+ * 3. **Foundation for replacing `formatX` bridges.** Once the derived
+ *    schema for a table is structurally equivalent to its public DTO
+ *    (minus internal-only columns), `formatX(row)` collapses to
+ *    `derivedSchema.parse(row)` plus an `omit({internal: true})` step.
+ *    PRs after this one will land that replacement table by table.
+ *
+ * Why this lives in `api-routes` and not `contracts`:
+ *
+ * The `contracts` package can't import from `db` because `db` already
+ * imports types (`LocationContext`, `ProviderName`, `DiscoveryCompetitorMapEntry`)
+ * from `contracts` for the `$type<>()` hints on JSON columns. `api-routes`
+ * sits above both and can import from either freely, so the derived
+ * schemas live here. The day we want contracts to consume these (and
+ * delete the hand-rolled DTOs entirely), we'd need to move the shared
+ * types to a third package or invert the db ↔ contracts dependency.
+ */
+
+import { createSelectSchema } from 'drizzle-zod'
+import { z } from 'zod'
+import {
+  notifications,
+  projects,
+  runs,
+  schedules,
+} from '@ainyc/canonry-db'
+import {
+  configSourceSchema,
+  locationContextSchema,
+  notificationEventSchema,
+  providerNameSchema,
+  runKindSchema,
+  runStatusSchema,
+  runTriggerSchema,
+  schedulableRunKindSchema,
+} from '@ainyc/canonry-contracts'
+
+// --- projects ---
+// `createSelectSchema` infers `text({mode:'json'}).$type<T>()` columns as
+// `ZodUnion` (drizzle-zod 0.8.x can't introspect TypeScript-only `$type`
+// hints; it falls back to a loose union). The refinements below replace
+// each JSON column with the narrowed Zod schema that matches the DB write
+// shape, so the derived row schema is fully typed.
+export const projectRowSchema = createSelectSchema(projects, {
+  ownedDomains: z.array(z.string()),
+  aliases: z.array(z.string()),
+  tags: z.array(z.string()),
+  labels: z.record(z.string(), z.string()),
+  providers: z.array(z.string()),
+  locations: z.array(locationContextSchema),
+  // text column → narrow to the configSource enum
+  configSource: configSourceSchema,
+})
+
+// --- runs ---
+export const runRowSchema = createSelectSchema(runs, {
+  kind: runKindSchema,
+  status: runStatusSchema,
+  trigger: runTriggerSchema,
+  // nullable JSON column. createSelectSchema preserves the null on the
+  // outer wrapper; the inner array shape needs the refinement.
+  queries: z.array(z.string()).nullable(),
+})
+
+// --- schedules ---
+export const scheduleRowSchema = createSelectSchema(schedules, {
+  kind: schedulableRunKindSchema,
+  providers: z.array(providerNameSchema),
+})
+
+// --- notifications ---
+// `config` is a JSON column with `{url, events}` shape; refine to the
+// narrowed structure the API surfaces via `formatNotification`.
+export const notificationRowSchema = createSelectSchema(notifications, {
+  channel: z.literal('webhook'),
+  config: z.object({
+    url: z.string().url(),
+    events: z.array(notificationEventSchema),
+  }),
+})
+
+// Inferred row types — re-exported for routes that want a fully-typed
+// `Project` / `Run` / `Schedule` / `Notification` row without manual cast
+// gymnastics. The hand-rolled DTOs in contracts remain the SDK source.
+export type ProjectRow = z.infer<typeof projectRowSchema>
+export type RunRow = z.infer<typeof runRowSchema>
+export type ScheduleRow = z.infer<typeof scheduleRowSchema>
+export type NotificationRow = z.infer<typeof notificationRowSchema>

--- a/packages/api-routes/test/db-derived-dtos.test.ts
+++ b/packages/api-routes/test/db-derived-dtos.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'vitest'
+import { getTableColumns } from 'drizzle-orm'
+import {
+  notifications,
+  projects,
+  runs,
+  schedules,
+} from '@ainyc/canonry-db'
+import {
+  notificationRowSchema,
+  projectRowSchema,
+  runRowSchema,
+  scheduleRowSchema,
+} from '../src/db-derived-dtos.js'
+
+/**
+ * Tests for the `drizzle-zod`-derived row schemas in `db-derived-dtos.ts`.
+ *
+ * Two invariants per table:
+ *
+ * 1. **Field coverage.** `Object.keys(derivedSchema.shape)` must equal
+ *    `Object.keys(getTableColumns(table))` — every DB column maps to a
+ *    derived-schema field, and there's no derived-schema field that
+ *    doesn't correspond to a column. This is stricter than the
+ *    `db-dto-coverage.test.ts` check (which only asserts DB columns are
+ *    accounted for in the consumer-facing DTO or an allowlist) — here we
+ *    catch schema additions BEFORE a hand-rolled DTO has a chance to
+ *    drift.
+ *
+ * 2. **Round-trip parse.** A representative typed row parses through the
+ *    derived schema without losing or transforming any field. Refinements
+ *    enforce enums (`configSource`, `runKind`, etc.) and JSON inner
+ *    shapes (`locations`, `config`, `providers`) — a refinement that
+ *    drops or mistypes a value surfaces here.
+ *
+ * Why DB → derived rather than derived → DTO compat: compat between
+ * the derived schema and the hand-rolled DTO is checked indirectly by
+ * the existing `composites.test.ts` end-to-end tests that round-trip
+ * through `formatX(row): SomeDto`. This file focuses on the schema/
+ * derived seam; the DTO/handler seam is already covered.
+ */
+
+const ENTRIES = [
+  { name: 'projects', table: projects, schema: projectRowSchema },
+  { name: 'runs', table: runs, schema: runRowSchema },
+  { name: 'schedules', table: schedules, schema: scheduleRowSchema },
+  { name: 'notifications', table: notifications, schema: notificationRowSchema },
+] as const
+
+describe('drizzle-zod derived row schemas', () => {
+  for (const entry of ENTRIES) {
+    it(`${entry.name}: derived schema field set equals DB column set`, () => {
+      const dbColumns = Object.keys(getTableColumns(entry.table)).sort()
+      const derivedFields = Object.keys(entry.schema.shape).sort()
+      expect(derivedFields, `${entry.name} drizzle-zod derived fields drifted from the table — re-derive or update refinements`).toEqual(dbColumns)
+    })
+  }
+
+  it('projectRowSchema round-trips a representative row', () => {
+    const row = {
+      id: 'p_1',
+      name: 'acme',
+      displayName: 'Acme Inc.',
+      canonicalDomain: 'acme.com',
+      ownedDomains: ['acme.com', 'acme.dev'],
+      aliases: ['acme', 'ACME'],
+      country: 'US',
+      language: 'en',
+      tags: ['saas', 'b2b'],
+      labels: { team: 'growth', tier: 'enterprise' },
+      providers: ['gemini', 'openai'],
+      locations: [{ label: 'us-east', city: 'New York', region: 'NY', country: 'US' }],
+      defaultLocation: 'us-east',
+      autoExtractBacklinks: true,
+      configSource: 'cli',
+      configRevision: 3,
+      icpDescription: 'Mid-market B2B SaaS',
+      createdAt: '2026-05-01T00:00:00Z',
+      updatedAt: '2026-05-17T00:00:00Z',
+    }
+    const parsed = projectRowSchema.parse(row)
+    expect(parsed).toEqual(row)
+  })
+
+  it('projectRowSchema rejects bad configSource', () => {
+    const result = projectRowSchema.safeParse({
+      id: 'p_1',
+      name: 'acme',
+      displayName: 'Acme',
+      canonicalDomain: 'acme.com',
+      ownedDomains: [],
+      aliases: [],
+      country: 'US',
+      language: 'en',
+      tags: [],
+      labels: {},
+      providers: [],
+      locations: [],
+      defaultLocation: null,
+      autoExtractBacklinks: false,
+      configSource: 'invalid-source',
+      configRevision: 1,
+      icpDescription: null,
+      createdAt: '2026-05-01T00:00:00Z',
+      updatedAt: '2026-05-17T00:00:00Z',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('runRowSchema round-trips a representative row with null queries', () => {
+    const row = {
+      id: 'r_1',
+      projectId: 'p_1',
+      kind: 'answer-visibility' as const,
+      status: 'completed' as const,
+      trigger: 'manual' as const,
+      location: null,
+      queries: null,
+      sourceId: null,
+      startedAt: '2026-05-17T00:00:00Z',
+      finishedAt: '2026-05-17T00:01:00Z',
+      error: null,
+      createdAt: '2026-05-17T00:00:00Z',
+    }
+    const parsed = runRowSchema.parse(row)
+    expect(parsed).toEqual(row)
+  })
+
+  it('runRowSchema round-trips a representative row with typed queries array', () => {
+    const row = {
+      id: 'r_2',
+      projectId: 'p_1',
+      kind: 'answer-visibility' as const,
+      status: 'completed' as const,
+      trigger: 'scheduled' as const,
+      location: 'us-east',
+      queries: ['what is acme?', 'acme reviews'],
+      sourceId: null,
+      startedAt: '2026-05-17T00:00:00Z',
+      finishedAt: '2026-05-17T00:01:00Z',
+      error: null,
+      createdAt: '2026-05-17T00:00:00Z',
+    }
+    const parsed = runRowSchema.parse(row)
+    expect(parsed).toEqual(row)
+  })
+
+  it('scheduleRowSchema round-trips with enabled=true and typed providers', () => {
+    const row = {
+      id: 's_1',
+      projectId: 'p_1',
+      kind: 'answer-visibility' as const,
+      cronExpr: '0 8 * * *',
+      preset: 'daily',
+      timezone: 'America/Los_Angeles',
+      enabled: true,
+      providers: ['gemini', 'openai'] as const,
+      sourceId: null,
+      lastRunAt: '2026-05-16T08:00:00Z',
+      nextRunAt: '2026-05-17T08:00:00Z',
+      createdAt: '2026-05-01T00:00:00Z',
+      updatedAt: '2026-05-17T00:00:00Z',
+    }
+    const parsed = scheduleRowSchema.parse(row)
+    expect(parsed).toEqual(row)
+  })
+
+  it('notificationRowSchema round-trips with typed config object', () => {
+    const row = {
+      id: 'n_1',
+      projectId: 'p_1',
+      channel: 'webhook' as const,
+      config: {
+        url: 'https://example.com/hook',
+        events: ['run.completed', 'insight.critical'],
+      },
+      webhookSecret: 'whsec_xyz',
+      enabled: true,
+      createdAt: '2026-05-01T00:00:00Z',
+      updatedAt: '2026-05-17T00:00:00Z',
+    }
+    const parsed = notificationRowSchema.parse(row)
+    expect(parsed).toEqual(row)
+  })
+
+  it('notificationRowSchema rejects config without url', () => {
+    const result = notificationRowSchema.safeParse({
+      id: 'n_1',
+      projectId: 'p_1',
+      channel: 'webhook',
+      config: { events: ['run.completed'] }, // missing url
+      webhookSecret: null,
+      enabled: true,
+      createdAt: '2026-05-01T00:00:00Z',
+      updatedAt: '2026-05-17T00:00:00Z',
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.1
         version: 0.45.1(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)
+      drizzle-zod:
+        specifier: ^0.8.3
+        version: 0.8.3(drizzle-orm@0.45.1(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2))(zod@4.3.6)
       fastify:
         specifier: ^5.4.0
         version: 5.8.2
@@ -2854,6 +2857,12 @@ packages:
         optional: true
       sqlite3:
         optional: true
+
+  drizzle-zod@0.8.3:
+    resolution: {integrity: sha512-66yVOuvGhKJnTdiqj1/Xaaz9/qzOdRJADpDa68enqS6g3t0kpNkwNYjUuaeXgZfO/UWuIM9HIhSlJ6C5ZraMww==}
+    peerDependencies:
+      drizzle-orm: '>=0.36.0'
+      zod: ^3.25.0 || ^4.0.0
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -7347,6 +7356,11 @@ snapshots:
     optionalDependencies:
       '@types/better-sqlite3': 7.6.13
       better-sqlite3: 12.6.2
+
+  drizzle-zod@0.8.3(drizzle-orm@0.45.1(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2))(zod@4.3.6):
+    dependencies:
+      drizzle-orm: 0.45.1(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)
+      zod: 4.3.6
 
   dunder-proto@1.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

Adds `drizzle-zod`-derived Zod schemas for the four migrated tables (projects, runs, schedules, notifications) via `createSelectSchema()`. This is the natural follow-up to the schema-mode migration in #573-#576 — now that the column types are expressive enough, we can derive a runtime validator directly from the schema rather than hand-rolling one.

## What's new

- **`packages/api-routes/src/db-derived-dtos.ts`** — exports `projectRowSchema`, `runRowSchema`, `scheduleRowSchema`, `notificationRowSchema`. Each uses `createSelectSchema(table, refinements)`:
  - JSON columns whose `\$type<>` is a TypeScript-only hint get refined to the actual Zod shape (drizzle-zod 0.8.x can't introspect `\$type` and falls back to a loose `ZodUnion`).
  - Text columns whose values are enums at the API layer are narrowed (configSource, runKind, runStatus, runTrigger, schedulableRunKind, notification channel).
- **`packages/api-routes/test/db-derived-dtos.test.ts`** — 11 tests:
  - 4 field-set assertions — derived schema's field names must equal the table's column names. Catches DB column additions BEFORE the consumer DTO has a chance to drift, complementing the looser check in `db-dto-coverage.test.ts` from #572.
  - 7 round-trip / refinement tests — representative rows parse cleanly and bad inputs (invalid enum, missing config field) are rejected.

## Why this lives in api-routes, not contracts

`@ainyc/canonry-db` already imports types from `@ainyc/canonry-contracts` for `\$type<>` (`LocationContext`, `ProviderName`, `DiscoveryCompetitorMapEntry`, plus the inline insight recommendation/cause shapes). Putting derived schemas in contracts would create a cycle (contracts → db → contracts). `api-routes` sits above both and can import from either freely.

The hand-rolled DTOs in `contracts` remain the OpenAPI / SDK source. The derived schemas are an internal validator at the DB → DTO seam.

## What this unlocks (future PRs)

- Replace `formatX(row)` bridge functions with `rowSchema.parse(row)` + internal-column omission. After PRs #573-#576 these bridges are mostly 1:1 row-to-DTO copies; the derived schema collapses them into validation-as-mapping.
- Extend the covered tables as more migrate (currently holding out `agentSessions` because of the pi-agent-core dep on `AgentMessage`, and `runs.error` because of the back-compat parsing in `parseRunError`).

## Dep added

`drizzle-zod@^0.8.3` as an api-routes runtime dep. Peer deps already satisfied:
- zod `^3.25.0 || ^4.0.0` → we have 4.3.6
- drizzle-orm `>=0.36.0` → we have 0.45.1

When Drizzle 1.0 GAs and ships the native `drizzle-orm/zod` subpath, swap the import — the API (`createSelectSchema` with refinements) is the same.

## Test plan

- [x] `pnpm -r typecheck` → 0 errors
- [x] `pnpm -r lint` → 0 errors
- [x] `npx vitest run --project api-routes --project canonry --project db --project contracts` → 1987/1989 pass (added 11 new tests; the 2 failures remain the pre-existing sqlite3-CLI shell-out in `schedules-migration.test.ts`)
- [x] Pre-commit hook ran full repo lint + test + typecheck

## Stacked on #573-#576

This branch contains the merges of #573, #574, #575, #576 because the derived schemas only make sense once the column-mode migration is in place. When those merge in any order, this PR will rebase cleanly. To make the diff readable on its own:
- New files: `db-derived-dtos.ts` + `db-derived-dtos.test.ts`
- Modified: `api-routes/package.json` (dep) + `api-routes/AGENTS.md` (docs) + `pnpm-lock.yaml`

## Series

- #572 — DB↔DTO coverage test (catches columns missing from DTO)
- #573 — projects table to native modes
- #574 — querySnapshots + runs to native modes
- #575 — schedules + notifications to native modes
- #576 — apiKeys/insights/healthSnapshots/discovery/google/gsc/bing/traffic to native modes
- **This PR** — adopt drizzle-zod, derive row schemas with refinements + compat tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)