### PR TITLE
feat(web): status-class filter (2xx/3xx/4xx/5xx) on traffic source detail

### DIFF
--- a/apps/web/src/lib/traffic-event-filter.ts
+++ b/apps/web/src/lib/traffic-event-filter.ts
@@ -2,11 +2,36 @@ import { TrafficEventKinds, type TrafficEventEntry } from '@ainyc/canonry-contra
 
 export type EventGranularity = 'hour' | 'day'
 
+/**
+ * Status-class filter values. `'all'` is the no-op default. The numbered
+ * values match an HTTP status's hundreds digit so the filter check is a
+ * cheap `Math.floor(status / 100)` comparison instead of a range lookup.
+ */
+export type StatusClassFilter = 'all' | '2xx' | '3xx' | '4xx' | '5xx'
+
+export const STATUS_CLASS_OPTIONS: ReadonlyArray<{ value: StatusClassFilter; label: string }> = [
+  { value: 'all', label: 'All status' },
+  { value: '2xx', label: '2xx success' },
+  { value: '3xx', label: '3xx redirect' },
+  { value: '4xx', label: '4xx client error' },
+  { value: '5xx', label: '5xx server error' },
+]
+
 export interface TrafficEventFilters {
   selectedBucket: string | null
   identity: string
   operator: string
   pathQuery: string
+  statusClass: StatusClassFilter
+}
+
+/**
+ * `'5xx'` → `5`. Returns null when the filter is `'all'` so callers can
+ * skip the check entirely.
+ */
+function statusClassDigit(filter: StatusClassFilter): number | null {
+  if (filter === 'all') return null
+  return Number.parseInt(filter[0]!, 10)
 }
 
 export function identityOf(event: TrafficEventEntry): string {
@@ -32,11 +57,13 @@ export function filterTrafficEvents(
   granularity: EventGranularity,
 ): TrafficEventEntry[] {
   const needle = filters.pathQuery.trim().toLowerCase()
+  const statusDigit = statusClassDigit(filters.statusClass)
   return events.filter((event) => {
     if (filters.selectedBucket && bucketKeyFor(event.tsHour, granularity) !== filters.selectedBucket) return false
     if (filters.identity && identityOf(event) !== filters.identity) return false
     if (filters.operator && event.operator !== filters.operator) return false
     if (needle && !pathOf(event).toLowerCase().includes(needle)) return false
+    if (statusDigit !== null && Math.floor(event.status / 100) !== statusDigit) return false
     return true
   })
 }

--- a/apps/web/src/pages/TrafficSourceDetailPage.tsx
+++ b/apps/web/src/pages/TrafficSourceDetailPage.tsx
@@ -35,7 +35,9 @@ import {
   bucketKeyFor,
   filterTrafficEvents,
   identityOf,
+  STATUS_CLASS_OPTIONS,
   type EventGranularity,
+  type StatusClassFilter,
 } from '../lib/traffic-event-filter.js'
 
 type SeriesKind = 'crawler' | 'ai-referral'
@@ -143,6 +145,7 @@ export function TrafficSourceDetailPage() {
   const [identityFilter, setIdentityFilter] = useState<string>('')
   const [operatorFilter, setOperatorFilter] = useState<string>('')
   const [pathFilter, setPathFilter] = useState<string>('')
+  const [statusClassFilter, setStatusClassFilter] = useState<StatusClassFilter>('all')
   const [syncError, setSyncError] = useState<string | null>(null)
   const [syncResult, setSyncResult] = useState<string | null>(null)
 
@@ -197,10 +200,11 @@ export function TrafficSourceDetailPage() {
           identity: identityFilter,
           operator: operatorFilter,
           pathQuery: pathFilter,
+          statusClass: statusClassFilter,
         },
         activeWindow.granularity,
       ),
-    [visibleEvents, selectedBucket, identityFilter, operatorFilter, pathFilter, activeWindow.granularity],
+    [visibleEvents, selectedBucket, identityFilter, operatorFilter, pathFilter, statusClassFilter, activeWindow.granularity],
   )
 
   const selectedBucketLabel = useMemo(
@@ -236,9 +240,12 @@ export function TrafficSourceDetailPage() {
     setIdentityFilter('')
     setOperatorFilter('')
     setPathFilter('')
+    setStatusClassFilter('all')
   }
 
-  const hasRowFilter = Boolean(selectedBucket || identityFilter || operatorFilter || pathFilter.trim())
+  const hasRowFilter = Boolean(
+    selectedBucket || identityFilter || operatorFilter || pathFilter.trim() || statusClassFilter !== 'all',
+  )
 
   const handleSync = async () => {
     setSyncError(null)
@@ -504,6 +511,18 @@ export function TrafficSourceDetailPage() {
                 </option>
               ))}
             </select>
