### PR TITLE
feat(web): verification filter and pagination on traffic events table

### DIFF
--- a/apps/web/src/lib/traffic-event-filter.ts
+++ b/apps/web/src/lib/traffic-event-filter.ts
@@ -1,4 +1,4 @@
-import { TrafficEventKinds, type TrafficEventEntry } from '@ainyc/canonry-contracts'
+import { TrafficEventKinds, VerificationStatuses, type TrafficEventEntry, type VerificationStatus } from '@ainyc/canonry-contracts'
 
 export type EventGranularity = 'hour' | 'day'
 
@@ -17,12 +17,30 @@ export const STATUS_CLASS_OPTIONS: ReadonlyArray<{ value: StatusClassFilter; lab
   { value: '5xx', label: '5xx server error' },
 ]
 
+/**
+ * Verification-class filter for crawler / AI-user-fetch claims. `'all'` is the
+ * no-op default. The three concrete values mirror `VerificationStatuses` —
+ * `verified` (source IP in the operator's published range), `claimed_unverified`
+ * (UA-only match), and `unknown_ai_like` (behavioral heuristic, reserved). Picking
+ * a concrete value excludes `ai-referral` events, which have no verification
+ * concept (they're session referrers, not bot fetches).
+ */
+export type VerificationFilter = 'all' | VerificationStatus
+
+export const VERIFICATION_OPTIONS: ReadonlyArray<{ value: VerificationFilter; label: string }> = [
+  { value: 'all', label: 'All claims' },
+  { value: VerificationStatuses.verified, label: 'Verified' },
+  { value: VerificationStatuses.claimed_unverified, label: 'Claimed unverified' },
+  { value: VerificationStatuses.unknown_ai_like, label: 'Unknown AI-like' },
+]
+
 export interface TrafficEventFilters {
   selectedBucket: string | null
   identity: string
   operator: string
   pathQuery: string
   statusClass: StatusClassFilter
+  verification: VerificationFilter
 }
 
 /**
@@ -54,6 +72,22 @@ export function pathOf(event: TrafficEventEntry): string {
   }
 }
 
+/**
+ * Returns the event's verification status, or `null` for ai-referral events
+ * (which lack the concept). A `null` return means "not subject to the
+ * verification filter" — picking a concrete verification class will exclude
+ * these events.
+ */
+export function verificationOf(event: TrafficEventEntry): string | null {
+  switch (event.kind) {
+    case TrafficEventKinds.crawler:
+    case TrafficEventKinds['ai-user-fetch']:
+      return event.verificationStatus
+    case TrafficEventKinds['ai-referral']:
+      return null
+  }
+}
+
 export function bucketKeyFor(tsHour: string, granularity: EventGranularity): string {
   if (granularity === 'hour') return tsHour
   const d = new Date(tsHour)
@@ -76,6 +110,7 @@ export function filterTrafficEvents(
     if (filters.operator && event.operator !== filters.operator) return false
     if (needle && !pathOf(event).toLowerCase().includes(needle)) return false
     if (statusDigit !== null && Math.floor(event.status / 100) !== statusDigit) return false
+    if (filters.verification !== 'all' && verificationOf(event) !== filters.verification) return false
     return true
   })
 }

--- a/apps/web/src/pages/TrafficSourceDetailPage.tsx
+++ b/apps/web/src/pages/TrafficSourceDetailPage.tsx
@@ -1,6 +1,6 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Link, useCanGoBack, useParams } from '@tanstack/react-router'
-import { ArrowLeft, RefreshCw, X } from 'lucide-react'
+import { ArrowLeft, ChevronLeft, ChevronRight, RefreshCw, X } from 'lucide-react'
 
 import { TrafficEventKinds, type TrafficEventEntry } from '@ainyc/canonry-contracts'
 
@@ -38,8 +38,10 @@ import {
   identityOf,
   pathOf,
   STATUS_CLASS_OPTIONS,
+  VERIFICATION_OPTIONS,
   type EventGranularity,
   type StatusClassFilter,
+  type VerificationFilter,
 } from '../lib/traffic-event-filter.js'
 
 type SeriesKind = 'crawler' | 'ai-user-fetch' | 'ai-referral'
