### PR TITLE
Swap portfolio headline metric from cited to mention

### DIFF
--- a/apps/web/src/build-dashboard.ts
+++ b/apps/web/src/build-dashboard.ts
@@ -628,9 +628,9 @@ export function buildPortfolioProject(data: ProjectData): PortfolioProjectVm {
   if (!overview) {
     return {
       project: dto,
-      visibilityScore: 0,
-      visibilityDelta: 'No data',
-      visibilityTone: 'neutral',
+      mentionScore: 0,
+      mentionDelta: 'No data',
+      mentionTone: 'neutral',
       lastRun: runItem,
       insight: 'No runs completed yet.',
       trend: [],
@@ -638,30 +638,32 @@ export function buildPortfolioProject(data: ProjectData): PortfolioProjectVm {
     }
   }
 
-  const visibility = overview.scores.visibility
-  // The visibility gauge's `value` is presentational ("67" or "No data");
+  // Mention Coverage is the headline portfolio metric (did the AI actually say
+  // the brand?), not the cited/source signal. Both ride on the overview; we
+  // read `mention`. The gauge's `value` is presentational ("67"/"No data");
   // `progress` is the same number as 0–100, so we read that for the score.
-  const visibilityScore = visibility.progress ?? 0
-  const cited = overview.queryCounts.citedQueries
+  const mention = overview.scores.mention
+  const mentionScore = mention.progress ?? 0
   const mentioned = overview.queryCounts.mentionedQueries
   const total = overview.queryCounts.totalQueries
   const providerCount = overview.providers.length
 
   return {
     project: dto,
-    visibilityScore,
-    visibilityDelta: total > 0 ? `${cited} of ${total} queries` : 'No data',
-    visibilityTone: visibility.tone as MetricTone,
-    providerCoverage: visibility.providerCoverage,
+    mentionScore,
+    mentionDelta: total > 0 ? `${mentioned} of ${total} queries` : 'No data',
+    mentionTone: mention.tone as MetricTone,
+    providerCoverage: mention.providerCoverage,
     lastRun: runItem,
-    // Subtitle reads the mention signal (answerMentioned), not cited — the
-    // word "mentioned" must be backed by mention data, not the cited count.
+    // Subtitle reads the mention signal (answerMentioned) — the word
+    // "mentioned" must be backed by mention data, not the cited count.
     insight: total > 0
       ? `${mentioned} of ${total} queries mentioned across ${providerCount} provider${providerCount === 1 ? '' : 's'}.`
       : 'No runs completed yet.',
-    // Cited-rate-over-time series (0–100, oldest→newest), computed server-side
-    // from runHistory — drives the per-project sparkline on the portfolio.
-    trend: visibility.trend ?? [],
+    // Mention-rate-over-time series (0–100, oldest→newest), computed
+    // server-side from runHistory — drives the per-project sparkline so the
+    // trend tracks the same signal as the headline number.
+    trend: mention.trend ?? [],
     competitorPressureLabel: overview.scores.competitorPressure.value,
   }
 }

--- a/apps/web/src/mock-data.ts
+++ b/apps/web/src/mock-data.ts
@@ -855,9 +855,9 @@ const baseDashboard: DashboardVm = {
     projects: [
       {
         project: projects[0],
-        visibilityScore: 61,
-        visibilityDelta: '-8 this week',
-        visibilityTone: 'caution',
+        mentionScore: 61,
+        mentionDelta: '-8 this week',
+        mentionTone: 'caution',
         lastRun: runCitypointVisibility,
         insight: 'Lost emergency-intent citations after competitors refreshed availability pages.',
         trend: [73, 71, 69, 66, 61],
@@ -865,9 +865,9 @@ const baseDashboard: DashboardVm = {
       },
       {
         project: projects[1],
-        visibilityScore: 74,
-        visibilityDelta: '+2 this week',
-        visibilityTone: 'positive',
+        mentionScore: 74,
+        mentionDelta: '+2 this week',
+        mentionTone: 'positive',
         lastRun: runHarborVisibility,
         insight: 'Practice-area consolidation is stabilizing branded and informational prompts.',
         trend: [68, 70, 71, 73, 74],
@@ -875,9 +875,9 @@ const baseDashboard: DashboardVm = {
       },
       {
         project: projects[2],
-        visibilityScore: 58,
-        visibilityDelta: 'Run in progress',
-        visibilityTone: 'caution',
+        mentionScore: 58,
+        mentionDelta: 'Run in progress',
+        mentionTone: 'caution',
         lastRun: runNorthstarVisibility,
         insight: 'Location pages are improving, but local treatment proof still trails competitors.',
         trend: [52, 54, 55, 57, 58],
@@ -1146,8 +1146,8 @@ export function createDashboardFixture(options: DashboardFixtureOptions = {}): D
     }
 
     if (portfolioProject) {
-      portfolioProject.visibilityScore = 49
-      portfolioProject.visibilityDelta = '-12 in 48h'
+      portfolioProject.mentionScore = 49
+      portfolioProject.mentionDelta = '-12 in 48h'
       portfolioProject.insight = 'Sharp citation drop detected; grounding now prefers competitors on multiple high-intent prompts.'
     }
   }

--- a/apps/web/src/pages/OverviewPage.tsx
+++ b/apps/web/src/pages/OverviewPage.tsx
@@ -37,9 +37,9 @@ function OverviewProjectCard({
       </div>
       <div className="project-row-stat">
         <div className="metric-inline-block">
-          <p className="metric-inline-label">Cited</p>
-          <p className={`metric-inline-value ${project.visibilityTone === 'caution' ? 'text-amber-400' : ''}`}>{project.visibilityScore}</p>
-          <p className="metric-inline-delta">{project.visibilityDelta}</p>
+          <p className="metric-inline-label">Mentioned</p>
+          <p className={`metric-inline-value ${project.mentionTone === 'caution' ? 'text-amber-400' : ''}`}>{project.mentionScore}</p>
+          <p className="metric-inline-delta">{project.mentionDelta}</p>
           {project.providerCoverage && <p className="text-[10px] font-medium text-amber-400/80">{project.providerCoverage}</p>}
         </div>
       </div>

--- a/apps/web/src/view-models.ts
+++ b/apps/web/src/view-models.ts
@@ -74,9 +74,11 @@ export interface RunListItemVm extends RunDto {
 
 export interface PortfolioProjectVm {
   project: ProjectDto
-  visibilityScore: number
-  visibilityDelta: string
-  visibilityTone: MetricTone
+  /** Headline metric — Mention Coverage (% of tracked queries whose AI answer
+   *  text mentioned the brand). This is the key portfolio metric, not cited. */
+  mentionScore: number
+  mentionDelta: string
+  mentionTone: MetricTone
   providerCoverage?: string
   lastRun: RunListItemVm
   insight: string

--- a/apps/web/test/build-dashboard.test.ts
+++ b/apps/web/test/build-dashboard.test.ts
@@ -1108,7 +1108,7 @@ test('buildProjectCommandCenter emits a single history-only row when no location
   expect(geminiRows).toHaveLength(2)
 })
 
-test('buildPortfolioProject carries the cited-rate trend and mention-count subtitle from the overview', () => {
+test('buildPortfolioProject carries the mention-rate trend, score, and subtitle from the overview', () => {
   const base: ProjectData = {
     project: {
       id: 'proj_portfolio',
@@ -1158,8 +1158,14 @@ test('buildPortfolioProject carries the cited-rate trend and mention-count subti
       providers: [{ provider: 'gemini', cited: 3, total: 4, citedRate: 0.75 }],
       transitions: { since: null, gained: 0, lost: 0, emerging: 0 },
       scores: {
-        // The server populates the visibility score's trend from runHistory.
+        // The server populates each headline score's trend from runHistory.
+        // Mention is the headline metric the portfolio row reads; give it a
+        // distinct trend + progress from visibility to prove the builder reads
+        // mention, not cited.
+        mention: { label: 'Mention Coverage', value: '60', delta: '3 of 4 queries mentioned', tone: 'positive', description: '', tooltip: '', trend: [40, 60, 80], progress: 60 },
         visibility: { label: 'Citation Coverage', value: '75', delta: '3 of 4 queries', tone: 'positive', description: '', tooltip: '', trend: [25, 50, 75], progress: 75 },
+        mentionShare: { label: 'Mention Share', value: 'No data', delta: '', tone: 'neutral', description: '', tooltip: '', trend: [], breakdown: { projectMentionSnapshots: 0, competitorMentionSnapshots: 0, perCompetitor: [], snapshotsWithAnswerText: 0, snapshotsTotal: 0 } },
+        mentionGaps: { label: 'Mention Gaps', value: '0', delta: '', tone: 'positive', description: '', tooltip: '', trend: [] },
         gapQueries: { label: 'Gap Queries', value: '0', delta: '', tone: 'positive', description: '', tooltip: '', trend: [] },
         indexCoverage: { label: 'Index Coverage', value: 'No data', delta: '', tone: 'neutral', description: '', tooltip: '', trend: [] },
         competitorPressure: { label: 'Competitor Pressure', value: 'None', delta: '', tone: 'neutral', description: '', tooltip: '', trend: [] },
@@ -1175,11 +1181,16 @@ test('buildPortfolioProject carries the cited-rate trend and mention-count subti
     },
   }
 
-  expect(buildPortfolioProject(base).trend).toEqual([25, 50, 75])
+  // The headline metric is Mention Coverage — the portfolio row reads the
+  // mention score + mention trend, NOT the cited/visibility ones. Mention's
+  // trend ([40,60,80]) and progress (60) differ from visibility's so this
+  // proves the builder switched signals.
+  expect(buildPortfolioProject(base).trend).toEqual([40, 60, 80])
+  expect(buildPortfolioProject(base).mentionScore).toBe(60)
 
-  // The subtitle ("N of M queries mentioned …") reads the MENTION count
+  // The headline delta + subtitle both read the MENTION count
   // (answerMentioned), never the cited count. Seed mentioned≠cited and prove
-  // the subtitle tracks mentioned while the cited block stays on cited.
+  // both track mentioned (1 of 4) rather than cited (3 of 4).
   const distinctMention = buildPortfolioProject({
     ...base,
     overview: {
@@ -1188,7 +1199,7 @@ test('buildPortfolioProject carries the cited-rate trend and mention-count subti
     },
   })
   expect(distinctMention.insight).toBe('1 of 4 queries mentioned across 1 provider.')
-  expect(distinctMention.visibilityDelta).toBe('3 of 4 queries')
+  expect(distinctMention.mentionDelta).toBe('1 of 4 queries')
 
   // Without an overview (no runs yet) the trend is empty and the sparkline no-ops.
   expect(buildPortfolioProject({ ...base, overview: null }).trend).toEqual([])

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.69.0",
+  "version": "4.69.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/composites.ts
+++ b/packages/api-routes/src/composites.ts
@@ -246,11 +246,13 @@ export async function compositeRoutes(app: FastifyInstance) {
       .slice(0, DEFAULT_RUN_HISTORY_LIMIT)
       .map(r => ({ id: r.id, createdAt: r.createdAt, status: r.status }))
     const runHistory: RunHistoryPointDto[] = buildRunHistory(sparklineRuns, snapshotsByRun)
-    // Surface the cited-rate-over-time series on the visibility score so the
-    // portfolio per-project sparkline (and `canonry overview --format json`)
-    // can render it. buildRunHistory is ascending (oldest→newest, 0–100), the
-    // order/scale the Sparkline expects. The pure buildVisibilityScore has no
-    // run history, so the cross-run trend is assembled here at the composite.
+    // Surface the over-time series on each headline score so the portfolio
+    // per-project sparkline (and `canonry overview --format json`) can render
+    // it. buildRunHistory is ascending (oldest→newest, 0–100), the order/scale
+    // the Sparkline expects. The pure score builders have no run history, so
+    // the cross-run trends are assembled here at the composite — each tracking
+    // its own signal (mention = answer-text, visibility = cited source).
+    scores.mention.trend = runHistory.map(p => p.mentionRate)
     scores.visibility.trend = runHistory.map(p => p.citationRate)
     const suggestedQueries: SuggestedQueriesSummaryDto = buildSuggestedQueriesFromGsc(
       app,

--- a/packages/api-routes/test/composites.test.ts
+++ b/packages/api-routes/test/composites.test.ts
@@ -264,10 +264,15 @@ describe('GET /api/v1/projects/:name/overview', () => {
     expect(body.runHistory).toHaveLength(2)
     expect(body.runHistory[0]?.citationRate).toBe(50) // previous run: A cited, B not
     expect(body.runHistory[1]?.citationRate).toBe(100) // latest run: both cited
+    // Mention is tracked per run independently: previous run had A mentioned
+    // (answerMentioned=true), B not → 50%; latest run had both mentioned → 100%.
+    expect(body.runHistory[0]?.mentionRate).toBe(50)
+    expect(body.runHistory[1]?.mentionRate).toBe(100)
 
-    // The visibility score carries the cited-rate-over-time series (the
-    // portfolio sparkline + `canonry overview` read it) — same ascending
+    // Each headline score carries its own over-time series (the portfolio
+    // sparkline + `canonry overview` read mention.trend now) — same ascending
     // 0–100 values as runHistory, derived from it.
+    expect(body.scores.mention.trend).toEqual([50, 100])
     expect(body.scores.visibility.trend).toEqual([50, 100])
 
     expect(body.dateRangeLabel).toBe('All time')

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.69.0",
+  "version": "4.69.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/contracts/src/composites.ts
+++ b/packages/contracts/src/composites.ts
@@ -157,12 +157,19 @@ export interface AttentionItemDto {
 
 // Per-run point used for sparklines in the overview. One entry per run in
 // the history window (newest first or oldest first — see endpoint docs).
+// Carries both signals per run (see AGENTS.md "Vocabulary"): `cited*` counts
+// queries whose answer cited the domain, `mentioned*` counts queries whose
+// answer text mentioned the brand. They are independent — never derive one
+// from the other — so the portfolio sparkline can track whichever the
+// headline metric uses.
 export interface RunHistoryPointDto {
   runId: string
   createdAt: string
   citedCount: number
   totalCount: number
   citationRate: number
+  mentionedCount: number
+  mentionRate: number
   status: string
 }
 

--- a/packages/intelligence/src/run-history.ts
+++ b/packages/intelligence/src/run-history.ts
@@ -9,18 +9,24 @@ export interface RunHistoryRun {
 export interface RunHistorySnapshot {
   queryId: string
   citationState: string
+  /** True when the project's brand or domain appeared in the AI answer text.
+   *  Optional so legacy callers that only track citations still compile; a
+   *  missing value counts as not-mentioned. */
+  answerMentioned?: boolean | null
 }
 
 export const DEFAULT_RUN_HISTORY_LIMIT = 12
 
 /**
- * Per-run citation rate sparkline data for the overview. Returns up to `limit`
- * most-recent runs in chronological order (oldest first), so consumers can
- * render a left-to-right trend chart without sorting.
+ * Per-run sparkline data for the overview. Returns up to `limit` most-recent
+ * runs in chronological order (oldest first), so consumers can render a
+ * left-to-right trend chart without sorting.
  *
- * Each point is computed at the *query* level: a query is "cited" for a run
- * if any snapshot in that run has citationState='cited'. Runs without any
- * snapshots produce a zero-rate point.
+ * Each point carries both signals, computed independently at the *query*
+ * level: a query is "cited" for a run if any snapshot in that run has
+ * citationState='cited', and "mentioned" if any snapshot has
+ * answerMentioned===true. The two are never derived from each other. Runs
+ * without any snapshots produce a zero-rate point.
  */
 export function buildRunHistory(
   runs: readonly RunHistoryRun[],
@@ -37,19 +43,26 @@ export function buildRunHistory(
   return recent.map(run => {
     const snapshots = snapshotsByRunId.get(run.id) ?? []
     const queryCited = new Map<string, boolean>()
+    const queryMentioned = new Map<string, boolean>()
     for (const snap of snapshots) {
       if (!queryCited.has(snap.queryId)) queryCited.set(snap.queryId, false)
       if (snap.citationState === CitationStates.cited) queryCited.set(snap.queryId, true)
+      if (!queryMentioned.has(snap.queryId)) queryMentioned.set(snap.queryId, false)
+      if (snap.answerMentioned === true) queryMentioned.set(snap.queryId, true)
     }
     const totalCount = queryCited.size
     const citedCount = [...queryCited.values()].filter(Boolean).length
     const citationRate = totalCount > 0 ? Math.round((citedCount / totalCount) * 100) : 0
+    const mentionedCount = [...queryMentioned.values()].filter(Boolean).length
+    const mentionRate = totalCount > 0 ? Math.round((mentionedCount / totalCount) * 100) : 0
     return {
       runId: run.id,
       createdAt: run.createdAt,
       citedCount,
       totalCount,
       citationRate,
+      mentionedCount,
+      mentionRate,
       status: run.status,
     }
   })

--- a/packages/intelligence/test/run-history.test.ts
+++ b/packages/intelligence/test/run-history.test.ts
@@ -10,8 +10,13 @@ function run(id: string, createdAt: string, status: string = 'completed'): RunHi
   return { id, createdAt, status }
 }
 
-function snap(_runId: string, queryId: string, citationState: string = 'cited'): RunHistorySnapshot {
-  return { queryId, citationState }
+function snap(
+  _runId: string,
+  queryId: string,
+  citationState: string = 'cited',
+  answerMentioned: boolean = false,
+): RunHistorySnapshot {
+  return { queryId, citationState, answerMentioned }
 }
 
 describe('buildRunHistory', () => {
@@ -21,7 +26,7 @@ describe('buildRunHistory', () => {
 
   it('returns one point per run with the correct fields', () => {
     const runs = [run('r1', '2026-01-01T00:00:00Z')]
-    const snapshots = new Map([['r1', [snap('r1', 'q1', 'cited')]]])
+    const snapshots = new Map([['r1', [snap('r1', 'q1', 'cited', true)]]])
     const result = buildRunHistory(runs, snapshots)
     expect(result).toEqual([
       {
@@ -30,6 +35,8 @@ describe('buildRunHistory', () => {
         citedCount: 1,
         totalCount: 1,
         citationRate: 100,
+        mentionedCount: 1,
+        mentionRate: 100,
         status: 'completed',
       },
     ])
@@ -77,6 +84,43 @@ describe('buildRunHistory', () => {
     expect(result[0]?.citationRate).toBe(100)
   })
 
+  it('treats a query as mentioned when ANY snapshot has answerMentioned, independent of cited', () => {
+    const runs = [run('r1', '2026-01-01T00:00:00Z')]
+    const snapshots = new Map([
+      ['r1', [
+        snap('r1', 'q1', 'not-cited', true),
+        snap('r1', 'q1', 'cited', false),
+      ]],
+    ])
+    const result = buildRunHistory(runs, snapshots)
+    expect(result[0]?.mentionedCount).toBe(1)
+    expect(result[0]?.mentionRate).toBe(100)
+    expect(result[0]?.citedCount).toBe(1)
+    expect(result[0]?.citationRate).toBe(100)
+  })
+
+  it('computes mention and cited rates independently across queries', () => {
+    const runs = [run('r1', '2026-01-01T00:00:00Z')]
+    // q1: cited but not mentioned. q2: mentioned but not cited. q3: cited but
+    // not mentioned. This drives the two signals to DIFFERENT values (cited
+    // 2/3, mentioned 1/3) so a regression that read mentioned off the cited
+    // map (or vice versa) can't hide behind a coincidentally-equal number.
+    const snapshots = new Map([
+      ['r1', [
+        snap('r1', 'q1', 'cited', false),
+        snap('r1', 'q2', 'not-cited', true),
+        snap('r1', 'q3', 'cited', false),
+      ]],
+    ])
+    const result = buildRunHistory(runs, snapshots)
+    // Cited: q1, q3 → 2/3 = 67%. Mentioned: q2 only → 1/3 = 33%.
+    expect(result[0]?.citedCount).toBe(2)
+    expect(result[0]?.mentionedCount).toBe(1)
+    expect(result[0]?.totalCount).toBe(3)
+    expect(result[0]?.citationRate).toBe(67)
+    expect(result[0]?.mentionRate).toBe(33)
+  })
+
   it('returns a zero-rate point for runs with no snapshots', () => {
     const runs = [run('r1', '2026-01-01T00:00:00Z')]
     const result = buildRunHistory(runs, new Map())
@@ -86,6 +130,8 @@ describe('buildRunHistory', () => {
       citedCount: 0,
       totalCount: 0,
       citationRate: 0,
+      mentionedCount: 0,
+      mentionRate: 0,
       status: 'completed',
     })
   })


### PR DESCRIPTION
The portfolio overview now leads with Mention Coverage — whether the AI named the brand in its answer text — instead of the cited/source signal.

- Adds per-run `mentionedCount`/`mentionRate` to `RunHistoryPointDto` and `buildRunHistory`, computed independently from the cited signal.
- Surfaces `scores.mention.trend` at the overview composite so the per-project sparkline tracks the same signal as the headline number.
- Renames the `PortfolioProjectVm` `visibility*` fields to `mention*` and relabels the overview card from "Cited" to "Mentioned".
- Updates tests (including a strengthened independence test that catches a cited/mention map swap) and bumps the version to 4.69.1.