### PR TITLE
chore(traffic): drop raw-sample stat from UI, correct Vercel IP docs

### DIFF
--- a/apps/web/src/pages/TrafficPage.tsx
+++ b/apps/web/src/pages/TrafficPage.tsx
@@ -149,7 +149,6 @@ function SourcesTable({ projectName, sources }: { projectName: string; sources: 
             <th className="px-4 py-2 text-right">24h crawler</th>
             <th className="px-4 py-2 text-right">24h AI hits</th>
             <th className="px-4 py-2 text-right">24h AI sessions</th>
-            <th className="px-4 py-2 text-right">24h samples</th>
             <th className="px-4 py-2 text-right" />
           </tr>
         </thead>
@@ -179,9 +178,6 @@ function SourcesTable({ projectName, sources }: { projectName: string; sources: 
               </td>
               <td className="px-4 py-3 text-right tabular-nums text-zinc-100">
                 {isLoading ? '—' : formatCompact(detail?.totals24h.aiReferralHits ?? 0)}
-              </td>
-              <td className="px-4 py-3 text-right tabular-nums text-zinc-300">
-                {isLoading ? '—' : formatCompact(detail?.totals24h.sampleCount ?? 0)}
               </td>
               <td className="px-4 py-3 text-right">
                 <Link

--- a/apps/web/src/pages/TrafficSourceDetailPage.tsx
+++ b/apps/web/src/pages/TrafficSourceDetailPage.tsx
@@ -326,7 +326,7 @@ export function TrafficSourceDetailPage() {
         <div className="rounded-md border border-emerald-800/50 bg-emerald-950/30 px-3 py-2 text-xs text-emerald-200">{syncResult}</div>
       ) : null}
 
-      <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         <ScoreGauge
           label="24h crawler hits"
           value={String(detail.totals24h.crawlerHits)}
@@ -353,15 +353,6 @@ export function TrafficSourceDetailPage() {
           description="Browser click-throughs from chatgpt.com, perplexity.ai, etc. (Referer / UTM evidence)."
           isNumeric
           progress={Math.min(100, Math.round((detail.totals24h.aiReferralHits / 1000) * 100))}
-        />
-        <ScoreGauge
-          label="24h sample rows"
-          value={String(detail.totals24h.sampleCount)}
-          delta="bounded per sync"
-          tone="neutral"
-          description="Per-request samples retained for evidence (capped to keep storage bounded)."
-          isNumeric
-          progress={Math.min(100, Math.round((detail.totals24h.sampleCount / 100) * 100))}
         />
       </section>
 

--- a/packages/integration-vercel/AGENTS.md
+++ b/packages/integration-vercel/AGENTS.md
@@ -43,8 +43,14 @@ with **no in-app instrumentation** required on the user's Vercel project.
   AI-referer detection happen in `packages/integration-traffic` alongside
   Cloud Run and WordPress events, so the classifier rule set evolves in one
   place.
-- **No client IP.** The endpoint does not expose a client IP, so `remoteIp` is
-  always `null` and Vercel events stay `claimed_unverified` in the classifier.
+- **No client IP from the pull endpoint.** `request-logs` does not expose a
+  client IP, so `remoteIp` is always `null` and Vercel crawler hits stay
+  `claimed_unverified` (UA-only) in the classifier. rDNS / IP-range
+  verification is impossible on this surface. Vercel only exposes the real
+  client IP via a **Configurable Log Drain** (`proxy.clientIp` in the
+  request-log payload), a push model (Vercel POSTs to an HTTPS receiver,
+  Pro/Enterprise plan only) that is not implemented here. Verified Vercel
+  hits would require building that receiver.
 - **Provider-neutral output.** Every adapter in the traffic stack emits the
   same `NormalizedTrafficRequest` shape from `@ainyc/canonry-contracts`. Do not
   leak Vercel-specific types past the package boundary.
@@ -74,3 +80,6 @@ with **no in-app instrumentation** required on the user's Vercel project.
   cursor) and fails loudly if `hasMore` is still true rather than advancing
   `lastSyncedAt` past un-pulled rows.
 - `plans/server-side-ai-traffic-ingestion.md` — overall traffic plan
+- Vercel Configurable Log Drains (`https://vercel.com/docs/drains`): the only
+  Vercel surface that exposes the client IP (`proxy.clientIp`). Relevant only
+  if verified Vercel crawler hits are ever required.

--- a/skills/canonry/references/server-side-traffic.md
+++ b/skills/canonry/references/server-side-traffic.md
@@ -243,7 +243,12 @@ domains, or PII are surfaced.
   rDNS-verified hits. Unverified bots claim a known UA but couldn't be
   cross-confirmed via reverse-DNS — they may be the real bot or an
   imitator. Don't promote unverified counts in client-facing copy.
-- **Two adapters shipped (Cloud Run + WordPress); more planned.** The
-  doctor checks and the report renderer are adapter-agnostic — adding
-  a new adapter is just a new entry in `traffic_sources.source_type`
-  and a `TrafficSourceValidator` registration.
+  **Vercel sources are a special case:** the Vercel pull API returns
+  no client IP, so every Vercel crawler hit is unverified by
+  construction (UA-only). A Vercel source reading 100% unverified is
+  expected, not a misconfiguration.
+- **Three adapters shipped (Cloud Run + WordPress + Vercel); more
+  planned.** The doctor checks and the report renderer are
+  adapter-agnostic — adding a new adapter is just a new entry in
+  `traffic_sources.source_type` and a `TrafficSourceValidator`
+  registration.


### PR DESCRIPTION
## Summary

- **Drop the `raw_event_samples` count from both UI surfaces** — the "24h sample rows" gauge on the traffic source detail page and the "24h samples" column on the `/traffic` sources list. It rendered beside real crawler/AI hit counts where it reads as a traffic metric, but it is a per-sync-capped internal buffer for classifier spot-checking and unknown-event reclassification, not a measurement. The DTO field (`totals24h.sampleCount`) and `cnry traffic status` are unchanged.
- **Correct the Vercel client-IP docs** (`packages/integration-vercel/AGENTS.md`) — the `request-logs` pull endpoint exposes no client IP, so Vercel crawler hits are UA-only and always `claimed_unverified`. A Configurable Log Drain *does* carry `proxy.clientIp`, but it is a push model (Pro/Enterprise plan) and is not implemented. Both are now documented, with a See Also link to Vercel's drains docs.
- **Skill reference fixes** (`skills/canonry/references/server-side-traffic.md`) — add a Vercel special-case note to the verified/unverified caveat (a Vercel source at 100% unverified is expected, not a misconfiguration) and fix the stale "two adapters shipped" line (Vercel is the third).
- No version bump: 15 non-doc lines changed, under the 100-line threshold.

## Test plan

- [x] `pnpm --filter @ainyc/canonry-web typecheck` passes
- [x] web lint clean (0 errors; 108 pre-existing warnings unchanged)
- [ ] Source detail page renders 3 gauges (crawler / AI fetches / AI sessions), grid no longer has a 4th tile
- [ ] `/traffic` sources table renders without the "24h samples" column, header and body column counts match

🤖 Generated with [Claude Code](https://claude.com/claude-code)