### PR TITLE
fix(vercel): drain starts at a small sub-window so a dense backlog can't wedge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.72.0",
+  "version": "4.72.2",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.72.0",
+  "version": "4.72.2",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/integration-vercel/AGENTS.md
+++ b/packages/integration-vercel/AGENTS.md
@@ -36,8 +36,15 @@ with **no in-app instrumentation** required on the user's Vercel project.
 - **Adaptive sub-window drain.** Page-number pagination has no resumable
   cursor, so a window denser than the page budget cannot be pulled in one
   pass. `drainVercelTrafficEvents` narrows the window into adaptive time
-  slices: it halves the span on page-budget overflow and generally doubles
+  slices: it **starts at a small `INITIAL_SUB_WINDOW_MS = 5min` span** (not the
+  full window), halves the span on page-budget overflow, and generally doubles
   back up after a clean slice, with `eventId` dedup across slice boundaries.
+  Starting small matters under the wall-clock `deadlineMs`: opening at the full
+  span means the first pulls are whole-window overflow pulls that exhaust the
+  page budget without completing a sub-window, so a dense multi-hour backlog can
+  burn the entire deadline with ZERO cursor progress and wedge permanently
+  (every retry re-hits the same window). A small first span completes fast, the
+  cursor advances, and partial progress is committed and resumed next run.
   The bisection floor is **one second** (`MIN_SUB_WINDOW_MS = 1_000`), small
   enough to drain real-world burst minutes (sites routinely hit 1000+ log
   pages in a single minute) without escalating to the floor-budget re-pull. A

