### PR TITLE
feat(web): conditional follow scroll for Aero transcript

### DIFF
--- a/apps/web/src/components/shared/AeroBar.tsx
+++ b/apps/web/src/components/shared/AeroBar.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { useChatScroll } from '../../lib/use-chat-scroll.js'
 import {
   Sparkles,
   X,
@@ -162,7 +163,7 @@ export function AeroBar({ projectName }: AeroBarProps) {
     return stored === 'all' ? 'all' : 'read-only'
   })
   const abortRef = useRef<AbortController | null>(null)
-  const transcriptRef = useRef<HTMLDivElement | null>(null)
+  const { ref: transcriptRef } = useChatScroll<HTMLDivElement>([messages, streamingText, liveTrail])
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const [paletteIndex, setPaletteIndex] = useState(0)
 
@@ -284,12 +285,6 @@ export function AeroBar({ projectName }: AeroBarProps) {
       abortRef.current?.abort()
     }
   }, [projectName])
-
-  // Auto-scroll to the bottom on new messages / streaming tokens.
-  useEffect(() => {
-    const el = transcriptRef.current
-    if (el) el.scrollTop = el.scrollHeight
-  }, [messages, streamingText, liveTrail])
 
   async function send(promptText: string) {
     const trimmed = promptText.trim()

--- a/apps/web/src/lib/use-chat-scroll.ts
+++ b/apps/web/src/lib/use-chat-scroll.ts
@@ -1,0 +1,85 @@
+import { useEffect, useLayoutEffect, useRef, type RefObject } from 'react'
+
+/**
+ * Scroll physics for chat-style transcripts. Mirrors the behavior described
+ * in the TanStack Virtual Chat blog post — end-anchored, conditional follow,
+ * stable through streaming growth — without pulling the dependency.
+ *
+ * The caller passes `deps` (typically the message list and any streaming
+ * state). When those change, if the user was already at the bottom we pin
+ * to the new bottom; if they had scrolled up, we leave the viewport alone.
+ * A `ResizeObserver` covers height changes that don't come through React
+ * deps (markdown reflow, image loads, late font metrics).
+ */
+export interface UseChatScrollOptions {
+  /** Pixels from the bottom within which the user counts as "at end". */
+  threshold?: number
+}
+
+export interface UseChatScrollResult<T extends HTMLElement> {
+  ref: RefObject<T | null>
+  scrollToEnd: () => void
+  isAtEnd: () => boolean
+}
+
+export function useChatScroll<T extends HTMLElement = HTMLDivElement>(
+  deps: ReadonlyArray<unknown>,
+  options: UseChatScrollOptions = {},
+): UseChatScrollResult<T> {
+  const { threshold = 80 } = options
+  const ref = useRef<T | null>(null)
+  const state = useRef({ scrollHeight: 0, wasAtEnd: true })
+
+  function distanceFromEnd(el: HTMLElement): number {
+    return el.scrollHeight - el.scrollTop - el.clientHeight
+  }
+
+  function isAtEnd(): boolean {
+    const el = ref.current
+    if (!el) return true
+    return distanceFromEnd(el) <= threshold
+  }
+
+  function scrollToEnd(): void {
+    const el = ref.current
+    if (!el) return
+    el.scrollTop = el.scrollHeight
+    state.current.wasAtEnd = true
+    state.current.scrollHeight = el.scrollHeight
+  }
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const onScroll = (): void => {
+      state.current.wasAtEnd = distanceFromEnd(el) <= threshold
+    }
+    el.addEventListener('scroll', onScroll, { passive: true })
+    return () => el.removeEventListener('scroll', onScroll)
+  }, [threshold])
+
+  useLayoutEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const newHeight = el.scrollHeight
+    const grew = newHeight > state.current.scrollHeight
+    if (grew && state.current.wasAtEnd) el.scrollTop = newHeight
+    state.current.scrollHeight = newHeight
+  }, deps)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el || typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(() => {
+      const newHeight = el.scrollHeight
+      const grew = newHeight > state.current.scrollHeight
+      if (grew && state.current.wasAtEnd) el.scrollTop = newHeight
+      state.current.scrollHeight = newHeight
+    })
+    observer.observe(el)
+    if (el.firstElementChild) observer.observe(el.firstElementChild)
+    return () => observer.disconnect()
+  }, [])
+
+  return { ref, scrollToEnd, isAtEnd }
+}

