### PR TITLE
fix(traffic): harden Vercel backfill drain (retention, dense minutes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.55.1",
+  "version": "4.55.2",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/traffic.ts
+++ b/packages/api-routes/src/traffic.ts
@@ -1324,6 +1324,20 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
           pagesPerSubWindow: vercelMaxPages,
           maxSubWindows: VERCEL_MAX_SUB_WINDOWS,
         })
+        if (drained.retentionClamped) {
+          // An idle source whose lastSyncedAt aged past Vercel's request-logs
+          // retention self-heals here: drain what is still served, advance the
+          // cursor, surface the gap rather than failing every sync forever.
+          app.log.warn(
+            {
+              sourceId: sourceRow.id,
+              requestedStart: windowStart.toISOString(),
+              servedStart: new Date(drained.effectiveStartMs).toISOString(),
+            },
+            'Vercel request-logs retention clamp: sync window predated plan retention; '
+              + 'ingested only the portion Vercel still serves',
+          )
+        }
         allEvents = drained.events
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e)
@@ -1816,6 +1830,26 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
           pagesPerSubWindow: vercelMaxPages,
           maxSubWindows: VERCEL_MAX_SUB_WINDOWS,
         })
+        if (drained.retentionClamped) {
+          // Requested more history than Vercel's plan retains. The drain
+          // clamped the start forward to what request-logs would serve, so
+          // the backfill succeeds with the available portion instead of
+          // failing on an opaque HTTP 400.
+          const servedDays = Math.round(
+            (windowEnd.getTime() - drained.effectiveStartMs) / 86_400_000,
+          )
+          app.log.warn(
+            {
+              sourceId: sourceRow.id,
+              requestedDays,
+              servedDays,
+              requestedStart: windowStart.toISOString(),
+              servedStart: new Date(drained.effectiveStartMs).toISOString(),
+            },
+            'Vercel request-logs retention clamp: backfill window predates plan retention; '
+              + 'ingested only the portion Vercel still serves',
+          )
+        }
         return drained.events
       }
     }

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.55.1",
+  "version": "4.55.2",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/integration-vercel/AGENTS.md
+++ b/packages/integration-vercel/AGENTS.md
@@ -37,7 +37,10 @@ with **no in-app instrumentation** required on the user's Vercel project.
   cursor, so a window denser than the page budget cannot be pulled in one
   pass. `drainVercelTrafficEvents` narrows the window into adaptive time
   slices — halving the span on page-budget overflow, doubling back up after a
-  clean slice — and dedupes by `eventId` across slice boundaries.
+  clean slice — and dedupes by `eventId` across slice boundaries. A slice that
+  still overflows at the `MIN_SUB_WINDOW_MS` floor is re-pulled once with the
+  larger `FLOOR_SLICE_MAX_PAGES` budget and drained whole, so a dense minute of
+  ordinary traffic no longer fails the backfill.
 - **Retention clamp.** Vercel rejects a window starting before the plan's
   `request-logs` retention with HTTP 400 `ExceedsBillingLimitError`.
   `drainVercelTrafficEvents` detects that, binary-searches the retention

--- a/packages/integration-vercel/AGENTS.md
+++ b/packages/integration-vercel/AGENTS.md
@@ -17,6 +17,7 @@ with **no in-app instrumentation** required on the user's Vercel project.
 | File | Role |
 |------|------|
 | `src/client.ts` | `listVercelTrafficEvents` — page-paginated `request-logs` pull, `VercelLogsApiError` |
+| `src/drain.ts` | `drainVercelTrafficEvents` — adaptive time-sub-window drain over a wide window; retention-clamps the start |
 | `src/normalize.ts` | `normalizeVercelLogRow` — converts a raw `request-logs` row into a `NormalizedTrafficRequest` |
 | `src/types.ts` | Adapter option/response shapes (`VercelRequestLogRow`, `ListVercelTrafficEventsOptions`, `VercelTrafficEventsPage`) |
 | `src/index.ts` | Re-exports public API |
@@ -32,6 +33,18 @@ with **no in-app instrumentation** required on the user's Vercel project.
   `page` and reports `hasMoreRows`. No push, no SaaS relay. Incremental syncs
   advance the time window (the `lastSyncedAt` timestamp is the cursor), not a
   page token.