--- a/packages/integration-vercel/src/drain.ts
+++ b/packages/integration-vercel/src/drain.ts
@@ -17,6 +17,21 @@ import type { ListVercelTrafficEventsOptions, VercelTrafficEventsPage } from './
 const MIN_SUB_WINDOW_MS = 1_000
 
 /**
+ * The span the drain STARTS each window at (and resets to after a retention
+ * clamp), instead of beginning at the full window width. Starting at the full
+ * span means the first pulls are whole-window overflow pulls that exhaust the
+ * entire `pagesPerSubWindow` budget (50 slow pages) before the span has been
+ * halved down to something drainable, so for a dense multi-hour backlog the
+ * drain can burn its whole wall-clock budget WITHOUT completing a single
+ * sub-window: zero cursor progress, and (because the deadline then commits
+ * nothing) the source wedges permanently as every retry re-hits the same
+ * window. Starting small bounds the first pull to a few pages so it completes
+ * fast and the cursor advances; the span doubles back up on clean drains, so a
+ * sparse window still drains in O(log) pulls.
+ */
+const INITIAL_SUB_WINDOW_MS = 5 * 60_000
+
+/**
  * Page budget for a re-pull of a floor-width slice (`MIN_SUB_WINDOW_MS`). When
  * even the floor slice overflows the caller's normal `pagesPerSubWindow`
  * budget, the drain cannot subdivide time any further, so it re-pulls that one
@@ -255,7 +270,9 @@ export async function drainVercelTrafficEvents(
   }
 
   let cursorMs = startMs
-  let spanMs = endMs - startMs
+  // Start small (not the full window) so the first pull completes and advances
+  // the cursor even on a dense multi-hour backlog. See INITIAL_SUB_WINDOW_MS.
+  let spanMs = Math.min(endMs - startMs, INITIAL_SUB_WINDOW_MS)
   let subWindowCount = 0
   let effectiveStartMs = startMs
   let retentionClamped = false
@@ -307,7 +324,9 @@ export async function drainVercelTrafficEvents(
         retentionClamped = retainedStartMs > cursorMs
         cursorMs = retainedStartMs
         effectiveStartMs = retainedStartMs
-        spanMs = Math.max(endMs - cursorMs, MIN_SUB_WINDOW_MS)
+        // Resume small (not the full remaining window) for the same reason the
+        // initial span is capped: keep the first post-clamp pull drainable.
+        spanMs = Math.max(Math.min(endMs - cursorMs, INITIAL_SUB_WINDOW_MS), MIN_SUB_WINDOW_MS)
         continue
       }
       throw error

--- a/packages/integration-vercel/test/drain.test.ts
+++ b/packages/integration-vercel/test/drain.test.ts
@@ -69,7 +69,7 @@ describe('drainVercelTrafficEvents', () => {
     expect(pull).not.toHaveBeenCalled()
   })
 
-  test('drains a window that fits in a single pull', async () => {
+  test('drains a sparse window cleanly, deduping repeated events across sub-windows', async () => {
     const events = [makeEvent('a'), makeEvent('b')]
     const pull = vi.fn(async () => page(events, false))
     const result = await drainVercelTrafficEvents({
@@ -78,14 +78,18 @@ describe('drainVercelTrafficEvents', () => {
       startDate: 0,
       endDate: 4 * HOUR,
     })
+    // Start-small opens at the 5-min initial span and grows, so a sparse 4h
+    // window drains across a few growing sub-windows (not one full-span pull);
+    // the same two events repeat and are deduped by eventId.
     expect(result.events).toEqual(events)
-    expect(result.subWindowCount).toBe(1)
-    expect(pull).toHaveBeenCalledTimes(1)
+    expect(result.drainedThroughMs).toBe(4 * HOUR)
+    expect(result.subWindowCount).toBeGreaterThan(0)
   })
 
-  test('sub-divides a window that overflows the page budget', async () => {
-    // Any slice longer than one hour overflows; shorter slices drain cleanly,
-    // each emitting one event keyed to its start.
+  test('sub-divides when a span overflows the page budget and still fully drains', async () => {
+    // Any slice longer than one hour overflows; shorter slices drain one event
+    // keyed to their start. Start-small opens at 5 min and grows, so subdivision
+    // kicks in once the growing span overshoots an hour; the whole window drains.
     const pull = vi.fn(async (o: ListVercelTrafficEventsOptions) => {
       const span = Number(o.endDate) - Number(o.startDate)
       if (span > HOUR) return page([], true)
@@ -97,10 +101,10 @@ describe('drainVercelTrafficEvents', () => {
       startDate: 0,
       endDate: 4 * HOUR,
     })
-    expect(result.events.map((e) => e.eventId).sort()).toEqual(
-      [`ev-0`, `ev-${HOUR}`, `ev-${2 * HOUR}`, `ev-${3 * HOUR}`].sort(),
-    )
     expect(result.subWindowCount).toBeGreaterThan(4)
+    expect(result.drainedThroughMs).toBe(4 * HOUR)
+    expect(result.events.length).toBeGreaterThan(1)
+    expect(result.events.map((e) => e.eventId)).toContain('ev-0')
   })
 
   test('deduplicates events shared across adjacent sub-windows', async () => {
@@ -291,8 +295,10 @@ describe('drainVercelTrafficEvents', () => {
     // Clamped onto the servable side, within one tolerance step of the boundary.
     expect(result.effectiveStartMs).toBeGreaterThanOrEqual(RETENTION_BOUNDARY)
     expect(result.effectiveStartMs).toBeLessThan(RETENTION_BOUNDARY + HOUR)
-    // The drained window starts at the clamped start, not the requested 0.
-    expect(result.events).toHaveLength(1)
+    // Drained from the clamped start forward; start-small slices the post-clamp
+    // window into several events, the first sitting at the clamp boundary, not 0.
+    expect(result.events.length).toBeGreaterThan(0)
+    expect(result.drainedThroughMs).toBe(100 * HOUR)
     expect(result.events[0].eventId).toBe(`ev-${result.effectiveStartMs}`)
   })
 
@@ -308,8 +314,10 @@ describe('drainVercelTrafficEvents', () => {
     expect(result.retentionClamped).toBe(false)
     expect(result.effectiveStartMs).toBe(5_000)
     expect(result.events).toEqual(events)
-    // No retention probe on the happy path — the first pull is the only call.
-    expect(pull).toHaveBeenCalledTimes(1)
+    expect(result.drainedThroughMs).toBe(5_000 + 4 * HOUR)
+    // Happy path: every pull is a normal forward pull; no retention probe fired
+    // (retentionClamped stays false). Start-small means several such pulls, not one.
+    expect(pull.mock.calls.every(([o]) => Number(o.startDate) >= 5_000)).toBe(true)
   })
 
   test('rethrows a non-retention 400 instead of clamping', async () => {
@@ -388,6 +396,35 @@ describe('drainVercelTrafficEvents', () => {
     expect(result.deadlineReached).toBe(true)
     expect(result.drainedThroughMs).toBeGreaterThan(0) // made progress
     expect(result.drainedThroughMs).toBeLessThan(100 * HOUR) // but did not finish
+    expect(result.events.length).toBeGreaterThan(0)
+  })
+
+  test('start-small makes forward progress on a dense backlog instead of wedging', async () => {
+    // The gjelina wedge: a dense multi-hour backlog where every span wider than a
+    // minute overflows the page budget. Opening at the full window would spend the
+    // whole deadline halving a 24h span without ever completing a sub-window (zero
+    // progress, permanent wedge). Starting at the 5-min initial span, the drain
+    // reaches a drainable slice within a few pulls and the cursor advances.
+    const pull = vi.fn(async (o: ListVercelTrafficEventsOptions) => {
+      const span = Number(o.endDate) - Number(o.startDate)
+      if (span > MINUTE) return page([], true)
+      return page([makeEvent(`ev-${Number(o.startDate)}`)], false)
+    })
+    let tick = 0
+    const result = await drainVercelTrafficEvents({
+      ...baseOptions,
+      pull,
+      startDate: 0,
+      endDate: 24 * HOUR,
+      deadlineMs: 8, // trips after a handful of loop checks
+      now: () => (tick += 1),
+    })
+    expect(result.deadlineReached).toBe(true)
+    // The first pull span is the 5-min initial cap, not the full 24h window.
+    const firstSpan = Number(pull.mock.calls[0][0].endDate) - Number(pull.mock.calls[0][0].startDate)
+    expect(firstSpan).toBeLessThanOrEqual(5 * MINUTE)
+    // Progress was made before the deadline (the old full-window start would be 0).
+    expect(result.drainedThroughMs).toBeGreaterThan(0)
     expect(result.events.length).toBeGreaterThan(0)
   })
 })


### PR DESCRIPTION
## Problem

A Vercel traffic source on a dense multi-hour backlog (watermark frozen after a transient failure) could fail **every** sync with `exceeded its drain budget without completing any sub-window` and never recover.

The drain opened each window at the **full span** and halved down on overflow. For a dense backlog those first pulls are whole-window overflow pulls that exhaust the page budget (up to 50 slow `request-logs` pages each) *before* the span is small enough to drain. So the wall-clock deadline (#681) could elapse without a single sub-window completing → **zero cursor progress** → the deadline commits nothing → every scheduled retry re-hit the same (growing) window. Permanent wedge.

Reproduced on a production source: a 16h backlog, with the `request-logs` endpoint paging at ~2–13s per 50-row page, so one 50-page sub-window pull alone can exceed the 4-min budget.

## Fix

Start the drain at **`INITIAL_SUB_WINDOW_MS = 5min`** (and resume small after a retention clamp) instead of the full window:

```
before:  span = full window  → first pulls are 24h/12h/6h… overflow slogs → 0 progress
after:   span = min(window, 5min) → first pull is a few pages → completes → cursor advances
         span then doubles back up on clean drains (sparse windows still O(log) pulls)
```

Dense backlogs now make **partial forward progress every run** (committed via the existing deadline/`drainedThroughMs` path) and converge over a few syncs instead of wedging. This is the durable complement to **#681** (which added the deadline + progress-preservation but only helps once at least one sub-window completes).

No API surface change (internal drain logic), so no SDK regen. Patch bump 4.72.0 → 4.72.2 (stacks after #685's 4.72.1).

## Tests

`integration-vercel` (36) + `api-routes` traffic (98) green; typecheck + lint clean. Adds a regression proving a dense **24h** backlog makes forward progress under a tight deadline (the old full-window start would be zero progress there), and the first pull span is bounded by the 5-min cap. The four sparse-window drain tests were reframed to assert outcomes (events drained, `drainedThroughMs`) rather than exact pull counts, since start-small intentionally drains a sparse window across a few growing sub-windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
