### PR TITLE
fix(web): resolve project overview audit findings (a11y, layout, motion)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,8 @@ The web dashboard follows a dark, professional analytics aesthetic inspired by *
 - No decorative background gradients. Keep it clean and flat.
 
 ### Components & Patterns
-- **Score gauges** (`ScoreGauge`): SVG radial progress rings for numeric and text metrics. Use on project pages instead of flat metric cards.
+- **AEO performance hero + metric cards:** the project overview leads with the AEO performance hero — three paired Mention / Cited / Mention-share rows with linear progress bars (stacking below `480px`) — followed by secondary metric cards in a `sm:grid-cols-2 lg:grid-cols-3` grid. Linear bars beat stacked radials when several numbers are read against each other. Keep a single `.metric-grid` / `.metric-card` definition; a duplicate once overrode the column count.
+- **Score gauges** (`ScoreGauge`): SVG radial progress rings for a single numeric/text metric (e.g. traffic-source detail). Don't rebuild the overview header as a gauge cluster.
 - **Data tables** for evidence, findings, and competitors (not card grids). Tables are more scanable for analysts.
 - **Insight cards** with left-border accent color based on tone (`insight-card-positive`, `insight-card-caution`, `insight-card-negative`).
 - **Sparklines** for inline trend visualization in overview project rows.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -342,17 +342,28 @@ Real shadows appear only on floating, state-carrying UI: the toast viewport, the
 ### Cards & Surfaces
 
 - **Surface Card (the dominant container):** `rounded-xl` (12px), Surface Ash at 30% opacity over the canvas, 60%-opacity hairline border. Internal padding `p-4`. This is the surface every section sits in.
+- **AEO performance hero:** Same surface family, `px-5 py-5`. Holds the three paired Mention / Cited / Mention-share rows plus the mention-share breakdown. The project overview's lead instrument (see "AEO performance hero" below).
 - **Score Gauge container:** Same surface family, `px-3 py-5` for tighter vertical rhythm around the radial.
-- **Metric Card:** Same surface family, `px-4 py-5`, includes the big-number stat plus a 1.5px progress bar and a 12px caption.
+- **Metric Card:** Same surface family, `px-4 py-5`, includes the big-number stat plus a 1.5px progress bar and a 12px caption. Laid out in a `sm:grid-cols-2 lg:grid-cols-3` grid for the overview's secondary metrics.
 - **Hero Copy (project landing):** Same surface family, `px-4 py-4`, contains the project title and brief positioning.
 - **No nested cards.** A card may contain a table, a sparkline, a list of rows, an action button, or a stat ladder, but never another card. If a child needs visual emphasis, lift its row (background tint + hairline) rather than wrapping it in a card.
 
-### Score Gauge (signature component)
+### AEO performance hero (project overview's first-glance instrument)
+
+The top of the project overview page is the **AEO performance hero** — a single Surface Card holding three comparable, full-width metric rows, not a cluster of radial gauges:
+
+- **Three paired rows** — `Mentioned`, `Cited`, `Mention share` — each a four-part grid: label + `InfoTooltip`, a `24px` tabular value, a 1.5px linear progress bar tinted by tone, and an `11px` delta/detail line. Below `480px` the row stacks (label → value → bar → detail) so the fixed desktop columns never overflow a phone.
+- **Mention-share breakdown** — a small ranked bar list (you vs. each tracked competitor) drops in beneath the rows whenever competitor data exists.
+- **Linear bars, not radials, on purpose.** The three numbers are meant to be read against each other top-to-bottom; stacked radials would read as three unrelated dials. Bar fills animate `width` only under `motion-safe` and take their color from `progress-fill-{tone}` (never a hard-coded fill).
+
+Directly below sit the **secondary metric cards** (`Mention Gaps`, `Citation Gaps`, `Index Coverage`) in a `sm:grid-cols-2 lg:grid-cols-3` grid of flat Surface Cards. This hero-plus-cards arrangement is the ratified overview pattern. There must be exactly one `.metric-grid` / `.metric-card` definition — a duplicate once lived in the stylesheet and silently overrode the column count (`lg:grid-cols-3` → `md:grid-cols-2`).
+
+### Score Gauge (radial component)
 
 - 96px (`size-24`) radial SVG ring with a 48px radius and 6px stroke. Background ring renders at 6% white opacity; fill renders in the metric's tone color (Signal Green, Caution Amber, Alert Rose, or neutral Smoke).
