### PR TITLE
feat(traffic): classify Claude-User as an AI user-fetch agent

### DIFF
--- a/packages/integration-traffic/src/ip-verify.ts
+++ b/packages/integration-traffic/src/ip-verify.ts
@@ -17,11 +17,13 @@
  *   - OpenAI OAI-SearchBot   (openai.com/searchbot.json)
  *   - PerplexityBot          (www.perplexity.ai/perplexitybot.json)
  *   - Perplexity-User        (www.perplexity.ai/perplexity-user.json)
- *   - ClaudeBot              (ARIN RDAP — Anthropic does not ship a
+ *   - ClaudeBot, Claude-User (ARIN RDAP — Anthropic does not ship a
  *                             machine-readable JSON; we use the three
  *                             networks registered to Anthropic, PBC
  *                             at ARIN. The crawler block is
- *                             AWS-ANTHROPIC 216.73.216.0/22.)
+ *                             AWS-ANTHROPIC 216.73.216.0/22. Both the
+ *                             crawler and the per-user fetcher verify
+ *                             against this shared set.)
  *
  * **Not covered (yet).** Meta, ByteDance, Apple, DeepSeek, Mistral,
  * DuckDuckGo, Yandex, Baidu, Amazon — these either don't publish a
@@ -100,10 +102,12 @@ const RULE_ID_TO_RANGES: Record<string, RawIpRanges> = {
   // PBC at ARIN (the authoritative allocation record). Maintained by
   // hand; refresh by re-querying the ARIN entity below. The crawler
   // block is AWS-ANTHROPIC 216.73.216.0/22 — empirical Cloud Run
-  // logs show all real ClaudeBot traffic comes from there. Same raw
-  // set is shared across every Claude-* UA the classifier emits.
+  // logs show all real ClaudeBot traffic comes from there. The same
+  // raw set is shared across every Claude-* UA the classifier emits:
+  // both the training crawler and the per-user fetcher map here.
   // src: https://rdap.arin.net/registry/entity/AP-2440
   'anthropic-claudebot': anthropicRaw as RawIpRanges,
+  'claude-user': anthropicRaw as RawIpRanges,
 }
 
 /**

--- a/packages/integration-traffic/src/rules.ts
+++ b/packages/integration-traffic/src/rules.ts
@@ -37,9 +37,11 @@ export const DEFAULT_AI_CRAWLER_RULES: AiCrawlerRule[] = [
     // Anthropic ships several Claude-* crawlers (ClaudeBot for training,
     // Claude-Web for chat fetches, Claude-SearchBot for search). The
     // `Claude-` prefix + `Bot/` suffix is the stable shape — pattern is
-    // permissive enough to catch new Claude-* variants as Anthropic
+    // permissive enough to catch new Claude-*Bot variants as Anthropic
     // adds them, without matching unrelated UAs that happen to mention
-    // "claude".
+    // "claude". The per-user fetcher `Claude-User` has no `Bot/` suffix
+    // and is intentionally NOT matched here — it routes through the
+    // separate `claude-user` rule below (purpose: 'user-agent').
     userAgentPatterns: [
       /ClaudeBot\//i,
       /Claude-Web\//i,
@@ -47,6 +49,21 @@ export const DEFAULT_AI_CRAWLER_RULES: AiCrawlerRule[] = [
       /Claude-[A-Z]+Bot\//i,
       /anthropic-ai/i,
     ],
+  },
+  {
+    // Anthropic's on-behalf-of-user fetcher: Claude fetches a URL when
+    // a person asks about it mid-conversation (citation click, "read
+    // this page" prompt). Distinct from ClaudeBot (training crawl) —
+    // same operator, opposite operational signal, mirroring OpenAI's
+    // GPTBot vs. ChatGPT-User split. The `anthropic-claudebot` rule
+    // above does not match `Claude-User/` (its `Claude-[A-Z]+Bot/`
+    // pattern needs a `Bot/` suffix), so this is the only rule that
+    // routes it — into the user-fetch bucket, not bulk crawl.
+    id: 'claude-user',
+    operator: 'Anthropic',
+    product: 'Claude-User',
+    purpose: 'user-agent',
+    userAgentPatterns: [/Claude-User\//i],
   },
   {
     id: 'perplexity-bot',
@@ -230,6 +247,7 @@ export const DEFAULT_AI_CRAWLER_USER_AGENT_SUBSTRINGS = [
   'ClaudeBot/',
   'Claude-Web/',
   'Claude-SearchBot/',
+  'Claude-User/',
   'anthropic-ai',
   'PerplexityBot/',
   'Google-Extended',

--- a/packages/integration-traffic/test/analysis.test.ts
+++ b/packages/integration-traffic/test/analysis.test.ts
@@ -540,6 +540,11 @@ describe('traffic analysis', () => {
     expect(classifyAiUserFetch(event({
       userAgent: 'Mozilla/5.0 (compatible; OAI-SearchBot/1.0; +https://openai.com/searchbot)',
     }))).toBeNull()
+    // ClaudeBot is the training crawler — the `claude-user` rule's
+    // `/Claude-User\//i` pattern must not swallow it.
+    expect(classifyAiUserFetch(event({
+      userAgent: 'Mozilla/5.0 (compatible; ClaudeBot/1.0; +claudebot@anthropic.com)',
+    }))).toBeNull()
   })
 
   it('routes MistralAI-User to ai-user-fetch and MistralBot to crawler (disjoint)', () => {
@@ -564,6 +569,33 @@ describe('traffic analysis', () => {
       botId: 'mistral-bot',
       operator: 'Mistral AI',
       product: 'MistralBot',
+    })
+  })
+
+  it('routes Claude-User to ai-user-fetch, not crawler', () => {
+    // Anthropic's on-behalf-of-user fetcher. The `anthropic-claudebot`
+    // crawler rule does not match `Claude-User/` (its `Claude-[A-Z]+Bot/`
+    // pattern needs a `Bot/` suffix), so before the `claude-user` rule
+    // this UA fell through to the `unknown` bucket entirely.
+    const evt = event({ userAgent: 'Mozilla/5.0 (compatible; Claude-User/1.0; +Anthropic)' })
+    expect(classifyCrawler(evt)).toBeNull()
+    expect(classifyAiUserFetch(evt)).toMatchObject({
+      botId: 'claude-user',
+      operator: 'Anthropic',
+      product: 'Claude-User',
+      verificationStatus: 'claimed_unverified',
+    })
+  })
+
+  it('promotes Claude-User to `verified` when the source IP is in Anthropic\'s range', () => {
+    // 216.73.216.0/22 is the AWS-ANTHROPIC ARIN allocation; the bundled
+    // anthropic.json verifies both ClaudeBot and Claude-User.
+    expect(classifyAiUserFetch(event({
+      userAgent: 'Mozilla/5.0 (compatible; Claude-User/1.0; +Anthropic)',
+      remoteIp: '216.73.216.76',
+    }))).toMatchObject({
+      botId: 'claude-user',
+      verificationStatus: 'verified',
     })
   })
 

--- a/packages/integration-traffic/test/ip-verify.test.ts
+++ b/packages/integration-traffic/test/ip-verify.test.ts
@@ -165,6 +165,17 @@ describe('verifyIpForRule', () => {
     expect(verifyIpForRule('2607:6bc0:ffff:ffff::1', 'anthropic-claudebot')).toBe(true)
   })
 
+  it('verifies Claude-User against the shared Anthropic ranges', () => {
+    // Anthropic's per-user fetcher shares the ClaudeBot crawler's ARIN
+    // allocation — the same bundled anthropic.json is keyed to both
+    // rule ids in RULE_ID_TO_RANGES.
+    expect(verifyIpForRule('216.73.216.76', 'claude-user')).toBe(true)
+    expect(verifyIpForRule('160.79.104.5', 'claude-user')).toBe(true)
+    expect(verifyIpForRule('2607:6bc0::1', 'claude-user')).toBe(true)
+    // Outside Anthropic's allocation — stays unverified.
+    expect(verifyIpForRule('1.2.3.4', 'claude-user')).toBe(false)
+  })
+
   it('returns false for a rule id without published ranges', () => {
     // Meta doesn't publish a public ranges file. The
     // meta-externalagent rule has no entry in RULE_ID_TO_RANGES, so
@@ -205,6 +216,7 @@ describe('hasVerificationDataFor', () => {
     expect(hasVerificationDataFor('perplexity-bot')).toBe(true)
     expect(hasVerificationDataFor('perplexity-user')).toBe(true)
     expect(hasVerificationDataFor('anthropic-claudebot')).toBe(true)
+    expect(hasVerificationDataFor('claude-user')).toBe(true)
   })
 
   it('is false for operators without bundled ranges yet', () => {


### PR DESCRIPTION
## Summary
- Adds a `claude-user` classifier rule (`purpose: 'user-agent'`) for Anthropic's **Claude-User** — the agent Claude uses to fetch a URL on a person's behalf mid-conversation (the direct analogue of ChatGPT-User).
- Before this, `Claude-User/` matched no rule and fell through to the `unknown` bucket. It was the one gap in the AI user-fetch channel — ChatGPT-User / Perplexity-User / MistralAI-User were already covered, Claude was not.
- IP verification reuses Anthropic's bundled ARIN ranges (`anthropic.json`), shared across every Claude-* UA — so verified Claude-User hits promote to `verified` just like ClaudeBot.

## Why it's disjoint
`classifyAiUserFetch` is generic over `purpose: 'user-agent'`, so the new rule routes automatically into `ai_user_fetch_events_hourly`. The `anthropic-claudebot` crawler rule deliberately does **not** match `Claude-User/` (its `Claude-[A-Z]+Bot/` pattern needs a `Bot/` suffix), so the crawler and user-fetch paths stay separate.

## No migration
A new rule only classifies traffic **going forward** — there are no pre-existing `claude-user` rows to relocate (unlike #611's split). Historical Claude-User hits within the 30-day `raw_event_samples` window can be partially recovered with `cnry backfill traffic-classification`; older hits are unrecoverable.

## Test plan
- [x] `vitest run packages/integration-traffic/` — 60/60 pass. Added: Claude-User routes to user-fetch not crawler; verified-promotion via Anthropic ranges; ClaudeBot is not swallowed by the new pattern; `verifyIpForRule` / `hasVerificationDataFor` coverage for `claude-user`.
- [x] `typecheck` + `lint` clean.
- [ ] After deploy: a `Claude-User/` request appears under "AI user fetches", not "unknown".

## Follow-up (not in this PR)
The AI-user-fetch UI/report copy still lists "ChatGPT-User, Perplexity-User" as examples — non-exhaustive (already omits Mistral). Worth a separate copy-refresh PR across the Traffic page cards + report (report-parity rule applies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)