### PR TITLE
fix(canonry): unbreak npm install (hotfix 4.51.2) + add publish-smoke-test CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,9 +100,46 @@ jobs:
       - run: pnpm -r run build
         name: Build all packages (catches missing deps, bundler errors)
 
+  publish-smoke-test:
+    # Catches the failure mode where a workspace dep leaks into runtime
+    # `dependencies` (pnpm publish rewrites `workspace:*` → `0.0.0`,
+    # which 404s on `npm install` because private workspace packages
+    # aren't published). Packs canonry the same way the publish workflow
+    # does and runs `npm install` against the tarball from a scratch
+    # directory — exactly what external users do when they `npm i -g`.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: pnpm --filter @ainyc/canonry build
+        name: Build canonry (required for pnpm pack)
+      - name: Pack canonry tarball
+        id: pack
+        shell: bash
+        run: |
+          cd packages/canonry
+          OUTPUT=$(pnpm pack --pack-destination /tmp)
+          TARBALL=$(echo "$OUTPUT" | grep -E '\.tgz$' | tail -1)
+          if [ -z "$TARBALL" ] || [ ! -f "$TARBALL" ]; then
+            echo "pnpm pack did not produce a tarball" >&2
+            echo "$OUTPUT" >&2
+            exit 1
+          fi
+          echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
+      - name: Install canonry from tarball into scratch project
+        shell: bash
+        run: |
+          SCRATCH=$(mktemp -d)
+          cd "$SCRATCH"
+          npm init -y > /dev/null
+          npm install "${{ steps.pack.outputs.tarball }}"
+          ./node_modules/.bin/canonry --version
+
   validate:
     runs-on: ubuntu-latest
-    needs: [typecheck, test, lint, codegen-drift, build]
+    needs: [typecheck, test, lint, codegen-drift, build, publish-smoke-test]
     if: always()
     steps:
       - name: Verify all validate jobs succeeded
@@ -111,7 +148,8 @@ jobs:
              [ "${{ needs.test.result }}" != "success" ] || \
              [ "${{ needs.lint.result }}" != "success" ] || \
              [ "${{ needs.codegen-drift.result }}" != "success" ] || \
-             [ "${{ needs.build.result }}" != "success" ]; then
+             [ "${{ needs.build.result }}" != "success" ] || \
+             [ "${{ needs.publish-smoke-test.result }}" != "success" ]; then
             echo "One or more validate jobs failed"
             exit 1
           fi

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.51.1",
+  "version": "4.51.2",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.51.1",
+  "version": "4.51.2",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",
@@ -45,7 +45,6 @@
   },
   "dependencies": {
     "@ainyc/aeo-audit": "1.3.2",
-    "@ainyc/canonry-api-client": "workspace:*",
     "@anthropic-ai/sdk": "^0.78.0",
     "@fastify/static": "^8.1.0",
     "@google/genai": "^1.46.0",
@@ -65,6 +64,7 @@
     "zod": "^4.1.12"
   },
   "devDependencies": {
+    "@ainyc/canonry-api-client": "workspace:*",
     "@ainyc/canonry-api-routes": "workspace:*",
     "@ainyc/canonry-config": "workspace:*",
     "@ainyc/canonry-contracts": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,9 +229,6 @@ importers:
       '@ainyc/aeo-audit':
         specifier: 1.3.2
         version: 1.3.2
-      '@ainyc/canonry-api-client':
-        specifier: workspace:*
-        version: link:../api-client-generated
       '@anthropic-ai/sdk':
         specifier: ^0.78.0
         version: 0.78.0(zod@4.3.6)
@@ -284,6 +281,9 @@ importers:
         specifier: ^4.1.12
         version: 4.3.6
     devDependencies:
+      '@ainyc/canonry-api-client':
+        specifier: workspace:*
+        version: link:../api-client-generated
       '@ainyc/canonry-api-routes':
         specifier: workspace:*
         version: link:../api-routes


### PR DESCRIPTION
## Summary

`npm install -g @ainyc/canonry` — the install command documented on the README — has been **broken for every published version since 2026-05-17 02:39 UTC**. Hotfix as **4.51.2**.

### Root cause

The `@ainyc/canonry-api-client` workspace package is `private: true` and never published. PR #565 (api-client scaffold) added it to canonry's runtime `dependencies` via `"workspace:*"`. `pnpm publish` rewrites `workspace:*` to the dep's actual version at publish time — for a private unpublished package, that's `0.0.0`. The published manifest therefore lists `"@ainyc/canonry-api-client": "0.0.0"`, which 404s on the registry:

```
npm error 404 Not Found - GET https://registry.npmjs.org/@ainyc%2fcanonry-api-client
npm error 404  The requested resource '@ainyc/canonry-api-client@0.0.0' could not be found
```

PR #565 was absorbed into the squash commit [`ecc4d06`](https://github.com/AINYC/canonry/commit/ecc4d069) (which closed PR #562, the OpenAPI codegen work) and merged 2026-05-17 02:39 UTC.

### Impact

| Version | Status |
|---|---|
| `4.47.0` | ✅ Last known good (4.48.x / 4.49.x were never published) |
| `4.50.0` | ❌ Broken — first version with the bad dep |
| `4.51.0` | ❌ Broken |
| `4.51.1` | ❌ Broken |

Every new install via the README's documented command has 404'd for ~1.5 days. First impression for every external evaluator, agent recommending canonry, blog reader, or CI pipeline trying the published package.

## Fix

Move `@ainyc/canonry-api-client` from `dependencies` → `devDependencies` in `packages/canonry/package.json`. `tsup` already bundles it into `dist/` at build time, so it isn't actually needed at install time. `devDependencies` get stripped from published manifests, killing the 404.

Verified locally with `pnpm pack` + `npm install <tarball>` in a scratch dir → succeeds (345 packages, no 404).

## Regression gate

New `publish-smoke-test` job in `.github/workflows/ci.yml`:
1. Builds canonry
2. `pnpm pack`s the tarball
3. `npm init`s a fresh scratch project
4. `npm install`s the tarball
5. Runs the installed `canonry --version`

This is exactly what an external user does. Added to the `validate` job's required dependencies, so the next time a workspace dep leaks into runtime `dependencies`, CI fails before merge instead of silently shipping broken installs.

## After this merges

The user (with npm publish permissions) needs to:
1. Wait for the publish workflow to ship 4.51.2 (auto-triggers on main since version bumped)
2. Deprecate the broken versions:
   ```bash
   npm deprecate @ainyc/canonry@">=4.50.0 <=4.51.1" "broken npm install — upgrade to 4.51.2+"
   ```

## Test plan
- [x] `pnpm run typecheck` — passes
- [x] `pnpm run test` — 3202/3202 pass
- [x] `pnpm run lint` — warnings unchanged
- [x] Local `pnpm pack` + `npm install` of tarball — succeeds
- [x] CI `publish-smoke-test` job runs green on this PR