### PR TITLE
fix(runs): graceful fallback when allLocations:true hits a 0-location project

### DIFF
--- a/packages/api-routes/src/runs.ts
+++ b/packages/api-routes/src/runs.ts
@@ -80,8 +80,25 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
     let resolvedLocation: LocationContext | null | undefined
     const projectLocations = project.locations
 
-    if (body.noLocation) {
-      resolvedLocation = null // explicitly no location
+    // `allLocations: true` on a project with zero configured locations is a
+    // common over-include from agents (Aero, Claude Code, scripts) that pass
+    // the optional field by reflex. Rather than failing the run loud (which
+    // makes the agent's "sweep everything" intent unactionable), degrade
+    // gracefully to a single locationless run — same outcome the operator
+    // would get by passing `noLocation: true` or omitting both flags on an
+    // unlocated project. The audit-log channel below still surfaces who
+    // triggered it so the noisy caller can be hunted down if needed.
+    const allLocationsRequestedButEmpty = body.allLocations === true && projectLocations.length === 0
+    if (allLocationsRequestedButEmpty) {
+      app.log.info({
+        projectId: project.id,
+        projectName: project.name,
+        trigger,
+      }, 'runs.all-locations-empty-fallback')
+    }
+
+    if (body.noLocation || allLocationsRequestedButEmpty) {
+      resolvedLocation = null // explicitly no location, or fallback from allLocations-on-empty
     } else if (body.allLocations) {
       // allLocations triggers one run per location — handled below
     } else if (body.location) {
@@ -107,11 +124,11 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
     // calls (manual + scheduled, two CLI shells, etc.) can no longer stack
     // duplicate sweeps on the same project, double-billing provider calls
     // and racing snapshots into the same window.
-    if (body.allLocations) {
-      if (projectLocations.length === 0) {
-        throw validationError('No locations configured for this project')
-      }
-
+    //
+    // Empty-locations case is the `allLocationsRequestedButEmpty` branch
+    // above — it falls through to the single locationless run below
+    // instead of hitting this fan-out path.
+    if (body.allLocations && !allLocationsRequestedButEmpty) {
       const result = app.db.transaction((tx) => {
         const activeRun = tx
           .select({ id: runs.id })

--- a/packages/api-routes/test/run-all-locations-empty-fallback.test.ts
+++ b/packages/api-routes/test/run-all-locations-empty-fallback.test.ts
@@ -1,0 +1,109 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import Fastify from 'fastify'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createClient, migrate } from '@ainyc/canonry-db'
+import { apiRoutes } from '../src/index.js'
+
+/**
+ * Regression test for the "🔧 Sweep activity FAILED — No locations configured"
+ * complaint. Agents (Aero, Claude Code, external scripts) routinely pass
+ * `allLocations: true` by reflex when triggering sweeps. Throwing 400 on
+ * projects with no configured locations made every agent-driven sweep on an
+ * unlocated project a hard failure even though the operator's intent
+ * ("sweep this project") was unambiguous.
+ *
+ * The new behavior: `allLocations: true` on a 0-location project degrades
+ * to a single locationless run — equivalent to `noLocation: true` or
+ * omitting both flags. Locations DO exist → still fan out as before.
+ */
+describe('POST /:name/runs allLocations on a 0-location project (graceful fallback)', () => {
+  let app: ReturnType<typeof Fastify>
+  let tmpDir: string
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-empty-loc-fallback-'))
+    const db = createClient(path.join(tmpDir, 'test.db'))
+    migrate(db)
+    app = Fastify()
+    await app.register(apiRoutes, { db, skipAuth: true })
+    await app.ready()
+    // Seed a project with NO locations.
+    await app.inject({
+      method: 'PUT',
+      url: '/api/v1/projects/no-loc',
+      payload: {
+        displayName: 'No Locations',
+        canonicalDomain: 'no-loc.example.com',
+        country: 'US',
+        language: 'en',
+        locations: [],
+      },
+    })
+  })
+
+  afterEach(async () => {
+    await app.close()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns 201 with a single locationless run instead of 400 No locations configured', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/no-loc/runs',
+      payload: { allLocations: true },
+    })
+
+    expect(res.statusCode).toBe(201)
+    const body = JSON.parse(res.body) as { id: string; location: string | null; status: string }
+    // Single-object response shape (not the 207 multi-location array).
+    expect(Array.isArray(body)).toBe(false)
+    expect(body.id).toBeDefined()
+    expect(body.location).toBeNull()
+    expect(body.status).toMatch(/queued|running/)
+  })
+
+  it('still fans out when the project has locations (no regression on the happy path)', async () => {
+    // Sanity check: graceful-fallback path must not have broken the
+    // multi-location fan-out when locations ARE configured.
+    await app.inject({
+      method: 'PUT',
+      url: '/api/v1/projects/with-loc',
+      payload: {
+        displayName: 'With Locations',
+        canonicalDomain: 'with-loc.example.com',
+        country: 'US',
+        language: 'en',
+        locations: [
+          { label: 'east', city: 'New York', region: 'NY', country: 'US' },
+          { label: 'west', city: 'San Francisco', region: 'CA', country: 'US' },
+        ],
+      },
+    })
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/with-loc/runs',
+      payload: { allLocations: true },
+    })
+
+    expect(res.statusCode).toBe(207)
+    const body = JSON.parse(res.body) as Array<{ id: string; location: string; status: string }>
+    expect(Array.isArray(body)).toBe(true)
+    expect(body).toHaveLength(2)
+    expect(body.map(r => r.location).sort()).toEqual(['east', 'west'])
+  })
+
+  it('rejects when allLocations is combined with location or noLocation (Zod refinement)', async () => {
+    // The Zod refinement on runTriggerRequestSchema only allows ONE of
+    // location / allLocations / noLocation. Make sure the graceful-fallback
+    // didn't accidentally bypass that.
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/no-loc/runs',
+      payload: { allLocations: true, noLocation: true },
+    })
+    expect(res.statusCode).toBe(400)
+  })
+})