-- Fill animates from 0 to the value over 600ms with `cubic-bezier(0.4, 0, 0.2, 1)` easing.
+- Fill animates from 0 to the value over 600ms with `cubic-bezier(0.4, 0, 0.2, 1)` easing; the transition is dropped entirely under `prefers-reduced-motion`.
 - Center value (`20px / 700`, tabular) sits inside the ring; eyebrow label drops below; an optional delta line and description follow.
-- Gauges are arranged in a `lg:grid-cols-5` row at the top of the project page. This is the canonical first-glance instrument cluster: visibility, AEO score, citation share, mention share, technical readiness.
+- Used where a **single** metric reads better as a radial (e.g. the traffic-source detail page), not as the project-overview header cluster. On the overview, reach for the AEO performance hero + metric cards instead.
 
 ### Sparkline (signature component)
 

--- a/apps/web/src/components/project/EvidenceTable.tsx
+++ b/apps/web/src/components/project/EvidenceTable.tsx
@@ -218,10 +218,10 @@ export function EvidenceTable({
           <thead>
             <tr>
               <th style={{ width: '2rem' }} />
-              <th>Query</th>
-              <th>Status</th>
-              <th>{historyHeader}</th>
-              <th>Change</th>
+              <th scope="col">Query</th>
+              <th scope="col">Status</th>
+              <th scope="col">{historyHeader}</th>
+              <th scope="col">Change</th>
               <th />
             </tr>
           </thead>

--- a/apps/web/src/components/shared/InfoTooltip.tsx
+++ b/apps/web/src/components/shared/InfoTooltip.tsx
@@ -6,13 +6,19 @@ interface TooltipPos {
   left: number
 }
 
+/**
+ * Inline help affordance. The trigger is a real <button> so it is reachable by
+ * keyboard and exposes the explanatory copy to assistive tech via its
+ * accessible name (`aria-label`) — the visual bubble is decorative
+ * (`aria-hidden`). Hover, focus, click (touch), and Escape all toggle it.
+ */
 export function InfoTooltip({ text }: { text: string }) {
   const [pos, setPos] = useState<TooltipPos | null>(null)
-  const iconRef = useRef<SVGSVGElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
 
   const show = useCallback(() => {
-    if (!iconRef.current) return
-    const rect = iconRef.current.getBoundingClientRect()
+    if (!triggerRef.current) return
+    const rect = triggerRef.current.getBoundingClientRect()
     setPos({
       top: rect.top,
       left: rect.left + rect.width / 2,
@@ -21,15 +27,34 @@ export function InfoTooltip({ text }: { text: string }) {
 
   const hide = useCallback(() => setPos(null), [])
 
+  const toggle = useCallback(() => {
+    if (pos === null) show()
+    else hide()
+  }, [pos, show, hide])
+
   return (
-    <span className="info-tooltip-wrapper" onMouseEnter={show} onMouseLeave={hide} onFocus={show} onBlur={hide}>
-      <svg ref={iconRef} className="info-tooltip-icon" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-        <circle cx="8" cy="8" r="7" stroke="currentColor" strokeWidth="1.5" />
-        <path d="M8 7v4M8 5.5v0" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-      </svg>
+    <span className="info-tooltip-wrapper" onMouseEnter={show} onMouseLeave={hide}>
+      <button
+        ref={triggerRef}
+        type="button"
+        className="info-tooltip-trigger"
+        aria-label={text}
+        aria-expanded={pos !== null}
+        onFocus={show}
+        onBlur={hide}
+        onClick={toggle}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') hide()
+        }}
+      >
+        <svg className="info-tooltip-icon" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <circle cx="8" cy="8" r="7" stroke="currentColor" strokeWidth="1.5" />
+          <path d="M8 7v4M8 5.5v0" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        </svg>
+      </button>
       {pos !== null && createPortal(
         <span
-          role="tooltip"
+          aria-hidden="true"
           style={{
             position: 'fixed',
             top: pos.top,

--- a/apps/web/src/lib/tone-helpers.ts
+++ b/apps/web/src/lib/tone-helpers.ts
@@ -54,3 +54,22 @@ export function competitorTone(label: string): MetricTone {
   if (label === 'Low') return 'neutral'
   return 'neutral'
 }
+
+/**
+ * Single source of truth for the 0-100 score → tone thresholds. Consumed by the
+ * per-model breakdown text color and its trend sparkline so the cutoffs never
+ * drift apart.
+ */
+export function toneFromScore(score: number): MetricTone {
+  if (score >= 70) return 'positive'
+  if (score >= 40) return 'caution'
+  return 'negative'
+}
+
+/** Maps a metric tone to its Tailwind text-color utility. */
+export const METRIC_TONE_TEXT_CLASS: Record<MetricTone, string> = {
+  positive: 'text-emerald-400',
+  caution: 'text-amber-400',
+  negative: 'text-rose-400',
+  neutral: 'text-zinc-400',
+}

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -23,6 +23,7 @@ import { CitationVisibilitySection } from '../components/project/CitationVisibil
 import { DiscoverySection } from '../components/project/DiscoverySection.js'
 import { ReportPage } from './ReportPage.js'
 import { formatTimestamp, SEARCH_METRIC_SHORT_LABELS, SearchMetric } from '../lib/format-helpers.js'
+import { METRIC_TONE_TEXT_CLASS, toneFromScore } from '../lib/tone-helpers.js'
 import { addToast } from '../lib/toast-store.js'
 import { asyncHandler } from '../lib/async-handler.js'
 import { ProjectSettingsSection } from '../components/project/ProjectSettingsSection.js'
@@ -1043,7 +1044,7 @@ function MovementBanner({
         ) : (
           <span className="text-zinc-500">−0 lost</span>
         )}
-        <span className="text-zinc-600 ml-2">{verdict}</span>
+        <span className="text-zinc-400 ml-2">{verdict}</span>
       </div>
       {(summary.gainedQueries?.length || summary.lostQueries?.length) ? (
         <div className="movement-banner-detail">
@@ -1125,6 +1126,13 @@ function MentionShareBreakdown({
  * (Recharts is overkill for a 12-point trend at 96px wide). Color is tone-
  * driven from the most recent point so a row reads at a glance.
  */
+const TREND_STROKE_BY_TONE = {
+  positive: 'rgb(52 211 153)', // emerald-400
+  caution: 'rgb(251 191 36)', // amber-400
+  negative: 'rgb(251 113 133)', // rose-400
+  neutral: 'rgb(161 161 170)', // zinc-400
+} as const
+
 function ProviderTrendSparkline({
   trend,
   currentScore,
@@ -1140,11 +1148,7 @@ function ProviderTrendSparkline({
   const max = 100
   const stepX = trend.length > 1 ? w / (trend.length - 1) : 0
   const pts = trend.map((v, i) => `${(i * stepX).toFixed(2)},${(h - (v / max) * h).toFixed(2)}`).join(' ')
-  const stroke = currentScore >= 70
-    ? 'rgb(52 211 153)' // emerald-400
-    : currentScore >= 40
-      ? 'rgb(251 191 36)' // amber-400
-      : 'rgb(251 113 133)' // rose-400
+  const stroke = TREND_STROKE_BY_TONE[toneFromScore(currentScore)]
   const dotX = (trend.length - 1) * stepX
   const dotY = h - (trend[trend.length - 1]! / max) * h
   return (
@@ -1818,7 +1822,7 @@ function ProjectPageContent({
             {(model.project.ownedDomains ?? []).length === 0 && !addingOwnedDomain && (
               <button
                 type="button"
-                className="ml-2 text-[10px] uppercase tracking-wide text-zinc-600 hover:text-zinc-400 transition-colors"
+                className="ml-2 rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800/60 transition-colors"
                 onClick={() => setAddingOwnedDomain(true)}
               >+ add domain</button>
             )}
@@ -1841,7 +1845,7 @@ function ProjectPageContent({
                   {d}
                   <button
                     type="button"
-                    className="ml-0.5 text-zinc-500 hover:text-zinc-200 transition-colors"
+                    className="-mr-1 ml-0.5 inline-flex items-center justify-center rounded p-1 leading-none text-zinc-500 hover:bg-zinc-700/40 hover:text-zinc-200 transition-colors"
                     disabled={ownedDomainSaving}
                     onClick={() => { void handleRemoveOwnedDomain(d) }}
                     aria-label={`Remove ${d}`}
@@ -1883,7 +1887,7 @@ function ProjectPageContent({
                 {a}
                 <button
                   type="button"
-                  className="ml-0.5 text-zinc-500 hover:text-zinc-200 transition-colors"
+                  className="-mr-1 ml-0.5 inline-flex items-center justify-center rounded p-1 leading-none text-zinc-500 hover:bg-zinc-700/40 hover:text-zinc-200 transition-colors"
                   disabled={aliasSaving}
                   onClick={() => { void handleRemoveAlias(a) }}
                   aria-label={`Remove ${a}`}
@@ -1956,7 +1960,7 @@ function ProjectPageContent({
         <>
           {/* Hero: three comparable AEO numbers (Mention, Cited, Mention Share). */}
           <section className="aeo-hero">
-            <p className="aeo-hero-title">AEO performance</p>
+            <h2 className="aeo-hero-title">AEO performance</h2>
             <div className="aeo-hero-rows">
               {([
                 { key: 'mention', label: 'Mentioned', tooltip: 'Your domain or company name was in the answer returned by the LLM.', summary: model.mentionSummary },
@@ -2003,6 +2007,7 @@ function ProjectPageContent({
 
           {/* Secondary: at-risk gaps (paired) + technical health */}
           <section className="metric-grid">
+            <h2 className="sr-only">Coverage gaps and index health</h2>
             <div className="metric-card">
               <p className="metric-card-eyebrow">
                 Mention Gaps
@@ -2224,10 +2229,10 @@ function ProjectPageContent({
                 <table className="evidence-table">
                   <thead>
                     <tr>
-                      <th>Model</th>
-                      <th>Score</th>
-                      <th>Trend</th>
-                      <th>Cited queries</th>
+                      <th scope="col">Model</th>
+                      <th scope="col">Score</th>
+                      <th scope="col">Trend</th>
+                      <th scope="col">Cited queries</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -2240,7 +2245,7 @@ function ProjectPageContent({
                           </div>
                         </td>
                         <td>
-                          <span className={`font-semibold ${ps.score >= 70 ? 'text-emerald-400' : ps.score >= 40 ? 'text-amber-400' : 'text-rose-400'}`}>
+                          <span className={`font-semibold ${METRIC_TONE_TEXT_CLASS[toneFromScore(ps.score)]}`}>
                             {ps.score}%
                           </span>
                         </td>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -467,6 +467,12 @@
     transition: stroke-dashoffset 0.6s cubic-bezier(0.4, 0, 0.2, 1);
   }
 
+  @media (prefers-reduced-motion: reduce) {
+    .gauge-fill {
+      transition: none;
+    }
+  }
+
   .gauge-fill-positive {
     stroke: #34d399;
   }
@@ -522,35 +528,47 @@
   }
 
   .aeo-hero-rows {
-    @apply space-y-3;
+    @apply space-y-4 sm:space-y-3;
   }
 
   .aeo-hero-row {
-    @apply grid items-center gap-x-4;
-    /* First col widened from 100px so "Mention share" fits on one line —
-       previously wrapped and pushed the InfoTooltip icon to the right edge,
-       which made the tooltip bubble render far right of where readers expect. */
-    grid-template-columns: 130px 90px 1fr auto;
+    @apply grid items-center gap-x-4 gap-y-1;
+    /* Mobile: stack label / value / bar / detail so the fixed desktop columns
+       never overflow a narrow viewport. ≥480px restores the single-row layout.
+       First desktop col widened from 100px so "Mention share" fits on one line. */
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas: "label" "value" "bar" "detail";
+  }
+
+  @media (min-width: 480px) {
+    .aeo-hero-row {
+      grid-template-columns: 130px 90px minmax(0, 1fr) auto;
+      grid-template-areas: "label value bar detail";
+    }
   }
 
   .aeo-hero-row-label {
     @apply text-sm font-medium text-zinc-200 flex items-center gap-1;
+    grid-area: label;
   }
 
   .aeo-hero-row-value {
     @apply text-2xl font-bold tracking-tight tabular-nums;
+    grid-area: value;
   }
 
   .aeo-hero-row-bar {
     @apply h-1.5 w-full rounded-full bg-zinc-800 overflow-hidden;
+    grid-area: bar;
   }
 
   .aeo-hero-row-detail {
     @apply text-[11px] text-zinc-500 tabular-nums;
+    grid-area: detail;
   }
 
   .aeo-hero-context {
-    @apply text-[11px] text-zinc-600 mt-4;
+    @apply text-[11px] text-zinc-400 mt-4;
   }
 
   .mention-share-breakdown {
@@ -567,7 +585,16 @@
 
   .mention-share-breakdown-row {
     @apply grid items-center gap-x-3 text-xs;
-    grid-template-columns: minmax(140px, 1fr) minmax(80px, 2fr) 32px 56px;
+    /* Floors relaxed on mobile so the four columns never exceed a narrow
+       viewport; the truncating label absorbs the squeeze. ≥480px restores the
+       roomier desktop track sizes. */
+    grid-template-columns: minmax(0, 1fr) minmax(56px, 2fr) 28px 48px;
+  }
+
+  @media (min-width: 480px) {
+    .mention-share-breakdown-row {
+      grid-template-columns: minmax(140px, 1fr) minmax(80px, 2fr) 32px 56px;
+    }
   }
 
   .mention-share-breakdown-label {
@@ -633,7 +660,10 @@
   }
 
   .metric-card-bar-fill {
-    @apply h-full rounded-full bg-emerald-500 transition-all duration-300;
+    /* Tone color comes from the paired `progress-fill-{tone}` class. Transition
+       is scoped to `width` (not `all`, which also crossfaded tone swaps) and
+       gated behind `motion-safe` so reduced-motion users get no animation. */
+    @apply h-full rounded-full motion-safe:transition-[width] motion-safe:duration-300;
   }
 
   .metric-card-movement {
@@ -834,7 +864,7 @@
   }
 
   .attention-action {
-    @apply pt-1 text-[10px] font-medium uppercase tracking-[0.14em] text-zinc-600;
+    @apply pt-1 text-[10px] font-medium uppercase tracking-[0.14em] text-zinc-400;
   }
 
   /* ── Compact run ── */
@@ -847,35 +877,12 @@
     @apply mt-0.5 text-[12px] text-zinc-600;
   }
 
-  /* ── Metric card (kept for overview) ── */
-
-  .metric-grid {
-    @apply grid gap-3 md:grid-cols-2;
-  }
-
-  .metric-card {
-    @apply grid gap-3;
-  }
-
-  .metric-card-head {
-    @apply flex items-center justify-between gap-3;
-  }
-
-  .metric-card-body {
-    @apply grid gap-3 sm:grid-cols-[minmax(0,1fr)_8rem] sm:items-center;
-  }
-
-  .metric-value {
-    @apply text-2xl font-semibold tracking-tight text-zinc-50;
-  }
-
-  .progress-track {
-    @apply h-1 overflow-hidden rounded-full bg-zinc-800;
-  }
-
-  .progress-fill {
-    @apply h-full rounded-full transition-all duration-500;
-  }
+  /* ── Metric progress-bar tone fills ──
+     Shared by `.metric-card-bar-fill` (secondary metric cards) and the AEO
+     performance hero rows. The metric card / grid layout itself lives in the
+     "Metric cards (non-gauge)" block above; the duplicate definitions that
+     once lived here silently overrode it (flipping `lg:grid-cols-3` to
+     `md:grid-cols-2`) and have been removed. */
 
   .progress-fill-positive {
     @apply bg-emerald-400;
@@ -1414,16 +1421,12 @@
     @apply relative inline-flex items-center ml-1 align-middle;
   }
 
+  .info-tooltip-trigger {
+    @apply inline-flex items-center justify-center rounded-full p-0.5 text-zinc-500 cursor-help transition hover:text-zinc-300 focus:outline-none focus-visible:ring-1 focus-visible:ring-zinc-500;
+  }
+
   .info-tooltip-icon {
-    @apply size-3 text-zinc-600 cursor-help transition hover:text-zinc-400;
-  }
-
-  .info-tooltip-bubble {
-    @apply pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 w-56 -translate-x-1/2 rounded-lg border border-zinc-700/60 bg-zinc-900 px-3 py-2 text-[11px] font-normal normal-case tracking-normal leading-4 text-zinc-300 opacity-0 shadow-lg transition-opacity;
-  }
-
-  .info-tooltip-wrapper:hover .info-tooltip-bubble {
-    @apply pointer-events-auto opacity-100;
+    @apply size-3;
   }
 
   /* Portal-rendered tooltip uses inline styles — see InfoTooltip.tsx */

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.56.0",
+  "version": "4.56.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.56.0",
+  "version": "4.56.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
Fixes the impeccable audit findings on the project overview page: makes the info tooltips keyboard/screen-reader accessible, removes the duplicate `.metric-grid`/`.metric-card` CSS that was overriding the 3-up metric row, raises low-contrast `zinc-600` text to AA, and stacks the AEO hero / mention-share rows on narrow viewports so they no longer overflow phones. Also scopes the metric-bar transition to `width` under `motion-safe` (with a reduced-motion guard on the score gauge), enlarges small chip touch targets, adds headings + `th scope="col"`, and centralizes the score-to-tone thresholds in `tone-helpers`. Ratifies the current aeo-hero + metric-card overview layout in `DESIGN.md` and `CLAUDE.md`, and bumps the version 4.55.4 -> 4.55.5. Verified with typecheck, lint (0 errors), the web test suite (245/245), and a production build.
