### PR TITLE
feat(serve): fail loud when DB or config is deleted under a running daemon

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,8 @@ Each check returns `status: ok | warn | fail | skipped`, a stable machine-readab
 
 | Category | ID | Scope | Purpose |
 |----------|----|-------|---------|
+| database | `db.file.present` | global | Configured SQLite database file still exists on disk (catches `rm ~/.canonry/data.db` against a running daemon — SQLite holds the inode open across `unlink`) |
+| config | `config.file.present` | global | Configured `~/.canonry/config.yaml` still exists on disk (same gotcha as above) |
 | auth | `google.auth.connection` | project | OAuth credentials present, refresh token works |
 | auth | `google.auth.property-access` | project | Authorized principal can list the selected GSC site |
 | auth | `google.auth.redirect-uri` | project | `publicUrl`-derived redirect URI is valid + advertised |

--- a/packages/api-routes/src/doctor.ts
+++ b/packages/api-routes/src/doctor.ts
@@ -22,6 +22,8 @@ export interface DoctorRoutesOptions {
    * skip with a clear `no-validator` code when an adapter doesn't register.
    */
   trafficSourceValidators?: Record<string, TrafficSourceValidator>
+  /** On-disk paths the daemon depends on. See `DoctorContext.runtimeStatePaths`. */
+  runtimeStatePaths?: { databasePath: string; configPath?: string | null }
 }
 
 function parseCheckIds(raw: string | undefined): string[] {
@@ -56,6 +58,7 @@ export async function doctorRoutes(app: FastifyInstance, opts: DoctorRoutesOptio
       redirectUri,
       providerSummary: opts.providerSummary,
       trafficSourceValidators: opts.trafficSourceValidators,
+      runtimeStatePaths: opts.runtimeStatePaths,
     }
     return runChecks(ctx, ALL_CHECKS, { checkIds })
   })
@@ -82,6 +85,7 @@ export async function doctorRoutes(app: FastifyInstance, opts: DoctorRoutesOptio
       redirectUri,
       providerSummary: opts.providerSummary,
       trafficSourceValidators: opts.trafficSourceValidators,
+      runtimeStatePaths: opts.runtimeStatePaths,
     }
     return runChecks(ctx, ALL_CHECKS, { checkIds })
   })

--- a/packages/api-routes/src/doctor/checks/runtime-state.ts
+++ b/packages/api-routes/src/doctor/checks/runtime-state.ts
@@ -1,0 +1,103 @@
+import fs from 'node:fs'
+import {
+  CheckCategories,
+  CheckScopes,
+  CheckStatuses,
+} from '@ainyc/canonry-contracts'
+import type { CheckDefinition } from '../types.js'
+
+/**
+ * Detects the case where the SQLite DB or `~/.canonry/config.yaml` was
+ * deleted out from under the running `canonry serve` daemon. SQLite holds
+ * the file inode open through `unlink`, so the daemon would otherwise keep
+ * serving cached data from an orphaned file and the operator would never
+ * see their wipe take effect — they'd `rm ~/.canonry/data.db`, refresh
+ * the dashboard, and the same projects would still be there.
+ *
+ * Pairs with the Fastify pre-request hook in `runtime-state-guard.ts`
+ * which fails all non-doctor / non-health requests with a 503
+ * `RUNTIME_STATE_MISSING` while these checks return `fail`. The hook
+ * surfaces it as an HTTP error; the doctor check surfaces it in
+ * `canonry doctor`.
+ *
+ * Both checks `skipped` when `runtimeStatePaths` isn't wired (cloud
+ * deployments use a managed Postgres, no local file paths).
+ */
+const dbFilePresentCheck: CheckDefinition = {
+  id: 'db.file.present',
+  category: CheckCategories.database,
+  scope: CheckScopes.global,
+  title: 'Database file present',
+  run: (ctx) => {
+    const path = ctx.runtimeStatePaths?.databasePath
+    if (!path) {
+      return {
+        status: CheckStatuses.skipped,
+        code: 'db.file.path-not-wired',
+        summary: 'No database file path configured for this deployment (cloud DB).',
+        remediation: null,
+      }
+    }
+    if (!fs.existsSync(path)) {
+      return {
+        status: CheckStatuses.fail,
+        code: 'db.file.missing',
+        summary: `Database file at \`${path}\` has been deleted while the daemon is running.`,
+        remediation:
+          'Restart `canonry serve` so a fresh database is created and migrations re-run. ' +
+          'Until you do, the daemon will keep serving stale data from a deleted-but-open file ' +
+          'handle and writes will be lost.',
+        details: { path },
+      }
+    }
+    return {
+      status: CheckStatuses.ok,
+      code: 'db.file.present',
+      summary: `Database file present at \`${path}\`.`,
+      remediation: null,
+      details: { path },
+    }
+  },
+}
+
+const configFilePresentCheck: CheckDefinition = {
+  id: 'config.file.present',
+  category: CheckCategories.config,
+  scope: CheckScopes.global,
+  title: 'Config file present',
+  run: (ctx) => {
+    const path = ctx.runtimeStatePaths?.configPath
+    if (!path) {
+      return {
+        status: CheckStatuses.skipped,
+        code: 'config.file.path-not-wired',
+        summary: 'No config file path configured for this deployment.',
+        remediation: null,
+      }
+    }
+    if (!fs.existsSync(path)) {
+      return {
+        status: CheckStatuses.fail,
+        code: 'config.file.missing',
+        summary: `Config file at \`${path}\` has been deleted while the daemon is running.`,
+        remediation:
+          'Restart `canonry serve` after the file is restored (provider keys, OAuth tokens, ' +
+          'and integration credentials live in this file; the in-memory copy is read-only ' +
+          'until restart).',
+        details: { path },
+      }
+    }
+    return {
+      status: CheckStatuses.ok,
+      code: 'config.file.present',
+      summary: `Config file present at \`${path}\`.`,
+      remediation: null,
+      details: { path },
+    }
+  },
+}
+
+export const RUNTIME_STATE_CHECKS: readonly CheckDefinition[] = [
+  dbFilePresentCheck,
+  configFilePresentCheck,
+]