--- a/packages/canonry/test/location-commands.test.ts
+++ b/packages/canonry/test/location-commands.test.ts
@@ -365,7 +365,14 @@ describe('location CLI commands', () => {
     }
   })
 
-  it('run --all-locations returns an error when no locations configured', async () => {
+  it('run --all-locations on a 0-location project falls back to a single locationless run', async () => {
+    // Was previously a hard 400. Agents (Aero, Claude Code, external scripts)
+    // routinely pass `allLocations: true` by reflex when triggering sweeps —
+    // failing loud just makes the agent's "sweep everything" intent
+    // unactionable on unlocated projects. We now treat
+    // `allLocations + projectLocations.length === 0` as a no-op for the flag
+    // and queue one locationless run (same outcome as `noLocation: true` or
+    // omitting both). See `runs.all-locations-empty-fallback` server log.
     await client.putProject('test-proj', {
       displayName: 'Test',
       canonicalDomain: 'example.com',
@@ -374,6 +381,23 @@ describe('location CLI commands', () => {
     })
 
     const { triggerRun } = await import('../src/commands/run.js')
-    await expect(() => triggerRun('test-proj', { allLocations: true })).rejects.toThrow(/No locations configured/)
+    const logs: string[] = []
+    const origLog = console.log
+    console.log = (...args: unknown[]) => logs.push(args.join(' '))
+    try {
+      await triggerRun('test-proj', { allLocations: true, format: 'json' })
+    } finally {
+      console.log = origLog
+    }
+
+    // Single-object response (not the 207 multi-location array shape).
+    const jsonLine = logs.find(l => {
+      try { JSON.parse(l); return true } catch { return false }
+    })
+    expect(jsonLine, 'should have a JSON log line').toBeDefined()
+    const parsed = JSON.parse(jsonLine) as { id: string; status: string; location: string | null }
+    expect(Array.isArray(parsed), 'response should be a single object, not the multi-location array').toBe(false)
+    expect(parsed.id, 'run should have an id').toBeDefined()
+    expect(parsed.location, 'fallback run should be locationless').toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

- Reported as "🔧 Sweep activity FAILED — No locations configured" on demand-iq / gjelina-hotel today. Both projects have `locations: []`. Investigation showed nothing in canonry's code defaults `allLocations: true` — the source is always an external caller (Aero, Claude Code, scripts), and LLM agents tend to over-include optional schema fields by reflex.
- Per the operator's intent (\"sweep this project\"), the natural fallback is one locationless run — equivalent to `noLocation: true` or omitting both flags. Throwing 400 on what's effectively a no-op flag combination made every agent-driven sweep on an unlocated project a hard failure.
- New behavior:
  - `allLocations: true` + `projectLocations.length === 0` → falls through to a single locationless run
  - `allLocations: true` + `projectLocations.length > 0` → fans out as before (unchanged)
  - `allLocations: true` + `noLocation: true` or `location: <x>` → still rejected by the existing Zod `.refine()` on `runTriggerRequestSchema`
- Server-side log `runs.all-locations-empty-fallback` fires on every fallback so a sustained noisy caller can still be traced.

## Test plan
- [x] `pnpm vitest run --project api-routes` — 922 passing, including 3 new cases in `run-all-locations-empty-fallback.test.ts` (single locationless run on 0-loc / still fans out on 2-loc / combinations still rejected)
- [x] `pnpm vitest run --project canonry` — updated the previous \"returns an error when no locations configured\" CLI test to assert the new fallback shape
- [x] `pnpm typecheck` clean across all 27 projects
- [x] `pnpm lint` clean (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)