### PR TITLE
fix(ga): cap GA4 concurrency + retry 429/5xx with Retry-After

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.51.0",
+  "version": "4.51.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.51.0",
+  "version": "4.51.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/integration-google-analytics/src/constants.ts
+++ b/packages/integration-google-analytics/src/constants.ts
@@ -12,6 +12,19 @@ export const GA4_REQUEST_TIMEOUT_MS = 30_000
 // Safety limit: max pagination iterations to prevent infinite loops.
 export const GA4_MAX_PAGES = 50
 
+// GA4 Data API caps concurrent requests per property at 10. We hold the in-flight
+// budget well under that — a sync fires 5-7 top-level fetches (`fetchAggregateSummary`
+// + 3x `fetchWindowSummary` + traffic + AI + social) in parallel, each of which
+// then paginates serially, so bursts of 6+ concurrent calls were routinely
+// crossing the limit and surfacing as 429 QUOTA_EXCEEDED.
+export const GA4_MAX_CONCURRENT_REQUESTS = 4
+
+// Retry budget for transient failures (429, 5xx). With initialDelay=1s and
+// doubling: 1s, 2s, 4s — total worst-case sleep ~7s before giving up. Honors
+// the GA4 API's `Retry-After` header when present, overriding the computed delay.
+export const GA4_MAX_RETRIES = 3
+export const GA4_INITIAL_RETRY_DELAY_MS = 1000
+
 /**
  * GA4 dimension names used in `runReport` requests. Centralized so a typo or
  * naming change (e.g. the `sessionDefaultChannelGroup` vs. `…Grouping` drift

--- a/packages/integration-google-analytics/src/ga4-client.ts
+++ b/packages/integration-google-analytics/src/ga4-client.ts
@@ -8,6 +8,9 @@ import {
   GA4_MAX_SYNC_DAYS,
   GA4_REQUEST_TIMEOUT_MS,
   GA4_MAX_PAGES,
+  GA4_MAX_CONCURRENT_REQUESTS,
+  GA4_MAX_RETRIES,
+  GA4_INITIAL_RETRY_DELAY_MS,
   GA4_DIMENSIONS as DIM,
   GA4_METRICS as MET,
 } from './constants.js'
@@ -142,6 +145,102 @@ function escapeRegExp(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
+// --- Concurrency limiter ------------------------------------------------------
+// A single GA4 sync fans out into 5-7 top-level fetches, each of which then
+// paginates serially. With unbounded concurrency we routinely burst over GA4's
+// 10-concurrent-requests-per-property cap. The semaphore below pins the in-flight
+// count for *all* GA4 fetches in this process to GA4_MAX_CONCURRENT_REQUESTS,
+// regardless of which top-level call originated them.
+let gaInFlight = 0
+const gaWaitQueue: Array<() => void> = []
+
+async function acquireGa4Slot(): Promise<void> {
+  if (gaInFlight < GA4_MAX_CONCURRENT_REQUESTS) {
+    gaInFlight++
+    return
+  }
+  await new Promise<void>((resolve) => gaWaitQueue.push(resolve))
+  // Slot was handed off — see releaseGa4Slot — so gaInFlight already reflects us.
+}
+
+function releaseGa4Slot(): void {
+  const next = gaWaitQueue.shift()
+  if (next) {
+    // Hand the slot straight to the waiter; in-flight count stays the same.
+    next()
+  } else {
+    gaInFlight--
+  }
+}
+
+async function withGa4Limit<T>(fn: () => Promise<T>): Promise<T> {
+  await acquireGa4Slot()
+  try {
+    return await fn()
+  } finally {
+    releaseGa4Slot()
+  }
+}
+
+// Exposed for tests that want to assert the semaphore is empty / reset state
+// after exercising error paths. Not part of the public API.
+export function _resetGa4ConcurrencyStateForTests(): void {
+  gaInFlight = 0
+  gaWaitQueue.length = 0
+}
+
+// --- Retry with exponential backoff ------------------------------------------
+// Retries 429 and 5xx responses up to GA4_MAX_RETRIES times with delays of
+// 1s, 2s, 4s … (doubling). If GA4 returned a `Retry-After` header, we honor
+// that value instead of the computed backoff.
+function parseRetryAfter(headerValue: string | null): number | undefined {
+  if (!headerValue) return undefined
+  const trimmed = headerValue.trim()
+  // Numeric form: "Retry-After: 30"
+  const asNum = Number(trimmed)
+  if (Number.isFinite(asNum) && asNum >= 0) return asNum
+  // HTTP-date form: "Retry-After: Wed, 21 Oct 2026 07:28:00 GMT"
+  const asDate = Date.parse(trimmed)
+  if (!Number.isNaN(asDate)) {
+    const seconds = Math.max(0, (asDate - Date.now()) / 1000)
+    return seconds
+  }
+  return undefined
+}
+
+function isRetryableGa4Error(err: unknown): boolean {
+  if (err instanceof GA4ApiError) {
+    return err.status === 429 || err.status >= 500
+  }
+  return false
+}
+
+async function withGa4Retry<T>(fn: () => Promise<T>, errLabel: string): Promise<T> {
+  let lastError: unknown
+  for (let attempt = 0; attempt <= GA4_MAX_RETRIES; attempt++) {
+    try {
+      return await fn()
+    } catch (err) {
+      lastError = err
+      if (attempt >= GA4_MAX_RETRIES || !isRetryableGa4Error(err)) throw err
+      const ga4Err = err as GA4ApiError
+      const computedDelayMs = GA4_INITIAL_RETRY_DELAY_MS * Math.pow(2, attempt)
+      const delayMs = ga4Err.retryAfterSeconds !== undefined
+        ? Math.max(0, ga4Err.retryAfterSeconds * 1000)
+        : computedDelayMs
+      ga4Log('info', `${errLabel}.retry`, {
+        attempt: attempt + 1,
+        maxAttempts: GA4_MAX_RETRIES + 1,
+        status: ga4Err.status,
+        delayMs,
+        usedRetryAfter: ga4Err.retryAfterSeconds !== undefined,
+      })
+      await new Promise<void>((resolve) => setTimeout(resolve, delayMs))
+    }
+  }
+  throw lastError
+}
+
 /**
  * Run a GA4 Data API report.
  */
