### PR TITLE
chore: bump version to 4.51.3 — ship View modal + project polling fixes to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.51.2",
+  "version": "4.51.3",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.51.2",
+  "version": "4.51.3",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Summary

Single bump from `4.51.2` → `4.51.3` to trigger the publish workflow and ship the last two merged fixes to npm.

## What's actually shipping

| PR | Commit | What it fixes |
|---|---|---|
| #604 | `6b65ef9e` | View button on project page silently failed to open the evidence modal |
| #605 | `24577652` | CLI-side writes (`cnry query add` / `cnry competitor add` / etc.) didn't surface on an open project page without manual refresh |

Both already merged to `main`. The publish workflows ran successfully but **skipped the npm publish step** because `version_changed` was `false`. This PR is the trigger that unlocks them.

## Scope

2 files, +2/−2. Version field only.

## After merge

`.github/workflows/publish.yml` should fire on push to `main`, detect `version_changed: true`, run typecheck + test, build, and `pnpm publish` 4.51.3 to npm. ~3 minutes end-to-end.

Verify with:
```bash
npm view @ainyc/canonry version  # should print 4.51.3
```

Once it's up, `npm install -g @ainyc/canonry` gets both fixes for the public.

## Test plan
- [x] Both files updated and consistent (`4.51.3` in root + `packages/canonry`)
- [ ] CI passes (typecheck / test / lint / build / publish-smoke-test all unchanged scope)
- [ ] After merge: publish workflow ships 4.51.3 to npm
- [ ] After publish: `npm view @ainyc/canonry version` shows `4.51.3`