### PR TITLE
fix(cli): drop --all-locations per-project for 0-location projects in `cnry run --all`

### DIFF
--- a/packages/canonry/src/commands/run.ts
+++ b/packages/canonry/src/commands/run.ts
@@ -123,7 +123,10 @@ export async function triggerRun(project: string, opts?: { provider?: string; qu
 
 export async function triggerRunAll(opts?: { provider?: string; wait?: boolean; format?: string; allLocations?: boolean; noLocation?: boolean }): Promise<void> {
   const client = getClient()
-  const projects = await client.listProjects() as Array<{ name: string }>
+  // Use full ProjectDto (not Array<{name}>) so we can check each
+  // project's `locations` per-iteration. `listProjects()` already returns
+  // the full DTO including `locations` and `defaultLocation`.
+  const projects = await client.listProjects()
 
   if (projects.length === 0) {
     if (opts?.format === 'json') {
@@ -134,22 +137,37 @@ export async function triggerRunAll(opts?: { provider?: string; wait?: boolean; 
     return
   }
 
-  const body: Record<string, unknown> = {}
+  const baseBody: Record<string, unknown> = {}
   if (opts?.provider) {
     const providerInputs = opts.provider.split(',').map(s => s.trim()).filter(Boolean)
     const resolved = providerInputs.flatMap(p => resolveProviderInput(p))
-    body.providers = resolved.length > 0 ? resolved : providerInputs
+    baseBody.providers = resolved.length > 0 ? resolved : providerInputs
   }
   if (opts?.allLocations) {
-    body.allLocations = true
+    baseBody.allLocations = true
   }
   if (opts?.noLocation) {
-    body.noLocation = true
+    baseBody.noLocation = true
   }
 
   const results: Array<{ project: string; runId: string; status: string; error?: string }> = []
 
   for (const p of projects) {
+    // Per-project body: drop `allLocations` when the project has no
+    // locations configured. The API correctly 400s `allLocations: true`
+    // on a 0-location project (the flag requests fan-out across a
+    // dimension that doesn't exist), but applying that strictly in a
+    // multi-project `--all` loop means one mis-configured project takes
+    // down the rest of the sweep. We drop the flag locally — the
+    // remaining body falls through to a single locationless run, same
+    // as `cnry run <project>` would do on the same project — and let
+    // the loud 400 surface only when a user explicitly aimed
+    // `--all-locations` at a single 0-location project.
+    const body: Record<string, unknown> = { ...baseBody }
+    if (body.allLocations && p.locations.length === 0) {
+      delete body.allLocations
+    }
+
     try {
       const run = await client.triggerRun(p.name, body) as { id: string; status: string }
       results.push({ project: p.name, runId: run.id, status: run.status })

--- a/packages/canonry/src/commands/run.ts
+++ b/packages/canonry/src/commands/run.ts
@@ -150,7 +150,12 @@ export async function triggerRunAll(opts?: { provider?: string; wait?: boolean; 
     baseBody.noLocation = true
   }
 
-  const results: Array<{ project: string; runId: string; status: string; error?: string }> = []
+  // `location: string | null` distinguishes the multi-location fan-out
+  // rows (one per configured location) from locationless / single-
+  // location runs. JSON output gains this field; the table output adds
+  // a corresponding LOCATION column. Both are additive — existing JSON
+  // consumers that ignore unknown fields keep working.
+  const results: Array<{ project: string; runId: string; status: string; location: string | null; error?: string }> = []
 
   for (const p of projects) {
     // Per-project body: drop `allLocations` when the project has no
@@ -169,11 +174,26 @@ export async function triggerRunAll(opts?: { provider?: string; wait?: boolean; 
     }
 
     try {
-      const run = await client.triggerRun(p.name, body) as { id: string; status: string }
-      results.push({ project: p.name, runId: run.id, status: run.status })
+      // Response shape varies by code path:
+      //   - `allLocations: true` + locations present → 207 + RunDto[] (one per location)
+      //   - everything else → 201 + RunDto (single run)
+      // Normalize to an array so we record one results row per dispatched
+      // run. Without this, multi-location projects had their entire fan-out
+      // collapsed into `{ runId: undefined, status: undefined }` and
+      // displayed as `(failed)` even when every per-location run was queued.
+      const response = await client.triggerRun(p.name, body)
+      const dispatched = Array.isArray(response) ? response : [response]
+      for (const r of dispatched) {
+        results.push({
+          project: p.name,
+          runId: r.id,
+          status: r.status,
+          location: r.location ?? null,
+        })
+      }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
-      results.push({ project: p.name, runId: '', status: 'error', error: msg })
+      results.push({ project: p.name, runId: '', status: 'error', location: null, error: msg })
     }
   }
 
@@ -194,13 +214,29 @@ export async function triggerRunAll(opts?: { provider?: string; wait?: boolean; 
     return
   }
 
-  console.log(`Triggered ${results.length} run(s):\n`)
-  console.log('  PROJECT                          RUN ID                                STATUS')
-  console.log('  ───────────────────────────────  ────────────────────────────────────  ──────────')
-  for (const r of results) {
-    const proj = r.project.padEnd(31)
-    const id = (r.runId || '(failed)').padEnd(36)
-    console.log(`  ${proj}  ${id}  ${r.status}`)
+  // Show a LOCATION column only when at least one row has a location set
+  // — keeps the older single-location-everywhere display clean and adds
+  // the column the moment any per-location fan-out happens in the sweep.
+  const showLocationColumn = results.some(r => r.location !== null)
+  const projectCount = new Set(results.map(r => r.project)).size
+  console.log(`Triggered ${results.length} run(s) across ${projectCount} project(s):\n`)
+  if (showLocationColumn) {
+    console.log('  PROJECT                          LOCATION         RUN ID                                STATUS')
+    console.log('  ───────────────────────────────  ───────────────  ────────────────────────────────────  ──────────')
+    for (const r of results) {
+      const proj = r.project.padEnd(31)
+      const loc = (r.location ?? '—').padEnd(15)
+      const id = (r.runId || '(failed)').padEnd(36)
+      console.log(`  ${proj}  ${loc}  ${id}  ${r.status}`)
+    }
+  } else {
+    console.log('  PROJECT                          RUN ID                                STATUS')
+    console.log('  ───────────────────────────────  ────────────────────────────────────  ──────────')
+    for (const r of results) {
+      const proj = r.project.padEnd(31)
+      const id = (r.runId || '(failed)').padEnd(36)
+      console.log(`  ${proj}  ${id}  ${r.status}`)
+    }
   }
 }
 

--- a/packages/canonry/test/location-commands.test.ts
+++ b/packages/canonry/test/location-commands.test.ts
@@ -376,4 +376,55 @@ describe('location CLI commands', () => {
     const { triggerRun } = await import('../src/commands/run.js')
     await expect(() => triggerRun('test-proj', { allLocations: true })).rejects.toThrow(/No locations configured/)
   })
+
+  it('run --all --all-locations is per-project-smart — drops the flag for 0-location projects', async () => {
+    // The single-project `cnry run <proj> --all-locations` against a
+    // 0-location project still fails loud (the test above). But in a
+    // multi-project `--all` loop, one mis-configured project shouldn't
+    // take down the whole sweep — drop `allLocations` per-project for
+    // 0-location projects and let them run a single locationless sweep.
+    // Reported as "🔧 Sweep activity FAILED — No locations configured"
+    // on demand-iq + gjelina-hotel in 2026-05.
+    await client.putProject('no-loc-1', {
+      displayName: 'No Loc 1',
+      canonicalDomain: 'no-loc-1.example.com',
+      country: 'US',
+      language: 'en',
+    })
+    await client.putProject('no-loc-2', {
+      displayName: 'No Loc 2',
+      canonicalDomain: 'no-loc-2.example.com',
+      country: 'US',
+      language: 'en',
+    })
+
+    const { triggerRunAll } = await import('../src/commands/run.js')
+    const logs: string[] = []
+    const origLog = console.log
+    console.log = (...args: unknown[]) => logs.push(args.join(' '))
+    try {
+      await triggerRunAll({ allLocations: true, format: 'json' })
+    } finally {
+      console.log = origLog
+    }
+
+    const jsonLine = logs.find(l => {
+      try { JSON.parse(l); return true } catch { return false }
+    })
+    expect(jsonLine, 'should have a JSON log line').toBeDefined()
+    const parsed = JSON.parse(jsonLine) as Array<{ project: string; runId: string; status: string; error?: string }>
+
+    // Both no-location projects should have queued successfully — before
+    // this fix, both would have returned `status: 'error'` with the
+    // "No locations configured for this project" message.
+    const byProject = new Map(parsed.map(r => [r.project, r]))
+    expect(byProject.get('no-loc-1')?.status, 'no-loc-1 should not error').not.toBe('error')
+    expect(byProject.get('no-loc-2')?.status, 'no-loc-2 should not error').not.toBe('error')
+    expect(byProject.get('no-loc-1')?.error, 'no-loc-1 should have no error message').toBeUndefined()
+    expect(byProject.get('no-loc-2')?.error, 'no-loc-2 should have no error message').toBeUndefined()
+    // And both should have a valid runId — the API returned a single-
+    // object response (201) once `allLocations` was dropped per-project.
+    expect(byProject.get('no-loc-1')?.runId).toBeTruthy()
+    expect(byProject.get('no-loc-2')?.runId).toBeTruthy()
+  })
 })

--- a/packages/canonry/test/location-commands.test.ts
+++ b/packages/canonry/test/location-commands.test.ts
@@ -377,26 +377,30 @@ describe('location CLI commands', () => {
     await expect(() => triggerRun('test-proj', { allLocations: true })).rejects.toThrow(/No locations configured/)
   })
 
-  it('run --all --all-locations is per-project-smart — drops the flag for 0-location projects', async () => {
-    // The single-project `cnry run <proj> --all-locations` against a
-    // 0-location project still fails loud (the test above). But in a
-    // multi-project `--all` loop, one mis-configured project shouldn't
-    // take down the whole sweep — drop `allLocations` per-project for
-    // 0-location projects and let them run a single locationless sweep.
-    // Reported as "🔧 Sweep activity FAILED — No locations configured"
-    // on demand-iq + gjelina-hotel in 2026-05.
-    await client.putProject('no-loc-1', {
-      displayName: 'No Loc 1',
-      canonicalDomain: 'no-loc-1.example.com',
+  it('run --all --all-locations handles mixed-config portfolios correctly', async () => {
+    // Two regressions this case guards:
+    //   1. 0-location projects (demand-iq, gjelina-hotel in the original
+    //      report) shouldn't 400 — the multi-project loop drops the flag
+    //      per-project so they run a single locationless sweep.
+    //   2. Projects with locations should still fan out and ALL their
+    //      per-location runs should appear in the results, not collapse
+    //      into a single `{ runId: undefined }` row. Pre-existing cast
+    //      bug — the cast `as { id, status }` silently mishandled the
+    //      207-array response shape.
+    await client.putProject('no-loc', {
+      displayName: 'No Loc',
+      canonicalDomain: 'no-loc.example.com',
       country: 'US',
       language: 'en',
     })
-    await client.putProject('no-loc-2', {
-      displayName: 'No Loc 2',
-      canonicalDomain: 'no-loc-2.example.com',
+    await client.putProject('with-loc', {
+      displayName: 'With Loc',
+      canonicalDomain: 'with-loc.example.com',
       country: 'US',
       language: 'en',
     })
+    await client.addLocation('with-loc', { label: 'nyc', city: 'New York', region: 'NY', country: 'US' })
+    await client.addLocation('with-loc', { label: 'lax', city: 'Los Angeles', region: 'CA', country: 'US' })
 
     const { triggerRunAll } = await import('../src/commands/run.js')
     const logs: string[] = []
@@ -412,19 +416,20 @@ describe('location CLI commands', () => {
       try { JSON.parse(l); return true } catch { return false }
     })
     expect(jsonLine, 'should have a JSON log line').toBeDefined()
-    const parsed = JSON.parse(jsonLine) as Array<{ project: string; runId: string; status: string; error?: string }>
+    const parsed = JSON.parse(jsonLine) as Array<{ project: string; runId: string; status: string; location: string | null; error?: string }>
 
-    // Both no-location projects should have queued successfully — before
-    // this fix, both would have returned `status: 'error'` with the
-    // "No locations configured for this project" message.
-    const byProject = new Map(parsed.map(r => [r.project, r]))
-    expect(byProject.get('no-loc-1')?.status, 'no-loc-1 should not error').not.toBe('error')
-    expect(byProject.get('no-loc-2')?.status, 'no-loc-2 should not error').not.toBe('error')
-    expect(byProject.get('no-loc-1')?.error, 'no-loc-1 should have no error message').toBeUndefined()
-    expect(byProject.get('no-loc-2')?.error, 'no-loc-2 should have no error message').toBeUndefined()
-    // And both should have a valid runId — the API returned a single-
-    // object response (201) once `allLocations` was dropped per-project.
-    expect(byProject.get('no-loc-1')?.runId).toBeTruthy()
-    expect(byProject.get('no-loc-2')?.runId).toBeTruthy()
+    // Three rows total: one for `no-loc` (locationless), two for
+    // `with-loc` (one per configured location).
+    expect(parsed).toHaveLength(3)
+
+    const byKey = new Map(parsed.map(r => [`${r.project}:${r.location ?? '—'}`, r]))
+    expect(byKey.get('no-loc:—')?.status, 'no-loc should not error').not.toBe('error')
+    expect(byKey.get('no-loc:—')?.runId, 'no-loc should have a runId').toBeTruthy()
+    expect(byKey.get('no-loc:—')?.error, 'no-loc should have no error').toBeUndefined()
+
+    expect(byKey.get('with-loc:nyc')?.runId, 'with-loc nyc fan-out should have a runId').toBeTruthy()
+    expect(byKey.get('with-loc:lax')?.runId, 'with-loc lax fan-out should have a runId').toBeTruthy()
+    expect(byKey.get('with-loc:nyc')?.status, 'with-loc nyc should not error').not.toBe('error')
+    expect(byKey.get('with-loc:lax')?.status, 'with-loc lax should not error').not.toBe('error')
   })
 })


### PR DESCRIPTION
## Summary

Supersedes #607 (closed) with the cleaner fix per @dev review, plus follow-up fixes from a hostile self-review.

### The original bug (commit 1)
- API validation on `allLocations + 0-location project` has been correct since PR #65 (2026-03-16). The strict 400 is the right contract — `allLocations: true` requests fan-out across a dimension that doesn't exist on a 0-location project, so silently degrading at the API layer (what #607 did) would mask real misconfiguration.
- The ergonomic bug is in **`cnry run --all --all-locations`** — one shared body sent to every project, so a single mis-configured project takes down the whole multi-project sweep.
- Fix: in `triggerRunAll`, clone the base body per-project and drop `allLocations` when `project.locations.length === 0`. The remaining body falls through to a single locationless run, same as `cnry run <project>` (no flag) would do.
- Single-project `cnry run <project> --all-locations` on a 0-location project **still** fails loud — that's an explicit user error worth surfacing.

### The follow-up array-response fix (commit 2)
Code review caught: the existing cast `await client.triggerRun(...) as { id, status }` doesn't handle the 207 multi-location response. After the per-project flag-drop, 0-location projects display correctly, but projects WITH locations still showed `(failed)` in the output table because the array got cast to a single object with both fields `undefined`.

- Normalize `triggerRun`'s response to an array (single → wrap; array → keep) and push one results row per dispatched run.
- Each results row now carries `location: string | null` (additive JSON field).
- Table output gains a LOCATION column when any row has a location set; falls back to the older PROJECT-only display when the sweep is locationless across the portfolio.
- Test rewritten to cover the mixed-config case: 1 project with 0 locations + 1 project with 2 locations → 3 results rows, all with valid runIds, no errors.

## Why this layer

| Concern | API-side fallback (closed #607) | CLI-side per-project drop (this PR) |
|---|---|---|
| Silently degrades `allLocations` semantics | yes | no |
| Surfaces misconfigured agent callers | hidden via server log only | still loud for direct single-project calls |
| Fixes the multi-project sweep ergonomics | yes | yes |
| Affects API contract consumers | all callers | none |
| Fixes the 207-array display bug (pre-existing) | n/a | yes (commit 2) |

## Test plan
- [x] `pnpm vitest run --project canonry` — adds case in `location-commands.test.ts` asserting 0-loc projects don't error AND with-loc projects fan out correctly in a multi-project `--all-locations` sweep
- [x] Existing case "run --all-locations returns an error when no locations configured" still passes — single-project strict behavior preserved
- [x] `pnpm typecheck` clean across all 27 projects
- [x] `pnpm lint` clean (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)