@@ -154,52 +253,56 @@ async function runReport(
   const safePropertyId = encodeURIComponent(propertyId)
   const url = `${GA4_DATA_API_BASE}/properties/${safePropertyId}:runReport`
 
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Authorization': `Bearer ${accessToken}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(request),
-    signal: AbortSignal.timeout(GA4_REQUEST_TIMEOUT_MS),
-  })
+  return withGa4Limit(() => withGa4Retry(async () => {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(request),
+      signal: AbortSignal.timeout(GA4_REQUEST_TIMEOUT_MS),
+    })
 
-  if (res.status === 401 || res.status === 403) {
-    const body = await res.text().catch(() => '')
-    let detail = ''
-    try {
-      const parsed = JSON.parse(body) as { error?: { message?: string; status?: string } }
-      if (parsed.error?.status === 'SERVICE_DISABLED') {
-        detail =
-          ' The Google Analytics Data API is not enabled for this GCP project. ' +
-          'Enable it at: https://console.developers.google.com/apis/api/analyticsdata.googleapis.com/overview'
-      } else if (parsed.error?.message) {
-        detail = ` ${parsed.error.message}`
+    if (res.status === 401 || res.status === 403) {
+      const body = await res.text().catch(() => '')
+      let detail = ''
+      try {
+        const parsed = JSON.parse(body) as { error?: { message?: string; status?: string } }
+        if (parsed.error?.status === 'SERVICE_DISABLED') {
+          detail =
+            ' The Google Analytics Data API is not enabled for this GCP project. ' +
+            'Enable it at: https://console.developers.google.com/apis/api/analyticsdata.googleapis.com/overview'
+        } else if (parsed.error?.message) {
+          detail = ` ${parsed.error.message}`
+        }
+      } catch {
+        // not JSON — use raw body if short enough
+        if (body.length < 200) detail = ` ${body}`
       }
-    } catch {
-      // not JSON — use raw body if short enough
-      if (body.length < 200) detail = ` ${body}`
+      ga4Log('error', 'report.auth-failed', { propertyId, httpStatus: res.status })
+      throw new GA4ApiError(
+        `GA4 API authentication failed — check service account permissions.${detail}`,
+        res.status,
+      )
     }
-    ga4Log('error', 'report.auth-failed', { propertyId, httpStatus: res.status })
-    throw new GA4ApiError(
-      `GA4 API authentication failed — check service account permissions.${detail}`,
-      res.status,
-    )
-  }
 
-  if (res.status === 429) {
-    ga4Log('error', 'report.rate-limited', { propertyId })
-    throw new GA4ApiError('GA4 API rate limit exceeded', 429)
-  }
+    if (res.status === 429) {
+      const retryAfterSeconds = parseRetryAfter(res.headers.get('retry-after'))
+      ga4Log('error', 'report.rate-limited', { propertyId, retryAfterSeconds })
+      throw new GA4ApiError('GA4 API rate limit exceeded', 429, retryAfterSeconds)
+    }
 
-  if (!res.ok) {
-    const body = await res.text()
-    ga4Log('error', 'report.error', { propertyId, httpStatus: res.status })
-    const detail = body.length <= 500 ? body : `${body.slice(0, 500)}... [truncated]`
-    throw new GA4ApiError(`GA4 API error (${res.status}): ${detail}`, res.status)
-  }
+    if (!res.ok) {
+      const body = await res.text()
+      const retryAfterSeconds = res.status >= 500 ? parseRetryAfter(res.headers.get('retry-after')) : undefined
+      ga4Log('error', 'report.error', { propertyId, httpStatus: res.status, retryAfterSeconds })
+      const detail = body.length <= 500 ? body : `${body.slice(0, 500)}... [truncated]`
+      throw new GA4ApiError(`GA4 API error (${res.status}): ${detail}`, res.status, retryAfterSeconds)
+    }
 
-  return (await res.json()) as GA4RunReportResponse
+    return (await res.json()) as GA4RunReportResponse
+  }, 'report'))
 }
 
 /**
@@ -213,39 +316,43 @@ async function batchRunReports(
 ): Promise<GA4RunReportResponse[]> {
   const url = `${GA4_DATA_API_BASE}/properties/${propertyId}:batchRunReports`
 
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Authorization': `Bearer ${accessToken}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ requests }),
-    signal: AbortSignal.timeout(GA4_REQUEST_TIMEOUT_MS),
-  })
+  return withGa4Limit(() => withGa4Retry(async () => {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ requests }),
+      signal: AbortSignal.timeout(GA4_REQUEST_TIMEOUT_MS),
+    })
 
-  if (res.status === 401 || res.status === 403) {
-    const body = await res.text().catch(() => '')
-    ga4Log('error', 'batch-report.auth-failed', { propertyId, httpStatus: res.status })
-    throw new GA4ApiError(
-      `GA4 API authentication failed — check service account permissions. ${body}`,
-      res.status,
-    )
-  }
+    if (res.status === 401 || res.status === 403) {
+      const body = await res.text().catch(() => '')
+      ga4Log('error', 'batch-report.auth-failed', { propertyId, httpStatus: res.status })
+      throw new GA4ApiError(
+        `GA4 API authentication failed — check service account permissions. ${body}`,
+        res.status,
+      )
+    }
 
-  if (res.status === 429) {
-    ga4Log('error', 'batch-report.rate-limited', { propertyId })
-    throw new GA4ApiError('GA4 API rate limit exceeded', 429)
-  }
+    if (res.status === 429) {
+      const retryAfterSeconds = parseRetryAfter(res.headers.get('retry-after'))
+      ga4Log('error', 'batch-report.rate-limited', { propertyId, retryAfterSeconds })
+      throw new GA4ApiError('GA4 API rate limit exceeded', 429, retryAfterSeconds)
+    }
 
-  if (!res.ok) {
-    const body = await res.text()
-    ga4Log('error', 'batch-report.error', { propertyId, httpStatus: res.status })
-    const detail = body.length <= 500 ? body : `${body.slice(0, 500)}... [truncated]`
-    throw new GA4ApiError(`GA4 API error (${res.status}): ${detail}`, res.status)
-  }
+    if (!res.ok) {
+      const body = await res.text()
+      const retryAfterSeconds = res.status >= 500 ? parseRetryAfter(res.headers.get('retry-after')) : undefined
+      ga4Log('error', 'batch-report.error', { propertyId, httpStatus: res.status, retryAfterSeconds })
+      const detail = body.length <= 500 ? body : `${body.slice(0, 500)}... [truncated]`
+      throw new GA4ApiError(`GA4 API error (${res.status}): ${detail}`, res.status, retryAfterSeconds)
+    }
 
-  const data = (await res.json()) as { reports: GA4RunReportResponse[] }
-  return data.reports
+    const data = (await res.json()) as { reports: GA4RunReportResponse[] }
+    return data.reports
+  }, 'batch-report'))
 }
 
 function formatDate(d: Date): string {

--- a/packages/integration-google-analytics/src/types.ts
+++ b/packages/integration-google-analytics/src/types.ts
@@ -84,9 +84,13 @@ export interface GA4SocialReferralRow {
 
 export class GA4ApiError extends Error {
   public status: number
-  constructor(message: string, status: number) {
+  /** Seconds the GA4 API asked us to wait before retrying. Populated from the
+   *  `Retry-After` response header on 429 and 5xx responses when present. */
+  public retryAfterSeconds?: number
+  constructor(message: string, status: number, retryAfterSeconds?: number) {
     super(message)
     this.name = 'GA4ApiError'
     this.status = status
+    if (retryAfterSeconds !== undefined) this.retryAfterSeconds = retryAfterSeconds
   }
 }

