### PR TITLE
fix(web): poll per-project dashboard so CLI-driven writes surface without refresh

### DIFF
--- a/apps/web/src/queries/query-client.ts
+++ b/apps/web/src/queries/query-client.ts
@@ -13,6 +13,16 @@ export const RUNS_STALE_MS = 30_000
 // end-to-end. Trade-off: ~30 req/min from one tab to a SQLite SELECT.
 export const PROJECTS_REFRESH_MS = 2_000
 
+// Per-project detail (queries, competitors, timeline, snapshots) polls
+// slower than the sidebar because each refetch fans out across ~9
+// endpoints (queries / competitors / timeline / latest+previous run
+// detail / GSC / Bing / insights / overview). 5s gives CLI-driven
+// `canonry query add` / `canonry competitor add` visible feedback on
+// the project page without the load multiplier of a 2s poll. Defaults
+// to background-paused via React Query's `refetchIntervalInBackground:
+// false` so idle tabs don't keep pulling.
+export const PROJECT_DETAIL_REFRESH_MS = 5_000
+
 export function createQueryClient() {
   return new QueryClient({
     defaultOptions: {

--- a/apps/web/src/queries/use-project-dashboard.ts
+++ b/apps/web/src/queries/use-project-dashboard.ts
@@ -19,7 +19,7 @@ import { buildProjectCommandCenter } from '../build-dashboard.js'
 import type { ProjectData } from '../build-dashboard.js'
 import type { ProjectCommandCenterVm } from '../view-models.js'
 import { useInitialDashboard } from '../contexts/dashboard-context.js'
-import { RUNS_STALE_MS, STATIC_VISIBILITY_STALE_MS } from './query-client.js'
+import { PROJECT_DETAIL_REFRESH_MS, RUNS_STALE_MS, STATIC_VISIBILITY_STALE_MS } from './query-client.js'
 
 /**
  * Heavy dashboard hook scoped to a single project. Fetches everything
@@ -156,6 +156,14 @@ export function useProjectDashboard(projectName: string | null | undefined) {
     enabled: !!project && !!projectName && runsQuery.isSuccess,
     staleTime: STATIC_VISIBILITY_STALE_MS,
     refetchOnWindowFocus: 'always',
+    // Poll so CLI-driven writes (`canonry query add`, `canonry competitor
+    // add`, etc.) surface on the open project page within a few seconds
+    // without the user having to refresh. The slim portfolio hook polls
+    // `/projects` every 2s for the same reason — the per-project detail
+    // got missed when `useProjectDashboard` was split out. Background
+    // tabs pause polling (React Query default behavior) so idle pages
+    // don't keep pulling.
+    refetchInterval: PROJECT_DETAIL_REFRESH_MS,
   })
 
   const commandCenter = useMemo<ProjectCommandCenterVm | null>(() => {


### PR DESCRIPTION
## Summary

`useProjectDashboard`'s `detailQuery` had no `refetchInterval`, so CLI-side writes (`cnry query add`, `cnry competitor add`, `cnry apply`, etc.) never appeared on an open project page until the user reloaded or fired a UI mutation. The slim `useDashboardOverview` hook already polls `/projects` every 2s for this exact reason — the per-project detail just got missed when `useProjectDashboard` was split out as its own hook.

## Behavior change

Open the project page → run `cnry query add <project> "new query"` in a terminal → the query appears in the table within ~5 seconds (was: never, until reload).

## Constants

- New: `PROJECT_DETAIL_REFRESH_MS = 5_000`
- Existing (unchanged): `PROJECTS_REFRESH_MS = 2_000`

5s (not 2s like the sidebar) because each refetch fans out across ~9 endpoints (queries / competitors / timeline / latest+previous run detail × N / GSC / Bing / insights / overview). Tradeoff: ~108 fetches/min from one open tab. Idle background tabs pause automatically via React Query's default `refetchIntervalInBackground: false`.

## Scope

2 files, +19/−1:
- `apps/web/src/queries/query-client.ts` — added constant + comment explaining the tradeoff
- `apps/web/src/queries/use-project-dashboard.ts` — wired the interval into `detailQuery`

## Why not bundle with PR #604

#604 fixes the View-button modal (a render-time bug). This is a data-freshness bug. Reviewable independently and easy to roll back if the polling load becomes a concern in larger projects.

## Test plan
- [x] `pnpm run typecheck` — passes
- [x] `pnpm --filter @ainyc/canonry-web lint` — no new warnings
- [x] Existing project-detail-invalidation tests still pass
- [ ] Manual: open project page, `cnry query add <p> "x"` from CLI, see it appear within 5s
- [ ] Manual: `cnry competitor add <p> example.com` from CLI, see it appear within 5s