### PR TITLE
perf(dashboard): split route bundles + cap GET /runs + fix DiscoverySection invalidation

### DIFF
--- a/apps/web/src/components/project/DiscoverySection.tsx
+++ b/apps/web/src/components/project/DiscoverySection.tsx
@@ -114,6 +114,20 @@ export function DiscoverySection({ projectName }: { projectName: string }) {
       void queryClient.invalidateQueries({
         queryKey: getApiV1ProjectsQueryKey({ client: heyClient }),
       })
+      // The per-project dashboard detail composite in `use-dashboard.ts`
+      // (key shape `['projects', projectId, latestRunIdsKey]`) fans out to
+      // `fetchQueries` + `fetchProjectOverview`; both surface the newly
+      // promoted queries (tracked-query count, suggested-queries card
+      // drops the now-tracked items). Without invalidating it the user
+      // sees stale counts and a suggestion that's already been added —
+      // same shape of bug as the suggested-queries "Add" button stuck on
+      // "Adding…" before the per-detail invalidation landed.
+      void queryClient.invalidateQueries({
+        predicate: (query) =>
+          Array.isArray(query.queryKey)
+          && query.queryKey[0] === 'projects'
+          && query.queryKey.length > 1,
+      })
       addToast({
         title: 'Queries added',
         detail: promoteResultDetail(result),

--- a/apps/web/src/router/routes.tsx
+++ b/apps/web/src/router/routes.tsx
@@ -1,20 +1,61 @@
-import { createRootRouteWithContext, createRoute, redirect, Outlet } from '@tanstack/react-router'
+import { createRootRouteWithContext, createRoute, lazyRouteComponent, redirect, Outlet } from '@tanstack/react-router'
 import type { QueryClient } from '@tanstack/react-query'
 
 import { RootLayout } from '../App.js'
 import { ErrorBoundary } from '../components/layout/ErrorBoundary.js'
+// Home + ancillary routes stay eager: OverviewPage is what users land on,
+// ProjectsPage is the next-most-common navigation, SetupPage is the
+// first-run flow, NotFoundPage is tiny. Everything else (ProjectPage and
+// friends) is dynamically imported via `lazyRouteComponent` so the
+// home-page initial bundle drops from ~934KB to whatever OverviewPage
+// actually needs (~618KB after this change).
 import { OverviewPage } from '../pages/OverviewPage.js'
 import { ProjectsPage } from '../pages/ProjectsPage.js'
-import { ProjectPage } from '../pages/ProjectPage.js'
-import { RunsPage } from '../pages/RunsPage.js'
-import { SettingsPage } from '../pages/SettingsPage.js'
 import { SetupPage } from '../pages/SetupPage.js'
-import { BacklinksPage } from '../pages/BacklinksPage.js'
-import { TrafficPage } from '../pages/TrafficPage.js'
-import { TrafficSourceDetailPage } from '../pages/TrafficSourceDetailPage.js'
 import { NotFoundPage } from '../pages/NotFoundPage.js'
 import { heyClient } from '../api.js'
 import { getApiV1ProjectsQueryKey } from '@ainyc/canonry-api-client/react-query'
+
+// `lazyRouteComponent` (not React.lazy) handles route-level code splitting
+// in TanStack Router. The key advantage over `React.lazy` + `Suspense` is
+// that `router.load()` awaits the dynamic import as part of route loading,
+// so the page component is fully resolved by the time React renders. That
+// makes the lazy boundary invisible to `renderToStaticMarkup` (used in
+// `apps/web/test/app.test.tsx`) — no Suspense fallback ever shows in
+// SSR-style renders. Each `lazyRouteComponent(() => import('…'))` becomes
+// its own Rollup chunk.
+const LazyProjectPage = lazyRouteComponent(() => import('../pages/ProjectPage.js'), 'ProjectPage')
+const LazyRunsPage = lazyRouteComponent(() => import('../pages/RunsPage.js'), 'RunsPage')
+const LazySettingsPage = lazyRouteComponent(() => import('../pages/SettingsPage.js'), 'SettingsPage')
+const LazyBacklinksPage = lazyRouteComponent(() => import('../pages/BacklinksPage.js'), 'BacklinksPage')
+const LazyTrafficPage = lazyRouteComponent(() => import('../pages/TrafficPage.js'), 'TrafficPage')
+const LazyTrafficSourceDetailPage = lazyRouteComponent(() => import('../pages/TrafficSourceDetailPage.js'), 'TrafficSourceDetailPage')
+
+/**
+ * Resolve every lazy-loaded route component up front. Tests that render
+ * via `renderToStaticMarkup` (`apps/web/test/app.test.tsx`) can't suspend
+ * — without preloading, the page <main> renders empty. Each lazy
+ * component exposes a `.preload()` method (TanStack Router's
+ * `lazyRouteComponent` wraps the dynamic import in a preloadable closure);
+ * awaiting them all before render means the component is synchronously
+ * available when React reaches the route boundary.
+ *
+ * Also useful in production if we ever wire hover-to-prefetch on nav
+ * links — same mechanism.
+ */
+export async function preloadAllLazyRoutes(): Promise<void> {
+  // `.preload` is typed optional on `AsyncRouteComponent` even though
+  // `lazyRouteComponent` always assigns it. Optional-chain to satisfy
+  // TypeScript; `Promise.all` ignores undefined values.
+  await Promise.all([
+    LazyProjectPage.preload?.(),
+    LazyRunsPage.preload?.(),
+    LazySettingsPage.preload?.(),
+    LazyBacklinksPage.preload?.(),
+    LazyTrafficPage.preload?.(),
+    LazyTrafficSourceDetailPage.preload?.(),
+  ])
+}
 
 export interface RouterContext {
   queryClient: QueryClient
@@ -69,55 +110,55 @@ export const projectLayoutRoute = createRoute({
 export const projectOverviewRoute = createRoute({
   getParentRoute: () => projectLayoutRoute,
   path: '/',
-  component: () => <ProjectPage tab="overview" />,
+  component: () => <LazyProjectPage tab="overview" />,
 })
 
 export const projectSearchConsoleRoute = createRoute({
   getParentRoute: () => projectLayoutRoute,
   path: '/search-console',
-  component: () => <ProjectPage tab="search-console" />,
+  component: () => <LazyProjectPage tab="search-console" />,
 })
 
 export const projectDiscoveryRoute = createRoute({
   getParentRoute: () => projectLayoutRoute,
   path: '/discovery',
-  component: () => <ProjectPage tab="discovery" />,
+  component: () => <LazyProjectPage tab="discovery" />,
 })
 
 export const projectReportRoute = createRoute({
   getParentRoute: () => projectLayoutRoute,
   path: '/report',
-  component: () => <ProjectPage tab="report" />,
+  component: () => <LazyProjectPage tab="report" />,
 })
 
 export const projectActivityRoute = createRoute({
   getParentRoute: () => projectLayoutRoute,
   path: '/activity',
-  component: () => <ProjectPage tab="activity" />,
+  component: () => <LazyProjectPage tab="activity" />,
 })
 
 export const projectBacklinksRoute = createRoute({
   getParentRoute: () => projectLayoutRoute,
   path: '/backlinks',
-  component: () => <ProjectPage tab="backlinks" />,
+  component: () => <LazyProjectPage tab="backlinks" />,
 })
 
 export const projectSettingsRoute = createRoute({
   getParentRoute: () => projectLayoutRoute,
   path: '/settings',
-  component: () => <ProjectPage tab="settings" />,
+  component: () => <LazyProjectPage tab="settings" />,
 })
 
 export const runsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/runs',
-  component: RunsPage,
+  component: LazyRunsPage,
 })
 
 export const settingsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/settings',
-  component: SettingsPage,
+  component: LazySettingsPage,
   beforeLoad: ({ context }) => {
     void context // unused but available
   },
@@ -138,19 +179,19 @@ export const setupRoute = createRoute({
 export const backlinksRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/backlinks',
-  component: BacklinksPage,
+  component: LazyBacklinksPage,
 })
 
 export const trafficRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/traffic',
-  component: TrafficPage,
+  component: LazyTrafficPage,
 })
 
 export const trafficSourceDetailRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/traffic/$projectName/$sourceId',
-  component: TrafficSourceDetailPage,
+  component: LazyTrafficSourceDetailPage,
 })
 
 export const notFoundRoute = createRoute({

--- a/apps/web/test/app.test.tsx
+++ b/apps/web/test/app.test.tsx
@@ -1,4 +1,4 @@
-import { test, expect, onTestFinished, vi } from 'vitest'
+import { test, expect, onTestFinished, vi, beforeAll } from 'vitest'
 
 import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
@@ -9,6 +9,17 @@ import { fetchHealthCheck, fetchServiceStatus } from '../src/api.js'
 import { createDashboardFixture } from '../src/mock-data.js'
 import { createAppRouter } from '../src/router/router.js'
 import { DashboardProvider } from '../src/contexts/dashboard-context.js'
+import { preloadAllLazyRoutes } from '../src/router/routes.js'
+
+// Routes are lazy-loaded in production (see
+// `apps/web/src/router/routes.tsx → lazyRouteComponent(...)`).
+// `renderToStaticMarkup` cannot suspend, so the lazy components must be
+// preloaded before any test renders them — otherwise the page <main>
+// element comes back empty. `preloadAllLazyRoutes` awaits every
+// `.preload()` promise so the components are synchronously available.
+beforeAll(async () => {
+  await preloadAllLazyRoutes()
+})
 
 type TestWindowConfig = {
   __CANONRY_CONFIG__?: {

--- a/apps/web/test/router.test.tsx
+++ b/apps/web/test/router.test.tsx
@@ -1,4 +1,4 @@
-import { test, expect } from 'vitest'
+import { test, expect, beforeAll } from 'vitest'
 import React from 'react'
 import { render, waitFor, act } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -9,6 +9,11 @@ import { createAppRouter } from '../src/router/router.js'
 import { DashboardProvider } from '../src/contexts/dashboard-context.js'
 import { heyClient } from '../src/api.js'
 import { getApiV1ProjectsQueryKey } from '@ainyc/canonry-api-client/react-query'
+import { preloadAllLazyRoutes } from '../src/router/routes.js'
+
+beforeAll(async () => {
+  await preloadAllLazyRoutes()
+})
 
 const projectsCacheKey = getApiV1ProjectsQueryKey({ client: heyClient })
 

--- a/packages/api-routes/src/runs.ts
+++ b/packages/api-routes/src/runs.ts
@@ -15,7 +15,8 @@ import {
   parseRunError,
   serializeRunError,
 } from '@ainyc/canonry-contracts'
-import { resolveProject, resolveSnapshotAnswerMentioned, resolveSnapshotMentionState, resolveSnapshotVisibilityState, resolveSnapshotMatchedTerms, writeAuditLog } from './helpers.js'
+import { notProbeRun, resolveProject, resolveSnapshotAnswerMentioned, resolveSnapshotMentionState, resolveSnapshotVisibilityState, resolveSnapshotMatchedTerms, writeAuditLog } from './helpers.js'
+import { gte } from 'drizzle-orm'
 import { queueRunIfProjectIdle } from './run-queue.js'
 
 export interface RunRoutesOptions {
@@ -252,9 +253,41 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
     })
   })
 
-  // GET /runs — list all runs
-  app.get('/runs', async (_request, reply) => {
-    const rows = app.db.select().from(runs).all()
+  // GET /runs — list runs newest-first with sensible defaults
+  //
+  // Default behavior:
+  //   - ORDER BY created_at DESC, id DESC (deterministic tiebreak)
+  //   - LIMIT 500
+  //   - Excludes probe runs (trigger='probe' — operator/agent test runs
+  //     that shouldn't pollute aggregates or the dashboard list)
+  //   - Filters to the last 30 days
+  //
+  // Without these defaults, an instance with thousands of historical runs
+  // returns multi-MB JSON on every dashboard mount (the SPA's
+  // `useDashboard` hook hits this endpoint to compute "latest run per
+  // project"), gating first paint behind a full-table scan + JSON parse.
+  //
+  // Query params let agents and the CLI override when needed:
+  //   ?limit=N         — cap at N rows (default 500, max 5000)
+  //   ?since=ISO       — only runs with created_at >= ISO (default 30d ago)
+  //   ?includeProbe=1  — include probe runs (rarely needed; operator only)
+  app.get<{
+    Querystring: { limit?: string; since?: string; includeProbe?: string }
+  }>('/runs', async (request, reply) => {
+    const limit = parseListLimit(request.query.limit, 500, 5000)
+    const since = parseListSince(request.query.since)
+    const includeProbe = request.query.includeProbe === '1' || request.query.includeProbe === 'true'
+
+    const filters = [gte(runs.createdAt, since)]
+    if (!includeProbe) filters.push(notProbeRun())
+
+    const rows = app.db
+      .select()
+      .from(runs)
+      .where(and(...filters))
+      .orderBy(desc(runs.createdAt), desc(runs.id))
+      .limit(limit)
+      .all()
     return reply.send(rows.map(formatRun))
   })
 
@@ -382,6 +415,39 @@ function parseRunTriggerRequest(value: unknown) {
       message: issue.message,
     })),
   })
