### PR TITLE
fix(traffic): use ARIN-allocated Anthropic blocks (incl. AWS-ANTHROPIC) for IP verification

### DIFF
--- a/packages/integration-traffic/src/ip-ranges/anthropic.json
+++ b/packages/integration-traffic/src/ip-ranges/anthropic.json
@@ -1,10 +1,10 @@
 {
-  "_source": "bgp.tools AS399358 + AS60808 (both registered to Anthropic, PBC)",
-  "_notes": "Anthropic does not publish a clean machine-readable IP-range JSON like Google or OpenAI do. These prefixes are the BGP-announced ranges for Anthropic's two ASNs, cross-checked against ARIN RDAP (handle ANTHR5-ARIN allocated 2023-07-31). 160.79.104.0/23 is the range consistently seen in webmaster logs for ClaudeBot crawler traffic; the others are included to cover Anthropic infrastructure as a whole, since the verification gate also requires a ClaudeBot UA match. Refresh by re-running bgp.tools/as/399358 + bgp.tools/as/60808.",
+  "_source": "ARIN RDAP — every network registered to Anthropic, PBC (handle AP-2440)",
+  "_query": "https://rdap.arin.net/registry/entity/AP-2440",
+  "_notes": "Anthropic does not publish a clean machine-readable IP-range JSON like Google or OpenAI do. These prefixes are taken straight from ARIN's authoritative allocation records (NOT bgp.tools' AS-based view, which can include misleading announcements — e.g. AS60808 is registered to Anthropic but announces 209.249.57.0/24 which actually belongs to Mitel Networks). 216.73.216.0/22 (AWS-ANTHROPIC) is the load-bearing prefix — empirical Cloud Run logs show 100% of real ClaudeBot traffic comes from there; the other two are Anthropic's own allocations for non-crawler infra (kept since the verification gate still requires a Claude-* UA match). Refresh by re-running the ARIN RDAP query above and replacing the prefix list.",
   "prefixes": [
-    { "ipv4Prefix": "160.79.104.0/23" },
-    { "ipv4Prefix": "209.249.57.0/24" },
-    { "ipv6Prefix": "2607:6bc0::/48" },
-    { "ipv6Prefix": "2607:6bc0:11::/48" }
+    { "ipv4Prefix": "216.73.216.0/22" },
+    { "ipv4Prefix": "160.79.104.0/21" },
+    { "ipv6Prefix": "2607:6bc0::/32" }
   ]
 }

--- a/packages/integration-traffic/src/ip-verify.ts
+++ b/packages/integration-traffic/src/ip-verify.ts
@@ -17,9 +17,11 @@
  *   - OpenAI OAI-SearchBot   (openai.com/searchbot.json)
  *   - PerplexityBot          (www.perplexity.ai/perplexitybot.json)
  *   - Perplexity-User        (www.perplexity.ai/perplexity-user.json)
- *   - ClaudeBot              (bgp.tools AS399358 + AS60808 — Anthropic
- *                             does not ship a JSON; we use the
- *                             BGP-announced prefixes for its two ASNs)
+ *   - ClaudeBot              (ARIN RDAP — Anthropic does not ship a
+ *                             machine-readable JSON; we use the three
+ *                             networks registered to Anthropic, PBC
+ *                             at ARIN. The crawler block is
+ *                             AWS-ANTHROPIC 216.73.216.0/22.)
  *
  * **Not covered (yet).** Meta, ByteDance, Apple, DeepSeek, Mistral,
  * DuckDuckGo, Yandex, Baidu, Amazon — these either don't publish a
@@ -94,12 +96,13 @@ const RULE_ID_TO_RANGES: Record<string, RawIpRanges> = {
   'perplexity-user': perplexityUserRaw as RawIpRanges,
 
   // Anthropic — no machine-readable JSON published. The bundled
-  // anthropic.json is the BGP-announced prefix list for the two ASNs
-  // ARIN has registered to "Anthropic, PBC", refreshed by hand from
-  // bgp.tools when those announcements change. Same raw set covers
-  // every Claude-* UA the classifier can emit.
-  // src: https://bgp.tools/as/399358 + https://bgp.tools/as/60808
-  // (verified against ARIN RDAP handle ANTHR5-ARIN)
+  // anthropic.json is the set of networks registered to Anthropic,
+  // PBC at ARIN (the authoritative allocation record). Maintained by
+  // hand; refresh by re-querying the ARIN entity below. The crawler
+  // block is AWS-ANTHROPIC 216.73.216.0/22 — empirical Cloud Run
+  // logs show all real ClaudeBot traffic comes from there. Same raw
+  // set is shared across every Claude-* UA the classifier emits.
+  // src: https://rdap.arin.net/registry/entity/AP-2440
   'anthropic-claudebot': anthropicRaw as RawIpRanges,
 }
 

--- a/packages/integration-traffic/test/analysis.test.ts
+++ b/packages/integration-traffic/test/analysis.test.ts
@@ -71,13 +71,13 @@ describe('traffic analysis', () => {
     })
   })
 
