### PR TITLE
feat(gbp): flag GBP-API vs rendered-listing discrepancy (#648 Phase A)

### DIFF
--- a/packages/intelligence/src/gbp-analyzer.ts
+++ b/packages/intelligence/src/gbp-analyzer.ts
@@ -91,7 +91,11 @@ export function analyzeGbp(signals: GbpLocationSignals[]): GbpInsightDraft[] {
   for (const loc of signals) {
     const base = { locationName: loc.locationName, query: loc.displayName, provider: GBP_INSIGHT_PROVIDER }
 
-    // 1. Lodging profile empty — AI engines have no structured amenity data.
+    // 1. Lodging profile empty — the GBP API exposes only owner-configured
+    //    attributes, so an empty profile is the operator's blind spot. Google's
+    //    rendered listing may still synthesize amenities from Hotel Center, OTAs,
+    //    and Places/user data, but that synthesized data is NOT what the
+    //    structured profile (the source AI answer engines read) exposes.
     if (loc.lodgingCapable && loc.lodgingEmpty) {
       drafts.push({
         ...base,
@@ -99,8 +103,8 @@ export function analyzeGbp(signals: GbpLocationSignals[]): GbpInsightDraft[] {
         severity: 'high',
         title: `${loc.displayName}: lodging profile has no structured attributes`,
         recommendation: {
-          action: 'Populate the hotel’s structured amenity attributes in Google Business Profile',
-          reason: 'AI answer engines have no structured amenity data to cite for this property, so it loses to hotels with complete profiles.',
+          action: 'Populate the hotel’s structured amenity attributes in Google Business Profile — the amenity source you directly control',
+          reason: 'The GBP API exposes only owner-configured attributes, and this profile has none. Google’s rendered listing may still show amenities it synthesizes from Hotel Center, OTAs, and user data — so the public listing can differ from this profile — but the structured attributes are what AI answer engines cite and the only amenity data you control.',
         },
       })
     }

--- a/packages/intelligence/test/gbp-analyzer.test.ts
+++ b/packages/intelligence/test/gbp-analyzer.test.ts
@@ -38,6 +38,10 @@ describe('analyzeGbp', () => {
       expect(lodging[0]!.provider).toBe('gbp')
       expect(lodging[0]!.query).toBe('Test Hotel')
       expect(lodging[0]!.locationName).toBe('locations/1')
+      // Flags the API-vs-rendered-listing discrepancy: the API returns only
+      // owner-configured attributes, so the public listing may differ (#648).
+      expect(lodging[0]!.recommendation?.reason).toMatch(/owner-configured/)
+      expect(lodging[0]!.recommendation?.reason).toMatch(/rendered listing/)
     })
 
     it('does not flag a populated lodging profile', () => {

--- a/skills/canonry/references/google-business-profile.md
+++ b/skills/canonry/references/google-business-profile.md
@@ -174,7 +174,7 @@ canonry doctor --project <name> --check 'gbp.*'
 
 A completed `gbp-sync` run generates location-scoped insights (`provider = 'gbp'`), surfaced in `canonry insights`, the dashboard, notifications (`insight.critical`/`insight.high`), and Aero's proactive wake-up:
 
-- `gbp-lodging-gap` (high) — a lodging-capable location with an empty attribute profile.
+- `gbp-lodging-gap` (high) — a lodging-capable location with an empty attribute profile. The insight flags that the GBP API exposes only owner-configured attributes, so the *rendered* Google listing (which synthesizes amenities from Hotel Center / OTAs / Places) may differ — an empty profile is the operator's blind spot, not proof the public listing is empty.
 - `gbp-cta-gap` (medium) — place actions present but no direct-merchant booking CTA (only aggregators).
 - `gbp-metric-drop` (high/medium) — a headline conversion metric (direction requests, website clicks, call clicks) fell sharply week-over-week within the synced window.
 - `gbp-keyword-drop` (high/medium) — a head search term's impressions fell month-over-month.
@@ -210,6 +210,7 @@ A property with only aggregator booking links and no direct merchant CTA is a re
 
 ## Important Constraints
 
+- **GBP API returns owner-configured data only** — the API exposes only what the profile owner has set. Google's *rendered* hotel listing synthesizes additional amenities, room pricing, and booking links from Google Hotel Center, OTA feeds (Booking/Expedia/Hotels.com), and Places/user-contributed data — none of which the GBP API returns. So an empty lodging profile (the `gbp-lodging-gap` insight) does **not** mean the public listing is empty; it means the operator hasn't populated the structured source AI answer engines read. Pulling the rendered-listing side from the Places API (and cross-referencing it against GBP attributes) is tracked in issue #648.
 - **No read-only OAuth scope** — `business.manage` is the only published scope. The consent screen will warn about write access even though canonry's v1 is read-only.
 - **300 QPM shared quota** — across all GBP sub-APIs on one Google Cloud project. Canonry's sync worker caps per-location concurrency at 4 (~28 in-flight calls at peak) to stay well under the cap.
 - **10 edits/min per profile** — hard cap on writes (relevant for Phase 4). Cannot be raised.


### PR DESCRIPTION
Phase A of #648. The GBP API returns only owner-configured profile data, but Google's rendered hotel listing synthesizes amenities, pricing, and booking links from Hotel Center, OTA feeds, and Places — so an empty lodging profile is the operator's blind spot, not proof the public listing is empty. This reframes the `gbp-lodging-gap` insight copy (action + reason) and the GBP skill reference to flag that discrepancy, plus a test assertion locking in the framing. Pure copy + doc change — no schema, API, or new dependency; the Places-API cross-reference is Phase B.

Stacked on `arberx/review-workspace-changes` (PR #646) since it edits `gbp-analyzer.ts` which lands there; retarget to `main` once #646 merges.

Closes part of #648 (the "at minimum, flag the discrepancy" ask).