@@ -61,7 +63,9 @@ const WINDOW_OPTIONS: readonly WindowOption[] = [
   { value: 90 * 24 * 60, label: '90d', granularity: 'day', fetchLimit: 5000 },
 ] as const
 
-const DEFAULT_WINDOW = WINDOW_OPTIONS.find((w) => w.label === '7d') ?? WINDOW_OPTIONS[2]
+const DEFAULT_WINDOW = WINDOW_OPTIONS.find((w) => w.label === '24h') ?? WINDOW_OPTIONS[2]
+
+const EVENTS_PAGE_SIZE = 50
 
 const CRAWLER_COLOR = CHART_SERIES_COLORS[0]
 const AI_USER_FETCH_COLOR = CHART_SERIES_COLORS[2]
@@ -152,6 +156,8 @@ export function TrafficSourceDetailPage() {
   const [operatorFilter, setOperatorFilter] = useState<string>('')
   const [pathFilter, setPathFilter] = useState<string>('')
   const [statusClassFilter, setStatusClassFilter] = useState<StatusClassFilter>('all')
+  const [verificationFilter, setVerificationFilter] = useState<VerificationFilter>('all')
+  const [eventsPage, setEventsPage] = useState<number>(1)
   const [syncError, setSyncError] = useState<string | null>(null)
   const [syncResult, setSyncResult] = useState<string | null>(null)
 
@@ -209,11 +215,38 @@ export function TrafficSourceDetailPage() {
           operator: operatorFilter,
           pathQuery: pathFilter,
           statusClass: statusClassFilter,
+          verification: verificationFilter,
         },
         activeWindow.granularity,
       ),
-    [visibleEvents, selectedBucket, identityFilter, operatorFilter, pathFilter, statusClassFilter, activeWindow.granularity],
+    [visibleEvents, selectedBucket, identityFilter, operatorFilter, pathFilter, statusClassFilter, verificationFilter, activeWindow.granularity],
   )
+
+  // Reset to page 1 whenever the underlying event slice changes — filter
+  // tweaks, series toggles, or a different time window — so the user doesn't
+  // land on a stale (now empty) page after a filter narrows the result set.
+  useEffect(() => {
+    setEventsPage(1)
+  }, [
+    visibleEvents,
+    selectedBucket,
+    identityFilter,
+    operatorFilter,
+    pathFilter,
+    statusClassFilter,
+    verificationFilter,
+  ])
+
+  const totalEventsPages = Math.max(1, Math.ceil(filteredEvents.length / EVENTS_PAGE_SIZE))
+  const currentEventsPage = Math.min(Math.max(1, eventsPage), totalEventsPages)
+  const eventsPageStart = (currentEventsPage - 1) * EVENTS_PAGE_SIZE
+  const pagedEvents = useMemo(
+    () => filteredEvents.slice(eventsPageStart, eventsPageStart + EVENTS_PAGE_SIZE),
+    [filteredEvents, eventsPageStart],
+  )
+  const showPagination = filteredEvents.length > EVENTS_PAGE_SIZE
+  const pageRangeStart = filteredEvents.length === 0 ? 0 : eventsPageStart + 1
+  const pageRangeEnd = Math.min(eventsPageStart + EVENTS_PAGE_SIZE, filteredEvents.length)
 
   const selectedBucketLabel = useMemo(
     () => (selectedBucket ? bucketLabelFor(selectedBucket, activeWindow.granularity) : null),
@@ -249,10 +282,16 @@ export function TrafficSourceDetailPage() {
     setOperatorFilter('')
     setPathFilter('')
     setStatusClassFilter('all')
+    setVerificationFilter('all')
   }
 
   const hasRowFilter = Boolean(
-    selectedBucket || identityFilter || operatorFilter || pathFilter.trim() || statusClassFilter !== 'all',
+    selectedBucket
+      || identityFilter
+      || operatorFilter
+      || pathFilter.trim()
+      || statusClassFilter !== 'all'
+      || verificationFilter !== 'all',
   )
 
   const handleSync = async () => {
@@ -548,6 +587,18 @@ export function TrafficSourceDetailPage() {
                 </option>
               ))}
             </select>
