### PR TITLE
feat(gsc): auto-refresh index coverage after GSC and Bing syncs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.56.1",
+  "version": "4.57.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/AGENTS.md
+++ b/packages/canonry/AGENTS.md
@@ -123,6 +123,12 @@ When a sweep finishes, the flow is: `JobRunner` → `RunCoordinator.onRunComplet
 
 `IntelligenceService` reads query snapshots from the DB, calls the pure analysis functions in `packages/intelligence/`, and persists insights + health snapshots. It also provides `backfill()` for reprocessing historical runs chronologically.
 
+### Index coverage auto-refresh
+
+`gscUrlInspections` (the index-coverage dashboard's source of truth) is only fully populated by a `inspect-sitemap` run — `gsc-sync` inspects just the top 50 pages by clicks, so newly-added / zero-click URLs silently fall out of coverage. To keep it fresh, `server.ts` chains a full GSC `inspect-sitemap` off the **success** of both `executeGscSync` (`gsc-sync`) and `executeBingInspectSitemap` (`bing-inspect-sitemap` — Bing's coverage sync, which has no separate `bing-sync` kind). The chaining lives in the `onGscSyncRequested` / `onBingInspectSitemapRequested` callbacks, so it covers UI and CLI uniformly (both hit the same endpoints) and the dashboard "Refresh all" button.
+
+`maybeRefreshGscCoverage` (`src/coverage-refresh.ts`) owns the decision: it no-ops when GSC isn't connected for the project (so the Bing → GSC chain is silent on Bing-only projects) and skips when an `inspect-sitemap` run already ran within `COVERAGE_REFRESH_MIN_INTERVAL_MS` (1 h) to stay under the URL Inspection quota (2000/property/day, ~1 req/sec). Its project lookup + spacing guard + run-row insert are synchronous so the GSC and Bing arms of "Refresh all" can't both pass the guard. The chained run is `trigger: scheduled`; a refresh failure is logged, never bubbled into the triggering sync's result.
+
 ### Backfill behavior
 
 `canonry backfill answer-visibility` does more than recompute `answerMentioned`. It also reparses stored provider `raw_response` payloads for supported API providers (OpenAI, Claude, Gemini, Perplexity) and refreshes derived snapshot fields such as `citationState`, `citedDomains`, `groundingSources`, and `searchQueries`.

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.56.1",
+  "version": "4.57.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/coverage-refresh.ts
+++ b/packages/canonry/src/coverage-refresh.ts
@@ -1,0 +1,135 @@
+import crypto from 'node:crypto'
+import { and, desc, eq, inArray } from 'drizzle-orm'
+import type { DatabaseClient } from '@ainyc/canonry-db'
+import { projects, runs } from '@ainyc/canonry-db'
+import { RunKinds, RunStatuses, RunTriggers } from '@ainyc/canonry-contracts'
+import type { CanonryConfig } from './config.js'
+import { getGoogleAuthConfig, getGoogleConnection } from './google-config.js'
+import { executeInspectSitemap } from './gsc-inspect-sitemap.js'
+import { createLogger } from './logger.js'
+
+const log = createLogger('CoverageRefresh')
+
+/**
+ * Minimum spacing between automatic GSC sitemap-coverage refreshes for one
+ * project.
+ *
+ * A successful `gsc-sync` (search performance) and `bing-inspect-sitemap`
+ * (Bing's coverage sync) both chain into a full GSC `inspect-sitemap` so the
+ * index-coverage dashboard (`gscUrlInspections`) doesn't go stale — `gsc-sync`
+ * only inspects the top 50 pages by clicks, so newly-added / zero-click URLs
+ * are never re-inspected and coverage silently drifts. But the URL Inspection
+ * API is quota-limited (2000 requests/property/day, ~1 request/sec), so we
+ * skip a refresh when one already ran within this window. This also keeps the
+ * dashboard "Refresh all" button — which fires a GSC sync and a Bing sync
+ * near-simultaneously — from inspecting the whole sitemap twice.
+ */
+export const COVERAGE_REFRESH_MIN_INTERVAL_MS = 60 * 60 * 1000
+
+/**
+ * Run states that mean "a coverage refresh already happened, or is about to"
+ * for the spacing guard. A `failed`/`cancelled` prior run does NOT block a
+ * retry — coverage never actually refreshed in those cases.
+ */
+const ACTIVE_OR_DONE_STATUSES = [
+  RunStatuses.queued,
+  RunStatuses.running,
+  RunStatuses.completed,
+  RunStatuses.partial,
+]
+
+export interface CoverageRefreshDeps {
+  executeInspectSitemap: typeof executeInspectSitemap
+}
+
+const defaultDeps: CoverageRefreshDeps = { executeInspectSitemap }
+
+/**
+ * Queue and run a full GSC `inspect-sitemap` to refresh the index-coverage
+ * dashboard, unless GSC isn't connected for the project or a coverage refresh
+ * already ran within {@link COVERAGE_REFRESH_MIN_INTERVAL_MS}.
+ *
+ * Called fire-and-forget after a successful `gsc-sync` or `bing-inspect-sitemap`
+ * completes (see the callback wiring in `server.ts`). Returns the new
+ * `inspect-sitemap` run id, or `null` when the refresh was skipped.
+ *
+ * The project lookup, spacing guard, and run-row insert run synchronously with
+ * no `await` between them, so two near-simultaneous callers (the GSC + Bing
+ * arms of "Refresh all") cannot both pass the guard — the second observes the
+ * first's freshly-inserted `queued` row and bails.
+ */
+export async function maybeRefreshGscCoverage(
+  db: DatabaseClient,
+  config: CanonryConfig,
+  projectId: string,
+  deps: CoverageRefreshDeps = defaultDeps,
+  nowMs: number = Date.now(),
+): Promise<string | null> {
+  const project = db
+    .select({ canonicalDomain: projects.canonicalDomain })
+    .from(projects)
+    .where(eq(projects.id, projectId))
+    .get()
+  if (!project) return null
+
+  // GSC must be fully connected — otherwise the inspect-sitemap run would just
+  // fail. Critically, this lets the Bing → GSC chain no-op silently on
+  // Bing-only (or unconnected) projects instead of logging a failed GSC run
+  // after every Bing sync.
+  const { clientId, clientSecret } = getGoogleAuthConfig(config)
+  if (!clientId || !clientSecret) return null
+  const conn = getGoogleConnection(config, project.canonicalDomain, 'gsc')
+  if (!conn?.refreshToken || !conn.propertyId) return null
+
+  // Spacing guard — skip if a coverage refresh already ran (or is running)
+  // within the window.
+  const recent = db
+    .select({ createdAt: runs.createdAt })
+    .from(runs)
+    .where(
+      and(
+        eq(runs.projectId, projectId),
+        eq(runs.kind, RunKinds['inspect-sitemap']),
+        inArray(runs.status, ACTIVE_OR_DONE_STATUSES),
+      ),
+    )
+    .orderBy(desc(runs.createdAt))
+    .limit(1)
+    .get()
+  if (recent) {
+    const ageMs = nowMs - Date.parse(recent.createdAt)
+    if (Number.isFinite(ageMs) && ageMs < COVERAGE_REFRESH_MIN_INTERVAL_MS) {
+      log.info('skip.recent', { projectId, ageMs })
+      return null
+    }
+  }
+
+  // Synchronous insert closes the guard race: a concurrent caller's SELECT
+  // above now observes this `queued` row and skips.
+  const runId = crypto.randomUUID()
+  db.insert(runs)
+    .values({
+      id: runId,
+      projectId,
+      kind: RunKinds['inspect-sitemap'],
+      status: RunStatuses.queued,
+      trigger: RunTriggers.scheduled,
+      createdAt: new Date(nowMs).toISOString(),
+    })
+    .run()
+
+  log.info('refresh.start', { projectId, runId })
+  try {
+    await deps.executeInspectSitemap(db, runId, projectId, { config })
+  } catch (err) {
+    // The executor records its own `failed` status on the run row; a
+    // coverage-refresh failure must never bubble into the triggering sync's
+    // result.
+    log.error('refresh.failed', {
+      projectId,
+      runId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+  return runId
+}

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -62,6 +62,7 @@ import { JobRunner } from './job-runner.js'
 import { executeGscSync } from './gsc-sync.js'
 import { executeInspectSitemap } from './gsc-inspect-sitemap.js'
 import { executeBingInspectSitemap } from './bing-inspect-sitemap.js'
+import { maybeRefreshGscCoverage } from './coverage-refresh.js'
 import { executeReleaseSync } from './commoncrawl-sync.js'
 import { executeBacklinkExtract } from './backlink-extract.js'
 import { executeDiscoveryRun } from './discovery-run.js'
@@ -1049,9 +1050,15 @@ export async function createServer(opts: {
       executeGscSync(opts.db, runId, projectId, {
         ...syncOpts,
         config: opts.config,
-      }).catch((err: unknown) => {
-        app.log.error({ runId, err }, 'GSC sync failed')
       })
+        // executeGscSync resolves only when the sync completed, so a full
+        // sitemap-coverage refresh chains directly off success. `gsc-sync`
+        // alone only inspects the top 50 pages by clicks, leaving newly-added
+        // URLs out of the coverage dashboard until the next manual inspection.
+        .then(() => maybeRefreshGscCoverage(opts.db, opts.config, projectId))
+        .catch((err: unknown) => {
+          app.log.error({ runId, err }, 'GSC sync failed')
+        })
     },
     onInspectSitemapRequested: (runId: string, projectId: string, inspectOpts?: { sitemapUrl?: string }) => {
       const { clientId: googleClientId, clientSecret: googleClientSecret } = getGoogleAuthConfig(opts.config)
@@ -1174,9 +1181,21 @@ export async function createServer(opts: {
       executeBingInspectSitemap(opts.db, runId, projectId, {
         ...inspectOpts,
         config: opts.config,
-      }).catch((err: unknown) => {
-        app.log.error({ runId, err }, 'Bing inspect sitemap failed')
       })
+        .then(() => {
+          // Unlike executeGscSync, the Bing executor resolves even when the run
+          // ends `failed` (every URL errored), so gate the cross-engine GSC
+          // coverage refresh on the run actually completing. maybeRefreshGscCoverage
+          // no-ops when GSC isn't connected, so Bing-only projects are unaffected.
+          const finished = opts.db.select({ status: runs.status }).from(runs).where(eq(runs.id, runId)).get()
+          if (finished?.status === RunStatuses.completed || finished?.status === RunStatuses.partial) {
+            return maybeRefreshGscCoverage(opts.db, opts.config, projectId)
+          }
+          return null
+        })
+        .catch((err: unknown) => {
+          app.log.error({ runId, err }, 'Bing inspect sitemap failed')
+        })
     },
     wordpressConnectionStore,
     ga4CredentialStore,

--- a/packages/canonry/test/coverage-refresh.test.ts
+++ b/packages/canonry/test/coverage-refresh.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import { eq } from 'drizzle-orm'
+import { createClient, migrate, projects, runs, type DatabaseClient } from '@ainyc/canonry-db'
+import { RunKinds, RunStatuses, RunTriggers } from '@ainyc/canonry-contracts'
+import type { CanonryConfig } from '../src/config.js'
+import {
+  maybeRefreshGscCoverage,
+  COVERAGE_REFRESH_MIN_INTERVAL_MS,
+  type CoverageRefreshDeps,
+} from '../src/coverage-refresh.js'
+
+const PROJECT_ID = 'proj-1'
+const DOMAIN = 'example.com'
+
+let tmpDir: string
+let db: DatabaseClient
+
+function seedProject(): void {
+  const now = new Date().toISOString()
+  db.insert(projects)
+    .values({
+      id: PROJECT_ID,
+      name: 'testproj',
+      displayName: 'Test Project',
+      canonicalDomain: DOMAIN,
+      country: 'US',
+      language: 'en',
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run()
+}
+
+function connectedConfig(): CanonryConfig {
+  const now = new Date().toISOString()
+  return {
+    apiUrl: 'http://localhost:4100',
+    database: ':memory:',
+    apiKey: 'cnry_test',
+    google: {
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      connections: [
+        {
+          domain: DOMAIN,
+          connectionType: 'gsc',
+          refreshToken: 'refresh-token',
+          accessToken: 'access-token',
+          tokenExpiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+          propertyId: 'sc-domain:example.com',
+          scopes: [],
+          createdAt: now,
+          updatedAt: now,
+        },
+      ],
+    },
+  } as CanonryConfig
+}
+
+/** A `deps.executeInspectSitemap` that records calls without touching the network. */
+function spyExecutor(): CoverageRefreshDeps & { calls: Array<{ runId: string; projectId: string }> } {
+  const calls: Array<{ runId: string; projectId: string }> = []
+  return {
+    calls,
+    executeInspectSitemap: async (_db, runId, projectId) => {
+      calls.push({ runId, projectId })
+    },
+  }
+}
+
+function insertInspectRun(opts: { status: string; createdAt: string; kind?: string }): string {
+  const id = `run-${Math.random().toString(36).slice(2)}`
+  db.insert(runs)
+    .values({
+      id,
+      projectId: PROJECT_ID,
+      kind: opts.kind ?? RunKinds['inspect-sitemap'],
+      status: opts.status,
+      trigger: RunTriggers.scheduled,
+      createdAt: opts.createdAt,
+    })
+    .run()
+  return id
+}
+
+function inspectRuns(): Array<typeof runs.$inferSelect> {
+  return db
+    .select()
+    .from(runs)
+    .where(eq(runs.kind, RunKinds['inspect-sitemap']))
+    .all()
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'coverage-refresh-test-'))
+  db = createClient(path.join(tmpDir, 'test.db'))
+  migrate(db)
+  seedProject()
+})
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+describe('maybeRefreshGscCoverage', () => {
+  it('creates a queued inspect-sitemap run (trigger=scheduled) and invokes the executor when GSC is connected', async () => {
+    const deps = spyExecutor()
+    const now = Date.now()
+
+    const runId = await maybeRefreshGscCoverage(db, connectedConfig(), PROJECT_ID, deps, now)
+
+    expect(runId).toBeTruthy()
+    expect(deps.calls).toEqual([{ runId, projectId: PROJECT_ID }])
+
+    const created = inspectRuns()
+    expect(created).toHaveLength(1)
+    expect(created[0]!.id).toBe(runId)
+    expect(created[0]!.kind).toBe(RunKinds['inspect-sitemap'])
+    expect(created[0]!.trigger).toBe(RunTriggers.scheduled)
+    expect(created[0]!.projectId).toBe(PROJECT_ID)
+    // Stamped from the injected clock so the spacing guard is deterministic.
+    expect(created[0]!.createdAt).toBe(new Date(now).toISOString())
+  })
+
+  it('returns null and creates no run when the project does not exist', async () => {
+    const deps = spyExecutor()
+    const runId = await maybeRefreshGscCoverage(db, connectedConfig(), 'missing-project', deps)
+    expect(runId).toBeNull()
+    expect(deps.calls).toHaveLength(0)
+    expect(inspectRuns()).toHaveLength(0)
+  })
+
+  it('skips silently (no run, no executor) when GSC has no connection for the domain — the Bing-only case', async () => {
+    const deps = spyExecutor()
+    const config = connectedConfig()
+    config.google!.connections = []
+
+    const runId = await maybeRefreshGscCoverage(db, config, PROJECT_ID, deps)
+
+    expect(runId).toBeNull()
+    expect(deps.calls).toHaveLength(0)
+    expect(inspectRuns()).toHaveLength(0)
+  })
+
+  it('skips when the GSC connection has no propertyId', async () => {
+    const deps = spyExecutor()
+    const config = connectedConfig()
+    config.google!.connections![0]!.propertyId = null
+
+    const runId = await maybeRefreshGscCoverage(db, config, PROJECT_ID, deps)
+
+    expect(runId).toBeNull()
+    expect(deps.calls).toHaveLength(0)
+    expect(inspectRuns()).toHaveLength(0)
+  })
+
+  it('skips when the GSC connection has no refreshToken', async () => {
+    const deps = spyExecutor()
+    const config = connectedConfig()
+    config.google!.connections![0]!.refreshToken = null
+
+    const runId = await maybeRefreshGscCoverage(db, config, PROJECT_ID, deps)
+
+    expect(runId).toBeNull()
+    expect(deps.calls).toHaveLength(0)
+    expect(inspectRuns()).toHaveLength(0)
+  })
+
+  it('skips when OAuth client credentials are missing from config', async () => {
+    const deps = spyExecutor()
+    const config = connectedConfig()
+    delete config.google!.clientId
+    delete config.google!.clientSecret
+
+    const runId = await maybeRefreshGscCoverage(db, config, PROJECT_ID, deps)
+
+    expect(runId).toBeNull()
+    expect(deps.calls).toHaveLength(0)
+    expect(inspectRuns()).toHaveLength(0)
+  })
+
+  it('skips when an inspect-sitemap run completed within the spacing window', async () => {
+    const deps = spyExecutor()
+    const now = Date.now()
+    const recentAt = new Date(now - (COVERAGE_REFRESH_MIN_INTERVAL_MS - 60_000)).toISOString()
+    insertInspectRun({ status: RunStatuses.completed, createdAt: recentAt })
+
+    const runId = await maybeRefreshGscCoverage(db, connectedConfig(), PROJECT_ID, deps, now)
+
+    expect(runId).toBeNull()
+    expect(deps.calls).toHaveLength(0)
+    expect(inspectRuns()).toHaveLength(1) // only the pre-existing one
+  })
+
+  it('skips when an inspect-sitemap run is still queued within the window (covers the Refresh-all double-fire)', async () => {
+    const deps = spyExecutor()
+    const now = Date.now()
+    insertInspectRun({ status: RunStatuses.queued, createdAt: new Date(now - 1_000).toISOString() })
+
+    const runId = await maybeRefreshGscCoverage(db, connectedConfig(), PROJECT_ID, deps, now)
+
+    expect(runId).toBeNull()
+    expect(deps.calls).toHaveLength(0)
+  })
+
+  it('proceeds when the most recent inspect-sitemap run within the window FAILED (retry allowed)', async () => {
+    const deps = spyExecutor()
+    const now = Date.now()
+    insertInspectRun({ status: RunStatuses.failed, createdAt: new Date(now - 60_000).toISOString() })
+
+    const runId = await maybeRefreshGscCoverage(db, connectedConfig(), PROJECT_ID, deps, now)
+
+    expect(runId).toBeTruthy()
+    expect(deps.calls).toHaveLength(1)
+    expect(inspectRuns()).toHaveLength(2) // the failed one + the new retry
+  })
+
+  it('proceeds when the last inspect-sitemap run is older than the spacing window', async () => {
+    const deps = spyExecutor()
+    const now = Date.now()
+    const staleAt = new Date(now - (COVERAGE_REFRESH_MIN_INTERVAL_MS + 60_000)).toISOString()
+    insertInspectRun({ status: RunStatuses.completed, createdAt: staleAt })
+
+    const runId = await maybeRefreshGscCoverage(db, connectedConfig(), PROJECT_ID, deps, now)
+
+    expect(runId).toBeTruthy()
+    expect(deps.calls).toHaveLength(1)
+  })
+
+  it('does not let a recent run of a DIFFERENT kind block the refresh', async () => {
+    const deps = spyExecutor()
+    const now = Date.now()
+    // A gsc-sync (not inspect-sitemap) ran a minute ago — must not gate coverage.
+    insertInspectRun({ status: RunStatuses.completed, createdAt: new Date(now - 60_000).toISOString(), kind: RunKinds['gsc-sync'] })
+
+    const runId = await maybeRefreshGscCoverage(db, connectedConfig(), PROJECT_ID, deps, now)
+
+    expect(runId).toBeTruthy()
+    expect(deps.calls).toHaveLength(1)
+  })
+
+  it('dedupes two near-simultaneous callers to a single inspect-sitemap run', async () => {
+    const deps = spyExecutor()
+    const now = Date.now()
+    const config = connectedConfig()
+
+    // Both invoked before either awaits — the second sees the first's synchronously
+    // inserted queued row and bails. Exactly one run + one executor call.
+    const [a, b] = await Promise.all([
+      maybeRefreshGscCoverage(db, config, PROJECT_ID, deps, now),
+      maybeRefreshGscCoverage(db, config, PROJECT_ID, deps, now),
+    ])
+
+    const created = inspectRuns()
+    expect(created).toHaveLength(1)
+    expect(deps.calls).toHaveLength(1)
+    expect([a, b].filter(Boolean)).toHaveLength(1)
+  })
+
+  it('still returns the run id when the executor throws (failure is logged, not propagated)', async () => {
+    const now = Date.now()
+    const failing: CoverageRefreshDeps = {
+      executeInspectSitemap: async () => {
+        throw new Error('quota exceeded')
+      },
+    }
+
+    const runId = await maybeRefreshGscCoverage(db, connectedConfig(), PROJECT_ID, failing, now)
+
+    expect(runId).toBeTruthy()
+    // The run row was still created (the executor owns marking it failed).
+    expect(inspectRuns()).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
Keeps the index-coverage dashboard (`gscUrlInspections`) fresh by chaining a full GSC `inspect-sitemap` off the success of both `executeGscSync` and `executeBingInspectSitemap` — `gsc-sync` alone only inspects the top 50 pages by clicks, so newly-added / zero-click URLs silently drift out of coverage. The new `maybeRefreshGscCoverage` (`src/coverage-refresh.ts`) no-ops when GSC isn't connected (so the Bing → GSC chain stays silent on Bing-only projects) and skips when an `inspect-sitemap` already ran within the 1h `COVERAGE_REFRESH_MIN_INTERVAL_MS` window to stay under the URL Inspection quota; its project lookup, spacing guard, and run-row insert are synchronous so the GSC and Bing arms of "Refresh all" can't both pass the guard. The Bing arm additionally gates on the run actually completing, since `executeBingInspectSitemap` resolves even on an all-errored `failed` run unlike `executeGscSync`. Ships with tests covering the connection gate, spacing window, retry-after-failure, cross-kind isolation, and concurrent dedup, plus an AGENTS.md section; version bumped to 4.57.0.