### PR TITLE
feat: rolling monthly Common Crawl windows + backlinks-sync schedule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,12 +77,13 @@ canonry report <project>                         # client-facing AEO report → 
 canonry report <project> --output dist/aeo.html
 canonry report <project> --format json           # raw report payload to stdout
 
-# Schedules — one row per (project, kind) where kind ∈ {answer-visibility, traffic-sync, gbp-sync, data-refresh}
+# Schedules — one row per (project, kind) where kind ∈ {answer-visibility, traffic-sync, gbp-sync, data-refresh, backlinks-sync}
 canonry schedule set <project> --preset daily                                                # answer-visibility (default kind)
 canonry schedule set <project> --kind traffic-sync --cron "*/15 * * * *" --source <id>       # traffic-sync (sourceId required)
 canonry schedule set <project> --kind gbp-sync --preset daily                                # gbp-sync (no source; syncs selected locations)
 canonry schedule set <project> --kind data-refresh --preset daily                            # data-refresh (refreshes connected GSC/Bing/GA/GBP; no source)
-canonry schedule show <project> [--kind answer-visibility|traffic-sync|gbp-sync|data-refresh] # default kind is answer-visibility
+canonry schedule set <project> --kind backlinks-sync --preset weekly                         # backlinks-sync (re-probe Common Crawl; sync only when a newer rolling window is published; no source/providers)
+canonry schedule show <project> [--kind answer-visibility|traffic-sync|gbp-sync|data-refresh|backlinks-sync] # default kind is answer-visibility
 canonry schedule enable  <project> [--kind ...]
 canonry schedule disable <project> [--kind ...]
 canonry schedule remove  <project> [--kind ...]                                              # delete the schedule for that kind

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - Watch AI engines crawl and refer traffic via [server-log ingestion](skills/canonry/references/server-side-traffic.md) — Cloud Run, Vercel, and the WordPress Traffic Logger plugin today
 - Diagnose against real traffic with built-in [GSC](docs/google-search-console-setup.md), [GA4](docs/google-analytics-setup.md), and [Bing Webmaster](docs/bing-webmaster-setup.md)
 - Track local AEO via [Google Business Profile](skills/canonry/references/google-business-profile.md) — search-term impressions, performance metrics, and hotel lodging + booking-CTA gaps
