### PR TITLE
fix(dashboard): scope /runs query to answer-visibility to unbreak evidence panel

### DIFF
--- a/apps/web/src/queries/use-dashboard.ts
+++ b/apps/web/src/queries/use-dashboard.ts
@@ -42,8 +42,23 @@ export function useDashboard(initialDashboard?: DashboardVm | null) {
     refetchInterval: PROJECTS_REFRESH_MS,
   })
 
+  // Scope the dashboard's `/runs` query to answer-visibility only. PR #580
+  // capped the endpoint at 500 rows to fix cold-load size; on projects with
+  // active integrations (bing-inspect, gsc-sync, ga-sync fire on a tight
+  // cron) the cap fills with sync rows in under an hour and pushes the
+  // sweep runs the dashboard actually needs off the response. Result: the
+  // dashboard sees `latestRunIds = []`, falls through to the "saved query
+  // not yet run" branch in `build-dashboard.ts`, and renders every tracked
+  // query as "Awaiting first run" even when sweeps exist and have recent
+  // snapshots. The `?kind=` filter (added alongside this change in the
+  // server) restores correctness without raising the cap.
+  //
+  // Side effect: per-project `recentRuns` widgets now only surface
+  // answer-visibility runs, not integration-sync runs. That matches the
+  // dashboard's purpose — sweeps are the primary signal; integration
+  // health lives on its own pages (Bing/GSC/GA sections + `cnry doctor`).
   const runsQuery = useQuery({
-    ...getApiV1RunsOptions({ client: heyClient }),
+    ...getApiV1RunsOptions({ client: heyClient, query: { kind: 'answer-visibility' } }),
     enabled: !effectiveInitial,
     staleTime: RUNS_STALE_MS,
     refetchInterval: (query) => {

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -2763,7 +2763,24 @@ export type GetApiV1ProjectsByNameRunsLatestResponse = GetApiV1ProjectsByNameRun
 export type GetApiV1RunsData = {
     body?: never;
     path?: never;
-    query?: never;
+    query?: {
+        /**
+         * Maximum number of records to return.
+         */
+        limit?: number;
+        /**
+         * Only return runs with created_at >= this ISO 8601 timestamp. Defaults to 30 days ago.
+         */
+        since?: string;
+        /**
+         * Set to "1" or "true" to include probe runs. Probes are excluded by default because they are operator/agent test runs and must not pollute dashboard aggregates.
+         */
+        includeProbe?: string;
+        /**
+         * Restrict results to a single run kind. Without this filter, integration syncs (bing-inspect, gsc-sync, ga-sync) can fill the default 500-row cap within minutes on busy projects and push answer-visibility runs out of the response.
+         */
+        kind?: 'answer-visibility' | 'site-audit' | 'gsc-sync' | 'inspect-sitemap' | 'ga-sync' | 'bing-inspect' | 'bing-inspect-sitemap' | 'backlink-extract' | 'traffic-sync' | 'aeo-discover-seed' | 'aeo-discover-probe';
+    };
     url: '/api/v1/runs';
 };
 

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -169,6 +169,42 @@ const scheduleKindQueryParameter: OpenApiParameter = {
   schema: { type: 'string', enum: ['answer-visibility', 'traffic-sync'] },
 }
 
+const runsListKindQueryParameter: OpenApiParameter = {
+  name: 'kind',
+  in: 'query',
+  description: 'Restrict results to a single run kind. Without this filter, integration syncs (bing-inspect, gsc-sync, ga-sync) can fill the default 500-row cap within minutes on busy projects and push answer-visibility runs out of the response.',
+  schema: {
+    type: 'string',
+    enum: [
+      'answer-visibility',
+      'site-audit',
+      'gsc-sync',
+      'inspect-sitemap',
+      'ga-sync',
+      'bing-inspect',
+      'bing-inspect-sitemap',
+      'backlink-extract',
+      'traffic-sync',
+      'aeo-discover-seed',
+      'aeo-discover-probe',
+    ],
+  },
+}
+
+const runsListSinceQueryParameter: OpenApiParameter = {
+  name: 'since',
+  in: 'query',
+  description: 'Only return runs with created_at >= this ISO 8601 timestamp. Defaults to 30 days ago.',
+  schema: stringSchema,
+}
+
+const runsListIncludeProbeQueryParameter: OpenApiParameter = {
+  name: 'includeProbe',
+  in: 'query',
+  description: 'Set to "1" or "true" to include probe runs. Probes are excluded by default because they are operator/agent test runs and must not pollute dashboard aggregates.',
+  schema: stringSchema,
+}
+
 const reportAudienceQueryParameter: OpenApiParameter = {
   name: 'audience',
   in: 'query',
@@ -756,6 +792,12 @@ const routeCatalog: OpenApiOperation[] = [
     path: '/api/v1/runs',
     summary: 'List all runs',
     tags: ['runs'],
+    parameters: [
+      limitQueryParameter,
+      runsListSinceQueryParameter,
+      runsListIncludeProbeQueryParameter,
+      runsListKindQueryParameter,
+    ],
     responses: {
       200: jsonArrayResponse('Runs returned.', 'RunDto'),
     },

--- a/packages/api-routes/src/runs.ts
+++ b/packages/api-routes/src/runs.ts
@@ -271,15 +271,23 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
   //   ?limit=N         — cap at N rows (default 500, max 5000)
   //   ?since=ISO       — only runs with created_at >= ISO (default 30d ago)
   //   ?includeProbe=1  — include probe runs (rarely needed; operator only)
+  //   ?kind=K          — restrict to a single run kind (e.g. 'answer-visibility').
+  //                      Critical for the dashboard: integration syncs
+  //                      (bing-inspect, gsc-sync, ga-sync) fire on cron and
+  //                      can easily fill the 500-row window in <1 hour,
+  //                      pushing the answer-visibility runs the dashboard
+  //                      actually needs off the response.
   app.get<{
-    Querystring: { limit?: string; since?: string; includeProbe?: string }
+    Querystring: { limit?: string; since?: string; includeProbe?: string; kind?: string }
   }>('/runs', async (request, reply) => {
     const limit = parseListLimit(request.query.limit, 500, 5000)
     const since = parseListSince(request.query.since)
     const includeProbe = request.query.includeProbe === '1' || request.query.includeProbe === 'true'
+    const kind = parseListKind(request.query.kind)
 
     const filters = [gte(runs.createdAt, since)]
     if (!includeProbe) filters.push(notProbeRun())
+    if (kind) filters.push(eq(runs.kind, kind))
 
     const rows = app.db
       .select()
@@ -431,6 +439,21 @@ function parseListLimit(raw: string | undefined, defaultValue: number, max: numb
     throw validationError('"limit" must be a positive integer')
   }
   return Math.min(parsed, max)
+}
+
+/**
+ * Parse the `?kind=` query param for `GET /runs`. Restricts the response to
+ * a single run kind. Returns `null` when the param is absent (no filter
+ * applied). Validates against the `RunKinds` enum so a typo produces a 400
+ * instead of silently returning empty.
+ */
+function parseListKind(raw: string | undefined): string | null {
+  if (raw === undefined || raw === '') return null
+  const validKinds = Object.values(RunKinds)
+  if (!validKinds.includes(raw as (typeof validKinds)[number])) {
+    throw validationError(`"kind" must be one of: ${validKinds.join(', ')}`)
+  }
+  return raw
 }
 
 /**

--- a/packages/api-routes/test/runs-list-filters.test.ts
+++ b/packages/api-routes/test/runs-list-filters.test.ts
@@ -1,0 +1,159 @@
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import Fastify from 'fastify'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createClient, migrate, projects, runs } from '@ainyc/canonry-db'
+import { apiRoutes } from '../src/index.js'
+
+/**
+ * Regression coverage for the dashboard's "Awaiting first run" bug:
+ *
+ * PR #580 (perf(dashboard): cap GET /runs) capped the response at 500 rows
+ * to stop the dashboard from pulling multi-MB JSON on cold load. On busy
+ * projects, integration syncs (bing-inspect, gsc-sync, ga-sync) fire on a
+ * tight cron and can fill that 500-row window in under an hour, pushing
+ * answer-visibility runs out of the response. The dashboard then has no
+ * latest-run-id to fan out from and renders every tracked query as
+ * "Awaiting first run" — even though the runs and snapshots exist.
+ *
+ * The `?kind=` filter lets the dashboard scope its query to just the run
+ * kind it actually consumes (`answer-visibility`), so integration syncs
+ * never displace what it needs. These tests pin that the server honours
+ * the filter and rejects typos rather than silently returning empty.
+ */
+
+interface Ctx {
+  app: ReturnType<typeof Fastify>
+  db: ReturnType<typeof createClient>
+  tmpDir: string
+  projectId: string
+  bingRunIds: string[]
+  answerVisibilityRunIds: string[]
+}
+
+function buildCtx(): Ctx {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-runs-filter-'))
+  const db = createClient(path.join(tmpDir, 'test.db'))
+  migrate(db)
+  const app = Fastify()
+  app.register(apiRoutes, { db, skipAuth: true })
+
+  const now = Date.now()
+  const projectId = crypto.randomUUID()
+  db.insert(projects).values({
+    id: projectId,
+    name: 'runs-filter',
+    displayName: 'Runs Filter',
+    canonicalDomain: 'example.com',
+    country: 'US',
+    language: 'en',
+    providers: ['openai'],
+    locations: [],
+    createdAt: new Date(now - 60_000).toISOString(),
+    updatedAt: new Date(now - 60_000).toISOString(),
+  }).run()
+
+  // Seed the exact pattern that breaks the dashboard: lots of integration
+  // sync runs created NEWER than the answer-visibility run. With a small
+  // cap (we use limit=10 in the test instead of the production 500), the
+  // unfiltered list returns only bing-inspect rows and zero
+  // answer-visibility rows. The filter must surface the older
+  // answer-visibility run anyway.
+  const bingRunIds: string[] = []
+  for (let i = 0; i < 20; i++) {
+    const id = crypto.randomUUID()
+    bingRunIds.push(id)
+    const createdAt = new Date(now - i * 1_000).toISOString() // newer than the AV run
+    db.insert(runs).values({
+      id,
+      projectId,
+      kind: 'bing-inspect',
+      status: 'completed',
+      trigger: 'manual',
+      startedAt: createdAt,
+      finishedAt: createdAt,
+      createdAt,
+    }).run()
+  }
+
+  const answerVisibilityRunIds: string[] = []
+  for (let i = 0; i < 3; i++) {
+    const id = crypto.randomUUID()
+    answerVisibilityRunIds.push(id)
+    const createdAt = new Date(now - 60_000 - i * 1_000).toISOString() // older than the bing runs
+    db.insert(runs).values({
+      id,
+      projectId,
+      kind: 'answer-visibility',
+      status: 'completed',
+      trigger: 'manual',
+      startedAt: createdAt,
+      finishedAt: createdAt,
+      createdAt,
+    }).run()
+  }
+
+  return { app, db, tmpDir, projectId, bingRunIds, answerVisibilityRunIds }
+}
+
+let ctx: Ctx
+
+beforeEach(() => { ctx = buildCtx() })
+afterEach(async () => {
+  await ctx.app.close()
+  fs.rmSync(ctx.tmpDir, { recursive: true, force: true })
+})
+
+async function get<T>(path: string): Promise<{ status: number; body: T }> {
+  const res = await ctx.app.inject({ method: 'GET', url: path })
+  return { status: res.statusCode, body: res.json() as T }
+}
+
+describe('GET /runs ?kind= filter', () => {
+  it('without the filter, a small limit returns only the newest kind (the bug)', async () => {
+    // Reproduces the production failure: the dashboard's unfiltered query
+    // can't see the answer-visibility runs because newer integration syncs
+    // fill the window.
+    const { body } = await get<Array<{ id: string; kind: string }>>(`/api/v1/runs?limit=10`)
+    expect(body).toHaveLength(10)
+    const kinds = new Set(body.map(r => r.kind))
+    expect(kinds.has('bing-inspect')).toBe(true)
+    expect(kinds.has('answer-visibility')).toBe(false)
+  })
+
+  it('?kind=answer-visibility returns the answer-visibility runs even when older', async () => {
+    const { status, body } = await get<Array<{ id: string; kind: string }>>(
+      `/api/v1/runs?limit=10&kind=answer-visibility`,
+    )
+    expect(status).toBe(200)
+    expect(body).toHaveLength(3)
+    expect(body.every(r => r.kind === 'answer-visibility')).toBe(true)
+    expect(new Set(body.map(r => r.id))).toEqual(new Set(ctx.answerVisibilityRunIds))
+  })
+
+  it('?kind=bing-inspect returns only bing runs', async () => {
+    const { body } = await get<Array<{ kind: string }>>(`/api/v1/runs?kind=bing-inspect`)
+    expect(body.length).toBeGreaterThan(0)
+    expect(body.every(r => r.kind === 'bing-inspect')).toBe(true)
+  })
+
+  it('?kind=<unknown> returns 400 with a clear error (not silently empty)', async () => {
+    // Silently returning an empty list on a typo would re-introduce the
+    // same class of bug — a misspelled filter giving the dashboard nothing
+    // looks identical to "no runs exist".
+    const { status, body } = await get<{ error: { code?: string; message?: string } }>(
+      `/api/v1/runs?kind=not-a-real-kind`,
+    )
+    expect(status).toBe(400)
+    const err = body as unknown as { error: { message?: string } }
+    expect(err.error.message).toMatch(/kind/i)
+  })
+
+  it('empty ?kind= behaves like no filter (returns all kinds)', async () => {
+    const { body } = await get<Array<{ kind: string }>>(`/api/v1/runs?kind=`)
+    const kinds = new Set(body.map(r => r.kind))
+    expect(kinds.size).toBeGreaterThan(1) // both bing-inspect and answer-visibility
+  })
+})


### PR DESCRIPTION
## Bug

After PR #580 capped \`GET /runs\` at 500 rows, the dashboard evidence panel started rendering every tracked query as **\"Awaiting first run\"** even on projects with completed sweeps and recent snapshots.

**azcoatings repro (diagnosed today):**

| Source | Result |
|---|---|
| \`cnry status azcoatings\` | 1,029 total runs, 25 completed \`answer-visibility\` |
| Direct API \`GET /runs/{latest-av-id}\` | 52 snapshots, 13 queries × 4 providers |
| Dashboard's \`GET /api/v1/runs\` (capped at 500) | **0** \`answer-visibility\` rows |

The 500-row window was 100% bing-inspect / ga-sync / gsc-sync from the last 36 minutes. Integration syncs fire on a tight cron and on a busy project they drown the sweep runs.

## Root cause

\`use-dashboard.ts\` filters for \`kind === 'answer-visibility'\` **client-side after** fetching all kinds. PR #580 added the cap server-side without telling the client to scope its query. Dashboard derivation:

1. Fetch unfiltered \`/runs\` → 500 rows, all integration syncs
2. Filter to \`answer-visibility\` → empty array
3. \`latestRunIds = []\` → \`latestRunDetails = []\`
4. \`buildEvidenceFromTimeline\` hits the \"saved query not seen in latest run\" branch at \`build-dashboard.ts:317\` → \"Awaiting first run\" for every query

## Fix

**Server (\`packages/api-routes/src/runs.ts\`):** \`GET /runs\` accepts \`?kind=<RunKind>\`. Additive, validated against the \`RunKinds\` enum (typo → 400, not silently empty — silent-empty would re-introduce the same class of bug). \`limit\` / \`since\` / \`includeProbe\` params (added in #580 but never documented) also added to the OpenAPI spec so the SDK regen surfaces them.

**Client (\`apps/web/src/queries/use-dashboard.ts\`):** Pass \`kind=answer-visibility\`. Per-project \`recentRuns\` widgets now only show sweep runs — integration-sync runs have dedicated Bing/GSC/GA pages plus \`cnry doctor\`, so removing them from the overview is a small UX win.

**Regression coverage (\`packages/api-routes/test/runs-list-filters.test.ts\`, 5 tests):** Seeds the exact production pattern — 20 newer integration runs + 3 older answer-visibility runs — and pins:
- Unfiltered + small limit returns only the newest kind (reproduces the bug)
- \`?kind=answer-visibility\` surfaces the older sweep runs
- \`?kind=<typo>\` → 400
- Empty \`?kind=\` behaves like no filter

## Verification

- \`pnpm typecheck\`: 0 errors
- \`pnpm test\`: **3126/3126 pass** (+5 new from this PR)
- \`pnpm lint\`: 0 errors, only pre-existing warnings (none in files I touched)
- \`pnpm gen\` clean — SDK type regenerated, includes \`kind\` param

## Follow-up

The proper fix per PR #580's own description (\"split \`useDashboard\` so the home page fetches 3 endpoints/project instead of 9\") is a half-day refactor and ships next as a separate PR. This hotfix unblocks the panel.

## Test plan

- [x] Open the dashboard, navigate to a project with completed sweeps; evidence panel populates instead of showing \"Awaiting first run\"
- [x] \`curl '\$API/runs?kind=answer-visibility'\` returns only answer-visibility rows
- [x] \`curl '\$API/runs?kind=not-a-kind'\` returns 400 with a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)