### PR TITLE
fix(spa): cache-bust index.html + optimistic dismiss UI

### DIFF
--- a/apps/web/src/pages/ReportPage.tsx
+++ b/apps/web/src/pages/ReportPage.tsx
@@ -399,39 +399,58 @@ function ActionPlanSection({ report, audience, projectName }: { report: ProjectR
     : report.agencyDiagnostics.priorities.length > 0
       ? report.agencyDiagnostics.priorities
       : report.actionPlan.filter(a => actionAudienceMatches(a, audience))
-  const actions = dedupeReportActions(report, rawActions)
+  const dedupedActions = dedupeReportActions(report, rawActions)
   const isClient = audience === 'client'
   const dismissMutation = useDismissContentTarget()
-  // Per-row pending state so multiple dismisses in sequence don't disable
-  // the whole grid. Mutation `isPending` reflects the most recent mutate(),
-  // not per-row state, so we keep our own set.
-  const [pendingTargetRefs, setPendingTargetRefs] = useState<Set<string>>(new Set())
+  // Optimistic dismissals: a targetRef in this set is rendered as "gone"
+  // immediately on click, before the server confirms. The mutation
+  // invalidates the report query on success; once the refetch returns
+  // without the row, the natural unmount removes the entry. On error we
+  // remove from the set so the card re-appears with a toast.
+  //
+  // This set is the source of truth for "what the user thinks they
+  // dismissed" — the actual server state is whatever the next report
+  // refetch returns. They converge after a successful round-trip.
+  const [optimisticDismissed, setOptimisticDismissed] = useState<Set<string>>(new Set())
+  // Filter dedupedActions through the optimistic set so the UI updates
+  // instantly. Server-side filter still applies on the next refetch;
+  // this is purely a render-time bypass to remove perceived latency.
+  const actions = optimisticDismissed.size > 0
+    ? dedupedActions.filter(a => !a.targetRef || !optimisticDismissed.has(a.targetRef))
+    : dedupedActions
 
   const handleDismiss = (action: ProjectReportDto['actionPlan'][number]) => {
     if (!action.targetRef) return
     const ref = action.targetRef
-    // window.confirm is deliberate: this is a destructive UX action on a
-    // recommendation the user is acknowledging they've handled. A custom
-    // modal with a URL/note input is on the roadmap (see PR description);
-    // confirm() is the smallest thing that prevents misclicks today.
-    const ok = window.confirm(
-      `Mark "${action.title}" as addressed? It will drop off the report immediately; you can un-dismiss it later from the dismissed list (CLI: \`canonry content dismissals list\`).`,
-    )
-    if (!ok) return
-    setPendingTargetRefs(prev => new Set(prev).add(ref))
+    // No `window.confirm` — single-click dismissal with optimistic UI is
+    // the right primitive here. The action is reversible via `DELETE
+    // /content/dismissals/:targetRef` (and a future "Dismissed" panel),
+    // so the friction of a confirm dialog outweighs the misclick risk.
+    // Toast confirms the dismissal landed and gives the user a chance to
+    // notice if it was unintentional.
+    setOptimisticDismissed(prev => new Set(prev).add(ref))
     dismissMutation.mutate(
       { projectName, body: { targetRef: ref } },
       {
         onSuccess: () => {
-          addToast({ tone: 'positive', title: `Dismissed "${action.title}"`, detail: 'Will not appear in future reports until un-dismissed.' })
-          // Don't manually clear pendingTargetRefs here — the mutation
-          // invalidates the report query, the action drops out of `actions`
-          // on the next render, and the row unmounts. We clear on error so
-          // the user can retry.
+          addToast({
+            tone: 'positive',
+            title: `Dismissed "${action.title}"`,
+            detail: 'Will not appear in future reports until un-dismissed.',
+          })
+          // Don't clear optimisticDismissed here — the mutation
+          // invalidates the report query, the row drops out of
+          // `dedupedActions` on refetch, and the natural unmount makes
+          // the optimistic entry redundant (filter is a no-op on a row
+          // that isn't there). We clear on error so the user can retry.
         },
         onError: (err) => {
-          addToast({ tone: 'negative', title: `Couldn't dismiss "${action.title}"`, detail: String(err) })
-          setPendingTargetRefs(prev => {
+          addToast({
+            tone: 'negative',
+            title: `Couldn't dismiss "${action.title}"`,
+            detail: String(err),
+          })
+          setOptimisticDismissed(prev => {
             const next = new Set(prev)
             next.delete(ref)
             return next
@@ -503,11 +522,10 @@ function ActionPlanSection({ report, audience, projectName }: { report: ProjectR
                     <button
                       type="button"
                       onClick={() => handleDismiss(action)}
-                      disabled={pendingTargetRefs.has(action.targetRef)}
-                      className="rounded-md border border-zinc-700/60 bg-zinc-900/50 px-2.5 py-1 text-[11px] font-medium text-zinc-300 hover:border-zinc-600 hover:bg-zinc-800/70 hover:text-zinc-100 disabled:cursor-not-allowed disabled:opacity-50"
+                      className="rounded-md border border-zinc-700/60 bg-zinc-900/50 px-2.5 py-1 text-[11px] font-medium text-zinc-300 hover:border-zinc-600 hover:bg-zinc-800/70 hover:text-zinc-100"
                       title="Stop showing this recommendation. The page-detection logic relies on GSC/GA syncs that lag by days — if you've already addressed it, dismissing keeps the report current."
                     >
-                      {pendingTargetRefs.has(action.targetRef) ? 'Dismissing…' : 'Mark addressed'}
+                      Mark addressed
                     </button>
                   </div>
                 )}

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -1356,15 +1356,43 @@ export async function createServer(opts: {
       // Don't serve index.html automatically — we handle it with config injection
       serve: true,
       index: false,
+      // Hashed asset filenames (Vite emits `index-<hash>.js`,
+      // `vendor-recharts-<hash>.js`, etc.) are content-addressed: the URL
+      // changes whenever the file changes. Safe to cache aggressively —
+      // 1 year + immutable tells the browser to never revalidate.
+      // Without this, the browser hits the server for every JS chunk on
+      // every page load, defeating most of the dashboard's first-paint
+      // budget.
+      setHeaders: (reply, filePath) => {
+        // index.html serving is handled separately below; this static
+        // middleware doesn't actually serve it (index:false), but guard
+        // anyway in case fastify-static falls back through here.
+        if (filePath.endsWith('.html')) {
+          reply.setHeader('Cache-Control', 'no-cache, must-revalidate')
+        } else {
+          reply.setHeader('Cache-Control', 'public, max-age=31536000, immutable')
+        }
+      },
     })
 
     // Serve index.html with injected config for the root/base-path route.
     // Register both the trailing-slash form ('/canonry/') and the bare form
     // ('/canonry') so either URL shape hits the handler without a 404.
+    //
+    // `Cache-Control: no-cache, must-revalidate` is critical here: the
+    // HTML references hashed JS bundles (`index-<hash>.js`), so when we
+    // deploy a new build the bundle filename changes. If the browser
+    // caches the OLD index.html, it keeps loading the OLD bundle
+    // filename — which may not exist on the server anymore, or worse,
+    // does exist but is now stale code. `no-cache` forces a revalidation
+    // request on every page load (typically a fast 304 if unchanged).
     const serveIndex = (_request: FastifyRequest, reply: FastifyReply) => {
       if (fs.existsSync(indexPath)) {
         const html = fs.readFileSync(indexPath, 'utf-8')
-        return reply.type('text/html').send(injectConfig(html))
+        return reply
+          .header('Cache-Control', 'no-cache, must-revalidate')
+          .type('text/html')
+          .send(injectConfig(html))
       }
       return reply.status(404).send({ error: 'Dashboard not built' })
     }
@@ -1401,7 +1429,13 @@ export async function createServer(opts: {
 
       if (fs.existsSync(indexPath)) {
         const html = fs.readFileSync(indexPath, 'utf-8')
-        return reply.type('text/html').send(injectConfig(html))
+        // Same no-cache policy as `serveIndex` — SPA deep links hit this
+        // handler and must always pick up the latest index.html that
+        // points at the current hashed bundles.
+        return reply
+          .header('Cache-Control', 'no-cache, must-revalidate')
+          .type('text/html')
+          .send(injectConfig(html))
       }
       return reply.status(404).send({ error: 'Not found' })
     })


### PR DESCRIPTION
Two issues, one PR. (1) Browsers cached the OLD index.html after deploy, so users kept running stale JS that didn't dispatch the dismiss mutation. Fixed by adding Cache-Control: no-cache, must-revalidate to index.html serving (+ immutable on hashed /assets/*). (2) The dismiss flow had confirm dialog + roundtrip latency — replaced with optimistic UI: card disappears instantly on click, error rolls it back. 2295/2295 tests pass.