### PR TITLE
fix(traffic): adaptive sub-windowing for Vercel sync and backfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.55.0",
+  "version": "4.55.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/traffic.ts
+++ b/packages/api-routes/src/traffic.ts
@@ -57,6 +57,7 @@ import type {
   WordpressTrafficEventsPage,
 } from '@ainyc/canonry-integration-wordpress-traffic'
 import {
+  drainVercelTrafficEvents,
   listVercelTrafficEvents,
   VercelLogsApiError,
 } from '@ainyc/canonry-integration-vercel'
@@ -222,12 +223,15 @@ const DEFAULT_SAMPLE_LIMIT = 100
 const DEFAULT_WP_PAGE_SIZE = 500
 const DEFAULT_WP_MAX_PAGES = 20
 // Vercel's `request-logs` endpoint paginates by page number within a fixed
-// `[startDate, endDate]` window and exposes no resumable page cursor — so a
-// sync must drain the entire window in one pass. This budget is generous
-// enough that an incremental sync (window clamped forward to `lastSyncedAt`)
-// never hits it; if it does, the sync fails loudly rather than advancing
-// `lastSyncedAt` past the un-pulled pages. Backfill uses BACKFILL_MAX_PAGES.
+// `[startDate, endDate]` window and exposes no resumable page cursor. A
+// window holding more than this many pages cannot be pulled in one pass, so
+// `drainVercelTrafficEvents` narrows the time window adaptively until each
+// slice fits. This is the per-sub-window page budget.
 const DEFAULT_VERCEL_MAX_PAGES = 50
+// Hard cap on adaptive sub-windows a single Vercel drain may walk before it
+// gives up. Generous enough that a normal sync or a 30-day backfill never
+// reaches it; a window this fragmented should be narrowed by the operator.
+const VERCEL_MAX_SUB_WINDOWS = 5_000
 // Bounded ring buffer of the most-recent normalized event IDs from the last
 // sync. Used to dedupe events that fall in the small overlap window between
 // `lastSyncedAt` and the new sync's `windowStart`. Sized for the practical