--- a/packages/api-routes/src/doctor/registry.ts
+++ b/packages/api-routes/src/doctor/registry.ts
@@ -3,10 +3,14 @@ import { BING_AUTH_CHECKS } from './checks/bing-auth.js'
 import { GA_AUTH_CHECKS } from './checks/ga-auth.js'
 import { GOOGLE_AUTH_CHECKS } from './checks/google-auth.js'
 import { PROVIDERS_CHECKS } from './checks/providers.js'
+import { RUNTIME_STATE_CHECKS } from './checks/runtime-state.js'
 import { TRAFFIC_SOURCE_CHECKS } from './checks/traffic-source.js'
 import type { CheckDefinition } from './types.js'
 
 export const ALL_CHECKS: readonly CheckDefinition[] = [
+  // Runtime-state checks run first so file-system gone errors surface
+  // before any auth/integration checks try to touch the (orphaned) DB.
+  ...RUNTIME_STATE_CHECKS,
   ...GOOGLE_AUTH_CHECKS,
   ...BING_AUTH_CHECKS,
   ...GA_AUTH_CHECKS,

--- a/packages/api-routes/src/doctor/types.ts
+++ b/packages/api-routes/src/doctor/types.ts
@@ -53,6 +53,14 @@ export interface DoctorContext {
    * registered surface a `skipped` result rather than a fail.
    */
   trafficSourceValidators?: Record<string, TrafficSourceValidator>
+  /**
+   * On-disk paths the daemon depends on at runtime. Wired in by
+   * `canonry serve`; cloud deployments (managed DB, no local config)
+   * leave this undefined and the `db.file.present` / `config.file.present`
+   * checks `skipped`. Used both by those checks and by the pre-request
+   * runtime-state guard hook.
+   */
+  runtimeStatePaths?: { databasePath: string; configPath?: string | null }
 }
 
 export interface ProjectInfo {

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance, FastifyError } from 'fastify'
 import type { DatabaseClient } from '@ainyc/canonry-db'
-import { AppError } from '@ainyc/canonry-contracts'
+import fs from 'node:fs'
+import { AppError, runtimeStateMissing } from '@ainyc/canonry-contracts'
 import { authPlugin } from './auth.js'
 import { projectRoutes } from './projects.js'
 import type { ProjectRoutesOptions } from './projects.js'
@@ -182,6 +183,14 @@ export interface ApiRoutesOptions {
    * dev workflows that point webhooks at localhost.
    */
   allowLoopbackWebhooks?: boolean
+  /**
+   * On-disk paths the daemon depends on at runtime. When wired, a pre-request
+   * hook fails non-doctor / non-health requests with HTTP 503
+   * `RUNTIME_STATE_MISSING` if either path has been deleted while the daemon
+   * is running. Pairs with the `db.file.present` / `config.file.present`
+   * doctor checks. Cloud deployments leave this undefined.
+   */
+  runtimeStatePaths?: { databasePath: string; configPath?: string | null }
 }
 
 export async function apiRoutes(app: FastifyInstance, opts: ApiRoutesOptions) {
@@ -223,6 +232,37 @@ export async function apiRoutes(app: FastifyInstance, opts: ApiRoutesOptions) {
       },
     })
   })