+- **Adaptive sub-window drain.** Page-number pagination has no resumable
+  cursor, so a window denser than the page budget cannot be pulled in one
+  pass. `drainVercelTrafficEvents` narrows the window into adaptive time
+  slices — halving the span on page-budget overflow, doubling back up after a
+  clean slice — and dedupes by `eventId` across slice boundaries.
+- **Retention clamp.** Vercel rejects a window starting before the plan's
+  `request-logs` retention with HTTP 400 `ExceedsBillingLimitError`.
+  `drainVercelTrafficEvents` detects that, binary-searches the retention
+  boundary, clamps the start forward to what Vercel will serve, and flags the
+  result `retentionClamped` instead of failing the whole drain. A normal
+  recurring sync keeps the window small, so the clamp only fires on a wide
+  backfill or a long-idle source.
 - **Internal endpoint, defensively read.** `request-logs` is not the
   documented `api.vercel.com` REST API — it is the endpoint the official CLI
   uses. Every field read is optional and tolerated-missing; never assume a
@@ -69,8 +82,8 @@ with **no in-app instrumentation** required on the user's Vercel project.
 - `packages/integration-cloud-run/` / `packages/integration-wordpress-traffic/`
   — sibling pull adapters; mirror this file layout
 - `packages/api-routes/src/traffic.ts` — the consumer: `POST /traffic/connect/vercel`
-  + the `vercel` branch of the sync / backfill dispatchers. The sync route drains
-  the whole time window in one pass (page-number pagination has no resumable
-  cursor) and fails loudly if `hasMore` is still true rather than advancing
-  `lastSyncedAt` past un-pulled rows.
+  + the `vercel` branch of the sync / backfill dispatchers. Both drain via
+  `drainVercelTrafficEvents`, which sub-windows the span and retention-clamps
+  the start; the route logs a warning when `retentionClamped` is set so an
+  operator can see the requested window was trimmed.
 - `plans/server-side-ai-traffic-ingestion.md` — overall traffic plan

--- a/packages/integration-vercel/src/drain.ts
+++ b/packages/integration-vercel/src/drain.ts
@@ -4,11 +4,22 @@ import { VercelLogsApiError } from './client.js'
 import type { ListVercelTrafficEventsOptions, VercelTrafficEventsPage } from './types.js'
 
 /**
- * Smallest sub-window the drain will attempt. If a slice this short still
- * overflows the page budget, the window is pathologically dense and the drain
- * gives up rather than spin.
+ * Smallest sub-window the drain will subdivide a span down to. A slice this
+ * short that still overflows the normal page budget is re-pulled once with the
+ * larger `FLOOR_SLICE_MAX_PAGES` budget rather than failing (see the drain
+ * loop).
  */
 const MIN_SUB_WINDOW_MS = 60_000
