### PR TITLE
feat(doctor): warn that WordPress traffic capture misses cache-served views

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.72.3",
+  "version": "4.72.4",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/doctor/checks/traffic-source.ts
+++ b/packages/api-routes/src/doctor/checks/traffic-source.ts
@@ -4,6 +4,7 @@ import {
   CheckScopes,
   CheckStatuses,
   TrafficSourceStatuses,
+  TrafficSourceTypes,
 } from '@ainyc/canonry-contracts'
 import {
   aiReferralEventsHourly,
@@ -365,9 +366,55 @@ const scopesCheck: CheckDefinition = {
   },
 }
 
+/**
+ * The WordPress adapter captures via the Canonry Traffic Logger plugin, which
+ * only logs requests that reach PHP. A full-page cache (LiteSpeed, WP Rocket,
+ * W3TC, WP Super Cache) or CDN serves cached pages before PHP runs, so
+ * cache-served page views (including live AI user-fetches like Claude-User
+ * and ChatGPT-User) are invisible to the plugin, while bot crawls of uncached
+ * endpoints (sitemap, assets, cache misses) still come through. This is
+ * inherent to hook-based capture, not a config error, so it warns whenever a
+ * WordPress source is present; log/edge adapters (cloud-run, vercel) are
+ * unaffected and skip.
+ */
+const cacheBlindSpotCheck: CheckDefinition = {
+  id: 'traffic.source.cache-blindspot',
+  category: CheckCategories.integrations,
+  scope: CheckScopes.project,
+  title: 'WordPress traffic cache blind spot',
+  run: (ctx) => {
+    if (!ctx.project) return skippedNoProject()
+    const wpSources = loadProbes(ctx).filter(
+      (s) => s.sourceType === TrafficSourceTypes.wordpress,
+    )
+    if (wpSources.length === 0) {
+      return {
+        status: CheckStatuses.skipped,
+        code: 'traffic.cache-blindspot.no-wordpress-source',
+        summary:
+          'No WordPress traffic source connected, so the plugin cache blind spot does not apply (log and edge adapters see cache-served requests).',
+      }
+    }
+    return {
+      status: CheckStatuses.warn,
+      code: 'traffic.cache-blindspot.wordpress-plugin',
+      summary:
+        `${wpSources.length} WordPress traffic source(s) capture via the Canonry Traffic Logger plugin, which only logs requests that execute PHP. ` +
+        'A full-page cache (LiteSpeed, WP Rocket, W3 Total Cache, WP Super Cache) or CDN serves cached pages before PHP runs, so cache-served page views, including live AI user-fetches such as Claude-User and ChatGPT-User, are not captured. Bot crawls of uncached endpoints (sitemap, feeds, assets, cache misses) still appear, which can make capture look healthy while real page views go uncounted.',
+      remediation:
+        'Exclude AI user-agents from the page cache so their requests reach PHP: LiteSpeed Cache has "Do Not Cache User Agents" under Cache > Excludes; WP Rocket uses the `rocket_cache_reject_ua` filter; W3 Total Cache and WP Super Cache have a "Rejected User Agents" box. Mirror the rule at any CDN in front. For cache-independent capture, ingest from server or edge access logs (a `cloud-run` or `vercel` source, or an edge worker) instead of the WordPress plugin.',
+      details: {
+        wordpressSourceCount: wpSources.length,
+        wordpressSourceIds: wpSources.map((s) => s.id),
+      },
+    }
+  },
+}
+
 export const TRAFFIC_SOURCE_CHECKS: readonly CheckDefinition[] = [
   sourceConnectedCheck,
   recentDataCheck,
   credentialsCheck,
   scopesCheck,
+  cacheBlindSpotCheck,
 ]

--- a/packages/api-routes/test/doctor-traffic-source.test.ts
+++ b/packages/api-routes/test/doctor-traffic-source.test.ts
@@ -19,6 +19,7 @@ const [
   recentDataCheck,
   credentialsCheck,
   scopesCheck,
+  cacheBlindSpotCheck,
 ] = TRAFFIC_SOURCE_CHECKS
 
 interface Harness {
@@ -318,14 +319,55 @@ describe('traffic.source.scopes', () => {
   })
 })
 
