### PR TITLE
fix(web): refresh project page after adding queries / competitors

### DIFF
--- a/apps/web/src/queries/mutations.ts
+++ b/apps/web/src/queries/mutations.ts
@@ -261,16 +261,29 @@ export function useTriggerInspectSitemap() {
 }
 
 /**
- * Predicate matching the per-project dashboard detail query keys (shape
- * `['projects', projectId, latestRunIdsKey]` — see `use-dashboard.ts`).
- * Used by mutations that change project-scoped state which is rendered out
- * of that composite query (suggested queries, content recommendations,
- * etc.) so the dashboard refetches and the UI reflects the new state.
+ * Predicate matching the per-project dashboard detail query keys. Two
+ * composite hooks build the project page today and both need to be
+ * invalidated when project-scoped state changes (queries, competitors,
+ * dismissed recommendations, etc.):
+ *
+ *   - `useDashboard` (legacy portfolio-wide) — key shape
+ *     `['projects', projectId, latestRunIdsKey]` from `use-dashboard.ts`.
+ *   - `useProjectDashboard` (current per-project, used by `ProjectPage`)
+ *     — key shape `['project-dashboard-full', projectId, latestRunIdsKey]`
+ *     from `use-project-dashboard.ts`. The split was added in
+ *     `use-project-dashboard.ts` to avoid the per-project fan-out tax
+ *     that the legacy hook paid on every dashboard mount.
+ *
+ * When the project hook was added, this predicate was not updated and
+ * silently stopped matching the per-project page, so newly-added queries
+ * / competitors didn't appear until the user reloaded the page or the
+ * 30-minute staleTime expired. Keep both prefixes in the allow-list
+ * until the legacy hook is fully removed.
  */
-function isProjectDetailQuery(query: { queryKey: readonly unknown[] }): boolean {
-  return Array.isArray(query.queryKey)
-    && query.queryKey[0] === 'projects'
-    && query.queryKey.length > 1
+export function isProjectDetailQuery(query: { queryKey: readonly unknown[] }): boolean {
+  if (!Array.isArray(query.queryKey) || query.queryKey.length <= 1) return false
+  const head: unknown = query.queryKey[0]
+  return head === 'projects' || head === 'project-dashboard-full'
 }
 
 export function useAppendQueries() {

--- a/apps/web/test/project-detail-invalidation.test.ts
+++ b/apps/web/test/project-detail-invalidation.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { isProjectDetailQuery } from '../src/queries/mutations.js'
+
+/**
+ * Regression test for the project-page-stops-refreshing bug fixed in this
+ * change. The `useAppendQueries` / `useDismissContentTarget` mutations use
+ * `isProjectDetailQuery` to invalidate the composite dashboard cache after
+ * a write. When `useProjectDashboard` was split out of the legacy
+ * `useDashboard` hook, it changed its cache-key prefix from `'projects'`
+ * to `'project-dashboard-full'` but the predicate wasn't updated — so
+ * newly-added queries / competitors stayed invisible on the project page
+ * until a 30-minute staleTime expired.
+ *
+ * Locking both prefixes in here so a future key rename can't silently
+ * resurrect the same bug.
+ */
+describe('isProjectDetailQuery', () => {
+  function q(key: readonly unknown[]) {
+    return { queryKey: key }
+  }
+
+  it('matches the per-project dashboard key (current — useProjectDashboard)', () => {
+    expect(isProjectDetailQuery(q(['project-dashboard-full', 'project-id', 'run-ids-key']))).toBe(true)
+    expect(isProjectDetailQuery(q(['project-dashboard-full', null, 'none']))).toBe(true)
+  })
+
+  it('matches the legacy portfolio-wide key (useDashboard)', () => {
+    expect(isProjectDetailQuery(q(['projects', 'project-id', 'run-ids-key']))).toBe(true)
+  })
+
+  it('does not match the slim portfolio overview (useDashboardOverview)', () => {
+    // The overview row is invalidated separately by its consumers; we
+    // don't want every query/competitor write to churn it.
+    expect(isProjectDetailQuery(q(['project-overview-slim', 'project-id', 'cache-bust']))).toBe(false)
+  })
+
+  it('does not match generated SDK query keys (object head with `_id`)', () => {
+    // The generated SDK uses `[{ _id: 'getApiV1...' }, ...]`. Mutations
+    // that need to invalidate generated keys do so with their own
+    // predicate; this one is for the hand-rolled tuple keys.
+    expect(isProjectDetailQuery(q([{ _id: 'getApiV1ProjectsByName' }, { name: 'p' }]))).toBe(false)
+  })
+
+  it('does not match the top-level projects-list key', () => {
+    // Just `'projects'` with no projectId tail is the legacy portfolio
+    // list, not the per-project detail.
+    expect(isProjectDetailQuery(q(['projects']))).toBe(false)
+  })
+
+  it('does not match unrelated tuple keys', () => {
+    expect(isProjectDetailQuery(q(['runs', 'run-id']))).toBe(false)
+    expect(isProjectDetailQuery(q(['something-else']))).toBe(false)
+    expect(isProjectDetailQuery(q([]))).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- Newly-added queries and competitors on the project page weren't appearing until the 30-minute `STATIC_VISIBILITY_STALE_MS` expired or the user reloaded.
- Root cause: `isProjectDetailQuery` predicate in `mutations.ts` matched only the legacy `useDashboard` cache key `['projects', projectId, ...]`. When `useProjectDashboard` was split out as a per-project hook (to avoid the portfolio-wide fan-out tax), its key prefix became `'project-dashboard-full'` but the predicate wasn't updated. Three mutations silently stopped refreshing the project page: `useAppendQueries`, `useDismissContentTarget`, `useUndismissContentTarget`.
- Widen the predicate to match both prefixes and lock with a regression test so the next rename can't resurrect the same bug.

## Test plan
- [x] `pnpm vitest run --project web` — 213 passing, including 6 new cases in `project-detail-invalidation.test.ts`
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (0 errors)
- [ ] Manual: load a project page, click "Add query" in the inline editor, confirm the new query appears in the table without a reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)