### PR TITLE
feat(web): delete tracked queries from the dashboard

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -11,6 +11,7 @@ import {
   getApiV1ProjectsByNameQueries,
   putApiV1ProjectsByNameQueries,
   postApiV1ProjectsByNameQueries,
+  deleteApiV1ProjectsByNameQueries,
   postApiV1ProjectsByNameQueriesGenerate,
   postApiV1ProjectsByNameContentDismissals,
   deleteApiV1ProjectsByNameContentDismissalsByTargetRef,
@@ -521,6 +522,18 @@ export function setQueries(projectName: string, queries: string[]): Promise<ApiQ
 export function appendQueries(projectName: string, queries: string[]): Promise<ApiQuery[]> {
   return invokeWeb<ApiQuery[]>(() =>
     postApiV1ProjectsByNameQueries({ client: heyClient, path: { name: projectName }, body: { queries } }),
+  )
+}
+
+/**
+ * Stop tracking specific queries. `DELETE /projects/:name/queries` removes the
+ * named queries by text and returns the remaining set. The server preserves the
+ * deleted queries' text on their historical snapshots, so analytics history is
+ * not lost — only future tracking stops.
+ */
+export function removeQueries(projectName: string, queries: string[]): Promise<ApiQuery[]> {
+  return invokeWeb<ApiQuery[]>(() =>
+    deleteApiV1ProjectsByNameQueries({ client: heyClient, path: { name: projectName }, body: { queries } }),
   )
 }
 

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -36,6 +36,7 @@ import {
   fetchTimeline,
   deleteProject as apiDeleteProject,
   appendQueries as apiAppendQueries,
+  removeQueries as apiRemoveQueries,
   fetchCompetitors as apiFetchCompetitors,
   setCompetitors as apiSetCompetitors,
   removeCompetitors as apiRemoveCompetitors,
@@ -1445,9 +1446,10 @@ function ProjectPageContent({
   const gbpConnected = (gbpConnectionQuery.data ?? []).some((c) => c.connectionType === 'gbp')
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [deleting, setDeleting] = useState(false)
-  const [addingQueries, setAddingQueries] = useState(false)
+  const [managingQueries, setManagingQueries] = useState(false)
   const [newQueryText, setNewQueryText] = useState('')
   const [querySaving, setQuerySaving] = useState(false)
+  const [removingQuery, setRemovingQuery] = useState<string | null>(null)
   const [addingCompetitor, setAddingCompetitor] = useState(false)
   const [newCompetitorDomain, setNewCompetitorDomain] = useState('')
   const [competitorSaving, setCompetitorSaving] = useState(false)
@@ -1483,6 +1485,15 @@ function ProjectPageContent({
   )
   const locationLabelsInEvidence = useMemo(() => new Set(visibilityEvidence.map(e => e.location ?? '')), [visibilityEvidence])
   const hasNullLocationEvidence = locationLabelsInEvidence.has('')
+  // The authoritative tracked-query set — every query the project tracks,
+  // including ones added but not yet run (build-dashboard seeds a "pending"
+  // evidence row for those). This is the same source as the "N queries tracked"
+  // header count, so the manage list and the count never diverge. Sorted for a
+  // stable order in the manage panel.
+  const trackedQueries = useMemo(
+    () => [...new Set(visibilityEvidence.map(e => e.query))].sort((a, b) => a.localeCompare(b)),
+    [visibilityEvidence],
+  )
   const distinctLocationsForCompare = useMemo(() => {
     // "Compare" needs ≥2 locations with selectable data. Prefer evidence-backed
     // locations, but fall back to configured locations so a fresh project that
@@ -1623,9 +1634,26 @@ function ProjectPageContent({
       await apiAppendQueries(projectName, queries)
       void refetch()
       setNewQueryText('')
-      setAddingQueries(false)
     } finally {
       setQuerySaving(false)
+    }
+  }
+
+  async function handleRemoveQuery(query: string) {
+    setRemovingQuery(query)
+    try {
+      await apiRemoveQueries(projectName, [query])
+      void refetch()
+    } catch (err) {
+      addToast({
+        title: 'Could not remove query',
+        detail: err instanceof Error ? err.message : `Failed to remove "${query}"`,
+        tone: 'negative',
+        dedupeKey: 'query:remove',
+        dedupeMode: 'replace',
+      })
+    } finally {
+      setRemovingQuery(null)
     }
   }
 
@@ -2047,23 +2075,44 @@ function ProjectPageContent({
                 <h2>What the LLMs said</h2>
               </div>
               <div className="flex items-center gap-3">
-                <p className="supporting-copy">{new Set(model.visibilityEvidence.map(e => e.query)).size} queries tracked</p>
-                <Button type="button" variant="outline" size="sm" onClick={() => setAddingQueries(!addingQueries)}>
-                  {addingQueries ? 'Cancel' : '+ Add queries'}
+                <p className="supporting-copy">{trackedQueries.length} queries tracked</p>
+                <Button type="button" variant="outline" size="sm" onClick={() => setManagingQueries(!managingQueries)}>
+                  {managingQueries ? 'Done' : 'Manage queries'}
                 </Button>
               </div>
             </div>
-            {addingQueries && (
+            {managingQueries && (
               <div className="mb-3 rounded-lg border border-zinc-800 bg-zinc-900/40 p-3">
+                {trackedQueries.length > 0 ? (
+                  <ul className="mb-3 max-h-64 divide-y divide-zinc-800/60 overflow-y-auto rounded border border-zinc-800/60">
+                    {trackedQueries.map((q) => (
+                      <li key={q} className="flex items-center justify-between gap-3 px-3 py-2">
+                        <span className="min-w-0 truncate text-sm text-zinc-200" title={q}>{q}</span>
+                        <button
+                          type="button"
+                          className="shrink-0 rounded px-1.5 py-0.5 text-xs text-zinc-500 transition-colors hover:text-rose-400 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-rose-500 disabled:opacity-50"
+                          aria-label={`Remove query ${q}`}
+                          title={`Stop tracking "${q}"`}
+                          disabled={removingQuery !== null}
+                          onClick={() => { void handleRemoveQuery(q) }}
+                        >
+                          {removingQuery === q ? 'Removing…' : 'Remove'}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="mb-3 text-xs text-zinc-500">No queries tracked yet. Add some below.</p>
+                )}
                 <textarea
                   className="w-full resize-none rounded border border-zinc-700 bg-transparent px-2 py-1.5 text-sm text-zinc-200 placeholder-zinc-600 focus:border-zinc-500 focus:outline-none"
                   rows={3}
-                  placeholder="Enter queries, one per line"
+                  placeholder="Enter queries to add, one per line"
                   value={newQueryText}
                   onChange={(e) => setNewQueryText(e.target.value)}
                 />
                 <div className="mt-2 flex items-center justify-between">
-                  <p className="text-xs text-zinc-500">{newQueryText.split('\n').filter(k => k.trim()).length} queries</p>
+                  <p className="text-xs text-zinc-500">{newQueryText.split('\n').filter(k => k.trim()).length} to add</p>
                   <Button type="button" size="sm" disabled={!newQueryText.trim() || querySaving} onClick={asyncHandler(handleAddQueries)}>
                     {querySaving ? 'Adding...' : 'Add queries'}
                   </Button>

--- a/apps/web/test/remove-queries.test.ts
+++ b/apps/web/test/remove-queries.test.ts
@@ -1,0 +1,31 @@
+import { test, expect, onTestFinished, describe } from 'vitest'
+
+import { removeQueries } from '../src/api.js'
+import { mockFetch, pathOf, jsonResponse } from './mock-fetch.js'
+
+/**
+ * Contract for the `removeQueries` web wrapper, which backs the "Manage
+ * queries → Remove" affordance on the project page. It must issue a
+ * `DELETE /projects/:name/queries` with the query texts in the body and
+ * surface the server's remaining-queries response back to the caller.
+ */
+describe('removeQueries', () => {
+  test('issues DELETE /projects/:name/queries with the query texts and returns the remaining set', async () => {
+    let observed: { url: string; method?: string; body?: string } | undefined
+    const remaining = [{ id: 'q1', query: 'kept query', createdAt: '2026-06-03T00:00:00.000Z' }]
+    const restore = mockFetch((url, init) => {
+      observed = { url, method: init?.method, body: init?.body ? String(init.body) : undefined }
+      return jsonResponse(remaining)
+    })
+    onTestFinished(restore)
+
+    const result = await removeQueries('demo project', ['old query', 'stale query'])
+
+    expect(observed?.method).toBe('DELETE')
+    // Path param is URL-encoded by the generated SDK.
+    expect(pathOf(observed?.url ?? '')).toBe('/api/v1/projects/demo%20project/queries')
+    expect(JSON.parse(observed?.body ?? '{}')).toEqual({ queries: ['old query', 'stale query'] })
+    // The caller receives the server's remaining-queries payload verbatim.
+    expect(result).toEqual(remaining)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.69.3",
+  "version": "4.70.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.69.3",
+  "version": "4.70.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
Queries were add-only in the dashboard even though the `DELETE /queries` endpoint, the `canonry query remove` CLI, and the `canonry_queries_remove` MCP tool already shipped — this wires that existing capability into the SPA.

- The project page's "+ Add queries" affordance becomes a **Manage queries** panel: every tracked query is listed with an inline **Remove** button (delete → refetch → error toast), with the add textarea retained below.
- Backed by a new `removeQueries()` wrapper over the generated SDK (no raw fetch); the manage list reuses the same evidence-derived query set as the existing "N queries tracked" count, so they never diverge.
- Adds a wrapper contract test (asserts DELETE path + body + response) and bumps the package to 4.70.0.