### PR TITLE
feat(web): default the trend chart to the by-engine view and clean up its UX

### DIFF
--- a/apps/web/src/components/project/VisibilityTrendSection.tsx
+++ b/apps/web/src/components/project/VisibilityTrendSection.tsx
@@ -6,14 +6,15 @@ import {
   CHART_AXIS_STROKE,
   CHART_AXIS_TICK,
   CHART_GRID_STROKE,
+  CHART_NEUTRAL,
   CHART_SERIES_COLORS,
   CHART_TONE,
   CHART_TOOLTIP_STYLE,
   ComposedChart,
   formatChartDateLabel,
   formatChartDateTick,
-  Legend,
   Line,
+  providerSeriesColor,
   RechartsTooltip,
   ResponsiveContainer,
   XAxis,
@@ -26,6 +27,7 @@ import {
   buildTrendRows,
   CITED_KEY,
   formatQueryChangeCaption,
+  latestSeriesValue,
   MENTIONED_KEY,
   type MetricChoice,
   type TrendSeriesMode,
@@ -38,8 +40,8 @@ const WINDOW_OPTIONS: Array<{ value: MetricsWindow; label: string }> = [
   { value: 'all', label: 'All' },
 ]
 const MODE_OPTIONS: Array<{ value: TrendSeriesMode; label: string }> = [
-  { value: 'overall', label: 'Overall' },
-  { value: 'byProvider', label: 'By provider' },
+  { value: 'byProvider', label: 'By engine' },
+  { value: 'overall', label: 'All engines' },
 ]
 const METRIC_OPTIONS: Array<{ value: MetricChoice; label: string }> = [
   { value: 'mentioned', label: 'Mentioned' },
@@ -48,6 +50,19 @@ const METRIC_OPTIONS: Array<{ value: MetricChoice; label: string }> = [
 
 /** Dark ring drawn around the active (hovered) dot so it reads against the line. */
 const ACTIVE_DOT_RING = '#18181b'
+
+/** Human-friendly engine names for the legend and tooltip (data keys are lowercase). */
+const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
+  claude: 'Claude',
+  openai: 'OpenAI',
+  gemini: 'Gemini',
+  perplexity: 'Perplexity',
+  local: 'Local',
+}
+
+function providerDisplayName(name: string): string {
+  return PROVIDER_DISPLAY_NAMES[name] ?? name.charAt(0).toUpperCase() + name.slice(1)
+}
 
 function round1(n: number): number {
   return Math.round(n * 10) / 10
@@ -60,13 +75,13 @@ function isOverallSeries(key: string): boolean {
 function seriesLabel(key: string): string {
   if (key === CITED_KEY) return 'Cited'
   if (key === MENTIONED_KEY) return 'Mentioned'
-  return key
+  return providerDisplayName(key)
 }
 
 function seriesColor(key: string, index: number): string {
   if (key === CITED_KEY) return CHART_TONE.positive // emerald
-  if (key === MENTIONED_KEY) return CHART_SERIES_COLORS[1] // blue
-  return CHART_SERIES_COLORS[index % CHART_SERIES_COLORS.length]
+  if (key === MENTIONED_KEY) return CHART_SERIES_COLORS[1]! // blue
+  return providerSeriesColor(key, index)
 }
 
 /**
@@ -110,7 +125,10 @@ function Segmented<T extends string>({
 export function VisibilityTrendSection({ projectName }: { projectName: string }) {
   const [window, setWindow] = useState<MetricsWindow>('all')
   const [metric, setMetric] = useState<MetricChoice>('mentioned')
-  const [mode, setMode] = useState<TrendSeriesMode>('overall')
+  // Default to the per-engine breakdown: the blended line hides that engines
+  // disagree wildly (a brand cited heavily by one engine and ignored by
+  // another), which is the first thing an operator needs to see.
+  const [mode, setMode] = useState<TrendSeriesMode>('byProvider')
 
   const metricsQuery = useQuery({
     queryKey: ['analytics-metrics', projectName, window],
@@ -125,9 +143,14 @@ export function VisibilityTrendSection({ projectName }: { projectName: string })
   // Headline readout: the selected metric's latest bucket value plus its change
   // across the visible window. Quantifies "where it sits now, which way it
   // moved" without reusing the removed trend badges.
+  const byProviderMode = mode === 'byProvider'
   const metricField = metric === 'cited' ? 'citationRate' : 'mentionRate'
   const metricLabel = metric === 'cited' ? 'Cited' : 'Mentioned'
-  const metricColor = metric === 'cited' ? CHART_TONE.positive : CHART_SERIES_COLORS[1]
+  const metricColor = metric === 'cited' ? CHART_TONE.positive : CHART_SERIES_COLORS[1]!
+  // In by-engine mode the headline is the blended rate across every engine,
+  // which no single line on the chart matches — neutralize the swatch (so it
+  // doesn't read as one engine's color) and tag it "avg".
+  const headlineDotColor = byProviderMode ? CHART_NEUTRAL.textDim : metricColor
   const buckets = data?.buckets ?? []
   const latestPct = buckets.length > 0 ? round1(buckets[buckets.length - 1]![metricField] * 100) : null
   const firstPct = buckets.length > 0 ? round1(buckets[0]![metricField] * 100) : null
@@ -145,8 +168,9 @@ export function VisibilityTrendSection({ projectName }: { projectName: string })
         </div>
         {latestPct !== null && (
           <div className="visibility-trend-current">
-            <span className="visibility-trend-current-dot" style={{ backgroundColor: metricColor }} aria-hidden="true" />
+            <span className="visibility-trend-current-dot" style={{ backgroundColor: headlineDotColor }} aria-hidden="true" />
             <span className="visibility-trend-current-label">{metricLabel}</span>
+            {byProviderMode && <span className="visibility-trend-current-qualifier">avg</span>}
             <span className="visibility-trend-current-value">{latestPct}%</span>
             {deltaPts !== null && (
               <span
@@ -185,7 +209,7 @@ export function VisibilityTrendSection({ projectName }: { projectName: string })
     } else if (mode === 'byProvider' && series.length === 0) {
       body = (
         <p className="text-sm text-zinc-400">
-          No per-provider breakdown for this data yet. Switch to <span className="text-zinc-200">Overall</span> to see the trend.
+          No per-engine breakdown for this data yet. Switch to <span className="text-zinc-200">All engines</span> to see the trend.
         </p>
       )
     } else {
@@ -195,6 +219,27 @@ export function VisibilityTrendSection({ projectName }: { projectName: string })
       body = (
         <>
           <p className="sr-only">{srSummary}</p>
+          {/* Per-engine key with each line's most recent value, so the engines
+              and where they sit now are readable at a glance — replaces the
+              cramped bottom legend and gives the by-engine view its payoff. */}
+          {mode === 'byProvider' && series.length > 0 && (
+            <ul className="trend-legend" aria-label="Engines">
+              {series.map((key, i) => {
+                const value = latestSeriesValue(rows, key)
+                return (
+                  <li key={key} className="trend-legend-item">
+                    <span
+                      className="trend-legend-swatch"
+                      style={{ backgroundColor: seriesColor(key, i) }}
+                      aria-hidden="true"
+                    />
+                    <span className="trend-legend-name">{seriesLabel(key)}</span>
+                    {value !== null && <span className="trend-legend-value">{value}%</span>}
+                  </li>
+                )
+              })}
+            </ul>
+          )}
           <div className="visibility-trend-chart">
             <ResponsiveContainer width="100%" height="100%">
               <ComposedChart data={rows} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
@@ -222,12 +267,6 @@ export function VisibilityTrendSection({ projectName }: { projectName: string })
                   labelFormatter={formatChartDateLabel}
                   formatter={(value, name) => [value == null ? 'no data' : `${value}%`, seriesLabel(String(name))]}
                 />
-                {mode === 'byProvider' && (
-                  <Legend
-                    wrapperStyle={{ fontSize: 11, color: CHART_AXIS_TICK.fill }}
-                    formatter={(value: string) => seriesLabel(value)}
-                  />
-                )}
                 {series.map((key, i) => (
                   <Line
                     key={key}
@@ -235,7 +274,7 @@ export function VisibilityTrendSection({ projectName }: { projectName: string })
                     dataKey={key}
                     name={key}
                     stroke={seriesColor(key, i)}
-                    strokeWidth={isOverallSeries(key) ? 2.5 : 1.5}
+                    strokeWidth={isOverallSeries(key) ? 2.5 : 2}
                     // A solid marker on every run/bucket point so the readings are visible.
                     dot={{ r: 2.5, fill: seriesColor(key, i), strokeWidth: 0 }}
                     activeDot={{ r: 4, strokeWidth: 2, stroke: ACTIVE_DOT_RING }}

--- a/apps/web/src/components/shared/ChartPrimitives.tsx
+++ b/apps/web/src/components/shared/ChartPrimitives.tsx
@@ -77,6 +77,26 @@ export const CHART_SERIES_COLORS = [
 ] as const
 
 /**
+ * Stable per-engine line colors. Aligned with the `ProviderBadge` identity
+ * (gemini = blue, openai = green, claude = amber/orange, perplexity =
+ * teal/cyan, local = violet) and drawn from `CHART_SERIES_COLORS` so a given
+ * engine reads as the SAME color in every chart, badge, and legend across the
+ * dashboard. Unknown engines fall back to the positional palette.
+ */
+export const PROVIDER_SERIES_COLORS: Record<string, string> = {
+  gemini: '#60a5fa', // blue-400
+  openai: '#34d399', // emerald-400
+  claude: '#fb923c', // orange-400
+  perplexity: '#22d3ee', // cyan-400
+  local: '#a78bfa', // violet-400
+}
+
+/** Color for an engine's line/legend swatch — stable map first, palette fallback. */
+export function providerSeriesColor(provider: string, fallbackIndex = 0): string {
+  return PROVIDER_SERIES_COLORS[provider] ?? CHART_SERIES_COLORS[fallbackIndex % CHART_SERIES_COLORS.length]!
+}
+
+/**
  * Neutral color tokens for custom SVG visualizations (non-Recharts).
  * Mirrors the dashboard's zinc neutral ramp so custom charts stay on
  * the documented palette in DESIGN.md.

--- a/apps/web/src/lib/visibility-trend-helpers.ts
+++ b/apps/web/src/lib/visibility-trend-helpers.ts
@@ -74,6 +74,21 @@ export function buildTrendRows(
   return { rows, series, hasData, singleBucket }
 }
 
+/**
+ * The most recent plotted value for a series — the value at the right end of
+ * its line. A direct read of the rows the chart already draws (skips the
+ * trailing `null`s `connectNulls` bridges over), used to label the per-engine
+ * legend without recomputing any rate. Returns null when the series never
+ * appears.
+ */
+export function latestSeriesValue(rows: TrendRow[], key: string): number | null {
+  for (let i = rows.length - 1; i >= 0; i--) {
+    const v = rows[i]![key]
+    if (typeof v === 'number' && Number.isFinite(v)) return v
+  }
+  return null
+}
+
 /** Map an API trend direction to a design-system tone. */
 export function trendToTone(direction: TrendDirection): MetricTone {
   switch (direction) {

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -2208,7 +2208,7 @@ function ProjectPageContent({
               <div className="section-head section-head-inline">
                 <div>
                   <p className="eyebrow eyebrow-soft">Model breakdown</p>
-                  <h2>Visibility by model <InfoTooltip text="Per-model citation rate today. Same query set, different LLMs — gaps between providers point at content / source issues, not the metric. The trend over time is in the chart above (switch it to By provider)." /></h2>
+                  <h2>Visibility by model <InfoTooltip text="Per-model citation rate today. Same query set, different LLMs — gaps between providers point at content / source issues, not the metric. The trend over time is in the chart above (the By engine view)." /></h2>
                 </div>
               </div>
               <div className="evidence-table-wrap">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -544,6 +544,12 @@
     @apply text-[11px] font-medium uppercase tracking-wide text-zinc-400;
   }
 
+  /* "avg" tag shown beside the headline in by-engine mode — the headline is the
+     blended rate across engines, not any single line on the chart. */
+  .visibility-trend-current-qualifier {
+    @apply rounded bg-zinc-800/80 px-1 py-px text-[10px] font-medium uppercase tracking-wide text-zinc-500;
+  }
+
   .visibility-trend-current-value {
     @apply text-2xl font-semibold tabular-nums tracking-tight text-zinc-50;
   }
@@ -562,6 +568,28 @@
 
   .visibility-trend-note {
     @apply mt-2 text-[11px] text-zinc-400;
+  }
+
+  /* Per-engine legend with live values, above the chart. Line-shaped swatches
+     (not dots) so each entry reads as the series it labels. */
+  .trend-legend {
+    @apply mb-2.5 flex flex-wrap items-center gap-x-4 gap-y-1.5;
+  }
+
+  .trend-legend-item {
+    @apply inline-flex items-center gap-1.5;
+  }
+
+  .trend-legend-swatch {
+    @apply h-[3px] w-3.5 shrink-0 rounded-full;
+  }
+
+  .trend-legend-name {
+    @apply text-[11px] font-medium text-zinc-300;
+  }
+
+  .trend-legend-value {
+    @apply text-[11px] font-semibold tabular-nums text-zinc-50;
   }
 
   /* Segmented control: an inset track with a raised selected chip. Used for the

--- a/apps/web/test/visibility-trend-helpers.test.ts
+++ b/apps/web/test/visibility-trend-helpers.test.ts
@@ -4,6 +4,7 @@ import {
   buildTrendRows,
   trendToTone,
   formatQueryChangeCaption,
+  latestSeriesValue,
   CITED_KEY,
   MENTIONED_KEY,
 } from '../src/lib/visibility-trend-helpers.js'
@@ -122,6 +123,38 @@ describe('buildTrendRows — data flags', () => {
     const res = buildTrendRows(dto([bucket('2026-04-01', { gemini: provider(0.5, 0.5) })]), 'cited', 'overall')
     expect(res.hasData).toBe(true)
     expect(res.singleBucket).toBe(true)
+  })
+})
+
+describe('latestSeriesValue', () => {
+  it('returns the most recent plotted value (right end of the line)', () => {
+    const d = dto([
+      bucket('2026-04-01', { gemini: provider(0.25, 0.1), openai: provider(0.5, 0.4) }),
+      bucket('2026-04-08', { gemini: provider(0.75, 0.5) }),
+    ])
+    const { rows } = buildTrendRows(d, 'cited', 'byProvider')
+    // gemini is in both buckets → its latest cited value is bucket 2 (75).
+    expect(latestSeriesValue(rows, 'gemini')).toBe(75)
+  })
+
+  it('skips trailing nulls so the value matches the visible line end', () => {
+    const d = dto([
+      bucket('2026-04-01', { openai: provider(0.5, 0.4) }),
+      bucket('2026-04-08', { gemini: provider(0.75, 0.5) }),
+    ])
+    const { rows } = buildTrendRows(d, 'cited', 'byProvider')
+    // openai only has data in bucket 1; bucket 2 is null. Latest = 50, not null.
+    expect(latestSeriesValue(rows, 'openai')).toBe(50)
+  })
+
+  it('returns null for a series that never appears', () => {
+    const d = dto([bucket('2026-04-01', { gemini: provider(0.5, 0.5) })])
+    const { rows } = buildTrendRows(d, 'cited', 'byProvider')
+    expect(latestSeriesValue(rows, 'claude')).toBeNull()
+  })
+
+  it('returns null for empty rows', () => {
+    expect(latestSeriesValue([], 'gemini')).toBeNull()
   })
 })
 

--- a/apps/web/test/visibility-trend-section.test.tsx
+++ b/apps/web/test/visibility-trend-section.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, expect, onTestFinished, test, vi } from 'vitest'
-import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 
 afterEach(cleanup)
 
@@ -68,7 +68,7 @@ function renderSection() {
   )
 }
 
-test('renders header, control toggles, and trend badges from the DTO', async () => {
+test('defaults to the by-engine view with a per-engine legend, and toggles to all-engines', async () => {
   const restore = mockFetch((url) => {
     const path = url.split('?')[0]!
     if (path.endsWith('/projects/test-project/analytics/metrics')) {
@@ -78,29 +78,45 @@ test('renders header, control toggles, and trend badges from the DTO', async () 
   })
   onTestFinished(restore)
 
-  const { container } = renderSection()
+  renderSection()
 
   expect(screen.getByText('Citations & mentions over time')).toBeTruthy()
 
-  // Chart renders once the DTO has loaded — wait on it.
-  await waitFor(() => {
-    expect(container.querySelector('.visibility-trend-chart')).toBeTruthy()
-  })
+  // The legend only renders once the DTO has loaded (and only in by-engine
+  // mode) — wait on it rather than the chart skeleton, which shares the
+  // `.visibility-trend-chart` class.
+  const legend = await screen.findByRole('list', { name: 'Engines' })
 
   // Segmented controls are toggle buttons (aria-pressed). Metric is Cited /
   // Mentioned (no "Both"); Mentioned is the default.
   expect(screen.queryByRole('button', { name: 'Both' })).toBeNull()
   expect(screen.getByRole('button', { name: 'Cited' })).toBeTruthy()
   expect(screen.getByRole('button', { name: 'Mentioned' }).getAttribute('aria-pressed')).toBe('true')
-  expect(screen.getByRole('button', { name: 'Overall' })).toBeTruthy()
-  expect(screen.getByRole('button', { name: 'By provider' })).toBeTruthy()
+
+  // By engine is the default breakdown; All engines is the other mode.
+  const byEngine = screen.getByRole('button', { name: 'By engine' })
+  const allEngines = screen.getByRole('button', { name: 'All engines' })
+  expect(byEngine.getAttribute('aria-pressed')).toBe('true')
+  expect(allEngines.getAttribute('aria-pressed')).toBe('false')
   expect(screen.getByRole('button', { name: 'All' })).toBeTruthy()
 
-  // Switching to By provider presses it (no refetch).
-  const byProvider = screen.getByRole('button', { name: 'By provider' })
-  expect(byProvider.getAttribute('aria-pressed')).toBe('false')
-  act(() => { fireEvent.click(byProvider) })
-  expect(byProvider.getAttribute('aria-pressed')).toBe('true')
+  // The headline is the blended average across engines, tagged "avg".
+  expect(screen.getByText('avg')).toBeTruthy()
+
+  // The legend lists each engine with its latest value (a direct read of the
+  // rightmost plotted point — gemini 50% in both buckets, openai 25% then gone).
+  expect(within(legend).getByText('Gemini')).toBeTruthy()
+  expect(within(legend).getByText('OpenAI')).toBeTruthy()
+  expect(within(legend).getByText('50%')).toBeTruthy()
+  expect(within(legend).getByText('25%')).toBeTruthy()
+
+  // Switching to All engines presses it (no refetch) and drops the per-engine
+  // legend + "avg" tag — the headline now matches the single plotted line.
+  act(() => { fireEvent.click(allEngines) })
+  expect(allEngines.getAttribute('aria-pressed')).toBe('true')
+  expect(byEngine.getAttribute('aria-pressed')).toBe('false')
+  expect(screen.queryByRole('list', { name: 'Engines' })).toBeNull()
+  expect(screen.queryByText('avg')).toBeNull()
 })
 
 test('shows an empty state when there are no buckets yet', async () => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.70.1",
+  "version": "4.71.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.70.1",
+  "version": "4.71.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
Defaults the "Citations & mentions over time" chart to **By engine + Mentioned** (was All engines), because the blended line hides how widely engines disagree — the first thing an operator needs to see. The by-engine view also gets a UX pass:

- **Stable per-engine colors** matched to the existing ProviderBadge identity (Gemini=blue, OpenAI=green, Claude=orange, Perplexity=cyan) — one color per engine across the dashboard, not the old positional palette.
- **A top legend that doubles as a readout** — each engine in its line color with its current value — replacing the cramped, value-less bottom legend.
- **A neutral swatch + "avg" tag** on the blended headline (which matched none of the plotted lines), plus clearer labels ("All engines / By engine"), nicer engine names, and heavier lines.

No new computed metrics — the legend surfaces values already in the API's per-bucket `byProvider`, so CLI/agent parity holds; bumps to 4.71.0.
