### PR TITLE
chore: bump version to 4.51.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.51.3",
+  "version": "4.51.4",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.51.3",
+  "version": "4.51.4",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Summary

Closes the daemon ↔ npm gap. `main` has had two CLI fixes from #608 since 2026-05-19 that aren't in the published 4.51.3 npm artifact — anyone running `npm install -g @ainyc/canonry@latest` still gets the version that 400s on `cnry run --all --all-locations` for 0-location projects.

```
                Before                              After
  ─────────────────────────────       ─────────────────────────────
  npm @latest      4.51.3              npm @latest      4.51.4  ✅
  package.json     4.51.3              package.json     4.51.4  ✅
  daemons in       4.51.3 + 2          daemons in       4.51.4 (1:1)
  prod                  unpublished    prod
                        commits
```

## What ships in 4.51.4 (vs 4.51.3)

| Commit | Title |
|---|---|
| [`8c32aae`](https://github.com/AINYC/canonry/commit/8c32aae) | `fix(cli): drop --all-locations per-project for 0-location projects in cnry run --all` |
| [`480cb1e`](https://github.com/AINYC/canonry/commit/480cb1e) | `fix(cli): handle 207-array fan-out response in triggerRunAll` |

Both from PR #608. CLI-only changes; no API change, no behavior change for any 4.51.3 caller that wasn't already in the failing edge case.

## Test plan
- [x] `pnpm typecheck` clean (pre-commit hook ran it)
- [x] `pnpm lint` clean (0 errors, 101 pre-existing warnings)
- [x] CI's `publish-smoke-test` job will pack the tarball and `npm install` it into a scratch dir — exercises the same path an external user takes.

## After merge
1. Tag `v4.51.4` on the merge commit.
2. Cut GitHub release with the two-commit changelog above.
3. npm publish (your OTP — separate step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)