### PR TITLE
docs(readme): add agent-driven setup prompt for Claude Code / Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,24 @@ cnry evidence my-site
 cnry insights my-site
 ```
 
+## Or set it up with your AI coding agent
+
+Drop this into Claude Code, Codex, or any shell-capable agent. It installs canonry, runs your first sweep, audits your site for AEO readiness, and stops for your sign-off before taking any action on your behalf:
+
+```text
+Set up canonry for me. Canonry is an open-source platform that tracks how AI answer engines (Gemini, ChatGPT, Claude, Perplexity) cite my site.
+
+1. Ask me for: my domain, 3–5 queries I want to track, and which provider I want to start with (gemini / openai / claude / perplexity). Wait for my answers before proceeding.
+2. Run `npm install -g @ainyc/canonry`.
+3. Run `cnry init` in this directory. This scaffolds config and installs the canonry skills into `.claude/skills/canonry/`, `.claude/skills/aero/`, `.codex/skills/canonry/`, and `.codex/skills/aero/`. If the skills aren't there afterwards, run `cnry skills install`.
+4. Read the operator playbook at `.claude/skills/canonry/SKILL.md` and follow it end-to-end: create the project with my domain and queries, wire up the provider key I chose, and trigger the first sweep.
+5. Open my browser to the dashboard so I can see the run results.
+6. Switch to the analyst playbook at `.claude/skills/aero/SKILL.md` and run a baseline AEO audit on my behalf. Read citation evidence with `cnry evidence <project> --format json`, then run `npx @ainyc/aeo-audit "<my-domain>" --format json` for a site-readiness score.
+7. Summarize what you found: my mention and citation rates per provider, the top 3 queries I'm not yet cited on, and the highest-impact site issues from the audit. Ask me for permission before taking any further action, such as drafting content, submitting URLs for indexing, editing files, or anything else that changes my site.
+```
+
+One-click copy at [canonry.ai](https://canonry.ai).
+
 ## If you get stuck
 
 | Problem | Fix |


### PR DESCRIPTION
## Summary

- Adds a new "Or set it up with your AI coding agent" section to the README with a copy-paste prompt for Claude Code, Codex, or any shell-capable agent.
- The prompt asks the user for their domain, queries, and provider, then installs canonry, runs the first sweep, opens the dashboard, runs an `npx @ainyc/aeo-audit` baseline audit, and stops for the user's permission before any further action.
- Points users at canonry.ai for the one-click copy version (the matching agent-setup section ships in the canonry-landing repo separately).

## Test plan

- [ ] Render README on GitHub and confirm the new section appears between "Run your first AI visibility check in 5 minutes" and "If you get stuck".
- [ ] Copy the prompt into Claude Code against a clean directory and verify the agent walks through install → sweep → audit → permission gate end-to-end.