### PR TITLE
fix(report): describe traffic verification accurately

### DIFF
--- a/apps/web/src/pages/ReportPage.tsx
+++ b/apps/web/src/pages/ReportPage.tsx
@@ -238,7 +238,7 @@ function ServerActivityClientView({ report }: { report: ProjectReportDto }) {
             </table>
           </div>
           <p className="mt-2 text-[11px] text-zinc-500">
-            Bot requests are bulk crawl (GPTBot, PerplexityBot, …). User fetches are on-demand reads triggered by real users inside an AI surface (ChatGPT-User, Perplexity-User, …). Verified requests are reverse-DNS confirmed; unverified requests are UA claims shown separately in agency diagnostics.
+            Bot requests are bulk crawl (GPTBot, PerplexityBot, …). User fetches are on-demand reads triggered by real users inside an AI surface (ChatGPT-User, Perplexity-User, …). Verified means the request came from an IP the operator publishes as its own; unverified means the user-agent matched but the IP is not in a published range. User-fetch totals count both, since many genuine user fetches come from outside any published range.
           </p>
         </div>
       )}

--- a/packages/api-routes/src/report-renderer.ts
+++ b/packages/api-routes/src/report-renderer.ts
@@ -1930,7 +1930,7 @@ function renderServerActivity(report: ProjectReportDto, audience: ReportAudience
           <thead><tr><th>AI tool</th><th class="numeric">Bot requests (7d)</th><th class="numeric">User fetches (7d)</th><th class="numeric">Referral sessions</th></tr></thead>
           <tbody>${clientOperatorRows}</tbody>
         </table>
-        <p class="meta">Bot requests are bulk crawl (GPTBot, PerplexityBot, …). User fetches are on-demand reads triggered by real users inside an AI surface (ChatGPT-User, Perplexity-User, …). Verified requests are reverse-DNS confirmed; unverified requests are UA claims shown separately in agency diagnostics.</p>
+        <p class="meta">Bot requests are bulk crawl (GPTBot, PerplexityBot, …). User fetches are on-demand reads triggered by real users inside an AI surface (ChatGPT-User, Perplexity-User, …). Verified means the request came from an IP the operator publishes as its own; unverified means the user-agent matched but the IP is not in a published range. User-fetch totals count both, since many genuine user fetches come from outside any published range.</p>
       </div>` : ''}`,
     )
   }
