### PR TITLE
fix(integration-vercel): retry transient 5xx/429/network errors

### DIFF
--- a/packages/integration-vercel/AGENTS.md
+++ b/packages/integration-vercel/AGENTS.md
@@ -55,6 +55,16 @@ with **no in-app instrumentation** required on the user's Vercel project.
   backfill or a long-idle source. Consumers must treat `retentionClamped` as
   an incomplete pull unless explicitly accepting a gap; the API route rejects
   it so `lastSyncedAt` never advances across missing history.
+- **Transient-failure retry.** `listVercelTrafficEvents` retries each page
+  fetch on HTTP 429, HTTP 5xx, and raw network errors up to `maxRetries`
+  times (default 3) with exponential backoff (1s, 2s, 4s). A `Retry-After`
+  header on the failed response overrides the computed delay for that
+  attempt. 4xx errors other than 429 — `Unauthorized`, `Forbidden`, the
+  retention `400` `ExceedsBillingLimitError` — surface immediately so the
+  drain's retention-probe path and the caller see the real error instead of
+  waiting through the backoff. Critical for long backfills: a 13-day pull
+  makes thousands of page fetches, and an unretried single 5xx anywhere in
+  that run would force the whole replace-mode transaction to roll back.
 - **Internal endpoint, defensively read.** `request-logs` is not the
   documented `api.vercel.com` REST API — it is the endpoint the official CLI
   uses. Every field read is optional and tolerated-missing; never assume a

--- a/packages/integration-vercel/src/client.ts
+++ b/packages/integration-vercel/src/client.ts
@@ -9,16 +9,60 @@ const VERCEL_REQUEST_LOGS_URL = 'https://vercel.com/api/logs/request-logs'
 const DEFAULT_ENVIRONMENT = 'production'
 const DEFAULT_MAX_PAGES = 1
 const DEFAULT_TIMEOUT_MS = 30_000