+            <select
+              aria-label="Filter by verification claim"
+              value={verificationFilter}
+              onChange={(e) => setVerificationFilter(e.target.value as VerificationFilter)}
+              className="rounded-md border border-zinc-800 bg-zinc-950 px-2.5 py-1.5 text-xs text-zinc-200 focus:outline-none focus-visible:ring-1 focus-visible:ring-zinc-600"
+            >
+              {VERIFICATION_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
             <input
               type="search"
               aria-label="Filter by path"
@@ -579,6 +630,12 @@ export function TrafficSourceDetailPage() {
                 onClear={() => setStatusClassFilter('all')}
               />
             ) : null}
+            {verificationFilter !== 'all' ? (
+              <ActiveFilterPill
+                label={`Claim: ${labelForVerification(verificationFilter)}`}
+                onClear={() => setVerificationFilter('all')}
+              />
+            ) : null}
             <button
               type="button"
               onClick={clearAllFilters}
@@ -589,7 +646,43 @@ export function TrafficSourceDetailPage() {
           </div>
         ) : null}
 
-        <EventsTable events={filteredEvents} />
+        <EventsTable events={pagedEvents} />
+
+        {showPagination ? (
+          <div className="mt-3 flex flex-wrap items-center justify-between gap-x-4 gap-y-2 text-xs text-zinc-400">
+            <p className="tabular-nums">
+              Showing <span className="text-zinc-300">{pageRangeStart.toLocaleString('en-US')}</span>–
+              <span className="text-zinc-300">{pageRangeEnd.toLocaleString('en-US')}</span> of{' '}
+              <span className="text-zinc-300">{filteredEvents.length.toLocaleString('en-US')}</span> events
+            </p>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setEventsPage((p) => Math.max(1, p - 1))}
+                disabled={currentEventsPage <= 1}
+                aria-label="Previous page"
+                className="inline-flex items-center gap-1 rounded-md border border-zinc-800 bg-zinc-950 px-2.5 py-1.5 text-zinc-200 transition hover:border-zinc-700 hover:text-zinc-50 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-zinc-800 disabled:hover:text-zinc-200"
+              >
+                <ChevronLeft className="size-3.5" />
+                Prev
+              </button>
+              <span className="tabular-nums">
+                Page <span className="text-zinc-200">{currentEventsPage}</span> of{' '}
+                <span className="text-zinc-200">{totalEventsPages}</span>
+              </span>
+              <button
+                type="button"
+                onClick={() => setEventsPage((p) => Math.min(totalEventsPages, p + 1))}
+                disabled={currentEventsPage >= totalEventsPages}
+                aria-label="Next page"
+                className="inline-flex items-center gap-1 rounded-md border border-zinc-800 bg-zinc-950 px-2.5 py-1.5 text-zinc-200 transition hover:border-zinc-700 hover:text-zinc-50 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-zinc-800 disabled:hover:text-zinc-200"
+              >
+                Next
+                <ChevronRight className="size-3.5" />
+              </button>
+            </div>
+          </div>
+        ) : null}
       </section>
     </div>
   )
@@ -671,6 +764,10 @@ function buildChartData(
   }
 
   return [...byBucket.values()].sort((a, b) => (a.bucket < b.bucket ? -1 : a.bucket > b.bucket ? 1 : 0))
