### PR TITLE
feat(schedule): add a data-refresh schedulable kind (native daemon refresh)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,10 +77,11 @@ canonry report <project>                         # client-facing AEO report → 
 canonry report <project> --output dist/aeo.html
 canonry report <project> --format json           # raw report payload to stdout
 
-# Schedules — one row per (project, kind) where kind ∈ {answer-visibility, traffic-sync}
+# Schedules — one row per (project, kind) where kind ∈ {answer-visibility, traffic-sync, data-refresh}
 canonry schedule set <project> --preset daily                                                # answer-visibility (default kind)
 canonry schedule set <project> --kind traffic-sync --cron "*/15 * * * *" --source <id>       # traffic-sync (sourceId required)
-canonry schedule show <project> [--kind answer-visibility|traffic-sync]                      # default kind is answer-visibility
+canonry schedule set <project> --kind data-refresh --preset daily                            # data-refresh (refreshes connected GSC/Bing/GA/GBP; no source)
+canonry schedule show <project> [--kind answer-visibility|traffic-sync|data-refresh]         # default kind is answer-visibility
 canonry schedule enable  <project> [--kind ...]
 canonry schedule disable <project> [--kind ...]
 canonry schedule remove  <project> [--kind ...]                                              # delete the schedule for that kind

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.58.0",
+  "version": "4.59.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -1520,7 +1520,7 @@ export type RunDto = {
 export type ScheduleDto = {
     id: string;
     projectId: string;
-    kind: 'answer-visibility' | 'traffic-sync';
+    kind: 'answer-visibility' | 'traffic-sync' | 'data-refresh';
     cronExpr: string;
     preset?: string | null;
     timezone: string;
@@ -3523,7 +3523,7 @@ export type DeleteApiV1ProjectsByNameScheduleData = {
         /**
          * Schedulable run kind. Defaults to "answer-visibility" for backward compatibility.
          */
-        kind?: 'answer-visibility' | 'traffic-sync';
+        kind?: 'answer-visibility' | 'traffic-sync' | 'data-refresh';
     };
     url: '/api/v1/projects/{name}/schedule';
 };
@@ -3558,7 +3558,7 @@ export type GetApiV1ProjectsByNameScheduleData = {
         /**
          * Schedulable run kind. Defaults to "answer-visibility" for backward compatibility.
          */
-        kind?: 'answer-visibility' | 'traffic-sync';
+        kind?: 'answer-visibility' | 'traffic-sync' | 'data-refresh';
     };
     url: '/api/v1/projects/{name}/schedule';
 };
