### PR TITLE
fix(gbp): dedup location insights to current-state instead of piling up per run

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.61.0",
+  "version": "4.61.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.61.0",
+  "version": "4.61.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/intelligence-service.ts
+++ b/packages/canonry/src/intelligence-service.ts
@@ -1,7 +1,7 @@
 import { eq, desc, asc, and, ne, or, inArray, gte, lte } from 'drizzle-orm'
 import type { DatabaseClient } from '@ainyc/canonry-db'
 import { competitors, groupRunsByCreatedAt, gscSearchData, healthSnapshots, insights, projects, queries, querySnapshots, runs, gbpLocations, gbpDailyMetrics, gbpKeywordMonthly, gbpPlaceActions, gbpLodgingSnapshots, gbpPlaceDetails } from '@ainyc/canonry-db'
-import { analyzeRuns, analyzeGbp, classifyRegressionSeverity, PERSISTENT_GAP_THRESHOLD } from '@ainyc/canonry-intelligence'
+import { analyzeRuns, analyzeGbp, classifyRegressionSeverity, PERSISTENT_GAP_THRESHOLD, GBP_INSIGHT_PROVIDER } from '@ainyc/canonry-intelligence'
 import type { RunData, Snapshot, AnalysisResult, Insight, GbpLocationSignals, GbpKeywordPoint } from '@ainyc/canonry-intelligence'
 import { extractPlaceAmenities, type PlaceDetails } from '@ainyc/canonry-integration-google-places'
 import { buildGbpSummary } from '@ainyc/canonry-api-routes'
@@ -15,6 +15,35 @@ const RECURRENCE_LOOKBACK_RUNS = 5
 const HISTORY_WINDOW_RUNS = Math.max(PERSISTENT_GAP_THRESHOLD, 5)
 
 const log = createLogger('IntelligenceService')
