### PR TITLE
feat(web): add competitor removal to the project page

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -14,6 +14,7 @@ import {
   postApiV1ProjectsByNameQueriesGenerate,
   postApiV1ProjectsByNameContentDismissals,
   deleteApiV1ProjectsByNameContentDismissalsByTargetRef,
+  deleteApiV1ProjectsByNameCompetitors,
   getApiV1ProjectsByNameCompetitors,
   putApiV1ProjectsByNameCompetitors,
   postApiV1ProjectsByNameLocations,
@@ -552,6 +553,21 @@ export function undismissContentTarget(projectName: string, targetRef: string): 
 export function setCompetitors(projectName: string, competitors: string[]): Promise<ApiCompetitor[]> {
   return invokeWeb<ApiCompetitor[]>(() =>
     putApiV1ProjectsByNameCompetitors({
+      client: heyClient,
+      path: { name: projectName },
+      body: { competitors },
+    }),
+  )
+}
+
+/**
+ * Remove specific competitors by domain. Returns the remaining tracked
+ * competitors. Domains are normalized server-side, so either the original or
+ * a subdomain form resolves to the stored registrable domain.
+ */
+export function removeCompetitors(projectName: string, competitors: string[]): Promise<ApiCompetitor[]> {
+  return invokeWeb<ApiCompetitor[]>(() =>
+    deleteApiV1ProjectsByNameCompetitors({
       client: heyClient,
       path: { name: projectName },
       body: { competitors },

--- a/apps/web/src/components/project/CompetitorTable.tsx
+++ b/apps/web/src/components/project/CompetitorTable.tsx
@@ -5,12 +5,16 @@ import type { ProjectCommandCenterVm } from '../../view-models.js'
 export function CompetitorTable({
   competitors,
   onSelectCompetitor,
+  onRemoveCompetitor,
   activeFilter,
 }: {
   competitors: ProjectCommandCenterVm['competitors']
   /** Click handler — fired when an analyst wants to filter the Evidence Table
    *  to the queries where this competitor surfaced. Receives the domain. */
   onSelectCompetitor?: (domain: string) => void
+  /** Remove handler — fired when an analyst removes a tracked competitor.
+   *  Receives the domain. When omitted, no remove control is rendered. */
+  onRemoveCompetitor?: (domain: string) => void
   /** Currently-active competitor filter, for row highlighting. */
   activeFilter?: string | null
 }) {
@@ -19,6 +23,7 @@ export function CompetitorTable({
   }
 
   const clickable = onSelectCompetitor != null
+  const removable = onRemoveCompetitor != null
 
   return (
     <div className="competitor-table-wrap">
@@ -29,6 +34,7 @@ export function CompetitorTable({
             <th>Pressure</th>
             <th>Citations</th>
             <th>Queries</th>
+            {removable && <th><span className="sr-only">Actions</span></th>}
           </tr>
         </thead>
         <tbody>
@@ -61,6 +67,22 @@ export function CompetitorTable({
                     ? competitor.citedQueries.join(', ')
                     : 'Not cited'}
                 </td>
+                {removable && (
+                  <td className="text-right">
+                    <button
+                      type="button"
+                      className="rounded px-1.5 py-0.5 text-xs text-zinc-500 transition-colors hover:text-rose-400 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-rose-500"
+                      aria-label={`Remove competitor ${competitor.domain}`}
+                      title={`Remove ${competitor.domain}`}
+                      onClick={(event) => {
+                        event.stopPropagation()
+                        onRemoveCompetitor!(competitor.domain)
+                      }}
+                    >
+                      Remove
+                    </button>
+                  </td>
+                )}
               </tr>
             )
           })}

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -35,6 +35,7 @@ import {
   appendQueries as apiAppendQueries,
   fetchCompetitors as apiFetchCompetitors,
   setCompetitors as apiSetCompetitors,
+  removeCompetitors as apiRemoveCompetitors,
   updateOwnedDomains as apiUpdateOwnedDomains,
   updateAliases as apiUpdateAliases,
   updateProject as apiUpdateProject,
@@ -1685,6 +1686,21 @@ function ProjectPageContent({
     }
   }
 
+  async function handleRemoveCompetitor(domain: string) {
+    try {
+      await apiRemoveCompetitors(projectName, [domain])
+      void refetch()
+    } catch (err) {
+      addToast({
+        title: 'Could not remove competitor',
+        detail: err instanceof Error ? err.message : `Failed to remove ${domain}`,
+        tone: 'negative',
+        dedupeKey: 'competitor:remove',
+        dedupeMode: 'replace',
+      })
+    }
+  }
+
   async function handleAddOwnedDomain() {
     const domain = newOwnedDomain.trim()
     if (!domain) return
@@ -2186,6 +2202,7 @@ function ProjectPageContent({
                 setCompetitorFilter(domain)
                 document.getElementById('evidence-section')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
               }}
+              onRemoveCompetitor={(domain) => { void handleRemoveCompetitor(domain) }}
               activeFilter={competitorFilter}
             />
           </section>

--- a/apps/web/test/competitor-table.test.tsx
+++ b/apps/web/test/competitor-table.test.tsx
@@ -1,0 +1,54 @@
+import { afterEach, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+afterEach(cleanup)
+
+import { CompetitorTable } from '../src/components/project/CompetitorTable.js'
+import type { CompetitorVm } from '../src/view-models.js'
+
+function competitor(overrides: Partial<CompetitorVm> = {}): CompetitorVm {
+  return {
+    id: 'c1',
+    domain: 'rival.com',
+    citationCount: 3,
+    totalQueries: 8,
+    pressureLabel: 'Moderate',
+    citedQueries: ['roofing estimate software'],
+    movement: 'steady',
+    notes: '',
+    ...overrides,
+  }
+}
+
+test('renders a remove control that reports the competitor domain', () => {
+  const onRemove = vi.fn()
+  render(<CompetitorTable competitors={[competitor()]} onRemoveCompetitor={onRemove} />)
+
+  fireEvent.click(screen.getByLabelText('Remove competitor rival.com'))
+
+  expect(onRemove).toHaveBeenCalledTimes(1)
+  expect(onRemove).toHaveBeenCalledWith('rival.com')
+})
+
+test('remove click does not also trigger the row filter (stops propagation)', () => {
+  const onRemove = vi.fn()
+  const onSelect = vi.fn()
+  render(
+    <CompetitorTable
+      competitors={[competitor()]}
+      onRemoveCompetitor={onRemove}
+      onSelectCompetitor={onSelect}
+    />,
+  )
+
+  fireEvent.click(screen.getByLabelText('Remove competitor rival.com'))
+
+  expect(onRemove).toHaveBeenCalledWith('rival.com')
+  expect(onSelect).not.toHaveBeenCalled()
+})
+
+test('omits the remove control when no remove handler is provided', () => {
+  render(<CompetitorTable competitors={[competitor()]} onSelectCompetitor={vi.fn()} />)
+
+  expect(screen.queryByLabelText('Remove competitor rival.com')).toBeNull()
+})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.55.4",
+  "version": "4.56.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.55.4",
+  "version": "4.56.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## What

Add a per-row **Remove** control to the competitor table on the project page, so competitors can be removed from the dashboard, not only from the CLI.

## Why

The table was read-only. The "Add competitor" control already existed, but removal required `canonry competitor remove`. This closes the UI/CLI parity gap for competitor management.

## Change

- New `removeCompetitors()` wrapper in `apps/web/src/api.ts`, delegating to the existing generated `deleteApiV1ProjectsByNameCompetitors` SDK function (`DELETE /projects/:name/competitors`).
- `CompetitorTable` gains an optional `onRemoveCompetitor` prop. When provided it renders a Remove button per row; the button stops click propagation so it never triggers the row's filter-evidence action. Has an `aria-label` and focus ring.
- `ProjectPage` wires `handleRemoveCompetitor` (delete, then refetch; toast on failure).

## Notes

- No backend or contract change. The DELETE endpoint, generated SDK function, and `canonry competitor remove` CLI command already existed.
- DELETE is idempotent server-side, so a double-click is harmless.
- Minor version bump to `4.56.0` (root + `packages/canonry`): the change is 109 lines, over the 100-line threshold, and adds a user-facing capability.

## Tests

- `apps/web/test/competitor-table.test.tsx`: Remove control reports the domain, stops propagation (does not trigger the row filter), and is omitted when no handler is passed.
- Full workspace green: typecheck, lint (0 errors), 3323 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
