### PR TITLE
feat(traffic): split AI user-fetch UAs into their own hourly rollup

### DIFF
--- a/apps/web/src/components/project/ActivitySection.tsx
+++ b/apps/web/src/components/project/ActivitySection.tsx
@@ -107,10 +107,10 @@ function ServerActivityPanel({ projectName }: { projectName: string }) {
       <div className="flex items-baseline justify-between mb-3">
         <div>
           <div className="eyebrow">Server activity (last 24h)</div>
-          <h2 className="text-lg font-semibold text-zinc-50">Engine crawler hits &amp; AI-referral sessions</h2>
+          <h2 className="text-lg font-semibold text-zinc-50">Crawler hits, AI fetches &amp; AI referral sessions</h2>
           <p className="text-xs text-zinc-500 mt-1">
-            Server-side log evidence of bots crawling the site and AI-referral sessions — orthogonal
-            to GA4 click-through traffic below. {' '}
+            Server-side log evidence of bulk crawlers, on-demand AI user fetches (ChatGPT-User, Perplexity-User),
+            and AI referral sessions — orthogonal to GA4 click-through traffic below.{' '}
             <Link to="/traffic" className="text-blue-400 hover:underline">Manage sources →</Link>
           </p>
         </div>
@@ -134,6 +134,7 @@ function ServerActivityPanel({ projectName }: { projectName: string }) {
                 <th className="text-left px-4 py-2 font-medium">Source</th>
                 <th className="text-left px-4 py-2 font-medium">Status</th>
                 <th className="text-right px-4 py-2 font-medium">Crawler hits 24h</th>
+                <th className="text-right px-4 py-2 font-medium">AI hits 24h</th>
                 <th className="text-right px-4 py-2 font-medium">AI sessions 24h</th>
                 <th className="text-right px-4 py-2 font-medium">Last sync</th>
                 <th className="text-left px-4 py-2 font-medium" aria-label="open" />
@@ -148,6 +149,9 @@ function ServerActivityPanel({ projectName }: { projectName: string }) {
                   </td>
                   <td className="px-4 py-3 text-right tabular-nums text-zinc-100">
                     {s.totals24h.crawlerHits.toLocaleString('en-US')}
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums text-zinc-100">
+                    {s.totals24h.aiUserFetchHits.toLocaleString('en-US')}
                   </td>
                   <td className="px-4 py-3 text-right tabular-nums text-zinc-100">
                     {s.totals24h.aiReferralHits.toLocaleString('en-US')}

--- a/apps/web/src/lib/traffic-event-filter.ts
+++ b/apps/web/src/lib/traffic-event-filter.ts
@@ -35,11 +35,23 @@ function statusClassDigit(filter: StatusClassFilter): number | null {
 }
 
 export function identityOf(event: TrafficEventEntry): string {
-  return event.kind === TrafficEventKinds.crawler ? event.botId : event.product
+  switch (event.kind) {
+    case TrafficEventKinds.crawler:
+    case TrafficEventKinds['ai-user-fetch']:
+      return event.botId
+    case TrafficEventKinds['ai-referral']:
+      return event.product
+  }
 }
 
 export function pathOf(event: TrafficEventEntry): string {
-  return event.kind === TrafficEventKinds.crawler ? event.pathNormalized : event.landingPathNormalized
+  switch (event.kind) {
+    case TrafficEventKinds.crawler:
+    case TrafficEventKinds['ai-user-fetch']:
+      return event.pathNormalized
+    case TrafficEventKinds['ai-referral']:
+      return event.landingPathNormalized
+  }
 }
 
 export function bucketKeyFor(tsHour: string, granularity: EventGranularity): string {

--- a/apps/web/src/pages/ReportPage.tsx
+++ b/apps/web/src/pages/ReportPage.tsx
@@ -181,9 +181,12 @@ function ServerActivityClientView({ report }: { report: ProjectReportDto }) {
   }
   const crawlerDelta = formatDeltaCopy(crawlerRequests, 'requests')
   const crawlerSubtitle = `${formatNumber(sa.verifiedCrawlerHits.current)} verified · ${formatNumber(sa.unverifiedCrawlerHits.current)} unverified${crawlerDelta ? ` · ${crawlerDelta}` : ''}`
+  const userFetchDelta = formatDeltaCopy(sa.aiUserFetchHits, 'requests')
   const referralDelta = formatDeltaCopy(sa.referralArrivals, 'sessions')
   // For the client view we cap at the top 5 entries — agencies see the full breakdown in the HTML report.
-  const topOperators = sa.byOperator.filter(o => o.verifiedHits > 0 || o.unverifiedHits > 0 || o.referralArrivals > 0).slice(0, 5)
+  const topOperators = sa.byOperator
+    .filter(o => o.verifiedHits > 0 || o.unverifiedHits > 0 || o.userFetchHits > 0 || o.referralArrivals > 0)
+    .slice(0, 5)
 
   return (
     <section className="page-section-divider">
@@ -192,11 +195,16 @@ function ServerActivityClientView({ report }: { report: ProjectReportDto }) {
         title={SERVER_ACTIVITY_TITLE}
         subtitle={SERVER_ACTIVITY_INTRO_HAS_DATA}
       />
-      <div className="grid gap-3 sm:grid-cols-2">
+      <div className="grid gap-3 sm:grid-cols-3">
         <Metric
           label="AI bot requests observed"
           value={formatNumber(crawlerRequests.current)}
           subtitle={crawlerSubtitle}
+        />
+        <Metric
+          label="AI user-fetch requests"
+          value={formatNumber(sa.aiUserFetchHits.current)}
+          subtitle={userFetchDelta || 'ChatGPT-User, Perplexity-User, MistralAI-User'}
         />
         <Metric
           label="AI referral sessions"
@@ -213,6 +221,7 @@ function ServerActivityClientView({ report }: { report: ProjectReportDto }) {
                 <tr>
                   <th>AI tool</th>
                   <th>Bot requests (7d)</th>
+                  <th>User fetches (7d)</th>
                   <th>Referral sessions</th>
                 </tr>
               </thead>
@@ -221,6 +230,7 @@ function ServerActivityClientView({ report }: { report: ProjectReportDto }) {
                   <tr key={o.operator}>
                     <td className="evidence-query-cell">{o.operator}</td>
                     <td>{formatNumber(o.verifiedHits + o.unverifiedHits)}</td>
+                    <td>{formatNumber(o.userFetchHits)}</td>
                     <td>{formatNumber(o.referralArrivals)}</td>
                   </tr>
                 ))}
@@ -228,7 +238,7 @@ function ServerActivityClientView({ report }: { report: ProjectReportDto }) {
             </table>
           </div>
           <p className="mt-2 text-[11px] text-zinc-500">
-            Verified requests are reverse-DNS confirmed. Unverified requests are user-agent claims shown separately in agency diagnostics.
+            Bot requests are bulk crawl (GPTBot, PerplexityBot, …). User fetches are on-demand reads triggered by real users inside an AI surface (ChatGPT-User, Perplexity-User, …). Verified requests are reverse-DNS confirmed; unverified requests are UA claims shown separately in agency diagnostics.
           </p>
         </div>
       )}

--- a/apps/web/src/pages/TrafficPage.tsx
+++ b/apps/web/src/pages/TrafficPage.tsx
@@ -58,7 +58,7 @@ export function TrafficPage() {
         <div className="page-header-left">
           <h1 className="page-title">Server traffic</h1>
           <p className="page-subtitle">
-            Crawler hits and AI-referral sessions pulled directly from your server logs. Independent of GA — useful when you need server-side evidence that GPTBot or ChatGPT-User actually hit a page.
+            Bulk crawler hits, AI user fetches (ChatGPT-User, Perplexity-User), and AI referral sessions pulled directly from your server logs. Independent of GA — useful when you need server-side evidence that an AI engine actually hit a page.
           </p>
         </div>
         <div className="flex flex-wrap items-center justify-end gap-2">
@@ -147,6 +147,7 @@ function SourcesTable({ projectName, sources }: { projectName: string; sources: 
             <th className="px-4 py-2 text-left">Status</th>
             <th className="px-4 py-2 text-left">Last sync</th>
             <th className="px-4 py-2 text-right">24h crawler</th>
+            <th className="px-4 py-2 text-right">24h AI hits</th>
             <th className="px-4 py-2 text-right">24h AI sessions</th>
             <th className="px-4 py-2 text-right">24h samples</th>
             <th className="px-4 py-2 text-right" />
@@ -172,6 +173,9 @@ function SourcesTable({ projectName, sources }: { projectName: string; sources: 
               <td className="px-4 py-3 text-zinc-300">{relativeTime(source.lastSyncedAt)}</td>
               <td className="px-4 py-3 text-right tabular-nums text-zinc-100">
                 {isLoading ? '—' : formatCompact(detail?.totals24h.crawlerHits ?? 0)}
+              </td>
+              <td className="px-4 py-3 text-right tabular-nums text-zinc-100">
+                {isLoading ? '—' : formatCompact(detail?.totals24h.aiUserFetchHits ?? 0)}
               </td>
               <td className="px-4 py-3 text-right tabular-nums text-zinc-100">
                 {isLoading ? '—' : formatCompact(detail?.totals24h.aiReferralHits ?? 0)}

--- a/apps/web/src/pages/TrafficSourceDetailPage.tsx
+++ b/apps/web/src/pages/TrafficSourceDetailPage.tsx
@@ -35,12 +35,13 @@ import {
   bucketKeyFor,
   filterTrafficEvents,
   identityOf,
+  pathOf,
   STATUS_CLASS_OPTIONS,
   type EventGranularity,
   type StatusClassFilter,
 } from '../lib/traffic-event-filter.js'
 
-type SeriesKind = 'crawler' | 'ai-referral'
+type SeriesKind = 'crawler' | 'ai-user-fetch' | 'ai-referral'
 type Granularity = EventGranularity
 
 interface WindowOption {
@@ -62,6 +63,7 @@ const WINDOW_OPTIONS: readonly WindowOption[] = [
 const DEFAULT_WINDOW = WINDOW_OPTIONS.find((w) => w.label === '7d') ?? WINDOW_OPTIONS[2]
 
 const CRAWLER_COLOR = CHART_SERIES_COLORS[0]
+const AI_USER_FETCH_COLOR = CHART_SERIES_COLORS[2]
 const AI_REFERRAL_COLOR = CHART_SERIES_COLORS[1]
 
 function formatHourLabel(iso: string): string {
@@ -139,7 +141,7 @@ export function TrafficSourceDetailPage() {
 
   const [windowMinutes, setWindowMinutes] = useState<number>(DEFAULT_WINDOW.value)
   const [visibleSeries, setVisibleSeries] = useState<Set<SeriesKind>>(
-    () => new Set<SeriesKind>(['crawler', 'ai-referral']),
+    () => new Set<SeriesKind>(['crawler', 'ai-user-fetch', 'ai-referral']),
   )
   const [selectedBucket, setSelectedBucket] = useState<string | null>(null)
   const [identityFilter, setIdentityFilter] = useState<string>('')
@@ -169,11 +171,13 @@ export function TrafficSourceDetailPage() {
 
   const visibleEvents = useMemo(
     () =>
-      allEvents.filter((event) =>
-        event.kind === TrafficEventKinds.crawler
-          ? visibleSeries.has('crawler')
-          : visibleSeries.has('ai-referral'),
-      ),
+      allEvents.filter((event) => {
+        switch (event.kind) {
+          case TrafficEventKinds.crawler: return visibleSeries.has('crawler')
+          case TrafficEventKinds['ai-user-fetch']: return visibleSeries.has('ai-user-fetch')
+          case TrafficEventKinds['ai-referral']: return visibleSeries.has('ai-referral')
+        }
+      }),
     [allEvents, visibleSeries],
   )
 
@@ -319,22 +323,31 @@ export function TrafficSourceDetailPage() {
         <div className="rounded-md border border-emerald-800/50 bg-emerald-950/30 px-3 py-2 text-xs text-emerald-200">{syncResult}</div>
       ) : null}
 
-      <section className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+      <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <ScoreGauge
           label="24h crawler hits"
           value={String(detail.totals24h.crawlerHits)}
           delta={detail.lastSyncedAt ? `last sync ${formatRelative(detail.lastSyncedAt)}` : 'never synced'}
           tone={detail.totals24h.crawlerHits > 0 ? 'positive' : 'neutral'}
-          description="GPTBot, ChatGPT-User, PerplexityBot, etc. — verified crawler requests in the last 24h."
+          description="Bulk machine crawl — GPTBot, OAI-SearchBot, PerplexityBot, Googlebot, etc."
           isNumeric
           progress={Math.min(100, Math.round((detail.totals24h.crawlerHits / 1000) * 100))}
+        />
+        <ScoreGauge
+          label="24h AI user fetches"
+          value={String(detail.totals24h.aiUserFetchHits)}
+          delta={detail.lastSyncedAt ? `last sync ${formatRelative(detail.lastSyncedAt)}` : 'never synced'}
+          tone={detail.totals24h.aiUserFetchHits > 0 ? 'positive' : 'neutral'}
+          description="ChatGPT-User, Perplexity-User — fetches initiated by a real user inside an AI surface (citation click, URL read)."
+          isNumeric
+          progress={Math.min(100, Math.round((detail.totals24h.aiUserFetchHits / 1000) * 100))}
         />
         <ScoreGauge
           label="24h AI referral sessions"
           value={String(detail.totals24h.aiReferralHits)}
           delta={detail.lastSyncedAt ? `last sync ${formatRelative(detail.lastSyncedAt)}` : 'never synced'}
           tone={detail.totals24h.aiReferralHits > 0 ? 'positive' : 'neutral'}
-          description="Sessionized visits arriving from chat.openai.com, perplexity.ai, etc. (Referer header evidence)."
+          description="Browser click-throughs from chatgpt.com, perplexity.ai, etc. (Referer / UTM evidence)."
           isNumeric
           progress={Math.min(100, Math.round((detail.totals24h.aiReferralHits / 1000) * 100))}
         />
@@ -382,6 +395,7 @@ export function TrafficSourceDetailPage() {
             {totals ? (
               <p className="mt-1.5 text-xs text-zinc-500">
                 {totals.crawlerHits.toLocaleString('en-US')} crawler ·{' '}
+                {totals.aiUserFetchHits.toLocaleString('en-US')} AI user fetches ·{' '}
                 {totals.aiReferralHits.toLocaleString('en-US')} AI referral sessions · last {activeWindow.label}
               </p>
             ) : null}
@@ -412,6 +426,13 @@ export function TrafficSourceDetailPage() {
               count={totals?.crawlerHits ?? 0}
               active={visibleSeries.has('crawler')}
               onToggle={() => toggleSeries('crawler')}
+            />
+            <SeriesToggle
+              label="AI user fetches"
+              color={AI_USER_FETCH_COLOR}
+              count={totals?.aiUserFetchHits ?? 0}
+              active={visibleSeries.has('ai-user-fetch')}
+              onToggle={() => toggleSeries('ai-user-fetch')}
             />
             <SeriesToggle
               label="AI referral sessions"
@@ -450,6 +471,16 @@ export function TrafficSourceDetailPage() {
                   <RechartsTooltip {...CHART_TOOLTIP_STYLE} />
                   {visibleSeries.has('crawler') ? (
                     <Bar dataKey="crawler" name="Crawler" fill={CRAWLER_COLOR} stackId="a">
+                      {chartData.map((row) => (
+                        <Cell
+                          key={row.bucket}
+                          fillOpacity={selectedBucket && selectedBucket !== row.bucket ? 0.25 : 1}
+                        />
+                      ))}
+                    </Bar>
+                  ) : null}
+                  {visibleSeries.has('ai-user-fetch') ? (
+                    <Bar dataKey="aiUserFetch" name="AI user fetch" fill={AI_USER_FETCH_COLOR} stackId="a">
                       {chartData.map((row) => (
                         <Cell
                           key={row.bucket}
@@ -574,7 +605,12 @@ interface ChartRow {
   bucket: string
   label: string
   crawler: number
+  aiUserFetch: number
   aiReferral: number
+}
+
+function emptyChartRow(bucket: string, label: string): ChartRow {
+  return { bucket, label, crawler: 0, aiUserFetch: 0, aiReferral: 0 }
 }
 
 function bucketLabelFor(key: string, granularity: Granularity): string {
@@ -592,13 +628,19 @@ function buildChartData(
     const key = bucketKeyFor(event.tsHour, granularity)
     let row = byBucket.get(key)
     if (!row) {
-      row = { bucket: key, label: bucketLabelFor(key, granularity), crawler: 0, aiReferral: 0 }
+      row = emptyChartRow(key, bucketLabelFor(key, granularity))
       byBucket.set(key, row)
     }
-    if (event.kind === TrafficEventKinds.crawler) {
-      row.crawler += event.hits
-    } else {
-      row.aiReferral += event.hits
+    switch (event.kind) {
+      case TrafficEventKinds.crawler:
+        row.crawler += event.hits
+        break
+      case TrafficEventKinds['ai-user-fetch']:
+        row.aiUserFetch += event.hits
+        break
+      case TrafficEventKinds['ai-referral']:
+        row.aiReferral += event.hits
+        break
     }
   }
 
@@ -617,7 +659,7 @@ function buildChartData(
         const d = String(current.getUTCDate()).padStart(2, '0')
         const key = `${y}-${m}-${d}`
         if (!byBucket.has(key)) {
-          byBucket.set(key, { bucket: key, label: bucketLabelFor(key, granularity), crawler: 0, aiReferral: 0 })
+          byBucket.set(key, emptyChartRow(key, bucketLabelFor(key, granularity)))
         }
         current.setUTCDate(current.getUTCDate() + 1)
       }
@@ -627,7 +669,7 @@ function buildChartData(
       while (current <= end) {
         const key = current.toISOString()
         if (!byBucket.has(key)) {
-          byBucket.set(key, { bucket: key, label: bucketLabelFor(key, granularity), crawler: 0, aiReferral: 0 })
+          byBucket.set(key, emptyChartRow(key, bucketLabelFor(key, granularity)))
         }
         current.setUTCHours(current.getUTCHours() + 1)
       }
@@ -690,6 +732,34 @@ function SeriesToggle({
   )
 }
 
+function renderKindLabel(kind: TrafficEventEntry['kind']): string {
+  switch (kind) {
+    case TrafficEventKinds.crawler: return 'Crawler'
+    case TrafficEventKinds['ai-user-fetch']: return 'AI hit'
+    case TrafficEventKinds['ai-referral']: return 'AI referral'
+  }
+}
+
+function renderIdentity(event: TrafficEventEntry): string {
+  switch (event.kind) {
+    case TrafficEventKinds.crawler:
+    case TrafficEventKinds['ai-user-fetch']:
+      return event.botId
+    case TrafficEventKinds['ai-referral']:
+      return event.product
+  }
+}
+
+function renderEvidence(event: TrafficEventEntry): string {
+  switch (event.kind) {
+    case TrafficEventKinds.crawler:
+    case TrafficEventKinds['ai-user-fetch']:
+      return `${event.verificationStatus} · HTTP ${event.status}`
+    case TrafficEventKinds['ai-referral']:
+      return `${event.evidenceType} · ${event.sourceDomain}`
+  }
+}
+
 function EventsTable({ events }: { events: readonly TrafficEventEntry[] }) {
   if (events.length === 0) {
     return <Card className="p-6 text-center text-sm text-zinc-500">No event rows match the current filters.</Card>
@@ -711,21 +781,13 @@ function EventsTable({ events }: { events: readonly TrafficEventEntry[] }) {
           {events.map((event, i) => (
             <tr key={`${event.kind}:${event.tsHour}:${i}`} className="hover:bg-zinc-900/40 transition-colors">
               <td className="px-4 py-2 font-mono text-xs text-zinc-300">{formatHourLabel(event.tsHour)}</td>
-              <td className="px-4 py-2 text-zinc-300">
-                {event.kind === TrafficEventKinds.crawler ? 'Crawler' : 'AI referral'}
-              </td>
+              <td className="px-4 py-2 text-zinc-300">{renderKindLabel(event.kind)}</td>
               <td className="px-4 py-2 text-zinc-100">
-                {event.kind === TrafficEventKinds.crawler ? event.botId : event.product}
+                {renderIdentity(event)}
                 <span className="ml-2 text-[11px] text-zinc-500">{event.operator}</span>
               </td>
-              <td className="px-4 py-2 text-zinc-300">
-                {event.kind === TrafficEventKinds.crawler
-                  ? `${event.verificationStatus} · HTTP ${event.status}`
-                  : `${event.evidenceType} · ${event.sourceDomain}`}
-              </td>
-              <td className="px-4 py-2 truncate font-mono text-xs text-zinc-300">
-                {event.kind === TrafficEventKinds.crawler ? event.pathNormalized : event.landingPathNormalized}
-              </td>
+              <td className="px-4 py-2 text-zinc-300">{renderEvidence(event)}</td>
+              <td className="px-4 py-2 truncate font-mono text-xs text-zinc-300">{pathOf(event)}</td>
               <td className="px-4 py-2 text-right tabular-nums text-zinc-100">{event.hits}</td>
             </tr>
           ))}

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -36,6 +36,7 @@ erDiagram
 
   projects ||--o{ traffic_sources : has
   traffic_sources ||--o{ crawler_events_hourly : "rolls up"
+  traffic_sources ||--o{ ai_user_fetch_events_hourly : "rolls up"
   traffic_sources ||--o{ ai_referral_events_hourly : "rolls up"
   traffic_sources ||--o{ raw_event_samples : "samples"
 
@@ -94,7 +95,8 @@ erDiagram
 | Table | Purpose |
 |-------|---------|
 | **traffic_sources** | Per-connection metadata (Cloud Run today; future WordPress / Cloudflare / Vercel). Status `connected` / `paused` / `error` / `archived`. Credentials live in `~/.canonry/config.yaml`, never here. FK: projectId → projects. |
-| **crawler_events_hourly** | Hourly rollup of server-observed AI crawler hits. Composite PK `(projectId, sourceId, tsHour, botId, verificationStatus, pathNormalized, status)` so repeat syncs upsert via `hits + ?`. |
+| **crawler_events_hourly** | Hourly rollup of server-observed bulk crawler hits (GPTBot, OAI-SearchBot, PerplexityBot, Googlebot, etc.). Composite PK `(projectId, sourceId, tsHour, botId, verificationStatus, pathNormalized, status)` so repeat syncs upsert via `hits + ?`. Excludes the per-user-fetch UAs — those land in `ai_user_fetch_events_hourly`. |
+| **ai_user_fetch_events_hourly** | Hourly rollup of on-demand per-user fetches from AI surfaces (ChatGPT-User, Perplexity-User, MistralAI-User). UA-evidenced like a crawler, but each hit was initiated by a real user inside an AI surface — kept disjoint from `crawler_events_hourly` so dashboard / API totals don't conflate machine crawl with human-in-the-loop fetch. Composite PK matches `crawler_events_hourly`. |
 | **ai_referral_events_hourly** | Hourly rollup of server-observed human AI-referral clicks (UTM or referer evidence). Composite PK matches the crawler bucket pattern. |
 | **raw_event_samples** | Bounded sample tail for classifier debugging (default 30-day retention). FK: sourceId → traffic_sources. |
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.51.4",
+  "version": "4.52.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-client-generated/src/generated/@tanstack/react-query.gen.ts
+++ b/packages/api-client-generated/src/generated/@tanstack/react-query.gen.ts
@@ -3299,9 +3299,9 @@ export const getApiV1ProjectsByNameTrafficSourcesByIdOptions = (options: Options
 export const getApiV1ProjectsByNameTrafficEventsQueryKey = (options: Options<GetApiV1ProjectsByNameTrafficEventsData>) => createQueryKey('getApiV1ProjectsByNameTrafficEvents', options);
 
 /**
- * List rolled-up crawler hits and AI-referral sessions within a window
+ * List rolled-up crawler hits, AI user-fetch hits, and AI-referral sessions within a window
  *
- * Returns hourly rollup rows from `crawler_events_hourly` and `ai_referral_events_hourly`. Defaults to the last 24h. Totals reflect the full window; the `events` array is capped by `limit` (default 500, max 5000).
+ * Returns hourly rollup rows from `crawler_events_hourly`, `ai_user_fetch_events_hourly`, and `ai_referral_events_hourly`. Defaults to the last 24h. Totals reflect the full window; the `events` array is capped by `limit` (default 500, max 5000).
  */
 export const getApiV1ProjectsByNameTrafficEventsOptions = (options: Options<GetApiV1ProjectsByNameTrafficEventsData>) => {
     return queryOptions({

--- a/packages/api-client-generated/src/generated/sdk.gen.ts
+++ b/packages/api-client-generated/src/generated/sdk.gen.ts
@@ -2939,9 +2939,9 @@ export const getApiV1ProjectsByNameTrafficSourcesById = <ThrowOnError extends bo
 };
 
 /**
- * List rolled-up crawler hits and AI-referral sessions within a window
+ * List rolled-up crawler hits, AI user-fetch hits, and AI-referral sessions within a window
  *
- * Returns hourly rollup rows from `crawler_events_hourly` and `ai_referral_events_hourly`. Defaults to the last 24h. Totals reflect the full window; the `events` array is capped by `limit` (default 500, max 5000).
+ * Returns hourly rollup rows from `crawler_events_hourly`, `ai_user_fetch_events_hourly`, and `ai_referral_events_hourly`. Defaults to the last 24h. Totals reflect the full window; the `events` array is capped by `limit` (default 500, max 5000).
  */
 export const getApiV1ProjectsByNameTrafficEvents = <ThrowOnError extends boolean = false>(options: Options<GetApiV1ProjectsByNameTrafficEventsData, ThrowOnError>) => {
     return (options.client ?? client).get<GetApiV1ProjectsByNameTrafficEventsResponses, GetApiV1ProjectsByNameTrafficEventsErrors, ThrowOnError>({

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -7571,7 +7571,7 @@ export type GetApiV1ProjectsByNameTrafficEventsData = {
          */
         until?: string;
         /**
-         * Filter to "crawler", "ai-referral", or "all" (default).
+         * Filter to "crawler", "ai-user-fetch", "ai-referral", or "all" (default).
          */
         kind?: string;
         /**

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -1551,10 +1551,21 @@ export type TrafficEventsResponse = {
     windowEnd: string;
     totals: {
         crawlerHits: number;
+        aiUserFetchHits: number;
         aiReferralHits: number;
     };
     events: Array<{
         kind: 'crawler';
+        sourceId: string;
+        tsHour: string;
+        botId: string;
+        operator: string;
+        verificationStatus: string;
+        pathNormalized: string;
+        status: number;
+        hits: number;
+    } | {
+        kind: 'ai-user-fetch';
         sourceId: string;
         tsHour: string;
         botId: string;
@@ -1594,6 +1605,7 @@ export type TrafficSourceDetailDto = {
     updatedAt: string;
     totals24h: {
         crawlerHits: number;
+        aiUserFetchHits: number;
         aiReferralHits: number;
         sampleCount: number;
     };
@@ -1660,6 +1672,7 @@ export type TrafficStatusResponse = {
         updatedAt: string;
         totals24h: {
             crawlerHits: number;
+            aiUserFetchHits: number;
             aiReferralHits: number;
             sampleCount: number;
         };
@@ -1679,9 +1692,11 @@ export type TrafficSyncResponse = {
     syncedAt: string;
     pulledEvents: number;
     crawlerHits: number;
+    aiUserFetchHits: number;
     aiReferralHits: number;
     unknownHits: number;
     crawlerBucketRows: number;
+    aiUserFetchBucketRows: number;
     aiReferralBucketRows: number;
     sampleRows: number;
     windowStart: string;

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -1057,6 +1057,11 @@ export type ProjectReportDto = {
             prior: number;
             deltaPct: number | null;
         };
+        aiUserFetchHits: {
+            current: number;
+            prior: number;
+            deltaPct: number | null;
+        };
         referralArrivals: {
             current: number;
             prior: number;
@@ -1066,6 +1071,7 @@ export type ProjectReportDto = {
             operator: string;
             verifiedHits: number;
             unverifiedHits: number;
+            userFetchHits: number;
             referralArrivals: number;
             deltaPct: number | null;
         }>;
@@ -1082,6 +1088,7 @@ export type ProjectReportDto = {
         dailyTrend: Array<{
             date: string;
             verifiedCrawlerHits: number;
+            userFetchHits: number;
             referralArrivals: number;
         }>;
         topReferralLandingPaths: Array<{

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -3221,15 +3221,15 @@ const routeCatalog: OpenApiOperation[] = [
   {
     method: 'get',
     path: '/api/v1/projects/{name}/traffic/events',
-    summary: 'List rolled-up crawler hits and AI-referral sessions within a window',
+    summary: 'List rolled-up crawler hits, AI user-fetch hits, and AI-referral sessions within a window',
     description:
-      'Returns hourly rollup rows from `crawler_events_hourly` and `ai_referral_events_hourly`. Defaults to the last 24h. Totals reflect the full window; the `events` array is capped by `limit` (default 500, max 5000).',
+      'Returns hourly rollup rows from `crawler_events_hourly`, `ai_user_fetch_events_hourly`, and `ai_referral_events_hourly`. Defaults to the last 24h. Totals reflect the full window; the `events` array is capped by `limit` (default 500, max 5000).',
     tags: ['traffic'],
     parameters: [
       nameParameter,
       { name: 'since', in: 'query', description: 'ISO-8601 window start (defaults to 24h ago).', schema: stringSchema },
       { name: 'until', in: 'query', description: 'ISO-8601 window end (defaults to now).', schema: stringSchema },
-      { name: 'kind', in: 'query', description: 'Filter to "crawler", "ai-referral", or "all" (default).', schema: stringSchema },
+      { name: 'kind', in: 'query', description: 'Filter to "crawler", "ai-user-fetch", "ai-referral", or "all" (default).', schema: stringSchema },
       { name: 'limit', in: 'query', description: 'Max rows per kind in the events array (default 500, max 5000).', schema: stringSchema },
       { name: 'sourceId', in: 'query', description: 'Restrict to a single traffic source.', schema: stringSchema },
     ],

--- a/packages/api-routes/src/report-renderer.ts
+++ b/packages/api-routes/src/report-renderer.ts
@@ -1892,13 +1892,17 @@ function renderServerActivity(report: ProjectReportDto, audience: ReportAudience
     const crawlerSubtitle = crawlerDelta
       ? `${escapeHtml(crawlerTrustSummary)} · ${crawlerDelta}`
       : escapeHtml(crawlerTrustSummary)
+    const userFetchDelta = formatDelta(sa.aiUserFetchHits, 'requests')
+    const userFetchSubtitle = userFetchDelta
+      || escapeHtml('ChatGPT-User, Perplexity-User, MistralAI-User')
     const clientOperators = sa.byOperator
-      .filter(o => o.verifiedHits > 0 || o.unverifiedHits > 0 || o.referralArrivals > 0)
+      .filter(o => o.verifiedHits > 0 || o.unverifiedHits > 0 || o.userFetchHits > 0 || o.referralArrivals > 0)
       .slice(0, 5)
     const clientOperatorRows = clientOperators.map(o => `
     <tr>
       <td>${escapeHtml(o.operator)}</td>
       <td class="numeric">${formatNumber(o.verifiedHits + o.unverifiedHits)}</td>
+      <td class="numeric">${formatNumber(o.userFetchHits)}</td>
       <td class="numeric">${formatNumber(o.referralArrivals)}</td>
     </tr>`).join('')
 
@@ -1911,6 +1915,11 @@ function renderServerActivity(report: ProjectReportDto, audience: ReportAudience
           <div class="subtitle">${crawlerSubtitle}</div>
         </div>
         <div class="metric">
+          <div class="label">AI user-fetch requests</div>
+          <div class="value">${formatNumber(sa.aiUserFetchHits.current)}</div>
+          <div class="subtitle">${userFetchSubtitle}</div>
+        </div>
+        <div class="metric">
           <div class="label">AI referral sessions</div>
           <div class="value">${formatNumber(sa.referralArrivals.current)}</div>
           <div class="subtitle">${formatDelta(sa.referralArrivals, 'sessions')}</div>
@@ -1918,10 +1927,10 @@ function renderServerActivity(report: ProjectReportDto, audience: ReportAudience
       </div>
       ${clientOperatorRows ? `<div class="chart-card"><h3>By AI tool</h3>
         <table class="report-table">
-          <thead><tr><th>AI tool</th><th class="numeric">Bot requests (7d)</th><th class="numeric">Referral sessions</th></tr></thead>
+          <thead><tr><th>AI tool</th><th class="numeric">Bot requests (7d)</th><th class="numeric">User fetches (7d)</th><th class="numeric">Referral sessions</th></tr></thead>
           <tbody>${clientOperatorRows}</tbody>
         </table>
-        <p class="meta">Verified requests are reverse-DNS confirmed. Unverified requests are user-agent claims shown separately in agency diagnostics.</p>
+        <p class="meta">Bot requests are bulk crawl (GPTBot, PerplexityBot, …). User fetches are on-demand reads triggered by real users inside an AI surface (ChatGPT-User, Perplexity-User, …). Verified requests are reverse-DNS confirmed; unverified requests are UA claims shown separately in agency diagnostics.</p>
       </div>` : ''}`,
     )
   }
@@ -1937,6 +1946,7 @@ function renderServerActivity(report: ProjectReportDto, audience: ReportAudience
       <td>${escapeHtml(o.operator)}</td>
       <td class="numeric">${formatNumber(o.verifiedHits)}</td>
       <td class="numeric meta">${formatNumber(o.unverifiedHits)}</td>
+      <td class="numeric">${formatNumber(o.userFetchHits)}</td>
       <td class="numeric">${formatNumber(o.referralArrivals)}</td>
       <td class="numeric ${toneClass}">${deltaText}</td>
     </tr>`
@@ -1985,6 +1995,11 @@ function renderServerActivity(report: ProjectReportDto, audience: ReportAudience
         <div class="subtitle">${formatDelta(sa.unverifiedCrawlerHits, 'hits')}</div>
       </div>
       <div class="metric">
+        <div class="label">AI user-fetch hits (7d)</div>
+        <div class="value">${formatNumber(sa.aiUserFetchHits.current)}</div>
+        <div class="subtitle">${formatDelta(sa.aiUserFetchHits, 'hits')}</div>
+      </div>
+      <div class="metric">
         <div class="label">AI-referral sessions (7d)</div>
         <div class="value">${formatNumber(sa.referralArrivals.current)}</div>
         <div class="subtitle">${formatDelta(sa.referralArrivals, 'sessions')}</div>
@@ -1992,9 +2007,9 @@ function renderServerActivity(report: ProjectReportDto, audience: ReportAudience
     </div>
     ${trendChart}
     ${operatorRows ? `<div class="chart-card"><h3>Per AI operator</h3>
-      <p class="meta">Verified means rDNS-confirmed. Unverified bots claim the user-agent but couldn't be verified — could be the real bot or an imitator.</p>
+      <p class="meta">Verified means rDNS-confirmed. Unverified bots claim the user-agent but couldn't be verified — could be the real bot or an imitator. User fetches are on-demand reads from an AI surface on behalf of a real user (ChatGPT-User, Perplexity-User, …) — disjoint from bulk crawl.</p>
       <table class="report-table">
-        <thead><tr><th>Operator</th><th class="numeric">Verified hits</th><th class="numeric">Unverified</th><th class="numeric">Referral sessions</th><th class="numeric">7d delta</th></tr></thead>
+        <thead><tr><th>Operator</th><th class="numeric">Verified hits</th><th class="numeric">Unverified</th><th class="numeric">User fetches</th><th class="numeric">Referral sessions</th><th class="numeric">7d delta</th></tr></thead>
         <tbody>${operatorRows}</tbody>
       </table>
     </div>` : ''}

--- a/packages/api-routes/src/report.ts
+++ b/packages/api-routes/src/report.ts
@@ -2,6 +2,7 @@ import { and, desc, eq, gte, inArray, lt, lte, ne, or, sql } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import {
   aiReferralEventsHourly,
+  aiUserFetchEventsHourly,
   bingCoverageSnapshots,
   competitors,
   crawlerEventsHourly,
@@ -660,10 +661,33 @@ function buildServerActivity(db: DatabaseClient, projectId: string): ProjectRepo
         .get()?.total ?? 0,
     )
 
+  // User-fetch hits roll verified + unverified together. For crawlers we
+  // split because rDNS confirmation is the trust signal; for user-fetch
+  // the operational question is "is an AI surface reading this page on
+  // behalf of a real user, yes or no?" — verification matters less.
+  const sumUserFetches = (windowStartIso: string, windowEndIso: string, exclusiveEnd = false) =>
+    Number(
+      db
+        .select({ total: sql<number>`COALESCE(SUM(${aiUserFetchEventsHourly.hits}), 0)` })
+        .from(aiUserFetchEventsHourly)
+        .where(
+          and(
+            eq(aiUserFetchEventsHourly.projectId, projectId),
+            gte(aiUserFetchEventsHourly.tsHour, windowStartIso),
+            exclusiveEnd
+              ? lt(aiUserFetchEventsHourly.tsHour, windowEndIso)
+              : lte(aiUserFetchEventsHourly.tsHour, windowEndIso),
+          ),
+        )
+        .get()?.total ?? 0,
+    )
+
   const verifiedCurrent = sumVerifiedCrawlers(headlineStart, headlineEnd)
   const verifiedPrior = sumVerifiedCrawlers(priorStart, headlineStart, true)
   const unverifiedCurrent = sumUnverifiedCrawlers(headlineStart, headlineEnd)
   const unverifiedPrior = sumUnverifiedCrawlers(priorStart, headlineStart, true)
+  const userFetchCurrent = sumUserFetches(headlineStart, headlineEnd)
+  const userFetchPrior = sumUserFetches(priorStart, headlineStart, true)
   const referralCurrent = sumReferrals(headlineStart, headlineEnd)
   const referralPrior = sumReferrals(priorStart, headlineStart, true)
 
@@ -719,13 +743,29 @@ function buildServerActivity(db: DatabaseClient, projectId: string): ProjectRepo
     .groupBy(aiReferralEventsHourly.operator)
     .all()
 
+  const userFetchByOperatorRows = db
+    .select({
+      operator: aiUserFetchEventsHourly.operator,
+      hits: sql<number>`COALESCE(SUM(${aiUserFetchEventsHourly.hits}), 0)`,
+    })
+    .from(aiUserFetchEventsHourly)
+    .where(
+      and(
+        eq(aiUserFetchEventsHourly.projectId, projectId),
+        gte(aiUserFetchEventsHourly.tsHour, headlineStart),
+        lte(aiUserFetchEventsHourly.tsHour, headlineEnd),
+      ),
+    )
+    .groupBy(aiUserFetchEventsHourly.operator)
+    .all()
+
   const operatorAgg = new Map<string, {
-    verified: number; unverified: number; referrals: number; prior: number
+    verified: number; unverified: number; userFetch: number; referrals: number; prior: number
   }>()
   const ensureOp = (op: string) => {
     let entry = operatorAgg.get(op)
     if (!entry) {
-      entry = { verified: 0, unverified: 0, referrals: 0, prior: 0 }
+      entry = { verified: 0, unverified: 0, userFetch: 0, referrals: 0, prior: 0 }
       operatorAgg.set(op, entry)
     }
     return entry
@@ -738,6 +778,9 @@ function buildServerActivity(db: DatabaseClient, projectId: string): ProjectRepo
   for (const r of crawlerByOperatorPriorRows) {
     ensureOp(r.operator).prior += Number(r.hits)
   }
+  for (const r of userFetchByOperatorRows) {
+    ensureOp(r.operator).userFetch += Number(r.hits)
+  }
   for (const r of referralByOperatorRows) {
     ensureOp(r.operator).referrals += Number(r.hits)
   }
@@ -747,12 +790,14 @@ function buildServerActivity(db: DatabaseClient, projectId: string): ProjectRepo
       operator,
       verifiedHits: v.verified,
       unverifiedHits: v.unverified,
+      userFetchHits: v.userFetch,
       referralArrivals: v.referrals,
       deltaPct: deltaPercent(v.verified, v.prior),
     }))
-    // Sort by total signal: verified hits first, then unverified and referrals as tiebreakers.
+    // Sort by total signal: verified hits first, then user-fetch, then unverified and referrals.
     .sort((a, b) =>
       b.verifiedHits - a.verifiedHits ||
+      b.userFetchHits - a.userFetchHits ||
       b.unverifiedHits - a.unverifiedHits ||
       b.referralArrivals - a.referralArrivals,
     )
@@ -868,14 +913,36 @@ function buildServerActivity(db: DatabaseClient, projectId: string): ProjectRepo
     .groupBy(sql`SUBSTR(${aiReferralEventsHourly.tsHour}, 1, 10)`)
     .all()
 
-  const dailyTrendMap = new Map<string, { verifiedCrawlerHits: number; referralArrivals: number }>()
+  const userFetchTrendRows = db
+    .select({
+      date: sql<string>`SUBSTR(${aiUserFetchEventsHourly.tsHour}, 1, 10)`,
+      hits: sql<number>`COALESCE(SUM(${aiUserFetchEventsHourly.hits}), 0)`,
+    })
+    .from(aiUserFetchEventsHourly)
+    .where(
+      and(
+        eq(aiUserFetchEventsHourly.projectId, projectId),
+        gte(aiUserFetchEventsHourly.tsHour, trendStart),
+        lte(aiUserFetchEventsHourly.tsHour, headlineEnd),
+      ),
+    )
+    .groupBy(sql`SUBSTR(${aiUserFetchEventsHourly.tsHour}, 1, 10)`)
+    .all()
+
+  const emptyTrendEntry = () => ({ verifiedCrawlerHits: 0, userFetchHits: 0, referralArrivals: 0 })
+  const dailyTrendMap = new Map<string, ReturnType<typeof emptyTrendEntry>>()
   for (const r of crawlerTrendRows) {
-    const e = dailyTrendMap.get(r.date) ?? { verifiedCrawlerHits: 0, referralArrivals: 0 }
+    const e = dailyTrendMap.get(r.date) ?? emptyTrendEntry()
     e.verifiedCrawlerHits += Number(r.hits)
     dailyTrendMap.set(r.date, e)
   }
+  for (const r of userFetchTrendRows) {
+    const e = dailyTrendMap.get(r.date) ?? emptyTrendEntry()
+    e.userFetchHits += Number(r.hits)
+    dailyTrendMap.set(r.date, e)
+  }
   for (const r of referralTrendRows) {
-    const e = dailyTrendMap.get(r.date) ?? { verifiedCrawlerHits: 0, referralArrivals: 0 }
+    const e = dailyTrendMap.get(r.date) ?? emptyTrendEntry()
     e.referralArrivals += Number(r.hits)
     dailyTrendMap.set(r.date, e)
   }
@@ -886,7 +953,8 @@ function buildServerActivity(db: DatabaseClient, projectId: string): ProjectRepo
   return {
     windowStart: headlineStart,
     windowEnd: headlineEnd,
-    hasData: verifiedCurrent + unverifiedCurrent + referralCurrent + verifiedPrior + unverifiedPrior + referralPrior > 0
+    hasData: verifiedCurrent + unverifiedCurrent + userFetchCurrent + referralCurrent
+      + verifiedPrior + unverifiedPrior + userFetchPrior + referralPrior > 0
       || byOperator.length > 0
       || topCrawledPaths.length > 0
       || referralProducts.length > 0,
@@ -899,6 +967,11 @@ function buildServerActivity(db: DatabaseClient, projectId: string): ProjectRepo
       current: unverifiedCurrent,
       prior: unverifiedPrior,
       deltaPct: deltaPercent(unverifiedCurrent, unverifiedPrior),
+    },
+    aiUserFetchHits: {
+      current: userFetchCurrent,
+      prior: userFetchPrior,
+      deltaPct: deltaPercent(userFetchCurrent, userFetchPrior),
     },
     referralArrivals: {
       current: referralCurrent,

--- a/packages/api-routes/src/traffic.ts
+++ b/packages/api-routes/src/traffic.ts
@@ -4,6 +4,7 @@ import type { FastifyInstance } from 'fastify'
 import {
   trafficSources,
   crawlerEventsHourly,
+  aiUserFetchEventsHourly,
   aiReferralEventsHourly,
   rawEventSamples,
   runs,
@@ -131,6 +132,8 @@ export interface TrafficSyncedEvent {
   pulledEvents: number
   /** Crawler hourly bucket inserts/updates. 0 for failed syncs. */
   crawlerHits: number
+  /** AI user-fetch hourly bucket inserts/updates (ChatGPT-User, Perplexity-User, …). 0 for failed syncs. */
+  aiUserFetchHits: number
   /** AI-referral hourly bucket inserts/updates. 0 for failed syncs. */
   aiReferralHits: number
   /** End-to-end duration including pull, classification, rollup write. */
@@ -398,6 +401,16 @@ async function runBackfillTask(options: RunBackfillTaskOptions): Promise<void> {
         )
         .run()
       tx
+        .delete(aiUserFetchEventsHourly)
+        .where(
+          and(
+            eq(aiUserFetchEventsHourly.sourceId, sourceRow.id),
+            gte(aiUserFetchEventsHourly.tsHour, windowStartIso),
+            lte(aiUserFetchEventsHourly.tsHour, windowEndIso),
+          ),
+        )
+        .run()
+      tx
         .delete(aiReferralEventsHourly)
         .where(
           and(
@@ -438,6 +451,26 @@ async function runBackfillTask(options: RunBackfillTaskOptions): Promise<void> {
           .run()
       }
 
+      for (const bucket of report.aiUserFetchEventsHourly) {
+        tx
+          .insert(aiUserFetchEventsHourly)
+          .values({
+            projectId: project.id,
+            sourceId: sourceRow.id,
+            tsHour: bucket.tsHour,
+            botId: bucket.botId,
+            operator: bucket.operator,
+            verificationStatus: bucket.verificationStatus,
+            pathNormalized: bucket.pathNormalized,
+            status: bucket.status ?? 0,
+            hits: bucket.hits,
+            sampledUserAgent: bucket.sampledUserAgent,
+            createdAt: finishedAt,
+            updatedAt: finishedAt,
+          })
+          .run()
+      }
+
       for (const bucket of report.aiReferralEventsHourly) {
         tx
           .insert(aiReferralEventsHourly)
@@ -460,7 +493,13 @@ async function runBackfillTask(options: RunBackfillTaskOptions): Promise<void> {
       }
 
       for (const sample of report.samples) {
-        const eventType = sample.crawler ? 'crawler' : sample.aiReferral ? 'ai_referral' : 'unknown'
+        const eventType = sample.crawler
+          ? 'crawler'
+          : sample.aiUserFetch
+            ? 'ai_user_fetch'
+            : sample.aiReferral
+              ? 'ai_referral'
+              : 'unknown'
         const refererHost = (() => {
           if (!sample.referer) return null
           try {
@@ -484,6 +523,7 @@ async function runBackfillTask(options: RunBackfillTaskOptions): Promise<void> {
             refererHost,
             classifierDetailsJson: {
               crawler: sample.crawler,
+              aiUserFetch: sample.aiUserFetch,
               aiReferral: sample.aiReferral,
             },
             createdAt: finishedAt,
@@ -982,6 +1022,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
           sourceId: sourceRow.id,
           pulledEvents: 0,
           crawlerHits: 0,
+          aiUserFetchHits: 0,
           aiReferralHits: 0,
           durationMs: Date.now() - syncStartedAtMs,
           errorCode,
@@ -1204,6 +1245,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
     }
 
     let crawlerBucketRows = 0
+    let aiUserFetchBucketRows = 0
     let aiReferralBucketRows = 0
     let sampleRows = 0
     // These get assigned inside the transaction (after we re-read the row to
@@ -1212,6 +1254,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
     let finishedAt = new Date().toISOString()
     let pulledEventsCount = 0
     let crawlerHitsCount = 0
+    let aiUserFetchHitsCount = 0
     let aiReferralHitsCount = 0
     let unknownHitsCount = 0
 
@@ -1259,6 +1302,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
       finishedAt = new Date().toISOString()
       pulledEventsCount = report.totals.normalizedEvents
       crawlerHitsCount = report.totals.crawlerHits
+      aiUserFetchHitsCount = report.totals.aiUserFetchHits
       aiReferralHitsCount = report.totals.aiReferralHits
       unknownHitsCount = report.totals.unknownHits
 
@@ -1301,6 +1345,44 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
         crawlerBucketRows += 1
       }
 
+      for (const bucket of report.aiUserFetchEventsHourly) {
+        const status = bucket.status ?? 0
+        tx
+          .insert(aiUserFetchEventsHourly)
+          .values({
+            projectId: project.id,
+            sourceId: sourceRow.id,
+            tsHour: bucket.tsHour,
+            botId: bucket.botId,
+            operator: bucket.operator,
+            verificationStatus: bucket.verificationStatus,
+            pathNormalized: bucket.pathNormalized,
+            status,
+            hits: bucket.hits,
+            sampledUserAgent: bucket.sampledUserAgent,
+            createdAt: finishedAt,
+            updatedAt: finishedAt,
+          })
+          .onConflictDoUpdate({
+            target: [
+              aiUserFetchEventsHourly.projectId,
+              aiUserFetchEventsHourly.sourceId,
+              aiUserFetchEventsHourly.tsHour,
+              aiUserFetchEventsHourly.botId,
+              aiUserFetchEventsHourly.verificationStatus,
+              aiUserFetchEventsHourly.pathNormalized,
+              aiUserFetchEventsHourly.status,
+            ],
+            set: {
+              hits: sql`${aiUserFetchEventsHourly.hits} + ${bucket.hits}`,
+              sampledUserAgent: bucket.sampledUserAgent,
+              updatedAt: finishedAt,
+            },
+          })
+          .run()
+        aiUserFetchBucketRows += 1
+      }
+
       for (const bucket of report.aiReferralEventsHourly) {
         const status = bucket.status ?? 0
         tx
@@ -1341,7 +1423,13 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
       }
 
       for (const sample of report.samples) {
-        const eventType = sample.crawler ? 'crawler' : sample.aiReferral ? 'ai_referral' : 'unknown'
+        const eventType = sample.crawler
+          ? 'crawler'
+          : sample.aiUserFetch
+            ? 'ai_user_fetch'
+            : sample.aiReferral
+              ? 'ai_referral'
+              : 'unknown'
         const refererHost = (() => {
           if (!sample.referer) return null
           try {
@@ -1365,6 +1453,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
             refererHost,
             classifierDetailsJson: {
               crawler: sample.crawler,
+              aiUserFetch: sample.aiUserFetch,
               aiReferral: sample.aiReferral,
             },
             createdAt: finishedAt,
@@ -1420,6 +1509,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
         sourceId: sourceRow.id,
         pulledEvents: pulledEventsCount,
         crawlerHits: crawlerHitsCount,
+        aiUserFetchHits: aiUserFetchHitsCount,
         aiReferralHits: aiReferralHitsCount,
         durationMs: Date.now() - syncStartedAtMs,
       })
@@ -1433,9 +1523,11 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
       syncedAt: finishedAt,
       pulledEvents: pulledEventsCount,
       crawlerHits: crawlerHitsCount,
+      aiUserFetchHits: aiUserFetchHitsCount,
       aiReferralHits: aiReferralHitsCount,
       unknownHits: unknownHitsCount,
       crawlerBucketRows,
+      aiUserFetchBucketRows,
       aiReferralBucketRows,
       sampleRows,
       windowStart: windowStart.toISOString(),
@@ -1691,6 +1783,17 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
       )
       .get()
 
+    const aiUserFetchTotals = app.db
+      .select({ total: sql<number>`COALESCE(SUM(${aiUserFetchEventsHourly.hits}), 0)` })
+      .from(aiUserFetchEventsHourly)
+      .where(
+        and(
+          eq(aiUserFetchEventsHourly.sourceId, row.id),
+          gte(aiUserFetchEventsHourly.tsHour, since),
+        ),
+      )
+      .get()
+
     const aiTotals = app.db
       .select({ total: sql<number>`COALESCE(SUM(${aiReferralEventsHourly.sessionsOrHits}), 0)` })
       .from(aiReferralEventsHourly)
@@ -1731,6 +1834,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
       ...rowToDto(row),
       totals24h: {
         crawlerHits: Number(crawlerTotals?.total ?? 0),
+        aiUserFetchHits: Number(aiUserFetchTotals?.total ?? 0),
         aiReferralHits: Number(aiTotals?.total ?? 0),
         sampleCount: Number(sampleTotals?.total ?? 0),
       },
@@ -1825,10 +1929,17 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
     const kindParam = request.query?.kind
     let kind: TrafficEventKind | 'all' = 'all'
     if (kindParam !== undefined) {
-      if (kindParam === 'all' || kindParam === TrafficEventKinds.crawler || kindParam === TrafficEventKinds['ai-referral']) {
+      if (
+        kindParam === 'all'
+        || kindParam === TrafficEventKinds.crawler
+        || kindParam === TrafficEventKinds['ai-user-fetch']
+        || kindParam === TrafficEventKinds['ai-referral']
+      ) {
         kind = kindParam
       } else {
-        throw validationError(`"kind" must be one of: all, ${TrafficEventKinds.crawler}, ${TrafficEventKinds['ai-referral']}`)
+        throw validationError(
+          `"kind" must be one of: all, ${TrafficEventKinds.crawler}, ${TrafficEventKinds['ai-user-fetch']}, ${TrafficEventKinds['ai-referral']}`,
+        )
       }
     }
 
@@ -1845,6 +1956,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
 
     const events: TrafficEventEntry[] = []
     let crawlerTotal = 0
+    let aiUserFetchTotal = 0
     let aiReferralTotal = 0
 
     if (kind === 'all' || kind === TrafficEventKinds.crawler) {
@@ -1873,6 +1985,44 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
       for (const r of rows) {
         events.push({
           kind: TrafficEventKinds.crawler,
+          sourceId: r.sourceId,
+          tsHour: r.tsHour,
+          botId: r.botId,
+          operator: r.operator,
+          verificationStatus: r.verificationStatus,
+          pathNormalized: r.pathNormalized,
+          status: r.status,
+          hits: r.hits,
+        })
+      }
+    }
+
+    if (kind === 'all' || kind === TrafficEventKinds['ai-user-fetch']) {
+      const userFetchFilters = [
+        eq(aiUserFetchEventsHourly.projectId, project.id),
+        gte(aiUserFetchEventsHourly.tsHour, sinceIso),
+        lte(aiUserFetchEventsHourly.tsHour, untilIso),
+      ]
+      if (sourceIdParam) userFetchFilters.push(eq(aiUserFetchEventsHourly.sourceId, sourceIdParam))
+      const userFetchWhere = and(...userFetchFilters)
+
+      const total = app.db
+        .select({ total: sql<number>`COALESCE(SUM(${aiUserFetchEventsHourly.hits}), 0)` })
+        .from(aiUserFetchEventsHourly)
+        .where(userFetchWhere)
+        .get()
+      aiUserFetchTotal = Number(total?.total ?? 0)
+
+      const rows = app.db
+        .select()
+        .from(aiUserFetchEventsHourly)
+        .where(userFetchWhere)
+        .orderBy(desc(aiUserFetchEventsHourly.tsHour))
+        .limit(limit)
+        .all()
+      for (const r of rows) {
+        events.push({
+          kind: TrafficEventKinds['ai-user-fetch'],
           sourceId: r.sourceId,
           tsHour: r.tsHour,
           botId: r.botId,
@@ -1932,6 +2082,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
       windowEnd: untilIso,
       totals: {
         crawlerHits: crawlerTotal,
+        aiUserFetchHits: aiUserFetchTotal,
         aiReferralHits: aiReferralTotal,
       },
       events: trimmed,

--- a/packages/api-routes/test/db-dto-coverage.test.ts
+++ b/packages/api-routes/test/db-dto-coverage.test.ts
@@ -371,6 +371,10 @@ const COVERAGE: Record<string, CoverageEntry> = {
     kind: 'internal-only',
     reason: 'Hourly rollup consumed via /traffic/events composite, not directly mapped to a DTO.',
   },
+  aiUserFetchEventsHourly: {
+    kind: 'internal-only',
+    reason: 'Hourly rollup consumed via /traffic/events composite, not directly mapped to a DTO.',
+  },
   aiReferralEventsHourly: {
     kind: 'internal-only',
     reason: 'Hourly rollup consumed via /traffic/events composite, not directly mapped to a DTO.',

--- a/packages/api-routes/test/report-renderer.test.ts
+++ b/packages/api-routes/test/report-renderer.test.ts
@@ -254,11 +254,13 @@ function richReport(): ProjectReportDto {
       hasData: true,
       verifiedCrawlerHits: { current: 234, prior: 117, deltaPct: 100 },
       unverifiedCrawlerHits: { current: 15, prior: 5, deltaPct: 200 },
+      aiUserFetchHits: { current: 42, prior: 18, deltaPct: 133 },
       referralArrivals: { current: 12, prior: 6, deltaPct: 100 },
       byOperator: [
-        { operator: 'OpenAI', verifiedHits: 140, unverifiedHits: 10, referralArrivals: 8, deltaPct: 75 },
-        { operator: 'Anthropic', verifiedHits: 70, unverifiedHits: 0, referralArrivals: 3, deltaPct: 40 },
-        { operator: 'Google AI', verifiedHits: 24, unverifiedHits: 5, referralArrivals: 1, deltaPct: null },
+        { operator: 'OpenAI', verifiedHits: 140, unverifiedHits: 10, userFetchHits: 32, referralArrivals: 8, deltaPct: 75 },
+        { operator: 'Anthropic', verifiedHits: 70, unverifiedHits: 0, userFetchHits: 0, referralArrivals: 3, deltaPct: 40 },
+        { operator: 'Google AI', verifiedHits: 24, unverifiedHits: 5, userFetchHits: 0, referralArrivals: 1, deltaPct: null },
+        { operator: 'Perplexity', verifiedHits: 0, unverifiedHits: 0, userFetchHits: 10, referralArrivals: 0, deltaPct: null },
       ],
       topCrawledPaths: [
         { path: '/blog/foo', verifiedHits: 80, distinctOperators: 2 },
@@ -269,8 +271,8 @@ function richReport(): ProjectReportDto {
         { product: 'Claude', arrivals: 3, distinctLandingPaths: 1 },
       ],
       dailyTrend: [
-        { date: '2026-04-29', verifiedCrawlerHits: 30, referralArrivals: 2 },
-        { date: '2026-04-30', verifiedCrawlerHits: 45, referralArrivals: 3 },
+        { date: '2026-04-29', verifiedCrawlerHits: 30, userFetchHits: 4, referralArrivals: 2 },
+        { date: '2026-04-30', verifiedCrawlerHits: 45, userFetchHits: 8, referralArrivals: 3 },
       ],
       topReferralLandingPaths: [
         { path: '/landing', arrivals: 5, distinctProducts: 2 },
@@ -545,17 +547,33 @@ describe('renderReportHtml', () => {
     expect(html).toContain('AI Visibility — Server-Side')
     // Plain-English client labels (NOT the analyst "Verified crawler hits" copy)
     expect(html).toContain('AI bot requests observed')
+    expect(html).toContain('AI user-fetch requests')
     expect(html).toContain('AI referral sessions')
     expect(html).toContain('reverse-DNS')
     // Section eyebrow in client view is the friendlier "AI engine attention" label
     expect(html).toContain('AI engine attention')
     // Per-engine breakdown rendered with operator names
     expect(html).toContain('OpenAI')
+    // Per-engine table renders the user-fetches column for the client too
+    expect(html).toContain('User fetches (7d)')
     // The agency-only labels MUST NOT appear in the client view
     expect(html).not.toContain('Verified crawler hits (7d)')
     expect(html).not.toContain('Top crawled paths')
     // Section 10 eyebrow is agency-only
     expect(html).not.toContain('Section 10')
+  })
+
+  test('agency HTML renders the AI user-fetch tile and operator column alongside crawler + referral', () => {
+    const html = renderReportHtml(richReport(), { audience: 'agency' })
+    // Headline tile for the new disjoint signal
+    expect(html).toContain('AI user-fetch hits (7d)')
+    // 7d delta against prior 7d, computed in formatDeltaCopy from the fixture
+    expect(html).toContain('Up 133% vs prior 7 days (18 hits)')
+    // Operator table gains a "User fetches" column
+    expect(html).toContain('<th class="numeric">User fetches</th>')
+    // A user-fetch-only operator (Perplexity in fixture) is sorted into the
+    // table even though its verifiedHits / unverifiedHits / referrals are 0
+    expect(html).toContain('Perplexity')
   })
 
   test('client HTML hides the section entirely when no traffic source is connected', () => {
@@ -619,6 +637,7 @@ describe('renderReportHtml', () => {
       hasData: false,
       verifiedCrawlerHits: { current: 0, prior: 0, deltaPct: null },
       unverifiedCrawlerHits: { current: 0, prior: 0, deltaPct: null },
+      aiUserFetchHits: { current: 0, prior: 0, deltaPct: null },
       referralArrivals: { current: 0, prior: 0, deltaPct: null },
       byOperator: [],
       topCrawledPaths: [],

--- a/packages/api-routes/test/traffic.test.ts
+++ b/packages/api-routes/test/traffic.test.ts
@@ -9,6 +9,7 @@ import {
   migrate,
   trafficSources,
   crawlerEventsHourly,
+  aiUserFetchEventsHourly,
   aiReferralEventsHourly,
   rawEventSamples,
   runs,
@@ -2804,7 +2805,59 @@ describe('GET /traffic/sources/:id', () => {
       expect(res.statusCode).toBe(200)
       const body = JSON.parse(res.payload)
       expect(body.latestRun).toBeNull()
-      expect(body.totals24h).toEqual({ crawlerHits: 0, aiReferralHits: 0, sampleCount: 0 })
+      expect(body.totals24h).toEqual({ crawlerHits: 0, aiUserFetchHits: 0, aiReferralHits: 0, sampleCount: 0 })
+    } finally { await h.close() }
+  })
+
+  it('counts ChatGPT-User hits as aiUserFetchHits (not crawlerHits) in totals24h', async () => {
+    // The defining ai-user-fetch behavior at the read path: ChatGPT-User
+    // arrives via UA evidence (same channel as GPTBot) but the operator
+    // wants to see it as a human-in-the-loop fetch, not bulk crawl. The
+    // detail endpoint MUST surface these in their own bucket so the
+    // dashboard's "AI hits" tile is meaningful.
+    const baseTime = new Date(Date.now() - 60 * 60_000)
+    baseTime.setMinutes(0, 0, 0)
+    const fromBase = (mins: number) => new Date(baseTime.getTime() + mins * 60_000).toISOString()
+
+    const events: NormalizedTrafficRequest[] = [
+      buildEvent({ userAgent: 'GPTBot/1.0', path: '/blog/foo', status: 200, observedAt: fromBase(1) }),
+      buildEvent({ userAgent: 'Mozilla/5.0 ChatGPT-User/1.0', path: '/', status: 200, observedAt: fromBase(5) }),
+      buildEvent({ userAgent: 'Mozilla/5.0 ChatGPT-User/1.0', path: '/pricing', status: 200, observedAt: fromBase(10) }),
+    ]
+    const h = await buildHarness(events)
+    try {
+      const connectRes = await h.app.inject({
+        method: 'POST',
+        url: '/api/v1/projects/test-project/traffic/connect/cloud-run',
+        payload: { gcpProjectId: 'openclaw-nyc', keyJson: SA_KEY },
+      })
+      const sourceId = JSON.parse(connectRes.payload).id
+      const syncRes = await h.app.inject({
+        method: 'POST',
+        url: `/api/v1/projects/test-project/traffic/sources/${sourceId}/sync`,
+        payload: { sinceMinutes: 120 },
+      })
+      const syncBody = JSON.parse(syncRes.payload)
+      expect(syncBody.crawlerHits).toBe(1)
+      expect(syncBody.aiUserFetchHits).toBe(2)
+      expect(syncBody.crawlerBucketRows).toBe(1)
+      expect(syncBody.aiUserFetchBucketRows).toBe(2)
+
+      // The new table holds the ChatGPT-User rows; the crawler table only
+      // sees the GPTBot row.
+      expect(h.db.select().from(crawlerEventsHourly).all().length).toBe(1)
+      const userFetchRows = h.db.select().from(aiUserFetchEventsHourly).all()
+      expect(userFetchRows.length).toBe(2)
+      expect(userFetchRows.every(r => r.botId === 'openai-chatgpt-user')).toBe(true)
+
+      const detail = await h.app.inject({
+        method: 'GET',
+        url: `/api/v1/projects/test-project/traffic/sources/${sourceId}`,
+      })
+      const body = JSON.parse(detail.payload)
+      expect(body.totals24h.crawlerHits).toBe(1)
+      expect(body.totals24h.aiUserFetchHits).toBe(2)
+      expect(body.totals24h.aiReferralHits).toBe(0)
     } finally { await h.close() }
   })
 
@@ -3001,10 +3054,103 @@ describe('GET /traffic/events', () => {
       expect(res.statusCode).toBe(200)
       const body = JSON.parse(res.payload)
       expect(body.totals.crawlerHits).toBe(2)
+      expect(body.totals.aiUserFetchHits).toBe(0)
       expect(body.totals.aiReferralHits).toBe(1)
       expect(body.events.length).toBe(2)
       const kinds = body.events.map((e: { kind: string }) => e.kind).sort()
       expect(kinds).toEqual(['ai-referral', 'crawler'])
+    } finally { await h.close() }
+  })
+
+  it('serializes ai-user-fetch entries alongside crawler + ai-referral', async () => {
+    // End-to-end at the read path: when ChatGPT-User events were persisted
+    // into ai_user_fetch_events_hourly, GET /traffic/events MUST return them
+    // as kind=ai-user-fetch with the same crawler-shaped fields (botId,
+    // operator, verificationStatus, pathNormalized, status, hits). This is
+    // what an agent calling `canonry traffic events --format json` reads.
+    const baseTime = new Date(Date.now() - 60 * 60_000)
+    baseTime.setMinutes(0, 0, 0)
+    const fromBase = (mins: number) => new Date(baseTime.getTime() + mins * 60_000).toISOString()
+
+    const events: NormalizedTrafficRequest[] = [
+      buildEvent({ userAgent: 'GPTBot/1.0', path: '/blog/foo', status: 200, observedAt: fromBase(1) }),
+      buildEvent({ userAgent: 'Mozilla/5.0 ChatGPT-User/1.0', path: '/', status: 200, observedAt: fromBase(5) }),
+      buildEvent({
+        userAgent: 'Mozilla/5.0',
+        path: '/landing',
+        queryString: 'utm_source=chatgpt.com',
+        status: 200,
+        observedAt: fromBase(15),
+      }),
+    ]
+    const h = await buildHarness(events)
+    try {
+      const connectRes = await h.app.inject({
+        method: 'POST',
+        url: '/api/v1/projects/test-project/traffic/connect/cloud-run',
+        payload: { gcpProjectId: 'openclaw-nyc', keyJson: SA_KEY },
+      })
+      const sourceId = JSON.parse(connectRes.payload).id
+      await h.app.inject({
+        method: 'POST',
+        url: `/api/v1/projects/test-project/traffic/sources/${sourceId}/sync`,
+        payload: { sinceMinutes: 120 },
+      })
+
+      const res = await h.app.inject({
+        method: 'GET',
+        url: '/api/v1/projects/test-project/traffic/events',
+      })
+      expect(res.statusCode).toBe(200)
+      const body = JSON.parse(res.payload)
+      expect(body.totals).toMatchObject({ crawlerHits: 1, aiUserFetchHits: 1, aiReferralHits: 1 })
+      const kinds = body.events.map((e: { kind: string }) => e.kind).sort()
+      expect(kinds).toEqual(['ai-referral', 'ai-user-fetch', 'crawler'])
+      const userFetch = body.events.find((e: { kind: string }) => e.kind === 'ai-user-fetch')
+      expect(userFetch).toMatchObject({
+        kind: 'ai-user-fetch',
+        botId: 'openai-chatgpt-user',
+        operator: 'OpenAI',
+        pathNormalized: '/',
+        hits: 1,
+      })
+    } finally { await h.close() }
+  })
+
+  it('filters by kind=ai-user-fetch', async () => {
+    const baseTime = new Date(Date.now() - 60 * 60_000)
+    baseTime.setMinutes(0, 0, 0)
+    const fromBase = (mins: number) => new Date(baseTime.getTime() + mins * 60_000).toISOString()
+
+    const events: NormalizedTrafficRequest[] = [
+      buildEvent({ userAgent: 'GPTBot/1.0', path: '/blog/foo', status: 200, observedAt: fromBase(1) }),
+      buildEvent({ userAgent: 'Mozilla/5.0 ChatGPT-User/1.0', path: '/', status: 200, observedAt: fromBase(5) }),
+    ]
+    const h = await buildHarness(events)
+    try {
+      const connectRes = await h.app.inject({
+        method: 'POST',
+        url: '/api/v1/projects/test-project/traffic/connect/cloud-run',
+        payload: { gcpProjectId: 'openclaw-nyc', keyJson: SA_KEY },
+      })
+      const sourceId = JSON.parse(connectRes.payload).id
+      await h.app.inject({
+        method: 'POST',
+        url: `/api/v1/projects/test-project/traffic/sources/${sourceId}/sync`,
+        payload: { sinceMinutes: 120 },
+      })
+
+      const res = await h.app.inject({
+        method: 'GET',
+        url: '/api/v1/projects/test-project/traffic/events?kind=ai-user-fetch',
+      })
+      expect(res.statusCode).toBe(200)
+      const body = JSON.parse(res.payload)
+      expect(body.totals.crawlerHits).toBe(0)
+      expect(body.totals.aiUserFetchHits).toBe(1)
+      expect(body.totals.aiReferralHits).toBe(0)
+      expect(body.events.length).toBe(1)
+      expect(body.events[0].kind).toBe('ai-user-fetch')
     } finally { await h.close() }
   })
 

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.51.4",
+  "version": "4.52.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/commands/backfill.ts
+++ b/packages/canonry/src/commands/backfill.ts
@@ -1,9 +1,9 @@
 import { and, eq, inArray, isNull, sql } from 'drizzle-orm'
 import type { GroundingSource, NormalizedQueryResult, NormalizedTrafficRequest } from '@ainyc/canonry-contracts'
 import type { DatabaseClient } from '@ainyc/canonry-db'
-import { auditLog, crawlerEventsHourly, createClient, gaAiReferrals, gaTrafficSnapshots, migrate, parseJsonColumn, competitors, projects, querySnapshots, rawEventSamples, runs } from '@ainyc/canonry-db'
+import { aiUserFetchEventsHourly, auditLog, crawlerEventsHourly, createClient, gaAiReferrals, gaTrafficSnapshots, migrate, parseJsonColumn, competitors, projects, querySnapshots, rawEventSamples, runs } from '@ainyc/canonry-db'
 import { determineAnswerMentioned, effectiveBrandNames, effectiveDomains, normalizeUrlPath, ProviderNames, RunKinds, TrafficEventConfidences, TrafficEventKinds, TrafficEvidenceKinds, TrafficSourceTypes } from '@ainyc/canonry-contracts'
-import { classifyCrawler } from '@ainyc/canonry-integration-traffic'
+import { classifyAiUserFetch, classifyCrawler } from '@ainyc/canonry-integration-traffic'
 import { reparseStoredResult as reparseOpenAIStoredResult } from '@ainyc/canonry-provider-openai'
 import { reparseStoredResult as reparseClaudeStoredResult } from '@ainyc/canonry-provider-claude'
 import { reparseStoredResult as reparseGeminiStoredResult } from '@ainyc/canonry-provider-gemini'
@@ -1320,7 +1320,12 @@ export async function backfillTrafficClassificationCommand(opts?: {
       providerResource: { type: 'cloud_run_revision', labels: {} },
       providerLabels: {},
     }
-    const classified = classifyCrawler(probe)
+    // Per-user-fetch UAs (ChatGPT-User, Perplexity-User, MistralAI-User) are
+    // disjoint from bulk-crawler UAs by rule purpose. Try the user-fetch
+    // matcher first so a ChatGPT-User UA isn't dropped just because
+    // classifyCrawler skips `purpose: 'user-agent'` rules.
+    const userFetch = classifyAiUserFetch(probe)
+    const classified = userFetch ?? classifyCrawler(probe)
     if (!classified) continue
 
     result.reclassified++
@@ -1330,42 +1335,74 @@ export async function backfillTrafficClassificationCommand(opts?: {
 
     // Update the sample row's event_type so the re-run filter excludes it.
     db.update(rawEventSamples)
-      .set({ eventType: TrafficEventKinds.crawler })
+      .set({ eventType: userFetch ? TrafficEventKinds['ai-user-fetch'] : TrafficEventKinds.crawler })
       .where(eq(rawEventSamples.id, snap.id))
       .run()
 
     // Bump the hourly rollup bucket. Snap ts → top of hour for the
-    // bucket key (matches what the live sync writes).
+    // bucket key (matches what the live sync writes). User-fetch and
+    // crawler hits go to disjoint tables.
     const tsHour = new Date(snap.ts)
     tsHour.setUTCMinutes(0, 0, 0)
-    db.insert(crawlerEventsHourly).values({
-      projectId: snap.projectId,
-      sourceId: snap.sourceId,
-      tsHour: tsHour.toISOString(),
-      botId: classified.botId,
-      operator: classified.operator,
-      verificationStatus: classified.verificationStatus,
-      pathNormalized: snap.pathNormalized,
-      status: snap.status ?? 200,
-      hits: 1,
-      sampledUserAgent: snap.userAgent,
-      createdAt: now,
-      updatedAt: now,
-    }).onConflictDoUpdate({
-      target: [
-        crawlerEventsHourly.projectId,
-        crawlerEventsHourly.sourceId,
-        crawlerEventsHourly.tsHour,
-        crawlerEventsHourly.botId,
-        crawlerEventsHourly.verificationStatus,
-        crawlerEventsHourly.pathNormalized,
-        crawlerEventsHourly.status,
-      ],
-      set: {
-        hits: sql`${crawlerEventsHourly.hits} + 1`,
+    if (userFetch) {
+      db.insert(aiUserFetchEventsHourly).values({
+        projectId: snap.projectId,
+        sourceId: snap.sourceId,
+        tsHour: tsHour.toISOString(),
+        botId: userFetch.botId,
+        operator: userFetch.operator,
+        verificationStatus: userFetch.verificationStatus,
+        pathNormalized: snap.pathNormalized,
+        status: snap.status ?? 200,
+        hits: 1,
+        sampledUserAgent: snap.userAgent,
+        createdAt: now,
         updatedAt: now,
-      },
-    }).run()
+      }).onConflictDoUpdate({
+        target: [
+          aiUserFetchEventsHourly.projectId,
+          aiUserFetchEventsHourly.sourceId,
+          aiUserFetchEventsHourly.tsHour,
+          aiUserFetchEventsHourly.botId,
+          aiUserFetchEventsHourly.verificationStatus,
+          aiUserFetchEventsHourly.pathNormalized,
+          aiUserFetchEventsHourly.status,
+        ],
+        set: {
+          hits: sql`${aiUserFetchEventsHourly.hits} + 1`,
+          updatedAt: now,
+        },
+      }).run()
+    } else {
+      db.insert(crawlerEventsHourly).values({
+        projectId: snap.projectId,
+        sourceId: snap.sourceId,
+        tsHour: tsHour.toISOString(),
+        botId: classified.botId,
+        operator: classified.operator,
+        verificationStatus: classified.verificationStatus,
+        pathNormalized: snap.pathNormalized,
+        status: snap.status ?? 200,
+        hits: 1,
+        sampledUserAgent: snap.userAgent,
+        createdAt: now,
+        updatedAt: now,
+      }).onConflictDoUpdate({
+        target: [
+          crawlerEventsHourly.projectId,
+          crawlerEventsHourly.sourceId,
+          crawlerEventsHourly.tsHour,
+          crawlerEventsHourly.botId,
+          crawlerEventsHourly.verificationStatus,
+          crawlerEventsHourly.pathNormalized,
+          crawlerEventsHourly.status,
+        ],
+        set: {
+          hits: sql`${crawlerEventsHourly.hits} + 1`,
+          updatedAt: now,
+        },
+      }).run()
+    }
   }
 
   // Recompute trailing unknown count so the report shows the net effect.

--- a/packages/canonry/src/commands/traffic.ts
+++ b/packages/canonry/src/commands/traffic.ts
@@ -449,26 +449,38 @@ export async function trafficStatus(project: string, opts: { format?: string }):
 }
 
 function formatEventLine(event: TrafficEventEntry): string {
-  if (event.kind === TrafficEventKinds.crawler) {
-    return [
-      event.tsHour,
-      'crawler',
-      event.botId,
-      event.verificationStatus,
-      String(event.status),
-      event.pathNormalized,
-      `${event.hits} hits`,
-    ].join('  ')
+  switch (event.kind) {
+    case TrafficEventKinds.crawler:
+      return [
+        event.tsHour,
+        'crawler',
+        event.botId,
+        event.verificationStatus,
+        String(event.status),
+        event.pathNormalized,
+        `${event.hits} hits`,
+      ].join('  ')
+    case TrafficEventKinds['ai-user-fetch']:
+      return [
+        event.tsHour,
+        'ai-user-fetch',
+        event.botId,
+        event.verificationStatus,
+        String(event.status),
+        event.pathNormalized,
+        `${event.hits} hits`,
+      ].join('  ')
+    case TrafficEventKinds['ai-referral']:
+      return [
+        event.tsHour,
+        'ai-referral',
+        event.product,
+        event.evidenceType,
+        event.sourceDomain,
+        event.landingPathNormalized,
+        `${event.hits} hits`,
+      ].join('  ')
   }
-  return [
-    event.tsHour,
-    'ai-referral',
-    event.product,
-    event.evidenceType,
-    event.sourceDomain,
-    event.landingPathNormalized,
-    `${event.hits} hits`,
-  ].join('  ')
 }
 
 export async function trafficEvents(project: string, opts: {
@@ -480,11 +492,17 @@ export async function trafficEvents(project: string, opts: {
   source?: string
   format?: string
 }): Promise<void> {
-  if (opts.kind && opts.kind !== 'all' && opts.kind !== TrafficEventKinds.crawler && opts.kind !== TrafficEventKinds['ai-referral']) {
+  if (
+    opts.kind
+    && opts.kind !== 'all'
+    && opts.kind !== TrafficEventKinds.crawler
+    && opts.kind !== TrafficEventKinds['ai-user-fetch']
+    && opts.kind !== TrafficEventKinds['ai-referral']
+  ) {
     throw new CliError({
       code: 'TRAFFIC_INVALID_KIND',
-      message: `--kind must be one of: all, ${TrafficEventKinds.crawler}, ${TrafficEventKinds['ai-referral']}`,
-      displayMessage: `Error: --kind must be "all", "${TrafficEventKinds.crawler}", or "${TrafficEventKinds['ai-referral']}"`,
+      message: `--kind must be one of: all, ${TrafficEventKinds.crawler}, ${TrafficEventKinds['ai-user-fetch']}, ${TrafficEventKinds['ai-referral']}`,
+      displayMessage: `Error: --kind must be "all", "${TrafficEventKinds.crawler}", "${TrafficEventKinds['ai-user-fetch']}", or "${TrafficEventKinds['ai-referral']}"`,
       details: { project, kind: opts.kind },
     })
   }
@@ -510,7 +528,8 @@ export async function trafficEvents(project: string, opts: {
   }
 
   console.log(`Traffic events for "${project}"  ${result.windowStart}  →  ${result.windowEnd}`)
-  console.log(`  Crawler hits (window):     ${result.totals.crawlerHits}`)
+  console.log(`  Crawler hits (window):         ${result.totals.crawlerHits}`)
+  console.log(`  AI user-fetch hits (window):   ${result.totals.aiUserFetchHits}`)
   console.log(`  AI referral sessions (window): ${result.totals.aiReferralHits}`)
   console.log('')
 

--- a/packages/canonry/test/backfill-traffic-classification.test.ts
+++ b/packages/canonry/test/backfill-traffic-classification.test.ts
@@ -128,7 +128,7 @@ describe('backfill traffic-classification', () => {
 
     const mistralBucket = db.select().from(crawlerEventsHourly)
       .where(and(
-        eq(crawlerEventsHourly.botId, 'mistral-ai'),
+        eq(crawlerEventsHourly.botId, 'mistral-bot'),
         eq(crawlerEventsHourly.tsHour, '2026-05-18T10:00:00.000Z'),
       ))
       .get()

--- a/packages/contracts/src/report.ts
+++ b/packages/contracts/src/report.ts
@@ -382,6 +382,15 @@ export const serverActivitySectionSchema = z.object({
   verifiedCrawlerHits: z.object({ current: z.number(), prior: z.number(), deltaPct: z.number().nullable() }),
   /** Last-7d total unverified crawler hits, separated from verified trust metrics. */
   unverifiedCrawlerHits: z.object({ current: z.number(), prior: z.number(), deltaPct: z.number().nullable() }),
+  /**
+   * Last-7d on-demand per-user fetches from AI surfaces (ChatGPT-User,
+   * Perplexity-User, MistralAI-User). Disjoint from `verifiedCrawlerHits` /
+   * `unverifiedCrawlerHits` — those measure bulk crawl; this measures human
+   * users asking an AI to read a URL. Counts verified + unverified together
+   * because the operational question for user-fetch is "is this happening?"
+   * not "is this a confirmed bot identity?"
+   */
+  aiUserFetchHits: z.object({ current: z.number(), prior: z.number(), deltaPct: z.number().nullable() }),
   /** Last-7d AI-referral sessions (sessionized from server-side request evidence). */
   referralArrivals: z.object({ current: z.number(), prior: z.number(), deltaPct: z.number().nullable() }),
 
@@ -391,6 +400,8 @@ export const serverActivitySectionSchema = z.object({
     verifiedHits: z.number(),
     /** Shown to agency audience only — claimed-bot UA, rDNS not confirmed. */
     unverifiedHits: z.number(),
+    /** Per-user fetches from this operator's AI surface (ChatGPT-User, …). */
+    userFetchHits: z.number(),
     referralArrivals: z.number(),
     deltaPct: z.number().nullable(),
   })),
@@ -421,6 +432,7 @@ export const serverActivitySectionSchema = z.object({
   dailyTrend: z.array(z.object({
     date: z.string(),
     verifiedCrawlerHits: z.number(),
+    userFetchHits: z.number(),
     referralArrivals: z.number(),
   })),
 

--- a/packages/contracts/src/traffic.ts
+++ b/packages/contracts/src/traffic.ts
@@ -174,9 +174,11 @@ export const trafficSyncResponseSchema = z.object({
   syncedAt: z.string(),
   pulledEvents: z.number().int().nonnegative(),
   crawlerHits: z.number().int().nonnegative(),
+  aiUserFetchHits: z.number().int().nonnegative(),
   aiReferralHits: z.number().int().nonnegative(),
   unknownHits: z.number().int().nonnegative(),
   crawlerBucketRows: z.number().int().nonnegative(),
+  aiUserFetchBucketRows: z.number().int().nonnegative(),
   aiReferralBucketRows: z.number().int().nonnegative(),
   sampleRows: z.number().int().nonnegative(),
   windowStart: z.string(),
@@ -210,6 +212,7 @@ export type TrafficBackfillResponse = z.infer<typeof trafficBackfillResponseSche
 
 export const trafficSourceTotalsSchema = z.object({
   crawlerHits: z.number().int().nonnegative(),
+  aiUserFetchHits: z.number().int().nonnegative(),
   aiReferralHits: z.number().int().nonnegative(),
   sampleCount: z.number().int().nonnegative(),
 })
@@ -239,7 +242,7 @@ export const trafficStatusResponseSchema = z.object({
 })
 export type TrafficStatusResponse = z.infer<typeof trafficStatusResponseSchema>
 
-export const trafficEventKindSchema = z.enum(['crawler', 'ai-referral'])
+export const trafficEventKindSchema = z.enum(['crawler', 'ai-user-fetch', 'ai-referral'])
 export type TrafficEventKind = z.infer<typeof trafficEventKindSchema>
 export const TrafficEventKinds = trafficEventKindSchema.enum
 
@@ -255,6 +258,23 @@ export const trafficCrawlerEventEntrySchema = z.object({
   hits: z.number().int().nonnegative(),
 })
 export type TrafficCrawlerEventEntry = z.infer<typeof trafficCrawlerEventEntrySchema>
+
+// On-demand per-user fetch from an AI surface (e.g. ChatGPT-User clicking a
+// citation, Perplexity-User fetching a referenced URL). UA-evidenced like a
+// crawler, but with a real user in the loop — kept in its own kind so the
+// dashboard / API / CLI don't conflate machine crawl with human-driven fetch.
+export const trafficAiUserFetchEventEntrySchema = z.object({
+  kind: z.literal(TrafficEventKinds['ai-user-fetch']),
+  sourceId: z.string(),
+  tsHour: z.string(),
+  botId: z.string(),
+  operator: z.string(),
+  verificationStatus: z.string(),
+  pathNormalized: z.string(),
+  status: z.number().int(),
+  hits: z.number().int().nonnegative(),
+})
+export type TrafficAiUserFetchEventEntry = z.infer<typeof trafficAiUserFetchEventEntrySchema>
 
 export const trafficAiReferralEventEntrySchema = z.object({
   kind: z.literal(TrafficEventKinds['ai-referral']),
@@ -272,6 +292,7 @@ export type TrafficAiReferralEventEntry = z.infer<typeof trafficAiReferralEventE
 
 export const trafficEventEntrySchema = z.discriminatedUnion('kind', [
   trafficCrawlerEventEntrySchema,
+  trafficAiUserFetchEventEntrySchema,
   trafficAiReferralEventEntrySchema,
 ])
 export type TrafficEventEntry = z.infer<typeof trafficEventEntrySchema>
@@ -281,6 +302,7 @@ export const trafficEventsResponseSchema = z.object({
   windowEnd: z.string(),
   totals: z.object({
     crawlerHits: z.number().int().nonnegative(),
+    aiUserFetchHits: z.number().int().nonnegative(),
     aiReferralHits: z.number().int().nonnegative(),
   }),
   events: z.array(trafficEventEntrySchema),

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1297,6 +1297,78 @@ export const MIGRATION_VERSIONS: ReadonlyArray<MigrationVersion> = [
       `ALTER TABLE audit_log ADD COLUMN actor_session TEXT`,
     ],
   },
+  {
+    version: 64,
+    name: 'ai-user-fetch-events-hourly',
+    // Splits per-user fetches (ChatGPT-User, Perplexity-User) out of
+    // crawler_events_hourly so the dashboard / API can distinguish bulk
+    // machine crawl from human-in-the-loop fetch. Bot IDs are pinned to the
+    // two `purpose: 'user-agent'` rules that existed before this change —
+    // future user-fetch UAs land in the new table directly via the
+    // refactored classifier and never need a backfill.
+    //
+    // Statements are idempotent: CREATE/INDEX are IF NOT EXISTS; the
+    // INSERT … SELECT uses ON CONFLICT DO NOTHING (composite PK rows
+    // already moved skip silently); the DELETE keys on `bot_id`, so a
+    // second run is a no-op after the first DELETE drains the source.
+    statements: [
+      `CREATE TABLE IF NOT EXISTS ai_user_fetch_events_hourly (
+         project_id           TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+         source_id            TEXT NOT NULL REFERENCES traffic_sources(id) ON DELETE CASCADE,
+         ts_hour              TEXT NOT NULL,
+         bot_id               TEXT NOT NULL,
+         operator             TEXT NOT NULL,
+         verification_status  TEXT NOT NULL,
+         path_normalized      TEXT NOT NULL,
+         status               INTEGER NOT NULL,
+         hits                 INTEGER NOT NULL DEFAULT 0,
+         sampled_user_agent   TEXT,
+         created_at           TEXT NOT NULL,
+         updated_at           TEXT NOT NULL,
+         PRIMARY KEY (project_id, source_id, ts_hour, bot_id, verification_status, path_normalized, status)
+       )`,
+      `CREATE INDEX IF NOT EXISTS idx_ai_user_fetch_hourly_project_ts ON ai_user_fetch_events_hourly(project_id, ts_hour)`,
+      `CREATE INDEX IF NOT EXISTS idx_ai_user_fetch_hourly_path ON ai_user_fetch_events_hourly(project_id, path_normalized)`,
+      `INSERT INTO ai_user_fetch_events_hourly
+         (project_id, source_id, ts_hour, bot_id, operator, verification_status, path_normalized, status, hits, sampled_user_agent, created_at, updated_at)
+       SELECT project_id, source_id, ts_hour, bot_id, operator, verification_status, path_normalized, status, hits, sampled_user_agent, created_at, updated_at
+         FROM crawler_events_hourly
+        WHERE bot_id IN ('openai-chatgpt-user', 'perplexity-user')
+       ON CONFLICT DO NOTHING`,
+      `DELETE FROM crawler_events_hourly WHERE bot_id IN ('openai-chatgpt-user', 'perplexity-user')`,
+    ],
+  },
+  {
+    version: 65,
+    name: 'split-mistral-ai-rule',
+    // The pre-existing `mistral-ai` rule matched both `MistralAI-User/*`
+    // (per-user fetch) and `MistralBot/*` (bulk crawl) under one id, so
+    // every historical row landed in crawler_events_hourly with
+    // bot_id='mistral-ai'. The rule is now split into `mistral-ai-user`
+    // (purpose: 'user-agent') and `mistral-bot` (purpose: 'crawl'); this
+    // migration best-effort routes the legacy rows using the bucket's
+    // representative sampled_user_agent.
+    //
+    // Mixed-UA buckets (where a single (project, source, hour, path,
+    // status) accumulated both UAs under the old shared id) are routed
+    // by whichever UA happened to be sampled — the bucket-key granularity
+    // doesn't preserve per-event UAs, so any heuristic has the same
+    // limitation. Going forward the split rules write to disjoint tables.
+    //
+    // Idempotent: the INSERT…SELECT uses ON CONFLICT DO NOTHING; the
+    // UPDATE and DELETE both filter on bot_id='mistral-ai', so a second
+    // run finds no rows after the first apply.
+    statements: [
+      `INSERT INTO ai_user_fetch_events_hourly
+         (project_id, source_id, ts_hour, bot_id, operator, verification_status, path_normalized, status, hits, sampled_user_agent, created_at, updated_at)
+       SELECT project_id, source_id, ts_hour, 'mistral-ai-user', operator, verification_status, path_normalized, status, hits, sampled_user_agent, created_at, updated_at
+         FROM crawler_events_hourly
+        WHERE bot_id = 'mistral-ai' AND sampled_user_agent LIKE '%MistralAI-User%'
+       ON CONFLICT DO NOTHING`,
+      `DELETE FROM crawler_events_hourly WHERE bot_id = 'mistral-ai' AND sampled_user_agent LIKE '%MistralAI-User%'`,
+      `UPDATE crawler_events_hourly SET bot_id = 'mistral-bot' WHERE bot_id = 'mistral-ai'`,
+    ],
+  },
 ]
 
 /**

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -649,6 +649,40 @@ export const crawlerEventsHourly = sqliteTable('crawler_events_hourly', {
   index('idx_crawler_hourly_path').on(table.projectId, table.pathNormalized),
 ])
 
+// Hourly rollup of on-demand per-user fetches from AI surfaces — ChatGPT-User,
+// Perplexity-User, MistralAI-User, etc. UA-evidenced like a crawler, but each
+// hit was initiated by a real user (citation click, "read this URL" prompt).
+// Kept disjoint from `crawler_events_hourly` so dashboard / API / report
+// totals don't conflate machine crawl with human-in-the-loop fetch.
+export const aiUserFetchEventsHourly = sqliteTable('ai_user_fetch_events_hourly', {
+  projectId: text('project_id').notNull().references(() => projects.id, { onDelete: 'cascade' }),
+  sourceId: text('source_id').notNull().references(() => trafficSources.id, { onDelete: 'cascade' }),
+  tsHour: text('ts_hour').notNull(),
+  botId: text('bot_id').notNull(),
+  operator: text('operator').notNull(),
+  verificationStatus: text('verification_status').notNull(),
+  pathNormalized: text('path_normalized').notNull(),
+  status: integer('status').notNull(),
+  hits: integer('hits').notNull().default(0),
+  sampledUserAgent: text('sampled_user_agent'),
+  createdAt: text('created_at').notNull(),
+  updatedAt: text('updated_at').notNull(),
+}, (table) => [
+  primaryKey({
+    columns: [
+      table.projectId,
+      table.sourceId,
+      table.tsHour,
+      table.botId,
+      table.verificationStatus,
+      table.pathNormalized,
+      table.status,
+    ],
+  }),
+  index('idx_ai_user_fetch_hourly_project_ts').on(table.projectId, table.tsHour),
+  index('idx_ai_user_fetch_hourly_path').on(table.projectId, table.pathNormalized),
+])
+
 // Hourly rollup of human visits with explicit AI-origin evidence (referer
 // host or UTM source). Independent from `crawler_events_hourly` — never
 // collapse the two; they answer different questions.

--- a/packages/db/test/traffic-tables.test.ts
+++ b/packages/db/test/traffic-tables.test.ts
@@ -9,9 +9,11 @@ import {
   projects,
   trafficSources,
   crawlerEventsHourly,
+  aiUserFetchEventsHourly,
   aiReferralEventsHourly,
   rawEventSamples,
 } from '../src/index.js'
+import { MIGRATION_VERSIONS } from '../src/migrate.js'
 
 function createTempDb() {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-traffic-test-'))
@@ -241,6 +243,216 @@ test('raw_event_samples stores debug samples without full IPs', () => {
   expect(row.eventType).toBe('crawler')
   expect(row.ipHash).toBe('abc123def')
   expect(row.userAgent).toBe('GPTBot/1.0')
+})
+
+test('ai_user_fetch_events_hourly accepts inserts keyed like crawler_events_hourly', () => {
+  // The new table mirrors crawler_events_hourly schema-wise but holds the
+  // human-in-the-loop UA matches (ChatGPT-User, Perplexity-User, etc.) so
+  // dashboard / API counts can split machine crawl from user-driven fetch.
+  const { db, tmpDir } = createTempDb()
+  onTestFinished(() => cleanup(tmpDir))
+
+  seedProject(db)
+
+  const now = new Date().toISOString()
+  db.insert(trafficSources).values({
+    id: 'src_user_fetch',
+    projectId: 'proj_1',
+    sourceType: 'cloud-run',
+    displayName: 'Cloud Run',
+    status: 'connected',
+    configJson: {},
+    createdAt: now,
+    updatedAt: now,
+  }).run()
+
+  db.insert(aiUserFetchEventsHourly).values({
+    projectId: 'proj_1',
+    sourceId: 'src_user_fetch',
+    tsHour: '2026-05-19T20:00:00.000Z',
+    botId: 'openai-chatgpt-user',
+    operator: 'OpenAI',
+    verificationStatus: 'verified',
+    pathNormalized: '/',
+    status: 200,
+    hits: 1,
+    sampledUserAgent: 'Mozilla/5.0 ChatGPT-User/1.0',
+    createdAt: now,
+    updatedAt: now,
+  }).run()
+
+  const [row] = db
+    .select()
+    .from(aiUserFetchEventsHourly)
+    .where(
+      and(
+        eq(aiUserFetchEventsHourly.projectId, 'proj_1'),
+        eq(aiUserFetchEventsHourly.botId, 'openai-chatgpt-user'),
+      ),
+    )
+    .all()
+
+  expect(row).toBeDefined()
+  expect(row.verificationStatus).toBe('verified')
+  expect(row.hits).toBe(1)
+})
+
+test('migration 64 moves legacy user-fetch rows out of crawler_events_hourly', () => {
+  // Before the split, ChatGPT-User and Perplexity-User UAs were classified as
+  // crawlers and persisted into crawler_events_hourly. The migration's job is
+  // to move those rows into ai_user_fetch_events_hourly so historical totals
+  // stop double-counting user-fetch as machine crawl. Re-runs the v64 SQL
+  // explicitly against pre-existing rows (the migration runner records v64
+  // as applied on first boot and won't re-run it, so this seeds the same
+  // state that production DBs reached just before applying v64).
+  const { db, tmpDir } = createTempDb()
+  onTestFinished(() => cleanup(tmpDir))
+
+  seedProject(db)
+
+  const now = new Date().toISOString()
+  db.insert(trafficSources).values({
+    id: 'src_legacy',
+    projectId: 'proj_1',
+    sourceType: 'cloud-run',
+    displayName: 'Cloud Run',
+    status: 'connected',
+    configJson: {},
+    createdAt: now,
+    updatedAt: now,
+  }).run()
+
+  // Two legacy user-fetch rows (one ChatGPT-User, one Perplexity-User) plus
+  // one genuine bulk crawler row that must stay put.
+  for (const row of [
+    {
+      botId: 'openai-chatgpt-user',
+      operator: 'OpenAI',
+      pathNormalized: '/',
+      sampledUserAgent: 'Mozilla/5.0 ChatGPT-User/1.0',
+    },
+    {
+      botId: 'perplexity-user',
+      operator: 'Perplexity',
+      pathNormalized: '/pricing',
+      sampledUserAgent: 'Mozilla/5.0 Perplexity-User/1.0',
+    },
+    {
+      botId: 'openai-gptbot',
+      operator: 'OpenAI',
+      pathNormalized: '/blog/post-1',
+      sampledUserAgent: 'GPTBot/1.0',
+    },
+  ]) {
+    db.insert(crawlerEventsHourly).values({
+      projectId: 'proj_1',
+      sourceId: 'src_legacy',
+      tsHour: '2026-05-19T20:00:00.000Z',
+      botId: row.botId,
+      operator: row.operator,
+      verificationStatus: 'verified',
+      pathNormalized: row.pathNormalized,
+      status: 200,
+      hits: 3,
+      sampledUserAgent: row.sampledUserAgent,
+      createdAt: now,
+      updatedAt: now,
+    }).run()
+  }
+
+  // Re-execute v64's statements directly. The runner has already applied
+  // them on the empty pre-seed DB; this proves the SQL itself handles the
+  // populated case correctly.
+  const v64 = MIGRATION_VERSIONS.find(v => v.version === 64)
+  expect(v64).toBeDefined()
+  for (const sql of v64!.statements) {
+    db.$client.exec(sql)
+  }
+
+  const moved = db.select().from(aiUserFetchEventsHourly).all()
+  expect(moved).toHaveLength(2)
+  expect(new Set(moved.map(r => r.botId))).toEqual(new Set(['openai-chatgpt-user', 'perplexity-user']))
+  expect(moved.every(r => r.hits === 3 && r.verificationStatus === 'verified')).toBe(true)
+
+  const remainingCrawlers = db.select().from(crawlerEventsHourly).all()
+  expect(remainingCrawlers).toHaveLength(1)
+  expect(remainingCrawlers[0].botId).toBe('openai-gptbot')
+})
+
+test('migration 65 splits legacy mistral-ai rows by sampled user agent', () => {
+  // The legacy `mistral-ai` rule matched both MistralAI-User (user-fetch)
+  // and MistralBot (bulk crawl), so historical buckets collapsed both
+  // under one id. v65 splits them: MistralAI-User-flavored rows move to
+  // ai_user_fetch_events_hourly (bot_id='mistral-ai-user'); the rest are
+  // renamed to bot_id='mistral-bot' in place.
+  const { db, tmpDir } = createTempDb()
+  onTestFinished(() => cleanup(tmpDir))
+
+  seedProject(db)
+
+  const now = new Date().toISOString()
+  db.insert(trafficSources).values({
+    id: 'src_mistral',
+    projectId: 'proj_1',
+    sourceType: 'cloud-run',
+    displayName: 'Cloud Run',
+    status: 'connected',
+    configJson: {},
+    createdAt: now,
+    updatedAt: now,
+  }).run()
+
+  for (const row of [
+    {
+      pathNormalized: '/blog/post-a',
+      sampledUserAgent: 'Mozilla/5.0 MistralAI-User/1.0',
+    },
+    {
+      pathNormalized: '/blog/post-b',
+      sampledUserAgent: 'Mozilla/5.0 (compatible; MistralBot/1.0; +https://mistral.ai)',
+    },
+    {
+      pathNormalized: '/blog/post-c',
+      // Null sample — historically possible since sampled_user_agent is
+      // nullable. Stays as crawler with renamed bot_id.
+      sampledUserAgent: null,
+    },
+  ]) {
+    db.insert(crawlerEventsHourly).values({
+      projectId: 'proj_1',
+      sourceId: 'src_mistral',
+      tsHour: '2026-05-19T20:00:00.000Z',
+      botId: 'mistral-ai',
+      operator: 'Mistral AI',
+      verificationStatus: 'claimed_unverified',
+      pathNormalized: row.pathNormalized,
+      status: 200,
+      hits: 5,
+      sampledUserAgent: row.sampledUserAgent,
+      createdAt: now,
+      updatedAt: now,
+    }).run()
+  }
+
+  const v65 = MIGRATION_VERSIONS.find(v => v.version === 65)
+  expect(v65).toBeDefined()
+  for (const sql of v65!.statements) {
+    db.$client.exec(sql)
+  }
+
+  const userFetch = db.select().from(aiUserFetchEventsHourly).all()
+  expect(userFetch).toHaveLength(1)
+  expect(userFetch[0]).toMatchObject({
+    botId: 'mistral-ai-user',
+    operator: 'Mistral AI',
+    pathNormalized: '/blog/post-a',
+    hits: 5,
+  })
+
+  const crawlers = db.select().from(crawlerEventsHourly).all()
+  expect(crawlers).toHaveLength(2)
+  expect(crawlers.every(r => r.botId === 'mistral-bot')).toBe(true)
+  expect(new Set(crawlers.map(r => r.pathNormalized))).toEqual(new Set(['/blog/post-b', '/blog/post-c']))
 })
 
 test('traffic_sources cascade deletes all dependent rows when project is removed', () => {

--- a/packages/integration-traffic/AGENTS.md
+++ b/packages/integration-traffic/AGENTS.md
@@ -9,7 +9,7 @@ Provider-neutral traffic classifier and rollup. Takes `NormalizedTrafficRequest`
 | File | Role |
 |------|------|
 | `src/rules.ts` | Bundled AI crawler UA patterns and known AI-referrer host rules |
-| `src/classifier.ts` | `classifyTrafficRequest` — UA/referrer matching → `ClassifiedCrawler` / `ClassifiedAiReferral` (heuristic; verification status is `claimed_unverified` until IP/rDNS is wired) |
+| `src/classifier.ts` | `classifyCrawler` / `classifyAiUserFetch` / `classifyAiReferral` — three disjoint matchers. `classifyCrawler` matches UA rules with `purpose !== 'user-agent'` (GPTBot, OAI-SearchBot, …). `classifyAiUserFetch` matches UA rules with `purpose === 'user-agent'` (ChatGPT-User, Perplexity-User) so per-user fetches stay separate from bulk crawl. `classifyAiReferral` matches referer host or `utm_source` against known AI domains. All return `claimed_unverified` until IP verification promotes to `verified`. |
 | `src/rollup.ts` | `buildTrafficProbeReport` — aggregates classified events into hourly buckets + top-N summaries |
 | `src/types.ts` | Bucket shapes (`CrawlerEventHourlyBucket`, `AiReferralEventHourlyBucket`), classifier output types, probe report shape |
 | `src/index.ts` | Re-exports public API |
@@ -17,7 +17,7 @@ Provider-neutral traffic classifier and rollup. Takes `NormalizedTrafficRequest`
 ## Patterns
 
 - **Pure functions, no I/O.** Adapters fetch and normalize; this package only classifies and rolls up. Unit-testable end-to-end with fixture events.
-- **Two evidence channels.** Crawlers via UA pattern match; human AI referrals via referer host (and UTM later). Never collapse the two — each maps to its own hourly bucket table per `plans/server-side-ai-traffic-ingestion.md`.
+- **Three evidence channels.** Bulk crawl via UA where `purpose !== 'user-agent'` (`crawler_events_hourly`); per-user AI fetches via UA where `purpose === 'user-agent'` (`ai_user_fetch_events_hourly`); human AI referrals via referer/UTM (`ai_referral_events_hourly`). Never collapse them — each answers a different question: "is AI training on me?" vs. "is AI reading me for a user right now?" vs. "are users clicking through from AI?"
 - **Verification status tiers.** UA-only matches stay `claimed_unverified`. Promotion to `verified` requires IP/rDNS verification, which is not yet implemented. The `unknown_ai_like` bucket is reserved for behavioral heuristics.
 - **Path normalization.** Rollups key on the normalized path so query-string variants don't fragment the bucket counts.
 - **Bounded sample tail.** `buildTrafficProbeReport` keeps a small sample slice for classifier debugging; the durable signal is the hourly bucket counts.

--- a/packages/integration-traffic/src/classifier.ts
+++ b/packages/integration-traffic/src/classifier.ts
@@ -1,7 +1,19 @@
 import type { NormalizedTrafficRequest } from '@ainyc/canonry-contracts'
 import { verifyIpForRule } from './ip-verify.js'
 import { DEFAULT_AI_CRAWLER_RULES, DEFAULT_AI_REFERRER_RULES } from './rules.js'
-import type { ClassifiedAiReferral, ClassifiedCrawler } from './types.js'
+import type {
+  ClassifiedAiReferral,
+  ClassifiedAiUserFetch,
+  ClassifiedCrawler,
+} from './types.js'
+
+// Rules with this `purpose` represent per-user, on-demand fetches from an AI
+// surface (e.g. ChatGPT-User, Perplexity-User, MistralAI-User) — not bulk
+// crawl. Operators care about the distinction: machine crawl is "AI may
+// reference my page someday"; user-fetch is "AI is reading my page right now
+// because a real user asked." Routed through classifyAiUserFetch, kept out of
+// classifyCrawler so the two signals stay disjoint end-to-end.
+const USER_FETCH_PURPOSE = 'user-agent'
 
 function normalizeHost(host: string): string {
   return host.trim().toLowerCase().replace(/^www\./, '')
@@ -53,6 +65,10 @@ export function classifyCrawler(event: NormalizedTrafficRequest): ClassifiedCraw
   if (!userAgent) return null
 
   for (const rule of DEFAULT_AI_CRAWLER_RULES) {
+    // Skip user-agent (per-user fetch) rules — those route through
+    // classifyAiUserFetch into their own bucket. Letting them match here
+    // would double-count human-in-the-loop fetches as machine crawl.
+    if (rule.purpose === USER_FETCH_PURPOSE) continue
     if (rule.userAgentPatterns.some((pattern) => pattern.test(userAgent))) {
       // UA matched — try to upgrade `claimed_unverified` → `verified` by
       // checking the request's source IP against the operator's
@@ -72,6 +88,30 @@ export function classifyCrawler(event: NormalizedTrafficRequest): ClassifiedCraw
         operator: rule.operator,
         product: rule.product,
         purpose: rule.purpose,
+        verificationStatus: verified ? 'verified' : 'claimed_unverified',
+        matchedUserAgent: userAgent,
+      }
+    }
+  }
+
+  return null
+}
+
+export function classifyAiUserFetch(event: NormalizedTrafficRequest): ClassifiedAiUserFetch | null {
+  const userAgent = event.userAgent?.trim()
+  if (!userAgent) return null
+
+  for (const rule of DEFAULT_AI_CRAWLER_RULES) {
+    if (rule.purpose !== USER_FETCH_PURPOSE) continue
+    if (rule.userAgentPatterns.some((pattern) => pattern.test(userAgent))) {
+      // Same IP-verification path as classifyCrawler — the operator's
+      // published ranges file (e.g. chatgpt-user.json) is what lifts
+      // a UA-only match to `verified`.
+      const verified = verifyIpForRule(event.remoteIp, rule.id)
+      return {
+        botId: rule.id,
+        operator: rule.operator,
+        product: rule.product,
         verificationStatus: verified ? 'verified' : 'claimed_unverified',
         matchedUserAgent: userAgent,
       }

--- a/packages/integration-traffic/src/rollup.ts
+++ b/packages/integration-traffic/src/rollup.ts
@@ -1,8 +1,9 @@
 import type { NormalizedTrafficRequest } from '@ainyc/canonry-contracts'
-import { classifyAiReferral, classifyCrawler } from './classifier.js'
+import { classifyAiReferral, classifyAiUserFetch, classifyCrawler } from './classifier.js'
 import type {
   AiReferralEventHourlyBucket,
   AiReferralEvidenceType,
+  AiUserFetchEventHourlyBucket,
   BuildTrafficProbeReportOptions,
   ClassifiedAiReferral,
   CrawlerEventHourlyBucket,
@@ -146,6 +147,13 @@ function sortCrawlerBuckets(a: CrawlerEventHourlyBucket, b: CrawlerEventHourlyBu
     String(a.status).localeCompare(String(b.status))
 }
 
+function sortAiUserFetchBuckets(a: AiUserFetchEventHourlyBucket, b: AiUserFetchEventHourlyBucket): number {
+  return a.tsHour.localeCompare(b.tsHour) ||
+    a.botId.localeCompare(b.botId) ||
+    a.pathNormalized.localeCompare(b.pathNormalized) ||
+    String(a.status).localeCompare(String(b.status))
+}
+
 function sortReferralBuckets(a: AiReferralEventHourlyBucket, b: AiReferralEventHourlyBucket): number {
   return a.tsHour.localeCompare(b.tsHour) ||
     a.product.localeCompare(b.product) ||
@@ -174,14 +182,18 @@ export function buildTrafficProbeReport(
     ? configuredSessionWindowMs
     : DEFAULT_AI_REFERRAL_SESSION_WINDOW_MS
   const crawlerBuckets = new Map<string, CrawlerEventHourlyBucket>()
+  const aiUserFetchBuckets = new Map<string, AiUserFetchEventHourlyBucket>()
   const aiReferralBuckets = new Map<string, AiReferralEventHourlyBucket>()
   const aiReferralSessions = new Map<string, AiReferralSession>()
   const topBots = new Map<string, { fields: { botId: string; operator: string }; hits: number }>()
   const topCrawlerPaths = new Map<string, { fields: { pathNormalized: string }; hits: number }>()
+  const topAiUserFetchBots = new Map<string, { fields: { botId: string; operator: string }; hits: number }>()
+  const topAiUserFetchPaths = new Map<string, { fields: { pathNormalized: string }; hits: number }>()
   const topAiReferrers = new Map<string, { fields: { sourceDomain: string; product: string }; hits: number }>()
   const topAiReferralLandingPaths = new Map<string, { fields: { landingPathNormalized: string }; hits: number }>()
 
   let crawlerHits = 0
+  let aiUserFetchHits = 0
   let aiReferralHits = 0
   let unknownHits = 0
   const samples: TrafficProbeReport['samples'] = []
@@ -190,6 +202,7 @@ export function buildTrafficProbeReport(
     const tsHour = hourBucket(event.observedAt)
     const pathNormalized = normalizeTrafficPathPattern(event.path)
     const crawler = classifyCrawler(event)
+    const aiUserFetch = classifyAiUserFetch(event)
     const aiReferral = classifyAiReferral(event)
 
     if (crawler) {
@@ -224,6 +237,38 @@ export function buildTrafficProbeReport(
       incrementBucket(topCrawlerPaths, pathNormalized, { pathNormalized })
     }
 
+    if (aiUserFetch) {
+      aiUserFetchHits += 1
+      const key = [
+        tsHour,
+        aiUserFetch.botId,
+        aiUserFetch.verificationStatus,
+        pathNormalized,
+        event.status ?? 'null',
+      ].join('\t')
+      const existing = aiUserFetchBuckets.get(key)
+      if (existing) {
+        existing.hits += 1
+      } else {
+        aiUserFetchBuckets.set(key, {
+          tsHour,
+          botId: aiUserFetch.botId,
+          operator: aiUserFetch.operator,
+          product: aiUserFetch.product,
+          verificationStatus: aiUserFetch.verificationStatus,
+          pathNormalized,
+          status: event.status,
+          hits: 1,
+          sampledUserAgent: event.userAgent,
+        })
+      }
+      const botKey = `${aiUserFetch.botId}\t${aiUserFetch.operator}`
+      const botEntry = topAiUserFetchBots.get(botKey)
+      if (botEntry) botEntry.hits += 1
+      else topAiUserFetchBots.set(botKey, { fields: { botId: aiUserFetch.botId, operator: aiUserFetch.operator }, hits: 1 })
+      incrementBucket(topAiUserFetchPaths, pathNormalized, { pathNormalized })
+    }
+
     if (aiReferral) {
       aiReferralHits += 1
       const landingPathNormalized = resolveAiReferralLandingPath(event, aiReferral.evidenceType)
@@ -243,7 +288,7 @@ export function buildTrafficProbeReport(
       }
     }
 
-    if (!crawler && !aiReferral) unknownHits += 1
+    if (!crawler && !aiUserFetch && !aiReferral) unknownHits += 1
 
     // Keep the most-recent `sampleLimit` events by iteration order, not the
     // first ones we see. Pulls run timestamp-asc, so a FIFO retention would
@@ -259,6 +304,7 @@ export function buildTrafficProbeReport(
       userAgent: event.userAgent,
       referer: event.referer,
       crawler,
+      aiUserFetch,
       aiReferral,
     })
     if (samples.length > sampleLimit) samples.shift()
@@ -296,14 +342,18 @@ export function buildTrafficProbeReport(
     totals: {
       normalizedEvents: events.length,
       crawlerHits,
+      aiUserFetchHits,
       aiReferralSessions: aiReferralSessions.size,
       aiReferralHits,
       unknownHits,
     },
     crawlerEventsHourly: [...crawlerBuckets.values()].sort(sortCrawlerBuckets),
+    aiUserFetchEventsHourly: [...aiUserFetchBuckets.values()].sort(sortAiUserFetchBuckets),
     aiReferralEventsHourly: [...aiReferralBuckets.values()].sort(sortReferralBuckets),
     topBots: topEntries(topBots, 10),
     topCrawlerPaths: topEntries(topCrawlerPaths, 10),
+    topAiUserFetchBots: topEntries(topAiUserFetchBots, 10),
+    topAiUserFetchPaths: topEntries(topAiUserFetchPaths, 10),
     topAiReferrers: topEntries(topAiReferrers, 10),
     topAiReferralLandingPaths: topEntries(topAiReferralLandingPaths, 10),
     samples,

--- a/packages/integration-traffic/src/rules.ts
+++ b/packages/integration-traffic/src/rules.ts
@@ -127,16 +127,23 @@ export const DEFAULT_AI_CRAWLER_RULES: AiCrawlerRule[] = [
     userAgentPatterns: [/Diffbot/i],
   },
   {
-    id: 'mistral-ai',
+    // Per-user, on-demand fetches initiated by a Mistral user (citation
+    // click, "read this URL" prompt). Separate from MistralBot (crawl)
+    // so the dashboard's user-fetch vs. bulk-crawl split stays honest.
+    id: 'mistral-ai-user',
     operator: 'Mistral AI',
     product: 'MistralAI-User',
+    purpose: 'user-agent',
+    userAgentPatterns: [/MistralAI-User\//i],
+  },
+  {
+    // Mistral's general crawler. Distinct from MistralAI-User (per-user
+    // fetch) — same operator, different operational signal.
+    id: 'mistral-bot',
+    operator: 'Mistral AI',
+    product: 'MistralBot',
     purpose: 'crawl',
-    // Mistral ships both `MistralAI-User/*` (chat-on-behalf-of-user
-    // fetches) and `MistralBot/*` (general crawler). Earlier rule only
-    // matched `MistralAI` and missed the bot — caught on 2026-05-18
-    // when canonry.ai/canonry-landing's classification chart went flat
-    // and the bot UA was sitting in the `unknown` bucket.
-    userAgentPatterns: [/MistralAI/i, /MistralBot/i],
+    userAgentPatterns: [/MistralBot\//i],
   },
   {
     id: 'deepseek',
@@ -144,6 +151,21 @@ export const DEFAULT_AI_CRAWLER_RULES: AiCrawlerRule[] = [
     product: 'DeepSeekBot',
     purpose: 'training',
     userAgentPatterns: [/DeepSeekBot/i],
+  },
+  {
+    id: 'xai-grok-bot',
+    operator: 'xAI',
+    product: 'xAI-Bot',
+    purpose: 'crawl',
+    // xAI documents its crawler at https://x.ai/bots/ as `xAI-Bot/<version>`.
+    // Operators have also observed `Grok-Bot/...` in production logs. xAI
+    // has been less consistent than OpenAI/Anthropic about publishing every
+    // UA variant they ship, so the pattern is intentionally permissive
+    // across the xAI/Grok family — better to over-match the operator than
+    // leave real hits in the `unknown` bucket. A separate `purpose:
+    // 'user-agent'` Grok rule can be added later if xAI ships a citation
+    // user-fetcher UA (the way OpenAI ships ChatGPT-User alongside GPTBot).
+    userAgentPatterns: [/xAI-Bot\//i, /Grok-Bot\//i, /GrokBot\//i],
   },
   // Classic search-engine crawlers. Not strictly "AI" by training origin,
   // but the same audience: machine traffic indexing the site for query
@@ -218,9 +240,12 @@ export const DEFAULT_AI_CRAWLER_USER_AGENT_SUBSTRINGS = [
   'CCBot/',
   'cohere-ai',
   'Diffbot',
-  'MistralAI',
-  'MistralBot',
+  'MistralAI-User/',
+  'MistralBot/',
   'DeepSeekBot',
+  'xAI-Bot/',
+  'Grok-Bot/',
+  'GrokBot/',
   'Googlebot',
   'bingbot/',
   'DuckDuckBot',
@@ -237,6 +262,7 @@ export const DEFAULT_AI_REFERRER_RULES: AiReferrerRule[] = [
   { domain: AI_ENGINE_DOMAINS.claude, operator: 'Anthropic', product: 'Claude' },
   { domain: AI_ENGINE_DOMAINS.gemini, operator: 'Google', product: 'Gemini' },
   { domain: AI_ENGINE_DOMAINS.copilotMicrosoft, operator: 'Microsoft', product: 'Copilot' },
+  { domain: AI_ENGINE_DOMAINS.grok, operator: 'xAI', product: 'Grok' },
   { domain: AI_ENGINE_DOMAINS.phind, operator: 'Phind', product: 'Phind' },
   { domain: AI_ENGINE_DOMAINS.you, operator: 'You.com', product: 'You.com' },
   { domain: AI_ENGINE_DOMAINS.metaAi, operator: 'Meta', product: 'Meta AI' },

--- a/packages/integration-traffic/src/types.ts
+++ b/packages/integration-traffic/src/types.ts
@@ -26,6 +26,19 @@ export interface ClassifiedCrawler {
   matchedUserAgent: string
 }
 
+// On-demand per-user fetches from an AI surface (ChatGPT-User, Perplexity-User,
+// MistralAI-User, …). Same UA evidence channel as ClassifiedCrawler, but kept
+// in a distinct type so the dashboard, API, and report can split "machine
+// crawl" from "human-in-the-loop fetch". See rules.ts for the `purpose:
+// 'user-agent'` discriminator.
+export interface ClassifiedAiUserFetch {
+  botId: string
+  operator: string
+  product: string
+  verificationStatus: CrawlerVerificationStatus
+  matchedUserAgent: string
+}
+
 export interface ClassifiedAiReferral {
   operator: string
   product: string
@@ -34,6 +47,18 @@ export interface ClassifiedAiReferral {
 }
 
 export interface CrawlerEventHourlyBucket {
+  tsHour: string
+  botId: string
+  operator: string
+  product: string
+  verificationStatus: CrawlerVerificationStatus
+  pathNormalized: string
+  status: number | null
+  hits: number
+  sampledUserAgent: string | null
+}
+
+export interface AiUserFetchEventHourlyBucket {
   tsHour: string
   botId: string
   operator: string
@@ -66,6 +91,7 @@ export interface TrafficProbeSample {
   userAgent: string | null
   referer: string | null
   crawler: ClassifiedCrawler | null
+  aiUserFetch: ClassifiedAiUserFetch | null
   aiReferral: ClassifiedAiReferral | null
 }
 
@@ -74,14 +100,18 @@ export interface TrafficProbeReport {
   totals: {
     normalizedEvents: number
     crawlerHits: number
+    aiUserFetchHits: number
     aiReferralSessions: number
     aiReferralHits: number
     unknownHits: number
   }
   crawlerEventsHourly: CrawlerEventHourlyBucket[]
+  aiUserFetchEventsHourly: AiUserFetchEventHourlyBucket[]
   aiReferralEventsHourly: AiReferralEventHourlyBucket[]
   topBots: Array<{ botId: string; operator: string; hits: number }>
   topCrawlerPaths: Array<{ pathNormalized: string; hits: number }>
+  topAiUserFetchBots: Array<{ botId: string; operator: string; hits: number }>
+  topAiUserFetchPaths: Array<{ pathNormalized: string; hits: number }>
   topAiReferrers: Array<{ sourceDomain: string; product: string; hits: number }>
   topAiReferralLandingPaths: Array<{ landingPathNormalized: string; hits: number }>
   samples: TrafficProbeSample[]

--- a/packages/integration-traffic/test/analysis.test.ts
+++ b/packages/integration-traffic/test/analysis.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest'
 import {
   buildTrafficProbeReport,
   classifyAiReferral,
+  classifyAiUserFetch,
   classifyCrawler,
   normalizeTrafficPathPattern,
 } from '../src/index.js'
@@ -138,12 +139,12 @@ describe('traffic analysis', () => {
       operator: 'Anthropic',
     })
 
-    // Mistral's general crawler (rule pattern was /MistralAI/i which
-    // doesn't match MistralBot).
+    // Mistral's general crawler — disjoint from MistralAI-User (per-user
+    // fetch) which routes through classifyAiUserFetch.
     expect(classifyCrawler(event({
       userAgent: 'Mozilla/5.0 (compatible; MistralBot/1.0; +https://mistral.ai)',
     }))).toMatchObject({
-      botId: 'mistral-ai',
+      botId: 'mistral-bot',
       operator: 'Mistral AI',
     })
 
@@ -161,6 +162,47 @@ describe('traffic analysis', () => {
     }))).toMatchObject({
       botId: 'applebot',
       operator: 'Apple',
+    })
+  })
+
+  it('classifies xAI Grok as a crawler (xAI-Bot / Grok-Bot UAs)', () => {
+    // xAI ships at least one documented crawler UA at https://x.ai/bots/.
+    // We use a permissive pattern (`xAI` family + `Grok-Bot` variant)
+    // because xAI has been less consistent than OpenAI/Anthropic about
+    // documenting every UA they ship — better to over-match the operator
+    // family than miss real hits and leave them in the `unknown` bucket.
+    expect(classifyCrawler(event({
+      userAgent: 'Mozilla/5.0 (compatible; xAI-Bot/1.0; +https://x.ai/bots/)',
+    }))).toMatchObject({
+      botId: 'xai-grok-bot',
+      operator: 'xAI',
+    })
+
+    expect(classifyCrawler(event({
+      userAgent: 'Mozilla/5.0 (compatible; Grok-Bot/1.0; +https://x.ai)',
+    }))).toMatchObject({
+      botId: 'xai-grok-bot',
+      operator: 'xAI',
+    })
+  })
+
+  it('classifies grok.com referer as an AI referral from Grok', () => {
+    expect(classifyAiReferral(event({ referer: 'https://grok.com/chat/abc' }))).toMatchObject({
+      product: 'Grok',
+      operator: 'xAI',
+      evidenceType: 'referer',
+      sourceDomain: 'grok.com',
+    })
+
+    // utm_source=grok short token must also resolve to the rule (first
+    // label of grok.com).
+    expect(classifyAiReferral(event({
+      referer: null,
+      queryString: 'utm_source=grok',
+    }))).toMatchObject({
+      product: 'Grok',
+      operator: 'xAI',
+      evidenceType: 'utm',
     })
   })
 
@@ -448,6 +490,127 @@ describe('traffic analysis', () => {
       referer: null,
       queryString: 'utm_source=newsletter',
     }))).toBeNull()
+  })
+
+  it('routes ChatGPT-User to ai-user-fetch, not crawler', () => {
+    // ChatGPT-User UA represents a per-user on-demand fetch (citation click,
+    // user-asked URL read) — NOT bulk crawl. It's published by OpenAI as a
+    // distinct UA from GPTBot/OAI-SearchBot precisely so operators can split
+    // these two signals. classifyCrawler must return null so the same event
+    // doesn't get double-counted into both buckets.
+    const evt = event({ userAgent: 'Mozilla/5.0 ChatGPT-User/1.0' })
+    expect(classifyCrawler(evt)).toBeNull()
+    expect(classifyAiUserFetch(evt)).toMatchObject({
+      botId: 'openai-chatgpt-user',
+      operator: 'OpenAI',
+      product: 'ChatGPT-User',
+      verificationStatus: 'claimed_unverified',
+    })
+  })
+
+  it('routes Perplexity-User to ai-user-fetch, not crawler', () => {
+    const evt = event({ userAgent: 'Mozilla/5.0 Perplexity-User/1.0' })
+    expect(classifyCrawler(evt)).toBeNull()
+    expect(classifyAiUserFetch(evt)).toMatchObject({
+      botId: 'perplexity-user',
+      operator: 'Perplexity',
+      product: 'Perplexity-User',
+      verificationStatus: 'claimed_unverified',
+    })
+  })
+
+  it('promotes ChatGPT-User to `verified` when the source IP is in OpenAI\'s published range', () => {
+    // 104.210.139.193 is in 104.210.139.192/28 — first published prefix in
+    // `src/ip-ranges/chatgpt-user.json`. UA match + IP match should upgrade
+    // `claimed_unverified` → `verified`.
+    expect(classifyAiUserFetch(event({
+      userAgent: 'Mozilla/5.0 ChatGPT-User/1.0',
+      remoteIp: '104.210.139.193',
+    }))).toMatchObject({
+      botId: 'openai-chatgpt-user',
+      verificationStatus: 'verified',
+    })
+  })
+
+  it('classifyAiUserFetch returns null for bulk crawler UAs', () => {
+    // Inverse of the routing rule: classifyAiUserFetch only matches the
+    // `purpose: 'user-agent'` rules; GPTBot, OAI-SearchBot, etc. stay in
+    // classifyCrawler's domain.
+    expect(classifyAiUserFetch(event({ userAgent: 'GPTBot/1.0' }))).toBeNull()
+    expect(classifyAiUserFetch(event({
+      userAgent: 'Mozilla/5.0 (compatible; OAI-SearchBot/1.0; +https://openai.com/searchbot)',
+    }))).toBeNull()
+  })
+
+  it('routes MistralAI-User to ai-user-fetch and MistralBot to crawler (disjoint)', () => {
+    // The legacy `mistral-ai` rule collapsed both UAs under one id with
+    // purpose='crawl', miscategorizing MistralAI-User as bulk crawl. The
+    // split rule pair (`mistral-ai-user` / `mistral-bot`) keeps the two
+    // operational signals disjoint, mirroring OpenAI's GPTBot vs.
+    // ChatGPT-User split.
+    const userEvent = event({ userAgent: 'Mozilla/5.0 MistralAI-User/1.0' })
+    expect(classifyCrawler(userEvent)).toBeNull()
+    expect(classifyAiUserFetch(userEvent)).toMatchObject({
+      botId: 'mistral-ai-user',
+      operator: 'Mistral AI',
+      product: 'MistralAI-User',
+    })
+
+    const botEvent = event({
+      userAgent: 'Mozilla/5.0 (compatible; MistralBot/1.0; +https://mistral.ai)',
+    })
+    expect(classifyAiUserFetch(botEvent)).toBeNull()
+    expect(classifyCrawler(botEvent)).toMatchObject({
+      botId: 'mistral-bot',
+      operator: 'Mistral AI',
+      product: 'MistralBot',
+    })
+  })
+
+  it('rolls ChatGPT-User hits into the ai-user-fetch bucket, not crawler', () => {
+    // End-to-end: the rollup must keep user-fetch hits and bulk-crawl hits
+    // in disjoint buckets. Counting ChatGPT-User into `crawlerHits` is the
+    // bug this whole change is built to fix.
+    const report = buildTrafficProbeReport([
+      event({
+        eventId: 'cu-1',
+        observedAt: '2026-05-01T13:05:00.000Z',
+        path: '/blog/post-1',
+        userAgent: 'Mozilla/5.0 ChatGPT-User/1.0',
+      }),
+      event({
+        eventId: 'cu-2',
+        observedAt: '2026-05-01T13:10:00.000Z',
+        path: '/blog/post-1',
+        userAgent: 'Mozilla/5.0 ChatGPT-User/1.0',
+      }),
+      event({
+        eventId: 'gpt-1',
+        observedAt: '2026-05-01T13:15:00.000Z',
+        path: '/blog/post-1',
+        userAgent: 'GPTBot/1.0',
+      }),
+    ], { generatedAt: '2026-05-01T14:00:00.000Z' })
+
+    expect(report.totals.crawlerHits).toBe(1)
+    expect(report.totals.aiUserFetchHits).toBe(2)
+    expect(report.crawlerEventsHourly).toEqual([
+      expect.objectContaining({
+        botId: 'openai-gptbot',
+        pathNormalized: '/blog/post-1',
+        hits: 1,
+      }),
+    ])
+    expect(report.aiUserFetchEventsHourly).toEqual([
+      expect.objectContaining({
+        tsHour: '2026-05-01T13:00:00.000Z',
+        botId: 'openai-chatgpt-user',
+        operator: 'OpenAI',
+        product: 'ChatGPT-User',
+        pathNormalized: '/blog/post-1',
+        hits: 2,
+      }),
+    ])
   })
 
   it('keeps the newest sampleLimit events instead of the oldest', () => {

--- a/packages/integration-traffic/test/ip-verify.test.ts
+++ b/packages/integration-traffic/test/ip-verify.test.ts
@@ -208,7 +208,8 @@ describe('hasVerificationDataFor', () => {
   })
 
   it('is false for operators without bundled ranges yet', () => {
-    expect(hasVerificationDataFor('mistral-ai')).toBe(false)
+    expect(hasVerificationDataFor('mistral-ai-user')).toBe(false)
+    expect(hasVerificationDataFor('mistral-bot')).toBe(false)
     expect(hasVerificationDataFor('deepseek')).toBe(false)
     expect(hasVerificationDataFor('bytespider')).toBe(false)
     expect(hasVerificationDataFor('meta-externalagent')).toBe(false)


### PR DESCRIPTION
## Summary

- Splits per-user AI fetches (ChatGPT-User, Perplexity-User, MistralAI-User) out of `crawler_events_hourly` into a new disjoint `ai_user_fetch_events_hourly` table — UA-evidenced like a crawler, but each hit is initiated by a real user inside an AI surface, a categorically different operational signal from bulk crawl.
- Adds a `classifyAiUserFetch` matcher gated on `purpose: 'user-agent'` rules, end-to-end plumbing through rollup → API → CLI → dashboard with dedicated buckets / samples / totals / `kind=ai-user-fetch` filter, and migrations 64 & 65 that move historical ChatGPT-User / Perplexity-User rows and split the legacy combined `mistral-ai` rule into `mistral-ai-user` (user-agent) + `mistral-bot` (crawl).
- Also adds xAI Grok crawler classification (`xAI-Bot` / `Grok-Bot` UAs) and a `grok.com` AI-referrer rule.

## Test plan

- [x] `pnpm typecheck` clean across all 26 workspace projects
- [x] `pnpm lint` (0 errors, warnings pre-existing)
- [x] Full vitest suite green: 3223 tests across 269 files
- [x] New tests cover MistralAI-User vs. MistralBot routing, ChatGPT-User → ai-user-fetch bucket, migration 64 (chatgpt/perplexity-user move) and migration 65 (mistral-ai split), xAI Grok crawler + Grok referrer, and the `kind=ai-user-fetch` API/CLI filter end-to-end