@@ -3583,7 +3583,7 @@ export type GetApiV1ProjectsByNameScheduleResponse = GetApiV1ProjectsByNameSched
 
 export type PutApiV1ProjectsByNameScheduleData = {
     body: {
-        kind?: 'answer-visibility' | 'traffic-sync';
+        kind?: 'answer-visibility' | 'traffic-sync' | 'data-refresh';
         preset?: string;
         cron?: string;
         timezone?: string;
@@ -3601,7 +3601,7 @@ export type PutApiV1ProjectsByNameScheduleData = {
         /**
          * Schedulable run kind. Defaults to "answer-visibility" for backward compatibility.
          */
-        kind?: 'answer-visibility' | 'traffic-sync';
+        kind?: 'answer-visibility' | 'traffic-sync' | 'data-refresh';
     };
     url: '/api/v1/projects/{name}/schedule';
 };

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -166,7 +166,7 @@ const scheduleKindQueryParameter: OpenApiParameter = {
   name: 'kind',
   in: 'query',
   description: 'Schedulable run kind. Defaults to "answer-visibility" for backward compatibility.',
-  schema: { type: 'string', enum: ['answer-visibility', 'traffic-sync'] },
+  schema: { type: 'string', enum: ['answer-visibility', 'traffic-sync', 'data-refresh'] },
 }
 
 const runsListKindQueryParameter: OpenApiParameter = {
@@ -1135,7 +1135,7 @@ const routeCatalog: OpenApiOperation[] = [
           schema: {
             type: 'object',
             properties: {
-              kind: { type: 'string', enum: ['answer-visibility', 'traffic-sync'] },
+              kind: { type: 'string', enum: ['answer-visibility', 'traffic-sync', 'data-refresh'] },
               preset: stringSchema,
               cron: stringSchema,
               timezone: stringSchema,

--- a/packages/api-routes/test/schedules.test.ts
+++ b/packages/api-routes/test/schedules.test.ts
@@ -129,6 +129,44 @@ describe('schedule per-kind invariants', () => {
     expect(body.error.message).toMatch(/sourceId.*traffic-sync/)
   })
 
+  it('accepts a well-formed data-refresh schedule (no sourceId) and round-trips via GET / DELETE', async () => {
+    const putRes = await harness.app.inject({
+      method: 'PUT',
+      url: '/api/v1/projects/site-a/schedule',
+      payload: { kind: 'data-refresh', preset: 'daily' },
+    })
+    expect(putRes.statusCode).toBe(201)
+    const created = JSON.parse(putRes.payload)
+    expect(created.kind).toBe('data-refresh')
+    expect(created.sourceId ?? null).toBeNull()
+    expect(created.providers).toEqual([])
+
+    const getRes = await harness.app.inject({
+      method: 'GET',
+      url: '/api/v1/projects/site-a/schedule?kind=data-refresh',
+    })
+    expect(getRes.statusCode).toBe(200)
+    expect(JSON.parse(getRes.payload).id).toBe(created.id)
+
+    const delRes = await harness.app.inject({
+      method: 'DELETE',
+      url: '/api/v1/projects/site-a/schedule?kind=data-refresh',
+    })
+    expect(delRes.statusCode).toBe(204)
+  })
+
+  it('rejects PUT /schedule with kind=data-refresh and sourceId set', async () => {
+    const res = await harness.app.inject({
+      method: 'PUT',
+      url: '/api/v1/projects/site-a/schedule',
+      payload: { kind: 'data-refresh', preset: 'daily', sourceId: harness.trafficSourceId },
+    })
+    expect(res.statusCode).toBe(400)
+    const body = JSON.parse(res.payload)
+    expect(body.error.code).toBe('VALIDATION_ERROR')
+    expect(body.error.message).toMatch(/sourceId.*traffic-sync/)
+  })
+
   it('rejects PUT /schedule with sourceId when kind is answer-visibility', async () => {
     const res = await harness.app.inject({
       method: 'PUT',

--- a/packages/canonry/AGENTS.md
+++ b/packages/canonry/AGENTS.md
@@ -31,7 +31,8 @@ The publishable npm package (`@ainyc/canonry`). Bundles the CLI, local Fastify s
 | `src/server.ts` | Fastify server setup — mounts api-routes, serves SPA, registers providers |
 | `src/job-runner.ts` | In-process job runner for visibility sweeps |
 | `src/provider-registry.ts` | `ProviderRegistry` — manages provider adapters |
-| `src/scheduler.ts` | Cron-based schedule runner |
+| `src/scheduler.ts` | Cron-based schedule runner (kinds: `answer-visibility`, `traffic-sync`, `data-refresh`; the `onDataRefreshRequested` callback fans out to every connected integration) |
+| `src/data-refresh.ts` | `refreshAllIntegrations` — fires GSC + Bing + GA + GBP syncs for a project via the in-process API client, `Promise.allSettled` for per-integration isolation. Wired to the scheduler's `data-refresh` kind in `server.ts`. |
 | `src/snapshot-service.ts` | Snapshot creation and diff logic |
 | `src/intelligence-service.ts` | Runs analysis after sweeps, persists insights + health snapshots |
 | `src/run-coordinator.ts` | Post-run orchestrator — dispatches to intelligence + notifications |

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.58.0",
+  "version": "4.59.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/cli-commands/schedule.ts
+++ b/packages/canonry/src/cli-commands/schedule.ts
@@ -6,7 +6,7 @@ import { usageError } from '../cli-error.js'
 export const SCHEDULE_CLI_COMMANDS: readonly CliCommandSpec[] = [
   {
     path: ['schedule', 'set'],
-    usage: 'canonry schedule set <project> (--preset <preset> | --cron <expr>) [--kind answer-visibility|traffic-sync] [--source <id>] [--timezone <tz>] [--provider <name>...] [--format json]',
+    usage: 'canonry schedule set <project> (--preset <preset> | --cron <expr>) [--kind answer-visibility|traffic-sync|data-refresh] [--source <id>] [--timezone <tz>] [--provider <name>...] [--format json]',
     options: {
       preset: stringOption(),
       cron: stringOption(),
@@ -16,7 +16,7 @@ export const SCHEDULE_CLI_COMMANDS: readonly CliCommandSpec[] = [
       provider: multiStringOption(),
     },
     run: async (input) => {
-      const usage = 'canonry schedule set <project> (--preset <preset> | --cron <expr>) [--kind answer-visibility|traffic-sync] [--source <id>] [--timezone <tz>] [--provider <name>...] [--format json]'
+      const usage = 'canonry schedule set <project> (--preset <preset> | --cron <expr>) [--kind answer-visibility|traffic-sync|data-refresh] [--source <id>] [--timezone <tz>] [--provider <name>...] [--format json]'
       const project = requireProject(input, 'schedule.set', usage)
       if (!getString(input.values, 'preset') && !getString(input.values, 'cron')) {
         throw usageError('Error: --preset or --cron is required', {
@@ -41,7 +41,7 @@ export const SCHEDULE_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['schedule', 'show'],
-    usage: 'canonry schedule show <project> [--kind answer-visibility|traffic-sync] [--format json]',
+    usage: 'canonry schedule show <project> [--kind answer-visibility|traffic-sync|data-refresh] [--format json]',
     options: { kind: stringOption() },
     run: async (input) => {
       const project = requireProject(input, 'schedule.show', 'canonry schedule show <project> [--kind ...]')
@@ -50,7 +50,7 @@ export const SCHEDULE_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['schedule', 'enable'],
-    usage: 'canonry schedule enable <project> [--kind answer-visibility|traffic-sync] [--format json]',
+    usage: 'canonry schedule enable <project> [--kind answer-visibility|traffic-sync|data-refresh] [--format json]',
     options: { kind: stringOption() },
     run: async (input) => {
       const project = requireProject(input, 'schedule.enable', 'canonry schedule enable <project> [--kind ...]')
@@ -59,7 +59,7 @@ export const SCHEDULE_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['schedule', 'disable'],
-    usage: 'canonry schedule disable <project> [--kind answer-visibility|traffic-sync] [--format json]',
+    usage: 'canonry schedule disable <project> [--kind answer-visibility|traffic-sync|data-refresh] [--format json]',
     options: { kind: stringOption() },
     run: async (input) => {
       const project = requireProject(input, 'schedule.disable', 'canonry schedule disable <project> [--kind ...]')
@@ -68,7 +68,7 @@ export const SCHEDULE_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['schedule', 'remove'],
-    usage: 'canonry schedule remove <project> [--kind answer-visibility|traffic-sync] [--format json]',
+    usage: 'canonry schedule remove <project> [--kind answer-visibility|traffic-sync|data-refresh] [--format json]',
     options: { kind: stringOption() },
     run: async (input) => {
       const project = requireProject(input, 'schedule.remove', 'canonry schedule remove <project> [--kind ...]')

--- a/packages/canonry/src/data-refresh.ts
+++ b/packages/canonry/src/data-refresh.ts
@@ -1,0 +1,48 @@
+import { createLogger } from './logger.js'
+
+const log = createLogger('DataRefresh')
+
+/**
+ * Minimal structural view of the integration-sync calls a data-refresh needs.
+ * `ApiClient` satisfies this, and tests can inject a fake without the full client.
+ */
+export interface DataRefreshClient {
+  gscSync(project: string, body?: { days?: number; full?: boolean }): Promise<unknown>
+  bingInspectSitemap(project: string, body?: { sitemapUrl?: string }): Promise<unknown>
+  gaSync(project: string, body?: { days?: number; only?: string }): Promise<unknown>
+  triggerGbpSync(
+    project: string,
+    body?: { locationNames?: string[]; daysOfMetrics?: number; monthsOfKeywords?: number },
+  ): Promise<unknown>
+}
+
+/**
+ * Refresh every data integration for a project in one shot: GSC, Bing, GA, GBP.
+ *
+ * Each integration's sync endpoint owns its own run-row lifecycle and self-gates
+ * when that integration isn't connected (a clear error, logged here rather than
+ * thrown). Per-integration isolation is via `Promise.allSettled`, so one failure
+ * never blocks the others — mirroring the external cron this replaces. This
+ * function never rejects: the caller treats it as fire-and-forget.
+ */
+export async function refreshAllIntegrations(client: DataRefreshClient, projectName: string): Promise<void> {
+  const integrations: Array<{ name: string; run: () => Promise<unknown> }> = [
+    { name: 'gsc', run: () => client.gscSync(projectName, {}) },
+    { name: 'bing', run: () => client.bingInspectSitemap(projectName, {}) },
+    { name: 'ga', run: () => client.gaSync(projectName, { days: 30 }) },
+    { name: 'gbp', run: () => client.triggerGbpSync(projectName, {}) },
+  ]
+
+  const results = await Promise.allSettled(integrations.map((i) => i.run()))
+
+  results.forEach((result, idx) => {
+    const integration = integrations[idx]!.name
+    if (result.status === 'fulfilled') {
+      log.info('integration.refreshed', { projectName, integration })
+    } else {
+      const reason: unknown = result.reason
+      const message = reason instanceof Error ? reason.message : String(reason)
+      log.warn('integration.refresh-failed', { projectName, integration, error: message })
+    }
+  })
+}

--- a/packages/canonry/src/scheduler.ts
+++ b/packages/canonry/src/scheduler.ts
@@ -19,6 +19,13 @@ export interface SchedulerCallbacks {
    * Fire-and-forget: errors are logged by the host, not by the scheduler.
    */
   onTrafficSyncRequested?: (projectName: string, sourceId: string) => void
+  /**
+   * Fired when a data-refresh schedule triggers. The host refreshes every
+   * CONNECTED data integration (GSC, Bing, GA, GBP) for the project. Each
+   * integration sync owns its own run row; per-integration errors are logged
+   * by the host, not the scheduler. Fire-and-forget.
+   */
+  onDataRefreshRequested?: (projectName: string) => void
 }
 
 /** Scheduler tasks are keyed by `(projectId, kind)` so a project can run an
@@ -184,6 +191,24 @@ export class Scheduler {
         }).where(eq(schedules.id, currentSchedule.id)).run()
         log.info('traffic-sync.triggered', { projectName: project.name, sourceId })
         this.callbacks.onTrafficSyncRequested(project.name, sourceId)
+        return
+      }
+
+      if (kind === SchedulableRunKinds['data-refresh']) {
+        // Data-refresh schedules fan out to every connected data integration
+        // (GSC, Bing, GA, GBP) via the host callback. Each integration sync
+        // owns its own run row + dedupe; the scheduler only fires the trigger.
+        if (!this.callbacks.onDataRefreshRequested) {
+          log.warn('data-refresh.no-callback', { scheduleId, projectId, msg: 'host did not register onDataRefreshRequested' })
+          return
+        }
+        this.db.update(schedules).set({
+          lastRunAt: now,
+          nextRunAt,
+          updatedAt: now,
+        }).where(eq(schedules.id, currentSchedule.id)).run()
+        log.info('data-refresh.triggered', { projectName: project.name })
+        this.callbacks.onDataRefreshRequested(project.name)
         return
       }
 

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -81,6 +81,7 @@ import {
 import { ccReleaseSyncs as ccReleaseSyncsTable } from '@ainyc/canonry-db'
 import { ProviderRegistry } from './provider-registry.js'
 import { Scheduler } from './scheduler.js'
+import { refreshAllIntegrations } from './data-refresh.js'
 import { Notifier } from './notifier.js'
 import { IntelligenceService } from './intelligence-service.js'
 import { RunCoordinator } from './run-coordinator.js'
@@ -493,6 +494,12 @@ export async function createServer(opts: {
       aeroClient.trafficSync(projectName, sourceId).catch((err: unknown) => {
         app.log.error({ projectName, sourceId, err: err instanceof Error ? err.message : String(err) }, 'Scheduled traffic sync failed')
       })
+    },
+    onDataRefreshRequested: (projectName) => {
+      // Fan out to every connected data integration (GSC, Bing, GA, GBP) via
+      // the same in-process client. refreshAllIntegrations isolates each
+      // integration's failure with Promise.allSettled and never rejects.
+      void refreshAllIntegrations(aeroClient, projectName)
     },
   })
 

--- a/packages/canonry/test/data-refresh.test.ts
+++ b/packages/canonry/test/data-refresh.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import { refreshAllIntegrations, type DataRefreshClient } from '../src/data-refresh.js'
+
+function makeClient(overrides: Partial<DataRefreshClient> = {}): DataRefreshClient {
+  return {
+    gscSync: vi.fn(async () => ({})),
+    bingInspectSitemap: vi.fn(async () => ({})),
+    gaSync: vi.fn(async () => ({})),
+    triggerGbpSync: vi.fn(async () => ({ runId: 'r', status: 'running' })),
+    ...overrides,
+  }
+}
+
+describe('refreshAllIntegrations', () => {
+  test('fires all four integration syncs for the project', async () => {
+    const client = makeClient()
+
+    await refreshAllIntegrations(client, 'proj')
+
+    expect(client.gscSync).toHaveBeenCalledTimes(1)
+    expect(client.gscSync).toHaveBeenCalledWith('proj', {})
+    expect(client.bingInspectSitemap).toHaveBeenCalledWith('proj', {})
+    expect(client.gaSync).toHaveBeenCalledWith('proj', { days: 30 })
+    expect(client.triggerGbpSync).toHaveBeenCalledWith('proj', {})
+  })
+
+  test('one integration failing does not block the others and never throws', async () => {
+    const client = makeClient({
+      bingInspectSitemap: vi.fn(async () => {
+        throw new Error('Bing is not connected for this project')
+      }),
+    })
+
+    await expect(refreshAllIntegrations(client, 'proj')).resolves.toBeUndefined()
+
+    // The remaining three still fired despite Bing rejecting.
+    expect(client.gscSync).toHaveBeenCalledTimes(1)
+    expect(client.gaSync).toHaveBeenCalledTimes(1)
+    expect(client.triggerGbpSync).toHaveBeenCalledTimes(1)
+  })
+
+  test('all integrations failing still resolves (fire-and-forget)', async () => {
+    const boom = vi.fn(async () => {
+      throw new Error('not connected')
+    })
+    const client = makeClient({
+      gscSync: boom,
+      bingInspectSitemap: boom,
+      gaSync: boom,
+      triggerGbpSync: boom,
+    })
+
+    await expect(refreshAllIntegrations(client, 'proj')).resolves.toBeUndefined()
+    expect(boom).toHaveBeenCalledTimes(4)
+  })
+})

--- a/packages/canonry/test/scheduler.test.ts
+++ b/packages/canonry/test/scheduler.test.ts
@@ -204,3 +204,87 @@ test('traffic-sync trigger skips silently when sourceId is missing', () => {
   expect(trafficCalls).toHaveLength(0)
   fs.rmSync(tmpDir, { recursive: true, force: true })
 })
+
+test('data-refresh trigger fires onDataRefreshRequested with the project name only', () => {
+  const { db, tmpDir } = createTempDb()
+  const now = new Date().toISOString()
+
+  db.insert(projects).values({
+    id: 'proj_dr',
+    name: 'refresh-project',
+    displayName: 'Refresh Project',
+    canonicalDomain: 'example.com',
+    country: 'US',
+    language: 'en',
+    createdAt: now,
+    updatedAt: now,
+  }).run()
+  db.insert(schedules).values({
+    id: 'sched_dr',
+    projectId: 'proj_dr',
+    kind: 'data-refresh',
+    cronExpr: '30 12 * * *',
+    timezone: 'UTC',
+    enabled: true,
+    providers: [],
+    createdAt: now,
+    updatedAt: now,
+  }).run()
+
+  const refreshCalls: string[] = []
+  const runCalls: string[] = []
+  const trafficCalls: unknown[] = []
+  const scheduler = new Scheduler(db, {
+    onRunCreated: (runId) => runCalls.push(runId),
+    onTrafficSyncRequested: () => trafficCalls.push(null),
+    onDataRefreshRequested: (projectName) => refreshCalls.push(projectName),
+  })
+
+  ;(scheduler as unknown as {
+    triggerRun: (scheduleId: string, projectId: string, kind: 'answer-visibility' | 'traffic-sync' | 'data-refresh') => void
+  }).triggerRun('sched_dr', 'proj_dr', 'data-refresh')
+
+  expect(refreshCalls).toEqual(['refresh-project'])
+  // Neither the answer-visibility nor the traffic-sync callback fires for data-refresh.
+  expect(runCalls).toHaveLength(0)
+  expect(trafficCalls).toHaveLength(0)
+
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+test('data-refresh trigger skips silently when no onDataRefreshRequested callback is registered', () => {
+  const { db, tmpDir } = createTempDb()
+  const now = new Date().toISOString()
+
+  db.insert(projects).values({
+    id: 'proj_dr2',
+    name: 'refresh-no-cb',
+    displayName: 'Refresh No Callback',
+    canonicalDomain: 'example.com',
+    country: 'US',
+    language: 'en',
+    createdAt: now,
+    updatedAt: now,
+  }).run()
+  db.insert(schedules).values({
+    id: 'sched_dr2',
+    projectId: 'proj_dr2',
+    kind: 'data-refresh',
+    cronExpr: '30 12 * * *',
+    timezone: 'UTC',
+    enabled: true,
+    providers: [],
+    createdAt: now,
+    updatedAt: now,
+  }).run()
+
+  const scheduler = new Scheduler(db, { onRunCreated: () => {} })
+
+  expect(() =>
+    (scheduler as unknown as {
+      triggerRun: (scheduleId: string, projectId: string, kind: 'answer-visibility' | 'traffic-sync' | 'data-refresh') => void
+    }).triggerRun('sched_dr2', 'proj_dr2', 'data-refresh'),
+  ).not.toThrow()
+
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})

--- a/packages/contracts/src/schedule.ts
+++ b/packages/contracts/src/schedule.ts
@@ -7,8 +7,9 @@ import { providerNameSchema } from './provider.js'
  *
  * - `answer-visibility` — citation/mention sweep across configured providers (the original schedulable kind).
  * - `traffic-sync` — server-side traffic-source pull (Cloud Run today; future adapters slot in here too).
+ * - `data-refresh` — refresh every connected data integration for the project (GSC, Bing, GA, GBP) in one trigger.
  */
-export const schedulableRunKindSchema = z.enum(['answer-visibility', 'traffic-sync'])
+export const schedulableRunKindSchema = z.enum(['answer-visibility', 'traffic-sync', 'data-refresh'])
 export type SchedulableRunKind = z.infer<typeof schedulableRunKindSchema>
 export const SchedulableRunKinds = schedulableRunKindSchema.enum
 

--- a/skills/canonry/references/canonry-cli.md
+++ b/skills/canonry/references/canonry-cli.md
@@ -185,6 +185,7 @@ cnry competitor list <project>
 ```bash
 cnry schedule set <project> --preset daily     # or: weekly, twice-daily, daily@09
 cnry schedule set <project> --cron "0 9 * * *" --timezone America/New_York
+cnry schedule set <project> --kind data-refresh --preset daily   # refresh all connected GSC/Bing/GA/GBP integrations (no --source)
 cnry schedule show <project>
 cnry schedule enable <project>
 cnry schedule disable <project>


### PR DESCRIPTION
## What

Add `data-refresh` as a third schedulable run kind. When it fires, the daemon's scheduler refreshes every connected data integration for the project (GSC, Bing, GA, GBP) in one trigger.

## Why

The daily integration refresh currently lives in an external cron script that shells out to `cnry google refresh` / `bing refresh` / `ga sync` / `gbp sync`. That script already depends on the daemon being up (the CLI talks to the running server), so it adds a moving part without adding resilience. Moving the schedule into the daemon's existing scheduler removes the external glue and gives the refresh timezone-aware, in-app scheduling.

## Design

- **No new RunKind.** `data-refresh` is a `SchedulableRunKind` (a trigger) only. It delegates to the existing per-integration syncs (`gsc-sync`, `bing-inspect-sitemap`, `ga-sync`, `gbp-sync`), each of which owns its own run row + dedupe and self-gates with a clear error when its integration isn't connected.
- **Per-integration isolation** via `Promise.allSettled` in `refreshAllIntegrations` — one integration failing (or being unconnected) never blocks the others, and the call never rejects. Mirrors the external script's per-command tolerance.
- Dispatch mirrors `traffic-sync`: a host callback (`onDataRefreshRequested`) fired by the scheduler, wired in `server.ts` to the same in-process client Aero uses.

## Change surface

- `contracts`: `data-refresh` added to `schedulableRunKindSchema`.
- `scheduler.ts`: `onDataRefreshRequested` callback + dispatch branch.
- `server.ts` + new `data-refresh.ts`: `refreshAllIntegrations` fans out the four syncs.
- `openapi.ts`: enum value added to the schedule request body + kind query param; SDK regenerated (types only).
- CLI usage strings updated.

## Usage

`cnry schedule set <project> --kind data-refresh --preset daily` (no `--source`). Bing maps to the full `bing-inspect-sitemap` coverage sync (matching the GSC coverage chain), not per-URL re-inspection.

## Notes

- Additive enum value; no endpoint path or method change.
- Minor version bump to 4.59.0 (feature, over the 100-line threshold).

## Tests

- `data-refresh.test.ts`: all four syncs fire; one failing does not block the others; never throws.
- `scheduler.test.ts`: data-refresh trigger fires only `onDataRefreshRequested`; skips silently with no callback registered.
- `schedules.test.ts`: route accepts a data-refresh schedule (no sourceId) and round-trips via GET/DELETE; rejects it when a sourceId is set.
- Full workspace green: typecheck, lint (0 errors), 3423 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