+
+  // Runtime-state guard — fail loud if the DB or config file the daemon
+  // depends on was deleted out from under it. SQLite holds the file
+  // inode open across `unlink`, so without this hook the daemon would
+  // keep serving stale data from an orphaned file and the operator's
+  // `rm ~/.canonry/data.db` would silently not take effect. Skips the
+  // health and doctor endpoints so operators can still diagnose. Only
+  // active when `runtimeStatePaths` is wired — cloud deployments leave
+  // this undefined (managed DB, no local config).
+  if (opts.runtimeStatePaths) {
+    const { databasePath, configPath } = opts.runtimeStatePaths
+    // Allow-listed paths bypass the guard so an operator can still
+    // diagnose the daemon when the files are gone: `/health` for liveness,
+    // `/doctor` (and `/projects/<name>/doctor`) for the actual `db.file.missing`
+    // / `config.file.missing` check output. Match `/doctor` either at the
+    // end of the URL or immediately followed by `?` so query-stringed
+    // doctor calls (`?check=db.*`) still pass.
+    const isDiagnosticUrl = (url: string) =>
+      url === '/health' || /\/doctor(?:\?|$)/.test(url)
+    app.addHook('onRequest', async (request) => {
+      if (isDiagnosticUrl(request.url)) return
+      const missing: string[] = []
+      if (!fs.existsSync(databasePath)) missing.push(`database file \`${databasePath}\``)
+      if (configPath && !fs.existsSync(configPath)) missing.push(`config file \`${configPath}\``)
+      if (missing.length === 0) return
+      throw runtimeStateMissing(
+        `Runtime state missing: ${missing.join(' and ')}. Restart \`canonry serve\` so a fresh state is created (the daemon's open file handles still point at the deleted inode, so writes are being lost).`,
+        { missing },
+      )
+    })
+  }
 
   // Register route plugins under the configured prefix (default: /api/v1).
   // When a basePath is set and the reverse proxy does not strip it, pass
@@ -357,6 +397,7 @@ export async function apiRoutes(app: FastifyInstance, opts: ApiRoutesOptions) {
       publicUrl: opts.publicUrl,
       providerSummary: opts.providerSummary,
       trafficSourceValidators: buildTrafficSourceValidators(opts),
+      runtimeStatePaths: opts.runtimeStatePaths,
     })
     // Local-only extension hook: canonry passes the Aero agent routes here
     // so they live inside the authenticated scope. Cloud leaves it undefined.

