### PR TITLE
fix(content): stable targetRef so dismissals survive orchestrator re-runs

### DIFF
--- a/packages/api-routes/test/content.test.ts
+++ b/packages/api-routes/test/content.test.ts
@@ -638,6 +638,54 @@ describe('content routes', () => {
       expect(secondRow.targetRef).toBe(firstRef)
       expect(secondBody.contextMetrics.latestRunId).toBe(newRunId)
     })
+
+    // Regression for the dismiss UX bug: a user marks a recommendation
+    // addressed, refreshes, and the recommendation reappears because the
+    // orchestrator picked a different "best matching owned page" between
+    // runs — which used to flip the targetRef even though the
+    // recommendation's intent (query + action) was identical. With
+    // `targetPage` removed from the hash input, the ref is now stable
+    // across that shift and the dismissal filter applies on subsequent
+    // loads.
+    it('produces the same targetRef when only the best-page candidate shifts', async () => {
+      const { projectId, latestRunId } = seedProject(db)
+
+      const before = await app.inject({ method: 'GET', url: '/projects/example/content/targets' })
+      const beforeBody = JSON.parse(before.payload)
+      const original = beforeBody.targets.find(
+        (t: { query: string }) => t.query === 'best email marketing software',
+      )
+      expect(original).toBeDefined()
+
+      // Shift the orchestrator's view of "best matching owned page" by
+      // inserting a stronger GSC row pointing at a different blog slug
+      // for the same query. The action stays 'refresh' (still poor SEO,
+      // not cited), so the new recommendation IS conceptually the same;
+      // only the inferred targetPage changes.
+      db.insert(gscSearchData).values({
+        id: crypto.randomUUID(),
+        projectId,
+        syncRunId: latestRunId,
+        date: '2026-04-01',
+        query: 'best email marketing software',
+        page: 'https://example.com/blog/email-marketing-2026-roundup',
+        clicks: 80,
+        impressions: 8000,
+        ctr: '0.01',
+        position: '4.2',
+        createdAt: new Date().toISOString(),
+      }).onConflictDoNothing().run()
+
+      const after = await app.inject({ method: 'GET', url: '/projects/example/content/targets' })
+      const afterBody = JSON.parse(after.payload)
+      const updated = afterBody.targets.find(
+        (t: { query: string }) => t.query === 'best email marketing software',
+      )
+      expect(updated).toBeDefined()
+      // Same intent (query + action) → same ref, regardless of which page
+      // the orchestrator picked as "ourBestPage" this time.
+      expect(updated.targetRef).toBe(original.targetRef)
+    })
   })
 
   describe('regression: filters by run status (no queued/failed runs become latest)', () => {

--- a/packages/intelligence/src/content-targets.ts
+++ b/packages/intelligence/src/content-targets.ts
@@ -156,7 +156,6 @@ export function buildContentTargetRows(input: OrchestratorInput): ContentTargetR
       projectId: input.projectId,
       query: cq.query,
       action,
-      targetPage: ourPage?.url ?? null,
     })
 
     const winningCompetitor = pickTopCompetitor(cq.competitorGroundingUrls)
@@ -362,13 +361,31 @@ function computeTargetRef(input: {
   projectId: string
   query: string
   action: string
-  targetPage: string | null
 }): string {
-  // Intentionally excludes run-level fields so the ref is stable across runs
-  // and can be matched against persisted content-action records (PR 3).
-  const key = [input.projectId, input.query, input.action, input.targetPage ?? ''].join('|')
-  // Stable hash — same inputs produce the same ref. Not a security boundary,
-  // just a deterministic identifier for client-side reference.
+  // The ref is the recommendation's *intent identity* — what the user
+  // would dismiss if they marked it "addressed" in the report. It must
+  // stay stable across orchestrator runs even when run-level state
+  // shifts. Two run-level signals to deliberately exclude:
+  //
+  //   1. `targetPage` — the orchestrator's view of "best matching owned
+  //      page" shifts whenever GSC inventory updates (a different page
+  //      starts ranking for the query, the previous best page drops
+  //      off, etc.). Including it meant the SAME recommendation
+  //      (same query, same action) would get a NEW ref on every report
+  //      load if the inventory shifted at all, so persisted dismissals
+  //      stopped matching after one cycle.
+  //   2. Anything tied to runId / location / sweep timestamp — same
+  //      reason; the dismissal is on the recommendation, not the
+  //      snapshot.
+  //
+  // When the action type itself shifts (`create` → `refresh` because a
+  // page now exists for the query), that's a new conceptual
+  // recommendation and the new ref is correct: a "refresh" dismissal
+  // shouldn't suppress a future "create" suggestion.
+  const key = [input.projectId, input.query, input.action].join('|')
+  // Stable hash — same inputs produce the same ref. Not a security
+  // boundary, just a deterministic identifier for client-side
+  // reference + matching against persisted dismissals.
   let hash = 0
   for (let i = 0; i < key.length; i++) {
     hash = ((hash << 5) - hash + key.charCodeAt(i)) | 0


### PR DESCRIPTION
## Summary

Bug found while testing PR #579's dismiss flow on production AZcoating data: user clicked "Mark addressed" on a recommendation, the dismissal persisted, but the card stayed visible.

```
Dismissed:  tgt_r1x2te  (the ref on the card the user clicked)
Next load:  tgt_5tto9r  (same project + query + action, NEW ref)
```

Root cause: `computeTargetRef` in `packages/intelligence/src/content-targets.ts` hashed `(projectId, query, action, targetPage)`. `targetPage` shifts whenever GSC/GA inventory updates, so the same conceptual recommendation got a new ref every report load. Dismissals stopped matching after one cycle.

## Fix

Drop `targetPage` from the hash input. New formula: `(projectId, query, action)` — the recommendation's intent identity, stable across orchestrator runs.

When the action type itself shifts (`create` → `refresh` because a page now exists), that's correctly a NEW ref — different conceptual recommendation, deserves its own dismissal decision.

## Behavior change

Existing `content_target_dismissals` rows written before this fix had the old hash shape — they no longer match anything the orchestrator produces. Those rows become harmless orphans (a few bytes each, no FK consequences). Users who dismissed something before this fix need to re-dismiss. For AZcoating that's 1 row.

## Test

New regression test in `packages/api-routes/test/content.test.ts`:

```
produces the same targetRef when only the best-page candidate shifts
```

Inserts a new GSC row that flips the orchestrator's best-page pick for a query and asserts the ref stays the same. Catches exactly the scenario that broke the dismiss flow in #579.

## Test plan

- [x] `pnpm -r typecheck` → 0 errors
- [x] `pnpm -r lint` → 0 errors
- [x] 2295/2295 tests pass (one new regression test added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)