+
+/**
+ * Page budget for a re-pull of a one-minute floor slice. When even a
+ * `MIN_SUB_WINDOW_MS` slice overflows the caller's normal `pagesPerSubWindow`
+ * budget, the drain cannot subdivide time any further, so it re-pulls that one
+ * slice with this larger budget and ingests it whole. A single minute of real
+ * request traffic is bounded, so this is deliberately generous headroom; a
+ * minute denser than this is pathological and fails loudly.
+ */
+const FLOOR_SLICE_MAX_PAGES = 1_000
 
 /**
  * Stop the retention-boundary binary search once the servable and unservable
@@ -141,8 +152,10 @@ async function resolveRetainedStart(
  * earliest instant Vercel will serve and the result is flagged
  * `retentionClamped`, rather than failing the whole drain.
  *
- * Throws if a `MIN_SUB_WINDOW_MS` slice still overflows, or if `maxSubWindows`
- * is reached before the window is fully drained.
+ * A `MIN_SUB_WINDOW_MS` slice that still overflows the normal page budget is
+ * re-pulled once with the larger `FLOOR_SLICE_MAX_PAGES` budget. Throws only if
+ * even that re-pull overflows, or if `maxSubWindows` is reached before the
+ * window is fully drained.
  */
 export async function drainVercelTrafficEvents(
   options: DrainVercelTrafficEventsOptions,
@@ -202,15 +215,33 @@ export async function drainVercelTrafficEvents(
 
     if (page.hasMore) {
       const subSpanMs = subEndMs - cursorMs
-      if (subSpanMs <= MIN_SUB_WINDOW_MS) {
+      if (subSpanMs > MIN_SUB_WINDOW_MS) {
+        // Sub-window still overflows: halve the span and retry from the same cursor.
+        spanMs = Math.max(Math.floor(subSpanMs / 2), MIN_SUB_WINDOW_MS)
+        continue
+      }
+      // The slice is already at the one-minute floor and the normal page budget
+      // still overflowed. Time cannot be sliced thinner, so re-pull this floor
+      // slice once with the much larger FLOOR_SLICE_MAX_PAGES budget and drain
+      // it whole. A single one-minute slice is bounded by real request volume,
+      // so the large budget is generous headroom; only a pathologically dense
+      // minute exceeds it, and that genuinely cannot be drained.
+      page = await options.pull({
+        token: options.token,
+        projectId: options.projectId,
+        teamId: options.teamId,
+        environment: options.environment,
+        startDate: cursorMs,
+        endDate: subEndMs,
+        maxPages: FLOOR_SLICE_MAX_PAGES,
+      })
+      subWindowCount += 1
+      if (page.hasMore) {
         throw new Error(
-          `Vercel window holds more than ${options.pagesPerSubWindow} pages within a `
-            + `${MIN_SUB_WINDOW_MS / 60_000}-minute slice — cannot subdivide further`,
+          `Vercel ${MIN_SUB_WINDOW_MS / 60_000}-minute slice holds more than `
+            + `${FLOOR_SLICE_MAX_PAGES} pages and cannot be drained further`,
         )
       }
-      // Sub-window still overflows: halve the span and retry from the same cursor.
-      spanMs = Math.max(Math.floor(subSpanMs / 2), MIN_SUB_WINDOW_MS)
-      continue
     }
 
     for (const event of page.events) {

--- a/packages/integration-vercel/src/drain.ts
+++ b/packages/integration-vercel/src/drain.ts
@@ -1,5 +1,6 @@
 import type { NormalizedTrafficRequest, VercelTrafficEnvironment } from '@ainyc/canonry-contracts'
 
+import { VercelLogsApiError } from './client.js'
 import type { ListVercelTrafficEventsOptions, VercelTrafficEventsPage } from './types.js'
 
 /**
@@ -8,6 +9,14 @@ import type { ListVercelTrafficEventsOptions, VercelTrafficEventsPage } from './
  * gives up rather than spin.
  */
 const MIN_SUB_WINDOW_MS = 60_000
+
+/**
+ * Stop the retention-boundary binary search once the servable and unservable
+ * probes are within this distance. The returned start is always on the
+ * servable side, so this only bounds the probe count (~10 for a 30-day
+ * window) and the slack of pre-retention data left undrained (≤ this much).
+ */
+const RETENTION_BOUNDARY_TOLERANCE_MS = 60 * 60_000
 
 export interface DrainVercelTrafficEventsOptions {
   /** Single-window pull — `listVercelTrafficEvents`, or a test double. */
@@ -29,10 +38,92 @@ export interface DrainVercelTrafficEventsResult {
   events: NormalizedTrafficRequest[]
   /** Number of sub-window pulls made, overflow retries included. */
   subWindowCount: number
+  /**
+   * Window start the drain actually pulled from (epoch ms). Equals the
+   * requested `startDate` unless `retentionClamped` is true.
+   */
+  effectiveStartMs: number
+  /**
+   * True when the requested window began before Vercel's `request-logs`
+   * retention ceiling. The start was clamped forward to the earliest instant
+   * Vercel would serve; `[effectiveStartMs, endDate]` is fully drained but the
+   * pre-retention remainder is unrecoverable — Vercel no longer holds it.
+   */
+  retentionClamped: boolean
 }
 
 function toMs(value: Date | number): number {
   return typeof value === 'number' ? value : value.getTime()
+}
+
+/**
+ * A retention rejection: Vercel answers HTTP 400 `ExceedsBillingLimitError`
+ * when the requested window starts before the plan's `request-logs` retention
+ * ceiling. Every other 400 (bad params, bad token) is a real error and must
+ * still surface, so the body is matched explicitly.
+ */
+function isRetentionError(error: unknown): boolean {
+  return (
+    error instanceof VercelLogsApiError
+    && error.status === 400
+    && (error.body ?? '').includes('ExceedsBillingLimitError')
+  )
+}
+
+/**
+ * Probe whether Vercel will serve a window starting at `windowStartMs`. A
+ * one-page pull is enough — a retention rejection lands on page 0. Returns
+ * `false` only on a retention rejection; every other error is rethrown.
+ */
+async function isServable(
+  options: DrainVercelTrafficEventsOptions,
+  windowStartMs: number,
+  windowEndMs: number,
+): Promise<boolean> {
+  try {
+    await options.pull({
+      token: options.token,
+      projectId: options.projectId,
+      teamId: options.teamId,
+      environment: options.environment,
+      startDate: windowStartMs,
+      endDate: windowEndMs,
+      maxPages: 1,
+    })
+    return true
+  } catch (error) {
+    if (isRetentionError(error)) return false
+    throw error
+  }
+}
+
+/**
+ * Find the earliest start Vercel will serve, given that `[unservableStartMs,
+ * endMs]` has already been rejected for retention. Binary-searches the
+ * boundary and returns a start on the servable side (within
+ * `RETENTION_BOUNDARY_TOLERANCE_MS`). Returns `endMs` when even the final
+ * minute of the window predates retention — nothing is drainable.
+ */
+async function resolveRetainedStart(
+  options: DrainVercelTrafficEventsOptions,
+  unservableStartMs: number,
+  endMs: number,
+): Promise<number> {
+  const tailStartMs = Math.max(unservableStartMs, endMs - MIN_SUB_WINDOW_MS)
+  if (!(await isServable(options, tailStartMs, endMs))) {
+    return endMs
+  }
+  let lo = unservableStartMs // predates retention
+  let hi = tailStartMs // within retention
+  while (hi - lo > RETENTION_BOUNDARY_TOLERANCE_MS) {
+    const mid = lo + Math.floor((hi - lo) / 2)
+    if (await isServable(options, mid, endMs)) {
+      hi = mid
+    } else {
+      lo = mid
+    }
+  }
+  return hi
 }
 
 /**
@@ -45,6 +136,11 @@ function toMs(value: Date | number): number {
  * are deduped by `eventId`, so the instant shared by adjacent sub-windows is
  * never double-counted.
  *
+ * If the requested window begins before Vercel's plan retention ceiling — the
+ * `ExceedsBillingLimitError` 400 — the start is clamped forward to the
+ * earliest instant Vercel will serve and the result is flagged
+ * `retentionClamped`, rather than failing the whole drain.
+ *
  * Throws if a `MIN_SUB_WINDOW_MS` slice still overflows, or if `maxSubWindows`
  * is reached before the window is fully drained.
  */
@@ -56,11 +152,16 @@ export async function drainVercelTrafficEvents(
 
   const events: NormalizedTrafficRequest[] = []
   const seenEventIds = new Set<string>()
-  if (endMs <= startMs) return { events, subWindowCount: 0 }
+  if (endMs <= startMs) {
+    return { events, subWindowCount: 0, effectiveStartMs: startMs, retentionClamped: false }
+  }
 
   let cursorMs = startMs
   let spanMs = endMs - startMs
   let subWindowCount = 0
+  let effectiveStartMs = startMs
+  let retentionClamped = false
+  let retentionResolved = false
 
   while (cursorMs < endMs) {
     if (subWindowCount >= options.maxSubWindows) {
@@ -70,15 +171,33 @@ export async function drainVercelTrafficEvents(
     }
 
     const subEndMs = Math.min(cursorMs + spanMs, endMs)
-    const page = await options.pull({
-      token: options.token,
-      projectId: options.projectId,
-      teamId: options.teamId,
-      environment: options.environment,
-      startDate: cursorMs,
-      endDate: subEndMs,
-      maxPages: options.pagesPerSubWindow,
-    })
+    let page: VercelTrafficEventsPage
+    try {
+      page = await options.pull({
+        token: options.token,
+        projectId: options.projectId,
+        teamId: options.teamId,
+        environment: options.environment,
+        startDate: cursorMs,
+        endDate: subEndMs,
+        maxPages: options.pagesPerSubWindow,
+      })
+    } catch (error) {
+      // The requested window predates Vercel's request-logs retention. This
+      // can only surface on the first pull — once the cursor is inside
+      // retention it only advances forward — so resolve the boundary once,
+      // clamp the cursor onto the servable side, and carry on.
+      if (isRetentionError(error) && !retentionResolved) {
+        retentionResolved = true
+        const retainedStartMs = await resolveRetainedStart(options, cursorMs, endMs)
+        retentionClamped = retainedStartMs > cursorMs
+        cursorMs = retainedStartMs
+        effectiveStartMs = retainedStartMs
+        spanMs = Math.max(endMs - cursorMs, MIN_SUB_WINDOW_MS)
+        continue
+      }
+      throw error
+    }
     subWindowCount += 1
 
     if (page.hasMore) {
@@ -108,5 +227,5 @@ export async function drainVercelTrafficEvents(
     }
   }
 
-  return { events, subWindowCount }
+  return { events, subWindowCount, effectiveStartMs, retentionClamped }
 }

--- a/packages/integration-vercel/test/drain.test.ts
+++ b/packages/integration-vercel/test/drain.test.ts
@@ -2,10 +2,20 @@ import { describe, expect, test, vi } from 'vitest'
 
 import type { NormalizedTrafficRequest } from '@ainyc/canonry-contracts'
 
+import { VercelLogsApiError } from '../src/client.js'
 import { drainVercelTrafficEvents } from '../src/drain.js'
 import type { ListVercelTrafficEventsOptions, VercelTrafficEventsPage } from '../src/types.js'
 
 const HOUR = 60 * 60_000
+
+/** A Vercel retention rejection — HTTP 400 with the `ExceedsBillingLimitError` body. */
+function retentionError(): VercelLogsApiError {
+  return new VercelLogsApiError(
+    'Vercel request-logs endpoint returned HTTP 400',
+    400,
+    '{"error":{"name":"ExceedsBillingLimitError","message":"Requested window exceeds plan retention"}}',
+  )
+}
 
 function makeEvent(eventId: string): NormalizedTrafficRequest {
   return {
@@ -130,5 +140,70 @@ describe('drainVercelTrafficEvents', () => {
         endDate: 100 * HOUR,
       }),
     ).rejects.toThrow(/within 3 sub-windows/)
+  })
+
+  test('clamps the start forward when the window predates Vercel retention', async () => {
+    const RETENTION_BOUNDARY = 40 * HOUR
+    // Vercel rejects any window starting before the retention boundary; a
+    // window starting at or after it drains cleanly with one event.
+    const pull = vi.fn(async (o: ListVercelTrafficEventsOptions) => {
+      if (Number(o.startDate) < RETENTION_BOUNDARY) throw retentionError()
+      return page([makeEvent(`ev-${Number(o.startDate)}`)], false)
+    })
+    const result = await drainVercelTrafficEvents({
+      ...baseOptions,
+      pull,
+      startDate: 0,
+      endDate: 100 * HOUR,
+    })
+    expect(result.retentionClamped).toBe(true)
+    // Clamped onto the servable side, within one tolerance step of the boundary.
+    expect(result.effectiveStartMs).toBeGreaterThanOrEqual(RETENTION_BOUNDARY)
+    expect(result.effectiveStartMs).toBeLessThan(RETENTION_BOUNDARY + HOUR)
+    // The drained window starts at the clamped start, not the requested 0.
+    expect(result.events).toHaveLength(1)
+    expect(result.events[0].eventId).toBe(`ev-${result.effectiveStartMs}`)
+  })
+
+  test('does not clamp when the whole window is within retention', async () => {
+    const events = [makeEvent('a'), makeEvent('b')]
+    const pull = vi.fn(async () => page(events, false))
+    const result = await drainVercelTrafficEvents({
+      ...baseOptions,
+      pull,
+      startDate: 5_000,
+      endDate: 5_000 + 4 * HOUR,
+    })
+    expect(result.retentionClamped).toBe(false)
+    expect(result.effectiveStartMs).toBe(5_000)
+    expect(result.events).toEqual(events)
+    // No retention probe on the happy path — the first pull is the only call.
+    expect(pull).toHaveBeenCalledTimes(1)
+  })
+
+  test('rethrows a non-retention 400 instead of clamping', async () => {
+    const pull = vi.fn(async () => {
+      throw new VercelLogsApiError('maxPages must be a positive integer', 400)
+    })
+    await expect(
+      drainVercelTrafficEvents({ ...baseOptions, pull, startDate: 0, endDate: 4 * HOUR }),
+    ).rejects.toThrow(/maxPages/)
+  })
+
+  test('drains nothing when the entire window predates retention', async () => {
+    // Every window — even the final minute — is rejected for retention.
+    const pull = vi.fn(async () => {
+      throw retentionError()
+    })
+    const result = await drainVercelTrafficEvents({
+      ...baseOptions,
+      pull,
+      startDate: 0,
+      endDate: 100 * HOUR,
+    })
+    expect(result.retentionClamped).toBe(true)
+    expect(result.effectiveStartMs).toBe(100 * HOUR)
+    expect(result.events).toEqual([])
+    expect(result.subWindowCount).toBe(0)
   })
 })

--- a/packages/integration-vercel/test/drain.test.ts
+++ b/packages/integration-vercel/test/drain.test.ts
@@ -118,11 +118,35 @@ describe('drainVercelTrafficEvents', () => {
     expect(result.events[0].eventId).toBe('shared-boundary')
   })
 
-  test('throws when even a one-minute slice overflows the budget', async () => {
+  test('drains a dense one-minute slice with the large floor page budget', async () => {
+    // Every pull at the normal 50-page budget overflows no matter how short the
+    // slice, so the drain narrows all the way to the one-minute floor. There it
+    // re-pulls with the larger floor budget, which drains the slice cleanly.
+    const MINUTE = 60_000
+    const pull = vi.fn(async (o: ListVercelTrafficEventsOptions) => {
+      if ((o.maxPages ?? 0) > baseOptions.pagesPerSubWindow) {
+        return page([makeEvent(`floor-${Number(o.startDate)}`)], false)
+      }
+      return page([], true)
+    })
+    const result = await drainVercelTrafficEvents({
+      ...baseOptions,
+      pull,
+      startDate: 0,
+      endDate: 3 * MINUTE,
+    })
+    expect(result.events.map((e) => e.eventId).sort()).toEqual(
+      [`floor-0`, `floor-${MINUTE}`, `floor-${2 * MINUTE}`].sort(),
+    )
+  })
+
+  test('throws only when a one-minute slice overflows even the floor budget', async () => {
+    // hasMore stays true regardless of maxPages, so even the large floor-budget
+    // re-pull cannot drain the slice and the drain genuinely gives up.
     const pull = vi.fn(async () => page([], true))
     await expect(
       drainVercelTrafficEvents({ ...baseOptions, pull, startDate: 0, endDate: 4 * HOUR }),
-    ).rejects.toThrow(/minute slice/)
+    ).rejects.toThrow(/cannot be drained further/)
   })
 
   test('throws when the window is not drained within the sub-window cap', async () => {


### PR DESCRIPTION
## Summary

Makes `cnry traffic backfill` actually complete for real Vercel sites. Two failure modes in the adaptive sub-window drain, both surfaced while backfilling a production client:

- **Retention ceiling.** A window starting before the plan's `request-logs` retention got a blunt HTTP 400 `ExceedsBillingLimitError`. The drain now detects that, binary-searches the retention boundary, clamps the start forward to what Vercel will serve, and flags the result `retentionClamped` instead of failing the whole drain.
- **Dense one-minute slices.** The drain narrows a window to a one-minute floor, then threw "cannot subdivide further" if that slice still overflowed the page budget. That budget (50 pages x 50 rows = 2,500 rows) counts every raw request-log row, not just crawler hits, so any real site has busy minutes past 2,500 rows. A 14-day backfill spans ~20,000 minutes, and one dense minute failed the whole all-or-nothing run. The floor slice is now re-pulled once with a large `FLOOR_SLICE_MAX_PAGES` (1,000) budget and drained whole.

The route logs a warning when `retentionClamped` is set so an operator can see the requested window was trimmed.

## Test plan

- [x] `drain.test.ts`: retention clamp forward / no-clamp / non-retention 400 rethrow / whole-window-predates-retention, plus dense-floor drain and the pathological floor-overflow throw
- [x] `pnpm exec vitest run packages/integration-vercel/`: 20 passed
- [x] `pnpm --filter @ainyc/canonry-integration-vercel typecheck` clean
- [ ] backfill a real Vercel source end to end once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)