### PR TITLE
fix(scheduler): compute nextRunAt with cron-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.68.0",
+  "version": "4.68.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/package.json
+++ b/packages/api-routes/package.json
@@ -31,6 +31,7 @@
     "@ainyc/canonry-integration-wordpress": "workspace:*",
     "@ainyc/canonry-integration-wordpress-traffic": "workspace:*",
     "@ainyc/canonry-intelligence": "workspace:*",
+    "cron-parser": "^5.5.0",
     "drizzle-orm": "^0.45.2",
     "drizzle-zod": "^0.8.3",
     "fastify": "^5.8.5",

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -425,6 +425,7 @@ export async function apiRoutes(app: FastifyInstance, opts: ApiRoutesOptions) {
 
 export type { DatabaseClient } from '@ainyc/canonry-db'
 export { queueRunIfProjectIdle } from './run-queue.js'
+export { nextRunFromCron } from './schedule-utils.js'
 export {
   executeDiscovery,
   classifyProbeBucket,

--- a/packages/api-routes/src/schedule-utils.ts
+++ b/packages/api-routes/src/schedule-utils.ts
@@ -4,6 +4,8 @@
  * not shared data shapes.
  */
 
+import { CronExpressionParser } from 'cron-parser'
+
 const DAY_MAP: Record<string, string> = {
   sun: '0', mon: '1', tue: '2', wed: '3', thu: '4', fri: '5', sat: '6',
 }
@@ -103,5 +105,40 @@ export function isValidTimezone(tz: string): boolean {
     return true
   } catch {
     return false
+  }
+}
+
+/**
+ * Compute the next fire time of a 5-field cron expression as an ISO-8601 string.
+ *
+ * This exists because node-cron's own `task.getNextRun()` is broken for
+ * day-of-week-constrained expressions: e.g. `0 6 * * 1` (every Monday at 06:00)
+ * returns the next January 1st that happens to fall on a Monday — years out —
+ * instead of next Monday. A future timestamp corrupts the stored `nextRunAt`
+ * AND silently disables the scheduler's downtime catch-up, because a missed
+ * slot then never reads as "in the past". node-cron's firing matcher is
+ * correct, so the scheduler keeps node-cron for firing and uses cron-parser
+ * here for the displayed / catch-up timestamp.
+ *
+ * @param cronExpr 5-field standard cron expression (e.g. `0 6 * * 1`)
+ * @param timezone IANA timezone the cron fields are interpreted in (e.g. `UTC`)
+ * @param from     compute the next run strictly after this instant (default: now)
+ * @returns ISO-8601 string, or null when the expression or timezone can't be
+ *          parsed (callers fall back to null, preserving the prior `?? null`
+ *          behavior of `getNextRun()?.toISOString() ?? null`).
+ */
+export function nextRunFromCron(
+  cronExpr: string,
+  timezone: string,
+  from: Date = new Date(),
+): string | null {
+  try {
+    const interval = CronExpressionParser.parse(cronExpr, {
+      currentDate: from,
+      tz: timezone,
+    })
+    return interval.next().toDate().toISOString()
+  } catch {
+    return null
   }
 }

--- a/packages/api-routes/test/schedule-utils.test.ts
+++ b/packages/api-routes/test/schedule-utils.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest'
-import { resolvePreset, validateCron, isValidTimezone } from '../src/schedule-utils.js'
+import { resolvePreset, validateCron, isValidTimezone, nextRunFromCron } from '../src/schedule-utils.js'
 
 // --- resolvePreset ---
 
@@ -68,4 +68,47 @@ test('isValidTimezone rejects invalid timezone strings', () => {
   expect(isValidTimezone('not/a-zone')).toBe(false)
   expect(isValidTimezone('')).toBe(false)
   expect(isValidTimezone('GMT+25')).toBe(false)
+})
+
+// --- nextRunFromCron ---
+// Anchor: 2026-06-01T15:33:00Z is a Monday afternoon.
+
+test('nextRunFromCron resolves a weekday cron to the NEXT matching weekday (node-cron getNextRun regression)', () => {
+  // node-cron@4's getNextRun() returns 2029-01-01 for `0 6 * * 1` here (the
+  // next Jan-1-on-a-Monday). The correct answer is the upcoming Monday 06:00.
+  expect(nextRunFromCron('0 6 * * 1', 'UTC', new Date('2026-06-01T15:33:00Z')))
+    .toBe('2026-06-08T06:00:00.000Z')
+})
+
+test('nextRunFromCron resolves a Sunday cron correctly', () => {
+  // node-cron@4 returns 2034-01-01 for `0 6 * * 0`; the correct answer is the
+  // upcoming Sunday 06:00.
+  expect(nextRunFromCron('0 6 * * 0', 'UTC', new Date('2026-06-01T15:33:00Z')))
+    .toBe('2026-06-07T06:00:00.000Z')
+})
+
+test('nextRunFromCron resolves a daily cron to tomorrow when today has passed', () => {
+  expect(nextRunFromCron('0 6 * * *', 'UTC', new Date('2026-06-01T15:33:00Z')))
+    .toBe('2026-06-02T06:00:00.000Z')
+})
+
+test('nextRunFromCron returns the same-day slot when it is still ahead', () => {
+  // Monday 05:00, cron fires Monday 06:00 — the next run is later today.
+  expect(nextRunFromCron('0 6 * * 1', 'UTC', new Date('2026-06-01T05:00:00Z')))
+    .toBe('2026-06-01T06:00:00.000Z')
+})
+
+test('nextRunFromCron interprets the cron in the supplied timezone', () => {
+  // 06:00 America/New_York (EDT, UTC-4) on 2026-06-02 == 10:00 UTC. From
+  // 11:33 EDT, today's 06:00 ET has passed, so the next run is tomorrow.
+  expect(nextRunFromCron('0 6 * * *', 'America/New_York', new Date('2026-06-01T15:33:00Z')))
+    .toBe('2026-06-02T10:00:00.000Z')
+})
+
+test('nextRunFromCron returns null for an unparseable expression', () => {
+  expect(nextRunFromCron('not a cron', 'UTC', new Date('2026-06-01T15:33:00Z'))).toBeNull()
+})
+
+test('nextRunFromCron returns null for an invalid timezone', () => {
+  expect(nextRunFromCron('0 6 * * *', 'not/a-zone', new Date('2026-06-01T15:33:00Z'))).toBeNull()
 })

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.68.0",
+  "version": "4.68.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",
@@ -54,6 +54,7 @@
     "@sinclair/typebox": "^0.34.41",
     "better-sqlite3": "^12.6.2",
     "chrome-remote-interface": "^0.33.2",
+    "cron-parser": "^5.5.0",
     "drizzle-orm": "^0.45.2",
     "fastify": "^5.8.5",
     "node-cron": "^4.2.1",

--- a/packages/canonry/src/scheduler.ts
+++ b/packages/canonry/src/scheduler.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto'
 import cron from 'node-cron'
 import { and, eq } from 'drizzle-orm'
-import { queueRunIfProjectIdle } from '@ainyc/canonry-api-routes'
+import { queueRunIfProjectIdle, nextRunFromCron } from '@ainyc/canonry-api-routes'
 import type { DatabaseClient } from '@ainyc/canonry-db'
 import { schedules, projects, runs } from '@ainyc/canonry-db'
 import type { ProviderName, LocationContext, SchedulableRunKind } from '@ainyc/canonry-contracts'
@@ -162,7 +162,7 @@ export class Scheduler {
 
     this.tasks.set(taskKey(projectId, kind), task)
     this.db.update(schedules).set({
-      nextRunAt: task.getNextRun()?.toISOString() ?? null,
+      nextRunAt: nextRunFromCron(cronExpr, timezone),
       updatedAt: new Date().toISOString(),
     }).where(eq(schedules.id, scheduleId)).run()
 
@@ -180,8 +180,7 @@ export class Scheduler {
         return
       }
 
-      const task = this.tasks.get(taskKey(projectId, kind))
-      const nextRunAt = task?.getNextRun()?.toISOString() ?? null
+      const nextRunAt = nextRunFromCron(currentSchedule.cronExpr, currentSchedule.timezone)
 
       // Check if project still exists
       const project = this.db.select().from(projects).where(eq(projects.id, projectId)).get()

--- a/packages/canonry/tsup.config.ts
+++ b/packages/canonry/tsup.config.ts
@@ -29,6 +29,10 @@ export default defineConfig({
     '@google/genai',
     '@anthropic-ai/sdk',
     'node-cron',
+    // cron-parser computes the scheduler's nextRunAt (node-cron's own
+    // getNextRun() is broken for weekday crons). Keep external in lockstep
+    // with the entry in `packages/canonry/package.json`.
+    'cron-parser',
     'yaml',
     'pino-pretty',
     'zod',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,9 @@ importers:
       '@ainyc/canonry-intelligence':
         specifier: workspace:*
         version: link:../intelligence
+      cron-parser:
+        specifier: ^5.5.0
+        version: 5.5.0
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)
@@ -266,6 +269,9 @@ importers:
       chrome-remote-interface:
         specifier: ^0.33.2
         version: 0.33.3
+      cron-parser:
+        specifier: ^5.5.0
+        version: 5.5.0
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)
@@ -2627,6 +2633,10 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
+  cron-parser@5.5.0:
+    resolution: {integrity: sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==}
+    engines: {node: '>=18'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -3673,6 +3683,10 @@ packages:
     resolution: {integrity: sha512-w3hD8/SQB7+lzU2r4VdFyzzOzKnUjTZIF/MQJGSSvni7Llewni4vuViRppfRAa2guOsY5k4jZyxw/i9DQHv+dw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -7238,6 +7252,10 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
+  cron-parser@5.5.0:
+    dependencies:
+      luxon: 3.7.2
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -8275,6 +8293,8 @@ snapshots:
   lucide-react@0.542.0(react@19.2.4):
     dependencies:
       react: 19.2.4
+
+  luxon@3.7.2: {}
 
   lz-string@1.5.0: {}
 


### PR DESCRIPTION
## What

The scheduler stored a wrong `nextRunAt` for any day-of-week-constrained cron (every `weekly` preset, plus custom DOW crons). `node-cron@4`'s `task.getNextRun()` resolves `0 6 * * 1` (every Monday 06:00) to the next January-1st that lands on a Monday (e.g. `2029-01-01`) instead of next Monday. `0 6 * * 0` (Sunday) gives `2034-01-01`. Daily and interval crons are unaffected.

Replace both `getNextRun()` call sites in the scheduler with a new `nextRunFromCron()` helper backed by `cron-parser`. `node-cron` stays the firing engine.

## Why it matters

`node-cron`'s firing matcher (`timeMatcher`) is correct, so schedules still fire on time. But the bogus future timestamp:

1. Shows a nonsense `nextRunAt` in `schedule show` / the dashboard.
2. Silently disables downtime catch-up: the scheduler triggers a missed run on boot when the stored `nextRunAt` is in the past, and a value years in the future never reads as missed. A weekly slot missed during downtime is skipped until the next natural fire.

## Approach

- `nextRunFromCron(cronExpr, timezone, from?)` in `api-routes/schedule-utils.ts` (the existing home for preset + cron-validation helpers), returning an ISO string or `null` on unparseable input (preserving the prior `?? null` shape).
- `cron-parser` added as a real dependency, kept `external` in canonry's tsup config in lockstep with `packages/canonry/package.json`, consistent with `node-cron`.
- 7 unit tests covering the regression case, Sunday, daily, same-day-still-ahead, timezone interpretation, and the two null paths. Expected instants verified against `cron-parser` directly.

## Notes

- `node-cron@4.2.1` is the latest published; the bug is present there, so a version bump is not an option.
- Patch bump to `4.68.1`.