### PR TITLE
feat(doctor): add a WordPress publishing-connection check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,6 +170,7 @@ Each check returns `status: ok | warn | fail | skipped`, a stable machine-readab
 | auth | `google.auth.redirect-uri` | project | `publicUrl`-derived redirect URI is valid + advertised |
 | auth | `google.auth.scopes` | project | Granted GSC + Indexing scopes match what's stored |
 | auth | `ga.auth.connection` | project | GA4 service account verifies against the configured property |
+| auth | `wordpress.publish.connection` | project | WordPress publishing connection (`integration-wordpress`): the Application Password authenticates and the `wp/v2` REST API responds; skipped when no connection is configured |
 | auth | `traffic.source.credentials` | project | Per-source-type credential validation (Cloud Run service-account access token resolves; WordPress and Vercel probe-call their endpoints) |
 | auth | `traffic.source.scopes` | project | Per-source-type scope validation (skipped where the adapter has no explicit scope check — e.g. WordPress Application Passwords, Vercel API tokens) |
 | integrations | `traffic.source.connected` | project | At least one non-archived server-side traffic source exists for the project |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.53.0",
+  "version": "4.54.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/doctor.ts
+++ b/packages/api-routes/src/doctor.ts
@@ -4,6 +4,7 @@ import { runChecks } from './doctor/runner.js'
 import type { DoctorContext, TrafficSourceValidator } from './doctor/types.js'
 import type { GoogleConnectionStore } from './google.js'
 import type { BingConnectionStore } from './bing.js'
+import type { WordpressConnectionStore } from './wordpress.js'
 import type { Ga4CredentialStore } from './ga.js'
 import type { ProviderSummaryEntry } from './settings.js'
 import { resolveProject } from './helpers.js'
