### PR TITLE
fix(intelligence): label citation gains/regressions with the project's own domain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.55.2",
+  "version": "4.55.3",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.55.2",
+  "version": "4.55.3",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/citation-utils.ts
+++ b/packages/canonry/src/citation-utils.ts
@@ -7,6 +7,30 @@ function domainMatches(domain: string, canonicalDomain: string): boolean {
   return d === normalized || d.endsWith(`.${normalized}`)
 }
 
+/**
+ * Of the domains an engine cited for a (query, provider) snapshot, return the
+ * first that belongs to the project (canonical or owned domain), or `undefined`
+ * when none do.
+ *
+ * `citedDomains` is the FULL set of cited sources — project domains, tracked
+ * competitors, and third-party references intermingled in provider order. A
+ * project citation gain/regression must be labeled with the project's OWN
+ * cited URL, not `citedDomains[0]`, which is frequently a co-cited competitor
+ * (e.g. a regression on the project's page mislabeled "audit winntile.com").
+ * Returns `undefined` when the citation was established via a grounding-source
+ * match with no project domain present in `citedDomains` — better an empty
+ * target than a competitor's.
+ */
+export function pickProjectCitedDomain(
+  citedDomains: readonly string[],
+  projectDomains: string[],
+): string | undefined {
+  for (const cited of citedDomains) {
+    if (projectDomains.some(pd => domainMatches(cited, pd))) return cited
+  }
+  return undefined
+}
+
 export function determineCitationState(
   normalized: NormalizedQueryResult,
   domains: string[],

--- a/packages/canonry/src/intelligence-service.ts
+++ b/packages/canonry/src/intelligence-service.ts
@@ -3,9 +3,10 @@ import type { DatabaseClient } from '@ainyc/canonry-db'
 import { competitors, groupRunsByCreatedAt, gscSearchData, healthSnapshots, insights, projects, queries, querySnapshots, runs } from '@ainyc/canonry-db'
 import { analyzeRuns, classifyRegressionSeverity, PERSISTENT_GAP_THRESHOLD } from '@ainyc/canonry-intelligence'
 import type { RunData, Snapshot, AnalysisResult, Insight } from '@ainyc/canonry-intelligence'
-import { CitationStates, RunKinds, RunTriggers } from '@ainyc/canonry-contracts'
+import { CitationStates, RunKinds, RunTriggers, effectiveDomains } from '@ainyc/canonry-contracts'
 import crypto from 'node:crypto'
 import { createLogger } from './logger.js'
+import { pickProjectCitedDomain } from './citation-utils.js'
 
 const RECURRENCE_LOOKBACK_RUNS = 5
 /** Number of recent runs to load for persistent-gap detection. Must be >= PERSISTENT_GAP_THRESHOLD. */
@@ -585,6 +586,21 @@ export class IntelligenceService {
     completedAt: string,
     location: string | null = null,
   ): RunData {
+    // Project-owned domains, used to label a citation gain/regression with the
+    // project's OWN cited URL rather than `citedDomains[0]` (which is often a
+    // co-cited competitor). One PK lookup per run in the window.
+    const projectDomainRow = this.db
+      .select({ canonicalDomain: projects.canonicalDomain, ownedDomains: projects.ownedDomains })
+      .from(projects)
+      .where(eq(projects.id, projectId))
+      .get()
+    const projectDomains = projectDomainRow
+      ? effectiveDomains({
+          canonicalDomain: projectDomainRow.canonicalDomain,
+          ownedDomains: projectDomainRow.ownedDomains,
+        })
+      : []
+
     const rows = this.db
       .select({
         query: queries.query,
@@ -624,7 +640,9 @@ export class IntelligenceService {
         query: resolvedQuery,
         provider: r.provider,
         cited: r.citationState === CitationStates.cited,
-        citationUrl: domains[0] ?? undefined,
+        // The project's OWN cited domain — never a co-cited competitor that
+        // happens to sort first in the full citedDomains set.
+        citationUrl: pickProjectCitedDomain(domains, projectDomains),
         // Snapshots carry their own location for downstream detectors. In
         // practice every snapshot in a single runId shares the run's
         // location; the per-row column is the same value duplicated, but

--- a/packages/canonry/test/intelligence-service.test.ts
+++ b/packages/canonry/test/intelligence-service.test.ts
@@ -202,6 +202,77 @@ describe('IntelligenceService', () => {
       expect(result!.regressions[0]!.query).toBe('roof repair phoenix')
     })
 
+    it('labels a regression with the project domain, not a co-cited competitor', () => {
+      const { db } = createTempDb('intel-regression-label-')
+      const projectId = seedProject(db) // canonicalDomain: example.com
+
+      const queryId = seedQuery(db, projectId, 'roof repair phoenix')
+
+      // Run 1: project cited, but a competitor sorts first in the FULL
+      // citedDomains set (provider order, not project order).
+      const run1 = seedRun(db, projectId, 'completed', '2024-01-01T00:00:00Z')
+      seedSnapshot(db, run1, queryId, 'gemini', 'cited', {
+        citedDomains: ['winntile.com', 'example.com'],
+      })
+
+      // Run 2: project lost its citation.
+      const run2 = seedRun(db, projectId, 'completed', '2024-02-01T00:00:00Z')
+      seedSnapshot(db, run2, queryId, 'gemini', 'not-cited')
+
+      const service = new IntelligenceService(db)
+      const result = service.analyzeAndPersist(run2, projectId)
+
+      expect(result!.regressions).toHaveLength(1)
+      // The regression is real (project lost its own citation), and its target
+      // must be the project's page — never the co-cited competitor.
+      expect(result!.regressions[0]!.previousCitationUrl).toBe('example.com')
+
+      const regressionInsight = db.select().from(insights).all()
+        .find(i => i.type === 'regression')
+      expect(regressionInsight?.recommendation?.target).toBe('example.com')
+    })
+
+    it('labels a gain with the project domain, not a co-cited competitor', () => {
+      const { db } = createTempDb('intel-gain-label-')
+      const projectId = seedProject(db)
+      const queryId = seedQuery(db, projectId, 'roof repair phoenix')
+
+      const run1 = seedRun(db, projectId, 'completed', '2024-01-01T00:00:00Z')
+      seedSnapshot(db, run1, queryId, 'gemini', 'not-cited')
+
+      const run2 = seedRun(db, projectId, 'completed', '2024-02-01T00:00:00Z')
+      seedSnapshot(db, run2, queryId, 'gemini', 'cited', {
+        citedDomains: ['winntile.com', 'example.com'],
+      })
+
+      const service = new IntelligenceService(db)
+      const result = service.analyzeAndPersist(run2, projectId)
+
+      const gain = result!.gains.find(g => g.query === 'roof repair phoenix')
+      expect(gain?.citationUrl).toBe('example.com')
+    })
+
+    it('leaves citationUrl undefined when the project was cited via grounding only', () => {
+      const { db } = createTempDb('intel-grounding-label-')
+      const projectId = seedProject(db)
+      const queryId = seedQuery(db, projectId, 'roof repair phoenix')
+
+      // citationState is 'cited' (matched via a grounding source upstream), but
+      // no project domain is present in the stored citedDomains set — only a
+      // competitor. We must not borrow the competitor as the project's URL.
+      const run1 = seedRun(db, projectId, 'completed', '2024-01-01T00:00:00Z')
+      seedSnapshot(db, run1, queryId, 'gemini', 'cited', { citedDomains: ['winntile.com'] })
+
+      const run2 = seedRun(db, projectId, 'completed', '2024-02-01T00:00:00Z')
+      seedSnapshot(db, run2, queryId, 'gemini', 'not-cited')
+
+      const service = new IntelligenceService(db)
+      const result = service.analyzeAndPersist(run2, projectId)
+
+      expect(result!.regressions).toHaveLength(1)
+      expect(result!.regressions[0]!.previousCitationUrl).toBeUndefined()
+    })
+
     it('persists first-citation, provider-pickup, persistent-gap, and competitor signals', () => {
       const { db } = createTempDb('intel-signals-')
       const projectId = seedProject(db)


### PR DESCRIPTION
## Summary

A project citation **gain**/**regression** is correctly gated on `citationState === 'cited'` (the project's own domain appearing in the sources) — that part is fine. But the `citationUrl` carried into the resulting insight was `citedDomains[0]`:

```ts
// intelligence-service.ts buildRunData (before)
citationUrl: domains[0] ?? undefined,   // domains = the FULL citedDomains set
```

`citedDomains` is the full co-cited set in provider order — project domains, tracked competitors, and third-party references intermingled. When a competitor or third-party sorts ahead of the project's own domain, the insight's `recommendation.target` points at the **wrong site**: a genuine regression on the *project's* page surfaces as `audit winntile.com`.

The detection is right; only the labeled URL is wrong.

## Fix

`buildRunData` now resolves `Snapshot.citationUrl` through a new helper:

```ts
// citation-utils.ts
export function pickProjectCitedDomain(
  citedDomains: readonly string[],
  projectDomains: string[],
): string | undefined
```

It returns the first cited domain that matches the project's canonical or owned domains (reusing the existing `domainMatches` semantics), or `undefined` when the citation was established via a grounding-source match with **no** project domain in `citedDomains` — better an empty target than a competitor's. Project domains are loaded once per run in `buildRunData` via `effectiveDomains`.

The transition gate (`cited: r.citationState === CitationStates.cited`) is untouched.

## Tests

Three new `intelligence-service.test.ts` cases:

- **regression** with `citedDomains: ['winntile.com', 'example.com']` → `previousCitationUrl` and the persisted `recommendation.target` are `example.com`, not the competitor sorted first.
- **gain** with the same shape → `citationUrl` is `example.com`.
- **grounding-only** (`citationState: 'cited'`, `citedDomains: ['winntile.com']`, no project domain) → `previousCitationUrl` is `undefined`.

All existing intelligence-service tests use `citedDomains: ['example.com']` (project first), so they're unaffected.

## Test plan

- [x] `pnpm --filter @ainyc/canonry run typecheck`
- [x] `npx vitest run packages/canonry/test/intelligence-service.test.ts` — 31 passed (28 existing + 3 new)
- [x] Full `pnpm run test` — only 2 unrelated pre-existing failures remain (`packages/db/test/schedules-migration.test.ts`, which shells out to a `sqlite3` CLI binary absent from the sandbox; verified identical on clean `main`)
- [x] `eslint` clean on both changed source files (0 new warnings)
- [x] Version bump 4.55.2 → 4.55.3 (root + `@ainyc/canonry`)

## Context

Found while triaging a real project whose dashboard kept surfacing `audit <competitor>.com` recommendations for its own citation losses. Companion to #399 (the short-displayName matcher fix) — same investigation, different subsystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)