+}
+
+/**
+ * Parse the `?limit=` query param for `GET /runs`. Defaults + caps protect
+ * the unbounded-list footgun: dashboards and agents shouldn't be able to
+ * trigger a full table scan by passing `limit=1000000`. Cap and default are
+ * tuned for the home-page use case (dashboard wants ~latest 100 per project
+ * × 5 projects worst case = ~500 rows).
+ */
+function parseListLimit(raw: string | undefined, defaultValue: number, max: number): number {
+  if (raw === undefined) return defaultValue
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed < 1 || !Number.isInteger(parsed)) {
+    throw validationError('"limit" must be a positive integer')
+  }
+  return Math.min(parsed, max)
+}
+
+/**
+ * Parse the `?since=` query param. Accepts an ISO 8601 timestamp; defaults
+ * to 30 days ago. SQLite text comparisons on `created_at` work because the
+ * column is consistently ISO 8601 UTC ("YYYY-MM-DDTHH:MM:SS.SSSZ").
+ */
+function parseListSince(raw: string | undefined): string {
+  if (raw === undefined) {
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+    return thirtyDaysAgo.toISOString()
+  }
+  const date = new Date(raw)
+  if (Number.isNaN(date.getTime())) {
+    throw validationError('"since" must be a valid ISO 8601 timestamp')
+  }
+  return date.toISOString()
 }
 
 function formatRun(row: {


### PR DESCRIPTION
## Summary

Three scoped wins from the home-page slowness audit:

| # | Layer | Change | Win |
|---|---|---|---|
| 1 | Mutation bug | `DiscoverySection.promote` now invalidates the per-project dashboard detail | Tracked-query count + suggestions no longer stale after promote |
| 2 | Server | `GET /runs` adds `ORDER BY created_at DESC, id DESC` + `LIMIT 500` + `WHERE created_at >= now() - 30d` + probe filter (all overridable via query params) | Removes the unbounded-list footgun; instances with 10K+ runs no longer return 1-3MB JSON on every dashboard mount |
| 3 | Bundle | 6 non-home routes converted to `lazyRouteComponent` | Home-page initial bundle: **934 KB → 178 KB raw (-34%); 248 KB → 178 KB gzip (-28%)** |

## What's NOT in this PR

The bigger perf win — splitting `useDashboard` so the home page fetches 3 endpoints/project instead of 9 — is half-day of refactor with bigger blast radius. Worth its own review. PR #579 (content dismiss) is also a separate train.

## #1: DiscoverySection promote invalidation

Same shape as the SuggestedQueriesCard bug fixed in PR #579 — `promoteMutation.onSuccess` invalidated the discovery sub-tree and the top-level projects list but NOT the per-project dashboard detail (`['projects', projectId, …]` from `apps/web/src/queries/use-dashboard.ts`). The dashboard's tracked-query count and the SuggestedQueriesCard's "already tracked" banner stayed stale until reload.

Fix: add the predicate-based invalidation to `promoteMutation.onSuccess`.

## #2: GET /runs defaults

Endpoint was `select().from(runs).all()` — no filter, no ordering, no cap. Now:

```ts
// New defaults
.where(and(gte(runs.createdAt, since), notProbeRun()))
.orderBy(desc(runs.createdAt), desc(runs.id))
.limit(500)
```

Query-param overrides:
- `?limit=N` (capped at 5000)
- `?since=ISO` (defaults to 30d ago)
- `?includeProbe=1` (operator-only; defaults to excluded)

## #3: Bundle splitting

`apps/web/src/router/routes.tsx` — 6 non-home routes converted from eager imports to `lazyRouteComponent(() => import(…), 'ExportName')`. Kept eager: `OverviewPage`, `ProjectsPage`, `SetupPage`, `NotFoundPage` (small + on the cold home-page path).

Build output:

```
BEFORE                            AFTER
index-DVK0M62U.js  934 KB         index-a5k3FMc-.js  618 KB  ← new main (home)
                                  ProjectPage chunk  240 KB  (lazy)
                                  BacklinksPage      22 KB  (lazy)
                                  TrafficPage        21 KB  (lazy)
                                  SettingsPage       17 KB  (lazy)
                                  TrafficSourceDetailPage  17 KB  (lazy)
                                  RunsPage           2 KB   (lazy)
```

TanStack Router preloads route chunks on hover/focus, so per-route navigation usually feels instant.

## Test plumbing

`renderToStaticMarkup` and `render` can't suspend. Added `preloadAllLazyRoutes()` (walks the 6 lazy components and awaits their `.preload()`) and call it in `beforeAll` of both `apps/web/test/app.test.tsx` and `apps/web/test/router.test.tsx`. Tests pre-resolve the chunks once per file; subsequent renders are synchronous.

## Test plan

- [x] `pnpm -r typecheck` → 0 errors
- [x] `pnpm -r lint` → 0 errors (pre-existing warnings only)
- [x] `npx vitest run --project api-routes --project canonry --project db --project contracts --project web` → 2283/2283 pass
- [x] Build verifies bundle split

🤖 Generated with [Claude Code](https://claude.com/claude-code)