### PR TITLE
fix(traffic): handle all:true option in pinned DNS lookup for undici v7

### DIFF
--- a/packages/api-routes/src/traffic.ts
+++ b/packages/api-routes/src/traffic.ts
@@ -600,12 +600,19 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
     const { address, family } = check.target
     return new UndiciAgent({
       connect: {
-        lookup: (_hostname, _options, cb) => {
+        lookup: (_hostname, options, cb) => {
           // Always resolve to the pre-validated public IP, regardless of
           // what the OS resolver would return now. Closes the rebinding
           // TOCTOU between `resolveWebhookTarget` above and the fetch
           // performed inside the WordPress integration package.
-          cb(null, address, family === 6 ? 6 : 4)
+          //
+          // undici v7 passes `{ hints: 32, all: true }`; Node.js expects
+          // an array of `{ address, family }` objects when `all` is set.
+          if (options?.all) {
+            cb(null, [{ address, family: family === 6 ? 6 : 4 }])
+          } else {
+            cb(null, address, family === 6 ? 6 : 4)
+          }
         },
       },
     })


### PR DESCRIPTION
## Problem

WordPress traffic sync has been failing since the undici v6 → v7 upgrade with `fetch failed`.

## Root Cause

undici v7's `buildConnector` calls the DNS `lookup` function with `{ hints: 32, all: true }`. When `all: true` is set, Node.js expects the callback to receive an array of `{ address, family }` objects — not a plain `(address, family)` tuple.

The SSRF guard in `assertWordpressTargetAllowed` creates a pinned undici `Agent` that overrides DNS with a pre-resolved IP. The pinned `lookup` callback was written for undici v6 which didn't use `all: true`. In v7, this causes:

```
TypeError [ERR_INVALID_IP_ADDRESS]: Invalid IP address: undefined
```

Node.js tries to index into the returned string as if it were an array, gets `undefined`, and rejects.

## Fix

Check `options.all` in the lookup callback and return the array format when set:

```ts
if (options?.all) {
  cb(null, [{ address, family }])
} else {
  cb(null, address, family)
}
```

## Testing

- [x] Manual test: fetch with pinned Agent succeeds
- [x] Manual test: unpinned Agent (no connect option) still works
