### PR TITLE
fix(doctor): fail GSC property-access on siteUnverifiedUser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.70.0",
+  "version": "4.70.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/doctor/checks/google-auth.ts
+++ b/packages/api-routes/src/doctor/checks/google-auth.ts
@@ -194,6 +194,21 @@ const propertyAccessCheck: CheckDefinition = {
         },
       }
     }
+    if (match.permissionLevel === 'siteUnverifiedUser') {
+      return {
+        status: CheckStatuses.fail,
+        code: 'google.auth.property-unverified',
+        summary: `Selected property "${conn.propertyId}" is present but unverified (permission: siteUnverifiedUser); Search Console reads will 403.`,
+        remediation:
+          `Re-verify the property in Search Console for the authorizing account ` +
+          `(for a sc-domain property this is a google-site-verification DNS TXT record), ` +
+          `then re-run \`canonry google sync ${ctx.project.name}\`.`,
+        details: {
+          selectedProperty: conn.propertyId,
+          permissionLevel: match.permissionLevel,
+        },
+      }
+    }
     return {
       status: CheckStatuses.ok,
       code: 'google.auth.property-accessible',

--- a/packages/api-routes/test/doctor-google-auth.test.ts
+++ b/packages/api-routes/test/doctor-google-auth.test.ts
@@ -142,6 +142,30 @@ describe('google.auth.property-access', () => {
     expect(result.status).toBe('fail')
     expect(result.code).toBe('google.auth.principal-forbidden')
   })
+
+  it('returns property-unverified when the property is present but the account is an unverified user', async () => {
+    refreshAccessTokenMock.mockResolvedValue({ access_token: 'tok', expires_in: 3600 })
+    listSitesMock.mockResolvedValue([
+      { siteUrl: 'sc-domain:example.com', permissionLevel: 'siteUnverifiedUser' },
+    ])
+    const result = await check.run(ctx({}))
+    expect(result.status).toBe('fail')
+    expect(result.code).toBe('google.auth.property-unverified')
+    expect(result.details).toMatchObject({
+      selectedProperty: 'sc-domain:example.com',
+      permissionLevel: 'siteUnverifiedUser',
+    })
+  })
+
+  it('returns ok for a usable non-owner permission level (siteRestrictedUser)', async () => {
+    refreshAccessTokenMock.mockResolvedValue({ access_token: 'tok', expires_in: 3600 })
+    listSitesMock.mockResolvedValue([
+      { siteUrl: 'sc-domain:example.com', permissionLevel: 'siteRestrictedUser' },
+    ])
+    const result = await check.run(ctx({}))
+    expect(result.status).toBe('ok')
+    expect(result.code).toBe('google.auth.property-accessible')
+  })
 })
 
 describe('google.auth.redirect-uri', () => {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.70.0",
+  "version": "4.70.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Problem

`canonry doctor`'s `google.auth.property-access` check passed whenever the configured GSC property appeared in the authorized account's accessible-sites list. Google returns `siteUnverifiedUser` associations in that list too, so when an account loses verification on a property (for a `sc-domain:` property, the `google-site-verification` DNS TXT record is removed or changed), the check reported `Property "..." is accessible (permission: siteUnverifiedUser)` and stayed green.

The account cannot read data at that level, so every GSC sync 403s. The failure only surfaced in run history as a partial sync, never as a doctor finding, even though the check already had the permission level in hand.

## Fix

Gate on `match.permissionLevel`: a present property with `siteUnverifiedUser` now fails (`google.auth.property-unverified`) with a re-verify remediation. Usable levels (owner / full / restricted) still pass.

## Tests (TDD)

- Failing-first: property present but `siteUnverifiedUser` -> fail.
- Guard: a usable non-owner level (`siteRestrictedUser`) -> still ok.
- Full doctor suite green; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