+describe('traffic.source.cache-blindspot', () => {
+  it('skips when no WordPress source is connected (cloud-run only)', async () => {
+    insertTrafficSource(h, { sourceType: 'cloud-run' })
+    const r = await cacheBlindSpotCheck.run(ctxFor(h))
+    expect(r.status).toBe('skipped')
+    expect(r.code).toBe('traffic.cache-blindspot.no-wordpress-source')
+  })
+
+  it('skips when there is no traffic source at all', async () => {
+    const r = await cacheBlindSpotCheck.run(ctxFor(h))
+    expect(r.status).toBe('skipped')
+    expect(r.code).toBe('traffic.cache-blindspot.no-wordpress-source')
+  })
+
+  it('warns when a WordPress source is connected — cache-served views can be missed', async () => {
+    insertTrafficSource(h, { sourceType: 'wordpress', displayName: 'WordPress · example.com' })
+    const r = await cacheBlindSpotCheck.run(ctxFor(h))
+    expect(r.status).toBe('warn')
+    expect(r.code).toBe('traffic.cache-blindspot.wordpress-plugin')
+    expect(r.remediation).toMatch(/user.?agent/i)
+    expect((r.details as { wordpressSourceCount: number }).wordpressSourceCount).toBe(1)
+  })
+
+  it('counts multiple WordPress sources and ignores non-wordpress ones', async () => {
+    insertTrafficSource(h, { sourceType: 'wordpress', displayName: 'A' })
+    insertTrafficSource(h, { sourceType: 'wordpress', displayName: 'B' })
+    insertTrafficSource(h, { sourceType: 'cloud-run', displayName: 'GCP' })
+    const r = await cacheBlindSpotCheck.run(ctxFor(h))
+    expect(r.status).toBe('warn')
+    expect((r.details as { wordpressSourceCount: number }).wordpressSourceCount).toBe(2)
+  })
+
+  it('skips with the project-missing code when project context is absent', async () => {
+    const ctx: DoctorContext = { db: h.db, project: null }
+    const r = await cacheBlindSpotCheck.run(ctx)
+    expect(r.status).toBe('skipped')
+    expect(r.code).toBe('traffic.no-project')
+  })
+})
+
 describe('check definitions', () => {
-  it('exports four checks at well-known IDs', () => {
+  it('exports five checks at well-known IDs', () => {
     const ids = TRAFFIC_SOURCE_CHECKS.map((c) => c.id)
     expect(ids).toEqual([
       'traffic.source.connected',
       'traffic.source.recent-data',
       'traffic.source.credentials',
       'traffic.source.scopes',
+      'traffic.source.cache-blindspot',
     ])
   })
 

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.72.3",
+  "version": "4.72.4",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/skills/canonry/references/server-side-traffic.md
+++ b/skills/canonry/references/server-side-traffic.md
@@ -66,8 +66,45 @@ sync flow does NOT echo the private key back in any response.
 ## Connecting a WordPress source
 
 The WordPress adapter pulls events from the **Canonry Traffic Logger**
-WordPress plugin, which captures every non-admin GET page-load and
-exposes a paginated REST endpoint protected by an Application Password.
+WordPress plugin, which captures every non-admin GET page-load **that
+reaches PHP** and exposes a paginated REST endpoint protected by an
+Application Password.
+
+> **Cache blind spot.** The plugin is a PHP hook, so it only sees
+> requests that execute WordPress. A full-page cache (LiteSpeed, WP
+> Rocket, W3 Total Cache, WP Super Cache) or CDN serves cached pages
+> before PHP runs, so cache-served page views, including live AI
+> user-fetches (Claude-User, ChatGPT-User), are NOT logged. Bot crawls
+> of uncached endpoints (sitemap, feeds, assets, cache misses) still
+> come through, which can make capture look healthy while real page
+> views go uncounted. Exclude AI user-agents from the cache (and any
+> CDN), or capture from access/edge logs instead. The
+> `traffic.source.cache-blindspot` doctor check warns whenever a
+> WordPress source is connected.
+
+**Which user-agents to exclude from the cache** (one per line in
+LiteSpeed's "Do Not Cache User Agents", WP Rocket's
+`rocket_cache_reject_ua`, or W3TC / WP Super Cache "Rejected User
+Agents"):
+
+```
+Claude-User
+ClaudeBot
+ChatGPT-User
+OAI-SearchBot
+GPTBot
+PerplexityBot
+Perplexity-User
+```
+
+These are the answer-engine fetchers in both live-user-fetch (`*-User`)
+and crawler forms. Do NOT add `Googlebot` or `Bingbot`: caching helps
+search crawlers (page speed is a ranking signal, and cached pages let
+them crawl more per visit, which matters most on crawl-budget-starved
+sites), and their crawl stats are already authoritative in GSC and Bing
+Webmaster Tools. Rule of thumb: bypass cache only for agents you cannot
+measure elsewhere and that gain nothing from being cached. Answer-engine
+fetchers fit both; search crawlers fit neither.
 
 ```bash
 # 1. Install the plugin. Download the latest release zip from the
@@ -223,7 +260,7 @@ MCP `canonry_traffic_status` tool.
 | Project dashboard `/projects/:name/activity` | Live source table + 24h totals + GA4 referrals (combined view) |
 | Top-level `/traffic` route | Cross-project source admin (connect, sync, archive) |
 | `cnry report <project>` (HTML + SPA) | "AI Visibility — Server-Side" section, ranked above Indexing Health |
-| `cnry doctor --project <name>` | `traffic.source.connected`, `recent-data`, `credentials`, `scopes` checks |
+| `cnry doctor --project <name>` | `traffic.source.connected`, `recent-data`, `credentials`, `scopes`, `cache-blindspot` checks |
 | MCP toolkit `traffic` | Tools: `canonry_traffic_status`, `_sources_list`, `_source_get`, `_events`, `_connect_cloud_run`, `_sync` |
 
 ## Doctor signals
@@ -237,6 +274,7 @@ The doctor checks are adapter-agnostic. When they fail or warn:
 | `traffic.source.recent-data` | `traffic.recent-data.stale` | Last sync was >7d ago. Run `cnry traffic sync …` or schedule a recurring sync. |
 | `traffic.source.recent-data` | `traffic.recent-data.empty` | Source connected but no data in 30d. Verify config and credentials with `cnry traffic sources <project>`. |
 | `traffic.source.credentials` | `traffic.credentials.resolve-failed` | Service-account key in `~/.canonry/config.yaml` is invalid or expired. Re-connect. |
+| `traffic.source.cache-blindspot` | `traffic.cache-blindspot.wordpress-plugin` | A WordPress source is connected, so the plugin cannot see cache-served page views. Exclude AI user-agents from the page cache and any CDN, or switch to a log/edge source. Warns only, not a failure. |
 
 ## Scheduling
 
@@ -276,6 +314,21 @@ domains, or PII are surfaced.
 
 ## Limits & caveats
 
+- **The WordPress plugin is blind to cache-served traffic.** The
+  `wordpress` adapter logs only requests that reach PHP. A full-page
+  cache or CDN serves cached pages from the edge, so cache-served page
+  views, including live AI user-fetches (Claude-User, ChatGPT-User),
+  never reach the plugin and go uncounted, even though bot crawls of
+  uncached endpoints (sitemap, assets) still appear. On a cached
+  WordPress site, treat the plugin's page-view counts as a floor, not a
+  total. Either exclude AI user-agents from the cache + CDN, or capture
+  cache-independent via a `cloud-run` / `vercel` / edge-log source. The
+  `traffic.source.cache-blindspot` doctor check surfaces this. Adapter
+  coverage differs: `vercel` ingests edge request-logs so cache hits are
+  captured (it records the `cache` HIT/MISS label), and `cloud-run` logs
+  every request that reaches the service, missing only what a CDN placed
+  in front of Cloud Run serves from its own edge cache. Only the
+  hook-based `wordpress` adapter has the always-present blind spot.
 - **Path-level citation cross-reference is not implemented yet.** The
   citation store is domain-grain (`query_snapshots.cited_domains`). A
   future iteration that lands URL-grain citation evidence will extend


### PR DESCRIPTION
## Problem

The `wordpress` traffic adapter captures via the Canonry Traffic Logger
plugin, a PHP hook that only logs requests which execute WordPress. When
a site sits behind a full-page cache (LiteSpeed, WP Rocket, W3TC, WP
Super Cache) or a CDN, cached pages are served before PHP runs, so
cache-served page views never reach the plugin.

The gap is invisible in the data: bot crawls of uncached endpoints
(sitemap, assets, cache misses) still come through, so capture looks
healthy while real page views, including live AI user-fetches
(Claude-User, ChatGPT-User), go uncounted.

## Change

- New doctor check `traffic.source.cache-blindspot`. Warns whenever a
  WordPress source is connected; `cloud-run` / `vercel` (log and edge
  based) are unaffected and skip. No source or no project resolves to
  skipped.
- Remediation covers both fixes: exclude AI user-agents from the cache
  (per-plugin UA exclusion plus any CDN), or capture cache-independent
  from server/edge logs.
- Documents the blind spot in the `server-side-traffic` skill reference
  (adapter note, doctor-signals table, limits and caveats).

## Tests (TDD)

Failing-first tests for the skip / warn / count paths and the
check-registry contract. Full doctor suite green (134), skill tests
green, typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