--- a/apps/web/test/use-chat-scroll.test.tsx
+++ b/apps/web/test/use-chat-scroll.test.tsx
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { useEffect } from 'react'
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
+import { useChatScroll, type UseChatScrollResult } from '../src/lib/use-chat-scroll.js'
+
+afterEach(() => cleanup())
+
+// JSDOM doesn't compute layout, so scrollHeight/clientHeight/scrollTop are all
+// zero by default. We install per-element accessors so the hook's distance
+// math has values to work against. Returns a small handle for the test to
+// mutate content height and read the latest scrollTop.
+function stubScrollMetrics(
+  el: HTMLElement,
+  init: { scrollHeight: number; clientHeight: number; scrollTop?: number },
+): { setHeight: (h: number) => void; getScrollTop: () => number; scrollTo: (top: number) => void } {
+  let scrollHeight = init.scrollHeight
+  let scrollTop = init.scrollTop ?? 0
+  Object.defineProperty(el, 'scrollHeight', { configurable: true, get: () => scrollHeight })
+  Object.defineProperty(el, 'clientHeight', { configurable: true, get: () => init.clientHeight })
+  Object.defineProperty(el, 'scrollTop', {
+    configurable: true,
+    get: () => scrollTop,
+    set: (v: number) => {
+      scrollTop = v
+    },
+  })
+  return {
+    setHeight: (h: number) => {
+      scrollHeight = h
+    },
+    getScrollTop: () => scrollTop,
+    scrollTo: (top: number) => {
+      scrollTop = top
+      fireEvent.scroll(el)
+    },
+  }
+}
+
+function Harness({
+  deps,
+  onApi,
+}: {
+  deps: ReadonlyArray<unknown>
+  onApi: (api: UseChatScrollResult<HTMLDivElement>) => void
+}): JSX.Element {
+  const api = useChatScroll<HTMLDivElement>(deps)
+  useEffect(() => {
+    onApi(api)
+  })
+  return <div ref={api.ref} data-testid="scroller" />
+}
+
+describe('useChatScroll', () => {
+  it('pins to the new bottom when content grows and the user was at end', () => {
+    let api: UseChatScrollResult<HTMLDivElement> | null = null
+    const { rerender, getByTestId } = render(<Harness deps={[0]} onApi={(a) => (api = a)} />)
+    const el = getByTestId('scroller')
+    // 200px tall content in a 200px viewport — at the bottom by default.
+    const ctrl = stubScrollMetrics(el, { scrollHeight: 200, clientHeight: 200 })
+
+    // Trigger a deps-driven re-render that "grows" the transcript.
+    ctrl.setHeight(600)
+    act(() => {
+      rerender(<Harness deps={[1]} onApi={(a) => (api = a)} />)
+    })
+
+    expect(ctrl.getScrollTop()).toBe(600)
+    expect(api?.isAtEnd()).toBe(true)
+  })
+
+  it('does NOT follow when the user has scrolled up past the threshold', () => {
+    let api: UseChatScrollResult<HTMLDivElement> | null = null
+    const { rerender, getByTestId } = render(<Harness deps={[0]} onApi={(a) => (api = a)} />)
+    const el = getByTestId('scroller')
+    const ctrl = stubScrollMetrics(el, { scrollHeight: 500, clientHeight: 200, scrollTop: 300 })
+    // Distance from end = 500 - 300 - 200 = 0 → at end. Scroll up well past threshold.
+    ctrl.scrollTo(0)
+
+    ctrl.setHeight(900)
+    act(() => {
+      rerender(<Harness deps={[1]} onApi={(a) => (api = a)} />)
+    })
+
+    expect(ctrl.getScrollTop()).toBe(0)
+    expect(api?.isAtEnd()).toBe(false)
+  })
+
+  it('resumes following after the user scrolls back to the bottom', () => {
+    const noop = (): void => {}
+    const { rerender, getByTestId } = render(<Harness deps={[0]} onApi={noop} />)
+    const el = getByTestId('scroller')
+    const ctrl = stubScrollMetrics(el, { scrollHeight: 500, clientHeight: 200, scrollTop: 300 })
+
+    // Scroll up, grow once — no follow.
+    ctrl.scrollTo(0)
+    ctrl.setHeight(700)
+    act(() => {
+      rerender(<Harness deps={[1]} onApi={noop} />)
+    })
+    expect(ctrl.getScrollTop()).toBe(0)
+
+    // Scroll back to the bottom, grow again — should follow.
+    ctrl.scrollTo(500)
+    ctrl.setHeight(1100)
+    act(() => {
+      rerender(<Harness deps={[2]} onApi={noop} />)
+    })
+    expect(ctrl.getScrollTop()).toBe(1100)
+  })
+
+  it('treats values within the threshold as "at end"', () => {
+    let api: UseChatScrollResult<HTMLDivElement> | null = null
+    const { getByTestId } = render(<Harness deps={[0]} onApi={(a) => (api = a)} />)
+    const el = getByTestId('scroller')
+    // Distance from end = 500 - 250 - 200 = 50, which is within the default 80px threshold.
+    const ctrl = stubScrollMetrics(el, { scrollHeight: 500, clientHeight: 200, scrollTop: 250 })
+    ctrl.scrollTo(250)
+
+    expect(api?.isAtEnd()).toBe(true)
+  })
+
+  it('scrollToEnd pins to the bottom regardless of prior position', () => {
+    let api: UseChatScrollResult<HTMLDivElement> | null = null
+    const { getByTestId } = render(<Harness deps={[0]} onApi={(a) => (api = a)} />)
+    const el = getByTestId('scroller')
+    const ctrl = stubScrollMetrics(el, { scrollHeight: 1000, clientHeight: 200, scrollTop: 0 })
+
+    act(() => {
+      api?.scrollToEnd()
+    })
+
+    expect(ctrl.getScrollTop()).toBe(1000)
+  })
+})


### PR DESCRIPTION
## Summary

Ports the [TanStack Virtual Chat](https://tanstack.com/blog/tanstack-virtual-chat) scroll dynamics into a local `useChatScroll` hook (no new dependency) and wires it into `AeroBar.tsx`, replacing the naive `scrollTop = scrollHeight` effect that yanked the viewport back to the bottom whenever the user tried to read earlier turns mid-stream. Auto-follow now only kicks in when the user was already at the bottom; a `ResizeObserver` covers height changes that don't come through React deps (markdown reflow, image loads, late font metrics).

## Test plan

- [x] `pnpm vitest run --project web` — 239/239 pass, including 5 new tests for `useChatScroll` (follows when at end, stays put when scrolled up, resumes following on return to bottom, threshold tolerance, imperative `scrollToEnd`).
- [x] `pnpm typecheck` clean.
- [x] `pnpm lint` clean (0 errors).
- [ ] Manual: open AeroBar, send a prompt, scroll up while Aero streams — viewport should stay where you left it; scroll back to bottom — should resume following.