### PR TITLE
feat(web): label the viewer's timezone on the server-traffic page

### DIFF
--- a/apps/web/src/lib/format-helpers.ts
+++ b/apps/web/src/lib/format-helpers.ts
@@ -102,3 +102,25 @@ export function scheduleLabel(preset: string | null, cronExpr: string, timezone:
   }
   return `${preset} · ${tzShort}`
 }
+
+/**
+ * Combine an IANA zone name with its short abbreviation into a display label,
+ * e.g. ("America/New_York", "EDT") → "America/New_York · EDT". Falls back to
+ * the zone name alone when no distinct abbreviation is available.
+ */
+export function formatTimeZoneLabel(zone: string, abbrev: string | undefined): string {
+  return abbrev && abbrev !== zone ? `${zone} · ${abbrev}` : zone
+}
+
+/**
+ * The viewer's local timezone, for labeling times rendered in local time
+ * (e.g. the server-traffic hourly rollups). Resolved from the browser's Intl
+ * settings — a presentation concern, not server data.
+ */
+export function localTimeZoneLabel(): string {
+  const zone = Intl.DateTimeFormat().resolvedOptions().timeZone
+  const abbrev = new Intl.DateTimeFormat('en-US', { timeZoneName: 'short' })
+    .formatToParts()
+    .find((part) => part.type === 'timeZoneName')?.value
+  return formatTimeZoneLabel(zone, abbrev)
+}

--- a/apps/web/src/pages/TrafficSourceDetailPage.tsx
+++ b/apps/web/src/pages/TrafficSourceDetailPage.tsx
@@ -30,6 +30,7 @@ import {
   useServerTrafficSource,
   useSyncServerTrafficSource,
 } from '../queries/server-traffic.js'
+import { localTimeZoneLabel } from '../lib/format-helpers.js'
 import {
   bucketForChartClick,
   bucketKeyFor,
@@ -65,6 +66,9 @@ const DEFAULT_WINDOW = WINDOW_OPTIONS.find((w) => w.label === '7d') ?? WINDOW_OP
 const CRAWLER_COLOR = CHART_SERIES_COLORS[0]
 const AI_USER_FETCH_COLOR = CHART_SERIES_COLORS[2]
 const AI_REFERRAL_COLOR = CHART_SERIES_COLORS[1]
+
+/** The viewer's timezone — hour labels on this page are rendered in local time. */
+const LOCAL_TZ = localTimeZoneLabel()
 
 function formatHourLabel(iso: string): string {
   const d = new Date(iso)
@@ -396,7 +400,7 @@ export function TrafficSourceDetailPage() {
               <p className="mt-1.5 text-xs text-zinc-500">
                 {totals.crawlerHits.toLocaleString('en-US')} crawler ·{' '}
                 {totals.aiUserFetchHits.toLocaleString('en-US')} AI user fetches ·{' '}
-                {totals.aiReferralHits.toLocaleString('en-US')} AI referral sessions · last {activeWindow.label}
+                {totals.aiReferralHits.toLocaleString('en-US')} AI referral sessions · last {activeWindow.label} · {LOCAL_TZ}
               </p>
             ) : null}
           </div>
@@ -512,7 +516,7 @@ export function TrafficSourceDetailPage() {
             <p className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500">Event rows</p>
             <p className="mt-1 text-xs text-zinc-500">
               Showing <span className="tabular-nums text-zinc-300">{filteredEvents.length.toLocaleString('en-US')}</span> of{' '}
-              <span className="tabular-nums text-zinc-500">{visibleEvents.length.toLocaleString('en-US')}</span> events
+              <span className="tabular-nums text-zinc-500">{visibleEvents.length.toLocaleString('en-US')}</span> events · {LOCAL_TZ}
             </p>
           </div>
           <div className="flex flex-wrap items-center gap-2">

--- a/apps/web/test/format-helpers.test.ts
+++ b/apps/web/test/format-helpers.test.ts
@@ -4,6 +4,8 @@ import {
   buildPreset,
   parsePreset,
   scheduleLabel,
+  formatTimeZoneLabel,
+  localTimeZoneLabel,
 } from '../src/lib/format-helpers.js'
 
 describe('formatHour', () => {
@@ -89,5 +91,27 @@ describe('scheduleLabel', () => {
 
   it('falls through to raw preset for unrecognized preset', () => {
     expect(scheduleLabel('something-else', '', 'UTC')).toBe('something-else · UTC')
+  })
+})
+
+describe('formatTimeZoneLabel', () => {
+  it('combines zone and abbreviation', () => {
+    expect(formatTimeZoneLabel('America/New_York', 'EDT')).toBe('America/New_York · EDT')
+  })
+
+  it('falls back to the zone alone when the abbreviation is missing', () => {
+    expect(formatTimeZoneLabel('America/New_York', undefined)).toBe('America/New_York')
+  })
+
+  it('does not duplicate when the abbreviation equals the zone', () => {
+    expect(formatTimeZoneLabel('UTC', 'UTC')).toBe('UTC')
+  })
+})
+
+describe('localTimeZoneLabel', () => {
+  it('resolves a non-empty timezone label from the runtime', () => {
+    const label = localTimeZoneLabel()
+    expect(typeof label).toBe('string')
+    expect(label.length).toBeGreaterThan(0)
   })
 })


### PR DESCRIPTION
## Summary
- The server-traffic page renders `ts_hour` in the browser's **local timezone** (`formatHourLabel` uses `Date.getHours()` / `getMonth()` / `getDate()`), with no indicator. A viewer can't tell the times are local, and they silently disagree with UTC server logs and the DB.
- Adds a small timezone label (IANA zone + short abbreviation, e.g. `America/New_York · EDT`) to the **Hourly rollups** metadata line and the **Event rows** metadata line — covering both the chart axis and the table HOUR column.

## Details
- New helpers in `apps/web/src/lib/format-helpers.ts`: `localTimeZoneLabel()` (reads `Intl`) plus a pure, tested `formatTimeZoneLabel(zone, abbrev)`.
- Pure-presentation change: it's the *viewer's* browser timezone, not server data — so no API/DB/CLI/contracts changes and no UI/CLI-parity obligation.
- No version bump (52 lines).

## Test plan
- [x] `apps/web` typecheck clean, lint 0 errors.
- [x] `vitest run apps/web` — 222/222 pass, including 4 new `formatTimeZoneLabel` / `localTimeZoneLabel` cases.
- [ ] After deploy: the Hourly rollups and Event rows lines show the viewer's timezone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)