### PR TITLE
feat(GBP): surface Google Business Profile in features and integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@
 - Track citations across Gemini, ChatGPT, Claude, Perplexity, and local LLMs
 - Watch AI engines crawl and refer traffic via [server-log ingestion](skills/canonry/references/server-side-traffic.md) — Cloud Run, Vercel, and the WordPress Traffic Logger plugin today
 - Diagnose against real traffic with built-in [GSC](docs/google-search-console-setup.md), [GA4](docs/google-analytics-setup.md), and [Bing Webmaster](docs/bing-webmaster-setup.md)
+- Track local AEO via [Google Business Profile](skills/canonry/references/google-business-profile.md) — search-term impressions, performance metrics, and hotel lodging + booking-CTA gaps
 - Execute fixes via [WordPress](docs/wordpress-setup.md), JSON-LD schema, and indexing submissions
 - Manage many clients declaratively — config-as-code YAML + `cnry apply`
-- Schedule recurring visibility checks AND traffic syncs, with webhook alerts on regressions
+- Schedule recurring visibility checks, traffic syncs, and Business Profile syncs, with webhook alerts on regressions
 - Generate client-ready HTML reports — `cnry report <project>`
 - Drive from your own agent via the [67-tool MCP adapter](docs/mcp.md) or webhooks
 - Or use **Aero** — Canonry's built-in agent that wakes up after every run
@@ -86,7 +87,7 @@ Configure during `cnry init`, in the dashboard `/settings`, or as env vars.
 | **Architecture & data model** | [docs/architecture.md](docs/architecture.md) · [docs/data-model.md](docs/data-model.md) |
 | **Aero — built-in agent** | [skills/aero/SKILL.md](skills/aero/SKILL.md) |
 | **MCP — Claude Desktop / Cursor / Codex** | [docs/mcp.md](docs/mcp.md) |
-| **Integrations** | [GSC](docs/google-search-console-setup.md) · [GA4](docs/google-analytics-setup.md) · [Bing](docs/bing-webmaster-setup.md) · [WordPress](docs/wordpress-setup.md) · [Server-side traffic (Cloud Run + Vercel + WordPress logs)](skills/canonry/references/server-side-traffic.md) |
+| **Integrations** | [GSC](docs/google-search-console-setup.md) · [GA4](docs/google-analytics-setup.md) · [Bing](docs/bing-webmaster-setup.md) · [Google Business Profile](skills/canonry/references/google-business-profile.md) · [WordPress](docs/wordpress-setup.md) · [Server-side traffic (Cloud Run + Vercel + WordPress logs)](skills/canonry/references/server-side-traffic.md) |
 | **Deployment** — Docker, Railway, Render, systemd, Tailscale | [docs/deployment.md](docs/deployment.md) |
 | **API** — 118+ endpoints | `GET /api/v1/openapi.json` (no auth) |
 | **Skills bundle** for Claude Code / Codex | `cnry skills install` ([details](skills/canonry/SKILL.md)) |

--- a/apps/web/src/components/project/GbpSection.tsx
+++ b/apps/web/src/components/project/GbpSection.tsx
@@ -1,9 +1,11 @@
+import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   getApiV1ProjectsByNameGoogleConnectionsOptions,
   getApiV1ProjectsByNameGbpSummaryOptions,
   getApiV1ProjectsByNameGbpLocationsOptions,
   getApiV1ProjectsByNameGbpKeywordsOptions,
+  getApiV1ProjectsByNameGbpPlacesOptions,
   postApiV1ProjectsByNameGbpSyncMutation,
   putApiV1ProjectsByNameGbpLocationsByLocationNameSelectionMutation,
 } from '@ainyc/canonry-api-client/react-query'