@@ -11,6 +12,7 @@ import { resolveProject } from './helpers.js'
 export interface DoctorRoutesOptions {
   googleConnectionStore?: GoogleConnectionStore
   bingConnectionStore?: BingConnectionStore
+  wordpressConnectionStore?: WordpressConnectionStore
   ga4CredentialStore?: Ga4CredentialStore
   getGoogleAuthConfig?: () => { clientId?: string; clientSecret?: string }
   /** Used to derive the redirect URI displayed by the redirect-uri check. */
@@ -53,6 +55,7 @@ export async function doctorRoutes(app: FastifyInstance, opts: DoctorRoutesOptio
       project: null,
       googleConnectionStore: opts.googleConnectionStore,
       bingConnectionStore: opts.bingConnectionStore,
+      wordpressConnectionStore: opts.wordpressConnectionStore,
       ga4CredentialStore: opts.ga4CredentialStore,
       getGoogleAuthConfig: opts.getGoogleAuthConfig,
       redirectUri,
@@ -80,6 +83,7 @@ export async function doctorRoutes(app: FastifyInstance, opts: DoctorRoutesOptio
       },
       googleConnectionStore: opts.googleConnectionStore,
       bingConnectionStore: opts.bingConnectionStore,
+      wordpressConnectionStore: opts.wordpressConnectionStore,
       ga4CredentialStore: opts.ga4CredentialStore,
       getGoogleAuthConfig: opts.getGoogleAuthConfig,
       redirectUri,

--- a/packages/api-routes/src/doctor/checks/wordpress-publish.ts
+++ b/packages/api-routes/src/doctor/checks/wordpress-publish.ts
@@ -1,0 +1,82 @@
+import {
+  CheckCategories,
+  CheckScopes,
+  CheckStatuses,
+} from '@ainyc/canonry-contracts'
+import { verifyWordpressConnection, WordpressApiError } from '@ainyc/canonry-integration-wordpress'
+import type { CheckDefinition } from '../types.js'
+
+export const WORDPRESS_PUBLISH_CHECKS: readonly CheckDefinition[] = [
+  {
+    id: 'wordpress.publish.connection',
+    category: CheckCategories.auth,
+    scope: CheckScopes.project,
+    title: 'WordPress publishing connection',
+    run: async (ctx) => {
+      if (!ctx.project) {
+        return {
+          status: CheckStatuses.skipped,
+          code: 'wordpress.publish.no-project',
+          summary: 'Project context required.',
+          remediation: null,
+        }
+      }
+
+      const store = ctx.wordpressConnectionStore
+      if (!store) {
+        return {
+          status: CheckStatuses.skipped,
+          code: 'wordpress.publish.store-unavailable',
+          summary: 'WordPress connection store is not configured for this deployment.',
+          remediation: null,
+        }
+      }
+
+      const connection = store.getConnection(ctx.project.name)
+      if (!connection) {
+        // The publisher is an optional integration. A project that does not
+        // push content to WordPress legitimately has no connection, so this
+        // is `skipped` rather than `fail`.
+        return {
+          status: CheckStatuses.skipped,
+          code: 'wordpress.publish.not-configured',
+          summary: `No WordPress publishing connection configured for ${ctx.project.name}.`,
+          remediation: `If this project publishes to WordPress, run \`canonry wordpress connect ${ctx.project.name} --url <url> --user <user>\`.`,
+        }
+      }
+
+      try {
+        const status = await verifyWordpressConnection(connection)
+        return {
+          status: CheckStatuses.ok,
+          code: 'wordpress.publish.connected',
+          summary: `WordPress publishing connection verified; wp/v2 REST API reachable at ${status.url}.`,
+          remediation: null,
+          details: {
+            url: status.url,
+            wordpressVersion: status.version,
+            pageCount: status.pageCount,
+          },
+        }
+      } catch (err) {
+        if (err instanceof WordpressApiError && err.code === 'AUTH_INVALID') {
+          return {
+            status: CheckStatuses.fail,
+            code: 'wordpress.publish.unauthorized',
+            summary: 'WordPress rejected the stored application password.',
+            remediation: `Regenerate the Application Password in wp-admin (Users → Profile → Application Passwords), then reconnect with \`canonry wordpress connect ${ctx.project.name} --url <url> --user <user>\`.`,
+            details: { error: err.message },
+          }
+        }
+        const message = err instanceof Error ? err.message : String(err)
+        return {
+          status: CheckStatuses.fail,
+          code: 'wordpress.publish.verification-failed',
+          summary: 'WordPress publishing connection could not be verified.',
+          remediation: 'Confirm the site URL is correct and the WordPress REST API is reachable.',
+          details: { error: message },
+        }
+      }
+    },
+  },
+]

--- a/packages/api-routes/src/doctor/registry.ts
+++ b/packages/api-routes/src/doctor/registry.ts
@@ -5,6 +5,7 @@ import { GOOGLE_AUTH_CHECKS } from './checks/google-auth.js'
 import { PROVIDERS_CHECKS } from './checks/providers.js'
 import { RUNTIME_STATE_CHECKS } from './checks/runtime-state.js'
 import { TRAFFIC_SOURCE_CHECKS } from './checks/traffic-source.js'
+import { WORDPRESS_PUBLISH_CHECKS } from './checks/wordpress-publish.js'
 import type { CheckDefinition } from './types.js'
 
 export const ALL_CHECKS: readonly CheckDefinition[] = [
@@ -13,6 +14,7 @@ export const ALL_CHECKS: readonly CheckDefinition[] = [
   ...RUNTIME_STATE_CHECKS,
   ...GOOGLE_AUTH_CHECKS,
   ...BING_AUTH_CHECKS,
+  ...WORDPRESS_PUBLISH_CHECKS,
   ...GA_AUTH_CHECKS,
   ...PROVIDERS_CHECKS,
   ...TRAFFIC_SOURCE_CHECKS,

--- a/packages/api-routes/src/doctor/types.ts
+++ b/packages/api-routes/src/doctor/types.ts
@@ -2,6 +2,7 @@ import type { DatabaseClient } from '@ainyc/canonry-db'
 import type { CheckCategory, CheckResultDto, CheckScope, CheckStatus } from '@ainyc/canonry-contracts'
 import type { GoogleConnectionStore } from '../google.js'
 import type { BingConnectionStore } from '../bing.js'
+import type { WordpressConnectionStore } from '../wordpress.js'
 import type { Ga4CredentialStore } from '../ga.js'
 import type { ProviderSummaryEntry } from '../settings.js'
 
@@ -41,6 +42,7 @@ export interface DoctorContext {
   project: ProjectInfo | null
   googleConnectionStore?: GoogleConnectionStore
   bingConnectionStore?: BingConnectionStore
+  wordpressConnectionStore?: WordpressConnectionStore
   ga4CredentialStore?: Ga4CredentialStore
   getGoogleAuthConfig?: () => { clientId?: string; clientSecret?: string }
   /** Resolved redirect URI (publicUrl + /api/v1/google/callback) used by the OAuth flow. */

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -392,6 +392,7 @@ export async function apiRoutes(app: FastifyInstance, opts: ApiRoutesOptions) {
     await api.register(doctorRoutes, {
       googleConnectionStore: opts.googleConnectionStore,
       bingConnectionStore: opts.bingConnectionStore,
+      wordpressConnectionStore: opts.wordpressConnectionStore,
       ga4CredentialStore: opts.ga4CredentialStore,
       getGoogleAuthConfig: opts.getGoogleAuthConfig,
       publicUrl: opts.publicUrl,

--- a/packages/api-routes/test/doctor-wordpress-publish.test.ts
+++ b/packages/api-routes/test/doctor-wordpress-publish.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { WordpressApiError } from '@ainyc/canonry-integration-wordpress'
+import type { WordpressConnectionRecord } from '@ainyc/canonry-integration-wordpress'
+import { WORDPRESS_PUBLISH_CHECKS } from '../src/doctor/checks/wordpress-publish.js'
+import type { DoctorContext, ProjectInfo } from '../src/doctor/types.js'
+import type { WordpressConnectionStore } from '../src/wordpress.js'
+
+const verifyMock = vi.fn()
+
+vi.mock('@ainyc/canonry-integration-wordpress', async () => {
+  const actual = await vi.importActual<typeof import('@ainyc/canonry-integration-wordpress')>(
+    '@ainyc/canonry-integration-wordpress',
+  )
+  return {
+    ...actual,
+    verifyWordpressConnection: (...args: unknown[]) => verifyMock(...args),
+  }
+})
+
+const project: ProjectInfo = {
+  id: 'p1',
+  name: 'demo',
+  canonicalDomain: 'example.com',
+  displayName: 'Demo',
+}
+
+function buildStore(connection?: Partial<WordpressConnectionRecord>): WordpressConnectionStore {
+  const conn: WordpressConnectionRecord | undefined = connection
+    ? {
+        projectName: 'demo',
+        url: 'https://example.com',
+        username: 'admin',
+        appPassword: 'app-pass',
+        defaultEnv: 'live',
+        createdAt: '2026-04-01T00:00:00.000Z',
+        updatedAt: '2026-04-01T00:00:00.000Z',
+        ...connection,
+      }
+    : undefined
+  return {
+    getConnection: () => conn,
+    upsertConnection: (record) => record,
+    updateConnection: () => conn,
+  }
+}
+
+function ctx(overrides: Partial<DoctorContext>): DoctorContext {
+  return {
+    db: {} as DoctorContext['db'],
+    project,
+    wordpressConnectionStore: buildStore({}),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  verifyMock.mockReset()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('wordpress.publish.connection', () => {
+  const check = WORDPRESS_PUBLISH_CHECKS.find((c) => c.id === 'wordpress.publish.connection')!
+
+  it('returns ok when the connection verifies', async () => {
+    verifyMock.mockResolvedValue({
+      url: 'https://example.com',
+      reachable: true,
+      pageCount: 12,
+      version: '6.8.1',
+      plugins: [],
+    })
+    const result = await check.run(ctx({}))
+    expect(result.status).toBe('ok')
+    expect(result.code).toBe('wordpress.publish.connected')
+    expect(result.details).toMatchObject({
+      url: 'https://example.com',
+      pageCount: 12,
+      wordpressVersion: '6.8.1',
+    })
+  })
+
+  it('skips when the project has no WordPress connection', async () => {
+    const result = await check.run(ctx({ wordpressConnectionStore: buildStore() }))
+    expect(result.status).toBe('skipped')
+    expect(result.code).toBe('wordpress.publish.not-configured')
+    expect(verifyMock).not.toHaveBeenCalled()
+  })
+
+  it('fails as unauthorized when the application password is rejected', async () => {
+    verifyMock.mockRejectedValue(new WordpressApiError('AUTH_INVALID', 'Authentication failed', 401))
+    const result = await check.run(ctx({}))
+    expect(result.status).toBe('fail')
+    expect(result.code).toBe('wordpress.publish.unauthorized')
+  })
+
+  it('fails as verification-failed when the site is unreachable', async () => {
+    verifyMock.mockRejectedValue(new Error('fetch failed'))
+    const result = await check.run(ctx({}))
+    expect(result.status).toBe('fail')
+    expect(result.code).toBe('wordpress.publish.verification-failed')
+    expect(result.details).toMatchObject({ error: 'fetch failed' })
+  })
+
+  it('skips when there is no project context', async () => {
+    const result = await check.run(ctx({ project: null }))
+    expect(result.status).toBe('skipped')
+    expect(result.code).toBe('wordpress.publish.no-project')
+  })
+
+  it('skips when the connection store is unavailable', async () => {
+    const result = await check.run(ctx({ wordpressConnectionStore: undefined }))
+    expect(result.status).toBe('skipped')
+    expect(result.code).toBe('wordpress.publish.store-unavailable')
+  })
+})

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.53.0",
+  "version": "4.54.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/integration-wordpress/package.json
+++ b/packages/integration-wordpress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry-integration-wordpress",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Summary

Adds a project-scoped doctor check for the WordPress publisher and marks the publisher GA.

- **New check `wordpress.publish.connection`** (`auth` category, project scope). Wraps `verifyWordpressConnection` from `integration-wordpress`: a stale Application Password surfaces as `wordpress.publish.unauthorized`, an unreachable site or `wp/v2` REST API as `wordpress.publish.verification-failed`, a healthy connection as `wordpress.publish.connected`. It is skipped when the project has no WordPress publishing connection, since the publisher is an optional integration. The check surfaces automatically through `canonry doctor`, the doctor API, and the `canonry_doctor` MCP tool.
- **Publisher GA:** `@ainyc/canonry-integration-wordpress` bumped `0.0.0` to `1.0.0`.
- **canonry** bumped `4.53.0` to `4.54.0`.

Wiring: `wordpressConnectionStore` is threaded into `DoctorContext`, `DoctorRoutesOptions`, and the doctor route registration, mirroring `bingConnectionStore`.

## Test plan

- [x] `pnpm typecheck` green
- [x] `pnpm lint` 0 errors
- [x] `pnpm test` green (270 files / 3240 tests)
- [x] New `doctor-wordpress-publish.test.ts` covers all six result codes (connected, unauthorized, verification-failed, not-configured, no-project, store-unavailable)

## Note on PR #617

#617 also bumps the version to 4.54.0 and also touches `packages/api-routes/src/index.ts` and root `AGENTS.md`. The version change is identical on both sides so it merges cleanly; the other touches are in different regions. If #617 ships in its own 4.54.0 release before this merges, this PR needs a re-bump to 4.55.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)