+/**
+ * Retry transient pull failures (HTTP 429, 5xx, network errors) up to this
+ * many times before giving up. A 13-day backfill makes thousands of pulls;
+ * one unretried 5xx anywhere in that run would otherwise force the whole
+ * replace-mode transaction to roll back. Mirrors the GA4 client retry shape.
+ */
+const DEFAULT_MAX_RETRIES = 3
+/** First backoff before retrying. Doubles each attempt (1s, 2s, 4s). */
+const DEFAULT_INITIAL_RETRY_DELAY_MS = 1_000
 
 export class VercelLogsApiError extends Error {
   constructor(
     message: string,
     public readonly status: number,
     public readonly body?: string,
+    /** Seconds parsed from the `Retry-After` header, if Vercel sent one. */
+    public readonly retryAfterSeconds?: number,
   ) {
     super(message)
     this.name = 'VercelLogsApiError'
   }
+}
+
+/**
+ * Parse `Retry-After` per RFC 7231 §7.1.3: either a delay-seconds integer
+ * or an HTTP-date. Returns the delay in seconds, or `undefined` if the
+ * header is absent or unparseable.
+ */
+function parseRetryAfter(headerValue: string | null): number | undefined {
+  if (!headerValue) return undefined
+  const trimmed = headerValue.trim()
+  const asNum = Number(trimmed)
+  if (Number.isFinite(asNum) && asNum >= 0) return asNum
+  const asDate = Date.parse(trimmed)
+  if (!Number.isNaN(asDate)) {
+    return Math.max(0, (asDate - Date.now()) / 1000)
+  }
+  return undefined
+}
+
+/**
+ * A transient failure is one a retry has a chance of recovering from:
+ * - `VercelLogsApiError` with HTTP 429 (rate limit) or 5xx (server-side)
+ * - any non-Vercel error (network failure, `fetch` rejection, abort/timeout)
+ *
+ * 4xx other than 429 — `Unauthorized`, `Forbidden`, retention `400`, bad
+ * params — are caller-fixable and surface immediately so the operator sees
+ * the real cause instead of waiting through the backoff schedule.
+ */
+function isRetryableVercelError(error: unknown): boolean {
+  if (error instanceof VercelLogsApiError) {
+    return error.status === 429 || error.status >= 500
+  }
+  return true
 }
 
 function trimRequired(name: string, value: string): string {
@@ -56,6 +100,41 @@ async function readErrorBody(response: Response): Promise<string | undefined> {
 }
 
 /**
+ * Wrap a single fetch+parse attempt with exponential-backoff retry on
+ * transient failures (`isRetryableVercelError`). Up to `maxRetries` retries
+ * (total attempts capped at `maxRetries + 1`), with backoff doubling each
+ * attempt. A `Retry-After` header on the error overrides the computed backoff
+ * for that attempt. The final failure is rethrown unchanged so callers see
+ * the real underlying error.
+ */
+async function withVercelRetry<T>(
+  attempt: () => Promise<T>,
+  maxRetries: number,
+  initialDelayMs: number,
+): Promise<T> {
+  let lastError: unknown
+  for (let attemptNumber = 0; attemptNumber <= maxRetries; attemptNumber += 1) {
+    try {
+      return await attempt()
+    } catch (error) {
+      lastError = error
+      if (attemptNumber >= maxRetries || !isRetryableVercelError(error)) throw error
+      const retryAfterSeconds = error instanceof VercelLogsApiError
+        ? error.retryAfterSeconds
+        : undefined
+      const computedDelayMs = initialDelayMs * Math.pow(2, attemptNumber)
+      const delayMs = retryAfterSeconds !== undefined
+        ? Math.max(0, retryAfterSeconds * 1_000)
+        : computedDelayMs
+      if (delayMs > 0) {
+        await new Promise<void>((resolve) => setTimeout(resolve, delayMs))
+      }
+    }
+  }
+  throw lastError
+}
+
+/**
  * Pull a page (or up to `maxPages` pages) of request logs from Vercel's
  * internal `request-logs` endpoint — the same endpoint the `vercel` CLI rides
  * — normalize each row into `NormalizedTrafficRequest`, and return the merged
@@ -75,6 +154,8 @@ export async function listVercelTrafficEvents(
   const endDate = toEpochMs('endDate', options.endDate)
   const maxPages = normalizeMaxPages(options.maxPages)
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES
+  const initialRetryDelayMs = options.initialRetryDelayMs ?? DEFAULT_INITIAL_RETRY_DELAY_MS
 
   let rawEntryCount = 0
   let skippedEntryCount = 0
@@ -91,25 +172,33 @@ export async function listVercelTrafficEvents(
     url.searchParams.set('endDate', endDate)
     url.searchParams.set('environment', environment)
 
-    const response = await fetch(url, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: 'application/json',
-      },
-      signal: AbortSignal.timeout(timeoutMs),
-    })
+    // One fetch+parse pass, wrapped in retry so a transient 429/5xx/network
+    // hiccup does not kill a multi-hour drain that has already pulled
+    // thousands of pages successfully.
+    const body = await withVercelRetry(async () => {
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/json',
+        },
+        signal: AbortSignal.timeout(timeoutMs),
+      })
 
-    if (!response.ok) {
-      const body = await readErrorBody(response)
-      throw new VercelLogsApiError(
-        `Vercel request-logs endpoint returned HTTP ${response.status}`,
-        response.status,
-        body,
-      )
-    }
+      if (!response.ok) {
+        const errorBody = await readErrorBody(response)
+        const retryAfterSeconds = parseRetryAfter(response.headers.get('retry-after'))
+        throw new VercelLogsApiError(
+          `Vercel request-logs endpoint returned HTTP ${response.status}`,
+          response.status,
+          errorBody,
+          retryAfterSeconds,
+        )
+      }
 
-    const body = (await response.json()) as VercelRequestLogsResponseBody
+      return (await response.json()) as VercelRequestLogsResponseBody
+    }, maxRetries, initialRetryDelayMs)
+
     const rows = body.rows ?? []
     rawEntryCount += rows.length
 

--- a/packages/integration-vercel/src/types.ts
+++ b/packages/integration-vercel/src/types.ts
@@ -60,6 +60,18 @@ export interface ListVercelTrafficEventsOptions {
   /** Max pages to walk (the endpoint paginates by `page`). Defaults to 1. */
   maxPages?: number
   timeoutMs?: number
+  /**
+   * Max retry attempts on transient failures (HTTP 429, 5xx, network errors).
+   * Defaults to 3 — total attempts capped at `maxRetries + 1`. Set to 0 to
+   * disable retry entirely (mirrors the pre-retry behavior).
+   */
+  maxRetries?: number
+  /**
+   * Initial backoff before the first retry. Doubles each subsequent attempt
+   * (1s, 2s, 4s …). A `Retry-After` header from Vercel overrides this for
+   * the corresponding attempt. Defaults to 1000ms.
+   */
+  initialRetryDelayMs?: number
 }
 
 export interface VercelTrafficEventsPage {

--- a/packages/integration-vercel/test/vercel-client.test.ts
+++ b/packages/integration-vercel/test/vercel-client.test.ts
@@ -209,4 +209,177 @@ describe('listVercelTrafficEvents', () => {
     expect(result.skippedEntryCount).toBe(1)
     expect(result.events).toHaveLength(1)
   })
+
+  /**
+   * Retry-on-transient is the difference between a 73-minute backfill that
+   * recovers from one Vercel 502 mid-flight and one that throws all its work
+   * away at the replace-mode rollback. The cases below pin the contract so a
+   * future refactor can't silently remove that resilience.
+   */
+  describe('transient-failure retry', () => {
+    const successPayload = () => new Response(
+      JSON.stringify({ rows: [statusZeroRow], hasMoreRows: false }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )
+
+    function makeFetch(responses: Array<Response | Error>): () => Promise<Response> {
+      let i = 0
+      return async () => {
+        const next = responses[i++]
+        if (!next) throw new Error('test fetch ran out of scripted responses')
+        if (next instanceof Error) throw next
+        return next
+      }
+    }
+
+    it('retries on HTTP 502 and returns the eventual success', async () => {
+      fetchSpy.mockImplementation(makeFetch([
+        new Response('upstream broken', { status: 502 }),
+        new Response('upstream broken', { status: 502 }),
+        successPayload(),
+      ]))
+
+      const result = await listVercelTrafficEvents({
+        token: 'vcp_test',
+        projectId: 'prj_abc',
+        teamId: 'team_xyz',
+        startDate: 0,
+        endDate: 1,
+        initialRetryDelayMs: 0,
+      })
+      expect(fetchSpy).toHaveBeenCalledTimes(3)
+      expect(result.events).toHaveLength(1)
+    })
+
+    it('retries on HTTP 503 and 429 too', async () => {
+      fetchSpy.mockImplementation(makeFetch([
+        new Response('service unavailable', { status: 503 }),
+        new Response('too many requests', { status: 429 }),
+        successPayload(),
+      ]))
+
+      const result = await listVercelTrafficEvents({
+        token: 'vcp_test',
+        projectId: 'prj_abc',
+        teamId: 'team_xyz',
+        startDate: 0,
+        endDate: 1,
+        initialRetryDelayMs: 0,
+      })
+      expect(fetchSpy).toHaveBeenCalledTimes(3)
+      expect(result.events).toHaveLength(1)
+    })
+
+    it('honors Retry-After when shorter than the computed backoff', async () => {
+      fetchSpy.mockImplementation(makeFetch([
+        new Response('rate limited', {
+          status: 429,
+          headers: { 'Retry-After': '0' },
+        }),
+        successPayload(),
+      ]))
+
+      // No need to mock timing; Retry-After=0 short-circuits any sleep.
+      await listVercelTrafficEvents({
+        token: 'vcp_test',
+        projectId: 'prj_abc',
+        teamId: 'team_xyz',
+        startDate: 0,
+        endDate: 1,
+        // Set a huge initialRetryDelayMs to prove Retry-After overrides it —
+        // if the override were broken this test would hang for ~60s.
+        initialRetryDelayMs: 60_000,
+      })
+      expect(fetchSpy).toHaveBeenCalledTimes(2)
+    })
+
+    it('retries on a network error from fetch itself', async () => {
+      fetchSpy.mockImplementation(makeFetch([
+        new TypeError('fetch failed'),
+        successPayload(),
+      ]))
+
+      const result = await listVercelTrafficEvents({
+        token: 'vcp_test',
+        projectId: 'prj_abc',
+        teamId: 'team_xyz',
+        startDate: 0,
+        endDate: 1,
+        initialRetryDelayMs: 0,
+      })
+      expect(fetchSpy).toHaveBeenCalledTimes(2)
+      expect(result.events).toHaveLength(1)
+    })
+
+    it('does NOT retry on 4xx auth/permission errors', async () => {
+      fetchSpy.mockImplementation(async () => new Response('forbidden', { status: 403 }))
+
+      const error = await listVercelTrafficEvents({
+        token: 'vcp_bad',
+        projectId: 'prj_abc',
+        teamId: 'team_xyz',
+        startDate: 0,
+        endDate: 1,
+        initialRetryDelayMs: 0,
+      }).catch((err: unknown) => err)
+      expect(error).toBeInstanceOf(VercelLogsApiError)
+      expect((error as VercelLogsApiError).status).toBe(403)
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('does NOT retry on a retention 400 (ExceedsBillingLimitError)', async () => {
+      // The drain.ts retention probe relies on this — a retried retention 400
+      // would multiply probe cost by 4x and slow the backfill noticeably.
+      fetchSpy.mockImplementation(async () => new Response(
+        '{"error":{"name":"ExceedsBillingLimitError","message":"out of retention"}}',
+        { status: 400 },
+      ))
+
+      const error = await listVercelTrafficEvents({
+        token: 'vcp_test',
+        projectId: 'prj_abc',
+        teamId: 'team_xyz',
+        startDate: 0,
+        endDate: 1,
+        initialRetryDelayMs: 0,
+      }).catch((err: unknown) => err)
+      expect(error).toBeInstanceOf(VercelLogsApiError)
+      expect((error as VercelLogsApiError).status).toBe(400)
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('gives up after maxRetries+1 attempts and rethrows the last error', async () => {
+      fetchSpy.mockImplementation(async () => new Response('upstream broken', { status: 502 }))
+
+      const error = await listVercelTrafficEvents({
+        token: 'vcp_test',
+        projectId: 'prj_abc',
+        teamId: 'team_xyz',
+        startDate: 0,
+        endDate: 1,
+        maxRetries: 2,
+        initialRetryDelayMs: 0,
+      }).catch((err: unknown) => err)
+      expect(error).toBeInstanceOf(VercelLogsApiError)
+      expect((error as VercelLogsApiError).status).toBe(502)
+      // maxRetries=2 means 1 initial + 2 retries = 3 attempts total.
+      expect(fetchSpy).toHaveBeenCalledTimes(3)
+    })
+
+    it('disables retry entirely when maxRetries=0', async () => {
+      fetchSpy.mockImplementation(async () => new Response('upstream broken', { status: 502 }))
+
+      const error = await listVercelTrafficEvents({
+        token: 'vcp_test',
+        projectId: 'prj_abc',
+        teamId: 'team_xyz',
+        startDate: 0,
+        endDate: 1,
+        maxRetries: 0,
+        initialRetryDelayMs: 0,
+      }).catch((err: unknown) => err)
+      expect(error).toBeInstanceOf(VercelLogsApiError)
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

A 13-day backfill on the new sub-second drain made it through **~73 minutes** of pulls then died on a single Vercel HTTP 502. Replace-mode rollback threw all the work away — \`lastSyncedAt\` unchanged, no rollups committed. The mechanism: \`listVercelTrafficEvents\` did one \`fetch\` per page with no retry, so any transient anywhere in a long backfill killed the whole run.

This adds exponential-backoff retry inside the client, mirroring the GA4 client shape.

## What retries

| Failure | Retried? | Why |
|---|---|---|
| HTTP 5xx | ✅ | Vercel-side hiccup, recovers in seconds |
| HTTP 429 | ✅ | Rate limit; honors \`Retry-After\` if sent |
| Network error (fetch throws, abort/timeout) | ✅ | Transport-level transient |
| HTTP 401 / 403 | ❌ | Caller-fixable; retry just delays the real signal |
| HTTP 400 retention (\`ExceedsBillingLimitError\`) | ❌ | The drain's retention-probe relies on this being immediate; 4× slower without |
| HTTP 400 other (bad params) | ❌ | Caller-fixable |

## Backoff

- Defaults: \`maxRetries=3\`, \`initialRetryDelayMs=1000\` (1s, 2s, 4s)
- \`Retry-After\` header (numeric or HTTP-date) overrides the computed delay for that attempt
- Final failure rethrown unchanged so the caller sees the real underlying error

## Test coverage

8 new tests pin the contract:

- retries on HTTP 502 / 503 / 429 / network error
- honors \`Retry-After\` (set to 0, paired with a 60s \`initialRetryDelayMs\` — test would hang for a minute if the override were broken)
- does NOT retry on 403 (auth) or 400 with \`ExceedsBillingLimitError\` (retention)
- gives up after \`maxRetries+1\` attempts and rethrows the final error
- \`maxRetries=0\` disables retry entirely (preserves pre-PR behavior as an opt-out)

## No caller changes

\`drainVercelTrafficEvents\` and \`packages/api-routes/src/traffic.ts\` use the defaults — retry is fully transparent to them.

## Validation

- [x] 3295/3295 workspace tests pass
- [x] typecheck + lint clean
- [ ] Deploy + re-run the gjelina-hotel 13-day backfill (the original failure case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)