+            <select
+              aria-label="Filter by HTTP status class"
+              value={statusClassFilter}
+              onChange={(e) => setStatusClassFilter(e.target.value as StatusClassFilter)}
+              className="rounded-md border border-zinc-800 bg-zinc-950 px-2.5 py-1.5 text-xs text-zinc-200 focus:outline-none focus-visible:ring-1 focus-visible:ring-zinc-600"
+            >
+              {STATUS_CLASS_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
             <input
               type="search"
               aria-label="Filter by path"
@@ -528,6 +547,12 @@ export function TrafficSourceDetailPage() {
             ) : null}
             {pathFilter.trim() ? (
               <ActiveFilterPill label={`Path: ${pathFilter.trim()}`} onClear={() => setPathFilter('')} />
+            ) : null}
+            {statusClassFilter !== 'all' ? (
+              <ActiveFilterPill
+                label={`Status: ${statusClassFilter}`}
+                onClear={() => setStatusClassFilter('all')}
+              />
             ) : null}
             <button
               type="button"

--- a/apps/web/test/traffic-event-filter.test.ts
+++ b/apps/web/test/traffic-event-filter.test.ts
@@ -75,25 +75,31 @@ describe('bucketKeyFor', () => {
 
 describe('filterTrafficEvents', () => {
   const events: TrafficEventEntry[] = [
-    crawler({ tsHour: '2026-05-07T02:00:00.000Z', botId: 'GPTBot', operator: 'OpenAI', pathNormalized: '/sitemap.xml' }),
-    crawler({ tsHour: '2026-05-07T03:00:00.000Z', botId: 'anthropic-claudebot', operator: 'Anthropic', pathNormalized: '/robots.txt' }),
-    aiReferral({ tsHour: '2026-05-08T05:00:00.000Z', product: 'ChatGPT', operator: 'OpenAI', landingPathNormalized: '/blog/post' }),
-    aiReferral({ tsHour: '2026-05-07T02:00:00.000Z', product: 'Perplexity', operator: 'Perplexity', landingPathNormalized: '/sitemap.xml' }),
+    crawler({ tsHour: '2026-05-07T02:00:00.000Z', botId: 'GPTBot', operator: 'OpenAI', pathNormalized: '/sitemap.xml', status: 200 }),
+    crawler({ tsHour: '2026-05-07T03:00:00.000Z', botId: 'anthropic-claudebot', operator: 'Anthropic', pathNormalized: '/robots.txt', status: 404 }),
+    aiReferral({ tsHour: '2026-05-08T05:00:00.000Z', product: 'ChatGPT', operator: 'OpenAI', landingPathNormalized: '/blog/post', status: 301 }),
+    aiReferral({ tsHour: '2026-05-07T02:00:00.000Z', product: 'Perplexity', operator: 'Perplexity', landingPathNormalized: '/sitemap.xml', status: 500 }),
   ]
 
+  // Default filter shape — keeps each test focused on the field it's
+  // exercising instead of repeating the full object literal.
+  const defaults = (): import('../src/lib/traffic-event-filter.js').TrafficEventFilters => ({
+    selectedBucket: null,
+    identity: '',
+    operator: '',
+    pathQuery: '',
+    statusClass: 'all',
+  })
+
   test('returns all events when no filters set', () => {
-    const result = filterTrafficEvents(
-      events,
-      { selectedBucket: null, identity: '', operator: '', pathQuery: '' },
-      'hour',
-    )
+    const result = filterTrafficEvents(events, defaults(), 'hour')
     expect(result.length).toBe(4)
   })
 
   test('filters by selected bucket at hour granularity', () => {
     const result = filterTrafficEvents(
       events,
-      { selectedBucket: '2026-05-07T02:00:00.000Z', identity: '', operator: '', pathQuery: '' },
+      { ...defaults(), selectedBucket: '2026-05-07T02:00:00.000Z' },
       'hour',
     )
     expect(result.length).toBe(2)
@@ -101,48 +107,38 @@ describe('filterTrafficEvents', () => {
   })
 
   test('filters by identity (covers both crawler.botId and ai-referral.product)', () => {
-    const result = filterTrafficEvents(
-      events,
-      { selectedBucket: null, identity: 'Perplexity', operator: '', pathQuery: '' },
-      'hour',
-    )
+    const result = filterTrafficEvents(events, { ...defaults(), identity: 'Perplexity' }, 'hour')
     expect(result.length).toBe(1)
     expect(identityOf(result[0]!)).toBe('Perplexity')
   })
 
   test('filters by operator', () => {
-    const result = filterTrafficEvents(
-      events,
-      { selectedBucket: null, identity: '', operator: 'OpenAI', pathQuery: '' },
-      'hour',
-    )
+    const result = filterTrafficEvents(events, { ...defaults(), operator: 'OpenAI' }, 'hour')
     expect(result.length).toBe(2)
     expect(result.every((e) => e.operator === 'OpenAI')).toBe(true)
   })
 
   test('filters path with case-insensitive substring match', () => {
-    const result = filterTrafficEvents(
-      events,
-      { selectedBucket: null, identity: '', operator: '', pathQuery: 'SITEMAP' },
-      'hour',
-    )
+    const result = filterTrafficEvents(events, { ...defaults(), pathQuery: 'SITEMAP' }, 'hour')
     expect(result.length).toBe(2)
     expect(result.every((e) => pathOf(e).includes('/sitemap.xml'))).toBe(true)
   })
 
   test('trims path query whitespace', () => {
-    const result = filterTrafficEvents(
-      events,
-      { selectedBucket: null, identity: '', operator: '', pathQuery: '   ' },
-      'hour',
-    )
+    const result = filterTrafficEvents(events, { ...defaults(), pathQuery: '   ' }, 'hour')
     expect(result.length).toBe(4)
   })
 
   test('combines all filters with AND semantics', () => {
     const result = filterTrafficEvents(
       events,
-      { selectedBucket: '2026-05-07T02:00:00.000Z', identity: 'GPTBot', operator: 'OpenAI', pathQuery: 'sitemap' },
+      {
+        selectedBucket: '2026-05-07T02:00:00.000Z',
+        identity: 'GPTBot',
+        operator: 'OpenAI',
+        pathQuery: 'sitemap',
+        statusClass: 'all',
+      },
       'hour',
     )
     expect(result.length).toBe(1)
@@ -152,10 +148,48 @@ describe('filterTrafficEvents', () => {
   test('returns empty when conflicting filters match nothing', () => {
     const result = filterTrafficEvents(
       events,
-      { selectedBucket: '2026-05-07T02:00:00.000Z', identity: 'anthropic-claudebot', operator: '', pathQuery: '' },
+      { ...defaults(), selectedBucket: '2026-05-07T02:00:00.000Z', identity: 'anthropic-claudebot' },
       'hour',
     )
     expect(result).toEqual([])
+  })
+
+  test('statusClass filter buckets events by hundreds digit', () => {
+    // 2xx — only the GPTBot/sitemap event (status 200) survives.
+    const twos = filterTrafficEvents(events, { ...defaults(), statusClass: '2xx' }, 'hour')
+    expect(twos.length).toBe(1)
+    expect(twos[0]!.status).toBe(200)
+
+    // 3xx — only the ChatGPT/blog event (status 301).
+    const threes = filterTrafficEvents(events, { ...defaults(), statusClass: '3xx' }, 'hour')
+    expect(threes.length).toBe(1)
+    expect(threes[0]!.status).toBe(301)
+
+    // 4xx — only the ClaudeBot/robots event (status 404).
+    const fours = filterTrafficEvents(events, { ...defaults(), statusClass: '4xx' }, 'hour')
+    expect(fours.length).toBe(1)
+    expect(fours[0]!.status).toBe(404)
+
+    // 5xx — only the Perplexity/sitemap event (status 500).
+    const fives = filterTrafficEvents(events, { ...defaults(), statusClass: '5xx' }, 'hour')
+    expect(fives.length).toBe(1)
+    expect(fives[0]!.status).toBe(500)
+
+    // 'all' is the no-op default.
+    const all = filterTrafficEvents(events, { ...defaults(), statusClass: 'all' }, 'hour')
+    expect(all.length).toBe(4)
+  })
+
+  test('statusClass composes with other filters (AND semantics)', () => {
+    // Both sitemap.xml events (200 and 500). Adding statusClass='2xx'
+    // narrows to just the 200.
+    const result = filterTrafficEvents(
+      events,
+      { ...defaults(), pathQuery: 'sitemap', statusClass: '2xx' },
+      'hour',
+    )
+    expect(result.length).toBe(1)
+    expect(result[0]!.status).toBe(200)
   })
 })
 


### PR DESCRIPTION
## Two things in one ask

You asked what \`claimed_unverified\` means and asked for a status-code filter. The first is just documentation (covered in chat — UA matched our rule list but not yet IP/rDNS verified; spoofable per-request, trustworthy in aggregate). The second is this PR.

## Status-class filter

New dropdown between the operator filter and the path search:

- All status (default — no-op)
- 2xx success
- 3xx redirect
- 4xx client error
- 5xx server error

Bucketed by hundreds digit rather than per-distinct-code because:

- There are usually only a handful of distinct codes per source. A flat dropdown would be sparse.
- \"Show me errors\" is the load-bearing question, not \"show me 418\".
- \`Math.floor(status / 100)\` keeps the comparison cheap on large windows.

## Diff scope

- **\`apps/web/src/lib/traffic-event-filter.ts\`** — \`TrafficEventFilters\` gets a \`statusClass\` field. \`STATUS_CLASS_OPTIONS\` is the dropdown source-of-truth so the page doesn't hand-roll labels. \`filterTrafficEvents\` applies the new field.
- **\`apps/web/src/pages/TrafficSourceDetailPage.tsx\`** — dropdown + active-filter pill + \`clearAllFilters\` updated to reset it.
- **\`apps/web/test/traffic-event-filter.test.ts\`** — 2 new test cases (per-class bucketing + composition with pathQuery). Existing 8 cases refactored to use a \`defaults()\` helper so future fields don't force every test to spell out the full filter object.

## Verification

- \`pnpm typecheck\`: 0 errors
- \`pnpm test\`: **3149 / 3149 pass** (+2 new + 8 refactored)
- \`pnpm lint\`: clean
- SPA rebuilt + server restarted on localhost:4100

## Test plan

- [ ] Open \`/traffic/<project>/<sourceId>\`
- [ ] Pick \`4xx client error\` from the new dropdown
- [ ] Confirm only events with status 4xx remain in the table; the active-filter pill \"Status: 4xx\" appears
- [ ] Click \"Clear all\" — filter resets to \"All status\"
- [ ] Combine with the path filter (e.g. \`pathQuery: /robots.txt\` + \`statusClass: 2xx\`) — AND semantics apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)