+}
+
+function labelForVerification(value: VerificationFilter): string {
+  return VERIFICATION_OPTIONS.find((opt) => opt.value === value)?.label ?? value
 }
 
 function ActiveFilterPill({ label, onClear }: { label: string; onClear: () => void }) {

--- a/apps/web/test/traffic-event-filter.test.ts
+++ b/apps/web/test/traffic-event-filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { TrafficEventKinds, type TrafficEventEntry } from '@ainyc/canonry-contracts'
+import { TrafficEventKinds, VerificationStatuses, type TrafficEventEntry } from '@ainyc/canonry-contracts'
 
 import {
   bucketForChartClick,
@@ -7,6 +7,7 @@ import {
   filterTrafficEvents,
   identityOf,
   pathOf,
+  verificationOf,
 } from '../src/lib/traffic-event-filter.js'
 
 function crawler(overrides: Partial<Extract<TrafficEventEntry, { kind: 'crawler' }>> = {}): TrafficEventEntry {
@@ -89,6 +90,7 @@ describe('filterTrafficEvents', () => {
     operator: '',
     pathQuery: '',
     statusClass: 'all',
+    verification: 'all',
   })
 
   test('returns all events when no filters set', () => {
@@ -138,6 +140,7 @@ describe('filterTrafficEvents', () => {
         operator: 'OpenAI',
         pathQuery: 'sitemap',
         statusClass: 'all',
+        verification: 'all',
       },
       'hour',
     )
@@ -190,6 +193,65 @@ describe('filterTrafficEvents', () => {
     )
     expect(result.length).toBe(1)
     expect(result[0]!.status).toBe(200)
+  })
+
+  test('verification=all is the no-op default', () => {
+    const result = filterTrafficEvents(events, { ...defaults(), verification: 'all' }, 'hour')
+    expect(result.length).toBe(4)
+  })
+
+  test('verification=verified keeps only events with that claim and excludes ai-referrals', () => {
+    // The base set has no `verified` crawler — seed one and confirm only
+    // it survives. The ai-referral events lack verificationStatus so they
+    // must drop out when a concrete claim is requested.
+    const seeded = [
+      ...events,
+      crawler({ tsHour: '2026-05-07T04:00:00.000Z', verificationStatus: VerificationStatuses.verified, botId: 'OAI-SearchBot' }),
+    ]
+    const result = filterTrafficEvents(seeded, { ...defaults(), verification: VerificationStatuses.verified }, 'hour')
+    expect(result.length).toBe(1)
+    expect(result[0]!.kind).toBe(TrafficEventKinds.crawler)
+    expect(identityOf(result[0]!)).toBe('OAI-SearchBot')
+  })
+
+  test('verification=claimed_unverified passes UA-only crawler matches and excludes ai-referrals', () => {
+    const result = filterTrafficEvents(
+      events,
+      { ...defaults(), verification: VerificationStatuses.claimed_unverified },
+      'hour',
+    )
+    // Both base crawler events are claimed_unverified; both ai-referrals
+    // must be excluded.
+    expect(result.length).toBe(2)
+    expect(result.every((e) => e.kind === TrafficEventKinds.crawler)).toBe(true)
+  })
+
+  test('verification composes with other filters (AND semantics)', () => {
+    // operator='OpenAI' alone returns 2 events (one crawler verified=false,
+    // one ai-referral). Adding verification=claimed_unverified excludes the
+    // ai-referral, leaving only the GPTBot crawler.
+    const result = filterTrafficEvents(
+      events,
+      { ...defaults(), operator: 'OpenAI', verification: VerificationStatuses.claimed_unverified },
+      'hour',
+    )
+    expect(result.length).toBe(1)
+    expect(identityOf(result[0]!)).toBe('GPTBot')
+  })
+})
+
+describe('verificationOf', () => {
+  test('returns the verification status for crawler events', () => {
+    expect(verificationOf(crawler({ verificationStatus: VerificationStatuses.verified }))).toBe(
+      VerificationStatuses.verified,
+    )
+    expect(verificationOf(crawler({ verificationStatus: VerificationStatuses.claimed_unverified }))).toBe(
+      VerificationStatuses.claimed_unverified,
+    )
+  })
+
+  test('returns null for ai-referral events (no verification concept)', () => {
+    expect(verificationOf(aiReferral())).toBeNull()
   })
 })
 


### PR DESCRIPTION
## Summary
- Adds a verification-claim dropdown (Verified / Claimed unverified / Unknown AI-like) to the traffic source detail page; picking a concrete claim filters crawler + ai-user-fetch rows and excludes ai-referrals (which have no verification concept).
- Adds 50-row client-side pagination with prev/next controls, a "Showing N–M of T" range label, and an auto-reset to page 1 on any filter, series-toggle, or window change.
- Default time window shifts from 7d to 24h.

## Test plan
- [x] `pnpm --filter @ainyc/canonry-web test traffic-event-filter` (29 passed, includes new verification + ai-referral exclusion + AND-composition cases)
- [x] `pnpm --filter @ainyc/canonry-web typecheck`
- [x] `pnpm --filter @ainyc/canonry-web lint` (0 errors)