### PR TITLE
feat: portfolio rows — graph-first, real mention subtitle, drop run-status line

### DIFF
--- a/apps/web/src/build-dashboard.ts
+++ b/apps/web/src/build-dashboard.ts
@@ -643,6 +643,7 @@ export function buildPortfolioProject(data: ProjectData): PortfolioProjectVm {
   // `progress` is the same number as 0–100, so we read that for the score.
   const visibilityScore = visibility.progress ?? 0
   const cited = overview.queryCounts.citedQueries
+  const mentioned = overview.queryCounts.mentionedQueries
   const total = overview.queryCounts.totalQueries
   const providerCount = overview.providers.length
 
@@ -653,8 +654,10 @@ export function buildPortfolioProject(data: ProjectData): PortfolioProjectVm {
     visibilityTone: visibility.tone as MetricTone,
     providerCoverage: visibility.providerCoverage,
     lastRun: runItem,
+    // Subtitle reads the mention signal (answerMentioned), not cited — the
+    // word "mentioned" must be backed by mention data, not the cited count.
     insight: total > 0
-      ? `${cited} of ${total} queries mentioned across ${providerCount} provider${providerCount === 1 ? '' : 's'}.`
+      ? `${mentioned} of ${total} queries mentioned across ${providerCount} provider${providerCount === 1 ? '' : 's'}.`
       : 'No runs completed yet.',
     // Cited-rate-over-time series (0–100, oldest→newest), computed server-side
     // from runHistory — drives the per-project sparkline on the portfolio.

--- a/apps/web/src/pages/OverviewPage.tsx
+++ b/apps/web/src/pages/OverviewPage.tsx
@@ -26,6 +26,9 @@ function OverviewProjectCard({
       params={{ projectId: project.project.id }}
       className="project-row cursor-pointer"
     >
+      <div className="project-row-chart">
+        <Sparkline points={project.trend} tone={toneFromRunStatus(project.lastRun.status)} />
+      </div>
       <div className="project-row-primary">
         <div>
           <p className="project-name">{project.project.name}</p>
@@ -49,9 +52,6 @@ function OverviewProjectCard({
             {project.lastRun.kindLabel} · {toTitleCase(project.lastRun.status)}
           </p>
         </div>
-      </div>
-      <div className="project-row-chart">
-        <Sparkline points={project.trend} tone={toneFromRunStatus(project.lastRun.status)} />
       </div>
       <span className="project-row-link">
         <ChevronRight className="h-4 w-4 text-zinc-500" />

--- a/apps/web/src/pages/OverviewPage.tsx
+++ b/apps/web/src/pages/OverviewPage.tsx
@@ -7,7 +7,6 @@ import { Sparkline } from '../components/shared/Sparkline.js'
 import { StatusBadge } from '../components/shared/StatusBadge.js'
 import { ToneBadge } from '../components/shared/ToneBadge.js'
 import { toneFromRunStatus } from '../lib/tone-helpers.js'
-import { toTitleCase } from '../lib/format-helpers.js'
 import { buildSystemHealthCards, serviceStatusTooltip } from '../lib/health-helpers.js'
 import { useDashboardOverview as useDashboard } from '../queries/use-dashboard-overview.js'
 import { useHealth } from '../queries/use-health.js'
@@ -48,9 +47,6 @@ function OverviewProjectCard({
         <div className="metric-inline-block">
           <p className="metric-inline-label">Competitor Pressure</p>
           <p className="metric-inline-value">{project.competitorPressureLabel}</p>
-          <p className="metric-inline-delta">
-            {project.lastRun.kindLabel} · {toTitleCase(project.lastRun.status)}
-          </p>
         </div>
       </div>
       <span className="project-row-link">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1320,7 +1320,7 @@
   /* ── Project row (overview) ── */
 
   .project-row {
-    @apply grid gap-3 rounded-xl border border-zinc-800/40 bg-zinc-900/15 px-4 py-3.5 transition hover:border-zinc-700/60 hover:bg-zinc-900/35 lg:grid-cols-[minmax(0,1.5fr)_9rem_9rem_10rem_9rem_auto] lg:items-center no-underline text-inherit;
+    @apply grid gap-3 rounded-xl border border-zinc-800/40 bg-zinc-900/15 px-4 py-3.5 transition hover:border-zinc-700/60 hover:bg-zinc-900/35 lg:grid-cols-[10rem_minmax(0,1.5fr)_9rem_9rem_9rem_auto] lg:items-center no-underline text-inherit;
   }
 
   .project-row-primary {

--- a/apps/web/test/build-dashboard.test.ts
+++ b/apps/web/test/build-dashboard.test.ts
@@ -548,7 +548,7 @@ test('buildProjectCommandCenter populates score gauges from the overview DTO whe
       latestRun: { totalRuns: 0, run: null },
       health: null,
       topInsights: [],
-      queryCounts: { totalQueries: 4, citedQueries: 3, notCitedQueries: 1, citedRate: 0.75 },
+      queryCounts: { totalQueries: 4, citedQueries: 3, notCitedQueries: 1, citedRate: 0.75, mentionedQueries: 3, notMentionedQueries: 1, mentionRate: 0.75 },
       providers: [{ provider: 'gemini', cited: 3, total: 4, citedRate: 0.75 }],
       transitions: { since: null, gained: 0, lost: 0, emerging: 0 },
       scores: {
@@ -623,7 +623,7 @@ test('buildProjectCommandCenter surfaces synthesized attention items (e.g. stale
       latestRun: { totalRuns: 0, run: null },
       health: null,
       topInsights: [],
-      queryCounts: { totalQueries: 0, citedQueries: 0, notCitedQueries: 0, citedRate: 0 },
+      queryCounts: { totalQueries: 0, citedQueries: 0, notCitedQueries: 0, citedRate: 0, mentionedQueries: 0, notMentionedQueries: 0, mentionRate: 0 },
       providers: [],
       transitions: { since: null, gained: 0, lost: 0, emerging: 0 },
       scores: {
@@ -1108,7 +1108,7 @@ test('buildProjectCommandCenter emits a single history-only row when no location
   expect(geminiRows).toHaveLength(2)
 })
 
-test('buildPortfolioProject carries the cited-rate trend from the overview for the sparkline', () => {
+test('buildPortfolioProject carries the cited-rate trend and mention-count subtitle from the overview', () => {
   const base: ProjectData = {
     project: {
       id: 'proj_portfolio',
@@ -1154,7 +1154,7 @@ test('buildPortfolioProject carries the cited-rate trend from the overview for t
       latestRun: { totalRuns: 0, run: null },
       health: null,
       topInsights: [],
-      queryCounts: { totalQueries: 4, citedQueries: 3, notCitedQueries: 1, citedRate: 0.75 },
+      queryCounts: { totalQueries: 4, citedQueries: 3, notCitedQueries: 1, citedRate: 0.75, mentionedQueries: 3, notMentionedQueries: 1, mentionRate: 0.75 },
       providers: [{ provider: 'gemini', cited: 3, total: 4, citedRate: 0.75 }],
       transitions: { since: null, gained: 0, lost: 0, emerging: 0 },
       scores: {
@@ -1176,6 +1176,19 @@ test('buildPortfolioProject carries the cited-rate trend from the overview for t
   }
 
   expect(buildPortfolioProject(base).trend).toEqual([25, 50, 75])
+
+  // The subtitle ("N of M queries mentioned …") reads the MENTION count
+  // (answerMentioned), never the cited count. Seed mentioned≠cited and prove
+  // the subtitle tracks mentioned while the cited block stays on cited.
+  const distinctMention = buildPortfolioProject({
+    ...base,
+    overview: {
+      ...base.overview!,
+      queryCounts: { totalQueries: 4, citedQueries: 3, notCitedQueries: 1, citedRate: 0.75, mentionedQueries: 1, notMentionedQueries: 3, mentionRate: 0.25 },
+    },
+  })
+  expect(distinctMention.insight).toBe('1 of 4 queries mentioned across 1 provider.')
+  expect(distinctMention.visibilityDelta).toBe('3 of 4 queries')
 
   // Without an overview (no runs yet) the trend is empty and the sparkline no-ops.
   expect(buildPortfolioProject({ ...base, overview: null }).trend).toEqual([])

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.68.0",
+  "version": "4.69.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/composites.ts
+++ b/packages/api-routes/src/composites.ts
@@ -480,17 +480,33 @@ function summarizeFromSnapshots(
   snapshots: readonly OverviewSnapshot[],
 ): { queryCounts: ProjectOverviewQueryCountsDto; providers: ProjectOverviewProviderEntryDto[] } {
   const empty = {
-    queryCounts: { totalQueries: 0, citedQueries: 0, notCitedQueries: 0, citedRate: 0 } as ProjectOverviewQueryCountsDto,
+    queryCounts: {
+      totalQueries: 0,
+      citedQueries: 0,
+      notCitedQueries: 0,
+      citedRate: 0,
+      mentionedQueries: 0,
+      notMentionedQueries: 0,
+      mentionRate: 0,
+    } as ProjectOverviewQueryCountsDto,
     providers: [] as ProjectOverviewProviderEntryDto[],
   }
   if (snapshots.length === 0) return empty
 
+  // Cited and mentioned are tracked per query as independent "any snapshot"
+  // rolls-ups — a query is cited if ANY snapshot is cited, mentioned if ANY
+  // snapshot has answerMentioned===true. Never derive one from the other.
   const perQuery = new Map<string, boolean>()
+  const perQueryMentioned = new Map<string, boolean>()
   const perProvider = new Map<string, { cited: number; total: number }>()
   for (const snap of snapshots) {
     const cited = snap.citationState === CitationStates.cited
     if (!perQuery.has(snap.queryId) || cited) {
       perQuery.set(snap.queryId, cited)
+    }
+    const mentioned = snap.answerMentioned === true
+    if (!perQueryMentioned.has(snap.queryId) || mentioned) {
+      perQueryMentioned.set(snap.queryId, mentioned)
     }
     const bucket = perProvider.get(snap.provider) ?? { cited: 0, total: 0 }
     bucket.total += 1
@@ -506,6 +522,13 @@ function summarizeFromSnapshots(
   const notCitedQueries = totalQueries - citedQueries
   const citedRate = totalQueries === 0 ? 0 : Number((citedQueries / totalQueries).toFixed(4))
 
+  let mentionedQueries = 0
+  for (const wasMentioned of perQueryMentioned.values()) {
+    if (wasMentioned) mentionedQueries += 1
+  }
+  const notMentionedQueries = totalQueries - mentionedQueries
+  const mentionRate = totalQueries === 0 ? 0 : Number((mentionedQueries / totalQueries).toFixed(4))
+
   const providers: ProjectOverviewProviderEntryDto[] = [...perProvider.entries()]
     .map(([provider, { cited, total }]) => ({
       provider,
@@ -516,7 +539,15 @@ function summarizeFromSnapshots(
     .sort((a, b) => a.provider.localeCompare(b.provider))
 
   return {
-    queryCounts: { totalQueries, citedQueries, notCitedQueries, citedRate },
+    queryCounts: {
+      totalQueries,
+      citedQueries,
+      notCitedQueries,
+      citedRate,
+      mentionedQueries,
+      notMentionedQueries,
+      mentionRate,
+    },
     providers,
   }
 }

--- a/packages/api-routes/test/composites.test.ts
+++ b/packages/api-routes/test/composites.test.ts
@@ -188,6 +188,9 @@ describe('GET /api/v1/projects/:name/overview', () => {
       citedQueries: 2,
       notCitedQueries: 0,
       citedRate: 1,
+      mentionedQueries: 2,
+      notMentionedQueries: 0,
+      mentionRate: 1,
     })
     expect(body.providers.map(p => p.provider)).toEqual(['gemini', 'openai'])
     expect(body.transitions.since).toBe('2026-04-18T14:10:00.000Z')
@@ -452,9 +455,71 @@ describe('GET /api/v1/projects/:name/overview', () => {
     expect(body.latestRun).toEqual({ totalRuns: 0, run: null })
     expect(body.health).toBeNull()
     expect(body.topInsights).toEqual([])
-    expect(body.queryCounts).toEqual({ totalQueries: 0, citedQueries: 0, notCitedQueries: 0, citedRate: 0 })
+    expect(body.queryCounts).toEqual({ totalQueries: 0, citedQueries: 0, notCitedQueries: 0, citedRate: 0, mentionedQueries: 0, notMentionedQueries: 0, mentionRate: 0 })
     expect(body.providers).toEqual([])
     expect(body.transitions).toEqual({ since: null, gained: 0, lost: 0, emerging: 0 })
+
+    await app.close()
+  })
+
+  // queryCounts.mentionedQueries must read the mention signal (answerMentioned)
+  // independently of cited — never derived from it. Seed queries where the two
+  // signals deliberately diverge and prove the counts track their own field.
+  it('counts mentioned queries from answerMentioned, disjoint from cited', async () => {
+    const { app, db, tmpDir } = buildApp()
+    cleanups.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }))
+
+    const projectId = crypto.randomUUID()
+    const runId = crypto.randomUUID()
+    const qCitedOnly = crypto.randomUUID()
+    const qMentionOnly = crypto.randomUUID()
+    const qBoth = crypto.randomUUID()
+    const qCitedOnly2 = crypto.randomUUID()
+
+    db.insert(projects).values({
+      id: projectId, name: 'split', displayName: 'Split', canonicalDomain: 'split.example',
+      country: 'US', language: 'en', ownedDomains: [], tags: [], providers: [],
+      createdAt: '2026-05-01T00:00:00.000Z', updatedAt: '2026-05-01T00:00:00.000Z',
+    }).run()
+    db.insert(queries).values([
+      { id: qCitedOnly, projectId, query: 'cited not mentioned', createdAt: '2026-05-01T00:00:00.000Z' },
+      { id: qMentionOnly, projectId, query: 'mentioned not cited', createdAt: '2026-05-01T00:00:00.000Z' },
+      { id: qBoth, projectId, query: 'cited and mentioned', createdAt: '2026-05-01T00:00:00.000Z' },
+      { id: qCitedOnly2, projectId, query: 'cited not mentioned two', createdAt: '2026-05-01T00:00:00.000Z' },
+    ]).run()
+    db.insert(runs).values({
+      id: runId, projectId, kind: 'answer-visibility', status: 'completed', trigger: 'manual',
+      createdAt: '2026-05-01T01:00:00.000Z', finishedAt: '2026-05-01T01:01:00.000Z',
+    }).run()
+    const snap = (queryId: string, citationState: string, answerMentioned: boolean) => ({
+      id: crypto.randomUUID(), runId, queryId, provider: 'gemini', citationState, answerMentioned,
+      citedDomains: citationState === 'cited' ? ['split.example'] : [],
+      competitorOverlap: [], recommendedCompetitors: [], answerText: null, createdAt: '2026-05-01T01:00:30.000Z',
+    })
+    db.insert(querySnapshots).values([
+      snap(qCitedOnly, 'cited', false),
+      snap(qMentionOnly, 'not-cited', true),
+      snap(qBoth, 'cited', true),
+      snap(qCitedOnly2, 'cited', false),
+    ]).run()
+
+    await app.ready()
+    const res = await app.inject({ method: 'GET', url: '/api/v1/projects/split/overview' })
+    expect(res.statusCode).toBe(200)
+    const qc = (JSON.parse(res.payload) as ProjectOverviewDto).queryCounts
+
+    expect(qc.totalQueries).toBe(4)
+    // cited = {CitedOnly, Both, CitedOnly2} = 3; mentioned = {MentionOnly, Both} = 2.
+    expect(qc.citedQueries).toBe(3)
+    expect(qc.mentionedQueries).toBe(2)
+    expect(qc.notCitedQueries).toBe(1)
+    expect(qc.notMentionedQueries).toBe(2)
+    expect(qc.citedRate).toBe(0.75)
+    expect(qc.mentionRate).toBe(0.5)
+    // Disjointness proof: the mentioned set INCLUDES a not-cited query and
+    // EXCLUDES a cited-but-not-mentioned query, so mentionedQueries cannot have
+    // been derived from the cited signal (and vice versa).
+    expect(qc.mentionedQueries).not.toBe(qc.citedQueries)
 
     await app.close()
   })

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.68.0",
+  "version": "4.69.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/commands/overview.ts
+++ b/packages/canonry/src/commands/overview.ts
@@ -138,7 +138,8 @@ export function renderHuman(overview: ProjectOverviewDto): void {
   printScore('Competitor press.', scores.competitorPressure)
   printScore('Run status       ', scores.runStatus)
 
-  console.log(`\n  Queries cited: ${queryCounts.citedQueries}/${queryCounts.totalQueries} (${pct(queryCounts.citedRate)})`)
+  console.log(`\n  Queries cited:     ${queryCounts.citedQueries}/${queryCounts.totalQueries} (${pct(queryCounts.citedRate)})`)
+  console.log(`  Queries mentioned: ${queryCounts.mentionedQueries}/${queryCounts.totalQueries} (${pct(queryCounts.mentionRate)})`)
 
   if (movementSummary.hasPreviousRun) {
     console.log(`  Movement: +${movementSummary.gained} gained, -${movementSummary.lost} lost (${movementSummary.tone})`)

--- a/packages/canonry/test/overview-command.test.ts
+++ b/packages/canonry/test/overview-command.test.ts
@@ -26,7 +26,7 @@ function makeOverview(overrides: Partial<ProjectOverviewDto> = {}): ProjectOverv
     latestRun: { run: null, totalRuns: 0 },
     health: null,
     topInsights: [],
-    queryCounts: { totalQueries: 0, citedQueries: 0, notCitedQueries: 0, citedRate: 0 },
+    queryCounts: { totalQueries: 0, citedQueries: 0, notCitedQueries: 0, citedRate: 0, mentionedQueries: 0, notMentionedQueries: 0, mentionRate: 0 },
     providers: [],
     transitions: { since: null, gained: 0, lost: 0, emerging: 0 },
     scores: {
@@ -189,5 +189,15 @@ describe('canonry overview — human output', () => {
     expect(output).toContain('Competitor press.')
     expect(output).toContain('Run status')
     expect(output).not.toMatch(/Share of [Vv]oice/)
+  })
+
+  it('renders cited and mentioned query-count lines from their own fields', () => {
+    const overview = makeOverview({
+      queryCounts: { totalQueries: 8, citedQueries: 4, notCitedQueries: 4, citedRate: 0.5, mentionedQueries: 6, notMentionedQueries: 2, mentionRate: 0.75 },
+    })
+    output = captureOutput(() => renderHuman(overview))
+    // Two independent lines — the mentioned line (6/8) must not borrow the cited count (4/8).
+    expect(output).toMatch(/Queries cited:\s+4\/8 \(50\.0%\)/)
+    expect(output).toMatch(/Queries mentioned:\s+6\/8 \(75\.0%\)/)
   })
 })

--- a/packages/canonry/test/reads-jsonl-degrade.test.ts
+++ b/packages/canonry/test/reads-jsonl-degrade.test.ts
@@ -174,7 +174,7 @@ function makeOverview(name: string) {
     latestRun: { run: null, totalRuns: 0 },
     health: null,
     topInsights: [],
-    queryCounts: { totalQueries: 0, citedQueries: 0, notCitedQueries: 0, citedRate: 0 },
+    queryCounts: { totalQueries: 0, citedQueries: 0, notCitedQueries: 0, citedRate: 0, mentionedQueries: 0, notMentionedQueries: 0, mentionRate: 0 },
     providers: [],
     transitions: { since: null, gained: 0, lost: 0, emerging: 0 },
     scores: {

--- a/packages/contracts/src/composites.ts
+++ b/packages/contracts/src/composites.ts
@@ -11,6 +11,13 @@ export interface ProjectOverviewQueryCountsDto {
   citedQueries: number
   notCitedQueries: number
   citedRate: number
+  // Mention is a distinct signal from cited (see AGENTS.md "Vocabulary"): a
+  // query is `mentioned` when its brand/domain appears in the AI answer text
+  // (`answerMentioned`) on at least one snapshot — computed independently of
+  // `cited`, never derived from it. Mirrors the cited triplet above.
+  mentionedQueries: number
+  notMentionedQueries: number
+  mentionRate: number
 }
 
 export interface ProjectOverviewProviderEntryDto {


### PR DESCRIPTION
Polishes the portfolio overview rows — three changes plus a version bump.

- **Graph-first layout** — the trend sparkline now leads each row (moved to the first grid column) so the trend is the first thing scanned.
- **Real mention subtitle** — the "N of M queries mentioned across P providers" subtitle was fed the *cited* count. Added `mentionedQueries` / `notMentionedQueries` / `mentionRate` to the overview `queryCounts` (computed independently from `answerMentioned`, never derived from cited), pointed the subtitle at it, and mirrored a "Queries mentioned" line in `canonry overview` for CLI parity.
- **Dropped the "Answer visibility sweep · Completed" line** under Competitor Pressure (and its dead import).

Version bumped 4.68.0 → 4.69.0. Typecheck + lint clean; 1766 tests pass across the affected packages, including new tests asserting cited and mentioned are computed disjointly.