### PR TITLE
fix(web): ProjectPage hooks-order violation crashing on cache key change

### DIFF
--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -71,7 +71,7 @@ import { GSC_STALE_MS } from '../queries/query-client.js'
 import { useDashboard } from '../queries/use-dashboard.js'
 import { useDrawer } from '../hooks/use-drawer.js'
 import { findProjectVm } from '../mock-data.js'
-import type { ProjectCommandCenterVm, RunHistoryPoint } from '../view-models.js'
+import type { DashboardVm, ProjectCommandCenterVm, RunHistoryPoint } from '../view-models.js'
 
 export type ProjectPageTab = 'overview' | 'search-console' | 'discovery' | 'report' | 'activity' | 'backlinks' | 'settings'
 
@@ -1373,15 +1373,23 @@ function SuggestedQueriesCard({
   )
 }
 
-export function ProjectPage({
-  tab,
-}: {
-  tab: ProjectPageTab
-}) {
-  const { projectId } = useParams({ from: '/projects/$projectId' })
-  const navigate = useNavigate()
+/**
+ * Thin shell that guards on dashboard readiness. The real component
+ * (`ProjectPageContent`) declares all the page's ~60 hooks, and React
+ * requires the same hook count on every render of a given component
+ * instance. Previously the body called `useDashboard()` and then
+ * early-returned the skeleton ABOVE the rest of the hook calls — fine
+ * on every render where data was already cached, but as soon as the
+ * runs-query cache key changed (PR #590) the first render landed in
+ * the loading branch (few hooks) and the second in the loaded branch
+ * (all hooks), tripping React error #310 ("rendered more hooks").
+ *
+ * Splitting the conditional into a parent component keeps the inner
+ * hook count constant: the parent renders either skeleton OR content,
+ * never partially through the content's hooks.
+ */
+export function ProjectPage(props: { tab: ProjectPageTab }) {
   const { dashboard, isLoading, refetch } = useDashboard()
-  const queryClient = useQueryClient()
 
   if (!dashboard || isLoading) {
     return (
@@ -1409,6 +1417,22 @@ export function ProjectPage({
       </div>
     )
   }
+
+  return <ProjectPageContent dashboard={dashboard} refetch={refetch} {...props} />
+}
+
+function ProjectPageContent({
+  tab,
+  dashboard,
+  refetch,
+}: {
+  tab: ProjectPageTab
+  dashboard: DashboardVm
+  refetch: () => Promise<void>
+}) {
+  const { projectId } = useParams({ from: '/projects/$projectId' })
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
 
   const model = findProjectVm(dashboard, projectId)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)


### PR DESCRIPTION
## Production crash

Users hit **React error #310** (\"rendered more hooks than during the previous render\") on the project page after PR #590 deployed.

\`\`\`
Minified React error #310; visit https://react.dev/errors/310 ...
\`\`\`

## Root cause: long-standing rules-of-hooks bug

\`ProjectPage\` called \`useDashboard()\` and then early-returned a loading skeleton at line 1386, **before** ~30 \`useState\` / \`useMemo\` calls below it.

- **Before PR #590:** users always had cached dashboard data on first render → \`isLoading=false\` → the guard never fired → all ~70 hooks called every render → React happy.
- **After PR #590:** the runs-query cache key changed (added \`kind=answer-visibility\`), invalidating existing browser caches. First render now hit \`isLoading=true\` → skeleton returned → only ~3 hooks called. Data resolved → re-render with \`isLoading=false\` → all ~70 hooks called → **hook count mismatch → React crashes the page.**

This was a latent bug PR #590 surfaced, not a bug introduced by PR #590.

## Fix: wrapper + content split

The canonical React pattern for \"guard on async data without hook-count drift\":

\`\`\`tsx
function ProjectPage(props) {
  const { dashboard, isLoading, refetch } = useDashboard()
  if (!dashboard || isLoading) return <Skeleton />
  return <ProjectPageContent dashboard={dashboard} refetch={refetch} {...props} />
}

function ProjectPageContent({ dashboard, refetch, tab }) {
  // ~70 hooks here, dashboard guaranteed non-null
}
\`\`\`

Each component instance now has a constant hook count. The outer wrapper renders skeleton OR content — never partway through content's hooks. The inner component only mounts after data is ready.

## Verification

- \`pnpm typecheck\`: 0 errors
- \`pnpm test\`: **3126/3126 pass**
- \`pnpm lint\`: 0 errors, 0 new warnings

## Test plan

- [ ] Clear browser cache / hard-refresh
- [ ] Navigate to \`/projects/<any-project-id>\`
- [ ] Verify: skeleton briefly shows, then full page renders without crash
- [ ] Open DevTools console, confirm no React error #310

## Follow-up

The same hooks-after-early-return pattern likely exists on other pages. Worth a focused audit to find others before they regress. Candidates: any page with \`useDashboard\` / \`useQuery\` followed by an early-return loading branch above other hooks. Quick grep:

\`\`\`bash
grep -A3 \"useDashboard\\|useQuery\" apps/web/src/pages/*.tsx | grep \"return.*Skeleton\\|return.*skeleton\"
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)