-- Discover who links to you with [Common Crawl backlinks](skills/canonry/references/canonry-cli.md#backlinks-common-crawl) — quarterly hyperlink-graph syncs, queried locally with DuckDB
+- Discover who links to you with [Common Crawl backlinks](skills/canonry/references/canonry-cli.md#backlinks-common-crawl) — follows Common Crawl's rolling monthly hyperlink graph, auto-syncing each new window on a schedule, queried locally with DuckDB
 - Execute fixes via [WordPress](docs/wordpress-setup.md), JSON-LD schema, and indexing submissions
 - Manage many clients declaratively — config-as-code YAML + `cnry apply`
 - Schedule recurring visibility checks, traffic syncs, and Business Profile syncs, with webhook alerts on regressions

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.67.0",
+  "version": "4.68.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -1550,7 +1550,7 @@ export type RunDto = {
 export type ScheduleDto = {
     id: string;
     projectId: string;
-    kind: 'answer-visibility' | 'traffic-sync' | 'gbp-sync' | 'data-refresh';
+    kind: 'answer-visibility' | 'traffic-sync' | 'gbp-sync' | 'data-refresh' | 'backlinks-sync';
     cronExpr: string;
     preset?: string | null;
     timezone: string;
@@ -3554,7 +3554,7 @@ export type DeleteApiV1ProjectsByNameScheduleData = {
         /**
          * Schedulable run kind. Defaults to "answer-visibility" for backward compatibility.
          */
-        kind?: 'answer-visibility' | 'traffic-sync' | 'gbp-sync' | 'data-refresh';
+        kind?: 'answer-visibility' | 'traffic-sync' | 'gbp-sync' | 'data-refresh' | 'backlinks-sync';
     };
     url: '/api/v1/projects/{name}/schedule';
 };
@@ -3589,7 +3589,7 @@ export type GetApiV1ProjectsByNameScheduleData = {
         /**
          * Schedulable run kind. Defaults to "answer-visibility" for backward compatibility.
          */
-        kind?: 'answer-visibility' | 'traffic-sync' | 'gbp-sync' | 'data-refresh';
+        kind?: 'answer-visibility' | 'traffic-sync' | 'gbp-sync' | 'data-refresh' | 'backlinks-sync';
     };
     url: '/api/v1/projects/{name}/schedule';
 };
@@ -3614,7 +3614,7 @@ export type GetApiV1ProjectsByNameScheduleResponse = GetApiV1ProjectsByNameSched
 
 export type PutApiV1ProjectsByNameScheduleData = {
     body: {
-        kind?: 'answer-visibility' | 'traffic-sync' | 'gbp-sync' | 'data-refresh';
+        kind?: 'answer-visibility' | 'traffic-sync' | 'gbp-sync' | 'data-refresh' | 'backlinks-sync';
         preset?: string;
         cron?: string;
         timezone?: string;
@@ -3632,7 +3632,7 @@ export type PutApiV1ProjectsByNameScheduleData = {
         /**
          * Schedulable run kind. Defaults to "answer-visibility" for backward compatibility.
          */
-        kind?: 'answer-visibility' | 'traffic-sync' | 'gbp-sync' | 'data-refresh';
+        kind?: 'answer-visibility' | 'traffic-sync' | 'gbp-sync' | 'data-refresh' | 'backlinks-sync';
     };
     url: '/api/v1/projects/{name}/schedule';
 };

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -1547,10 +1547,12 @@ export type RunDto = {
     createdAt: string;
 };
 
+export type SchedulableRunKind = 'answer-visibility' | 'traffic-sync' | 'gbp-sync' | 'data-refresh' | 'backlinks-sync';
+
 export type ScheduleDto = {
     id: string;
     projectId: string;
-    kind: 'answer-visibility' | 'traffic-sync' | 'gbp-sync' | 'data-refresh' | 'backlinks-sync';
+    kind: SchedulableRunKind;
     cronExpr: string;
     preset?: string | null;
     timezone: string;
@@ -3554,7 +3556,7 @@ export type DeleteApiV1ProjectsByNameScheduleData = {
         /**
          * Schedulable run kind. Defaults to "answer-visibility" for backward compatibility.
          */
-        kind?: 'answer-visibility' | 'traffic-sync' | 'gbp-sync' | 'data-refresh' | 'backlinks-sync';
+        kind?: SchedulableRunKind;
     };
     url: '/api/v1/projects/{name}/schedule';
 };
@@ -3589,7 +3591,7 @@ export type GetApiV1ProjectsByNameScheduleData = {
         /**
          * Schedulable run kind. Defaults to "answer-visibility" for backward compatibility.
          */
-        kind?: 'answer-visibility' | 'traffic-sync' | 'gbp-sync' | 'data-refresh' | 'backlinks-sync';
+        kind?: SchedulableRunKind;
     };
     url: '/api/v1/projects/{name}/schedule';
 };
@@ -3614,7 +3616,7 @@ export type GetApiV1ProjectsByNameScheduleResponse = GetApiV1ProjectsByNameSched
 
 export type PutApiV1ProjectsByNameScheduleData = {
     body: {
-        kind?: 'answer-visibility' | 'traffic-sync' | 'gbp-sync' | 'data-refresh' | 'backlinks-sync';
+        kind?: SchedulableRunKind;
         preset?: string;
         cron?: string;
         timezone?: string;
@@ -3632,7 +3634,7 @@ export type PutApiV1ProjectsByNameScheduleData = {
         /**
          * Schedulable run kind. Defaults to "answer-visibility" for backward compatibility.
          */
-        kind?: 'answer-visibility' | 'traffic-sync' | 'gbp-sync' | 'data-refresh' | 'backlinks-sync';
+        kind?: SchedulableRunKind;
     };
     url: '/api/v1/projects/{name}/schedule';
 };

--- a/packages/api-routes/src/backlinks.ts
+++ b/packages/api-routes/src/backlinks.ts
@@ -222,7 +222,7 @@ export async function backlinksRoutes(app: FastifyInstance, opts: BacklinksRoute
     if (!release) {
       if (!opts.discoverLatestRelease) {
         throw validationError(
-          'No `release` provided and auto-discovery is unavailable on this deployment. Pass an explicit release id (e.g., cc-main-2026-jan-feb-mar).',
+          'No `release` provided and auto-discovery is unavailable on this deployment. Pass an explicit release id (e.g., cc-main-2026-mar-apr-may).',
         )
       }
       const discovered = await opts.discoverLatestRelease()
@@ -234,7 +234,7 @@ export async function backlinksRoutes(app: FastifyInstance, opts: BacklinksRoute
       release = discovered.release
     }
     if (!isValidReleaseId(release)) {
-      throw validationError('Invalid release id. Expected form: cc-main-YYYY-{jan-feb-mar,apr-may-jun,jul-aug-sep,oct-nov-dec}')
+      throw validationError('Invalid release id. Expected form: cc-main-YYYY-<mon>-<mon>-<mon> (a rolling 3-month window, e.g. cc-main-2026-mar-apr-may).')
     }
 
     if (!opts.getBacklinksStatus || !opts.onReleaseSyncRequested) {

--- a/packages/api-routes/src/openapi-schemas.ts
+++ b/packages/api-routes/src/openapi-schemas.ts
@@ -91,6 +91,7 @@ import {
   queryDtoSchema,
   runDetailDtoSchema,
   runDtoSchema,
+  schedulableRunKindSchema,
   scheduleDtoSchema,
   settingsDtoSchema,
   snapshotDiffResponseSchema,
@@ -189,6 +190,7 @@ const SCHEMA_TABLE = {
   QueryDto: queryDtoSchema,
   RunDetailDto: runDetailDtoSchema,
   RunDto: runDtoSchema,
+  SchedulableRunKind: schedulableRunKindSchema,
   ScheduleDto: scheduleDtoSchema,
   SettingsDto: settingsDtoSchema,
   SnapshotDiffResponse: snapshotDiffResponseSchema,
@@ -234,6 +236,19 @@ const SCHEMA_TABLE = {
 export type RegisteredSchemaName = keyof typeof SCHEMA_TABLE
 
 /**
+ * Properties whose value is a shared enum that also exists as its own
+ * component. Zod's `toJSONSchema` inlines the enum union at every use site;
+ * we rewrite those occurrences to a `$ref` so codegen emits ONE named TS type
+ * (e.g. `SchedulableRunKind`) instead of repeating the union in every DTO.
+ * Both sides derive from the same Zod schema, so the values can't drift.
+ * Route-level uses (query params, request bodies) `$ref` the component
+ * directly in `openapi.ts`.
+ */
+const SHARED_ENUM_REFS: ReadonlyArray<{ schema: RegisteredSchemaName; property: string; component: RegisteredSchemaName }> = [
+  { schema: 'ScheduleDto', property: 'kind', component: 'SchedulableRunKind' },
+]
+
+/**
  * Convert every registered schema to its OpenAPI 3.0 JSON Schema. Called once
  * during spec build, embedded as `components.schemas` in the OpenAPI doc.
  */
@@ -241,6 +256,12 @@ export function buildComponentSchemas(): Record<string, Record<string, unknown>>
   const out: Record<string, Record<string, unknown>> = {}
   for (const [name, schema] of Object.entries(SCHEMA_TABLE) as [string, ZodType][]) {
     out[name] = z.toJSONSchema(schema, { target: 'openapi-3.0' }) as Record<string, unknown>
+  }
+  for (const { schema, property, component } of SHARED_ENUM_REFS) {
+    const properties = out[schema]?.properties as Record<string, unknown> | undefined
+    if (properties && properties[property]) {
+      properties[property] = { $ref: `#/components/schemas/${component}` }
+    }
   }
   return out
 }

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance } from 'fastify'
-import { AGENT_PROVIDER_IDS, SchedulableRunKinds } from '@ainyc/canonry-contracts'
+import { AGENT_PROVIDER_IDS } from '@ainyc/canonry-contracts'
 import {
   buildComponentSchemas,
   errorResponse,
@@ -65,7 +65,6 @@ const integerSchema = { type: 'integer' }
 const objectSchema = { type: 'object', additionalProperties: true }
 const stringArraySchema = { type: 'array', items: stringSchema }
 const googleConnectionTypeSchema = { type: 'string', enum: ['gsc', 'ga4', 'gbp'] }
-const scheduleKindEnum = Object.values(SchedulableRunKinds)
 const locationSchema = {
   type: 'object',
   required: ['label', 'city', 'region', 'country'],
@@ -167,7 +166,7 @@ const scheduleKindQueryParameter: OpenApiParameter = {
   name: 'kind',
   in: 'query',
   description: 'Schedulable run kind. Defaults to "answer-visibility" for backward compatibility.',
-  schema: { type: 'string', enum: scheduleKindEnum },
+  schema: { $ref: '#/components/schemas/SchedulableRunKind' },
 }
 
 const runsListKindQueryParameter: OpenApiParameter = {
@@ -1136,7 +1135,7 @@ const routeCatalog: OpenApiOperation[] = [
           schema: {
             type: 'object',
             properties: {
-              kind: { type: 'string', enum: scheduleKindEnum },
+              kind: { $ref: '#/components/schemas/SchedulableRunKind' },
               preset: stringSchema,
               cron: stringSchema,
               timezone: stringSchema,

--- a/packages/api-routes/src/schedules.ts
+++ b/packages/api-routes/src/schedules.ts
@@ -83,6 +83,11 @@ export async function scheduleRoutes(app: FastifyInstance, opts: ScheduleRoutesO
       throw validationError(`"sourceId" is only valid when kind is "traffic-sync"`)
     }
 
+    // backlinks-sync is workspace-global (re-probes Common Crawl): no providers.
+    if (kind === SchedulableRunKinds['backlinks-sync'] && providers && providers.length > 0) {
+      throw validationError('"providers" is not valid for kind "backlinks-sync"')
+    }
+
     // Validate provider names against registered adapters
     const validNames = opts.validProviderNames ?? []
     if (validNames.length && providers?.length) {

--- a/packages/api-routes/test/openapi-contract.test.ts
+++ b/packages/api-routes/test/openapi-contract.test.ts
@@ -122,7 +122,7 @@ describe('openapi contract', () => {
     expect(body.paths['/api/v1/projects/{name}/google/callback']?.get?.security).toEqual([])
   })
 
-  it('documents all schedulable kinds (incl. backlinks-sync) in schedule request parameters and bodies', async () => {
+  it('documents all schedulable kinds (incl. backlinks-sync) via a single SchedulableRunKind component', async () => {
     const ctx = buildObservedApp()
     contexts.push(ctx)
     await ctx.app.ready()
@@ -131,23 +131,31 @@ describe('openapi contract', () => {
     expect(res.statusCode).toBe(200)
 
     const body = res.json() as {
+      components?: { schemas?: Record<string, { enum?: string[] }> }
       paths: Record<string, Record<string, {
-        parameters?: Array<{ name: string; schema?: { enum?: string[] } }>
+        parameters?: Array<{ name: string; schema?: { $ref?: string } }>
         requestBody?: {
-          content?: Record<string, { schema?: { properties?: Record<string, { enum?: string[] }> } }>
+          content?: Record<string, { schema?: { properties?: Record<string, { $ref?: string }> } }>
         }
       }>>
     }
-    const schedulePath = body.paths['/api/v1/projects/{name}/schedule']!
 
+    // The enum values live in exactly one place — the shared component — so the
+    // union isn't repeated across every schedule param, body, and the DTO.
+    const KIND_REF = '#/components/schemas/SchedulableRunKind'
+    expect(body.components?.schemas?.SchedulableRunKind?.enum).toEqual(
+      ['answer-visibility', 'traffic-sync', 'gbp-sync', 'data-refresh', 'backlinks-sync'],
+    )
+
+    const schedulePath = body.paths['/api/v1/projects/{name}/schedule']!
     for (const method of ['put', 'get', 'delete'] as const) {
       const kindParam = schedulePath[method]?.parameters?.find((p) => p.name === 'kind')
-      expect(kindParam?.schema?.enum).toEqual(['answer-visibility', 'traffic-sync', 'gbp-sync', 'data-refresh', 'backlinks-sync'])
+      expect(kindParam?.schema?.$ref).toBe(KIND_REF)
     }
 
-    const requestKindEnum = schedulePath.put?.requestBody
-      ?.content?.['application/json']?.schema?.properties?.kind?.enum
-    expect(requestKindEnum).toEqual(['answer-visibility', 'traffic-sync', 'gbp-sync', 'data-refresh', 'backlinks-sync'])
+    const requestKindRef = schedulePath.put?.requestBody
+      ?.content?.['application/json']?.schema?.properties?.kind?.$ref
+    expect(requestKindRef).toBe(KIND_REF)
   })
 
   it('every 2xx response declares a body schema (or carries a non-JSON content type)', async () => {

--- a/packages/api-routes/test/openapi-contract.test.ts
+++ b/packages/api-routes/test/openapi-contract.test.ts
@@ -122,7 +122,7 @@ describe('openapi contract', () => {
     expect(body.paths['/api/v1/projects/{name}/google/callback']?.get?.security).toEqual([])
   })
 
-  it('documents gbp-sync and data-refresh as schedulable kinds in schedule request parameters and bodies', async () => {
+  it('documents all schedulable kinds (incl. backlinks-sync) in schedule request parameters and bodies', async () => {
     const ctx = buildObservedApp()
     contexts.push(ctx)
     await ctx.app.ready()
@@ -142,12 +142,12 @@ describe('openapi contract', () => {
 
     for (const method of ['put', 'get', 'delete'] as const) {
       const kindParam = schedulePath[method]?.parameters?.find((p) => p.name === 'kind')
-      expect(kindParam?.schema?.enum).toEqual(['answer-visibility', 'traffic-sync', 'gbp-sync', 'data-refresh'])
+      expect(kindParam?.schema?.enum).toEqual(['answer-visibility', 'traffic-sync', 'gbp-sync', 'data-refresh', 'backlinks-sync'])
     }
 
     const requestKindEnum = schedulePath.put?.requestBody
       ?.content?.['application/json']?.schema?.properties?.kind?.enum
-    expect(requestKindEnum).toEqual(['answer-visibility', 'traffic-sync', 'gbp-sync', 'data-refresh'])
+    expect(requestKindEnum).toEqual(['answer-visibility', 'traffic-sync', 'gbp-sync', 'data-refresh', 'backlinks-sync'])
   })
 
   it('every 2xx response declares a body schema (or carries a non-JSON content type)', async () => {

--- a/packages/api-routes/test/schedules.test.ts
+++ b/packages/api-routes/test/schedules.test.ts
@@ -283,6 +283,56 @@ describe('schedule per-kind invariants', () => {
     expect(body.error.code).toBe('VALIDATION_ERROR')
     expect(body.error.message).toMatch(/sourceId.*traffic-sync/)
   })
+
+  it('accepts a well-formed backlinks-sync schedule (no sourceId, no providers) and round-trips via GET / DELETE', async () => {
+    const putRes = await harness.app.inject({
+      method: 'PUT',
+      url: '/api/v1/projects/site-a/schedule',
+      payload: { kind: 'backlinks-sync', preset: 'weekly' },
+    })
+    expect(putRes.statusCode).toBe(201)
+    const created = JSON.parse(putRes.payload)
+    expect(created.kind).toBe('backlinks-sync')
+    expect(created.sourceId ?? null).toBeNull()
+    expect(created.providers).toEqual([])
+
+    const getRes = await harness.app.inject({
+      method: 'GET',
+      url: '/api/v1/projects/site-a/schedule?kind=backlinks-sync',
+    })
+    expect(getRes.statusCode).toBe(200)
+    expect(JSON.parse(getRes.payload).id).toBe(created.id)
+
+    const delRes = await harness.app.inject({
+      method: 'DELETE',
+      url: '/api/v1/projects/site-a/schedule?kind=backlinks-sync',
+    })
+    expect(delRes.statusCode).toBe(204)
+  })
+
+  it('rejects PUT /schedule with kind=backlinks-sync and a sourceId', async () => {
+    const res = await harness.app.inject({
+      method: 'PUT',
+      url: '/api/v1/projects/site-a/schedule',
+      payload: { kind: 'backlinks-sync', preset: 'weekly', sourceId: harness.trafficSourceId },
+    })
+    expect(res.statusCode).toBe(400)
+    const body = JSON.parse(res.payload)
+    expect(body.error.code).toBe('VALIDATION_ERROR')
+    expect(body.error.message).toMatch(/sourceId.*traffic-sync/)
+  })
+
+  it('rejects PUT /schedule with kind=backlinks-sync and providers set', async () => {
+    const res = await harness.app.inject({
+      method: 'PUT',
+      url: '/api/v1/projects/site-a/schedule',
+      payload: { kind: 'backlinks-sync', preset: 'weekly', providers: ['gemini'] },
+    })
+    expect(res.statusCode).toBe(400)
+    const body = JSON.parse(res.payload)
+    expect(body.error.code).toBe('VALIDATION_ERROR')
+    expect(body.error.message).toMatch(/providers.*not valid.*backlinks-sync/)
+  })
 })
 
 describe('apply preserves traffic-sync schedules', () => {

--- a/packages/canonry/AGENTS.md
+++ b/packages/canonry/AGENTS.md
@@ -31,7 +31,7 @@ The publishable npm package (`@ainyc/canonry`). Bundles the CLI, local Fastify s
 | `src/server.ts` | Fastify server setup — mounts api-routes, serves SPA, registers providers |
 | `src/job-runner.ts` | In-process job runner for visibility sweeps |
 | `src/provider-registry.ts` | `ProviderRegistry` — manages provider adapters |
-| `src/scheduler.ts` | Cron-based schedule runner (kinds: `answer-visibility`, `traffic-sync`, `data-refresh`; the `onDataRefreshRequested` callback fans out to every connected integration) |
+| `src/scheduler.ts` | Cron-based schedule runner (kinds: `answer-visibility`, `traffic-sync`, `gbp-sync`, `data-refresh`, `backlinks-sync`; the `onDataRefreshRequested` callback fans out to every connected integration, and `onBacklinksSyncRequested` re-probes Common Crawl + syncs the workspace release when a newer rolling window appears) |
 | `src/data-refresh.ts` | `refreshAllIntegrations` — fires GSC + Bing + GA + GBP syncs for a project via the in-process API client, `Promise.allSettled` for per-integration isolation. Wired to the scheduler's `data-refresh` kind in `server.ts`. |
 | `src/snapshot-service.ts` | Snapshot creation and diff logic |
 | `src/intelligence-service.ts` | Runs analysis after sweeps, persists insights + health snapshots |

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.67.0",
+  "version": "4.68.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/cli-commands/schedule.ts
+++ b/packages/canonry/src/cli-commands/schedule.ts
@@ -6,7 +6,7 @@ import { usageError } from '../cli-error.js'
 export const SCHEDULE_CLI_COMMANDS: readonly CliCommandSpec[] = [
   {
     path: ['schedule', 'set'],
-    usage: 'canonry schedule set <project> (--preset <preset> | --cron <expr>) [--kind answer-visibility|traffic-sync|gbp-sync|data-refresh] [--source <id>] [--timezone <tz>] [--provider <name>...] [--format json]',
+    usage: 'canonry schedule set <project> (--preset <preset> | --cron <expr>) [--kind answer-visibility|traffic-sync|gbp-sync|data-refresh|backlinks-sync] [--source <id>] [--timezone <tz>] [--provider <name>...] [--format json]',
     options: {
       preset: stringOption(),
       cron: stringOption(),
@@ -16,7 +16,7 @@ export const SCHEDULE_CLI_COMMANDS: readonly CliCommandSpec[] = [
       provider: multiStringOption(),
     },
     run: async (input) => {
-      const usage = 'canonry schedule set <project> (--preset <preset> | --cron <expr>) [--kind answer-visibility|traffic-sync|gbp-sync|data-refresh] [--source <id>] [--timezone <tz>] [--provider <name>...] [--format json]'
+      const usage = 'canonry schedule set <project> (--preset <preset> | --cron <expr>) [--kind answer-visibility|traffic-sync|gbp-sync|data-refresh|backlinks-sync] [--source <id>] [--timezone <tz>] [--provider <name>...] [--format json]'
       const project = requireProject(input, 'schedule.set', usage)
       if (!getString(input.values, 'preset') && !getString(input.values, 'cron')) {
         throw usageError('Error: --preset or --cron is required', {
@@ -41,7 +41,7 @@ export const SCHEDULE_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['schedule', 'show'],
-    usage: 'canonry schedule show <project> [--kind answer-visibility|traffic-sync|gbp-sync|data-refresh] [--format json]',
+    usage: 'canonry schedule show <project> [--kind answer-visibility|traffic-sync|gbp-sync|data-refresh|backlinks-sync] [--format json]',
     options: { kind: stringOption() },
     run: async (input) => {
       const project = requireProject(input, 'schedule.show', 'canonry schedule show <project> [--kind ...]')
@@ -50,7 +50,7 @@ export const SCHEDULE_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['schedule', 'enable'],
-    usage: 'canonry schedule enable <project> [--kind answer-visibility|traffic-sync|gbp-sync|data-refresh] [--format json]',
+    usage: 'canonry schedule enable <project> [--kind answer-visibility|traffic-sync|gbp-sync|data-refresh|backlinks-sync] [--format json]',
     options: { kind: stringOption() },
     run: async (input) => {
       const project = requireProject(input, 'schedule.enable', 'canonry schedule enable <project> [--kind ...]')
@@ -59,7 +59,7 @@ export const SCHEDULE_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['schedule', 'disable'],
-    usage: 'canonry schedule disable <project> [--kind answer-visibility|traffic-sync|gbp-sync|data-refresh] [--format json]',
+    usage: 'canonry schedule disable <project> [--kind answer-visibility|traffic-sync|gbp-sync|data-refresh|backlinks-sync] [--format json]',
     options: { kind: stringOption() },
     run: async (input) => {
       const project = requireProject(input, 'schedule.disable', 'canonry schedule disable <project> [--kind ...]')
@@ -68,7 +68,7 @@ export const SCHEDULE_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['schedule', 'remove'],
-    usage: 'canonry schedule remove <project> [--kind answer-visibility|traffic-sync|gbp-sync|data-refresh] [--format json]',
+    usage: 'canonry schedule remove <project> [--kind answer-visibility|traffic-sync|gbp-sync|data-refresh|backlinks-sync] [--format json]',
     options: { kind: stringOption() },
     run: async (input) => {
       const project = requireProject(input, 'schedule.remove', 'canonry schedule remove <project> [--kind ...]')

--- a/packages/canonry/src/scheduler.ts
+++ b/packages/canonry/src/scheduler.ts
@@ -36,6 +36,17 @@ export interface SchedulerCallbacks {
    * by the host, not the scheduler. Fire-and-forget.
    */
   onDataRefreshRequested?: (projectName: string) => void
+  /**
+   * Fired when a backlinks-sync schedule triggers. The host re-probes Common
+   * Crawl for the latest hyperlink-graph release and, when a newer rolling
+   * window is published, runs the workspace-level release sync (which
+   * auto-extracts per-project backlinks for projects with `autoExtractBacklinks`).
+   * The Common Crawl sync is workspace-GLOBAL, so the scheduler creates no
+   * per-project run row here — it only fires the trigger. The host owns the
+   * de-dupe gate (skip when the newest release is already synced) and error
+   * logging. Fire-and-forget.
+   */
+  onBacklinksSyncRequested?: (projectName: string) => void
 }
 
 /** Scheduler tasks are keyed by `(projectId, kind)` so a project can run an
@@ -248,6 +259,26 @@ export class Scheduler {
         }).where(eq(schedules.id, currentSchedule.id)).run()
         log.info('data-refresh.triggered', { projectName: project.name })
         this.callbacks.onDataRefreshRequested(project.name)
+        return
+      }
+
+      if (kind === SchedulableRunKinds['backlinks-sync']) {
+        // Backlinks-sync re-probes Common Crawl and runs the workspace-level
+        // release sync when a newer rolling window is published. The sync is
+        // workspace-global (no per-project run row); the host owns the
+        // probe + de-dupe gate + trigger. Skip without side effects if the
+        // host never registered the callback.
+        if (!this.callbacks.onBacklinksSyncRequested) {
+          log.warn('backlinks-sync.no-callback', { scheduleId, projectId, msg: 'host did not register onBacklinksSyncRequested' })
+          return
+        }
+        this.db.update(schedules).set({
+          lastRunAt: now,
+          nextRunAt,
+          updatedAt: now,
+        }).where(eq(schedules.id, currentSchedule.id)).run()
+        log.info('backlinks-sync.triggered', { projectName: project.name })
+        this.callbacks.onBacklinksSyncRequested(project.name)
         return
       }
 

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -3,7 +3,7 @@ import crypto from 'node:crypto'
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { eq } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 
 const _require = createRequire(import.meta.url)
 const { version: PKG_VERSION } = _require('../package.json') as { version: string }
@@ -18,7 +18,7 @@ import { claudeAdapter } from '@ainyc/canonry-provider-claude'
 import { localAdapter } from '@ainyc/canonry-provider-local'
 import { cdpChatgptAdapter } from '@ainyc/canonry-provider-cdp'
 import { perplexityAdapter } from '@ainyc/canonry-provider-perplexity'
-import { authInvalid, validationError, RunKinds, RunStatuses, RunTriggers, type ProviderAdapter } from '@ainyc/canonry-contracts'
+import { authInvalid, validationError, CcReleaseSyncStatuses, RunKinds, RunStatuses, RunTriggers, type ProviderAdapter } from '@ainyc/canonry-contracts'
 import type { CanonryConfig, ProviderConfigEntry } from './config.js'
 import { saveConfigPatch, loadConfig, getConfigPath } from './config.js'
 import { getPlacesConfig } from './places-config.js'
@@ -532,6 +532,43 @@ export async function createServer(opts: {
       // the same in-process client. refreshAllIntegrations isolates each
       // integration's failure with Promise.allSettled and never rejects.
       void refreshAllIntegrations(aeroClient, projectName)
+    },
+    onBacklinksSyncRequested: (projectName) => {
+      // Re-probe Common Crawl for the newest rolling window. The release sync is
+      // workspace-GLOBAL, so we gate on freshness: skip when the latest published
+      // release is already synced READY (avoids re-downloading a ~4 GB/~13 GB
+      // near-identical window every tick). We match on (release, status) directly
+      // rather than the most-recently-updated ready row, so re-syncing an older
+      // release out of band doesn't make us re-trigger an already-synced latest.
+      // Otherwise reuse POST /backlinks/syncs, which owns insert/dedupe (UNIQUE
+      // release + non-terminal check) and the per-project auto-extract fan-out.
+      // Probe directly (not the 5-min cache) so each tick sees fresh results.
+      void (async () => {
+        const probed = await probeLatestRelease().catch((err: unknown) => {
+          app.log.warn({ projectName, err }, 'Scheduled backlinks sync: latest-release probe failed')
+          return null
+        })
+        if (!probed) return
+        const alreadySynced = opts.db
+          .select()
+          .from(ccReleaseSyncsTable)
+          .where(and(
+            eq(ccReleaseSyncsTable.release, probed.release),
+            eq(ccReleaseSyncsTable.status, CcReleaseSyncStatuses.ready),
+          ))
+          .limit(1)
+          .get()
+        if (alreadySynced) {
+          app.log.info({ projectName, release: probed.release }, 'Scheduled backlinks sync: already up to date, skipping')
+          return
+        }
+        aeroClient.backlinksTriggerSync(probed.release).catch((err: unknown) => {
+          app.log.error(
+            { projectName, release: probed.release, err: err instanceof Error ? err.message : String(err) },
+            'Scheduled backlinks sync failed',
+          )
+        })
+      })()
     },
   })
 

--- a/packages/canonry/test/scheduler.test.ts
+++ b/packages/canonry/test/scheduler.test.ts
@@ -394,3 +394,97 @@ test('data-refresh trigger skips silently when no onDataRefreshRequested callbac
 
   fs.rmSync(tmpDir, { recursive: true, force: true })
 })
+
+test('backlinks-sync trigger fires onBacklinksSyncRequested with the project name and creates no run row', () => {
+  const { db, tmpDir } = createTempDb()
+  const now = new Date().toISOString()
+
+  db.insert(projects).values({
+    id: 'proj_bl',
+    name: 'backlinks-project',
+    displayName: 'Backlinks Project',
+    canonicalDomain: 'example.com',
+    country: 'US',
+    language: 'en',
+    createdAt: now,
+    updatedAt: now,
+  }).run()
+  db.insert(schedules).values({
+    id: 'sched_bl',
+    projectId: 'proj_bl',
+    kind: 'backlinks-sync',
+    cronExpr: '0 4 * * 1',
+    timezone: 'UTC',
+    enabled: true,
+    providers: [],
+    createdAt: now,
+    updatedAt: now,
+  }).run()
+
+  const backlinksCalls: string[] = []
+  const runCalls: string[] = []
+  const refreshCalls: unknown[] = []
+  const scheduler = new Scheduler(db, {
+    onRunCreated: (runId) => runCalls.push(runId),
+    onDataRefreshRequested: () => refreshCalls.push(null),
+    onBacklinksSyncRequested: (projectName) => backlinksCalls.push(projectName),
+  })
+
+  ;(scheduler as unknown as {
+    triggerRun: (scheduleId: string, projectId: string, kind: 'answer-visibility' | 'backlinks-sync') => void
+  }).triggerRun('sched_bl', 'proj_bl', 'backlinks-sync')
+
+  expect(backlinksCalls).toEqual(['backlinks-project'])
+
+  // Workspace-global sync — the scheduler creates NO per-project run row.
+  const runRows = db.select().from(runs).where(eq(runs.projectId, 'proj_bl')).all()
+  expect(runRows).toHaveLength(0)
+
+  // lastRunAt advanced on the schedule row.
+  const sched = db.select().from(schedules).where(eq(schedules.id, 'sched_bl')).get()
+  expect(sched!.lastRunAt).not.toBeNull()
+
+  // Other kinds' callbacks must NOT fire for a backlinks-sync trigger.
+  expect(runCalls).toHaveLength(0)
+  expect(refreshCalls).toHaveLength(0)
+
+  scheduler.stop()
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+test('backlinks-sync trigger skips silently when no onBacklinksSyncRequested callback is registered', () => {
+  const { db, tmpDir } = createTempDb()
+  const now = new Date().toISOString()
+
+  db.insert(projects).values({
+    id: 'proj_bl2',
+    name: 'backlinks-no-cb',
+    displayName: 'Backlinks No Callback',
+    canonicalDomain: 'example.com',
+    country: 'US',
+    language: 'en',
+    createdAt: now,
+    updatedAt: now,
+  }).run()
+  db.insert(schedules).values({
+    id: 'sched_bl2',
+    projectId: 'proj_bl2',
+    kind: 'backlinks-sync',
+    cronExpr: '0 4 * * 1',
+    timezone: 'UTC',
+    enabled: true,
+    providers: [],
+    createdAt: now,
+    updatedAt: now,
+  }).run()
+
+  const scheduler = new Scheduler(db, { onRunCreated: () => {} })
+
+  expect(() =>
+    (scheduler as unknown as {
+      triggerRun: (scheduleId: string, projectId: string, kind: 'answer-visibility' | 'backlinks-sync') => void
+    }).triggerRun('sched_bl2', 'proj_bl2', 'backlinks-sync'),
+  ).not.toThrow()
+
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})

--- a/packages/contracts/src/schedule.ts
+++ b/packages/contracts/src/schedule.ts
@@ -9,8 +9,11 @@ import { providerNameSchema } from './provider.js'
  * - `traffic-sync` — server-side traffic-source pull (Cloud Run today; future adapters slot in here too).
  * - `gbp-sync` — Google Business Profile performance + local-signal pull over the project's selected locations.
  * - `data-refresh` — refresh every connected data integration for the project (GSC, Bing, GA, GBP) in one trigger.
+ * - `backlinks-sync` — re-probe Common Crawl for the latest hyperlink-graph release and, when a newer rolling
+ *   window is published, run the workspace-level release sync (which auto-extracts per-project backlinks for
+ *   projects with `autoExtractBacklinks`). Workspace-global: no `sourceId`, no `providers`.
  */
-export const schedulableRunKindSchema = z.enum(['answer-visibility', 'traffic-sync', 'gbp-sync', 'data-refresh'])
+export const schedulableRunKindSchema = z.enum(['answer-visibility', 'traffic-sync', 'gbp-sync', 'data-refresh', 'backlinks-sync'])
 export type SchedulableRunKind = z.infer<typeof schedulableRunKindSchema>
 export const SchedulableRunKinds = schedulableRunKindSchema.enum
 

--- a/packages/contracts/test/schedule.test.ts
+++ b/packages/contracts/test/schedule.test.ts
@@ -2,20 +2,24 @@ import { describe, it, expect } from 'vitest'
 import { schedulableRunKindSchema, SchedulableRunKinds } from '../src/schedule.js'
 
 describe('schedulableRunKindSchema', () => {
-  it('accepts answer-visibility, traffic-sync, and gbp-sync', () => {
+  it('accepts answer-visibility, traffic-sync, gbp-sync, data-refresh, and backlinks-sync', () => {
     expect(schedulableRunKindSchema.safeParse('answer-visibility').success).toBe(true)
     expect(schedulableRunKindSchema.safeParse('traffic-sync').success).toBe(true)
     expect(schedulableRunKindSchema.safeParse('gbp-sync').success).toBe(true)
+    expect(schedulableRunKindSchema.safeParse('data-refresh').success).toBe(true)
+    expect(schedulableRunKindSchema.safeParse('backlinks-sync').success).toBe(true)
   })
 
   it('rejects non-schedulable run kinds', () => {
     // gsc-sync is a real RunKind but is not user-schedulable.
     expect(schedulableRunKindSchema.safeParse('gsc-sync').success).toBe(false)
     expect(schedulableRunKindSchema.safeParse('inspect-sitemap').success).toBe(false)
+    expect(schedulableRunKindSchema.safeParse('backlink-extract').success).toBe(false)
     expect(schedulableRunKindSchema.safeParse('nonsense').success).toBe(false)
   })
 
-  it('exposes a gbp-sync enum constant', () => {
+  it('exposes gbp-sync and backlinks-sync enum constants', () => {
     expect(SchedulableRunKinds['gbp-sync']).toBe('gbp-sync')
+    expect(SchedulableRunKinds['backlinks-sync']).toBe('backlinks-sync')
   })
 })

--- a/packages/integration-commoncrawl/AGENTS.md
+++ b/packages/integration-commoncrawl/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Common Crawl hyperlink-graph backlinks extractor. Downloads the domain-level vertex + edge gzip files that Common Crawl publishes quarterly, runs a multi-target DuckDB query over them, and returns backlink rows ready to persist into SQLite. DuckDB is an **opt-in plugin** installed at runtime into `~/.canonry/plugins/` — it is not a canonry dependency.
+Common Crawl hyperlink-graph backlinks extractor. Downloads the domain-level vertex + edge gzip files that Common Crawl publishes as rolling, monthly-stepped, overlapping 3-month windows, runs a multi-target DuckDB query over them, and returns backlink rows ready to persist into SQLite. DuckDB is an **opt-in plugin** installed at runtime into `~/.canonry/plugins/` — it is not a canonry dependency.
 
 ## Key Files
 
@@ -10,7 +10,7 @@ Common Crawl hyperlink-graph backlinks extractor. Downloads the domain-level ver
 |------|------|
 | `src/constants.ts` | `CC_BASE_URL`, `PLUGIN_DIR`, `DUCKDB_SPEC`, release-slug regex |
 | `src/release-id.ts` | `isValidReleaseId()` validator |
-| `src/release-discovery.ts` | `probeLatestRelease()` — HEAD-probes quarterly slugs |
+| `src/release-discovery.ts` | `probeLatestRelease()` — HEAD-probes rolling monthly-window slugs |
 | `src/reverse-domain.ts` | `reverseDomain()` / `forwardDomain()` — `roots.io` ↔ `io.roots` |
 | `src/downloader.ts` | Streaming download with SHA-256 + sidecar cache + atomic rename |
 | `src/plugin-resolver.ts` | `loadDuckdb()` via `createRequire` against the plugin dir; throws `MISSING_DEPENDENCY` |
@@ -29,9 +29,10 @@ Common Crawl hyperlink-graph backlinks extractor. Downloads the domain-level ver
 
 ### Releases
 
-- Common Crawl publishes ~quarterly: `cc-main-YYYY-{jan-feb-mar,apr-may-jun,jul-aug-sep,oct-nov-dec}`.
-- Files live at `https://data.commoncrawl.org/projects/hyperlinkgraph/<release>/domain/<release>-domain-{vertices,edges}.txt.gz` (verified 2026-04).
-- `probeLatestRelease()` issues HEAD requests working backward from the current quarter to find the newest published release.
+- Common Crawl publishes **rolling, monthly-stepped, overlapping 3-month windows**: `cc-main-YYYY-<mon>-<mon>-<mon>`, e.g. `cc-main-2026-mar-apr-may`. A release is named by its **first month's year** (`cc-main-2025-oct-nov-dec` = Oct/Nov/Dec 2025). The old fixed calendar quarters (`jan-feb-mar`, `apr-may-jun`, …) are still published as a subset of this cadence, so legacy slugs keep resolving.
+- Empirically (verified 2026-06 via HEAD probe): windows whose **first month is Jan–Oct** are published; cross-year windows (first month Nov/Dec, e.g. `nov-dec-jan`) and not-yet-crawled future windows 404. `RELEASE_ID_REGEX` accepts any well-formed `<mon>-<mon>-<mon>` triplet — it gates slug **shape**, not existence; a well-formed-but-unpublished slug 404s at probe/download time.
+- Files live at `https://data.commoncrawl.org/projects/hyperlinkgraph/<release>/domain/<release>-domain-{vertices,edges}.txt.gz`.
+- `probeLatestRelease()` issues HEAD requests working backward **one month at a time** from the current month (the window's first month) to find the newest published release. `probeRecentReleases()` lists the overlapping monthly windows newest-first.
 
 ### Downloads
 

--- a/packages/integration-commoncrawl/src/constants.ts
+++ b/packages/integration-commoncrawl/src/constants.ts
@@ -11,7 +11,16 @@ export const DUCKDB_SPEC = process.env.CANONRY_DUCKDB_SPEC ?? '@duckdb/node-api@
 export const CC_CACHE_DIR = process.env.CANONRY_CC_CACHE_DIR
   ?? path.join(os.homedir(), '.canonry', 'cache', 'commoncrawl')
 
-export const RELEASE_ID_REGEX = /^cc-main-(\d{4})-(jan-feb-mar|apr-may-jun|jul-aug-sep|oct-nov-dec)$/
+const CC_MONTH = '(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)'
+/**
+ * Common Crawl publishes the hyperlink graph as rolling, monthly-stepped,
+ * overlapping 3-month windows (`cc-main-YYYY-<mon>-<mon>-<mon>`), named by the
+ * window's FIRST month's year. This validates the slug SHAPE only — a
+ * well-formed-but-unpublished window (e.g. a cross-year `nov-dec-jan`) 404s at
+ * probe/download time, which is the authoritative existence check. Group 1 is
+ * the year, group 2 is the full `mon-mon-mon` window slug.
+ */
+export const RELEASE_ID_REGEX = new RegExp(`^cc-main-(\\d{4})-(${CC_MONTH}-${CC_MONTH}-${CC_MONTH})$`)
 
 export interface ReleasePaths {
   vertexUrl: string

--- a/packages/integration-commoncrawl/src/release-discovery.ts
+++ b/packages/integration-commoncrawl/src/release-discovery.ts
@@ -1,12 +1,15 @@
 import { ccReleasePaths } from './constants.js'
-import { formatReleaseId, type ParsedRelease } from './release-id.js'
+import { formatReleaseId } from './release-id.js'
 
-const QUARTERS: ParsedRelease['quarter'][] = [
-  'oct-nov-dec',
-  'jul-aug-sep',
-  'apr-may-jun',
-  'jan-feb-mar',
-]
+const MONTHS = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'] as const
+
+/** Build the `mon-mon-mon` window slug for a window whose FIRST month is `firstMonthIndex` (0-11). */
+function windowSlug(firstMonthIndex: number): string {
+  const a = MONTHS[firstMonthIndex % 12]
+  const b = MONTHS[(firstMonthIndex + 1) % 12]
+  const c = MONTHS[(firstMonthIndex + 2) % 12]
+  return `${a}-${b}-${c}`
+}
 
 export interface ProbedRelease {
   release: string
@@ -19,16 +22,29 @@ export interface ProbedRelease {
 
 export interface ProbeOptions {
   now?: Date
-  maxQuartersBack?: number
+  /** How many months to walk back from `now`, inclusive. Default 14 (15 candidate windows). */
+  maxMonthsBack?: number
   fetchImpl?: typeof fetch
 }
 
-function probeCandidates(now: Date, maxBack: number): { year: number; quarter: ParsedRelease['quarter'] }[] {
-  const year = now.getUTCFullYear()
-  const out: { year: number; quarter: ParsedRelease['quarter'] }[] = []
-  for (let y = year; y >= year - maxBack; y--) {
-    for (const q of QUARTERS) {
-      out.push({ year: y, quarter: q })
+/**
+ * Generate candidate releases newest-first by walking the window's FIRST month
+ * back one month at a time from `now`. Common Crawl names a release by its first
+ * month's year, so the wrapped 2nd/3rd months never change the slug year
+ * (`cc-main-2025-oct-nov-dec` = Oct/Nov/Dec 2025). Cross-year windows (first
+ * month Nov/Dec) are generated and probed too — they 404 today but cost one HEAD
+ * pair and future-proof discovery if Common Crawl ever publishes them.
+ */
+function probeCandidates(now: Date, maxMonthsBack: number): { year: number; window: string }[] {
+  let year = now.getUTCFullYear()
+  let month = now.getUTCMonth() // 0-11, the candidate window's FIRST month
+  const out: { year: number; window: string }[] = []
+  for (let step = 0; step <= maxMonthsBack; step++) {
+    out.push({ year, window: windowSlug(month) })
+    month -= 1
+    if (month < 0) {
+      month = 11
+      year -= 1
     }
   }
   return out
@@ -53,11 +69,11 @@ export async function probeRelease(release: string, fetchImpl: typeof fetch = fe
 
 export async function probeLatestRelease(opts: ProbeOptions = {}): Promise<ProbedRelease | null> {
   const now = opts.now ?? new Date()
-  const maxBack = opts.maxQuartersBack ?? 3
+  const maxBack = opts.maxMonthsBack ?? 14
   const fetchImpl = opts.fetchImpl ?? fetch
   const candidates = probeCandidates(now, maxBack)
-  for (const { year, quarter } of candidates) {
-    const release = formatReleaseId(year, quarter)
+  for (const { year, window } of candidates) {
+    const release = formatReleaseId(year, window)
     const result = await probeRelease(release, fetchImpl)
     if (result) return result
   }
@@ -66,14 +82,14 @@ export async function probeLatestRelease(opts: ProbeOptions = {}): Promise<Probe
 
 export async function probeRecentReleases(opts: ProbeOptions & { limit?: number } = {}): Promise<ProbedRelease[]> {
   const now = opts.now ?? new Date()
-  const maxBack = opts.maxQuartersBack ?? 3
+  const maxBack = opts.maxMonthsBack ?? 14
   const fetchImpl = opts.fetchImpl ?? fetch
   const limit = opts.limit ?? 8
   const candidates = probeCandidates(now, maxBack)
   const out: ProbedRelease[] = []
-  for (const { year, quarter } of candidates) {
+  for (const { year, window } of candidates) {
     if (out.length >= limit) break
-    const release = formatReleaseId(year, quarter)
+    const release = formatReleaseId(year, window)
     const result = await probeRelease(release, fetchImpl)
     if (result) out.push(result)
   }

--- a/packages/integration-commoncrawl/src/release-id.ts
+++ b/packages/integration-commoncrawl/src/release-id.ts
@@ -6,17 +6,21 @@ export function isValidReleaseId(id: string): boolean {
 
 export interface ParsedRelease {
   year: number
-  quarter: 'jan-feb-mar' | 'apr-may-jun' | 'jul-aug-sep' | 'oct-nov-dec'
+  /** The `mon-mon-mon` window slug, e.g. 'mar-apr-may'. */
+  window: string
+  /** Convenience split of `window` into its three month tokens. */
+  months: [string, string, string]
 }
 
 export function parseReleaseId(id: string): ParsedRelease | null {
   const match = RELEASE_ID_REGEX.exec(id)
   if (!match) return null
   const year = Number.parseInt(match[1]!, 10)
-  const quarter = match[2] as ParsedRelease['quarter']
-  return { year, quarter }
+  const window = match[2]!
+  const [a, b, c] = window.split('-')
+  return { year, window, months: [a!, b!, c!] }
 }
 
-export function formatReleaseId(year: number, quarter: ParsedRelease['quarter']): string {
-  return `cc-main-${year}-${quarter}`
+export function formatReleaseId(year: number, window: string): string {
+  return `cc-main-${year}-${window}`
 }

--- a/packages/integration-commoncrawl/test/constants.test.ts
+++ b/packages/integration-commoncrawl/test/constants.test.ts
@@ -2,21 +2,40 @@ import { describe, expect, test } from 'vitest'
 import { CC_BASE_URL, ccReleasePaths, RELEASE_ID_REGEX } from '../src/constants.js'
 
 describe('ccReleasePaths', () => {
-  test('builds the verified 2026-04 Common Crawl layout', () => {
-    const paths = ccReleasePaths('cc-main-2026-jan-feb-mar')
+  test('builds the verified Common Crawl layout', () => {
+    const paths = ccReleasePaths('cc-main-2026-mar-apr-may')
     expect(paths.vertexUrl).toBe(
-      `${CC_BASE_URL}/cc-main-2026-jan-feb-mar/domain/cc-main-2026-jan-feb-mar-domain-vertices.txt.gz`,
+      `${CC_BASE_URL}/cc-main-2026-mar-apr-may/domain/cc-main-2026-mar-apr-may-domain-vertices.txt.gz`,
     )
     expect(paths.edgesUrl).toBe(
-      `${CC_BASE_URL}/cc-main-2026-jan-feb-mar/domain/cc-main-2026-jan-feb-mar-domain-edges.txt.gz`,
+      `${CC_BASE_URL}/cc-main-2026-mar-apr-may/domain/cc-main-2026-mar-apr-may-domain-edges.txt.gz`,
     )
-    expect(paths.vertexFilename).toBe('cc-main-2026-jan-feb-mar-domain-vertices.txt.gz')
-    expect(paths.edgesFilename).toBe('cc-main-2026-jan-feb-mar-domain-edges.txt.gz')
+    expect(paths.vertexFilename).toBe('cc-main-2026-mar-apr-may-domain-vertices.txt.gz')
+    expect(paths.edgesFilename).toBe('cc-main-2026-mar-apr-may-domain-edges.txt.gz')
   })
 })
 
 describe('RELEASE_ID_REGEX', () => {
   test('rejects trailing whitespace', () => {
     expect(RELEASE_ID_REGEX.test('cc-main-2024-jul-aug-sep\n')).toBe(false)
+  })
+
+  test.each([
+    'cc-main-2025-oct-nov-dec', // legacy fixed quarter
+    'cc-main-2026-mar-apr-may', // rolling monthly window
+    'cc-main-2025-may-jun-jul', // rolling monthly window
+    // Cross-year window: accepted at the shape layer by design (404s at probe time).
+    'cc-main-2025-nov-dec-jan',
+  ])('accepts %s', (id) => {
+    expect(RELEASE_ID_REGEX.test(id)).toBe(true)
+  })
+
+  test.each([
+    'cc-main-2025-jan-feb', // two tokens
+    'cc-main-2025-jan-feb-mar-apr', // four tokens
+    'cc-main-2025-foo-bar-baz', // non-month tokens
+    'cc-main-25-jan-feb-mar', // 2-digit year
+  ])('rejects %s', (id) => {
+    expect(RELEASE_ID_REGEX.test(id)).toBe(false)
   })
 })

--- a/packages/integration-commoncrawl/test/release-discovery.test.ts
+++ b/packages/integration-commoncrawl/test/release-discovery.test.ts
@@ -15,6 +15,18 @@ function head404(): Response {
   return new Response(null, { status: 404 })
 }
 
+/** Build a fetch stub that returns 200 for any release slug in `hits`, else 404. */
+function fetchFor(hits: Set<string>): typeof fetch {
+  const impl = async (url: string | URL | Request): Promise<Response> => {
+    const s = String(url)
+    for (const hit of hits) {
+      if (s.includes(`/${hit}/`)) return headOk(100, 'x')
+    }
+    return head404()
+  }
+  return impl as typeof fetch
+}
+
 describe('probeRelease', () => {
   test('returns null when either file is missing', async () => {
     const fetchImpl = async (url: string | URL | Request): Promise<Response> => {
@@ -31,11 +43,11 @@ describe('probeRelease', () => {
         ? headOk(4_000_000_000, 'Tue, 24 Mar 2026 00:00:00 GMT')
         : headOk(13_000_000_000, 'Tue, 24 Mar 2026 00:00:00 GMT')
     }
-    const got = await probeRelease('cc-main-2026-jan-feb-mar', fetchImpl as typeof fetch)
+    const got = await probeRelease('cc-main-2026-mar-apr-may', fetchImpl as typeof fetch)
     expect(got).toEqual({
-      release: 'cc-main-2026-jan-feb-mar',
-      vertexUrl: expect.stringContaining('/cc-main-2026-jan-feb-mar/domain/cc-main-2026-jan-feb-mar-domain-vertices.txt.gz'),
-      edgesUrl: expect.stringContaining('/cc-main-2026-jan-feb-mar/domain/cc-main-2026-jan-feb-mar-domain-edges.txt.gz'),
+      release: 'cc-main-2026-mar-apr-may',
+      vertexUrl: expect.stringContaining('/cc-main-2026-mar-apr-may/domain/cc-main-2026-mar-apr-may-domain-vertices.txt.gz'),
+      edgesUrl: expect.stringContaining('/cc-main-2026-mar-apr-may/domain/cc-main-2026-mar-apr-may-domain-edges.txt.gz'),
       vertexBytes: 4_000_000_000,
       edgesBytes: 13_000_000_000,
       lastModified: 'Tue, 24 Mar 2026 00:00:00 GMT',
@@ -44,71 +56,62 @@ describe('probeRelease', () => {
 })
 
 describe('probeLatestRelease', () => {
-  test('walks current year backward through quarters to find the newest available', async () => {
-    const hits = new Set(['cc-main-2026-jan-feb-mar'])
-    const fetchImpl = async (url: string | URL | Request): Promise<Response> => {
-      const s = String(url)
-      for (const hit of hits) {
-        if (s.includes(`/${hit}/`)) return headOk(100, 'x')
-      }
-      return head404()
-    }
+  test('walks month-by-month to find the newest available window', async () => {
+    // now=2026-04-19 → first candidate window is apr-may-jun (404), step back one
+    // month to mar-apr-may (HIT). Proves monthly stepping reaches the issue exemplar.
     const got = await probeLatestRelease({
       now: new Date('2026-04-19T00:00:00Z'),
-      fetchImpl: fetchImpl as typeof fetch,
+      fetchImpl: fetchFor(new Set(['cc-main-2026-mar-apr-may'])),
     })
-    expect(got?.release).toBe('cc-main-2026-jan-feb-mar')
+    expect(got?.release).toBe('cc-main-2026-mar-apr-may')
   })
 
-  test('prefers newer quarter within the same year', async () => {
-    const hits = new Set(['cc-main-2025-jan-feb-mar', 'cc-main-2025-jul-aug-sep'])
-    const fetchImpl = async (url: string | URL | Request): Promise<Response> => {
-      const s = String(url)
-      for (const hit of hits) {
-        if (s.includes(`/${hit}/`)) return headOk(100, 'x')
-      }
-      return head404()
-    }
+  test('prefers the newest window when several overlapping windows are published', async () => {
+    // Candidates: apr-may-jun(miss) → mar-apr-may(miss) → feb-mar-apr(HIT).
     const got = await probeLatestRelease({
       now: new Date('2026-04-19T00:00:00Z'),
-      fetchImpl: fetchImpl as typeof fetch,
+      fetchImpl: fetchFor(new Set(['cc-main-2026-feb-mar-apr', 'cc-main-2026-jan-feb-mar'])),
     })
-    expect(got?.release).toBe('cc-main-2025-jul-aug-sep')
+    expect(got?.release).toBe('cc-main-2026-feb-mar-apr')
+  })
+
+  test('crosses the year boundary while stepping back', async () => {
+    // now=2026-01-15 → jan-feb-mar(2026,miss) → dec-jan-feb(2025,miss) →
+    // nov-dec-jan(2025,miss) → oct-nov-dec(2025,HIT). Proves the year decrement
+    // and that a release's slug year is its FIRST month's year.
+    const got = await probeLatestRelease({
+      now: new Date('2026-01-15T00:00:00Z'),
+      fetchImpl: fetchFor(new Set(['cc-main-2025-oct-nov-dec'])),
+    })
+    expect(got?.release).toBe('cc-main-2025-oct-nov-dec')
   })
 
   test('returns null when nothing published in the lookback window', async () => {
-    const fetchImpl = async (): Promise<Response> => head404()
     const got = await probeLatestRelease({
       now: new Date('2026-04-19T00:00:00Z'),
-      fetchImpl: fetchImpl as typeof fetch,
-      maxQuartersBack: 1,
+      fetchImpl: fetchFor(new Set()),
+      maxMonthsBack: 1,
     })
     expect(got).toBeNull()
   })
 })
 
 describe('probeRecentReleases', () => {
-  test('lists up to `limit` published releases, newest first', async () => {
-    const hits = new Set([
-      'cc-main-2026-jan-feb-mar',
-      'cc-main-2025-oct-nov-dec',
-      'cc-main-2025-jul-aug-sep',
-    ])
-    const fetchImpl = async (url: string | URL | Request): Promise<Response> => {
-      const s = String(url)
-      for (const hit of hits) {
-        if (s.includes(`/${hit}/`)) return headOk(100, 'x')
-      }
-      return head404()
-    }
+  test('lists overlapping monthly windows newest-first, truncated to limit', async () => {
+    // Candidates from now=2026-04-19: apr-may-jun(miss), mar-apr-may(miss),
+    // feb-mar-apr(HIT), jan-feb-mar(HIT) → stops at limit 2.
     const got = await probeRecentReleases({
       now: new Date('2026-04-19T00:00:00Z'),
-      fetchImpl: fetchImpl as typeof fetch,
+      fetchImpl: fetchFor(new Set([
+        'cc-main-2026-feb-mar-apr',
+        'cc-main-2026-jan-feb-mar',
+        'cc-main-2025-dec-jan-feb',
+      ])),
       limit: 2,
     })
     expect(got.map((r) => r.release)).toEqual([
+      'cc-main-2026-feb-mar-apr',
       'cc-main-2026-jan-feb-mar',
-      'cc-main-2025-oct-nov-dec',
     ])
   })
 })

--- a/packages/integration-commoncrawl/test/release-id.test.ts
+++ b/packages/integration-commoncrawl/test/release-id.test.ts
@@ -3,10 +3,21 @@ import { formatReleaseId, isValidReleaseId, parseReleaseId } from '../src/releas
 
 describe('isValidReleaseId', () => {
   test.each([
+    // Legacy fixed quarters — still published as a subset of the monthly cadence.
     'cc-main-2024-jul-aug-sep',
     'cc-main-2026-jan-feb-mar',
     'cc-main-2020-apr-may-jun',
     'cc-main-2030-oct-nov-dec',
+    // Rolling, monthly-stepped windows — the current Common Crawl cadence.
+    'cc-main-2025-may-jun-jul',
+    'cc-main-2025-aug-sep-oct',
+    'cc-main-2026-feb-mar-apr',
+    'cc-main-2026-mar-apr-may',
+    // Cross-year windows are accepted at the SHAPE layer by design. A
+    // well-formed-but-unpublished slug just 404s at probe/download time —
+    // validation gates shape, the HEAD probe is the authoritative existence check.
+    'cc-main-2025-nov-dec-jan',
+    'cc-main-2025-dec-jan-feb',
   ])('accepts %s', (id) => {
     expect(isValidReleaseId(id)).toBe(true)
   })
@@ -14,21 +25,38 @@ describe('isValidReleaseId', () => {
   test.each([
     '',
     'cc-main',
-    'cc-main-24-jan-feb-mar',
-    'cc-main-2024-foo-bar-baz',
-    'CC-MAIN-2024-jan-feb-mar',
-    'cc-main-2024-jan-feb-mar ',
-    ' cc-main-2024-jan-feb-mar',
-    'cc-main-2024-jan',
+    'cc-main-24-jan-feb-mar', // 2-digit year
+    'cc-main-2024-foo-bar-baz', // non-month tokens
+    'CC-MAIN-2024-jan-feb-mar', // uppercase
+    'cc-main-2024-jan-feb-mar ', // trailing space
+    ' cc-main-2024-jan-feb-mar', // leading space
+    'cc-main-2024-jan', // single token
+    'cc-main-2024-jan-feb', // two tokens
+    'cc-main-2024-jan-feb-mar-apr', // four tokens
   ])('rejects %s', (id) => {
     expect(isValidReleaseId(id)).toBe(false)
+  })
+
+  test('accepts the issue exemplar rolling window cc-main-2026-mar-apr-may', () => {
+    expect(isValidReleaseId('cc-main-2026-mar-apr-may')).toBe(true)
   })
 })
 
 describe('parseReleaseId', () => {
-  test('extracts year + quarter', () => {
-    expect(parseReleaseId('cc-main-2026-jan-feb-mar')).toEqual({ year: 2026, quarter: 'jan-feb-mar' })
-    expect(parseReleaseId('cc-main-2024-oct-nov-dec')).toEqual({ year: 2024, quarter: 'oct-nov-dec' })
+  test('extracts year + window + months for a rolling window', () => {
+    expect(parseReleaseId('cc-main-2026-mar-apr-may')).toEqual({
+      year: 2026,
+      window: 'mar-apr-may',
+      months: ['mar', 'apr', 'may'],
+    })
+  })
+
+  test('extracts a legacy fixed quarter', () => {
+    expect(parseReleaseId('cc-main-2024-oct-nov-dec')).toEqual({
+      year: 2024,
+      window: 'oct-nov-dec',
+      months: ['oct', 'nov', 'dec'],
+    })
   })
 
   test('returns null for invalid ids', () => {
@@ -37,8 +65,8 @@ describe('parseReleaseId', () => {
 })
 
 describe('formatReleaseId', () => {
-  test('reconstructs the original id', () => {
-    const parsed = parseReleaseId('cc-main-2026-jan-feb-mar')!
-    expect(formatReleaseId(parsed.year, parsed.quarter)).toBe('cc-main-2026-jan-feb-mar')
+  test('reconstructs the original id from a parsed window', () => {
+    const parsed = parseReleaseId('cc-main-2026-mar-apr-may')!
+    expect(formatReleaseId(parsed.year, parsed.window)).toBe('cc-main-2026-mar-apr-may')
   })
 })

--- a/skills/canonry/references/canonry-cli.md
+++ b/skills/canonry/references/canonry-cli.md
@@ -186,6 +186,7 @@ cnry competitor list <project>
 cnry schedule set <project> --preset daily     # or: weekly, twice-daily, daily@09
 cnry schedule set <project> --cron "0 9 * * *" --timezone America/New_York
 cnry schedule set <project> --kind data-refresh --preset daily   # refresh all connected GSC/Bing/GA/GBP integrations (no --source)
+cnry schedule set <project> --kind backlinks-sync --preset weekly # re-probe Common Crawl; sync only when a newer rolling window is published (no --source/--provider)
 cnry schedule show <project>
 cnry schedule enable <project>
 cnry schedule disable <project>
@@ -416,12 +417,16 @@ cnry gbp summary <project> [--location locations/{n}]
 
 Workspace-level Common Crawl release sync + per-project backlink extraction. Requires DuckDB; install once with `cnry backlinks install`. Releases are downloaded once per workspace and reused across all projects.
 
+Common Crawl publishes the hyperlink graph as **rolling, monthly-stepped, overlapping 3-month windows** named by the window's first month's year: `cc-main-YYYY-<mon>-<mon>-<mon>` (e.g. `cc-main-2026-mar-apr-may`). Omit `--release` to auto-discover the newest published window; the legacy fixed-quarter slugs (`jan-feb-mar`, …) still resolve since they're a subset of the cadence.
+
 ```bash
 cnry backlinks install                         # install bundled DuckDB binary
 cnry backlinks doctor                          # show install + plugin status
 cnry backlinks status                          # latest workspace release sync
 cnry backlinks releases                        # list cached releases on disk
-cnry backlinks sync --release <id>             # download + query a release (workspace-wide)
+cnry backlinks releases latest                 # probe Common Crawl for the newest published rolling window
+cnry backlinks sync                            # auto-discover + download + query the newest release (workspace-wide)
+cnry backlinks sync --release cc-main-2026-mar-apr-may   # pin a specific rolling window
 cnry backlinks sync --release <id> --wait      # block until ready/failed
 cnry backlinks list <project>                  # top linking domains for the project
 cnry backlinks list <project> --limit 100 --release <id>
@@ -431,6 +436,8 @@ cnry backlinks cache prune --release <id>      # delete cached release files fro
 ```
 
 All commands support `--format json`. A release sync has statuses `queued` → `downloading` → `querying` → `ready` / `failed`. Per-project extract runs use the standard run statuses (`queued` → `running` → `completed` / `failed`). Projects with the `autoExtractBacklinks` setting enabled get an extract run enqueued automatically when a release sync transitions to `ready`.
+
+To keep backlinks fresh automatically, schedule a `backlinks-sync` kind (`cnry schedule set <project> --kind backlinks-sync --preset weekly`): each tick re-probes Common Crawl and runs the workspace release sync **only when a newer rolling window is published** (it skips when the newest `ready` sync already covers the latest release, so it never re-downloads a near-identical window).
 
 ## CDP / Browser Provider
 


### PR DESCRIPTION
Common Crawl moved the hyperlink graph from fixed calendar quarters to rolling, monthly-stepped, overlapping 3-month windows (e.g. `cc-main-2026-mar-apr-may`), so the old fixed-quarter discovery probed dead slugs and rejected real ones before download. This generalizes the release model and adds an automatic, freshness-gated sync.

- **Release model:** `RELEASE_ID_REGEX` now accepts any `cc-main-YYYY-<mon>-<mon>-<mon>` window, `ParsedRelease` carries `window`/`months` instead of a quarter union, and `probeLatestRelease`/`probeRecentReleases` walk back month-by-month from the current month.
- **New `backlinks-sync` schedule kind** re-probes Common Crawl on a cron and runs the workspace release sync only when the latest published window isn't already synced `ready`, skipping a re-download of a near-identical ~17 GB window.
- Threads the new kind through contracts/CLI/OpenAPI + generated SDK types, adds tests across every touched package, updates docs (AGENTS/README/skill), and bumps to 4.68.0.

Closes #667