-  it('promotes ClaudeBot to `verified` when the IP is in Anthropic\'s bundled prefixes', () => {
-    // 160.79.104.0/23 is in the bundled anthropic.json (BGP-announced
-    // by Anthropic's AS399358). A ClaudeBot UA from that range is the
-    // real crawler.
+  it('promotes ClaudeBot to `verified` when the IP is in Anthropic\'s AWS-allocated crawler prefix', () => {
+    // 216.73.216.0/22 is the AWS-ANTHROPIC ARIN allocation —
+    // empirical Cloud Run logs (canonry-landing 5/2026) show every
+    // real ClaudeBot request comes from here.
     expect(classifyCrawler(event({
       userAgent: 'Mozilla/5.0 (compatible; ClaudeBot/1.0; +claudebot@anthropic.com)',
-      remoteIp: '160.79.104.42',
+      remoteIp: '216.73.216.76',
     }))).toMatchObject({
       botId: 'anthropic-claudebot',
       verificationStatus: 'verified',

--- a/packages/integration-traffic/test/ip-verify.test.ts
+++ b/packages/integration-traffic/test/ip-verify.test.ts
@@ -138,22 +138,31 @@ describe('verifyIpForRule', () => {
   })
 
   it('verifies a known Anthropic ClaudeBot IPv4 inside the bundled prefix', () => {
-    // 160.79.104.0/23 is the AS399358 prefix bundled in
-    // anthropic.json. Pick an address inside it.
+    // 216.73.216.0/22 is the AWS-ANTHROPIC prefix — empirical Cloud
+    // Run logs show all real ClaudeBot traffic comes from here.
+    expect(verifyIpForRule('216.73.216.76', 'anthropic-claudebot')).toBe(true)
+    expect(verifyIpForRule('216.73.217.125', 'anthropic-claudebot')).toBe(true)
+    expect(verifyIpForRule('216.73.219.255', 'anthropic-claudebot')).toBe(true)
+    // 160.79.104.0/21 is Anthropic's own ARIN allocation.
     expect(verifyIpForRule('160.79.104.5', 'anthropic-claudebot')).toBe(true)
-    // 209.249.57.0/24 (AS60808) is also Anthropic — bundled too.
-    expect(verifyIpForRule('209.249.57.10', 'anthropic-claudebot')).toBe(true)
+    expect(verifyIpForRule('160.79.111.254', 'anthropic-claudebot')).toBe(true)
   })
 
   it('does not verify a random IP outside Anthropic prefixes', () => {
     expect(verifyIpForRule('1.2.3.4', 'anthropic-claudebot')).toBe(false)
-    // Adjacent /23 outside the allocation — must not match.
-    expect(verifyIpForRule('160.79.106.1', 'anthropic-claudebot')).toBe(false)
+    // Adjacent /22 outside the AWS-ANTHROPIC allocation.
+    expect(verifyIpForRule('216.73.220.1', 'anthropic-claudebot')).toBe(false)
+    // Adjacent /21 outside Anthropic's own allocation.
+    expect(verifyIpForRule('160.79.112.1', 'anthropic-claudebot')).toBe(false)
+    // bgp.tools had once attributed 209.249.57.0/24 to Anthropic's
+    // AS60808; ARIN says it's Mitel Networks. Must NOT verify.
+    expect(verifyIpForRule('209.249.57.10', 'anthropic-claudebot')).toBe(false)
   })
 
-  it('verifies Anthropic IPv6 (AS399358 announces v6 too)', () => {
+  it('verifies Anthropic IPv6 (entire /32 ANTHROPIC-V6 allocation)', () => {
     expect(verifyIpForRule('2607:6bc0::1', 'anthropic-claudebot')).toBe(true)
     expect(verifyIpForRule('2607:6bc0:11::cafe', 'anthropic-claudebot')).toBe(true)
+    expect(verifyIpForRule('2607:6bc0:ffff:ffff::1', 'anthropic-claudebot')).toBe(true)
   })
 
   it('returns false for a rule id without published ranges', () => {


### PR DESCRIPTION
## Summary

- Empirical Cloud Run logs from `canonry-landing` and `openclaw-nyc` show **100% of real ClaudeBot traffic comes from `216.73.216.0/22`** (an ARIN-allocated block named `AWS-ANTHROPIC`, registered directly to Anthropic, PBC). With the previous bgp.tools-derived ranges (`160.79.104.0/23` etc.), every legit ClaudeBot hit was landing as `claimed_unverified` because the actual crawler infra isn't in Anthropic's own ASN announcements — it's in AWS-allocated space.
- Replace the bgp.tools-derived ranges with the three networks ARIN registers to Anthropic, PBC (handle `AP-2440`):
  - `216.73.216.0/22`  — AWS-ANTHROPIC, the crawler block
  - `160.79.104.0/21`  — Anthropic's own IPv4 allocation (widened from the partial /23 BGP announcement)
  - `2607:6bc0::/32`   — ANTHROPIC-V6 (widened from two /48 slices)
- Drop `209.249.57.0/24` — bgp.tools said AS60808 was Anthropic and announces that prefix, but ARIN says the block actually belongs to **Mitel Networks**. Trust ARIN's allocation record over BGP announcements as the ownership source of truth.

## Test plan
- [x] `pnpm --filter @ainyc/canonry-integration-traffic test` (49 passing)
- [x] Verified `216.73.216.76` (a real ClaudeBot IP from `canonry-landing` logs) now classifies as `verified`
- [ ] After merge + deploy + backfill, confirm Anthropic verified count goes from 0 → non-zero on the `canonry.ai` / `ainyc` traffic source detail pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)