@@ -1266,12 +1270,10 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
       }
     } else {
       // Vercel `request-logs` adapter. Pulls a clamped `[windowStart,
-      // windowEnd]` time window — like Cloud Run — but Vercel paginates by
-      // page number with no resumable cursor, so the whole window must be
-      // drained in one pass. We walk every page up to `vercelMaxPages`; if
-      // the adapter still reports `hasMore`, the window overflowed the
-      // budget and we fail rather than advance `lastSyncedAt` past the
-      // un-pulled pages (which would silently drop them).
+      // windowEnd]` time window. Vercel paginates by page number with no
+      // resumable cursor, so a dense window is drained in adaptive time
+      // sub-windows: `drainVercelTrafficEvents` narrows the span until each
+      // slice fits the per-sub-window page budget, deduping by eventId.
       auditAction = 'traffic.vercel.synced'
       const credentialStore = opts.vercelTrafficCredentialStore
       if (!credentialStore) {
@@ -1310,32 +1312,24 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
         Math.min(windowEnd.getTime(), Math.max(requestedStartMs, lastSyncedMs)),
       )
 
-      let page: VercelTrafficEventsPage
       try {
-        page = await pullVercelEvents({
+        const drained = await drainVercelTrafficEvents({
+          pull: pullVercelEvents,
           token: credential.token,
           projectId: vercelProjectId,
           teamId: vercelTeamId,
           environment: vercelEnvironment,
           startDate: windowStart.getTime(),
           endDate: windowEnd.getTime(),
-          maxPages: vercelMaxPages,
+          pagesPerSubWindow: vercelMaxPages,
+          maxSubWindows: VERCEL_MAX_SUB_WINDOWS,
         })
+        allEvents = drained.events
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e)
         markFailed(msg, 'PROVIDER_PULL')
         throw providerError(`Vercel pull failed: ${msg}`)
       }
-      if (page.hasMore) {
-        // Budget exhausted with the window not fully drained. Advancing
-        // `lastSyncedAt` here would skip the un-pulled pages, so fail
-        // instead — the next sync (or a narrower `--since-minutes`, or a
-        // backfill) can cover the window without losing rows.
-        const msg = `Vercel sync window exceeded the ${vercelMaxPages}-page budget — narrow the window with --since-minutes or run a backfill`
-        markFailed(msg, 'PROVIDER_PULL')
-        throw providerError(`Vercel pull failed: ${msg}`)
-      }
-      allEvents = page.events
     }
 
     let crawlerBucketRows = 0
@@ -1811,21 +1805,18 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
 
       pullErrorPrefix = 'Vercel pull failed'
       pullForBackfill = async () => {
-        const page = await pullVercelEvents({
+        const drained = await drainVercelTrafficEvents({
+          pull: pullVercelEvents,
           token: credential.token,
           projectId: vercelProjectId,
           teamId: vercelTeamId,
           environment: vercelEnvironment,
           startDate: windowStart.getTime(),
           endDate: windowEnd.getTime(),
-          maxPages: BACKFILL_MAX_PAGES,
+          pagesPerSubWindow: vercelMaxPages,
+          maxSubWindows: VERCEL_MAX_SUB_WINDOWS,
         })
-        if (page.hasMore) {
-          throw new Error(
-            `backfill window exceeded the ${BACKFILL_MAX_PAGES}-page budget — narrow the window with --days`,
-          )
-        }
-        return page.events
+        return drained.events
       }
     }
 

--- a/packages/api-routes/test/traffic.test.ts
+++ b/packages/api-routes/test/traffic.test.ts
@@ -791,21 +791,26 @@ describe('POST /traffic/sources/:id/sync — Vercel', () => {
     }
   })
 
-  it('fails loudly without advancing lastSyncedAt when the window overflows the page budget (hasMore=true)', async () => {
-    const baseTime = new Date(Date.now() - 60 * 60_000)
-    baseTime.setMinutes(0, 0, 0)
-    // The adapter reports hasMore=true — the window has more pages than the
-    // per-sync budget could drain. The sync must refuse to advance the cursor.
+  it('drains a window that overflows the per-sub-window page budget via sub-windows', async () => {
+    // The first (full-window) pull reports hasMore=true; the drain halves the
+    // span and the narrower slices drain cleanly, so the sync succeeds
+    // instead of failing wholesale.
+    const observedAt = new Date(Date.now() - 2 * 86_400_000).toISOString()
+    let pullCount = 0
     const h = await buildHarness([], {
       vercelPullPages: ({ maxPages }) => {
         if (maxPages === 1) {
           return { events: [], rawEntryCount: 0, skippedEntryCount: 0, hasMore: false, endpoint: '' }
         }
+        pullCount += 1
+        if (pullCount === 1) {
+          return { events: [], rawEntryCount: 0, skippedEntryCount: 0, hasMore: true, endpoint: '' }
+        }
         return {
-          events: [buildVercelEvent({ eventId: 'vercel:overflow:1', userAgent: 'GPTBot/1.0', path: '/x', observedAt: baseTime.toISOString() })],
+          events: [buildVercelEvent({ eventId: `vercel:sub:${pullCount}`, userAgent: 'GPTBot/1.0', path: '/x', observedAt })],
           rawEntryCount: 1,
           skippedEntryCount: 0,
-          hasMore: true,
+          hasMore: false,
           endpoint: '',
         }
       },
@@ -818,28 +823,19 @@ describe('POST /traffic/sources/:id/sync — Vercel', () => {
         url: `/api/v1/projects/test-project/traffic/sources/${sourceId}/sync`,
         payload: {},
       })
-      // providerError → 502; the message must point the operator at the fix.
-      expect(syncRes.statusCode).toBe(502)
-      expect(JSON.parse(syncRes.payload).error.message).toMatch(/page budget/)
-      expect(JSON.parse(syncRes.payload).error.message).toMatch(/--since-minutes/)
+      expect(syncRes.statusCode).toBe(200)
+      // The drain made more than one sub-window pull to cover the window.
+      expect(pullCount).toBeGreaterThan(1)
 
-      // The cursor must NOT advance — a partially-drained window means the
-      // next sync (or a narrower one) still has to cover it.
+      // The cursor advanced and the sub-window events rolled up.
       const sourceRow = h.db.select().from(trafficSources).where(eq(trafficSources.id, sourceId)).get()!
-      expect(sourceRow.lastSyncedAt).toBeNull()
-      expect(sourceRow.status).toBe(TrafficSourceStatuses.error)
-      expect(sourceRow.lastError).toMatch(/page budget/)
+      expect(sourceRow.lastSyncedAt).not.toBeNull()
+      expect(sourceRow.status).toBe(TrafficSourceStatuses.connected)
+      expect(h.db.select().from(crawlerEventsHourly).all().length).toBeGreaterThan(0)
 
-      // Run finalized as failed; no rollup rows were written.
       const runRows = h.db.select().from(runs).all()
       expect(runRows.length).toBe(1)
-      expect(runRows[0].status).toBe(RunStatuses.failed)
-      expect(h.db.select().from(crawlerEventsHourly).all().length).toBe(0)
-
-      // Telemetry hook saw a failed sync with the PROVIDER_PULL error code.
-      const synced = h.getTrafficSyncedEvents() as Array<{ status: string; errorCode?: string }>
-      expect(synced.at(-1)?.status).toBe('failed')
-      expect(synced.at(-1)?.errorCode).toBe('PROVIDER_PULL')
+      expect(runRows[0].status).toBe(RunStatuses.completed)
     } finally {
       await h.close()
     }
@@ -948,11 +944,11 @@ describe('POST /traffic/sources/:id/backfill — Vercel', () => {
       expect(finalRun.trigger).toBe('backfill')
       expect(finalRun.kind).toBe(RunKinds['traffic-sync'])
 
-      // The backfill pull walked the requested window with the large
-      // backfill page budget — not the probe's maxPages=1.
+      // The backfill drains the requested window with the per-sub-window
+      // page budget, not the probe's maxPages=1.
       const backfillCalls = observedWindows.filter((c) => c.maxPages !== 1)
       expect(backfillCalls.length).toBeGreaterThanOrEqual(1)
-      expect(backfillCalls[0]!.maxPages).toBe(1000)
+      expect(backfillCalls[0]!.maxPages).toBe(50)
       expect(backfillCalls[0]!.startDate).toBe(new Date(submitted.windowStart).getTime())
       expect(backfillCalls[0]!.endDate).toBe(new Date(submitted.windowEnd).getTime())
 
@@ -971,23 +967,25 @@ describe('POST /traffic/sources/:id/backfill — Vercel', () => {
     }
   })
 
-  it('fails the backfill run when the window overflows the page budget (hasMore=true)', async () => {
-    const baseTime = new Date(Date.now() - 60 * 60_000)
-    baseTime.setMinutes(0, 0, 0)
-    // The adapter reports hasMore=true — the window has more pages than the
-    // backfill budget could drain. Backfill is replace mode, so a truncated
-    // pull would delete the window's existing rollups and leave only a
-    // partial set; the run must fail instead of completing.
+  it('drains a backfill window that overflows the per-sub-window budget via sub-windows', async () => {
+    // The first (full-window) pull reports hasMore=true; the drain halves the
+    // span so the backfill completes instead of failing wholesale.
+    const observedAt = new Date(Date.now() - 2 * 86_400_000).toISOString()
+    let pullCount = 0
     const h = await buildHarness([], {
       vercelPullPages: ({ maxPages }) => {
         if (maxPages === 1) {
           return { events: [], rawEntryCount: 0, skippedEntryCount: 0, hasMore: false, endpoint: '' }
         }
+        pullCount += 1
+        if (pullCount === 1) {
+          return { events: [], rawEntryCount: 0, skippedEntryCount: 0, hasMore: true, endpoint: '' }
+        }
         return {
-          events: [buildVercelEvent({ eventId: 'vercel:bf:overflow:1', userAgent: 'GPTBot/1.0', path: '/x', observedAt: baseTime.toISOString() })],
+          events: [buildVercelEvent({ eventId: `vercel:bf:${pullCount}`, userAgent: 'GPTBot/1.0', path: '/x', observedAt })],
           rawEntryCount: 1,
           skippedEntryCount: 0,
-          hasMore: true,
+          hasMore: false,
           endpoint: '',
         }
       },
@@ -1004,16 +1002,9 @@ describe('POST /traffic/sources/:id/backfill — Vercel', () => {
       const submitted = JSON.parse(submitRes.payload)
 
       const finalRun = await waitForRunComplete(h.db, submitted.runId)
-      expect(finalRun.status).toBe(RunStatuses.failed)
-      expect(finalRun.error).toMatch(/page budget/)
-      expect(finalRun.error).toMatch(/--days/)
-
-      // Replace mode never ran — no rollup rows were written, and the
-      // source row carries the error.
-      expect(h.db.select().from(crawlerEventsHourly).all().length).toBe(0)
-      const sourceRow = h.db.select().from(trafficSources).where(eq(trafficSources.id, sourceId)).get()!
-      expect(sourceRow.status).toBe(TrafficSourceStatuses.error)
-      expect(sourceRow.lastError).toMatch(/page budget/)
+      expect(finalRun.status).toBe(RunStatuses.completed)
+      expect(pullCount).toBeGreaterThan(1)
+      expect(h.db.select().from(crawlerEventsHourly).all().length).toBeGreaterThan(0)
     } finally {
       await h.close()
     }

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.55.0",
+  "version": "4.55.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/integration-vercel/src/drain.ts
+++ b/packages/integration-vercel/src/drain.ts
@@ -1,0 +1,112 @@
+import type { NormalizedTrafficRequest, VercelTrafficEnvironment } from '@ainyc/canonry-contracts'
+
+import type { ListVercelTrafficEventsOptions, VercelTrafficEventsPage } from './types.js'
+
+/**
+ * Smallest sub-window the drain will attempt. If a slice this short still
+ * overflows the page budget, the window is pathologically dense and the drain
+ * gives up rather than spin.
+ */
+const MIN_SUB_WINDOW_MS = 60_000
+
+export interface DrainVercelTrafficEventsOptions {
+  /** Single-window pull — `listVercelTrafficEvents`, or a test double. */
+  pull: (options: ListVercelTrafficEventsOptions) => Promise<VercelTrafficEventsPage>
+  token: string
+  projectId: string
+  teamId: string
+  environment?: VercelTrafficEnvironment
+  /** Window bounds (epoch ms or Date). */
+  startDate: Date | number
+  endDate: Date | number
+  /** Page budget for each sub-window pull. */
+  pagesPerSubWindow: number
+  /** Hard cap on sub-window pulls before the drain gives up. */
+  maxSubWindows: number
+}
+
+export interface DrainVercelTrafficEventsResult {
+  events: NormalizedTrafficRequest[]
+  /** Number of sub-window pulls made, overflow retries included. */
+  subWindowCount: number
+}
+
+function toMs(value: Date | number): number {
+  return typeof value === 'number' ? value : value.getTime()
+}
+
+/**
+ * Drain a Vercel `request-logs` time window in adaptive sub-windows.
+ *
+ * Vercel paginates `request-logs` by page number with no resumable cursor, so
+ * a window holding more than `pagesPerSubWindow` pages cannot be pulled in one
+ * pass. Instead of failing, this narrows the time window: on overflow the span
+ * is halved and retried; after a clean drain the span doubles back up. Events
+ * are deduped by `eventId`, so the instant shared by adjacent sub-windows is
+ * never double-counted.
+ *
+ * Throws if a `MIN_SUB_WINDOW_MS` slice still overflows, or if `maxSubWindows`
+ * is reached before the window is fully drained.
+ */
+export async function drainVercelTrafficEvents(
+  options: DrainVercelTrafficEventsOptions,
+): Promise<DrainVercelTrafficEventsResult> {
+  const startMs = toMs(options.startDate)
+  const endMs = toMs(options.endDate)
+
+  const events: NormalizedTrafficRequest[] = []
+  const seenEventIds = new Set<string>()
+  if (endMs <= startMs) return { events, subWindowCount: 0 }
+
+  let cursorMs = startMs
+  let spanMs = endMs - startMs
+  let subWindowCount = 0
+
+  while (cursorMs < endMs) {
+    if (subWindowCount >= options.maxSubWindows) {
+      throw new Error(
+        `Vercel window not drained within ${options.maxSubWindows} sub-windows — narrow the time range`,
+      )
+    }
+
+    const subEndMs = Math.min(cursorMs + spanMs, endMs)
+    const page = await options.pull({
+      token: options.token,
+      projectId: options.projectId,
+      teamId: options.teamId,
+      environment: options.environment,
+      startDate: cursorMs,
+      endDate: subEndMs,
+      maxPages: options.pagesPerSubWindow,
+    })
+    subWindowCount += 1
+
+    if (page.hasMore) {
+      const subSpanMs = subEndMs - cursorMs
+      if (subSpanMs <= MIN_SUB_WINDOW_MS) {
+        throw new Error(
+          `Vercel window holds more than ${options.pagesPerSubWindow} pages within a `
+            + `${MIN_SUB_WINDOW_MS / 60_000}-minute slice — cannot subdivide further`,
+        )
+      }
+      // Sub-window still overflows: halve the span and retry from the same cursor.
+      spanMs = Math.max(Math.floor(subSpanMs / 2), MIN_SUB_WINDOW_MS)
+      continue
+    }
+
+    for (const event of page.events) {
+      if (!seenEventIds.has(event.eventId)) {
+        seenEventIds.add(event.eventId)
+        events.push(event)
+      }
+    }
+    cursorMs = subEndMs
+    // Clean drain: grow the span for the next stretch, capped at what is left.
+    const remainingMs = endMs - cursorMs
+    if (remainingMs > 0) {
+      spanMs = Math.min(spanMs * 2, remainingMs)
+    }
+  }
+
+  return { events, subWindowCount }
+}

--- a/packages/integration-vercel/src/index.ts
+++ b/packages/integration-vercel/src/index.ts
@@ -1,3 +1,4 @@
 export * from './client.js'
+export * from './drain.js'
 export * from './normalize.js'
 export type * from './types.js'

--- a/packages/integration-vercel/test/drain.test.ts
+++ b/packages/integration-vercel/test/drain.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import type { NormalizedTrafficRequest } from '@ainyc/canonry-contracts'
+
+import { drainVercelTrafficEvents } from '../src/drain.js'
+import type { ListVercelTrafficEventsOptions, VercelTrafficEventsPage } from '../src/types.js'
+
+const HOUR = 60 * 60_000
+
+function makeEvent(eventId: string): NormalizedTrafficRequest {
+  return {
+    sourceType: 'vercel',
+    evidenceKind: 'raw-request',
+    confidence: 'observed',
+    eventId,
+    observedAt: '2026-05-21T12:00:00.000Z',
+    method: 'GET',
+    requestUrl: 'https://example.com/',
+    host: 'example.com',
+    path: '/',
+    queryString: null,
+    status: 200,
+    userAgent: 'GPTBot/1.0',
+    remoteIp: null,
+    referer: null,
+    latencyMs: null,
+    requestSizeBytes: null,
+    responseSizeBytes: null,
+    providerResource: { type: 'vercel_deployment', labels: {} },
+    providerLabels: {},
+  }
+}
+
+function page(events: NormalizedTrafficRequest[], hasMore: boolean): VercelTrafficEventsPage {
+  return { events, rawEntryCount: events.length, skippedEntryCount: 0, hasMore, endpoint: '' }
+}
+
+const baseOptions = {
+  token: 't',
+  projectId: 'prj_x',
+  teamId: 'team_x',
+  pagesPerSubWindow: 50,
+  maxSubWindows: 1_000,
+}
+
+describe('drainVercelTrafficEvents', () => {
+  test('returns nothing for an empty window without pulling', async () => {
+    const pull = vi.fn(async () => page([], false))
+    const result = await drainVercelTrafficEvents({
+      ...baseOptions,
+      pull,
+      startDate: 1_000,
+      endDate: 1_000,
+    })
+    expect(result.events).toEqual([])
+    expect(result.subWindowCount).toBe(0)
+    expect(pull).not.toHaveBeenCalled()
+  })
+
+  test('drains a window that fits in a single pull', async () => {
+    const events = [makeEvent('a'), makeEvent('b')]
+    const pull = vi.fn(async () => page(events, false))
+    const result = await drainVercelTrafficEvents({
+      ...baseOptions,
+      pull,
+      startDate: 0,
+      endDate: 4 * HOUR,
+    })
+    expect(result.events).toEqual(events)
+    expect(result.subWindowCount).toBe(1)
+    expect(pull).toHaveBeenCalledTimes(1)
+  })
+
+  test('sub-divides a window that overflows the page budget', async () => {
+    // Any slice longer than one hour overflows; shorter slices drain cleanly,
+    // each emitting one event keyed to its start.
+    const pull = vi.fn(async (o: ListVercelTrafficEventsOptions) => {
+      const span = Number(o.endDate) - Number(o.startDate)
+      if (span > HOUR) return page([], true)
+      return page([makeEvent(`ev-${Number(o.startDate)}`)], false)
+    })
+    const result = await drainVercelTrafficEvents({
+      ...baseOptions,
+      pull,
+      startDate: 0,
+      endDate: 4 * HOUR,
+    })
+    expect(result.events.map((e) => e.eventId).sort()).toEqual(
+      [`ev-0`, `ev-${HOUR}`, `ev-${2 * HOUR}`, `ev-${3 * HOUR}`].sort(),
+    )
+    expect(result.subWindowCount).toBeGreaterThan(4)
+  })
+
+  test('deduplicates events shared across adjacent sub-windows', async () => {
+    // Every drained slice re-emits the same boundary event.
+    const pull = vi.fn(async (o: ListVercelTrafficEventsOptions) => {
+      const span = Number(o.endDate) - Number(o.startDate)
+      if (span > HOUR) return page([], true)
+      return page([makeEvent('shared-boundary')], false)
+    })
+    const result = await drainVercelTrafficEvents({
+      ...baseOptions,
+      pull,
+      startDate: 0,
+      endDate: 4 * HOUR,
+    })
+    expect(result.events).toHaveLength(1)
+    expect(result.events[0].eventId).toBe('shared-boundary')
+  })
+
+  test('throws when even a one-minute slice overflows the budget', async () => {
+    const pull = vi.fn(async () => page([], true))
+    await expect(
+      drainVercelTrafficEvents({ ...baseOptions, pull, startDate: 0, endDate: 4 * HOUR }),
+    ).rejects.toThrow(/minute slice/)
+  })
+
+  test('throws when the window is not drained within the sub-window cap', async () => {
+    const pull = vi.fn(async (o: ListVercelTrafficEventsOptions) => {
+      const span = Number(o.endDate) - Number(o.startDate)
+      if (span > HOUR) return page([], true)
+      return page([makeEvent(`ev-${Number(o.startDate)}`)], false)
+    })
+    await expect(
+      drainVercelTrafficEvents({
+        ...baseOptions,
+        pull,
+        maxSubWindows: 3,
+        startDate: 0,
+        endDate: 100 * HOUR,
+      }),
+    ).rejects.toThrow(/within 3 sub-windows/)
+  })
+})


### PR DESCRIPTION
## Summary

- A Vercel `request-logs` window with more pages than the per-pull budget could not be drained: the sync and backfill failed wholesale when the adapter still reported `hasMore`. A busy source (one bot crawl in the hour is enough) could never complete its first sync, so `lastSyncedAt` never advanced and it stayed permanently stuck.
- New `drainVercelTrafficEvents` (in `integration-vercel`) walks the window in **adaptive time sub-windows**: on overflow it halves the span and retries, after a clean drain it grows the span back, and it dedupes events by `eventId` across sub-window boundaries.
- The Vercel **sync** and **backfill** branches now drain through it. A dense window is covered in chunks instead of failing. It throws only when a one-minute slice still overflows, or when the sub-window cap (5,000) is exhausted.

This makes both Vercel sync paths robust:
- **Initial load:** `cnry traffic backfill <project> --source <id> --days 30` drains history in sub-windows.
- **Recurring:** a `cnry schedule --kind traffic-sync` run drains `[lastSyncedAt, now]` in sub-windows.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint` (0 errors), `pnpm test` (3270 tests pass)
- [x] Vitest: `drainVercelTrafficEvents` unit-tested (single-pull, sub-divide, dedup, both throw paths); the Vercel sync + backfill route tests cover draining an overflowing window
- [ ] Post-deploy: backfill gjelina-hotel, then validate the ingested rollups for consistency and accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)