### PR TITLE
fix(web): refetch project page on window focus so CLI mutations surface on alt-tab

### DIFF
--- a/apps/web/src/queries/use-project-dashboard.ts
+++ b/apps/web/src/queries/use-project-dashboard.ts
@@ -52,10 +52,22 @@ export function useProjectDashboard(projectName: string | null | undefined) {
     ) ?? null
   }, [contextDashboard, projectName])
 
+  // The three project-page queries below all override the global
+  // `refetchOnWindowFocus: false` default. Rationale: CLI-driven
+  // mutations (`cnry query add`, `cnry competitor add`, `cnry project
+  // create`, etc.) bypass React Query entirely — the dashboard's cache
+  // has no idea state changed on the server. Without focus-refetch,
+  // the operator's typical workflow ("open dashboard → alt-tab to
+  // terminal → run a CLI mutation → alt-tab back") shows stale data
+  // for up to 30 minutes (STATIC_VISIBILITY_STALE_MS). Use `'always'`
+  // (not just `true`) so the refetch fires regardless of staleTime —
+  // a `true` value would only refetch if the cached data had aged
+  // past staleTime, which defeats the alt-tab use case.
   const projectQuery = useQuery({
     ...getApiV1ProjectsByNameOptions({ client: heyClient, path: { name: projectName ?? '' } }),
     enabled: !!projectName && !initialCommandCenter,
     staleTime: STATIC_VISIBILITY_STALE_MS,
+    refetchOnWindowFocus: 'always',
   })
 
   // Project-scoped runs list (still kind-filtered so the cap doesn't bite
@@ -64,6 +76,7 @@ export function useProjectDashboard(projectName: string | null | undefined) {
     ...getApiV1RunsOptions({ client: heyClient, query: { kind: 'answer-visibility' } }),
     enabled: !!projectName,
     staleTime: RUNS_STALE_MS,
+    refetchOnWindowFocus: 'always',
     refetchInterval: (query) => {
       const runs = query.state.data
       const hasActive = runs?.some(r =>
@@ -142,6 +155,7 @@ export function useProjectDashboard(projectName: string | null | undefined) {
     },
     enabled: !!project && !!projectName && runsQuery.isSuccess,
     staleTime: STATIC_VISIBILITY_STALE_MS,
+    refetchOnWindowFocus: 'always',
   })
 
   const commandCenter = useMemo<ProjectCommandCenterVm | null>(() => {


### PR DESCRIPTION
## Summary

- Follows #599 (which fixed in-UI mutations). CLI-driven mutations (`cnry query add`, `cnry competitor add`, etc.) bypass React Query entirely — the dashboard cache has no idea state changed on the server. With `staleTime: 30 min` and no refetch trigger, the project page shows stale data until a hard reload.
- Override the global `refetchOnWindowFocus: false` to `'always'` on `useProjectDashboard`'s three queries. Catches the canonical operator workflow: open dashboard → alt-tab to terminal → run CLI mutation → alt-tab back → page re-fetches.
- Use `'always'` (not `true`) so the refetch fires regardless of how recently the cache was populated — `true` would honour the 30-min staleTime and silently no-op for the typical "add then switch back within seconds" flow.
- No interval polling: focus-refetch handles the canonical workflow at zero idle cost. Users who keep the dashboard always-visible (e.g., side-by-side with terminal) can hard-reload when needed — a polling fallback would burn cycles for everyday users to optimize a less-common workflow.

## Test plan
- [x] `pnpm vitest run --project web` — 213 passing
- [x] `pnpm typecheck` clean
- [ ] Manual: open project page, run `cnry query add <project> "..."` in terminal, alt-tab back → new query appears without reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)