### PR TITLE
docs: run aeo-audit with --sitemap in README agent setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Set up canonry for me. Canonry is an open-source platform that tracks how AI ans
 3. Run `cnry init` in this directory. This scaffolds config and installs the canonry skills into `.claude/skills/canonry/`, `.claude/skills/aero/`, `.codex/skills/canonry/`, and `.codex/skills/aero/`. If the skills aren't there afterwards, run `cnry skills install`.
 4. Read the operator playbook at `.claude/skills/canonry/SKILL.md` and follow it end-to-end: create the project with my domain and queries, wire up the provider key I chose, and trigger the first sweep.
 5. Open my browser to the dashboard so I can see the run results.
-6. Switch to the analyst playbook at `.claude/skills/aero/SKILL.md` and run a baseline AEO audit on my behalf. Read citation evidence with `cnry evidence <project> --format json`, then run `npx @ainyc/aeo-audit "<my-domain>" --format json` for a site-readiness score.
+6. Switch to the analyst playbook at `.claude/skills/aero/SKILL.md` and run a baseline AEO audit on my behalf. Read citation evidence with `cnry evidence <project> --format json`, then run `npx @ainyc/aeo-audit "<my-domain>" --sitemap --format json` for a site-readiness score. The `--sitemap` flag audits every page listed in my sitemap instead of just the homepage, so the readiness score reflects the whole site.
 7. Summarize what you found: my mention and citation rates per provider, the top 3 queries I'm not yet cited on, and the highest-impact site issues from the audit. Ask me for permission before taking any further action, such as drafting content, submitting URLs for indexing, editing files, or anything else that changes my site.
 ```
 

--- a/skills/aero/references/orchestration.md
+++ b/skills/aero/references/orchestration.md
@@ -12,7 +12,7 @@ Trigger: First sweep completes for a new project
 Steps:
 1. `cnry evidence <project> --format json` → get initial citation data
 2. Compute baseline: cited rate, provider breakdown, top/bottom queries
-3. `npx @ainyc/aeo-audit "<domain>" --format json` → site readiness score
+3. `npx @ainyc/aeo-audit "<domain>" --sitemap --format json` → site readiness score across every page in the sitemap (auto-discovered; add `--limit <n>` to cap, default 200)
 4. Identify top 3 gaps (uncited queries with fixable site issues)
 5. Generate onboarding report with baseline + action plan
 6. Store baseline metrics in memory

--- a/skills/canonry/SKILL.md
+++ b/skills/canonry/SKILL.md
@@ -71,7 +71,7 @@ Configure `spec.brandAliases` on the project (or pass via `cnry apply`) so the m
 
 A canonry engagement follows the same loop regardless of project size:
 
-1. **Diagnose** — Run a baseline sweep (`cnry run <project> --wait`) and a technical audit (`npx @ainyc/aeo-audit@latest <url> --format json`). Read Mention Coverage first, Citation Coverage second. See `references/aeo-analysis.md`.
+1. **Diagnose** — Run a baseline sweep (`cnry run <project> --wait`) and a technical audit (`npx @ainyc/aeo-audit@latest <url> --sitemap --format json`). `--sitemap` audits every page in the site's sitemap (auto-discovered from `/sitemap.xml`, the sitemap index, or `robots.txt`) so readiness reflects the whole site, not just one page. Read Mention Coverage first, Citation Coverage second. See `references/aeo-analysis.md`.
 2. **Prioritize** — Triage by impact: indexing gaps → schema gaps → content gaps → query strategy. Branded-term losses are urgent.
 3. **Execute** — Apply fixes via the canonry CLI or platform integrations. Use `--dry-run` on supported mutations (`cnry project delete`, `cnry query replace`, `cnry backfill ...`) to preview before committing. See `references/canonry-cli.md` for the full command catalog and `references/wordpress-integration.md` for the WordPress workflow.
 4. **Monitor** — Re-run sweeps weekly (`cnry run --all --wait` fans out across every project). Correlate visibility shifts with deployments and competitor moves.


### PR DESCRIPTION
Update the agent setup instructions so the baseline AEO audit covers
every page in the sitemap rather than just the homepage.