### PR TITLE
feat(web): poll projects list so CLI mutations appear in the dashboard

### DIFF
--- a/apps/web/src/queries/query-client.ts
+++ b/apps/web/src/queries/query-client.ts
@@ -6,6 +6,12 @@ export const STATIC_VISIBILITY_STALE_MS = 30 * 60_000
 export const TRAFFIC_STALE_MS = 30_000
 export const GSC_STALE_MS = 60_000
 export const RUNS_STALE_MS = 30_000
+// Projects list polls quickly so CLI-driven mutations (e.g.
+// `canonry project create`) show up in the dashboard sidebar within
+// seconds — the entire project-card fan-out cascades from this query
+// on first mount, so a fast poll here makes the overview reactive
+// end-to-end. Trade-off: ~30 req/min from one tab to a SQLite SELECT.
+export const PROJECTS_REFRESH_MS = 2_000
 
 export function createQueryClient() {
   return new QueryClient({

--- a/apps/web/src/queries/use-dashboard.ts
+++ b/apps/web/src/queries/use-dashboard.ts
@@ -29,7 +29,7 @@ import type { DashboardVm } from '../view-models.js'
 function projectDetailQueryKey(projectId: string, latestRunIdsKey?: string) {
   return ['projects', projectId, latestRunIdsKey] as const
 }
-import { RUNS_STALE_MS, STATIC_VISIBILITY_STALE_MS } from './query-client.js'
+import { PROJECTS_REFRESH_MS, RUNS_STALE_MS, STATIC_VISIBILITY_STALE_MS } from './query-client.js'
 import { useInitialDashboard } from '../contexts/dashboard-context.js'
 
 export function useDashboard(initialDashboard?: DashboardVm | null) {
@@ -39,6 +39,7 @@ export function useDashboard(initialDashboard?: DashboardVm | null) {
   const projectsQuery = useQuery({
     ...getApiV1ProjectsOptions({ client: heyClient }),
     enabled: !effectiveInitial,
+    refetchInterval: PROJECTS_REFRESH_MS,
   })
 
   const runsQuery = useQuery({


### PR DESCRIPTION
## Summary

- The dashboard's projects query fetched once on mount and never refetched — CLI mutations like \`canonry project create\` required a manual page reload before the new project appeared in the sidebar.
- Add a 2s \`refetchInterval\` to the projects query in \`use-dashboard.ts\`. Defined as \`PROJECTS_REFRESH_MS\` in \`query-client.ts\` alongside the other tunables.
- The entire project-card fan-out cascades from this one query, so the overview becomes reactive end-to-end without further changes. Runs and health already poll, so sweep status and system health stay live too.

## Why this works (the cascade)

| Event | Update path | Source |
|---|---|---|
| CLI adds project | New \`refetchInterval\` (2s) | **This PR** |
| Project card mounts | Fan-out auto-fires on first render | Existing |
| CLI starts sweep | Runs poll catches it at 3s active | Existing |
| Sweep completes | Runs query updates → project detail re-keys on \`latestRunIdsKey\` | Existing |

## Cost

Loopback SQLite SELECT, ~30 req/min from one tab. Negligible.

## Test plan

- [ ] Run \`canonry serve\` + open dashboard
- [ ] In another terminal: \`canonry project create demo --domain demo.example --country US --language en\`
- [ ] Verify the new project appears in the sidebar within ~2s without refreshing
- [ ] Trigger a sweep on the new project; verify the run badge appears and transitions live
- [ ] Open DevTools Network tab; confirm \`GET /api/v1/projects\` fires every 2s and returns a small JSON payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)