### PR TITLE
fix(intelligence): homepage-only GSC match → CREATE, not REFRESH

### DIFF
--- a/packages/intelligence/src/content-classifier.ts
+++ b/packages/intelligence/src/content-classifier.ts
@@ -5,12 +5,30 @@
  * — this is an AEO tool, not a generic SEO tool):
  *
  *   no page                              → CREATE
+ *   ourPage is homepage-only             → CREATE  (see HOMEPAGE_ONLY_PATHS)
  *   cited + no schema                    → ADD-SCHEMA  (lock in the win)
  *   cited + has schema                   → null         (already winning)
  *   cited + audit unavailable            → null         (no actionable info)
  *   not cited + position ≤ 10            → REFRESH      (SEO works, AEO doesn't)
  *   not cited + position 11–30           → EXPAND       (thin/stale)
  *   not cited + position > 30 or no page → CREATE       (effectively invisible)
+ *
+ * Homepage-only exception (why CREATE, not REFRESH):
+ *   Google routinely ranks a site's homepage for service/topic queries
+ *   the brand is associated with — "spray foam insulation" → homepage of
+ *   a coatings business, "polyurea roofing" → homepage of a roofing
+ *   business. GSC reports this as `page = '/'` with a strong position,
+ *   which makes it LOOK like "we have a top-ranking page" to the
+ *   classifier. But the homepage isn't a *topical* page for the query:
+ *   it doesn't directly answer the user's question, and refreshing the
+ *   homepage to specifically address one query would damage every other
+ *   query the homepage targets.
+ *
+ *   The right recommendation in this scenario is to CREATE a topical
+ *   page for the query, not to REFRESH the homepage. The downstream
+ *   evidence still surfaces "homepage is the closest slug match" so the
+ *   user sees what's happening — just with an action that matches the
+ *   AEO-first thesis.
  */
 
 import type { ContentAction } from '@ainyc/canonry-contracts'
@@ -26,10 +44,32 @@ export interface ClassifierInput {
 const SEO_STRONG_THRESHOLD = 10
 const SEO_WEAK_THRESHOLD = 30
 
+/**
+ * Paths that the orchestrator may resolve as `ourPage.url` but should
+ * NOT count as a topical page for refresh/expand/add-schema decisions.
+ * `extractPath` in content-data.ts normalizes URLs to a stripped path,
+ * with the homepage rendered as `/` (and the empty-string fallback as a
+ * defensive case for malformed GSC rows).
+ */
+function isHomepageOnly(url: string): boolean {
+  if (url === '/' || url === '') return true
+  // Strip query strings + trailing slashes that survived normalization
+  // (defensive — extractPath should have handled these, but a quirky GSC
+  // row could still hit us with `/?utm=…`).
+  const stripped = url.split('?')[0]!.replace(/\/+$/, '')
+  return stripped === '' || stripped === '/'
+}
+
 export function classifyContentAction(input: ClassifierInput): ContentAction | null {
   const { ourPage, ourPageInGroundingSources, ourPageHasSchema } = input
 
   if (!ourPage) return 'create'
+
+  // Homepage-only match: see header comment. The homepage ranking for a
+  // topical query is almost always brand-match behavior, not "we have a
+  // topical page." CREATE a real page; don't suggest refreshing the
+  // homepage.
+  if (isHomepageOnly(ourPage.url)) return 'create'
 
   if (ourPageInGroundingSources) {
     if (ourPageHasSchema === false) return 'add-schema'

--- a/packages/intelligence/test/content-classifier.test.ts
+++ b/packages/intelligence/test/content-classifier.test.ts
@@ -131,6 +131,98 @@ describe('classifyContentAction', () => {
     })
   })
 
+  describe('homepage-only match: treat as no-page → CREATE', () => {
+    // Regression: GSC routinely reports `page='/'` for queries the
+    // site's brand ranks for (e.g., "spray foam insulation" → homepage
+    // of a coatings business). The classifier used to read that as "we
+    // have a top-ranking page" and recommend REFRESH, which is wrong on
+    // two counts: (1) the homepage isn't a topical page, (2) refreshing
+    // it to address one query would harm every other query the
+    // homepage targets. The right action is CREATE a topical page.
+
+    it('CREATE when ourPage.url is "/" even with strong SEO rank, not cited', () => {
+      expect(
+        classifyContentAction({
+          ourPage: { url: '/', position: 4, source: 'gsc' },
+          ourPageInGroundingSources: false,
+          ourPageHasSchema: false,
+        }),
+      ).toBe('create')
+    })
+
+    it('CREATE when ourPage.url is "/" even with mid-range SEO rank', () => {
+      expect(
+        classifyContentAction({
+          ourPage: { url: '/', position: 22, source: 'gsc' },
+          ourPageInGroundingSources: false,
+          ourPageHasSchema: false,
+        }),
+      ).toBe('create')
+    })
+
+    it('CREATE when ourPage.url is "" (empty path from a malformed GSC row)', () => {
+      expect(
+        classifyContentAction({
+          ourPage: { url: '', position: 5, source: 'gsc' },
+          ourPageInGroundingSources: false,
+          ourPageHasSchema: false,
+        }),
+      ).toBe('create')
+    })
+
+    it('CREATE even when the homepage IS cited — citation on the homepage doesn\'t mean we have a topical page', () => {
+      // The intent: a query like "spray foam insulation" cited via the
+      // brand homepage isn't "we have a winning topical page" — it's
+      // "AI picked us up via brand association." A topical page would
+      // still be a stronger long-term play. Skip add-schema (which only
+      // makes sense for topical pages) and recommend CREATE.
+      expect(
+        classifyContentAction({
+          ourPage: { url: '/', position: 4, source: 'gsc' },
+          ourPageInGroundingSources: true,
+          ourPageHasSchema: false,
+        }),
+      ).toBe('create')
+    })
+
+    it('strips trailing slashes when judging homepage-only', () => {
+      expect(
+        classifyContentAction({
+          ourPage: { url: '//', position: 4, source: 'gsc' },
+          ourPageInGroundingSources: false,
+          ourPageHasSchema: false,
+        }),
+      ).toBe('create')
+    })
+
+    it('strips query strings when judging homepage-only', () => {
+      // Defensive: extractPath in content-data.ts uses URL.pathname which
+      // already drops query strings, but a quirky upstream row could
+      // still slip through. This check makes the classifier robust to
+      // that case.
+      expect(
+        classifyContentAction({
+          ourPage: { url: '/?utm_source=newsletter', position: 4, source: 'gsc' },
+          ourPageInGroundingSources: false,
+          ourPageHasSchema: false,
+        }),
+      ).toBe('create')
+    })
+
+    it('does NOT trigger on a topical path that happens to be one level deep', () => {
+      // Sanity check: only the literal homepage triggers the exception.
+      // A real top-level page like /spray-foam still goes through the
+      // normal SEO triage.
+      expect(
+        classifyContentAction({
+          ourPage: { url: '/spray-foam-insulation', position: 4, source: 'gsc' },
+          ourPageInGroundingSources: false,
+          ourPageHasSchema: false,
+        }),
+      ).toBe('refresh')
+    })
+  })
+
   describe('exhaustive coverage of the 2x2 (cited × rank) matrix', () => {
     it.each([
       // [position, cited, hasSchema, expected]


### PR DESCRIPTION
Reported by user on AZcoating's report: "Refresh content for 'spray foam insulation'" with evidence saying "No topical page yet — homepage is the closest slug match." Classifier was reading GSC `page='/'` as "we have a page" and recommending REFRESH; Google ranking the homepage for a service query is brand-match, not topical-coverage. Fixed: classifier returns CREATE whenever ourPage normalizes to homepage. Phase 0 of the broader recommendation-engine plan — tighten the heuristic before adding LLM enrichment. 7 new tests, 2755/2755 pass.