--- a/packages/api-routes/test/doctor-runtime-state.test.ts
+++ b/packages/api-routes/test/doctor-runtime-state.test.ts
@@ -1,0 +1,119 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { CheckStatuses } from '@ainyc/canonry-contracts'
+import { RUNTIME_STATE_CHECKS } from '../src/doctor/checks/runtime-state.js'
+import type { DoctorContext } from '../src/doctor/types.js'
+
+/**
+ * Regression coverage for the project-page-doesnt-update bug: deleting
+ * the DB or config out from under a running `canonry serve` leaves the
+ * daemon serving stale data from an orphaned SQLite inode. Both checks
+ * here fire when the files vanish so the operator sees the cause.
+ */
+
+const dbCheck = RUNTIME_STATE_CHECKS.find((c) => c.id === 'db.file.present')!
+const cfgCheck = RUNTIME_STATE_CHECKS.find((c) => c.id === 'config.file.present')!
+
+function makeCtx(paths: DoctorContext['runtimeStatePaths']): DoctorContext {
+  return {
+    // Only `runtimeStatePaths` matters for these checks; the other fields
+    // are stubbed out as nulls/undefined.
+    db: null as unknown as DoctorContext['db'],
+    project: null,
+    runtimeStatePaths: paths,
+  }
+}
+
+describe('db.file.present', () => {
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-doctor-db-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+
+  it('returns ok when the configured database file exists', async () => {
+    const dbPath = path.join(tmp, 'data.db')
+    fs.writeFileSync(dbPath, 'fake-sqlite')
+    const result = await Promise.resolve(dbCheck.run(makeCtx({ databasePath: dbPath })))
+    expect(result.status).toBe(CheckStatuses.ok)
+    expect(result.code).toBe('db.file.present')
+    expect(result.details).toMatchObject({ path: dbPath })
+  })
+
+  it('returns fail with a clear remediation when the database file has been deleted', async () => {
+    const dbPath = path.join(tmp, 'data.db')
+    fs.writeFileSync(dbPath, 'fake-sqlite')
+    fs.unlinkSync(dbPath)
+    const result = await Promise.resolve(dbCheck.run(makeCtx({ databasePath: dbPath })))
+    expect(result.status).toBe(CheckStatuses.fail)
+    expect(result.code).toBe('db.file.missing')
+    // Remediation must mention restarting `canonry serve` — that's the
+    // actual fix for the open-inode situation.
+    expect(result.remediation).toMatch(/restart `canonry serve`/i)
+    expect(result.details).toMatchObject({ path: dbPath })
+  })
+
+  it('returns skipped when no path is wired (cloud deployment)', async () => {
+    const result = await Promise.resolve(dbCheck.run(makeCtx(undefined)))
+    expect(result.status).toBe(CheckStatuses.skipped)
+    expect(result.code).toBe('db.file.path-not-wired')
+  })
+})
+
+describe('config.file.present', () => {
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-doctor-config-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+
+  it('returns ok when the configured config file exists', async () => {
+    const cfgPath = path.join(tmp, 'config.yaml')
+    fs.writeFileSync(cfgPath, 'apiKey: cnry_test\n')
+    const result = await Promise.resolve(cfgCheck.run(
+      makeCtx({ databasePath: '/tmp/ignored', configPath: cfgPath }),
+    ))
+    expect(result.status).toBe(CheckStatuses.ok)
+    expect(result.code).toBe('config.file.present')
+  })
+
+  it('returns fail when the config file has been deleted', async () => {
+    const cfgPath = path.join(tmp, 'config.yaml')
+    fs.writeFileSync(cfgPath, 'apiKey: cnry_test\n')
+    fs.unlinkSync(cfgPath)
+    const result = await Promise.resolve(cfgCheck.run(
+      makeCtx({ databasePath: '/tmp/ignored', configPath: cfgPath }),
+    ))
+    expect(result.status).toBe(CheckStatuses.fail)
+    expect(result.code).toBe('config.file.missing')
+    expect(result.remediation).toMatch(/restart `canonry serve`/i)
+  })
+
+  it('returns skipped when no config path is wired (cloud deployment)', async () => {
+    const result = await Promise.resolve(cfgCheck.run(
+      makeCtx({ databasePath: '/tmp/ignored' }),
+    ))
+    expect(result.status).toBe(CheckStatuses.skipped)
+    expect(result.code).toBe('config.file.path-not-wired')
+  })
+
+  it('returns skipped when paths object is wired but configPath is null', async () => {
+    // Explicit null is the "we know there is no config" case — separate
+    // from undefined (no paths wired at all). Both skip.
+    const result = await Promise.resolve(cfgCheck.run(
+      makeCtx({ databasePath: '/tmp/ignored', configPath: null }),
+    ))
+    expect(result.status).toBe(CheckStatuses.skipped)
+    expect(result.code).toBe('config.file.path-not-wired')
+  })
+})