@@ -11,7 +13,7 @@ import {
 import { Button } from '../ui/button.js'
 import { Card } from '../ui/card.js'
 import { ToneBadge } from '../shared/ToneBadge.js'
-import { heyClient } from '../../api.js'
+import { fetchInsights, heyClient } from '../../api.js'
 import { addToast } from '../../lib/toast-store.js'
 
 // Headline conversion metrics first, then the impression breakdowns. Any metric
@@ -63,6 +65,10 @@ function DeltaChip({ delta }: { delta: number | null | undefined }) {
 
 export function GbpSection({ projectName }: { projectName: string }) {
   const queryClient = useQueryClient()
+  // `null` = all tracked locations (aggregate). A locationName scopes every read
+  // to one location. A single tracked location reads 1:1 with no selector.
+  const [scopeLocation, setScopeLocation] = useState<string | null>(null)
+  const [showManage, setShowManage] = useState(false)
 
   const connectionsQuery = useQuery(
     getApiV1ProjectsByNameGoogleConnectionsOptions({ client: heyClient, path: { name: projectName } }),
@@ -70,16 +76,29 @@ export function GbpSection({ projectName }: { projectName: string }) {
   const gbpConnection = connectionsQuery.data?.find((c) => c.connectionType === 'gbp')
   const connected = Boolean(gbpConnection)
 
-  const summaryQuery = useQuery({
-    ...getApiV1ProjectsByNameGbpSummaryOptions({ client: heyClient, path: { name: projectName } }),
-    enabled: connected,
-  })
+  const scopeQuery = scopeLocation ? { locationName: scopeLocation } : undefined
+
   const locationsQuery = useQuery({
     ...getApiV1ProjectsByNameGbpLocationsOptions({ client: heyClient, path: { name: projectName } }),
     enabled: connected,
   })
+  const summaryQuery = useQuery({
+    ...getApiV1ProjectsByNameGbpSummaryOptions({ client: heyClient, path: { name: projectName }, query: scopeQuery }),
+    enabled: connected,
+  })
   const keywordsQuery = useQuery({
-    ...getApiV1ProjectsByNameGbpKeywordsOptions({ client: heyClient, path: { name: projectName } }),
+    ...getApiV1ProjectsByNameGbpKeywordsOptions({ client: heyClient, path: { name: projectName }, query: scopeQuery }),
+    enabled: connected,
+  })
+  const placesQuery = useQuery({
+    ...getApiV1ProjectsByNameGbpPlacesOptions({ client: heyClient, path: { name: projectName }, query: scopeQuery }),
+    enabled: connected,
+  })
+  // Use the typed `fetchInsights` wrapper (the generated insights op is loosely
+  // typed) so `data` is `InsightDto[]` and the gap filter below is type-safe.
+  const insightsQuery = useQuery({
+    queryKey: ['gbp-section-insights', projectName],
+    queryFn: () => fetchInsights(projectName),
     enabled: connected,
   })
 
@@ -106,15 +125,45 @@ export function GbpSection({ projectName }: { projectName: string }) {
     onSuccess: () => invalidateGbp(),
   })
 
-  // Self-gating: the section only appears for projects with a GBP connection.
-  // Narrowing on `gbpConnection` (not the derived `connected`) lets TS treat it
-  // as defined below.
-  if (connectionsQuery.isLoading || !gbpConnection) return null
+  if (connectionsQuery.isLoading) return null
+
+  // The dedicated "Local Presence" tab can be reached by direct navigation even
+  // without a connection — render an explicit empty state, not a blank page.
+  if (!gbpConnection) {
+    return (
+      <section className="page-section-divider">
+        <Card className="surface-card compact-card">
+          <p className="eyebrow eyebrow-soft">Local presence</p>
+          <h2>Google Business Profile</h2>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-zinc-500">
+            No Google Business Profile is connected for this project. Connect one with{' '}
+            <span className="font-mono text-zinc-400">canonry gbp connect {projectName}</span> to track local
+            performance, search terms, booking CTAs, and how your public Maps listing compares to the profile you control.
+          </p>
+        </Card>
+      </section>
+    )
+  }
 
   const summary = summaryQuery.data
   const locations = locationsQuery.data?.locations ?? []
+  const trackedLocations = locations.filter((l) => l.selected)
   const keywords = keywordsQuery.data?.keywords ?? []
+  const places = placesQuery.data?.places ?? []
   const account = locations.length > 0 ? locations[0].accountName : gbpConnection.domain
+
+  const scopeDisplayName = scopeLocation
+    ? locations.find((l) => l.locationName === scopeLocation)?.displayName ?? null
+    : null
+
+  // The owner-vs-public amenity gap is computed server-side by the GBP analyzer
+  // (the `gbp-listing-discrepancy` / `gbp-lodging-gap` insights); we only render
+  // it. Filter to the active scope via the location-labelled title/query.
+  const gapInsights = (insightsQuery.data ?? []).filter((ins) =>
+    !ins.dismissed
+    && (ins.type === 'gbp-listing-discrepancy' || ins.type === 'gbp-lodging-gap')
+    && (!scopeDisplayName || ins.query === scopeLocation || ins.title.startsWith(scopeDisplayName)),
+  )
 
   return (
     <section className="page-section-divider">
@@ -124,7 +173,7 @@ export function GbpSection({ projectName }: { projectName: string }) {
             <p className="eyebrow eyebrow-soft">Local presence</p>
             <h2>Google Business Profile</h2>
             <p className="mt-1 max-w-3xl text-sm leading-6 text-zinc-500">
-              How AI answer engines and Maps surface this business — performance, search terms, booking CTAs, and profile completeness.
+              How AI answer engines and Maps surface this business — performance, search terms, booking CTAs, and how your public listing compares to the profile you control.
             </p>
           </div>
           <div className="flex items-center gap-2">
@@ -143,151 +192,262 @@ export function GbpSection({ projectName }: { projectName: string }) {
 
         <p className="mb-4 text-xs text-zinc-500">
           {account ? <>Account <span className="font-mono text-zinc-400">{account}</span> · </> : null}
-          {locationsQuery.data ? `${locationsQuery.data.totalSelected} of ${locationsQuery.data.totalDiscovered} locations selected` : 'Loading locations…'}
+          {locationsQuery.data ? `${locationsQuery.data.totalSelected} of ${locationsQuery.data.totalDiscovered} locations tracked` : 'Loading locations…'}
         </p>
 
-        {/* Performance scorecard — totals + 7-day deltas (all computed server-side). */}
-        {summary && (
-          <div className="mb-6">
-            <p className="eyebrow eyebrow-soft mb-2">Performance · last 7 days vs prior 7</p>
-            {orderedMetrics(summary.performance.totals).length === 0 ? (
-              <p className="text-sm text-zinc-500">No performance data yet — run a sync.</p>
-            ) : (
-              <div className="metric-grid grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-                {orderedMetrics(summary.performance.totals).map((metric) => (
-                  <div key={metric} className="metric-card rounded-lg border border-zinc-800/60 bg-zinc-900/30 px-3 py-2">
-                    <div className="text-[11px] uppercase tracking-wide text-zinc-500">{metricLabel(metric)}</div>
-                    <div className="mt-1 flex items-baseline justify-between">
-                      <span className="font-mono text-lg text-zinc-50">{(summary.performance.totals[metric] ?? 0).toLocaleString()}</span>
-                      <DeltaChip delta={summary.performance.deltaPct[metric]} />
-                    </div>
-                    <div className="mt-0.5 text-[11px] text-zinc-600">
-                      {(summary.performance.recent7d[metric] ?? 0).toLocaleString()} recent · {(summary.performance.prior7d[metric] ?? 0).toLocaleString()} prior
-                    </div>
+        {/* Location scope selector — only when more than one location is tracked. */}
+        {trackedLocations.length > 1 && (
+          <div className="mb-5 flex flex-wrap gap-1.5" role="tablist" aria-label="Location">
+            <ScopeChip label="All locations" active={scopeLocation === null} onClick={() => setScopeLocation(null)} />
+            {trackedLocations.map((loc) => (
+              <ScopeChip
+                key={loc.id}
+                label={loc.displayName}
+                active={scopeLocation === loc.locationName}
+                onClick={() => setScopeLocation(loc.locationName)}
+              />
+            ))}
+          </div>
+        )}
+
+        {trackedLocations.length === 0 ? (
+          <p className="text-sm text-zinc-500">
+            No locations are tracked yet. Open <span className="font-medium text-zinc-300">Manage locations</span> below to track the one(s) for this business.
+          </p>
+        ) : (
+          <>
+            {/* Owner-vs-public gap (server-computed insights) — the headline AEO signal. */}
+            {gapInsights.length > 0 && (
+              <div className="mb-6 grid gap-2">
+                {gapInsights.map((ins) => (
+                  <div key={ins.id} className="insight-card insight-card-negative rounded-r-lg border border-zinc-800/60 bg-zinc-900/30 p-3 pl-4">
+                    <p className="text-sm font-medium text-zinc-200">{ins.title}</p>
+                    {ins.recommendation?.reason && (
+                      <p className="text-sm leading-6 text-zinc-400">{ins.recommendation.reason}</p>
+                    )}
                   </div>
                 ))}
               </div>
             )}
-          </div>
-        )}
 
-        {/* CTA presence + lodging completeness tiles. */}
-        {summary && (
-          <div className="mb-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-            <SignalTile label="Reservation CTA" present={summary.placeActions.hasReservationCta} />
-            <SignalTile label="Booking CTA" present={summary.placeActions.hasBookingCta} />
-            <SignalTile
-              label="Direct booking link"
-              present={summary.placeActions.hasDirectMerchantCta}
-              absentTone="caution"
-              absentHint="Only aggregator/OTA links — AI may surface third-party booking"
-            />
-            <div className="rounded-lg border border-zinc-800/60 bg-zinc-900/30 px-3 py-2">
-              <div className="text-[11px] uppercase tracking-wide text-zinc-500">Lodging profile</div>
-              {summary.lodging.lodgingLocationCount === 0 ? (
-                <div className="mt-1 text-sm text-zinc-500">Not a lodging property</div>
-              ) : (
-                <div className="mt-1 flex items-baseline justify-between">
-                  <span className="font-mono text-lg text-zinc-50">
-                    {summary.lodging.populatedLodgingCount}/{summary.lodging.lodgingLocationCount}
-                  </span>
-                  {summary.lodging.emptyLodgingCount > 0 ? (
-                    <ToneBadge tone="caution">{summary.lodging.emptyLodgingCount} empty</ToneBadge>
+            {/* Performance scorecard — totals + 7-day deltas (all computed server-side). */}
+            {summary && (
+              <div className="mb-6">
+                <p className="eyebrow eyebrow-soft mb-2">Performance · last 7 days vs prior 7</p>
+                {orderedMetrics(summary.performance.totals).length === 0 ? (
+                  <p className="text-sm text-zinc-500">No performance data yet — run a sync.</p>
+                ) : (
+                  <div className="metric-grid grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                    {orderedMetrics(summary.performance.totals).map((metric) => (
+                      <div key={metric} className="metric-card rounded-lg border border-zinc-800/60 bg-zinc-900/30 px-3 py-2">
+                        <div className="text-[11px] uppercase tracking-wide text-zinc-500">{metricLabel(metric)}</div>
+                        <div className="mt-1 flex items-baseline justify-between">
+                          <span className="font-mono text-lg text-zinc-50">{(summary.performance.totals[metric] ?? 0).toLocaleString()}</span>
+                          <DeltaChip delta={summary.performance.deltaPct[metric]} />
+                        </div>
+                        <div className="mt-0.5 text-[11px] text-zinc-600">
+                          {(summary.performance.recent7d[metric] ?? 0).toLocaleString()} recent · {(summary.performance.prior7d[metric] ?? 0).toLocaleString()} prior
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* CTA presence + lodging completeness tiles. */}
+            {summary && (
+              <div className="mb-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                <SignalTile label="Reservation CTA" present={summary.placeActions.hasReservationCta} />
+                <SignalTile label="Booking CTA" present={summary.placeActions.hasBookingCta} />
+                <SignalTile
+                  label="Direct booking link"
+                  present={summary.placeActions.hasDirectMerchantCta}
+                  absentTone="caution"
+                  absentHint="Only aggregator/OTA links — AI may surface third-party booking"
+                />
+                <div className="rounded-lg border border-zinc-800/60 bg-zinc-900/30 px-3 py-2">
+                  <div className="text-[11px] uppercase tracking-wide text-zinc-500">Lodging profile</div>
+                  {summary.lodging.lodgingLocationCount === 0 ? (
+                    <div className="mt-1 text-sm text-zinc-500">Not a lodging property</div>
                   ) : (
-                    <ToneBadge tone="positive">complete</ToneBadge>
+                    <div className="mt-1 flex items-baseline justify-between">
+                      <span className="font-mono text-lg text-zinc-50">
+                        {summary.lodging.populatedLodgingCount}/{summary.lodging.lodgingLocationCount}
+                      </span>
+                      {summary.lodging.emptyLodgingCount > 0 ? (
+                        <ToneBadge tone="caution">{summary.lodging.emptyLodgingCount} empty</ToneBadge>
+                      ) : (
+                        <ToneBadge tone="positive">complete</ToneBadge>
+                      )}
+                    </div>
                   )}
                 </div>
+              </div>
+            )}
+
+            {/* Public listing (Places, #648) — amenities Google's public Maps listing
+                advertises, derived server-side. The gap vs the owner profile is the
+                AEO signal surfaced above as an insight. */}
+            {places.length > 0 && (
+              <div className="mb-6">
+                <p className="eyebrow eyebrow-soft mb-2">Public listing · Google Maps</p>
+                <div className="grid gap-2">
+                  {places.map((place) => {
+                    const loc = locations.find((l) => l.locationName === place.locationName)
+                    return (
+                      <div key={place.locationName} className="rounded-lg border border-zinc-800/60 bg-zinc-900/30 px-3 py-3">
+                        <div className="flex items-center justify-between gap-3">
+                          <span className="text-sm text-zinc-300">{loc?.displayName ?? place.locationName}</span>
+                          <span className="text-[11px] text-zinc-600">
+                            {place.amenities.length} amenit{place.amenities.length === 1 ? 'y' : 'ies'} advertised
+                          </span>
+                        </div>
+                        {place.amenities.length > 0 ? (
+                          <div className="mt-2 flex flex-wrap gap-1.5">
+                            {place.amenities.map((a) => (
+                              <span key={a} className="rounded-full border border-zinc-700/60 px-2 py-0.5 text-[11px] text-zinc-400">{a}</span>
+                            ))}
+                          </div>
+                        ) : (
+                          <p className="mt-1 text-sm text-zinc-500">Public listing advertises no structured amenities.</p>
+                        )}
+                        {loc?.mapsUri && (
+                          <a
+                            href={loc.mapsUri}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="mt-2 inline-block text-[11px] text-zinc-500 hover:text-zinc-300"
+                          >
+                            View on Google Maps →
+                          </a>
+                        )}
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+            )}
+
+            {/* Search keywords table. */}
+            <div className="mb-2">
+              <div className="section-head section-head-inline mb-2">
+                <p className="eyebrow eyebrow-soft">Search terms</p>
+                {keywordsQuery.data && keywordsQuery.data.total > 0 && (
+                  <span className="text-[11px] text-zinc-600">
+                    {keywordsQuery.data.thresholdedPct}% privacy-thresholded
+                  </span>
+                )}
+              </div>
+              {keywords.length === 0 ? (
+                <p className="text-sm text-zinc-500">No keyword impressions stored yet.</p>
+              ) : (
+                <table className="data-table w-full text-sm">
+                  <thead>
+                    <tr>
+                      <th className="text-left">Search term</th>
+                      <th className="text-right">Impressions</th>
+                      <th className="text-right">Window</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {keywords.slice(0, 25).map((kw) => (
+                      <tr key={`${kw.locationName}:${kw.keyword}`}>
+                        <td className="text-zinc-300">{kw.keyword}</td>
+                        <td className="text-right font-mono text-zinc-200">
+                          {kw.valueCount !== null
+                            ? kw.valueCount.toLocaleString()
+                            : <span className="text-zinc-500" title="Privacy floor — Google withheld the exact count">{'<'}{kw.valueThreshold}</span>}
+                        </td>
+                        <td className="text-right font-mono text-[11px] text-zinc-600">{kw.periodStart}–{kw.periodEnd}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
               )}
             </div>
-          </div>
+          </>
         )}
 
-        {/* Search keywords table. */}
-        <div className="mb-6">
-          <div className="section-head section-head-inline mb-2">
-            <p className="eyebrow eyebrow-soft">Search terms</p>
-            {keywordsQuery.data && keywordsQuery.data.total > 0 && (
-              <span className="text-[11px] text-zinc-600">
-                {keywordsQuery.data.thresholdedPct}% privacy-thresholded
-              </span>
-            )}
-          </div>
-          {keywords.length === 0 ? (
-            <p className="text-sm text-zinc-500">No keyword impressions stored yet.</p>
-          ) : (
-            <table className="data-table w-full text-sm">
-              <thead>
-                <tr>
-                  <th className="text-left">Search term</th>
-                  <th className="text-right">Impressions</th>
-                  <th className="text-right">Window</th>
-                </tr>
-              </thead>
-              <tbody>
-                {keywords.slice(0, 25).map((kw) => (
-                  <tr key={`${kw.locationName}:${kw.keyword}`}>
-                    <td className="text-zinc-300">{kw.keyword}</td>
-                    <td className="text-right font-mono text-zinc-200">
-                      {kw.valueCount !== null
-                        ? kw.valueCount.toLocaleString()
-                        : <span className="text-zinc-500" title="Privacy floor — Google withheld the exact count">{'<'}{kw.valueThreshold}</span>}
-                    </td>
-                    <td className="text-right font-mono text-[11px] text-zinc-600">{kw.periodStart}–{kw.periodEnd}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
-        </div>
-
-        {/* Locations table with selection toggle. */}
-        <div>
-          <p className="eyebrow eyebrow-soft mb-2">Locations</p>
-          {locations.length === 0 ? (
-            <p className="text-sm text-zinc-500">No locations discovered. Run <span className="font-mono">canonry gbp locations discover</span>.</p>
-          ) : (
-            <table className="data-table w-full text-sm">
-              <thead>
-                <tr>
-                  <th className="text-left">Location</th>
-                  <th className="text-left">Address</th>
-                  <th className="text-left">Status</th>
-                  <th className="text-right">Action</th>
-                </tr>
-              </thead>
-              <tbody>
-                {locations.map((loc) => (
-                  <tr key={loc.id}>
-                    <td className="text-zinc-200">{loc.displayName}</td>
-                    <td className="text-zinc-500">{loc.storefrontAddress ?? '—'}</td>
-                    <td>
-                      <ToneBadge tone={loc.selected ? 'positive' : 'neutral'}>
-                        {loc.selected ? 'Tracked' : 'Not tracked'}
-                      </ToneBadge>
-                    </td>
-                    <td className="text-right">
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        disabled={selectionMutation.isPending}
-                        onClick={() => selectionMutation.mutate({
-                          client: heyClient,
-                          path: { name: projectName, locationName: loc.locationName },
-                          body: { selected: !loc.selected },
-                        })}
-                      >
-                        {loc.selected ? 'Untrack' : 'Track'}
-                      </Button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+        {/* Manage locations — demoted. Discovery surfaces every location the
+            connected Google account can see (often unrelated businesses); track
+            only the one(s) for this project here. */}
+        <div className="mt-6 border-t border-zinc-800/60 pt-4">
+          <button
+            type="button"
+            className="flex items-center gap-1.5 text-xs font-medium text-zinc-400 hover:text-zinc-200"
+            onClick={() => setShowManage((v) => !v)}
+            aria-expanded={showManage}
+          >
+            <span aria-hidden="true">{showManage ? '▾' : '▸'}</span> Manage locations ({locations.length})
+          </button>
+          {showManage && (
+            <div className="mt-3">
+              {locations.length === 0 ? (
+                <p className="text-sm text-zinc-500">No locations discovered. Run <span className="font-mono">canonry gbp locations discover</span>.</p>
+              ) : (
+                <table className="data-table w-full text-sm">
+                  <thead>
+                    <tr>
+                      <th className="text-left">Location</th>
+                      <th className="text-left">Address</th>
+                      <th className="text-left">Status</th>
+                      <th className="text-right">Action</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {locations.map((loc) => (
+                      <tr key={loc.id}>
+                        <td className="text-zinc-200">{loc.displayName}</td>
+                        <td className="text-zinc-500">{loc.storefrontAddress ?? '—'}</td>
+                        <td>
+                          <ToneBadge tone={loc.selected ? 'positive' : 'neutral'}>
+                            {loc.selected ? 'Tracked' : 'Not tracked'}
+                          </ToneBadge>
+                        </td>
+                        <td className="text-right">
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            disabled={selectionMutation.isPending}
+                            onClick={() => selectionMutation.mutate({
+                              client: heyClient,
+                              path: { name: projectName, locationName: loc.locationName },
+                              body: { selected: !loc.selected },
+                            })}
+                          >
+                            {loc.selected ? 'Untrack' : 'Track'}
+                          </Button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
           )}
         </div>
       </Card>
     </section>
+  )
+}
+
+function ScopeChip({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={`rounded-full border px-3 py-1 text-xs transition-colors ${
+        active
+          ? 'border-zinc-500 bg-zinc-800 text-zinc-100'
+          : 'border-zinc-700/60 text-zinc-400 hover:border-zinc-600 hover:text-zinc-200'
+      }`}
+    >
+      {label}
+    </button>
   )
 }
 

--- a/apps/web/src/components/project/GbpSection.tsx
+++ b/apps/web/src/components/project/GbpSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   getApiV1ProjectsByNameGoogleConnectionsOptions,
@@ -124,6 +124,19 @@ export function GbpSection({ projectName }: { projectName: string }) {
     ...putApiV1ProjectsByNameGbpLocationsByLocationNameSelectionMutation(),
     onSuccess: () => invalidateGbp(),
   })
+
+  // If the active scope is no longer a selectable location — it was untracked,
+  // or the tracked set shrank below the 2 needed to render the scope selector —
+  // fall back to the aggregate view. Otherwise the selector disappears while
+  // `scopeLocation` persists, leaving the section stuck on a hidden/untracked
+  // location with no control to reset it.
+  useEffect(() => {
+    if (!scopeLocation || !locationsQuery.data) return
+    const tracked = locationsQuery.data.locations.filter((l) => l.selected)
+    if (tracked.length <= 1 || !tracked.some((l) => l.locationName === scopeLocation)) {
+      setScopeLocation(null)
+    }
+  }, [scopeLocation, locationsQuery.data])
 
   if (connectionsQuery.isLoading) return null
 

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -78,7 +78,7 @@ import { useInitialDashboard } from '../contexts/dashboard-context.js'
 import { useDrawer } from '../hooks/use-drawer.js'
 import type { ProjectCommandCenterVm, RunHistoryPoint } from '../view-models.js'
 
-export type ProjectPageTab = 'overview' | 'search-console' | 'discovery' | 'report' | 'activity' | 'backlinks' | 'settings'
+export type ProjectPageTab = 'overview' | 'search-console' | 'local' | 'discovery' | 'report' | 'activity' | 'backlinks' | 'settings'
 
 type SearchConsoleWorkspace = 'google' | 'bing'
 
@@ -1488,6 +1488,13 @@ function ProjectPageContent({
 }) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
+  // Gate the "Local Presence" tab on an actual GBP connection (same cached
+  // query GbpSection uses, so this dedupes — no extra fetch). Non-local
+  // projects never see the tab.
+  const gbpConnectionQuery = useQuery(
+    getApiV1ProjectsByNameGoogleConnectionsOptions({ client: heyClient, path: { name: model.project.name } }),
+  )
+  const gbpConnected = (gbpConnectionQuery.data ?? []).some((c) => c.connectionType === 'gbp')
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [addingQueries, setAddingQueries] = useState(false)
@@ -1784,6 +1791,9 @@ function ProjectPageContent({
   const projectTabItems: Array<{ key: ProjectPageTab; label: string; href: string }> = [
     { key: 'overview', label: 'Overview', href: `/projects/${model.project.id}` },
     { key: 'search-console', label: 'Search Engine Intelligence', href: `/projects/${model.project.id}/search-console` },
+    ...(gbpConnected
+      ? [{ key: 'local' as const, label: 'Local Presence', href: `/projects/${model.project.id}/local` }]
+      : []),
     { key: 'activity', label: 'Activity', href: `/projects/${model.project.id}/activity` },
     { key: 'report', label: 'Report', href: `/projects/${model.project.id}/report` },
     { key: 'backlinks', label: 'Backlinks', href: `/projects/${model.project.id}/backlinks` },
@@ -2292,13 +2302,12 @@ function ProjectPageContent({
         <ActivitySection projectName={model.project.name} />
       ) : tab === 'backlinks' ? (
         <BacklinksSection projectName={model.project.name} />
+      ) : tab === 'local' ? (
+        // Local presence (Google Business Profile + Places). GbpSection
+        // self-gates on the connection and renders its own empty state.
+        <GbpSection projectName={model.project.name} />
       ) : (
-        <>
-          <SearchConsoleSection projectName={model.project.name} />
-          {/* Local presence (Google Business Profile). Self-gates: renders only
-              when the project has a GBP connection. */}
-          <GbpSection projectName={model.project.name} />
-        </>
+        <SearchConsoleSection projectName={model.project.name} />
       )}
     </div>
   )

--- a/apps/web/src/router/routes.tsx
+++ b/apps/web/src/router/routes.tsx
@@ -119,6 +119,12 @@ export const projectSearchConsoleRoute = createRoute({
   component: () => <LazyProjectPage tab="search-console" />,
 })
 
+export const projectLocalRoute = createRoute({
+  getParentRoute: () => projectLayoutRoute,
+  path: '/local',
+  component: () => <LazyProjectPage tab="local" />,
+})
+
 export const projectDiscoveryRoute = createRoute({
   getParentRoute: () => projectLayoutRoute,
   path: '/discovery',
@@ -206,6 +212,7 @@ export const routeTree = rootRoute.addChildren([
   projectLayoutRoute.addChildren([
     projectOverviewRoute,
     projectSearchConsoleRoute,
+    projectLocalRoute,
     projectDiscoveryRoute,
     projectReportRoute,
     projectActivityRoute,

--- a/apps/web/test/gbp-section.test.tsx
+++ b/apps/web/test/gbp-section.test.tsx
@@ -24,7 +24,29 @@ const gbpConnection = {
   updatedAt: '2026-05-01T00:00:00.000Z',
 }
 
-test('renders connected GBP data: scorecard, keywords, and locations', async () => {
+function makeLocation(over: Record<string, unknown>) {
+  return {
+    id: 'loc-1', projectId: 'p1', accountName: 'accounts/1', locationName: 'locations/123',
+    displayName: 'Gjelina Venice', primaryCategoryDisplayName: 'Hotel',
+    storefrontAddress: '1429 Abbot Kinney Blvd', websiteUri: 'https://gjelina.com',
+    placeId: 'ChIJ-place-123', mapsUri: 'https://maps.google.com/?cid=123',
+    selected: true, syncedAt: '2026-05-20T00:00:00.000Z',
+    createdAt: '2026-05-01T00:00:00.000Z', updatedAt: '2026-05-20T00:00:00.000Z',
+    ...over,
+  }
+}
+
+function emptySummary() {
+  return {
+    scope: { locationName: null, locationCount: 1 },
+    performance: { totals: {}, recent7d: {}, prior7d: {}, deltaPct: {} },
+    keywords: { total: 0, thresholdedCount: 0, thresholdedPct: 0 },
+    placeActions: { total: 0, hasReservationCta: false, hasBookingCta: false, hasDirectMerchantCta: false },
+    lodging: { lodgingLocationCount: 0, populatedLodgingCount: 0, emptyLodgingCount: 0 },
+  }
+}
+
+test('renders connected GBP data: scorecard, keywords, and public listing', async () => {
   const restoreFetch = mockFetch((url) => {
     const urlPath = url.split('?')[0]!
     if (urlPath.endsWith('/projects/test-project/google/connections')) {
@@ -45,17 +67,7 @@ test('renders connected GBP data: scorecard, keywords, and locations', async () 
       })
     }
     if (urlPath.endsWith('/projects/test-project/gbp/locations')) {
-      return jsonResponse({
-        locations: [{
-          id: 'loc-1', projectId: 'p1', accountName: 'accounts/1', locationName: 'locations/123',
-          displayName: 'Gjelina Venice', primaryCategoryDisplayName: 'Hotel',
-          storefrontAddress: '1429 Abbot Kinney Blvd', websiteUri: 'https://gjelina.com',
-          selected: true, syncedAt: '2026-05-20T00:00:00.000Z',
-          createdAt: '2026-05-01T00:00:00.000Z', updatedAt: '2026-05-20T00:00:00.000Z',
-        }],
-        totalDiscovered: 1,
-        totalSelected: 1,
-      })
+      return jsonResponse({ locations: [makeLocation({})], totalDiscovered: 1, totalSelected: 1 })
     }
     if (urlPath.endsWith('/projects/test-project/gbp/keywords')) {
       return jsonResponse({
@@ -66,6 +78,18 @@ test('renders connected GBP data: scorecard, keywords, and locations', async () 
         total: 1,
         thresholdedPct: 0,
       })
+    }
+    if (urlPath.endsWith('/projects/test-project/gbp/places')) {
+      return jsonResponse({
+        places: [{
+          locationName: 'locations/123', placeId: 'ChIJ-place-123', tier: 'atmosphere',
+          amenities: ['Pool', 'Free Wi-Fi', 'Spa'], syncedAt: '2026-05-20T00:00:00.000Z', place: {},
+        }],
+        total: 1,
+      })
+    }
+    if (urlPath.endsWith('/projects/test-project/insights')) {
+      return jsonResponse([])
     }
     throw new Error(`Unexpected fetch: ${url}`)
   })
@@ -79,14 +103,90 @@ test('renders connected GBP data: scorecard, keywords, and locations', async () 
   expect(screen.getByText('Connected')).toBeTruthy()
   // Server-computed delta (the component does no math).
   expect(screen.getByText('-80%')).toBeTruthy()
-  // Keyword row + location row.
+  // Keyword row.
   expect(screen.getByText('venice beach hotel')).toBeTruthy()
-  expect(screen.getByText('Gjelina Venice')).toBeTruthy()
   // Lodging gap surfaced (empty profile).
   expect(screen.getByText('1 empty')).toBeTruthy()
+  // Public listing (Places) amenities render; the location name shows in that card.
+  expect(screen.getByText('Pool')).toBeTruthy()
+  expect(screen.getByText('Free Wi-Fi')).toBeTruthy()
+  expect(screen.getByText('Gjelina Venice')).toBeTruthy()
+  // Single tracked location → no scope selector.
+  expect(screen.queryByText('All locations')).toBeNull()
 })
 
-test('self-gates to nothing when the project has no GBP connection', async () => {
+test('renders the owner-vs-public amenity gap insight (server-computed)', async () => {
+  const restoreFetch = mockFetch((url) => {
+    const urlPath = url.split('?')[0]!
+    if (urlPath.endsWith('/projects/test-project/google/connections')) return jsonResponse([gbpConnection])
+    if (urlPath.endsWith('/projects/test-project/gbp/summary')) return jsonResponse(emptySummary())
+    if (urlPath.endsWith('/projects/test-project/gbp/locations')) {
+      return jsonResponse({ locations: [makeLocation({})], totalDiscovered: 1, totalSelected: 1 })
+    }
+    if (urlPath.endsWith('/projects/test-project/gbp/keywords')) {
+      return jsonResponse({ keywords: [], total: 0, thresholdedPct: 0 })
+    }
+    if (urlPath.endsWith('/projects/test-project/gbp/places')) {
+      return jsonResponse({
+        places: [{
+          locationName: 'locations/123', placeId: 'ChIJ-place-123', tier: 'atmosphere',
+          amenities: ['Pool', 'Spa'], syncedAt: '2026-05-20T00:00:00.000Z', place: {},
+        }],
+        total: 1,
+      })
+    }
+    if (urlPath.endsWith('/projects/test-project/insights')) {
+      return jsonResponse([{
+        id: 'ins-1', projectId: 'p1', runId: 'r1', type: 'gbp-listing-discrepancy',
+        severity: 'high', title: 'Gjelina Venice: public listing shows 2 amenities your GBP profile doesn’t',
+        query: 'locations/123', provider: 'gbp',
+        recommendation: { action: 'Populate amenities', reason: 'Google’s rendered listing advertises Pool, Spa but your GBP profile has none.' },
+        dismissed: false, createdAt: '2026-05-21T00:00:00.000Z',
+      }])
+    }
+    throw new Error(`Unexpected fetch: ${url}`)
+  })
+  onTestFinished(restoreFetch)
+
+  renderGbpSection()
+
+  await waitFor(() => expect(
+    screen.getByText('Gjelina Venice: public listing shows 2 amenities your GBP profile doesn’t'),
+  ).toBeTruthy())
+  expect(screen.getByText(/Google’s rendered listing advertises Pool, Spa/)).toBeTruthy()
+})
+
+test('shows a location scope selector when multiple locations are tracked', async () => {
+  const restoreFetch = mockFetch((url) => {
+    const urlPath = url.split('?')[0]!
+    if (urlPath.endsWith('/projects/test-project/google/connections')) return jsonResponse([gbpConnection])
+    if (urlPath.endsWith('/projects/test-project/gbp/summary')) return jsonResponse(emptySummary())
+    if (urlPath.endsWith('/projects/test-project/gbp/locations')) {
+      return jsonResponse({
+        locations: [
+          makeLocation({}),
+          makeLocation({ id: 'loc-2', locationName: 'locations/456', displayName: 'AZ Coatings', placeId: null, mapsUri: null }),
+        ],
+        totalDiscovered: 2,
+        totalSelected: 2,
+      })
+    }
+    if (urlPath.endsWith('/projects/test-project/gbp/keywords')) return jsonResponse({ keywords: [], total: 0, thresholdedPct: 0 })
+    if (urlPath.endsWith('/projects/test-project/gbp/places')) return jsonResponse({ places: [], total: 0 })
+    if (urlPath.endsWith('/projects/test-project/insights')) return jsonResponse([])
+    throw new Error(`Unexpected fetch: ${url}`)
+  })
+  onTestFinished(restoreFetch)
+
+  renderGbpSection()
+
+  // Two tracked locations → the scope selector renders with an "All" option + each location.
+  await waitFor(() => expect(screen.getByText('All locations')).toBeTruthy())
+  expect(screen.getByText('Gjelina Venice')).toBeTruthy()
+  expect(screen.getByText('AZ Coatings')).toBeTruthy()
+})
+
+test('shows a connect empty-state when the project has no GBP connection', async () => {
   const restoreFetch = mockFetch((url) => {
     const urlPath = url.split('?')[0]!
     if (urlPath.endsWith('/projects/test-project/google/connections')) {
@@ -97,9 +197,10 @@ test('self-gates to nothing when the project has no GBP connection', async () =>
   })
   onTestFinished(restoreFetch)
 
-  const { container } = renderGbpSection()
+  renderGbpSection()
 
-  // Give the connections query a tick to resolve, then assert nothing rendered.
-  await waitFor(() => expect(container.querySelector('section')).toBeNull())
-  expect(screen.queryByText('Google Business Profile')).toBeNull()
+  // The dedicated tab renders an explicit empty state (not nothing) so direct
+  // navigation isn't a blank page. No data endpoints are fetched.
+  await waitFor(() => expect(screen.getByText(/No Google Business Profile is connected/)).toBeTruthy())
+  expect(screen.getByText('Google Business Profile')).toBeTruthy()
 })

--- a/apps/web/test/gbp-section.test.tsx
+++ b/apps/web/test/gbp-section.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, expect, onTestFinished, test } from 'vitest'
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { GbpSection } from '../src/components/project/GbpSection.js'
 import { mockFetch, jsonResponse } from './mock-fetch.js'
 
@@ -184,6 +184,56 @@ test('shows a location scope selector when multiple locations are tracked', asyn
   await waitFor(() => expect(screen.getByText('All locations')).toBeTruthy())
   expect(screen.getByText('Gjelina Venice')).toBeTruthy()
   expect(screen.getByText('AZ Coatings')).toBeTruthy()
+})
+
+test('falls back to the aggregate scope when the scoped location is untracked', async () => {
+  let bTracked = true
+  // Record the scope of every /gbp/summary fetch so we can prove the section
+  // re-reads in aggregate after the scoped location is untracked.
+  const summaryScopes: string[] = []
+  const restoreFetch = mockFetch((url, init) => {
+    const urlPath = url.split('?')[0]!
+    if (urlPath.endsWith('/projects/test-project/google/connections')) return jsonResponse([gbpConnection])
+    if (urlPath.endsWith('/projects/test-project/gbp/summary')) {
+      summaryScopes.push(/[?&]locationName=/.test(url) ? 'scoped' : 'aggregate')
+      return jsonResponse(emptySummary())
+    }
+    if (urlPath.endsWith('/projects/test-project/gbp/locations')) {
+      return jsonResponse({
+        locations: [
+          makeLocation({}),
+          makeLocation({ id: 'loc-2', locationName: 'locations/456', displayName: 'AZ Coatings', placeId: null, mapsUri: null, selected: bTracked }),
+        ],
+        totalDiscovered: 2,
+        totalSelected: bTracked ? 2 : 1,
+      })
+    }
+    if (urlPath.includes('/gbp/locations/') && urlPath.endsWith('/selection') && init?.method === 'PUT') {
+      bTracked = false
+      return jsonResponse(makeLocation({ id: 'loc-2', locationName: 'locations/456', displayName: 'AZ Coatings', selected: false }))
+    }
+    if (urlPath.endsWith('/projects/test-project/gbp/keywords')) return jsonResponse({ keywords: [], total: 0, thresholdedPct: 0 })
+    if (urlPath.endsWith('/projects/test-project/gbp/places')) return jsonResponse({ places: [], total: 0 })
+    if (urlPath.endsWith('/projects/test-project/insights')) return jsonResponse([])
+    throw new Error(`Unexpected fetch: ${url} ${init?.method ?? ''}`)
+  })
+  onTestFinished(restoreFetch)
+
+  renderGbpSection()
+
+  // Scope to the second location → reads re-fetch with ?locationName=.
+  await waitFor(() => expect(screen.getByRole('tab', { name: 'AZ Coatings' })).toBeTruthy())
+  fireEvent.click(screen.getByRole('tab', { name: 'AZ Coatings' }))
+  await waitFor(() => expect(summaryScopes).toContain('scoped'))
+
+  // Untrack that same location via the Manage locations panel.
+  fireEvent.click(screen.getByRole('button', { name: /Manage locations/ }))
+  fireEvent.click(screen.getAllByRole('button', { name: 'Untrack' })[1]!)
+
+  // Selector disappears (one tracked location left) and the scope resets to
+  // aggregate — without the reset the section stays stuck on the untracked one.
+  await waitFor(() => expect(screen.queryByText('All locations')).toBeNull())
+  await waitFor(() => expect(summaryScopes.at(-1)).toBe('aggregate'))
 })
 
 test('shows a connect empty-state when the project has no GBP connection', async () => {

--- a/apps/web/test/router.test.tsx
+++ b/apps/web/test/router.test.tsx
@@ -88,6 +88,15 @@ test('/projects/$id/report renders the report tab', async () => {
   expect(container.innerHTML).toMatch(/Loading report/)
 })
 
+test('/projects/$id/local renders the local presence tab', async () => {
+  const { container } = await renderRoute('/projects/project_citypoint/local')
+  // Route resolves to the project shell...
+  expect(container.innerHTML).toMatch(/Citypoint Dental NYC/)
+  // ...and the Local Presence tab renders GbpSection. The fixture has no GBP
+  // connection, so its connect empty-state renders (heading shows in every state).
+  await waitFor(() => expect(container.innerHTML).toMatch(/Google Business Profile/))
+})
+
 test('/projects/$id/discovery renders the discovery tab with plain-language copy', async () => {
   const { container } = await renderRoute('/projects/project_citypoint/discovery')
   expect(container.innerHTML).toMatch(/Find new queries to track/)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.61.1",
+  "version": "4.62.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.61.1",
+  "version": "4.62.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Summary

Promotes Google Business Profile from a self-gating section under **Search Engine Intelligence** to a dedicated **Local Presence** tab on the project page, and surfaces the #648 Places cross-reference (the owner GBP profile vs. Google's public Maps listing) as the headline local-AEO signal.

The tab only appears for projects with a GBP connection; direct navigation to `/projects/:id/local` without one renders an explicit connect empty-state instead of a blank page.

## What's new

- **Dedicated Local Presence tab** (`/projects/:id/local`) — gated on an active GBP connection via the same cached connections query the section already reads, so it dedupes (no extra fetch). Non-local projects never see the tab.
- **Owner-vs-public gap insights** — the server-computed `gbp-listing-discrepancy` / `gbp-lodging-gap` insights are rendered at the top as the headline signal (the component does no math — it only filters to the active scope).
- **Public listing (Places) section** — shows the amenities Google's public Maps listing advertises (server-derived in #648), with a "View on Google Maps" link per location.
- **Location scope selector** — when a project tracks more than one location, chips scope every read (summary, keywords, places, gap insights) to a single location or the aggregate. Single-location projects read 1:1 with no selector.
- **Collapsible "Manage locations" panel** — demoted below the fold, since discovery surfaces every location the connected Google account can see (often unrelated businesses); operators track only the relevant one(s) here.

## Fixes

- **Scope no longer gets stuck on an untracked location.** The selector only renders while more than one location is tracked, but `scopeLocation` lived in component state independently — untracking the active location (or shrinking the tracked set to one) hid the selector while leaving the reads scoped to a now-untracked location with no control to reset. The scope now falls back to the aggregate view when it's no longer a selectable location.

## Docs

- README: adds a Local Presence feature bullet (search-term impressions, performance metrics, and hotel lodging + booking-CTA gaps), includes Business Profile syncs in the scheduling line, and links the GBP reference doc from the integrations row.

## Testing

- New/updated tests cover the public-listing render, the gap insight, the multi-location scope selector, the connect empty-state, the `/local` route, and the scope → untrack → reset regression (verified failing without the fix).
- `pnpm typecheck`, `lint` (0 errors), and the full web suite (257 tests) pass.

Version bumped 4.61.0 → 4.62.0 (minor — new feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
