### PR TITLE
feat(runs): add --kind filter to the per-project runs endpoint

### DIFF
--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -2710,6 +2710,10 @@ export type GetApiV1ProjectsByNameRunsData = {
          * Maximum number of records to return.
          */
         limit?: number;
+        /**
+         * Restrict results to a single run kind. Without this filter, integration syncs (bing-inspect, gsc-sync, ga-sync) can fill the default 500-row cap within minutes on busy projects and push answer-visibility runs out of the response.
+         */
+        kind?: 'answer-visibility' | 'site-audit' | 'gsc-sync' | 'inspect-sitemap' | 'ga-sync' | 'bing-inspect' | 'bing-inspect-sitemap' | 'backlink-extract' | 'traffic-sync' | 'aeo-discover-seed' | 'aeo-discover-probe';
     };
     url: '/api/v1/projects/{name}/runs';
 };

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -772,7 +772,7 @@ const routeCatalog: OpenApiOperation[] = [
     path: '/api/v1/projects/{name}/runs',
     summary: 'List project runs',
     tags: ['runs'],
-    parameters: [nameParameter, limitQueryParameter],
+    parameters: [nameParameter, limitQueryParameter, runsListKindQueryParameter],
     responses: {
       200: jsonArrayResponse('Runs returned.', 'RunDto'),
     },

--- a/packages/api-routes/src/runs.ts
+++ b/packages/api-routes/src/runs.ts
@@ -199,24 +199,32 @@ export async function runRoutes(app: FastifyInstance, opts: RunRoutesOptions) {
   // GET /projects/:name/runs — list runs for project
   app.get<{
     Params: { name: string }
-    Querystring: { limit?: string }
+    Querystring: { limit?: string; kind?: string }
   }>('/projects/:name/runs', async (request, reply) => {
     const project = resolveProject(app.db, request.params.name)
 
     const parsedLimit = parseInt(request.query.limit ?? '', 10)
     const limit = Number.isNaN(parsedLimit) || parsedLimit <= 0 ? undefined : parsedLimit
 
+    // Per-URL integration runs (bing-inspect especially) can fill the limit
+    // window and push answer-visibility runs out — the same footgun GET /runs
+    // guards against. ?kind= scopes the list to the one kind a caller needs.
+    const kind = parseListKind(request.query.kind)
+    const where = kind
+      ? and(eq(runs.projectId, project.id), eq(runs.kind, kind))
+      : eq(runs.projectId, project.id)
+
     const rows = limit == null
       ? app.db
         .select()
         .from(runs)
-        .where(eq(runs.projectId, project.id))
+        .where(where)
         .orderBy(asc(runs.createdAt))
         .all()
       : app.db
         .select()
         .from(runs)
-        .where(eq(runs.projectId, project.id))
+        .where(where)
         .orderBy(desc(runs.createdAt))
         .limit(limit)
         .all()

--- a/packages/api-routes/test/runs-list-filters.test.ts
+++ b/packages/api-routes/test/runs-list-filters.test.ts
@@ -157,3 +157,35 @@ describe('GET /runs ?kind= filter', () => {
     expect(kinds.size).toBeGreaterThan(1) // both bing-inspect and answer-visibility
   })
 })
+
+describe('GET /projects/:name/runs ?kind= filter', () => {
+  it('?kind=answer-visibility surfaces AV runs the limit window would hide', async () => {
+    // limit=10 with 20 newer bing-inspect runs returns zero AV runs unfiltered.
+    const { body: unfiltered } = await get<Array<{ kind: string }>>(
+      `/api/v1/projects/runs-filter/runs?limit=10`,
+    )
+    expect(unfiltered.every(r => r.kind === 'bing-inspect')).toBe(true)
+
+    const { status, body } = await get<Array<{ id: string; kind: string }>>(
+      `/api/v1/projects/runs-filter/runs?limit=10&kind=answer-visibility`,
+    )
+    expect(status).toBe(200)
+    expect(body).toHaveLength(3)
+    expect(body.every(r => r.kind === 'answer-visibility')).toBe(true)
+    expect(new Set(body.map(r => r.id))).toEqual(new Set(ctx.answerVisibilityRunIds))
+  })
+
+  it('?kind=<unknown> returns 400 rather than a silently empty list', async () => {
+    const { status, body } = await get<{ error: { message?: string } }>(
+      `/api/v1/projects/runs-filter/runs?kind=not-a-real-kind`,
+    )
+    expect(status).toBe(400)
+    const err = body as unknown as { error: { message?: string } }
+    expect(err.error.message).toMatch(/kind/i)
+  })
+
+  it('empty ?kind= behaves like no filter', async () => {
+    const { body } = await get<Array<{ kind: string }>>(`/api/v1/projects/runs-filter/runs?kind=`)
+    expect(new Set(body.map(r => r.kind)).size).toBeGreaterThan(1)
+  })
+})

--- a/packages/canonry/src/cli-commands/run.ts
+++ b/packages/canonry/src/cli-commands/run.ts
@@ -92,19 +92,21 @@ export const RUN_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['runs'],
-    usage: 'canonry runs <project> [--limit <n>] [--format json]',
+    usage: 'canonry runs <project> [--limit <n>] [--kind <kind>] [--format json]',
     options: {
       limit: stringOption(),
+      kind: stringOption(),
     },
     run: async (input) => {
-      const project = requireProject(input, 'runs', 'canonry runs <project> [--limit <n>] [--format json]')
+      const project = requireProject(input, 'runs', 'canonry runs <project> [--limit <n>] [--kind <kind>] [--format json]')
       await listRuns(project, {
         format: input.format,
         limit: parseIntegerOption(input, 'limit', {
           command: 'runs',
-          usage: 'canonry runs <project> [--limit <n>] [--format json]',
+          usage: 'canonry runs <project> [--limit <n>] [--kind <kind>] [--format json]',
           message: '--limit must be an integer',
         }),
+        kind: getString(input.values, 'kind'),
       })
     },
   },

--- a/packages/canonry/src/client.ts
+++ b/packages/canonry/src/client.ts
@@ -125,6 +125,7 @@ import {
   deleteApiV1ProjectsByNameCompetitors,
   // Runs / timeline / history / snapshots
   getApiV1ProjectsByNameRuns,
+  type GetApiV1ProjectsByNameRunsData,
   postApiV1ProjectsByNameRuns,
   getApiV1ProjectsByNameRunsLatest,
   getApiV1RunsById,
@@ -832,9 +833,14 @@ export class ApiClient {
     )
   }
 
-  async listRuns(project: string, limit?: number): Promise<RunDto[]> {
+  async listRuns(project: string, limit?: number, kind?: string): Promise<RunDto[]> {
     return this.invoke<RunDto[]>(() =>
-      getApiV1ProjectsByNameRuns({ client: this.heyClient, path: { name: project }, query: { limit } }),
+      getApiV1ProjectsByNameRuns({
+        client: this.heyClient,
+        path: { name: project },
+        // kind arrives as a free CLI string; the server validates it against the enum.
+        query: { limit, kind } as GetApiV1ProjectsByNameRunsData['query'],
+      }),
     )
   }
 

--- a/packages/canonry/src/commands/run.ts
+++ b/packages/canonry/src/commands/run.ts
@@ -291,9 +291,9 @@ export async function showRun(id: string, format?: string): Promise<void> {
   printRunDetail(run)
 }
 
-export async function listRuns(project: string, opts?: { format?: string; limit?: number }): Promise<void> {
+export async function listRuns(project: string, opts?: { format?: string; limit?: number; kind?: string }): Promise<void> {
   const client = getClient()
-  const runs = await client.listRuns(project, opts?.limit) as Array<{
+  const runs = await client.listRuns(project, opts?.limit, opts?.kind) as Array<{
     id: string
     status: string
     kind: string


### PR DESCRIPTION
## Summary
- `GET /projects/:name/runs` and `cnry runs` gain an optional `kind` filter, mirroring the existing `GET /runs?kind=`.
- On busy projects, per-URL `bing-inspect` runs (one row per inspected URL) flood the run history and push `answer-visibility` runs past any `--limit` window, so a caller asking "what was the last sweep?" gets an empty answer. `?kind=answer-visibility` scopes the query so integration-sync noise can't hide real sweeps.
- Unknown `kind` values return 400 (validated against `RunKinds`) rather than a silently-empty list.

## Changes
- `GET /api/v1/projects/{name}/runs`: accept `?kind=`, reusing the existing `parseListKind` validator and `runsListKindQueryParameter` OpenAPI parameter.
- `cnry runs <project> --kind <kind>`: new CLI flag, plumbed through the client and command layers.
- API client SDK regenerated.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors
- [x] `pnpm test` — 3278 passed
- [x] New `runs-list-filters.test.ts` cases for the per-project endpoint: AV runs surface through a small limit window, unknown kind returns 400, empty kind applies no filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)