--- a/packages/api-routes/test/runtime-state-guard.test.ts
+++ b/packages/api-routes/test/runtime-state-guard.test.ts
@@ -1,0 +1,140 @@
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import Fastify from 'fastify'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { apiKeys, createClient, migrate } from '@ainyc/canonry-db'
+import { apiRoutes } from '../src/index.js'
+
+/**
+ * Integration test for the runtime-state pre-request guard. The guard
+ * exists so deleting the DB or config file out from under `canonry serve`
+ * fails loudly with a 503 instead of silently serving cached data from
+ * the now-orphaned SQLite inode. The doctor endpoint and `/health` must
+ * still be reachable so operators can diagnose.
+ */
+describe('runtime-state guard hook', () => {
+  let tmp: string
+  let dbPath: string
+  let cfgPath: string
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'runtime-state-guard-'))
+    dbPath = path.join(tmp, 'data.db')
+    cfgPath = path.join(tmp, 'config.yaml')
+    fs.writeFileSync(cfgPath, 'apiKey: cnry_test\n')
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+
+  async function buildApp() {
+    const db = createClient(dbPath)
+    migrate(db)
+    db.insert(apiKeys).values({
+      id: crypto.randomUUID(),
+      name: 'test',
+      keyHash: crypto.createHash('sha256').update('cnry_test').digest('hex'),
+      keyPrefix: 'cnry_test',
+      scopes: ['*'],
+      createdAt: new Date().toISOString(),
+    }).run()
+    const app = Fastify()
+    await app.register(apiRoutes, {
+      db,
+      runtimeStatePaths: { databasePath: dbPath, configPath: cfgPath },
+    })
+    await app.ready()
+    return app
+  }
+
+  const authHeader = { authorization: 'Bearer cnry_test' }
+
+  it('passes through when both files are present', async () => {
+    const app = await buildApp()
+    try {
+      const res = await app.inject({ method: 'GET', url: '/api/v1/projects', headers: authHeader })
+      expect(res.statusCode).toBe(200)
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('returns 503 RUNTIME_STATE_MISSING when the DB file is deleted while serving', async () => {
+    const app = await buildApp()
+    try {
+      // Simulate `rm ~/.canonry/data.db` mid-flight.
+      fs.unlinkSync(dbPath)
+      const res = await app.inject({ method: 'GET', url: '/api/v1/projects', headers: authHeader })
+      expect(res.statusCode).toBe(503)
+      const body = JSON.parse(res.body) as { error: { code: string; message: string; details?: { missing: string[] } } }
+      expect(body.error.code).toBe('RUNTIME_STATE_MISSING')
+      expect(body.error.message).toMatch(/database file/i)
+      expect(body.error.message).toMatch(/restart `canonry serve`/i)
+      expect(body.error.details?.missing[0]).toContain(dbPath)
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('returns 503 with both files listed when DB and config are both deleted', async () => {
+    const app = await buildApp()
+    try {
+      fs.unlinkSync(dbPath)
+      fs.unlinkSync(cfgPath)
+      const res = await app.inject({ method: 'GET', url: '/api/v1/projects', headers: authHeader })
+      expect(res.statusCode).toBe(503)
+      const body = JSON.parse(res.body) as { error: { code: string; details?: { missing: string[] } } }
+      expect(body.error.code).toBe('RUNTIME_STATE_MISSING')
+      expect(body.error.details?.missing).toHaveLength(2)
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('still serves /api/v1/doctor so operators can diagnose with files missing', async () => {
+    const app = await buildApp()
+    try {
+      fs.unlinkSync(dbPath)
+      // Doctor must respond so the user can read the db.file.missing /
+      // config.file.missing diagnostics, not get blocked at the gate.
+      const res = await app.inject({ method: 'GET', url: '/api/v1/doctor', headers: authHeader })
+      expect(res.statusCode).toBe(200)
+      const body = JSON.parse(res.body) as { checks: { id: string; status: string; code: string }[] }
+      const dbFileCheck = body.checks.find((c) => c.id === 'db.file.present')
+      expect(dbFileCheck).toBeDefined()
+      expect(dbFileCheck?.status).toBe('fail')
+      expect(dbFileCheck?.code).toBe('db.file.missing')
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('does not engage when runtimeStatePaths is not wired (cloud deployments)', async () => {
+    // Cloud `apps/api` registers apiRoutes without runtimeStatePaths,
+    // so the guard must be a no-op there even if other paths don't exist.
+    const db = createClient(dbPath)
+    migrate(db)
+    db.insert(apiKeys).values({
+      id: crypto.randomUUID(),
+      name: 'test',
+      keyHash: crypto.createHash('sha256').update('cnry_test').digest('hex'),
+      keyPrefix: 'cnry_test',
+      scopes: ['*'],
+      createdAt: new Date().toISOString(),
+    }).run()
+    const app = Fastify()
+    await app.register(apiRoutes, { db })
+    await app.ready()
+    try {
+      // Even with cfg deleted, no runtimeStatePaths = no guard.
+      fs.unlinkSync(cfgPath)
+      const res = await app.inject({ method: 'GET', url: '/api/v1/projects', headers: authHeader })
+      expect(res.statusCode).toBe(200)
+    } finally {
+      await app.close()
+    }
+  })
+})

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -20,7 +20,7 @@ import { cdpChatgptAdapter } from '@ainyc/canonry-provider-cdp'
 import { perplexityAdapter } from '@ainyc/canonry-provider-perplexity'
 import { authInvalid, validationError, RunKinds, RunStatuses, RunTriggers, type ProviderAdapter } from '@ainyc/canonry-contracts'
 import type { CanonryConfig, ProviderConfigEntry } from './config.js'
-import { saveConfigPatch, loadConfig } from './config.js'
+import { saveConfigPatch, loadConfig, getConfigPath } from './config.js'
 import {
   getGoogleAuthConfig,
   getGoogleConnection,
@@ -925,6 +925,24 @@ export async function createServer(opts: {
     sessionCookieName: SESSION_COOKIE_NAME,
     resolveSessionApiKeyId,
     explainContentRecommendation,
+    // On-disk paths the daemon depends on. The api-routes plugin uses these
+    // to fail loud (HTTP 503) when the operator wipes the DB or config out
+    // from under a running serve — SQLite holds the inode open across
+    // `unlink`, so without this the daemon keeps serving stale data from
+    // an orphaned file and `rm ~/.canonry/data.db` silently does nothing.
+    //
+    // Only attach `configPath` if it actually exists at construction time:
+    // production always boots via `serveCommand`, which calls `loadConfig()`
+    // and would have thrown if the file were missing; tests that construct
+    // `createServer` directly (bypassing `loadConfig`) won't have written
+    // a config and shouldn't get 503s from a stub-missing file.
+    runtimeStatePaths: (() => {
+      const configPath = getConfigPath()
+      return {
+        databasePath: opts.config.database,
+        configPath: fs.existsSync(configPath) ? configPath : null,
+      }
+    })(),
     // Local canonry serve runs on the operator's machine, where pointing a
     // webhook at localhost (Discord test container, Pipedream-mock dev server,
     // etc.) is a legitimate workflow. Default to allowing it for the local

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -15,6 +15,7 @@ export type ErrorCode =
   | 'DELIVERY_FAILED'
   | 'AGENT_BUSY'
   | 'MISSING_DEPENDENCY'
+  | 'RUNTIME_STATE_MISSING'
 
 export class AppError extends Error {
   readonly code: ErrorCode
@@ -111,4 +112,17 @@ export function missingDependency(message: string, details?: Record<string, unkn
 
 export function internalError(message: string, details?: Record<string, unknown>): AppError {
   return new AppError('INTERNAL_ERROR', message, 500, details)
+}
+
+/**
+ * Fires when a runtime-essential file (DB or config) the daemon opened at
+ * boot has been removed from disk while the daemon is still running. SQLite
+ * holds the inode open through `unlink`, so the daemon would otherwise keep
+ * serving stale data from an orphaned file with no surfacing — operator
+ * deletes `~/.canonry/data.db` expecting a clean slate, daemon happily
+ * returns the old projects, UI looks wrong. This 503 fails loud so the
+ * operator knows to restart `canonry serve`.
+ */
+export function runtimeStateMissing(message: string, details?: Record<string, unknown>): AppError {
+  return new AppError('RUNTIME_STATE_MISSING', message, 503, details)
 }


### PR DESCRIPTION
## Summary

- Deleting `~/.canonry/data.db` or `~/.canonry/config.yaml` while `canonry serve` is running left the daemon silently serving stale data. SQLite holds the inode open across `unlink`, so reads/writes continue against an orphaned file and the operator's `rm` appears to do nothing.
- Add two layers of detection:
  - **Doctor checks** `db.file.present` (category `database`) and `config.file.present` (category `config`). Each stats the configured path; returns `fail` with a "restart `canonry serve`" remediation when missing.
  - **Pre-request Fastify hook** in `api-routes` that runs the same stat check on every incoming request (skipping `/health` and any `/doctor` URL so operators can still diagnose) and throws a 503 `RUNTIME_STATE_MISSING` envelope when either file is gone. UI shows the explicit error instead of stale data.
- Wired through `runtimeStatePaths` on `ApiRoutesOptions` and into `DoctorContext`. Only engaged when `canonry serve` boots from a real config (production); cloud `apps/api` and tests that bypass `loadConfig` leave the paths undefined and the guard no-ops.

## Test plan
- [x] `pnpm vitest run --project api-routes --project canonry --project contracts` — 2094 passing, including 12 new cases across `doctor-runtime-state.test.ts` + `runtime-state-guard.test.ts`
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (0 errors)
- [ ] Manual: with daemon running, `rm ~/.canonry/data.db` → UI dashboard shows 503 `RUNTIME_STATE_MISSING` with the restart instruction; `canonry doctor` shows `db.file.missing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)