### PR TITLE
chore(traffic): version the WordPress traffic-logger plugin to 1.0.0

### DIFF
--- a/packages/integration-wordpress/package.json
+++ b/packages/integration-wordpress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry-integration-wordpress",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "private": true,
   "type": "module",
   "license": "FSL-1.1-ALv2",

--- a/packages/wordpress-traffic-logger-plugin/package.json
+++ b/packages/wordpress-traffic-logger-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry-wordpress-traffic-logger-plugin",
-  "version": "0.3.1",
+  "version": "1.0.0",
   "private": true,
   "license": "FSL-1.1-ALv2",
   "description": "PHP WordPress plugin that emits canonry traffic-logger events for the integration-wordpress-traffic adapter to pull.",

--- a/packages/wordpress-traffic-logger-plugin/plugin/canonry-traffic-logger.php
+++ b/packages/wordpress-traffic-logger-plugin/plugin/canonry-traffic-logger.php
@@ -3,7 +3,7 @@
  * Plugin Name: Canonry Traffic Logger
  * Plugin URI:  https://canonry.ai
  * Description: Captures non-admin page-load events and exposes them via REST for the canonry traffic-ingestion pipeline. No classification; the server does that.
- * Version:     0.3.1
+ * Version:     1.0.0
  * Requires PHP: 7.4
  * Author:      Canonry
  * License:     MIT

--- a/packages/wordpress-traffic-logger-plugin/plugin/includes/class-rest.php
+++ b/packages/wordpress-traffic-logger-plugin/plugin/includes/class-rest.php
@@ -180,7 +180,7 @@ final class Rest {
             'has_more'    => $hasMore,
             'site'        => [
                 'url'             => function_exists('home_url') ? home_url() : null,
-                'plugin_version'  => '0.3.1',
+                'plugin_version'  => '1.0.0',
             ],
         ], 200);
     }


### PR DESCRIPTION
## Summary

Marks the WordPress traffic-logger plugin **1.0.0**. The plugin has shipped real-client-IP capture, the in-place schema migration, and the page-cache opt-out, so it is promoted from 0.3.1 to a 1.0 GA marker. The bump covers `package.json`, the plugin `Version:` header, and the `plugin_version` the REST endpoint reports. On merge, `wp-plugin-release.yml` publishes `wp-traffic-logger-v1.0.0`.

Also reverts `integration-wordpress` from `1.0.0` back to `0.0.0`. That package took 1.0.0 in #619 from a misread of "publisher"; it is an internal bundled package and 0.0.0 is the convention for those. The 1.0 marker belongs on the installable plugin, not the internal TS client.

## Test plan

- [x] `pnpm typecheck` green
- [x] `pnpm exec vitest run packages/integration-wordpress` green
- [x] Version-strings-only change, no logic touched (PHP plugin tests unaffected; no test pins the version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)