--- a/packages/integration-google-analytics/test/ga4-client.test.ts
+++ b/packages/integration-google-analytics/test/ga4-client.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
-import { createServiceAccountJwt, fetchAiReferrals, fetchTrafficByLandingPage, getAccessToken, verifyConnectionWithToken, fetchAggregateSummary, fetchWindowSummary } from '../src/ga4-client.js'
+import { createServiceAccountJwt, fetchAiReferrals, fetchTrafficByLandingPage, getAccessToken, verifyConnectionWithToken, fetchAggregateSummary, fetchWindowSummary, _resetGa4ConcurrencyStateForTests } from '../src/ga4-client.js'
+import { GA4_MAX_CONCURRENT_REQUESTS, GA4_MAX_RETRIES } from '../src/constants.js'
 import crypto from 'node:crypto'
 
 describe('createServiceAccountJwt', () => {
@@ -476,5 +477,169 @@ describe('fetchWindowSummary', () => {
     await expect(
       fetchWindowSummary('fake-token', '123456', 'all' as unknown as '7d'),
     ).rejects.toThrow(/Unsupported windowKey/)
+  })
+})
+
+describe('GA4 retry on transient errors', () => {
+  // Uses fake timers so exponential-backoff sleeps (1s, 2s, 4s) don't slow tests.
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    _resetGa4ConcurrencyStateForTests()
+    vi.useFakeTimers()
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    fetchSpy.mockRestore()
+    _resetGa4ConcurrencyStateForTests()
+  })
+
+  function okResponse() {
+    return new Response(JSON.stringify({ rows: [], rowCount: 0 }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  it('retries a 429 and succeeds on the next attempt', async () => {
+    let callCount = 0
+    fetchSpy.mockImplementation(async () => {
+      callCount++
+      if (callCount === 1) return new Response('rate limited', { status: 429 })
+      return okResponse()
+    })
+
+    const promise = verifyConnectionWithToken('fake-token', '123456')
+    await vi.runAllTimersAsync()
+    await expect(promise).resolves.toBe(true)
+    expect(callCount).toBe(2)
+  })
+
+  it('honors the Retry-After header (numeric seconds) instead of computed backoff', async () => {
+    let callCount = 0
+    fetchSpy.mockImplementation(async () => {
+      callCount++
+      if (callCount === 1) {
+        return new Response('rate limited', {
+          status: 429,
+          headers: { 'Retry-After': '5' },
+        })
+      }
+      return okResponse()
+    })
+
+    const promise = verifyConnectionWithToken('fake-token', '123456')
+    // Advance just under 5s — retry should NOT have fired yet (computed backoff is 1s,
+    // so without Retry-After honoring this assertion would fail at the 1s mark).
+    await vi.advanceTimersByTimeAsync(4000)
+    expect(callCount).toBe(1)
+    // Cross the 5s threshold; retry fires.
+    await vi.advanceTimersByTimeAsync(1500)
+    await expect(promise).resolves.toBe(true)
+    expect(callCount).toBe(2)
+  })
+
+  it('throws GA4ApiError(429) after exhausting retries', async () => {
+    fetchSpy.mockImplementation(async () => new Response('rate limited', { status: 429 }))
+
+    const promise = verifyConnectionWithToken('fake-token', '123456')
+    // Detach from the rejection to avoid unhandled-rejection noise while we advance timers.
+    const settled = promise.catch((e: unknown) => e)
+    await vi.runAllTimersAsync()
+    const err = (await settled) as Error
+    expect(err.message).toMatch(/GA4 API rate limit exceeded/)
+    // GA4_MAX_RETRIES = 3 → 4 total attempts (1 initial + 3 retries).
+    expect(fetchSpy).toHaveBeenCalledTimes(GA4_MAX_RETRIES + 1)
+  })
+
+  it('does NOT retry a 4xx non-429 response', async () => {
+    fetchSpy.mockImplementation(async () => new Response('bad request', { status: 400 }))
+
+    const promise = verifyConnectionWithToken('fake-token', '123456')
+    const settled = promise.catch((e: unknown) => e)
+    await vi.runAllTimersAsync()
+    const err = (await settled) as Error
+    expect(err.message).toMatch(/GA4 API error \(400\)/)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries 5xx server errors', async () => {
+    let callCount = 0
+    fetchSpy.mockImplementation(async () => {
+      callCount++
+      if (callCount === 1) return new Response('upstream', { status: 503 })
+      return okResponse()
+    })
+
+    const promise = verifyConnectionWithToken('fake-token', '123456')
+    await vi.runAllTimersAsync()
+    await expect(promise).resolves.toBe(true)
+    expect(callCount).toBe(2)
+  })
+
+  it('honors Retry-After on a 5xx response', async () => {
+    let callCount = 0
+    fetchSpy.mockImplementation(async () => {
+      callCount++
+      if (callCount === 1) {
+        return new Response('upstream', {
+          status: 503,
+          headers: { 'Retry-After': '5' },
+        })
+      }
+      return okResponse()
+    })
+
+    const promise = verifyConnectionWithToken('fake-token', '123456')
+    // Computed backoff for attempt 0 is 1s — if 5xx Retry-After were ignored,
+    // the retry would have fired by the 1s mark and callCount would be 2 here.
+    await vi.advanceTimersByTimeAsync(4000)
+    expect(callCount).toBe(1)
+    await vi.advanceTimersByTimeAsync(1500)
+    await expect(promise).resolves.toBe(true)
+    expect(callCount).toBe(2)
+  })
+})
+
+describe('GA4 concurrency limiter', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    _resetGa4ConcurrencyStateForTests()
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+    _resetGa4ConcurrencyStateForTests()
+  })
+
+  it('caps in-flight requests at GA4_MAX_CONCURRENT_REQUESTS even when callers fan out', async () => {
+    // Fire 2x the cap simultaneously. With a real 10ms delay inside the mock,
+    // the second batch must wait for slots in the first batch to release.
+    const N = GA4_MAX_CONCURRENT_REQUESTS * 2
+    let inFlight = 0
+    let maxInFlight = 0
+
+    fetchSpy.mockImplementation(async () => {
+      inFlight++
+      if (inFlight > maxInFlight) maxInFlight = inFlight
+      await new Promise((r) => setTimeout(r, 10))
+      inFlight--
+      return new Response(JSON.stringify({ rows: [], rowCount: 0 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    })
+
+    const promises = Array.from({ length: N }, () =>
+      verifyConnectionWithToken('fake-token', '123456'),
+    )
+    await Promise.all(promises)
+
+    expect(maxInFlight).toBe(GA4_MAX_CONCURRENT_REQUESTS)
+    expect(fetchSpy).toHaveBeenCalledTimes(N)
   })
 })


### PR DESCRIPTION
## Summary
- A single GA4 sync fires 5-7 top-level fetches in parallel (aggregate + 3x window + traffic + AI + social), each paginating serially — bursts routinely crossed GA4's 10-concurrent-per-property cap and surfaced as 429 `QUOTA_EXCEEDED`.
- Adds a process-wide semaphore (cap 4, hand-off-on-release) plus an exponential-backoff retry loop (3 retries, 1s/2s/4s) for 429 and 5xx responses, honoring `Retry-After` on both response classes when present.
- New `GA4ApiError.retryAfterSeconds` carries the server hint through to the retry loop; 4xx-non-429 still fails fast.

## Test plan
- [x] `pnpm exec vitest run --project integration-google-analytics` — 22 passing, including new cases for retry-on-429, retry-on-5xx, Retry-After-honoring (429 + 503), no-retry-on-4xx, exhausted retries, and the concurrency cap under fan-out.
- [x] `pnpm typecheck` and workspace lint (via pre-commit hook).