### PR TITLE
fix(web): open evidence modal on project routes (View button silently broken)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 import {
@@ -41,8 +41,9 @@ import { ProviderBadge } from './components/shared/ProviderBadge.js'
 import { StatusBadge } from './components/shared/StatusBadge.js'
 import { Drawer } from './components/layout/Drawer.js'
 import { EvidenceDetailModal } from './components/layout/EvidenceDetailModal.js'
-import { findEvidenceById, findRunById } from './mock-data.js'
+import { findEvidenceForModal, findRunById } from './mock-data.js'
 import { useDashboardOverview as useDashboard } from './queries/use-dashboard-overview.js'
+import { useProjectDashboard } from './queries/use-project-dashboard.js'
 import { useHealth } from './queries/use-health.js'
 import { useRunDetail } from './queries/use-run-detail.js'
 import { useDrawer } from './hooks/use-drawer.js'
@@ -355,7 +356,32 @@ export function RootLayout() {
     && safeDashboard.portfolioOverview.projects.length === 0
 
   const selectedRun = runId && safeDashboard ? findRunById(safeDashboard, runId) : undefined
-  const selectedEvidenceContext = evidenceId && safeDashboard ? findEvidenceById(safeDashboard, evidenceId) : undefined
+
+  // Evidence lookup spans two data sources because `useDashboard()` here is
+  // the slim portfolio hook — its per-project `visibilityEvidence` is
+  // intentionally empty (see use-dashboard-overview.ts). The full evidence
+  // list is only built by `useProjectDashboard`, which the ProjectPage uses
+  // to render the table whose "View" button writes `?evidenceId=…` into the
+  // URL. Without this second lookup the modal silently never opens on a
+  // project route.
+  //
+  // Subscribing to `useProjectDashboard` here is free in steady state — its
+  // query keys overlap with ProjectPage's, so React Query dedupes the
+  // fetches via the shared cache.
+  const projectIdFromRoute = useMemo(() => {
+    const match = location.pathname.match(/^\/projects\/([^/]+)/)
+    return match?.[1] ?? null
+  }, [location.pathname])
+  const currentProjectName = useMemo(() => {
+    if (!projectIdFromRoute || !safeDashboard) return null
+    return safeDashboard.projects.find(p => p.project.id === projectIdFromRoute)?.project.name ?? null
+  }, [projectIdFromRoute, safeDashboard])
+  const { commandCenter: currentProjectCommandCenter } = useProjectDashboard(currentProjectName)
+
+  const selectedEvidenceContext = useMemo(() => {
+    if (!evidenceId) return undefined
+    return findEvidenceForModal(currentProjectCommandCenter, safeDashboard, evidenceId)
+  }, [evidenceId, currentProjectCommandCenter, safeDashboard])
 
   // Derive breadcrumb label from current location
   const breadcrumbLabel = (() => {

--- a/apps/web/src/mock-data.ts
+++ b/apps/web/src/mock-data.ts
@@ -1176,3 +1176,33 @@ export function findEvidenceById(
 
   return undefined
 }
+
+/**
+ * Cross-source evidence lookup for the modal listener in `App.tsx`.
+ *
+ * The slim `useDashboardOverview` hook intentionally leaves per-project
+ * `visibilityEvidence` empty (see `queries/use-dashboard-overview.ts`).
+ * The full evidence list lives on the per-project `commandCenter` built
+ * by `useProjectDashboard`, which is what ProjectPage uses to render the
+ * EvidenceTable whose "View" button writes `?evidenceId=…` into the URL.
+ *
+ * So the modal lookup tries the project-specific source first, then
+ * falls back to the dashboard walk (still useful if the slim shape ever
+ * starts carrying evidence for cross-project deep links).
+ */
+export function findEvidenceForModal(
+  commandCenter: ProjectCommandCenterVm | null | undefined,
+  dashboard: DashboardVm | null | undefined,
+  evidenceId: string,
+): { project: ProjectCommandCenterVm; evidence: CitationInsightVm } | undefined {
+  if (commandCenter) {
+    const evidence = commandCenter.visibilityEvidence.find((entry) => entry.id === evidenceId)
+    if (evidence) {
+      return { project: commandCenter, evidence }
+    }
+  }
+  if (dashboard) {
+    return findEvidenceById(dashboard, evidenceId)
+  }
+  return undefined
+}

--- a/apps/web/test/find-evidence-for-modal.test.ts
+++ b/apps/web/test/find-evidence-for-modal.test.ts
@@ -1,0 +1,111 @@
+import { test, expect } from 'vitest'
+
+import { findEvidenceForModal } from '../src/mock-data.js'
+import type {
+  CitationInsightVm,
+  DashboardVm,
+  ProjectCommandCenterVm,
+} from '../src/view-models.js'
+
+// Minimal shapes — only the fields findEvidenceForModal touches matter.
+
+function makeEvidence(id: string): CitationInsightVm {
+  return {
+    id,
+    query: 'test query',
+    provider: 'gemini',
+    model: 'gemini-2.5-flash',
+    location: null,
+    citationState: 'cited',
+    changeLabel: '',
+    answerSnippet: '',
+    citedDomains: [],
+    evidenceUrls: [],
+    competitorDomains: [],
+    recommendedCompetitors: [],
+    matchedTerms: [],
+    relatedTechnicalSignals: [],
+    groundingSources: [],
+    summary: '',
+    runHistory: [],
+  } as unknown as CitationInsightVm
+}
+
+function makeCommandCenter(name: string, evidence: CitationInsightVm[]): ProjectCommandCenterVm {
+  return {
+    project: { id: `proj_${name}`, name, displayName: name },
+    visibilityEvidence: evidence,
+  } as unknown as ProjectCommandCenterVm
+}
+
+function makeDashboard(projects: ProjectCommandCenterVm[]): DashboardVm {
+  return { projects } as unknown as DashboardVm
+}
+
+test('findEvidenceForModal prefers the project command center over the slim dashboard', () => {
+  // Regression: this is the View-button bug. The slim `useDashboardOverview`
+  // returns dashboard.projects[*].visibilityEvidence = [] by design (see
+  // queries/use-dashboard-overview.ts). The full evidence list is on the
+  // commandCenter built by useProjectDashboard. Without the cross-source
+  // lookup, clicking View navigated the URL but the modal silently never
+  // opened because the slim dashboard didn't have the evidence id.
+
+  const evidence = makeEvidence('evidence_ainyc_0')
+  const commandCenter = makeCommandCenter('ainyc', [evidence])
+  const slimDashboard = makeDashboard([
+    makeCommandCenter('ainyc', []),
+  ])
+
+  const result = findEvidenceForModal(commandCenter, slimDashboard, 'evidence_ainyc_0')
+
+  expect(result).toBeDefined()
+  expect(result!.evidence.id).toBe('evidence_ainyc_0')
+  expect(result!.project.project.name).toBe('ainyc')
+})
+
+test('findEvidenceForModal falls back to the dashboard when the command center has no match', () => {
+  // If the evidence id isn't in the currently-viewed project but is reachable
+  // through the full dashboard walk (e.g. future cross-project deep link, or
+  // a stale URL), we still find it.
+
+  const evidence = makeEvidence('evidence_other_42')
+  const commandCenter = makeCommandCenter('ainyc', [makeEvidence('evidence_ainyc_0')])
+  const dashboard = makeDashboard([
+    makeCommandCenter('ainyc', []),
+    makeCommandCenter('other', [evidence]),
+  ])
+
+  const result = findEvidenceForModal(commandCenter, dashboard, 'evidence_other_42')
+
+  expect(result).toBeDefined()
+  expect(result!.evidence.id).toBe('evidence_other_42')
+  expect(result!.project.project.name).toBe('other')
+})
+
+test('findEvidenceForModal works when only the dashboard is available (no project route)', () => {
+  // Modal listener runs at the root layout, so on non-project routes
+  // currentProjectCommandCenter is null. The dashboard walk is the only
+  // available source.
+
+  const evidence = makeEvidence('evidence_x_0')
+  const dashboard = makeDashboard([makeCommandCenter('x', [evidence])])
+
+  const result = findEvidenceForModal(null, dashboard, 'evidence_x_0')
+
+  expect(result).toBeDefined()
+  expect(result!.evidence.id).toBe('evidence_x_0')
+})
+
+test('findEvidenceForModal returns undefined when both sources lack the evidence', () => {
+  const commandCenter = makeCommandCenter('ainyc', [makeEvidence('evidence_ainyc_0')])
+  const dashboard = makeDashboard([makeCommandCenter('ainyc', [])])
+
+  const result = findEvidenceForModal(commandCenter, dashboard, 'evidence_does_not_exist')
+
+  expect(result).toBeUndefined()
+})
+
+test('findEvidenceForModal returns undefined when both sources are null/undefined', () => {
+  expect(findEvidenceForModal(null, null, 'anything')).toBeUndefined()
+  expect(findEvidenceForModal(undefined, undefined, 'anything')).toBeUndefined()
+})


### PR DESCRIPTION
## Summary

Clicking **View** on any evidence row in the project page navigates the URL to `?evidenceId=…` but the `EvidenceDetailModal` silently never opens. Discovered while running the demo workflow — bug was production-shipped.

## Root cause

Two disconnected data sources:

- **`App.tsx`** (root layout, owns the modal listener) reads `safeDashboard` from `useDashboardOverview` — the **slim** hook. Per its own comment (`queries/use-dashboard-overview.ts:30-34`): *"the resulting ProjectCommandCenterVm has empty visibilityEvidence"*.
- **`ProjectPage`** renders the `EvidenceTable` using data from `useProjectDashboard` — the **heavy** hook, which **does** build `visibilityEvidence`.

So clicking View:

1. URL changes to `?evidenceId=evidence_<project>_<idx>` ✓
2. `findEvidenceById(safeDashboard, evidenceId)` walks `dashboard.projects[*].visibilityEvidence` — all empty
3. Returns `undefined`, no modal renders ✗

Likely introduced when the slim overview was split out as a perf optimization — the modal listener wasn't updated.

## Fix

`App.tsx` now also subscribes to the project-specific `commandCenter` from `useProjectDashboard` when on a project route. The lookup tries the project-specific source first, then falls back to the dashboard walk (still useful for cross-project deep links).

Cost: zero in steady state — `useProjectDashboard`'s query keys overlap with `ProjectPage`'s, so React Query dedupes the fetches via the shared cache.

Cross-source lookup is extracted as `findEvidenceForModal(commandCenter, dashboard, evidenceId)` in `mock-data.ts`.

## Sibling-bug audit

I also walked every other `safeDashboard.*` reader in `App.tsx` to see if the same pattern bites anywhere else:

| Lookup | Field accessed | Status |
|---|---|---|
| `findEvidenceById` | `project.visibilityEvidence` | ❌ **Fixed by this PR** |
| `findRunById` | `dashboard.runs` | ✓ Slim populates |
| `findProjectVm` | `dashboard.projects` (metadata only) | ✓ Slim populates |
| Sidebar `visibilitySummary.tone` | from `overview` composite | ✓ Slim populates |
| Run drawer | Separate `useRunDetail(runId)` fetch | ✓ Unaffected |
| Client-side `buildAttentionItems` from `visibilityEvidence` | `visibilityEvidence` | ⚠️ Already-known limitation, documented in `use-dashboard-overview.ts:40-45`; server-side `overview.attentionItems` covers it. |

Only one active consumer-facing bug from this pattern. This PR fixes it.

## Test plan
- [x] New regression test `find-evidence-for-modal.test.ts` covering: bug-regression case (commandCenter has evidence, slim dashboard does not), dashboard fallback, no-project-route, not-found
- [x] `pnpm run typecheck` — passes
- [x] `pnpm --filter @ainyc/canonry-web lint` — no new warnings/errors
- [x] Existing tests unchanged (54 pre-existing failures on `main` predate this PR — verified by stashing the change and re-running)
- [ ] Manual: click View in the populated `ainyc` project → modal opens