### PR TITLE
set up impeccable design system and apply first audit fixes

### DIFF
--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,203 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-05-27T00:00:00.000Z",
+  "title": "Design System: Canonry",
+  "extensions": {
+    "colorMeta": {
+      "zinc-night": {
+        "role": "neutral",
+        "displayName": "Zinc Night",
+        "canonical": "oklch(14% 0.005 286)",
+        "tonalRamp": ["#09090b", "#18181b", "#27272a", "#3f3f46", "#52525b", "#71717a", "#a1a1aa", "#d4d4d8"]
+      },
+      "snow": {
+        "role": "primary",
+        "displayName": "Snow",
+        "canonical": "oklch(98% 0 0)",
+        "tonalRamp": ["#09090b", "#27272a", "#52525b", "#71717a", "#a1a1aa", "#d4d4d8", "#e4e4e7", "#fafafa"]
+      },
+      "surface-ash": {
+        "role": "neutral",
+        "displayName": "Surface Ash",
+        "canonical": "oklch(20% 0.005 286)",
+        "tonalRamp": ["#09090b", "#18181b", "#27272a", "#3f3f46", "#52525b", "#71717a", "#a1a1aa", "#d4d4d8"]
+      },
+      "signal-green": {
+        "role": "secondary",
+        "displayName": "Signal Green",
+        "canonical": "oklch(77% 0.13 162)",
+        "tonalRamp": ["#022c22", "#065f46", "#047857", "#10b981", "#34d399", "#6ee7b7", "#a7f3d0", "#ecfdf5"]
+      },
+      "caution-amber": {
+        "role": "tertiary",
+        "displayName": "Caution Amber",
+        "canonical": "oklch(82% 0.14 80)",
+        "tonalRamp": ["#451a03", "#92400e", "#b45309", "#f59e0b", "#fbbf24", "#fcd34d", "#fde68a", "#fffbeb"]
+      },
+      "alert-rose": {
+        "role": "tertiary",
+        "displayName": "Alert Rose",
+        "canonical": "oklch(70% 0.18 14)",
+        "tonalRamp": ["#4c0519", "#9f1239", "#be123c", "#f43f5e", "#fb7185", "#fda4af", "#fecdd3", "#fff1f2"]
+      }
+    },
+    "typographyMeta": {
+      "hero": { "displayName": "Hero", "purpose": "Single h1 on the project landing card. One per page maximum." },
+      "page-title": { "displayName": "Page Title", "purpose": "Page header title at the top of every route." },
+      "stat": { "displayName": "Stat", "purpose": "Big numeric values in hero rows, metric cards, stat strips. Tabular." },
+      "gauge": { "displayName": "Gauge", "purpose": "Center value of radial score gauges. Tabular." },
+      "body": { "displayName": "Body", "purpose": "Paragraph copy, lede, descriptions. Cap line length 65–75ch." },
+      "body-compact": { "displayName": "Body Compact", "purpose": "Row titles in attention items, run rows, evidence cells. Dominant text size in the dashboard." },
+      "eyebrow": { "displayName": "Eyebrow", "purpose": "Section labels above a card, table headers. Uppercase 0.18em." },
+      "eyebrow-soft": { "displayName": "Eyebrow Soft", "purpose": "The faintest label tier; eyebrows on score gauges and metric cards." },
+      "mono": { "displayName": "Mono", "purpose": "Version strings, code spans, debug payloads. Geist Mono with tnum." }
+    },
+    "shadows": [
+      { "name": "mascot-atmosphere", "value": "drop-shadow(0 10px 18px rgba(8, 11, 15, 0.34))", "purpose": "Brand bird icon at the sidebar top. Only ambient shadow in the resting interface." },
+      { "name": "bubble-glow", "value": "0 8px 20px -10px rgba(245, 158, 11, 0.4), inset 0 0 0 1px rgba(245, 158, 11, 0.06)", "purpose": "Brand update bubble — colored ambient glow under the chirp moment." },
+      { "name": "toast-lift", "value": "0 12px 28px rgba(0, 0, 0, 0.32)", "purpose": "Toast cards floating above content. The only fully-rendered drop shadow." },
+      { "name": "card-hairline", "value": "0 0 0 1px rgba(255, 255, 255, 0.01)", "purpose": "Sub-pixel inset highlight on the Radix Card primitive. Edge sheen, not depth." }
+    ],
+    "motion": [
+      { "name": "ease-standard", "value": "cubic-bezier(0.4, 0, 0.2, 1)", "purpose": "Default easing. 600ms gauge-ring fill animation." },
+      { "name": "ease-out-quint", "value": "cubic-bezier(0.16, 1, 0.3, 1)", "purpose": "Toast slide-in over 180ms." },
+      { "name": "bubble-pop", "value": "cubic-bezier(0.34, 1.56, 0.64, 1)", "purpose": "Brand update bubble pop, 540ms. The one moment of overshoot allowed in the system." },
+      { "name": "skeleton-pulse", "value": "1.5s ease-in-out infinite", "purpose": "Loading skeleton opacity pulse, 0.4 → 0.8." },
+      { "name": "aero-dot-pulse", "value": "1.2s ease-in-out infinite", "purpose": "Aero typing indicator dots, staggered 0.15s apart." }
+    ],
+    "breakpoints": [
+      { "name": "md", "value": "768px" },
+      { "name": "lg", "value": "1024px" },
+      { "name": "xl", "value": "1280px" }
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-default",
+      "description": "Snow-on-Zinc inverted primary action. The dominant CTA on action surfaces.",
+      "html": "<button class=\"ds-btn-primary\">Run sweep</button>",
+      "css": ".ds-btn-primary { display: inline-flex; align-items: center; justify-content: center; gap: 8px; white-space: nowrap; height: 36px; padding: 0 16px; border: none; border-radius: 6px; background-color: #fafafa; color: #09090b; font-family: 'Geist', 'Inter', ui-sans-serif, system-ui, sans-serif; font-size: 14px; font-weight: 500; font-feature-settings: 'cv11', 'ss01', 'ss03'; cursor: pointer; transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1); } .ds-btn-primary:hover { background-color: #e4e4e7; } .ds-btn-primary:focus-visible { outline: none; box-shadow: 0 0 0 2px #09090b, 0 0 0 4px #a1a1aa; } .ds-btn-primary:disabled { pointer-events: none; opacity: 0.5; }"
+    },
+    {
+      "name": "Secondary Button",
+      "kind": "button",
+      "refersTo": "button-secondary",
+      "description": "Zinc-Night fill with a hairline border. The non-primary action; sits next to a primary in a header row.",
+      "html": "<button class=\"ds-btn-secondary\">Configure</button>",
+      "css": ".ds-btn-secondary { display: inline-flex; align-items: center; justify-content: center; gap: 8px; white-space: nowrap; height: 36px; padding: 0 16px; border: 1px solid #27272a; border-radius: 6px; background-color: #09090b; color: #f4f4f5; font-family: 'Geist', 'Inter', ui-sans-serif, system-ui, sans-serif; font-size: 14px; font-weight: 500; cursor: pointer; transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1); } .ds-btn-secondary:hover { background-color: #18181b; } .ds-btn-secondary:focus-visible { outline: none; box-shadow: 0 0 0 2px #09090b, 0 0 0 4px #a1a1aa; }"
+    },
+    {
+      "name": "Ghost Button",
+      "kind": "button",
+      "refersTo": "button-ghost",
+      "description": "Transparent at rest. Used in sidebars, footers, and dense control rows where the button must not compete for attention.",
+      "html": "<button class=\"ds-btn-ghost\">Cancel</button>",
+      "css": ".ds-btn-ghost { display: inline-flex; align-items: center; justify-content: center; gap: 8px; white-space: nowrap; height: 36px; padding: 0 16px; border: none; border-radius: 6px; background-color: transparent; color: #a1a1aa; font-family: 'Geist', 'Inter', ui-sans-serif, system-ui, sans-serif; font-size: 14px; font-weight: 500; cursor: pointer; transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1), color 150ms cubic-bezier(0.4, 0, 0.2, 1); } .ds-btn-ghost:hover { background-color: #18181b; color: #fafafa; } .ds-btn-ghost:focus-visible { outline: none; box-shadow: 0 0 0 2px #09090b, 0 0 0 4px #a1a1aa; }"
+    },
+    {
+      "name": "Success Badge",
+      "kind": "chip",
+      "refersTo": "badge-success",
+      "description": "Triple-low-opacity tone badge used for OK / cited / positive state.",
+      "html": "<div class=\"ds-badge-success\">Cited</div>",
+      "css": ".ds-badge-success { display: inline-flex; align-items: center; padding: 2px 8px; border: 1px solid rgba(16, 185, 129, 0.25); border-radius: 6px; background-color: rgba(16, 185, 129, 0.1); color: #6ee7b7; font-family: 'Geist', 'Inter', ui-sans-serif, system-ui, sans-serif; font-size: 11px; font-weight: 500; letter-spacing: 0.025em; }"
+    },
+    {
+      "name": "Health Pill (OK)",
+      "kind": "chip",
+      "refersTo": "health-pill-ok",
+      "description": "Always-visible system-health indicator in the topbar. Full-radius pill, uppercase, very tight tracking.",
+      "html": "<div class=\"ds-health-pill-ok\">OK</div>",
+      "css": ".ds-health-pill-ok { display: inline-flex; align-items: center; padding: 2px 8px; border: 1px solid rgba(16, 185, 129, 0.2); border-radius: 9999px; background-color: rgba(16, 185, 129, 0.08); color: #34d399; font-family: 'Geist', 'Inter', ui-sans-serif, system-ui, sans-serif; font-size: 10px; font-weight: 500; line-height: 1; text-transform: uppercase; letter-spacing: 0.1em; }"
+    },
+    {
+      "name": "Filter Chip (Active)",
+      "kind": "chip",
+      "refersTo": "filter-chip-active",
+      "description": "Pill-shaped filter selector. Active state carried by the fill, never by a side-stripe accent.",
+      "html": "<button class=\"ds-filter-chip-active\">All providers</button>",
+      "css": ".ds-filter-chip-active { display: inline-flex; align-items: center; padding: 6px 12px; border: 1px solid #52525b; border-radius: 9999px; background-color: #27272a; color: #f4f4f5; font-family: 'Geist', 'Inter', ui-sans-serif, system-ui, sans-serif; font-size: 14px; font-weight: 400; cursor: pointer; transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1), color 150ms cubic-bezier(0.4, 0, 0.2, 1); } .ds-filter-chip-active:hover { background-color: #3f3f46; }"
+    },
+    {
+      "name": "Surface Card",
+      "kind": "card",
+      "refersTo": "surface-card",
+      "description": "The dominant container in the dashboard. Surface Ash at 30% over Zinc Night, hairline border, 12px radius.",
+      "html": "<section class=\"ds-surface-card\"><div class=\"ds-eyebrow\">Visibility</div><div class=\"ds-stat\">42%</div><div class=\"ds-caption\">Up 6 points since last sweep</div></section>",
+      "css": ".ds-surface-card { padding: 16px; border: 1px solid rgba(39, 39, 42, 0.6); border-radius: 12px; background-color: rgba(24, 24, 27, 0.3); display: flex; flex-direction: column; gap: 12px; font-family: 'Geist', 'Inter', ui-sans-serif, system-ui, sans-serif; min-width: 220px; } .ds-surface-card .ds-eyebrow { font-size: 10px; font-weight: 500; line-height: 1; letter-spacing: 0.16em; text-transform: uppercase; color: #52525b; } .ds-surface-card .ds-stat { font-size: 24px; font-weight: 700; line-height: 1.1; letter-spacing: -0.02em; color: #fafafa; font-variant-numeric: tabular-nums; font-feature-settings: 'cv11', 'ss01', 'ss03', 'tnum'; } .ds-surface-card .ds-caption { font-size: 12px; line-height: 1.4; color: #71717a; }"
+    },
+    {
+      "name": "Input",
+      "kind": "input",
+      "refersTo": "input",
+      "description": "Form input on the setup wizard and inline edit surfaces. Hairline border, quiet focus state (no glow, no colored ring).",
+      "html": "<input class=\"ds-input\" type=\"text\" placeholder=\"example.com\" />",
+      "css": ".ds-input { display: inline-block; height: 36px; padding: 8px 12px; border: 1px solid #3f3f46; border-radius: 6px; background-color: rgba(24, 24, 27, 0.5); color: #f4f4f5; font-family: 'Geist', 'Inter', ui-sans-serif, system-ui, sans-serif; font-size: 14px; font-weight: 400; outline: none; transition: border-color 150ms cubic-bezier(0.4, 0, 0.2, 1), box-shadow 150ms cubic-bezier(0.4, 0, 0.2, 1); } .ds-input::placeholder { color: #52525b; } .ds-input:focus { border-color: #71717a; box-shadow: 0 0 0 1px #71717a; } .ds-input:disabled { opacity: 0.5; cursor: not-allowed; }"
+    },
+    {
+      "name": "Score Gauge (signature)",
+      "kind": "custom",
+      "refersTo": "score-gauge",
+      "description": "96px radial SVG ring with a tone-colored fill. Center value runs in Geist Sans 20/700 tabular. The instrument cluster at the top of every project page.",
+      "html": "<div class=\"ds-score-gauge\"><div class=\"ds-gauge-ring-wrapper\"><svg class=\"ds-gauge-ring\" viewBox=\"0 0 120 120\" aria-hidden=\"true\"><circle class=\"ds-gauge-bg\" cx=\"60\" cy=\"60\" r=\"48\" stroke-width=\"6\"></circle><circle class=\"ds-gauge-fill\" cx=\"60\" cy=\"60\" r=\"48\" stroke-width=\"6\" stroke-dasharray=\"301.59\" stroke-dashoffset=\"108.57\" transform=\"rotate(-90 60 60)\"></circle></svg><div class=\"ds-gauge-center\"><span class=\"ds-gauge-value\">64</span></div></div><p class=\"ds-gauge-label\">Visibility</p><p class=\"ds-gauge-delta\">+6 vs last</p><p class=\"ds-gauge-description\">Cited or mentioned in 64% of tracked queries.</p></div>",
+      "css": ".ds-score-gauge { display: flex; flex-direction: column; align-items: center; padding: 20px 12px; border: 1px solid rgba(39, 39, 42, 0.6); border-radius: 12px; background-color: rgba(24, 24, 27, 0.3); min-width: 180px; font-family: 'Geist', 'Inter', ui-sans-serif, system-ui, sans-serif; } .ds-score-gauge .ds-gauge-ring-wrapper { position: relative; width: 96px; height: 96px; } .ds-score-gauge .ds-gauge-ring { width: 100%; height: 100%; } .ds-score-gauge .ds-gauge-bg { fill: none; stroke: rgba(255, 255, 255, 0.06); } .ds-score-gauge .ds-gauge-fill { fill: none; stroke: #34d399; stroke-linecap: round; transition: stroke-dashoffset 600ms cubic-bezier(0.4, 0, 0.2, 1); } .ds-score-gauge .ds-gauge-center { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; } .ds-score-gauge .ds-gauge-value { font-size: 20px; font-weight: 700; letter-spacing: -0.01em; color: #fafafa; font-variant-numeric: tabular-nums; font-feature-settings: 'cv11', 'ss01', 'ss03', 'tnum'; } .ds-score-gauge .ds-gauge-label { margin-top: 12px; font-size: 10px; font-weight: 500; text-transform: uppercase; letter-spacing: 0.12em; color: #71717a; text-align: center; } .ds-score-gauge .ds-gauge-delta { margin-top: 6px; font-size: 11px; color: #a1a1aa; text-align: center; } .ds-score-gauge .ds-gauge-description { margin-top: 10px; font-size: 11px; line-height: 1.45; color: #71717a; text-align: center; max-width: 180px; }"
+    },
+    {
+      "name": "Sparkline (signature)",
+      "kind": "custom",
+      "refersTo": "sparkline",
+      "description": "Inline polyline trend, 132×42, tone-colored stroke, 1px white-at-6% baseline guide.",
+      "html": "<svg class=\"ds-sparkline ds-sparkline-positive\" viewBox=\"0 0 132 42\" aria-hidden=\"true\"><line class=\"ds-sparkline-guide\" x1=\"5\" x2=\"127\" y1=\"37\" y2=\"37\"></line><polyline points=\"5,30 23,28 41,22 59,24 77,18 95,12 113,14 127,8\"></polyline></svg>",
+      "css": ".ds-sparkline { height: 42px; width: 132px; overflow: hidden; } .ds-sparkline polyline { fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; } .ds-sparkline-guide { stroke: rgba(255, 255, 255, 0.06); stroke-width: 1; } .ds-sparkline-positive polyline { stroke: #34d399; } .ds-sparkline-caution polyline { stroke: #fbbf24; } .ds-sparkline-negative polyline { stroke: #fb7185; } .ds-sparkline-neutral polyline { stroke: #a1a1aa; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Listening Post",
+    "overview": "Canonry is an instrument, not a marketing surface. It sits on an analyst's desk while they (or their agent) scan what AI answer engines are saying about a domain, drill into the regression that just appeared, and decide whether to act. The visual system serves that posture: the room is dim, the chrome is quiet, the data is loud, the rhythm is fast. Whitespace exists to create hierarchy, not atmosphere. Tone color (emerald, amber, rose) is rationed; it appears only when it carries meaning, never as decoration. The aesthetic family is operator-grade dark mode in the Vercel lineage: cool zinc neutrals, tinted toward black with no synthetic blue cast, Geist Sans as a single sans-serif workhorse (no display pairing), tabular numerics everywhere a number lives, eyebrow labels in tight letter-spacing to mark sections, hairline borders instead of cards-within-cards. It explicitly rejects the Semrush / Ahrefs reflex (every-pixel-occupied SEO dashboard) and the AI-startup reflex (purple-to-pink gradients, sparkle icons, glass blurs). The system carries one deliberate moment of warmth: the mascot bird in the sidebar chirps and tilts when a new canonry version is available, with a small amber bubble announcing the upgrade. That is the entire personality budget for the surface.",
+    "keyCharacteristics": [
+      "Dark zinc base (#09090b) with sub-step surface tinting at low opacities, no #000 and no #fff.",
+      "Geist Sans + Geist Mono pairing, OpenType stylistic sets cv11, ss01, ss03 enabled globally.",
+      "Tabular numerics on every metric, gauge value, and stat strip.",
+      "Tables, not card grids, for any list of three or more structured items.",
+      "Tone color is semantic only: emerald = positive, amber = caution, rose = negative, zinc = neutral.",
+      "Hairline borders carry shape; shadows are reserved for floating UI (toasts, evidence modal).",
+      "Page width capped at 1152px; fixed 224px sidebar; no fluid headings."
+    ],
+    "rules": [
+      { "name": "The Semantic-Only Rule", "body": "Tone color (Signal Green, Caution Amber, Alert Rose) is reserved for indicating state. It is forbidden as a decorative accent. A card is never green because green looks nice; it is green because it is reporting a positive signal.", "section": "colors" },
+      { "name": "The White-As-Accent Rule", "body": "The brand accent is Snow (#fafafa). It carries primary actions, active states, and the brightest text. There is no chromatic brand color. Adding one would betray the operator-instrument identity and pull the surface toward SaaS.", "section": "colors" },
+      { "name": "The Rationed Rose Rule", "body": "Alert Rose is the loudest color in the system. A page with three Alert Rose elements is almost certainly wrong: the analyst stops being able to triage. Pull rose back to the genuinely-negative signal.", "section": "colors" },
+      { "name": "The Single-Sans Rule", "body": "Geist carries everything. No serif headlines, no display-only weight, no editorial pairing. The interface earns its hierarchy from scale and weight contrast, not from a font swap.", "section": "typography" },
+      { "name": "The Tabular-Numerics Rule", "body": "Every number that lives inside a column, a gauge, a stat strip, or a delta carries font-variant-numeric: tabular-nums. Two 42.0% values stacked vertically must align at the decimal.", "section": "typography" },
+      { "name": "The Eyebrow-Over-Headline Rule", "body": "Section context is carried by the 10–11px uppercase eyebrow above a card or stat, not by an oversized headline inside it. Inverting this proportion reads as marketing.", "section": "typography" },
+      { "name": "The Flat-By-Default Rule", "body": "Surfaces are flat at rest. Shadows appear only when an element actually floats (toast, modal, mascot drop-shadow) or as a one-moment state response (the amber bubble glow). A card with a drop shadow at rest is wrong.", "section": "elevation" },
+      { "name": "The Tint-Then-Border Rule", "body": "When a surface needs to lift off the canvas, it earns it through a low-opacity background tint plus a hairline border. Never through box-shadow.", "section": "elevation" }
+    ],
+    "dos": [
+      "Do use the Geist + Geist Mono pairing for every typographic decision; turn on cv11, ss01, ss03 (and ss02 for mono) so the 11–13px glyphs hold.",
+      "Do apply tabular numerics (font-variant-numeric: tabular-nums) to every numeric value that lives in a column, a gauge, a stat strip, or a delta.",
+      "Do prefer data tables over card grids for any list of three or more structured items.",
+      "Do use Surface Ash at 30% opacity (bg-zinc-900/30) plus a 60%-opacity hairline border (border-zinc-800/60) as the default container.",
+      "Do ration tone color (Signal Green, Caution Amber, Alert Rose) to semantic state only.",
+      "Do route every chart through components/shared/ChartPrimitives.tsx and use the shared style constants.",
+      "Do use the ToneBadge primitive for every status indicator. Map tones through the helpers (toneFromRunStatus, toneFromCitationState).",
+      "Do show two glyphs when rendering snapshot state in a single cell: one for cited (C/c), one for mentioned (M/m), with – for missing.",
+      "Do respect prefers-reduced-motion. The toast slide, the aero typing dots, the brand mascot's chirp, and the bubble pop must all disable.",
+      "Do keep the page width capped at max-w-6xl (1152px). The sidebar is always 224px."
+    ],
+    "donts": [
+      "Don't use #000 or #fff. The base is Zinc Night (#09090b), the brightest body is Snow (#fafafa).",
+      "Don't introduce a chromatic brand color (no canonry purple, no canonry blue). The accent is Snow.",
+      "Don't ship gradient hero text, gradient buttons, glassmorphism cards, sparkle icons, mesh-gradient backgrounds, or AI-powered stickers.",
+      "Don't build dashboards that look like Semrush or Ahrefs (every-pixel occupied, panels competing for attention) or Profound (the AEO-category reflex).",
+      "Don't import recharts directly. Use ChartPrimitives.tsx. Don't add Chart.js, Highcharts, D3, Plotly, Nivo, or Victory.",
+      "Don't use display fonts for UI labels, buttons, or data.",
+      "Don't drop a card inside a card. Lift the child row with a background tint and a hairline instead.",
+      "Don't apply drop shadows to resting surfaces. Shadows are reserved for the mascot, the toast lift, the bubble glow, and the sub-pixel Card highlight.",
+      "Don't reach for a modal as the first thought. Inline the form, slide a drawer, expand a row, anything before a modal.",
+      "Don't invent a new color name when an existing zinc / emerald / amber / rose token will do."
+    ]
+  }
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,419 @@
+---
+name: Canonry
+description: Operator-grade dashboard for the agent-first AEO operating platform.
+colors:
+  zinc-night: "#09090b"
+  surface-ash: "#18181b"
+  surface-ash-faint: "#27272a"
+  hairline: "#3f3f46"
+  hairline-soft: "#52525b"
+  snow: "#fafafa"
+  silver: "#e4e4e7"
+  smoke: "#a1a1aa"
+  fog: "#71717a"
+  shadow-text: "#52525b"
+  whisper: "#3f3f46"
+  signal-green: "#34d399"
+  signal-green-deep: "#10b981"
+  caution-amber: "#fbbf24"
+  caution-amber-deep: "#f59e0b"
+  alert-rose: "#fb7185"
+  alert-rose-deep: "#f43f5e"
+  destructive-rose: "#e11d48"
+  series-blue: "#60a5fa"
+  series-pink: "#f472b6"
+  series-yellow: "#facc15"
+  series-violet: "#a78bfa"
+  series-orange: "#fb923c"
+  series-cyan: "#22d3ee"
+  series-red: "#f87171"
+  track-sky: "#38bdf8"
+  provider-gemini: "#93c5fd"
+  provider-openai: "#86efac"
+  provider-claude: "#fcd34d"
+  provider-perplexity: "#5eead4"
+  provider-local: "#d8b4fe"
+  meta-theme: "#10141c"
+typography:
+  page-title:
+    fontFamily: "Geist, Inter, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "18px"
+    fontWeight: 600
+    lineHeight: "1.25"
+    letterSpacing: "-0.02em"
+    fontFeature: "cv11, ss01, ss03"
+  hero:
+    fontFamily: "Geist, Inter, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "28px"
+    fontWeight: 600
+    lineHeight: "1.15"
+    letterSpacing: "-0.02em"
+    fontFeature: "cv11, ss01, ss03"
+  stat:
+    fontFamily: "Geist, Inter, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "24px"
+    fontWeight: 700
+    lineHeight: "1.1"
+    letterSpacing: "-0.02em"
+    fontFeature: "cv11, ss01, ss03, tnum"
+  gauge:
+    fontFamily: "Geist, Inter, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "20px"
+    fontWeight: 700
+    lineHeight: "1"
+    letterSpacing: "-0.01em"
+    fontFeature: "cv11, ss01, ss03, tnum"
+  section-title:
+    fontFamily: "Geist, Inter, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "14px"
+    fontWeight: 600
+    lineHeight: "1.35"
+    letterSpacing: "-0.01em"
+  body:
+    fontFamily: "Geist, Inter, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "14px"
+    fontWeight: 400
+    lineHeight: "1.55"
+    letterSpacing: "normal"
+    fontFeature: "cv11, ss01, ss03"
+  body-compact:
+    fontFamily: "Geist, Inter, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "13px"
+    fontWeight: 400
+    lineHeight: "1.45"
+  caption:
+    fontFamily: "Geist, Inter, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "12px"
+    fontWeight: 400
+    lineHeight: "1.4"
+  eyebrow:
+    fontFamily: "Geist, Inter, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "11px"
+    fontWeight: 500
+    lineHeight: "1"
+    letterSpacing: "0.18em"
+    textTransform: "uppercase"
+  eyebrow-soft:
+    fontFamily: "Geist, Inter, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "10px"
+    fontWeight: 500
+    lineHeight: "1"
+    letterSpacing: "0.16em"
+    textTransform: "uppercase"
+  mono:
+    fontFamily: "Geist Mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace"
+    fontSize: "13px"
+    fontWeight: 400
+    fontFeature: "ss02, cv11, tnum"
+rounded:
+  sm: "4px"
+  md: "6px"
+  lg: "8px"
+  xl: "12px"
+  "2xl": "16px"
+  full: "9999px"
+spacing:
+  hair: "2px"
+  xs: "4px"
+  sm: "8px"
+  md: "12px"
+  base: "16px"
+  lg: "20px"
+  xl: "24px"
+  "2xl": "32px"
+  sidebar-width: "224px"
+  page-max: "1152px"
+components:
+  button-default:
+    backgroundColor: "{colors.snow}"
+    textColor: "{colors.zinc-night}"
+    rounded: "{rounded.md}"
+    height: "36px"
+    padding: "0 16px"
+    typography: "{typography.body-compact}"
+  button-default-hover:
+    backgroundColor: "{colors.silver}"
+  button-secondary:
+    backgroundColor: "{colors.zinc-night}"
+    textColor: "{colors.silver}"
+    rounded: "{rounded.md}"
+    height: "36px"
+    padding: "0 16px"
+  button-secondary-hover:
+    backgroundColor: "{colors.surface-ash}"
+  button-ghost:
+    backgroundColor: "transparent"
+    textColor: "{colors.smoke}"
+    rounded: "{rounded.md}"
+    height: "36px"
+    padding: "0 16px"
+  button-ghost-hover:
+    backgroundColor: "{colors.surface-ash}"
+    textColor: "{colors.snow}"
+  button-destructive:
+    backgroundColor: "{colors.destructive-rose}"
+    textColor: "{colors.snow}"
+    rounded: "{rounded.md}"
+    height: "36px"
+    padding: "0 16px"
+  badge-neutral:
+    backgroundColor: "{colors.zinc-night}"
+    textColor: "{colors.silver}"
+    rounded: "{rounded.md}"
+    padding: "2px 8px"
+  badge-success:
+    backgroundColor: "{colors.signal-green}"
+    textColor: "{colors.signal-green}"
+    rounded: "{rounded.md}"
+    padding: "2px 8px"
+  badge-warning:
+    backgroundColor: "{colors.caution-amber}"
+    textColor: "{colors.caution-amber}"
+    rounded: "{rounded.md}"
+    padding: "2px 8px"
+  badge-destructive:
+    backgroundColor: "{colors.alert-rose}"
+    textColor: "{colors.alert-rose}"
+    rounded: "{rounded.md}"
+    padding: "2px 8px"
+  surface-card:
+    backgroundColor: "{colors.surface-ash}"
+    rounded: "{rounded.xl}"
+    padding: "16px"
+  health-pill-ok:
+    backgroundColor: "{colors.signal-green}"
+    textColor: "{colors.signal-green}"
+    rounded: "{rounded.full}"
+    padding: "2px 8px"
+  filter-chip:
+    backgroundColor: "{colors.zinc-night}"
+    textColor: "{colors.fog}"
+    rounded: "{rounded.full}"
+    padding: "6px 12px"
+  filter-chip-active:
+    backgroundColor: "{colors.surface-ash}"
+    textColor: "{colors.silver}"
+    rounded: "{rounded.full}"
+    padding: "6px 12px"
+  input:
+    backgroundColor: "{colors.surface-ash}"
+    textColor: "{colors.silver}"
+    rounded: "{rounded.md}"
+    padding: "8px 12px"
+    height: "36px"
+---
+
+# Design System: Canonry
+
+## 1. Overview
+
+**Creative North Star: "The Listening Post"**
+
+Canonry is an instrument, not a marketing surface. It sits on an analyst's desk while they (or their agent) scan what AI answer engines are saying about a domain, drill into the regression that just appeared, and decide whether to act. The visual system serves that posture: the room is dim, the chrome is quiet, the data is loud, the rhythm is fast. Whitespace exists to create hierarchy, not atmosphere. Tone color (emerald, amber, rose) is rationed; it appears only when it carries meaning, never as decoration.
+
+The aesthetic family is **operator-grade dark mode in the Vercel lineage**: cool zinc neutrals, tinted toward black with no synthetic blue cast, Geist Sans as a single sans-serif workhorse (no display pairing), tabular numerics everywhere a number lives, eyebrow labels in tight letter-spacing to mark sections, hairline borders instead of cards-within-cards. It explicitly rejects the Semrush / Ahrefs reflex (every-pixel-occupied SEO dashboard, panels competing for attention) and the "AI startup" reflex (purple-to-pink gradients, sparkle icons, glass blurs, "✨ AI-powered" stickers). Canonry is itself an AI product, which is exactly why none of those tropes appear.
+
+The system carries one deliberate moment of warmth: the mascot bird in the sidebar chirps and tilts when a new canonry version is available, with a small amber bubble announcing the upgrade. That is the entire personality budget for the surface. Everywhere else, the data does the talking.
+
+**Key Characteristics:**
+- Dark zinc base (`#09090b`) with sub-step surface tinting at low opacities, no `#000` and no `#fff`.
+- Geist Sans + Geist Mono pairing, OpenType stylistic sets `cv11`, `ss01`, `ss03` enabled globally for sharper `i / l / I / 0` disambiguation.
+- Tabular numerics on every metric, gauge value, and stat strip.
+- Tables, not card grids, for any list of three or more structured items.
+- Tone color is semantic only: emerald = positive, amber = caution, rose = negative, zinc = neutral.
+- Hairline borders (`#27272a / #3f3f46`) carry shape; shadows are reserved for floating UI (toasts, evidence modal).
+- Page width capped at 1152px (`max-w-6xl`); fixed 224px sidebar; no fluid headings.
+
+## 2. Colors: The Listening Post Palette
+
+A near-monochromatic zinc field with three rationed tone colors and a multi-series chart palette held back for data viz.
+
+### Primary
+
+- **Snow** (`#fafafa`): The interface's accent. Used as the primary button fill (white-on-dark inverted), active subnav background, and the brightest body text. This is a chroma-free accent: maximum lightness carries weight where a saturated brand color would in a marketing surface.
+- **Zinc Night** (`#09090b`): The base canvas. Slightly tinted toward neutral-cool, never pure black. Applied to `<body>`, the sidebar, the topbar (at 95% opacity for a faint frosted-glass effect under content scroll).
+
+### Tone (semantic, never decorative)
+
+- **Signal Green** (`#34d399`, emerald-400): Cited, positive, success, gain, OK-state health pill, score-gauge fill when reading positive. Paired with `bg-emerald-500/10` and `border-emerald-500/25` for badges; with `bg-emerald-950/25` for sustained-state surfaces like the citation leaderboard "you" row.
+- **Caution Amber** (`#fbbf24`, amber-400): Partial state, warning, drift, "checking" health, the brand update bubble. The only tone allowed to appear as a sustained sidebar accent (the mascot's chirp bubble).
+- **Alert Rose** (`#fb7185`, rose-400): Lost, failed, regression, negative-delta, destructive-action error state. Sustained-state surfaces use `bg-rose-950/20` to keep the dark room from feeling alarmed.
+- **Destructive Rose** (`#e11d48`, rose-600): Solid fill for destructive primary buttons only. Distinct from Alert Rose, which is for state indication.
+
+### Neutral (the ash scale)
+
+- **Surface Ash** (`#18181b`, zinc-900): Card and table-header surface at 30–50% opacity. Lifts cards just enough off Zinc Night to read as containers without becoming objects.
+- **Surface Ash Faint** (`#27272a`, zinc-800): Track color for progress bars, chart grid lines, divider lines between table rows.
+- **Hairline** (`#3f3f46`, zinc-700): Default border between surface and canvas. Almost always rendered at 60% opacity (`border-zinc-800/60`) so it sits as a hint, not a frame.
+- **Silver** (`#e4e4e7`, zinc-200) → **Smoke** (`#a1a1aa`, zinc-400) → **Fog** (`#71717a`, zinc-500) → **Whisper** (`#3f3f46`, zinc-700): the text ramp. Snow is the headline; Smoke is the body; Fog is the caption; Whisper is the eyebrow that almost dissolves.
+
+### Series (chart-only)
+
+`Series Blue` `#60a5fa`, `Series Pink` `#f472b6`, `Series Yellow` `#facc15`, `Series Violet` `#a78bfa`, `Series Orange` `#fb923c`, `Series Cyan` `#22d3ee`, `Series Red` `#f87171`. Saturated 400-step hues used only when a chart genuinely needs three or more series. Never appear in surface chrome, buttons, badges, or non-chart UI.
+
+### Provider Identity (closed set, chrome-only)
+
+Each LLM answer engine canonry tracks has a fixed identity color, applied only in `ProviderBadge` and provider-related chrome (model picker, provider-scoped headings). This is the one place the dashboard reaches outside the Listening Post zinc palette into provider-brand territory, because the user needs to recognize "Gemini" vs "Claude" vs "OpenAI" at a glance across long evidence tables. The colors are deliberately the lighter `-300` Tailwind step so they sit quietly inside the badge tint pattern (`border-{hue}-800/50 bg-{hue}-950/40 text-{hue}-300`), never as a saturated fill.
+
+- **Provider Gemini** (`#93c5fd`, blue-300): Google's Gemini family.
+- **Provider OpenAI** (`#86efac`, green-300): OpenAI / ChatGPT.
+- **Provider Claude** (`#fcd34d`, amber-300): Anthropic's Claude.
+- **Provider Perplexity** (`#5eead4`, teal-300): Perplexity.
+- **Provider Local** (`#d8b4fe`, purple-300): Local / self-hosted LLM (e.g., Ollama, vLLM).
+
+The set is closed: adding a sixth color requires adding a sixth provider, not borrowing one of these for a different purpose.
+
+### Named Rules
+
+**The Semantic-Only Rule.** Tone color (Signal Green, Caution Amber, Alert Rose) is reserved for indicating state. It is forbidden as a decorative accent. A card is never green because green looks nice; it is green because it is reporting a positive signal.
+
+**The White-As-Accent Rule.** The brand "accent" is Snow (`#fafafa`). It carries primary actions, active states, and the brightest text. There is no chromatic brand color. Adding one (a "canonry purple", a "canonry blue") would betray the operator-instrument identity and pull the surface toward SaaS.
+
+**The Rationed Rose Rule.** Alert Rose is the loudest color in the system. A page with three Alert Rose elements is almost certainly wrong: the analyst stops being able to triage. Pull rose back to the genuinely-negative signal; let other rows render in Smoke even when their value is below target.
+
+**The Provider-Identity Rule.** The five Provider Identity colors (Gemini blue, OpenAI green, Claude amber, Perplexity teal, Local purple) are a closed set used only in provider chrome (`ProviderBadge`, the AeroBar model picker, provider-scoped section headings). They are never used decoratively, never reappear in non-provider UI, and never trade places (Claude is never green even if the visual rhythm would benefit). Adding a sixth color requires adding a sixth provider.
+
+## 3. Typography
+
+**Display + Body Font:** Geist (Google Fonts), with fallback `Inter, ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif`. Weights loaded: 400, 500, 600, 700, 800.
+**Mono Font:** Geist Mono, with fallback `ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace`. Weights loaded: 400, 500, 600.
+
+**Character:** Geist is the typographic floor of the Vercel design language: a geometric humanist sans engineered for product UI density. Canonry runs it as a single workhorse (no serif display, no decorative pairing) and turns on its OpenType alternates (`cv11`, `ss01`, `ss03`) so the `1 / I / l`, `0 / O`, and `i / l` distinctions hold at 11–13px. Geist Mono carries every number that lives inside a column, a gauge, or a stat strip; `ss02` and `cv11` are enabled in mono so `0` and `1` stay unambiguous in dense tabular data. Hierarchy is built through scale and weight, not through font swap.
+
+### Hierarchy
+
+- **Hero** (`28px / 600 / -0.02em / 1.15`): The single `<h1>` on the project landing card. Snow color. One per page maximum.
+- **Page Title** (`18px / 600 / -0.02em`): The page header title at the top of every route. Tightened tracking; Snow color.
+- **Section Title** (`14px / 600 / -0.01em`): The `<h2>` / `<h3>` that opens a card or a panel. Silver color, never Snow (Snow is reserved for the page title).
+- **Stat** (`24px / 700 / -0.02em`, tabular): Big numbers in the AEO hero rows, metric cards, and stat strips. Tabular numerics non-negotiable.
+- **Gauge** (`20px / 700 / -0.01em`, tabular): Center value of the radial score gauges.
+- **Body** (`14px / 400 / 1.55`): Paragraph copy, lede, descriptions. Cap line length at 65–75ch in prose surfaces; tables can run longer.
+- **Body Compact** (`13px / 400 / 1.45`): Row titles in attention items, run rows, project lists, evidence cells. The dominant text size in the dashboard.
+- **Caption** (`12px / 400 / 1.4`): Secondary detail copy in tables and metric subtitles. Fog color.
+- **Eyebrow** (`11px / 500 / uppercase / 0.18em`): Section labels above a card, table headers (`0.14em`). Fog color.
+- **Eyebrow Soft** (`10px / 500 / uppercase / 0.16em`): The faintest label tier; eyebrows on score gauges and metric cards. Whisper / Fog color.
+- **Mono** (`13px / 400`, tabular): Version strings, code spans, command examples, debug payloads. Geist Mono with `tnum`.
+
+### Named Rules
+
+**The Single-Sans Rule.** Geist carries everything. No serif headlines, no display-only weight, no editorial pairing. The interface earns its hierarchy from scale and weight contrast (the Body → Section Title → Page Title → Hero ladder), not from a font swap.
+
+**The Tabular-Numerics Rule.** Every number that lives inside a column, a gauge, a stat strip, or a delta carries `font-variant-numeric: tabular-nums`. Two `42.0%` values stacked vertically must align at the decimal. This is non-negotiable for an analyst surface.
+
+**The Eyebrow-Over-Headline Rule.** Section context is carried by the 10–11px uppercase eyebrow above a card or stat, not by an oversized headline inside it. The eyebrow is the section's signage; the value inside is the content. Inverting this proportion (big headline, small label) reads as marketing.
+
+## 4. Elevation
+
+Canonry is flat. Surfaces are differentiated by hairline borders and ~25–50% opacity tints over the Zinc Night canvas, not by drop shadows. The one-step lift from `Zinc Night → Surface Ash` is the only "elevation" the resting interface needs. Cards do not sit *on* the canvas, they sit *in* it.
+
+Real shadows appear only on floating, state-carrying UI: the toast viewport, the evidence modal, the brand mascot's drop-shadow at the sidebar top. Decorative shadows under cards, buttons, or chips are forbidden.
+
+### Shadow Vocabulary
+
+- **Mascot Atmosphere** (`drop-shadow: 0 10px 18px rgba(8, 11, 15, 0.34)`): On the brand icon (the canonry bird) at the sidebar top. The only ambient shadow in the resting interface; gives the mascot a sense of place above the deep canvas.
+- **Bubble Glow** (`box-shadow: 0 8px 20px -10px rgba(245, 158, 11, 0.4), inset 0 0 0 1px rgba(245, 158, 11, 0.06)`): The colored ambient glow under the brand update bubble. Tints the room amber for the one moment that bubble exists.
+- **Toast Lift** (`box-shadow: 0 12px 28px rgba(0, 0, 0, 0.32)`): On the toast cards. The toast viewport floats above content, so this is the only fully-rendered drop shadow in the system.
+- **Hairline Card** (`box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.01)`): Sub-pixel inset highlight on the Radix Card primitive. Not a shadow in the depth sense; a one-pixel sheen that keeps the card edge from disappearing on low-contrast displays.
+
+### Named Rules
+
+**The Flat-By-Default Rule.** Surfaces are flat at rest. Shadows appear only when an element actually floats (toast, modal, mascot drop-shadow) or as a one-moment state response (the amber bubble glow). A card with a drop shadow at rest is wrong.
+
+**The Tint-Then-Border Rule.** When a surface needs to lift off the canvas, it earns it through a low-opacity background tint (`bg-zinc-900/30`) plus a hairline border (`border-zinc-800/60`). Never through `box-shadow`. This keeps the room dim and the rhythm scanable.
+
+## 5. Components
+
+### Buttons
+
+- **Shape:** medium-radius (`rounded-md`, 6px). Heights of 36px (default) and 32px (`sm`). No pill-shaped CTAs in the action surface.
+- **Default (Primary):** Snow background, Zinc Night text. The inverted-white "Run sweep" CTA. Hover steps down to Silver (`#e4e4e7`).
+- **Secondary:** Zinc Night background, Silver text, hairline border. Hover lifts the background one step to Surface Ash.
+- **Ghost:** Transparent background, Smoke text. Hover gives a Surface Ash background and lifts the text to Snow. Used in sidebars, footers, and dense control rows.
+- **Outline:** Transparent background, hairline border, Silver text. Hover background = Surface Ash. Used when a button must read as a non-primary action but the row lacks a colored background to ground a ghost.
+- **Destructive:** Destructive Rose (`#e11d48`) background, Snow text. Hover deepens to rose-700 (`#be123c`). For irreversible actions only; flagged inline before invocation, never as the lone primary on a screen.
+- **Focus:** 2px Smoke focus ring with a 2px Zinc Night offset (visible on dark backgrounds without halation).
+
+### Badges & Pills
+
+- **Neutral / Success / Warning / Destructive (`Badge` primitive):** Pill-radius `rounded-md`, 11px font, `tracking-wide`. Tone variants render as `border-{tone}-500/25 bg-{tone}-500/10 text-{tone}-300` — a triple-low-opacity treatment that keeps the badge readable without painting the row.
+- **Health Pills (topbar):** `rounded-full`, 10px uppercase with `0.1em` tracking. OK = signal green, Checking = neutral zinc, Error = alert rose. Live, always-visible state for global system health.
+- **Filter Chips:** `rounded-full`, 14px text. Default = transparent over Zinc Night with Fog text; active = Surface Ash background with Silver text and a slightly brighter border. No left-stripe accent; the active state is carried by the fill.
+
+### Cards & Surfaces
+
+- **Surface Card (the dominant container):** `rounded-xl` (12px), Surface Ash at 30% opacity over the canvas, 60%-opacity hairline border. Internal padding `p-4`. This is the surface every section sits in.
+- **Score Gauge container:** Same surface family, `px-3 py-5` for tighter vertical rhythm around the radial.
+- **Metric Card:** Same surface family, `px-4 py-5`, includes the big-number stat plus a 1.5px progress bar and a 12px caption.
+- **Hero Copy (project landing):** Same surface family, `px-4 py-4`, contains the project title and brief positioning.
+- **No nested cards.** A card may contain a table, a sparkline, a list of rows, an action button, or a stat ladder, but never another card. If a child needs visual emphasis, lift its row (background tint + hairline) rather than wrapping it in a card.
+
+### Score Gauge (signature component)
+
+- 96px (`size-24`) radial SVG ring with a 48px radius and 6px stroke. Background ring renders at 6% white opacity; fill renders in the metric's tone color (Signal Green, Caution Amber, Alert Rose, or neutral Smoke).
+- Fill animates from 0 to the value over 600ms with `cubic-bezier(0.4, 0, 0.2, 1)` easing.
+- Center value (`20px / 700`, tabular) sits inside the ring; eyebrow label drops below; an optional delta line and description follow.
+- Gauges are arranged in a `lg:grid-cols-5` row at the top of the project page. This is the canonical first-glance instrument cluster: visibility, AEO score, citation share, mention share, technical readiness.
+
+### Sparkline (signature component)
+
+- 132×42 SVG polyline, 2px stroke with round caps. Stroke color follows the row's tone. A 1px white-at-6% baseline guide sits under the line. Clipped with an 8px-rounded rect so the line's edges feather rather than terminate hard.
+- Inline next to a project row's stat strip; never appears as a standalone hero chart.
+
+### Tables (the dominant evidence container)
+
+- Wrap in a `rounded-xl` border-soft container with `overflow-x-auto` so wide tables scroll horizontally on narrow screens rather than reflowing.
+- Headers render in Eyebrow style (`11px / 600 / uppercase / 0.14em`, Fog color) over a Surface Ash header band with a hairline bottom border.
+- Body cells: `px-4 py-3`, Silver text. Row separators are 30%-opacity hairlines, no zebra striping. Hover tints the row to `bg-zinc-900/30`.
+- Tables hold evidence, findings, competitors, traffic events: anything tabular and scannable. They do not hold narrative; that is what insight cards are for.
+
+### Inputs & Form Controls
+
+- **Style:** `rounded-md`, Surface Ash background at 50% opacity, hairline border (Hairline Soft, zinc-700 default), Silver text, Whisper placeholder.
+- **Focus:** Border steps up to `border-zinc-500`; a 1px Smoke ring joins it. No glow, no colored ring. The change is decisive but quiet.
+- **Disabled:** 50% opacity, `cursor-not-allowed`. State, not invisibility.
+- **Setup wizard inputs** carry an Eyebrow Soft label above each field; no inline floating labels.
+
+### Sidebar Navigation
+
+- Fixed 224px wide, hidden below `lg`. Items: 13px font, `rounded-lg`, Fog text at rest, Surface Ash background and Silver text on hover, full Surface Ash background with `font-medium` Silver text when active.
+- Section titles render as Eyebrow Soft `0.18em` in Whisper color. Projects in the projects section each carry a 1.5px colored dot (Signal Green / Caution Amber / Alert Rose / neutral Whisper) to indicate visibility health at a glance.
+- The mascot bird sits at the top with its drop-shadow. When a new canonry version ships, the bird chirps and an amber bubble appears below it.
+
+### Aero Composer (command bar)
+
+- The bottom command bar on every project-scoped route is the human → Aero interface (the built-in analyst LLM). It collapses to a single input row at rest and expands into a chat transcript on demand.
+- Behavior is documented in `apps/web/src/components/shared/AeroBar.tsx`; visually it follows the same surface vocabulary (Surface Ash container, hairline border, Smoke text, monospaced tool-trail blocks) as the rest of the dashboard. It never adopts a chatbot bubble aesthetic; tool calls render as inline collapsed blocks, not as chat heads.
+
+## 6. Do's and Don'ts
+
+### Do:
+
+- **Do** use the Geist + Geist Mono pairing for every typographic decision; turn on `cv11`, `ss01`, `ss03` (and `ss02` for mono) so the 11–13px glyphs hold.
+- **Do** apply tabular numerics (`font-variant-numeric: tabular-nums`) to every numeric value that lives in a column, a gauge, a stat strip, or a delta.
+- **Do** prefer data tables over card grids for any list of three or more structured items (evidence, findings, competitors, traffic events).
+- **Do** use Surface Ash at 30% opacity (`bg-zinc-900/30`) plus a 60%-opacity hairline border (`border-zinc-800/60`) as the default container. Vary padding (`p-4` / `px-4 py-5` / `px-3 py-5`) to fit the contents.
+- **Do** ration tone color (Signal Green, Caution Amber, Alert Rose) to semantic state only. A row gets a tone color when it is reporting that state, never because the design needs accent.
+- **Do** route every chart through `components/shared/ChartPrimitives.tsx`. Use `CHART_TOOLTIP_STYLE`, `CHART_AXIS_TICK`, `CHART_GRID_STROKE`, `CHART_AXIS_STROKE`, `CHART_SERIES_COLORS` so all charts in the surface share a single vocabulary.
+- **Do** use the `ToneBadge` primitive (and its `Badge` underneath) for every status indicator. Map tones through the helpers (`toneFromRunStatus`, `toneFromCitationState`).
+- **Do** show two glyphs when rendering snapshot state in a single cell: one for cited (`C / c`), one for mentioned (`M / m`), with `–` for missing. Never collapse the two signals into one label.
+- **Do** respect `prefers-reduced-motion`. The toast slide, the aero typing dots, the brand mascot's chirp, and the bubble pop must all disable when the user requests reduced motion. Check the existing `@media (prefers-reduced-motion: reduce)` blocks in `styles.css` for the pattern.
+- **Do** keep the page width capped at `max-w-6xl` (1152px). The sidebar is always 224px. Resist the temptation to widen for "more breathing room"; density is the design metric here.
+
+### Don't:
+
+- **Don't** use `#000` or `#fff`. The base is Zinc Night (`#09090b`), the brightest body is Snow (`#fafafa`). Anything purer reads as cheap.
+- **Don't** introduce a chromatic brand color (no "canonry purple", no "canonry blue"). The accent is Snow. Adding a brand hue pulls the surface toward generic SaaS.
+- **Don't** ship gradient hero text, gradient buttons, glassmorphism cards, sparkle icons, mesh-gradient backgrounds, or "✨ AI-powered" stickers. Canonry is an AI product; that is exactly why none of those tropes appear. (Anti-references from PRODUCT.md.)
+- **Don't** build dashboards that look like Semrush or Ahrefs (every-pixel occupied, panels competing for attention) or Profound (the AEO-category reflex). Density is good; chaos is not.
+- **Don't** import `recharts` directly. Use `ChartPrimitives.tsx`. Don't add Chart.js, Highcharts, D3, Plotly, Nivo, or Victory. ESLint enforces this.
+- **Don't** use display fonts for UI labels, buttons, or data. Geist + Geist Mono is the entire type system.
+- **Don't** drop a card inside a card. If you find yourself nesting `surface-card`, lift the child row with a background tint and a hairline instead.
+- **Don't** apply drop shadows to resting surfaces. The only shadows allowed are the mascot drop-shadow, the toast lift, the bubble glow, and the sub-pixel Card highlight.
+- **Don't** reach for a modal as the first thought. Inline the form, slide a drawer, expand a row, anything before a modal. The evidence-detail modal is the existing exception; new modals need to justify themselves.
+- **Don't** invent a new color name when an existing zinc / emerald / amber / rose token will do. Saturate carefully: every new hue is one more thing for an analyst's eye to triage.
+
+### House exception: side-stripe borders
+
+The current `styles.css` carries `border-l-2 border-l-{tone}-500/60` on `.attention-item-*`, `.insight-row-*`, `.insight-card-*`, `.opportunity-card-*`, and `.opportunity-item-*`. This pattern conflicts with the general design rule that bans side-stripe borders as colored accents on cards or list items. It is preserved here as a **deliberate house exception**: the stripe is the visual cue an analyst uses to scan a long list and triage by severity (rose first, amber next, emerald acknowledged). Removing it would force the eye to read the tone badge or the row title to recover the same information.
+
+If a future revision wants to fold this into the general rule, the alternatives to consider in order: (1) replace the stripe with a leading 12px tone-colored circle (preserves scan but removes the side accent), (2) replace with a full-row background tint at very low opacity (e.g. `bg-rose-950/15`, already in use on citation-leaderboard rows), (3) keep the stripe but graduate to a 1px hairline so it reads as a marker rather than an accent. Until that decision is made, the side-stripe is correct.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,62 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+**Primary**: AEO (Answer Engine Optimization) analysts. Humans whose job is to track how AI answer engines (ChatGPT, Gemini, Claude, Perplexity) cite a given domain for tracked queries, diagnose regressions, and act on the signal.
+
+**Co-primary**: Aero, the built-in LLM analyst that ships inside canonry, plus external agents the user attaches via webhook or MCP. The dashboard is one of two clients on the API; the other is software. Whatever the human can see, an agent can fetch.
+
+**Derivative audiences** (via the HTML report renderer): clients (less technical, want the "what" and the "so what") and agencies (operator-grade, want the evidence and the recommended next move).
+
+Context of use: focused, ops-shaped sessions. Open the dashboard, scan what changed since last sweep, drill into the failing run or the lost citation, decide whether to act through content + integrations or escalate. Not casual browsing. Not first-time onboarding marketing.
+
+## Product Purpose
+
+Canonry is the **agent-first open-source AEO operating platform**. It tracks citation + mention behavior across LLM answer engines for a tracked set of queries, surfaces regressions, and acts on the signal through integrations (Google Search Console, Bing Webmaster, GA4, WordPress) and an AI analyst (Aero).
+
+Success looks like an analyst (or their agent) detecting, diagnosing, and acting on an AEO regression faster than they could with Semrush, Ahrefs, or Profound — and being able to script the entire workflow because every surface is API-first.
+
+## Brand Personality
+
+Three words: **expert · agentic · honest**.
+
+Voice: the instrument, not the showroom. Speak the way a senior analyst would in a postmortem — direct, evidence-led, no posturing. Numbers carry the headline; commentary explains the move. Never marketing-voice ("Unlock the power of…", "AI-driven insights"). Never coy.
+
+Emotional goal: when the user opens the dashboard, the feeling is "I'm running an instrument" — not "I'm reading a SaaS landing page." Confidence comes from data density and signal clarity, not from chrome.
+
+References in spirit: Linear (operator-grade, no fluff), Raycast (tool-density), Vercel (typographic polish on dense surfaces), Stripe docs (evidence-led prose). Bloomberg Terminal in attitude, Vercel in restraint.
+
+## Anti-references
+
+What canonry must explicitly NOT look or feel like:
+
+- **Semrush / Ahrefs** — overstuffed SEO dashboards where every pixel is occupied, every panel competes for attention, and no scanning rhythm exists. Density is good; chaos is not.
+- **Profound and the AEO-tool reflex** — the obvious aesthetic for this category. If a user could guess "this is an AEO dashboard" from the chrome alone, we've fallen into the category reflex. Lean against it on purpose.
+- **Generic SaaS marketing** — gradient hero, three feature cards in a row, testimonial carousel, big "Get started free" CTA. Canonry has no marketing surface inside the app, and never should.
+- **"AI startup" aesthetic** — purple-to-pink gradients, sparkle/wand icons, generative-art backgrounds, glassmorphism, "✨ Powered by AI" stickers, animated mesh gradients. Canonry IS an AI product, which is exactly why none of these belong.
+
+## Design Principles
+
+Strategic principles that should guide every design call, not visual rules.
+
+1. **Agent-first means machine-readable.** The UI is a consumer of the API, never a privileged surface. Every metric a human sees, an agent can fetch via CLI / API / MCP in a single call. Derived calculations live in the API response, not in component code. If a UI widget displays something an agent cannot retrieve, that's a bug in the API, not a "UI-only metric." (Encoded as the UI/CLI parity rule in `AGENTS.md`.)
+
+2. **Density over decoration.** Analysts scan; they don't browse. Data tables beat card grids for any list of 3+ structured items. Information per square inch is the design metric. Whitespace is for rhythm and hierarchy, not for atmosphere. Cards are reserved for narrative — insights, interpretations — not for evidence lists.
+
+3. **Two signals, never collapsed.** "Cited" (the domain appears in the source links the LLM used) and "mentioned" (the brand appears in the answer text) are independent signals. A model can do either, both, or neither. The UI must always disambiguate — never invent a unified "visibility" score that collapses them, never label one and compute from the other. (Encoded as the Vocabulary rule in `AGENTS.md`.)
+
+4. **Honest over hype.** No gradient-text headlines, no "AI-powered ✨" stickers, no manufactured urgency, no fake counts, no fabricated trends. The data is the story. When a metric is zero, say zero. When data is missing, say missing — don't infer a fallback that pretends the signal exists.
+
+5. **One DTO, many renderers.** The CLI text output, the dashboard SPA, the downloadable HTML report, and the MCP/API JSON all render from the same underlying contract. Drift between any two is a bug, not a styling difference. Visual choices are constrained by what survives across all four surfaces — anything dashboard-only (rich React components, hover-only affordances) needs a deliberate degradation path for the static and machine-readable renderers.
+
+## Accessibility & Inclusion
+
+- WCAG: aim for AA contrast as a floor. The dark zinc-950 base + zinc-50 primary text already clears AA; tone colors (emerald, amber, rose) on zinc-900/30 surfaces have been chosen with this in mind. Verify any new tone-on-surface combination before shipping.
+- Keyboard: skip-to-content link, focus-visible rings on every interactive element, `aria-current="page"` on active nav, `aria-label` on nav landmarks, `.sr-only` labels where icons stand alone.
+- Reduced motion: respect `prefers-reduced-motion` for sparklines, gauges, and chart animations. Charts already use exponential ease-out curves; static fallbacks should drop the entry animation entirely rather than shortening it.
+- Color-blind safety: tone is never carried by hue alone. Every tone-colored element pairs with an icon, glyph, or label (`ToneBadge`, two-glyph snapshot cells like `[citation][mention]` from `canonry citations`). Severity is encoded redundantly.
+- Internationalization: the dashboard is English-first today; UI copy should still avoid idioms that don't translate. Numbers use `en-US` locale formatting via shared utilities in `packages/contracts/src/formatting.ts`.

--- a/apps/web/src/components/project/ActivitySection.tsx
+++ b/apps/web/src/components/project/ActivitySection.tsx
@@ -12,6 +12,7 @@ import {
   CHART_TOOLTIP_STYLE,
   CHART_AXIS_TICK,
   CHART_AXIS_STROKE,
+  CHART_NEUTRAL,
   CHART_SERIES_COLORS,
   formatChartDateLabel,
   formatChartDateTick,
@@ -56,8 +57,8 @@ const TRAFFIC_WINDOWS: MetricsWindow[] = ['7d', '30d', '90d', 'all']
 
 const SOURCE_COLORS = CHART_SERIES_COLORS
 
-const SOCIAL_OTHER_COLOR = '#71717a'
-const SOCIAL_TOTAL_COLOR = '#52525b'
+const SOCIAL_OTHER_COLOR = CHART_NEUTRAL.textDim
+const SOCIAL_TOTAL_COLOR = CHART_NEUTRAL.textFaint
 const SOCIAL_TABLE_DEFAULT_LIMIT = 25
 
 type PageSortKey = 'landingPage' | 'sessions' | 'organicSessions' | 'users'
@@ -679,7 +680,7 @@ function ClickThroughActivity({ projectName }: { projectName: string }) {
                         }}
                       />
                       <Legend
-                        wrapperStyle={{ fontSize: 11, color: '#a1a1aa' }}
+                        wrapperStyle={{ fontSize: 11, color: CHART_NEUTRAL.text }}
                         formatter={(value: string) => {
                           if (value === '_totalSessions') return 'Total Sessions'
                           if (value === '_organicSessions') return 'Organic Sessions'
@@ -690,8 +691,8 @@ function ClickThroughActivity({ projectName }: { projectName: string }) {
                       <Area
                         type="monotone"
                         dataKey="_totalSessions"
-                        stroke="#52525b"
-                        fill="#27272a"
+                        stroke={CHART_NEUTRAL.textFaint}
+                        fill={CHART_NEUTRAL.surface}
                         fillOpacity={0.4}
                         strokeWidth={1.5}
                         dot={false}
@@ -915,7 +916,7 @@ function ClickThroughActivity({ projectName }: { projectName: string }) {
                         type="monotone"
                         dataKey={SOCIAL_TOTAL_KEY}
                         stroke={SOCIAL_TOTAL_COLOR}
-                        fill="#27272a"
+                        fill={CHART_NEUTRAL.surface}
                         fillOpacity={0.4}
                         strokeWidth={1.5}
                         dot={false}
@@ -1286,12 +1287,16 @@ function SortHeader<K extends string>({
 }) {
   const active = current === key
   return (
-    <th
-      className={`py-1 font-medium cursor-pointer select-none hover:text-zinc-300 transition-colors ${align === 'right' ? 'text-right' : 'text-left'}`}
-      onClick={() => onSort(key)}
-    >
-      {label}
-      {active && <span className="ml-0.5">{dir === 'asc' ? '↑' : '↓'}</span>}
+    <th className={`py-1 ${align === 'right' ? 'text-right' : 'text-left'}`}>
+      <button
+        type="button"
+        className="font-medium cursor-pointer select-none hover:text-zinc-300 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-zinc-400 rounded"
+        onClick={() => onSort(key)}
+        aria-label={`Sort by ${label}${active ? ` (currently ${dir === 'asc' ? 'ascending' : 'descending'})` : ''}`}
+      >
+        {label}
+        {active && <span className="ml-0.5">{dir === 'asc' ? '↑' : '↓'}</span>}
+      </button>
     </th>
   )
 }

--- a/apps/web/src/components/project/EvidenceTable.tsx
+++ b/apps/web/src/components/project/EvidenceTable.tsx
@@ -242,8 +242,16 @@ export function EvidenceTable({
               return (
                 <Fragment key={groupKey}>
                   <tr
-                    className="evidence-phrase-row cursor-pointer hover:bg-zinc-800/40"
+                    className="evidence-phrase-row cursor-pointer hover:bg-zinc-800/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400"
                     onClick={() => toggleRow(groupKey)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        toggleRow(groupKey)
+                      }
+                    }}
+                    tabIndex={0}
+                    role="button"
                     aria-expanded={isExpanded}
                   >
                     <td>

--- a/apps/web/src/components/project/GscSection.tsx
+++ b/apps/web/src/components/project/GscSection.tsx
@@ -7,6 +7,7 @@ import type { GscPerformanceDailyDto, MetricsWindow } from '@ainyc/canonry-contr
 import { Button } from '../ui/button.js'
 import { Card } from '../ui/card.js'
 import { ToneBadge } from '../shared/ToneBadge.js'
+import { CHART_NEUTRAL, CHART_TONE, CHART_SERIES_COLORS } from '../shared/ChartPrimitives.js'
 import { formatTimestamp, formatBooleanState, SearchMetric, SEARCH_METRIC_LABELS } from '../../lib/format-helpers.js'
 import { addToast } from '../../lib/toast-store.js'
 import { asyncHandler } from '../../lib/async-handler.js'
@@ -775,7 +776,7 @@ export function GscSection({
                                 {/* Indexed arc — emerald */}
                                 <circle
                                   cx="64" cy="64" r={r} fill="none"
-                                  stroke="#10b981" strokeWidth="14"
+                                  stroke={CHART_TONE.positiveDeep} strokeWidth="14"
                                   strokeDasharray={circ} strokeDashoffset={indexedOffset}
                                   strokeLinecap="round"
                                   transform="rotate(-90 64 64)"
@@ -785,7 +786,7 @@ export function GscSection({
                                 {coverage.summary.notIndexed > 0 && (
                                   <circle
                                     cx="64" cy="64" r={r} fill="none"
-                                    stroke="#52525b" strokeWidth="14"
+                                    stroke={CHART_NEUTRAL.textFaint} strokeWidth="14"
                                     strokeDasharray={`${notIndexedArc} ${circ - notIndexedArc}`}
                                     strokeDashoffset={-notIndexedStart}
                                     transform="rotate(-90 64 64)"
@@ -904,8 +905,17 @@ export function GscSection({
                             {(coverage.reasonGroups ?? []).map((group) => (
                               <tr
                                 key={group.reason}
-                                className="cursor-pointer hover:bg-zinc-800/40"
+                                className="cursor-pointer hover:bg-zinc-800/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400"
                                 onClick={() => setSelectedReason(group.reason)}
+                                onKeyDown={(e) => {
+                                  if (e.key === 'Enter' || e.key === ' ') {
+                                    e.preventDefault()
+                                    setSelectedReason(group.reason)
+                                  }
+                                }}
+                                tabIndex={0}
+                                role="button"
+                                aria-label={`View ${group.reason} pages`}
                               >
                                 <td className="text-zinc-200">{group.reason}</td>
                                 <td className="text-right tabular-nums text-zinc-400">{group.count}</td>
@@ -1143,7 +1153,7 @@ export function GscSection({
                           <span className="text-xs text-zinc-400">Clicks <span className="text-zinc-200 tabular-nums font-medium">{totalClicks.toLocaleString()}</span></span>
                         </div>
                         <div className="flex items-center gap-1.5">
-                          <span className="inline-block h-2.5 w-2.5 rounded-sm bg-blue-500" />
+                          <span className="inline-block h-2.5 w-2.5 rounded-sm bg-blue-400" />
                           <span className="text-xs text-zinc-400">Impressions <span className="text-zinc-200 tabular-nums font-medium">{totalImpressions.toLocaleString()}</span></span>
                         </div>
                         <span className="text-xs text-zinc-500">CTR <span className="text-amber-400 tabular-nums font-medium">{avgCtr}%</span></span>
@@ -1156,7 +1166,7 @@ export function GscSection({
                             return (
                               <g key={`t-${i}`}>
                                 <line x1={pad.left} y1={y} x2={w - pad.right} y2={y} stroke="rgba(255,255,255,0.06)" strokeWidth="1" />
-                                <text x={pad.left - 6} y={y + 3.5} textAnchor="end" fill="#a1a1aa" fontSize="10" fontFamily="inherit">{fmtNum(tick)}</text>
+                                <text x={pad.left - 6} y={y + 3.5} textAnchor="end" fill={CHART_NEUTRAL.text} fontSize="10" fontFamily="inherit">{fmtNum(tick)}</text>
                               </g>
                             )
                           })}
@@ -1174,7 +1184,7 @@ export function GscSection({
                                   width={barW}
                                   height={Math.max(impressionH, 1)}
                                   rx={2}
-                                  fill="#3b82f6"
+                                  fill={CHART_SERIES_COLORS[1]}
                                   opacity={0.85}
                                 />
                                 <rect
@@ -1183,7 +1193,7 @@ export function GscSection({
                                   width={barW}
                                   height={Math.max(clickH, 1)}
                                   rx={2}
-                                  fill="#10b981"
+                                  fill={CHART_TONE.positiveDeep}
                                   opacity={0.85}
                                 />
                               </g>
@@ -1196,7 +1206,7 @@ export function GscSection({
                               const idx = sorted.length === 1 ? 0 : Math.round((i / (labelCount - 1)) * (sorted.length - 1))
                               const cx = pad.left + barGroupW * idx + barGroupW / 2
                               return (
-                                <text key={`xl-${idx}`} x={cx} y={h - 8} textAnchor="middle" fill="#71717a" fontSize="10" fontFamily="inherit">
+                                <text key={`xl-${idx}`} x={cx} y={h - 8} textAnchor="middle" fill={CHART_NEUTRAL.textDim} fontSize="10" fontFamily="inherit">
                                   {sorted[idx]!.date.slice(5)}
                                 </text>
                               )

--- a/apps/web/src/components/shared/AeroBar.tsx
+++ b/apps/web/src/components/shared/AeroBar.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { useChatScroll } from '../../lib/use-chat-scroll.js'
 import {
-  Sparkles,
+  Radio,
   X,
   RotateCcw,
   ArrowUp,
@@ -400,7 +400,7 @@ export function AeroBar({ projectName }: AeroBarProps) {
           <div className={expanded ? 'flex h-full flex-col' : 'flex flex-col overflow-hidden rounded-2xl border border-zinc-800/80 bg-zinc-950/95 shadow-xl backdrop-blur'}>
             <div className="flex items-center justify-between gap-2 border-b border-zinc-800/70 px-4 py-2.5">
               <div className="flex items-center gap-2">
-                <Sparkles className="h-4 w-4 text-emerald-400" aria-hidden="true" />
+                <Radio className="h-4 w-4 text-emerald-400" aria-hidden="true" />
                 <span className="text-sm font-medium text-zinc-100">Aero</span>
                 <span className="text-[10px] uppercase tracking-wider text-zinc-500">
                   {streaming ? 'working…' : projectName}
@@ -592,7 +592,7 @@ export function AeroBar({ projectName }: AeroBarProps) {
             className="flex w-full items-center justify-between rounded-full border border-zinc-800/80 bg-zinc-950/95 px-4 py-2 text-left text-sm text-zinc-400 shadow-lg backdrop-blur transition hover:border-zinc-700 hover:bg-zinc-900/90 hover:text-zinc-200"
           >
             <span className="flex items-center gap-2">
-              <Sparkles className="h-4 w-4 text-emerald-400" aria-hidden="true" />
+              <Radio className="h-4 w-4 text-emerald-400" aria-hidden="true" />
               Ask Aero about {projectName}…
             </span>
             <span className="text-[10px] uppercase tracking-wider text-zinc-600">Enter</span>

--- a/apps/web/src/components/shared/ChartPrimitives.tsx
+++ b/apps/web/src/components/shared/ChartPrimitives.tsx
@@ -72,6 +72,33 @@ export const CHART_SERIES_COLORS = [
   '#f87171', // red-400
 ] as const
 
+/**
+ * Neutral color tokens for custom SVG visualizations (non-Recharts).
+ * Mirrors the dashboard's zinc neutral ramp so custom charts stay on
+ * the documented palette in DESIGN.md.
+ */
+export const CHART_NEUTRAL = {
+  text: '#a1a1aa',      // zinc-400 — primary axis labels
+  textDim: '#71717a',   // zinc-500 — secondary text
+  textFaint: '#52525b', // zinc-600 — faintest text, track lines
+  surface: '#27272a',   // zinc-800 — area fill, track surface
+  gridLine: 'rgba(255, 255, 255, 0.06)',
+} as const
+
+/**
+ * Tone fills for direct categorical charts (bars, donuts).
+ * Matches the Listening Post tone palette in DESIGN.md. Use the
+ * `Deep` variant when the chart wants heavier visual weight
+ * (large donut arcs); use the base variant for sparklines and gauges.
+ */
+export const CHART_TONE = {
+  positive: '#34d399',     // emerald-400 — gauge fill, sparkline positive
+  positiveDeep: '#10b981', // emerald-500 — donut arc weight
+  caution: '#fbbf24',      // amber-400
+  negative: '#fb7185',     // rose-400
+  neutral: '#a1a1aa',      // zinc-400
+} as const
+
 /** Parse a date string that may be a date-only ("2026-03-15") or full ISO timestamp. */
 function parseChartDate(value: string): Date {
   const s = String(value)

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -17,9 +17,9 @@ const buttonVariants = cva(
         destructive: 'bg-rose-600 text-white hover:bg-rose-700',
       },
       size: {
-        default: 'h-9 px-4',
-        sm: 'h-8 px-3 text-xs',
-        icon: 'size-9',
+        default: 'h-10 px-4 md:h-9',
+        sm: 'h-9 px-3 text-xs md:h-8',
+        icon: 'size-10 md:size-9',
       },
     },
     defaultVariants: {

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
     <div
       ref={ref}
       className={cn(
-        'rounded-xl border border-zinc-800 bg-zinc-950/75 shadow-[0_0_0_1px_rgba(255,255,255,0.01)] backdrop-blur',
+        'rounded-xl border border-zinc-800 bg-zinc-950/75 shadow-[0_0_0_1px_rgba(255,255,255,0.01)]',
         className,
       )}
       {...props}

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -1232,8 +1232,17 @@ function InsightSignals({
                 return (
                   <div key={insight.id}>
                     <div
-                      className={`opportunity-item opportunity-item-${insight.tone} ${hasAffected ? 'cursor-pointer' : ''}`}
+                      className={`opportunity-item opportunity-item-${insight.tone} ${hasAffected ? 'cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400' : ''}`}
                       onClick={hasAffected ? () => setExpandedId(isExpanded ? null : insight.id) : undefined}
+                      onKeyDown={hasAffected ? (e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault()
+                          setExpandedId(isExpanded ? null : insight.id)
+                        }
+                      } : undefined}
+                      tabIndex={hasAffected ? 0 : undefined}
+                      role={hasAffected ? 'button' : undefined}
+                      aria-expanded={hasAffected ? isExpanded : undefined}
                     >
                       <div className="flex items-start gap-1.5 min-w-0">
                         {hasAffected && (


### PR DESCRIPTION
## Summary

Adds `PRODUCT.md`, `DESIGN.md`, and `.impeccable/design.json` to scaffold the canonry dashboard's design system as **The Listening Post** — operator-grade dark mode in the Vercel lineage, with a closed Provider Identity palette for the five tracked LLM engines (Gemini, OpenAI, Claude, Perplexity, Local). Then applies the first round of audit fixes against that spec: replaces the AeroBar `Sparkles` icon with `Radio` (the cliché ✨ icon was a direct PRODUCT.md anti-reference); adds keyboard support (role / tabIndex / onKeyDown) to five clickable rows or cells across `EvidenceTable`, `GscSection` coverage, `ProjectPage` opportunities, and `ActivitySection` sortable headers; centralizes ten inline chart hex codes via new `CHART_NEUTRAL` and `CHART_TONE` exports in `ChartPrimitives.tsx`; drops `backdrop-blur` from the `Card` primitive (Flat-By-Default Rule); and bumps `Button` touch targets to 40px below `md` while preserving 36px on desktop. Typecheck, lint (0 errors), and the full 3,316-test suite all pass.

## Test plan

- [x] `pnpm run typecheck` — all packages pass
- [x] `pnpm run lint` — 0 errors (110 pre-existing warnings, none in changed lines)
- [x] `pnpm run test` — 3,316 tests pass across 273 files
- [x] Manually verify AeroBar Radio icon renders correctly at 16px in the collapsed launcher and expanded header
- [x] Manually verify keyboard navigation: Tab through EvidenceTable rows, GscSection coverage rows, ProjectPage opportunity items, and ActivitySection sortable headers; confirm Enter / Space activates each
- [x] Manually verify GscSection clicks-vs-impressions chart legend swatch (`bg-blue-400`) visually matches the bar fill (`CHART_SERIES_COLORS[1]`)
- [ ] Manually verify `Card` primitive instances still read as containers without the backdrop blur