### PR TITLE
fix(settings): show the effective provider model in UI and CLI

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -667,6 +667,7 @@ export interface ApiProviderSummary {
   keyUrl?: string
   modelHint?: string
   model?: string
+  defaultModel?: string
   configured: boolean
   quota?: {
     maxConcurrency: number

--- a/apps/web/src/build-dashboard.ts
+++ b/apps/web/src/build-dashboard.ts
@@ -746,6 +746,7 @@ export function buildDashboard(projectDataList: ProjectData[], apiSettings?: Api
         keyUrl: p.keyUrl,
         modelHint: p.modelHint,
         model: p.model,
+        defaultModel: p.defaultModel,
         state: (p.configured ? 'ready' : 'needs-config') as 'ready' | 'needs-config',
         detail: p.configured ? 'Provider is configured.' : 'API key is missing.',
         quota: p.quota,

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -63,7 +63,12 @@ export function SettingsPage() {
             <dl className="definition-list mt-3">
               <div>
                 <dt>Model</dt>
-                <dd className="font-mono text-xs">{provider.model}</dd>
+                <dd className="font-mono text-xs">
+                  {provider.model ?? provider.defaultModel ?? 'unknown'}
+                  {!provider.model && provider.defaultModel && (
+                    <span className="ml-1 font-sans text-zinc-500">(default)</span>
+                  )}
+                </dd>
               </div>
               {provider.quota && (
                 <>

--- a/apps/web/src/view-models.ts
+++ b/apps/web/src/view-models.ts
@@ -261,6 +261,7 @@ export interface ProviderStatusVm {
   keyUrl?: string
   modelHint?: string
   model?: string
+  defaultModel?: string
   state: 'ready' | 'needs-config'
   detail: string
   quota?: {

--- a/apps/web/test/build-dashboard.test.ts
+++ b/apps/web/test/build-dashboard.test.ts
@@ -110,6 +110,29 @@ test('buildDashboard maps Google settings into the dashboard view model', () => 
   expect(dashboard.settings.bootstrapNote).toMatch(/Authentication credentials persist to local config/)
 })
 
+test('buildDashboard surfaces both the model override and the adapter default model', () => {
+  const apiSettings: ApiSettings = {
+    providers: [
+      { name: 'gemini', configured: true, model: 'gemini-2.5-flash', defaultModel: 'gemini-3-flash-preview' },
+      { name: 'openai', configured: true, defaultModel: 'gpt-5.4' },
+    ],
+    google: { configured: false },
+  }
+
+  const statuses = buildDashboard([], apiSettings).settings.providerStatuses
+
+  // Explicit override is preserved verbatim.
+  const gemini = statuses.find((p) => p.name === 'gemini')
+  expect(gemini?.model).toBe('gemini-2.5-flash')
+  expect(gemini?.defaultModel).toBe('gemini-3-flash-preview')
+
+  // No override: model stays undefined, but the adapter default is carried
+  // through so the settings card can show the effective model instead of a blank.
+  const openai = statuses.find((p) => p.name === 'openai')
+  expect(openai?.model).toBeUndefined()
+  expect(openai?.defaultModel).toBe('gpt-5.4')
+})
+
 test('buildDashboard marks Google settings as needing config when OAuth is not configured', () => {
   const apiSettings: ApiSettings = {
     providers: [],

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -1407,6 +1407,7 @@ export type SettingsDto = {
         keyUrl?: string;
         modelHint?: string;
         model?: string;
+        defaultModel?: string;
         configured: boolean;
         quota?: {
             maxConcurrency: number;

--- a/packages/api-routes/src/settings.ts
+++ b/packages/api-routes/src/settings.ts
@@ -26,6 +26,8 @@ export interface ProviderSummaryEntry {
   keyUrl?: string
   modelHint?: string
   model?: string
+  /** The adapter's built-in default model (used when `model` is unset). */
+  defaultModel?: string
   configured: boolean
   quota?: ProviderQuotaPolicy
   /** Whether Vertex AI is configured for this provider (Gemini only) */

--- a/packages/canonry/src/commands/settings.ts
+++ b/packages/canonry/src/commands/settings.ts
@@ -43,6 +43,7 @@ export async function showSettings(format?: string): Promise<void> {
     providers: Array<{
       name: string
       model?: string
+      defaultModel?: string
       configured: boolean
       quota?: { maxConcurrency: number; maxRequestsPerMinute: number; maxRequestsPerDay: number }
     }>
@@ -64,7 +65,12 @@ export async function showSettings(format?: string): Promise<void> {
     const status = provider.configured ? 'configured' : 'not configured'
     console.log(`  ${provider.name.padEnd(10)} ${status}`)
     if (provider.configured) {
-      console.log(`    Model:     ${provider.model ?? '(default)'}`)
+      const modelLabel = provider.model
+        ? provider.model
+        : provider.defaultModel
+          ? `${provider.defaultModel} (default)`
+          : '(default)'
+      console.log(`    Model:     ${modelLabel}`)
       if (provider.quota) {
         console.log(`    Quota:     ${provider.quota.maxConcurrency} concurrent · ${provider.quota.maxRequestsPerMinute}/min · ${provider.quota.maxRequestsPerDay}/day`)
       }

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -501,6 +501,7 @@ export async function createServer(opts: {
     keyUrl: adapter.keyUrl,
     modelHint: `e.g. ${adapter.modelRegistry.defaultModel}`,
     model: registry.get(adapter.name)?.config.model,
+    defaultModel: adapter.modelRegistry.defaultModel,
     configured: !!registry.get(adapter.name),
     quota: registry.get(adapter.name)?.config.quotaPolicy,
     vertexConfigured: adapter.name === 'gemini' ? !!opts.config.providers?.gemini?.vertexProject : undefined,

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -16,6 +16,11 @@ export const providerSummaryEntryDtoSchema = z.object({
   keyUrl: z.string().optional(),
   modelHint: z.string().optional(),
   model: z.string().optional(),
+  /**
+   * The adapter's built-in default model. Surfaced so the UI and CLI can show
+   * the effective model even when no explicit `model` override is configured.
+   */
+  defaultModel: z.string().optional(),
   configured: z.boolean(),
   quota: providerQuotaPolicySchema.optional(),
   /** Whether Vertex AI is configured for this provider (Gemini only). */

--- a/packages/contracts/test/settings.test.ts
+++ b/packages/contracts/test/settings.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'vitest'
+
+import { providerSummaryEntryDtoSchema } from '../src/settings.js'
+
+describe('providerSummaryEntryDtoSchema', () => {
+  test('keeps an explicit model override alongside the adapter default model', () => {
+    const parsed = providerSummaryEntryDtoSchema.parse({
+      name: 'openai',
+      configured: true,
+      model: 'gpt-4o',
+      defaultModel: 'gpt-5.4',
+    })
+
+    expect(parsed.model).toBe('gpt-4o')
+    expect(parsed.defaultModel).toBe('gpt-5.4')
+  })
+
+  test('allows the default model with no explicit override (the common case)', () => {
+    const parsed = providerSummaryEntryDtoSchema.parse({
+      name: 'claude',
+      configured: true,
+      defaultModel: 'claude-sonnet-4-6',
+    })
+
+    expect(parsed.model).toBeUndefined()
+    expect(parsed.defaultModel).toBe('claude-sonnet-4-6')
+  })
+
+  test('treats defaultModel as optional so older payloads still parse', () => {
+    const parsed = providerSummaryEntryDtoSchema.parse({
+      name: 'local',
+      configured: false,
+    })
+
+    expect(parsed.defaultModel).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## What

Surface the **effective** provider model on the settings page and in `canonry settings`. Adds an optional `defaultModel` field to the provider settings DTO carrying the adapter's built-in default.

## Why

The settings card rendered only an explicitly-configured model override. Providers running on the adapter default showed a blank Model field in the dashboard, and the CLI printed `(default)` with no name, so an operator could not tell which model a provider was actually using.

## Change

- `defaultModel` added to `providerSummaryEntryDtoSchema` (contracts) and the server-side `ProviderSummaryEntry`; populated from `adapter.modelRegistry.defaultModel` in `createServer`.
- SDK regenerated. Only `types.gen.ts` changes (additive optional response property, no operation/signature change).
- Dashboard settings card and `canonry settings` now render `model ?? defaultModel`, tagging the default case so an explicit override stays distinguishable. Both surfaces read the same two fields (UI/CLI parity).

## Notes

- Additive, optional field only. No endpoint path or method change.
- Under the 100-line threshold, so no version bump.

## Tests

- `packages/contracts/test/settings.test.ts`: schema round-trip for override, default-only, and legacy-absent cases.
- `apps/web/test/build-dashboard.test.ts`: asserts both `model` and `defaultModel` propagate into provider statuses, including the no-override path.
- Full workspace green: typecheck, lint (0 errors), 3320 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
