### PR TITLE
fix(traffic): stop WordPress page caching from freezing the traffic sync

### DIFF
--- a/packages/integration-wordpress-traffic/AGENTS.md
+++ b/packages/integration-wordpress-traffic/AGENTS.md
@@ -30,6 +30,12 @@ site and shares only the Application-Password auth pattern.
 - **Pull-only, cursor-paginated.** `listWordpressTrafficEvents` accepts an opaque
   `cursor` string returned from the previous page (`next_cursor`). No push,
   no SaaS relay.
+- **Cache-buster on every request.** Each call to the plugin endpoint carries
+  a unique `_cb` query param and a `Cache-Control: no-cache` request header.
+  Some WordPress hosts front the site with a page cache (LiteSpeed and
+  similar) that caches the REST response keyed on the URL despite its
+  no-cache headers; without a varying URL the sync reads a frozen page and
+  silently misses new events.
 - **No classification.** This package only pulls + normalizes. UA pattern
   matching and AI-referer detection happen in `packages/integration-traffic`
   alongside Cloud Run events, so classifier rules evolve without plugin updates.

--- a/packages/integration-wordpress-traffic/src/client.ts
+++ b/packages/integration-wordpress-traffic/src/client.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import { normalizeWordpressTrafficEvent } from './normalize.js'
 import type {
   ListWordpressTrafficEventsOptions,
@@ -100,12 +101,19 @@ export async function listWordpressTrafficEvents(
       // EXCLUSIVE upper bound — the plugin filters `observed_at < until`.
       url.searchParams.set('until', options.until)
     }
+    // Cache-buster. Some WordPress hosts front the site with a page cache
+    // (LiteSpeed and similar) that caches this REST response keyed on the URL
+    // despite its no-cache headers. Without a unique param the sync's request
+    // URL is identical every run, so it reads a frozen page and never sees new
+    // events. A fresh value per request forces a distinct cache key.
+    url.searchParams.set('_cb', randomUUID())
 
     const response = await fetch(url, {
       method: 'GET',
       headers: {
         Authorization: authHeader,
         Accept: 'application/json',
+        'Cache-Control': 'no-cache',
       },
       signal: AbortSignal.timeout(timeoutMs),
     })

--- a/packages/integration-wordpress-traffic/test/wordpress-traffic-client.test.ts
+++ b/packages/integration-wordpress-traffic/test/wordpress-traffic-client.test.ts
@@ -186,7 +186,9 @@ describe('listWordpressTrafficEvents', () => {
 
     expect(fetchSpy).toHaveBeenCalledTimes(1)
     const [url, init] = fetchSpy.mock.calls[0]!
-    expect(String(url)).toBe('https://example.com/wp-json/canonry/v1/events?limit=500')
+    const parsedUrl = new URL(String(url))
+    expect(parsedUrl.origin + parsedUrl.pathname).toBe('https://example.com/wp-json/canonry/v1/events')
+    expect(parsedUrl.searchParams.get('limit')).toBe('500')
     expect((init as RequestInit).method).toBe('GET')
     const headers = (init as RequestInit).headers as Record<string, string>
     expect(headers.Authorization).toBe(
@@ -216,9 +218,8 @@ describe('listWordpressTrafficEvents', () => {
     })
 
     expect(result.endpoint).toBe('https://example.com/wp-json/canonry/v1/events')
-    expect(String(fetchSpy.mock.calls[0]![0])).toBe(
-      'https://example.com/wp-json/canonry/v1/events?limit=500',
-    )
+    const composedUrl = new URL(String(fetchSpy.mock.calls[0]![0]))
+    expect(composedUrl.origin + composedUrl.pathname).toBe('https://example.com/wp-json/canonry/v1/events')
   })
 
   it('paginates through multiple pages until has_more is false', async () => {
@@ -254,8 +255,12 @@ describe('listWordpressTrafficEvents', () => {
     })
 
     expect(fetchSpy).toHaveBeenCalledTimes(2)
-    expect(urls[0]).toBe('https://example.com/wp-json/canonry/v1/events?limit=100')
-    expect(urls[1]).toBe('https://example.com/wp-json/canonry/v1/events?limit=100&cursor=1')
+    const page0 = new URL(urls[0]!)
+    expect(page0.searchParams.get('limit')).toBe('100')
+    expect(page0.searchParams.get('cursor')).toBeNull()
+    const page1 = new URL(urls[1]!)
+    expect(page1.searchParams.get('limit')).toBe('100')
+    expect(page1.searchParams.get('cursor')).toBe('1')
     expect(result.events.map((event) => event.path)).toEqual(['/a', '/b'])
     expect(result.rawEntryCount).toBe(2)
     expect(result.nextCursor).toBeUndefined()
@@ -409,5 +414,31 @@ describe('listWordpressTrafficEvents', () => {
     const u = new URL(urls[0]!)
     expect(u.searchParams.has('since')).toBe(false)
     expect(u.searchParams.has('until')).toBe(false)
+  })
+
+  it('adds a unique cache-buster param and a no-cache header on every request', async () => {
+    const urls: string[] = []
+    fetchSpy.mockImplementation(async (input) => {
+      urls.push(String(input))
+      return new Response(JSON.stringify({ events: [], next_cursor: null, has_more: false }), {
+        status: 200, headers: { 'Content-Type': 'application/json' },
+      })
+    })
+
+    // Two separate syncs against the same site. A page cache keys on the URL,
+    // so the cache-buster must differ between calls or the second sync reads
+    // the first sync's cached (now stale) page.
+    await listWordpressTrafficEvents({ baseUrl: 'https://example.com', username: 'u', applicationPassword: 'p' })
+    await listWordpressTrafficEvents({ baseUrl: 'https://example.com', username: 'u', applicationPassword: 'p' })
+
+    expect(urls).toHaveLength(2)
+    const cb1 = new URL(urls[0]!).searchParams.get('_cb')
+    const cb2 = new URL(urls[1]!).searchParams.get('_cb')
+    expect(cb1).toBeTruthy()
+    expect(cb2).toBeTruthy()
+    expect(cb1).not.toBe(cb2)
+
+    const init = fetchSpy.mock.calls[0]![1] as RequestInit
+    expect((init.headers as Record<string, string>)['Cache-Control']).toBe('no-cache')
   })
 })

--- a/packages/wordpress-traffic-logger-plugin/AGENTS.md
+++ b/packages/wordpress-traffic-logger-plugin/AGENTS.md
@@ -29,14 +29,14 @@ plugin/
   includes/
     class-plugin.php            Activation + uninstall + retention prune callback
     class-recorder.php          Request -> row writer (shutdown hook entry point)
-    class-rest.php              GET /wp-json/canonry/v1/events handler + cursor pagination + since/until
+    class-rest.php              GET /wp-json/canonry/v1/events handler + cursor pagination + since/until + page-cache opt-out
     class-client-ip.php         Pure client-IP resolver (proxy-header aware)
     class-settings-page.php     Settings → Canonry Traffic Logger admin form
 test/
   run-tests.php                 Discovers *Test.php, runs every public test_* method
   lib/TestCase.php              Minimal assertion API (no PHPUnit dependency)
   lib/WpShim.php                In-memory stub of the WP API surface the plugin touches
-  *Test.php                     Test cases (Activation, Ingestion, ClientIp, EndpointAuth, CursorPagination, WindowFilter, Uninstall, Retention, SettingsPage)
+  *Test.php                     Test cases (Activation, Ingestion, ClientIp, EndpointAuth, CursorPagination, WindowFilter, CacheControl, Uninstall, Retention, SettingsPage)
 ```
 
 ## Auth
@@ -89,6 +89,13 @@ on `admin_init`, so an in-place plugin update is migrated too), and the old
   accepts optional `since` / `until` ISO 8601 query params and filters
   events to the half-open window `[since, until)`. Powers the TS backfill
   route's historical pulls.
+- **Page-cache opt-out.** `GET /wp-json/canonry/v1/events` signals fronting
+  page caches not to store its response: the LiteSpeed
+  `litespeed_control_set_nocache` action, the `DONOTCACHEPAGE` constant, and
+  an `X-LiteSpeed-Cache-Control` header. The feed is authenticated and
+  per-request, so a cached copy would freeze the traffic canonry pulls. The
+  TS pull adapter also appends a unique cache-buster param as a second line
+  of defense.
 
 ## What's out of scope (deferred)
 
@@ -130,6 +137,9 @@ Test files cover:
   filter events to the half-open window `[since, until)`; cursor pagination
   still walks inside the window; invalid timestamps → 400. Used by the TS
   backfill route to scope historical pulls.
+- **CacheControlTest** verifies the events endpoint signals fronting page
+  caches (the LiteSpeed `litespeed_control_set_nocache` action plus the
+  `DONOTCACHEPAGE` constant) not to cache its authenticated per-request response.
 - **UninstallTest** — table dropped + options deleted; scheduled prune cleared.
 - **RetentionTest** — daily cron scheduled at activation, cleared at
   uninstall; `pruneExpired()` deletes rows older than the configured

--- a/packages/wordpress-traffic-logger-plugin/package.json
+++ b/packages/wordpress-traffic-logger-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry-wordpress-traffic-logger-plugin",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "license": "FSL-1.1-ALv2",
   "description": "PHP WordPress plugin that emits canonry traffic-logger events for the integration-wordpress-traffic adapter to pull.",

--- a/packages/wordpress-traffic-logger-plugin/plugin/canonry-traffic-logger.php
+++ b/packages/wordpress-traffic-logger-plugin/plugin/canonry-traffic-logger.php
@@ -3,7 +3,7 @@
  * Plugin Name: Canonry Traffic Logger
  * Plugin URI:  https://canonry.ai
  * Description: Captures non-admin page-load events and exposes them via REST for the canonry traffic-ingestion pipeline. No classification; the server does that.
- * Version:     0.3.0
+ * Version:     0.3.1
  * Requires PHP: 7.4
  * Author:      Canonry
  * License:     MIT

--- a/packages/wordpress-traffic-logger-plugin/plugin/includes/class-rest.php
+++ b/packages/wordpress-traffic-logger-plugin/plugin/includes/class-rest.php
@@ -52,7 +52,33 @@ final class Rest {
         );
     }
 
+    /**
+     * Tell a fronting page cache not to store this endpoint's response.
+     * The events feed is authenticated and per-request; a cached copy
+     * silently freezes the traffic the canonry sync reads. WordPress already
+     * sends `Cache-Control: no-cache` for an authenticated REST request, but
+     * page caches key on the URL and ignore it, so the common ones are
+     * signalled explicitly. The canonry pull adapter also appends a unique
+     * cache-buster param as a second line of defense.
+     */
+    private static function disablePageCache(): void {
+        // LiteSpeed Cache plugin: its documented per-request opt-out action.
+        if (function_exists('do_action')) {
+            do_action('litespeed_control_set_nocache', 'canonry traffic events endpoint is per-request');
+        }
+        // W3 Total Cache / WP Super Cache / WP Rocket / Batcache honor this.
+        if (!defined('DONOTCACHEPAGE')) {
+            define('DONOTCACHEPAGE', true);
+        }
+        // LiteSpeed at the web-server level reads this response header.
+        if (!headers_sent()) {
+            header('X-LiteSpeed-Cache-Control: no-cache');
+        }
+    }
+
     public static function handleList(\WP_REST_Request $request) {
+        self::disablePageCache();
+
         $limitRaw = $request->get_param('limit');
         $limit = self::clampLimit($limitRaw);
         $cursorRaw = $request->get_param('cursor');
@@ -154,7 +180,7 @@ final class Rest {
             'has_more'    => $hasMore,
             'site'        => [
                 'url'             => function_exists('home_url') ? home_url() : null,
-                'plugin_version'  => '0.3.0',
+                'plugin_version'  => '0.3.1',
             ],
         ], 200);
     }

--- a/packages/wordpress-traffic-logger-plugin/test/CacheControlTest.php
+++ b/packages/wordpress-traffic-logger-plugin/test/CacheControlTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * The events REST endpoint signals fronting page caches (LiteSpeed, W3 Total
+ * Cache, and similar) not to cache its response, so the authenticated,
+ * per-request traffic feed the canonry sync reads is never served stale from
+ * a frozen copy.
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../plugin/canonry-traffic-logger.php';
+
+use Canonry\TrafficLogger\Test\TestCase;
+
+final class CacheControlTest extends TestCase {
+    public function setUp(): void {
+        wpshim_reset();
+    }
+
+    public function test_events_endpoint_fires_litespeed_nocache_action(): void {
+        $reason = null;
+        add_action('litespeed_control_set_nocache', function ($r = '') use (&$reason) {
+            $reason = $r;
+        });
+
+        $response = \Canonry\TrafficLogger\Rest::handleList(new \WP_REST_Request('GET'));
+
+        $this->assertSame(200, $response->get_status());
+        $this->assertNotNull($reason, 'litespeed_control_set_nocache must fire for the events endpoint');
+        $this->assertStringContainsString('canonry', (string) $reason);
+    }
+
+    public function test_events_endpoint_defines_donotcachepage(): void {
+        \Canonry\TrafficLogger\Rest::handleList(new \WP_REST_Request('GET'));
+
+        $this->assertTrue(defined('DONOTCACHEPAGE'));
+        $this->assertSame(true, constant('DONOTCACHEPAGE'));
+    }
+}


### PR DESCRIPTION
## Summary

The WordPress traffic-sync pull always requests one identical URL, `/wp-json/canonry/v1/events?limit=500` (page size 500, and a site under 500 events never paginates to a varying URL). A page cache on the WordPress host caches that URL and serves a frozen copy, so the sync silently stops ingesting new events. The plugin records every hit correctly; the sync just never sees rows past the cache's snapshot. Confirmed in production: LiteSpeed Cache on azcoatingsllc.com froze the feed at 13 events while the origin held 18.

This is independent of the IP fix in #616 and hits any client site running LiteSpeed or a similar page cache.

Two layers of defense:

- **Adapter** (`integration-wordpress-traffic`): every request gets a unique `_cb` cache-buster query param plus a `Cache-Control: no-cache` request header, so each pull has a distinct cache key. Fixes every client on the next canonry release, no plugin update required.
- **Plugin** (`class-rest.php`, bumped to 0.3.1): the events endpoint signals fronting page caches not to store its response. It fires the LiteSpeed `litespeed_control_set_nocache` action, defines `DONOTCACHEPAGE` (honored by W3 Total Cache, WP Super Cache, WP Rocket, Batcache), and sends an `X-LiteSpeed-Cache-Control: no-cache` header.

## Verified

Against the production azcoatingsllc.com endpoint:

- `?limit=500` (the sync's URL): `x-litespeed-cache: hit`, 13 stale events
- `?limit=500&_cb=<uuid>`: `x-litespeed-cache: miss`, 18 fresh events

## Test plan

- [ ] `pnpm typecheck`, `pnpm lint`, `pnpm test` green (269 test files)
- [ ] Adapter suite asserts the cache-buster is unique per request and the no-cache header is sent
- [ ] Plugin `CacheControlTest` asserts the endpoint fires the nocache signals (CI runs no PHP; verify with `php test/run-tests.php`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)