@@ -2007,7 +2007,7 @@ function renderServerActivity(report: ProjectReportDto, audience: ReportAudience
     </div>
     ${trendChart}
     ${operatorRows ? `<div class="chart-card"><h3>Per AI operator</h3>
-      <p class="meta">Verified means rDNS-confirmed. Unverified bots claim the user-agent but couldn't be verified — could be the real bot or an imitator. User fetches are on-demand reads from an AI surface on behalf of a real user (ChatGPT-User, Perplexity-User, …) — disjoint from bulk crawl.</p>
+      <p class="meta">Verified means the request's source IP falls inside the operator's published range. Unverified bots claim the user-agent but the IP is not in a published range, so it could be the real bot or an imitator. User fetches are on-demand reads from an AI surface on behalf of a real user (ChatGPT-User, Perplexity-User, …), disjoint from bulk crawl and counted whether or not the IP can be verified.</p>
       <table class="report-table">
         <thead><tr><th>Operator</th><th class="numeric">Verified hits</th><th class="numeric">Unverified</th><th class="numeric">User fetches</th><th class="numeric">Referral sessions</th><th class="numeric">7d delta</th></tr></thead>
         <tbody>${operatorRows}</tbody>

--- a/packages/api-routes/src/report.ts
+++ b/packages/api-routes/src/report.ts
@@ -572,9 +572,9 @@ function nonSubresourceReferralPathCondition() {
  * the latter returns a populated section with `hasData=false` and zeroed
  * counters so the UI can show a "we're collecting" empty state).
  *
- * Crawler trust is split: verified hits are rDNS-confirmed, while
- * claimed-unverified hits are still surfaced separately so a real crawl
- * burst does not look like zero activity before verification lands.
+ * Crawler trust is split: verified hits have a source IP inside the
+ * operator's published range, while claimed-unverified hits are surfaced
+ * separately so a real crawl burst still shows activity.
  */
 function buildServerActivity(db: DatabaseClient, projectId: string): ProjectReportDto['serverActivity'] {
   // 1. Bail if no traffic source is connected at all.
@@ -662,9 +662,9 @@ function buildServerActivity(db: DatabaseClient, projectId: string): ProjectRepo
     )
 
   // User-fetch hits roll verified + unverified together. For crawlers we
-  // split because rDNS confirmation is the trust signal; for user-fetch
+  // split because IP-range confirmation is the trust signal; for user-fetch
   // the operational question is "is an AI surface reading this page on
-  // behalf of a real user, yes or no?" — verification matters less.
+  // behalf of a real user, yes or no?", so verification matters less.
   const sumUserFetches = (windowStartIso: string, windowEndIso: string, exclusiveEnd = false) =>
     Number(
       db

--- a/packages/api-routes/test/report-renderer.test.ts
+++ b/packages/api-routes/test/report-renderer.test.ts
@@ -528,7 +528,7 @@ describe('renderReportHtml', () => {
     expect(html).toContain('Verified crawler hits (7d)')
     expect(html).toContain('Unverified crawler hits (7d)')
     expect(html).toContain('AI-referral sessions (7d)')
-    expect(html).toContain('rDNS-confirmed')
+    expect(html).toContain('could be the real bot or an imitator')
     // Per-operator breakdown headings
     expect(html).toContain('Per AI operator')
     expect(html).toContain('Top crawled paths')
@@ -549,7 +549,7 @@ describe('renderReportHtml', () => {
     expect(html).toContain('AI bot requests observed')
     expect(html).toContain('AI user-fetch requests')
     expect(html).toContain('AI referral sessions')
-    expect(html).toContain('reverse-DNS')
+    expect(html).toContain('User-fetch totals count both')
     // Section eyebrow in client view is the friendlier "AI engine attention" label
     expect(html).toContain('AI engine attention')
     // Per-engine breakdown rendered with operator names

--- a/packages/contracts/src/report.ts
+++ b/packages/contracts/src/report.ts
@@ -398,7 +398,7 @@ export const serverActivitySectionSchema = z.object({
   byOperator: z.array(z.object({
     operator: z.string(),
     verifiedHits: z.number(),
-    /** Shown to agency audience only — claimed-bot UA, rDNS not confirmed. */
+    /** Shown to agency audience only: claimed-bot UA, source IP not in a published range. */
     unverifiedHits: z.number(),
     /** Per-user fetches from this operator's AI surface (ChatGPT-User, …). */
     userFetchHits: z.number(),

--- a/packages/contracts/src/traffic.ts
+++ b/packages/contracts/src/traffic.ts
@@ -79,8 +79,9 @@ export type TrafficSourceAuthMode = z.infer<typeof trafficSourceAuthModeSchema>
 export const TrafficSourceAuthModes = trafficSourceAuthModeSchema.enum
 
 // Crawler verification tiers. See `packages/integration-traffic/AGENTS.md`:
-// UA-only matches stay `claimed_unverified` until IP/rDNS verification is wired;
-// `unknown_ai_like` is reserved for behavioral heuristics.
+// a UA-only match stays `claimed_unverified` unless the source IP falls in the
+// operator's published range; `unknown_ai_like` is reserved for behavioral
+// heuristics.
 export const verificationStatusSchema = z.enum(['verified', 'claimed_unverified', 'unknown_ai_like'])
 export type VerificationStatus = z.infer<typeof verificationStatusSchema>
 export const VerificationStatuses = verificationStatusSchema.enum

--- a/packages/integration-traffic/AGENTS.md
+++ b/packages/integration-traffic/AGENTS.md
@@ -18,14 +18,14 @@ Provider-neutral traffic classifier and rollup. Takes `NormalizedTrafficRequest`
 
 - **Pure functions, no I/O.** Adapters fetch and normalize; this package only classifies and rolls up. Unit-testable end-to-end with fixture events.
 - **Three evidence channels.** Bulk crawl via UA where `purpose !== 'user-agent'` (`crawler_events_hourly`); per-user AI fetches via UA where `purpose === 'user-agent'` (`ai_user_fetch_events_hourly`); human AI referrals via referer/UTM (`ai_referral_events_hourly`). Never collapse them — each answers a different question: "is AI training on me?" vs. "is AI reading me for a user right now?" vs. "are users clicking through from AI?"
-- **Verification status tiers.** UA-only matches stay `claimed_unverified`. Promotion to `verified` requires IP/rDNS verification, which is not yet implemented. The `unknown_ai_like` bucket is reserved for behavioral heuristics.
+- **Verification status tiers.** A UA-only match stays `claimed_unverified`; it is promoted to `verified` only when the source IP falls in the operator's published range (see `ip-verify.ts`). User-fetch agents are a caveat: an on-device fetch egresses from the user's own IP, so a genuine user fetch can stay `claimed_unverified` permanently. The `unknown_ai_like` bucket is reserved for behavioral heuristics.
 - **Path normalization.** Rollups key on the normalized path so query-string variants don't fragment the bucket counts.
 - **Bounded sample tail.** `buildTrafficProbeReport` keeps a small sample slice for classifier debugging; the durable signal is the hourly bucket counts.
 
 ## Common Mistakes
 
 - **Adding I/O here.** Network/file/DB calls belong in adapters or service code. Keep this package pure.
-- **Treating UA-only matches as verified.** Anyone can spoof a user agent. Until IP/rDNS verification is wired, never promote UA-only matches above `claimed_unverified`.
+- **Treating UA-only matches as verified.** Anyone can spoof a user agent. Promote above `claimed_unverified` only when `verifyIpForRule` confirms the source IP against the operator's published range.
 - **Mixing crawler and referral signals into one bucket.** They answer different questions (machine activity vs human clicks); keep them in separate tables and separate API surfaces.
 
 ## See Also

--- a/packages/integration-traffic/src/ip-verify.ts
+++ b/packages/integration-traffic/src/ip-verify.ts
@@ -35,6 +35,17 @@
  * ones (same shape: `{ prefixes: [{ ipv4Prefix } | { ipv6Prefix }] }`)
  * and adding the rule-id mapping below.
  *
+ * **User-fetch agents and on-device fetches.** A user-triggered fetch
+ * (`ChatGPT-User`, `Claude-User`, `Perplexity-User`, …) does not always
+ * leave the operator's servers. Some surfaces fetch the URL server-side,
+ * so it egresses from the operator's cloud IP and verifies here. A local
+ * app can instead fetch straight from the user's device, egressing from
+ * the user's own residential or cellular IP, which no operator publishes
+ * and never could. That on-device case is structurally unverifiable: a
+ * genuine user fetch then stays `claimed_unverified` permanently, and
+ * that is correct, not a coverage gap. Treat the `ai_user_fetch` channel
+ * count as the signal; an IP-confirmed `verified` is a bonus subset.
+ *
  * **Refresh.** Run `scripts/refresh-ip-ranges.ts` to re-fetch all
  * bundled lists from the publishers. The script is git-friendly: it
  * writes pretty-printed JSON so diffs show exactly which prefixes the


### PR DESCRIPTION
## Summary

The report described traffic verification inaccurately. It told clients "Verified requests are reverse-DNS confirmed" and "Verified means rDNS-confirmed". canonry does not use reverse-DNS: it verifies by **IP-range** (the request's source IP must fall inside the operator's published IP ranges, see `integration-traffic/ip-verify.ts`). rDNS is not implemented.

- **Report copy** corrected on both surfaces (`ReportPage.tsx` SPA + `report-renderer.ts` HTML, kept verbatim-identical per the report-parity rule): verification is IP-range, and user-fetch totals explicitly count verified + unverified together.
- **Internal comments** in `report.ts` and `contracts` corrected, plus the stale "verification is not yet implemented" lines in `integration-traffic/AGENTS.md` (it has been implemented since `ip-verify.ts` landed).
- **New note** in the `ip-verify.ts` header: a user-triggered fetch can egress from the user's own device rather than the operator's servers, so a genuine user fetch can stay `claimed_unverified` permanently. That is correct behavior, not a coverage gap. The `ai_user_fetch` channel count is the signal; `verified` is a bonus subset.

No metric or scoring change: user-fetch counts already summed verified + unverified, and the visibility score does not read traffic at all. This is a copy and accuracy fix.

## Test plan

- [x] `pnpm exec vitest run packages/api-routes/test/report-renderer.test.ts` green (66 tests; the two verification-copy assertions updated)
- [x] `pnpm typecheck` green
- [x] Copy is verbatim-identical between the SPA and HTML report surfaces

## Note on PR #617

#617 also touches `report-renderer.ts` and `report-renderer.test.ts` (its report-CSP hardening). The changes sit in different regions of those files (CSP/head vs the server-activity section), so they should merge cleanly; whichever lands second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)