+
+/**
+ * The two mutually-exclusive lodging insights (`gbp-lodging-gap` and its
+ * evidence-backed `gbp-listing-discrepancy` upgrade) share ONE slot per
+ * location, so the discrepancy supersedes the plain gap instead of coexisting.
+ * Every other GBP insight type is its own slot.
+ */
+function gbpInsightSlot(typeOrSlot: string): string {
+  return typeOrSlot === 'gbp-lodging-gap' || typeOrSlot === 'gbp-listing-discrepancy'
+    ? 'lodging'
+    : typeOrSlot
+}
+
+/** Stable, run-independent GBP insight id: `${projectId}::gbp::${location}::${slot}`. */
+function gbpInsightId(projectId: string, locationName: string, type: string): string {
+  return `${projectId}::gbp::${locationName}::${gbpInsightSlot(type)}`
+}
+
+/**
+ * Decode a GBP insight id into `{ location, slot }`. Location + slot are always
+ * the last two `::`-segments, so this also matches the legacy
+ * `${runId}::gbp::${location}::${type}` scheme — letting the dedup replace stale
+ * rows and preserve dismissals written before this fix shipped.
+ */
+function parseGbpInsightId(id: string): { location: string; slot: string } | null {
+  const parts = id.split('::')
+  if (parts.length !== 4 || parts[1] !== 'gbp') return null
+  return { location: parts[2]!, slot: gbpInsightSlot(parts[3]!) }
+}
 
 export class IntelligenceService {
   constructor(private db: DatabaseClient) {}
@@ -159,7 +188,7 @@ export class IntelligenceService {
 
     if (!runRow) {
       log.info('gbp-intelligence.skip', { runId, reason: 'run not found' })
-      this.persistGbpInsights(runId, projectId, [])
+      this.persistGbpInsights(runId, projectId, [], [])
       return []
     }
 
@@ -178,7 +207,7 @@ export class IntelligenceService {
 
     if (selected.length === 0) {
       log.info('gbp-intelligence.skip', { runId, reason: 'no locations synced during run' })
-      this.persistGbpInsights(runId, projectId, [])
+      this.persistGbpInsights(runId, projectId, [], [])
       return []
     }
 
@@ -190,10 +219,11 @@ export class IntelligenceService {
 
     const now = new Date().toISOString()
     const builtInsights: Insight[] = drafts.map((d) => ({
-      // Stable id: unique per (run, location, type). Embedding runId keeps the
-      // PK unique across runs; embedding locationName keeps two chain locations
-      // that share a displayName from colliding.
-      id: `${runId}::gbp::${d.locationName}::${d.type}`,
+      // Stable, run-independent id per (project, location, slot) so each sync
+      // REPLACES the prior insight for that slot instead of appending a per-run
+      // copy. The lodging slot is shared by gbp-lodging-gap and its
+      // gbp-listing-discrepancy upgrade, so the latter supersedes the former.
+      id: gbpInsightId(projectId, d.locationName, d.type),
       type: d.type,
       severity: d.severity,
       title: d.title,
@@ -203,7 +233,7 @@ export class IntelligenceService {
       createdAt: now,
     }))
 
-    this.persistGbpInsights(runId, projectId, builtInsights)
+    this.persistGbpInsights(runId, projectId, builtInsights, signals.map((s) => s.locationName))
     log.info('gbp-intelligence.analyzed', { runId, locations: selected.length, insights: builtInsights.length })
     return builtInsights
   }
@@ -308,25 +338,48 @@ export class IntelligenceService {
   }
 
   /**
-   * Persist GBP insights for a run. Mirrors `persistResult`'s idempotency
-   * (delete-then-insert for the run) and dismissal preservation, but keyed by
-   * the stable insight id (GBP insights aren't query/provider-scoped) and
-   * WITHOUT a health snapshot.
+   * Persist GBP insights as CURRENT STATE for the locations a sync evaluated.
+   * GBP insights are point-in-time profile facts, not run-to-run transitions, so
+   * each sync REPLACES the prior insights for the locations it covered — keyed by
+   * the run-independent `${projectId}::gbp::${location}::${slot}` id — instead of
+   * appending a fresh per-run copy. This collapses run-over-run duplicates,
+   * supersedes `gbp-lodging-gap` with `gbp-listing-discrepancy` (shared `lodging`
+   * slot), and clears a location's stale insight once its gap is resolved.
+   * Dismissals are preserved by (location, slot). Locations NOT covered by this
+   * run (e.g. a `--location`-scoped sync) are left untouched.
    */
-  private persistGbpInsights(runId: string, projectId: string, gbpInsights: Insight[]): void {
-    const previouslyDismissed = new Set<string>()
+  private persistGbpInsights(
+    runId: string,
+    projectId: string,
+    gbpInsights: Insight[],
+    coveredLocationNames: string[],
+  ): void {
+    const covered = new Set(coveredLocationNames)
+
     const existing = this.db
       .select({ id: insights.id, dismissed: insights.dismissed })
       .from(insights)
-      .where(eq(insights.runId, runId))
+      .where(and(eq(insights.projectId, projectId), eq(insights.provider, GBP_INSIGHT_PROVIDER)))
       .all()
+
+    // Prior rows for the covered locations are replaced; remember which
+    // (location, slot) the operator dismissed so the refreshed row stays dismissed.
+    const staleIds: string[] = []
+    const dismissedSlots = new Set<string>()
     for (const row of existing) {
-      if (row.dismissed) previouslyDismissed.add(row.id)
+      const parsed = parseGbpInsightId(row.id)
+      if (!parsed) continue
+      if (covered.has(parsed.location)) staleIds.push(row.id)
+      if (row.dismissed) dismissedSlots.add(`${parsed.location}::${parsed.slot}`)
     }
 
     this.db.transaction((tx) => {
-      tx.delete(insights).where(eq(insights.runId, runId)).run()
+      for (const id of staleIds) {
+        tx.delete(insights).where(eq(insights.id, id)).run()
+      }
       for (const insight of gbpInsights) {
+        const parsed = parseGbpInsightId(insight.id)
+        const dismissed = parsed ? dismissedSlots.has(`${parsed.location}::${parsed.slot}`) : false
         tx.insert(insights).values({
           id: insight.id,
           projectId,
@@ -338,13 +391,13 @@ export class IntelligenceService {
           provider: insight.provider,
           recommendation: insight.recommendation ?? null,
           cause: insight.cause ?? null,
-          dismissed: previouslyDismissed.has(insight.id),
+          dismissed,
           createdAt: insight.createdAt,
         }).run()
       }
     })
 
-    log.info('gbp-intelligence.persisted', { runId, insights: gbpInsights.length })
+    log.info('gbp-intelligence.persisted', { runId, insights: gbpInsights.length, replaced: staleIds.length })
   }
 
   /**

--- a/packages/canonry/test/intelligence-service-gbp.test.ts
+++ b/packages/canonry/test/intelligence-service-gbp.test.ts
@@ -100,7 +100,7 @@ describe('IntelligenceService.analyzeAndPersistGbp', () => {
       for (const i of result) {
         expect(i.provider).toBe('gbp')
         expect(i.query).toBe('Gjelina Venice')
-        expect(i.id.startsWith('run_gbp::gbp::locations/A::')).toBe(true)
+        expect(i.id.startsWith('proj_gbp::gbp::locations/A::')).toBe(true)
       }
 
       // Severities: lodging high, cta medium, metric -80% high, keyword -70% high.
@@ -202,7 +202,7 @@ describe('IntelligenceService.analyzeAndPersistGbp', () => {
 
       service.analyzeAndPersistGbp('run_gbp', 'proj_gbp')
       // Dismiss the lodging-gap insight.
-      const lodgingId = 'run_gbp::gbp::locations/A::gbp-lodging-gap'
+      const lodgingId = 'proj_gbp::gbp::locations/A::lodging'
       db.update(insights).set({ dismissed: true }).where(eq(insights.id, lodgingId)).run()
 
       // Re-analyze the same run — the dismissed flag must survive.
@@ -214,6 +214,87 @@ describe('IntelligenceService.analyzeAndPersistGbp', () => {
       const cta = db.select().from(insights)
         .where(and(eq(insights.runId, 'run_gbp'), eq(insights.type, 'gbp-cta-gap'))).get()
       expect(cta!.dismissed).toBe(false)
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  test('replaces prior-run insights instead of duplicating, and supersedes the lodging gap across runs', () => {
+    const { db, tmpDir } = createTempDb()
+    try {
+      seed(db)
+      const service = new IntelligenceService(db)
+
+      // First sync: location A has an empty lodging profile, no Places data.
+      seedRun(db, 'run_1')
+      service.analyzeAndPersistGbp('run_1', 'proj_gbp')
+      expect(db.select().from(insights).where(eq(insights.provider, 'gbp')).all().map((r) => r.type).sort())
+        .toEqual(['gbp-cta-gap', 'gbp-keyword-drop', 'gbp-lodging-gap', 'gbp-metric-drop'])
+
+      // A Places snapshot now proves the public listing advertises amenities.
+      db.insert(gbpPlaceDetails).values({
+        id: 'pd1', projectId: 'proj_gbp', locationName: 'locations/A', placeId: 'ChIJa',
+        contentHash: 'ph1', tier: 'atmosphere',
+        attributes: { servesBreakfast: true, parkingOptions: { freeParkingLot: true } },
+        syncedAt: NOW, syncRunId: null,
+      }).run()
+
+      // Second sync must NOT duplicate: still exactly 4 GBP insights for the
+      // project, and the lodging slot now holds the discrepancy (gap superseded).
+      seedRun(db, 'run_2')
+      service.analyzeAndPersistGbp('run_2', 'proj_gbp')
+      const after = db.select().from(insights).where(eq(insights.provider, 'gbp')).all()
+      expect(after).toHaveLength(4)
+      expect(after.map((r) => r.type).sort())
+        .toEqual(['gbp-cta-gap', 'gbp-keyword-drop', 'gbp-listing-discrepancy', 'gbp-metric-drop'])
+      const lodgingRow = db.select().from(insights)
+        .where(eq(insights.id, 'proj_gbp::gbp::locations/A::lodging')).get()
+      expect(lodgingRow!.type).toBe('gbp-listing-discrepancy')
+      // The latest run owns the refreshed rows.
+      expect(after.every((r) => r.runId === 'run_2')).toBe(true)
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  test('clears a location insight once its gap is resolved', () => {
+    const { db, tmpDir } = createTempDb()
+    try {
+      seed(db)
+      const service = new IntelligenceService(db)
+      seedRun(db, 'run_1')
+      service.analyzeAndPersistGbp('run_1', 'proj_gbp')
+      expect(db.select().from(insights).where(eq(insights.id, 'proj_gbp::gbp::locations/A::lodging')).get()).toBeDefined()
+
+      // Operator fills location A's lodging attributes — the gap is resolved.
+      db.update(gbpLodgingSnapshots).set({ populatedGroupCount: 5 })
+        .where(eq(gbpLodgingSnapshots.locationName, 'locations/A')).run()
+
+      seedRun(db, 'run_2')
+      service.analyzeAndPersistGbp('run_2', 'proj_gbp')
+      // No lodging insight remains for A, and no stale duplicate lingers.
+      expect(db.select().from(insights).where(eq(insights.id, 'proj_gbp::gbp::locations/A::lodging')).get()).toBeUndefined()
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  test('preserves a dismissal across a later run that re-emits the same slot', () => {
+    const { db, tmpDir } = createTempDb()
+    try {
+      seed(db)
+      const service = new IntelligenceService(db)
+      seedRun(db, 'run_1')
+      service.analyzeAndPersistGbp('run_1', 'proj_gbp')
+      const lodgingId = 'proj_gbp::gbp::locations/A::lodging'
+      db.update(insights).set({ dismissed: true }).where(eq(insights.id, lodgingId)).run()
+
+      // A later run re-emits the lodging gap for the same location/slot.
+      seedRun(db, 'run_2')
+      service.analyzeAndPersistGbp('run_2', 'proj_gbp')
+      const row = db.select().from(insights).where(eq(insights.id, lodgingId)).get()
+      expect(row).toBeDefined()
+      expect(row!.dismissed).toBe(true)
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true })
     }


### PR DESCRIPTION
## What

GBP location insights now represent **current state** instead of accumulating a fresh per-run copy on every sync.

## Why

The GBP insight id was run-scoped (`${runId}::gbp::${location}::${type}`), and `persistGbpInsights` deletes only by `runId` — so prior runs were never cleared. Each `gbp-sync` appended another copy:

- repeated syncs piled up duplicate `gbp-metric-drop` / `gbp-keyword-drop` rows, and
- a stale `gbp-lodging-gap` lingered next to its evidence-backed `gbp-listing-discrepancy` upgrade (they're mutually exclusive, but emitted by different runs).

`GET /insights` returns all undismissed rows across all runs, so the dashboard and `cnry insights` showed the duplicates.

## Change

GBP insights are point-in-time profile facts, not run-to-run transitions, so:

- Key them by a **run-independent** `${projectId}::gbp::${location}::${slot}` id.
- Each sync **replaces** the prior insights for the locations it covered (from the run's signals), so duplicates collapse and a resolved gap is cleared.
- `gbp-lodging-gap` and `gbp-listing-discrepancy` share one `lodging` slot, so the discrepancy supersedes the plain gap.
- Dismissals are preserved by (location, slot).
- A `--location`-scoped sync only touches the locations it covered.
- Legacy run-scoped rows self-heal on the next sync (the id decoder tolerates both schemes), so no migration is needed.

## Verification

typecheck clean, lint 0 errors, full canonry suite green (909 tests). New tests cover cross-run dedup, lodging-gap → discrepancy supersession, resolved-gap clearing, and dismissal preservation across runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
