### PR TITLE
feat(web): paginate AI referrer landing-pages table (50 per page)

### DIFF
--- a/apps/web/src/components/project/ActivitySection.tsx
+++ b/apps/web/src/components/project/ActivitySection.tsx
@@ -60,6 +60,7 @@ const SOURCE_COLORS = CHART_SERIES_COLORS
 const SOCIAL_OTHER_COLOR = CHART_NEUTRAL.textDim
 const SOCIAL_TOTAL_COLOR = CHART_NEUTRAL.textFaint
 const SOCIAL_TABLE_DEFAULT_LIMIT = 25
+const AI_LANDING_PAGE_SIZE = 50
 
 type PageSortKey = 'landingPage' | 'sessions' | 'organicSessions' | 'users'
 type ReferralSortKey = 'source' | 'medium' | 'sessions' | 'users'
@@ -188,7 +189,9 @@ export function ActivitySection({ projectName }: { projectName: string }) {
   )
 }
 
-function ClickThroughActivity({ projectName }: { projectName: string }) {
+// Exported for focused testing of the GA4 click-through panel (e.g. landing-page
+// pagination) without standing up a router for the sibling ServerActivityPanel's links.
+export function ClickThroughActivity({ projectName }: { projectName: string }) {
   const queryClient = useQueryClient()
   const [status, setStatus] = useState<ApiGaStatus | null>(null)
   const [traffic, setTraffic] = useState<ApiGaTraffic | null>(null)
@@ -205,6 +208,7 @@ function ClickThroughActivity({ projectName }: { projectName: string }) {
   const [socialSortDir, setSocialSortDir] = useState<SortDir>('desc')
   const [aiLandingSortKey, setAiLandingSortKey] = useState<AiLandingPageSortKey>('sessions')
   const [aiLandingSortDir, setAiLandingSortDir] = useState<SortDir>('desc')
+  const [aiLandingPage, setAiLandingPage] = useState(1)
   const [aiHistory, setAiHistory] = useState<GA4AiReferralHistoryEntry[]>([])
   const [sessionHistory, setSessionHistory] = useState<GA4SessionHistoryEntry[]>([])
   const [socialHistory, setSocialHistory] = useState<GA4SocialReferralHistoryEntry[]>([])
@@ -357,6 +361,7 @@ function ClickThroughActivity({ projectName }: { projectName: string }) {
   }
 
   function handleAiLandingSort(key: AiLandingPageSortKey) {
+    setAiLandingPage(1)
     if (aiLandingSortKey === key) {
       setAiLandingSortDir((d) => (d === 'desc' ? 'asc' : 'desc'))
     } else {
@@ -400,6 +405,15 @@ function ClickThroughActivity({ projectName }: { projectName: string }) {
       return aiLandingSortDir === 'asc' ? (av as number) - (bv as number) : (bv as number) - (av as number)
     })
   }, [traffic?.aiReferralLandingPages, aiLandingSortKey, aiLandingSortDir])
+
+  const aiLandingTotalPages = Math.max(1, Math.ceil(sortedAiLandingPages.length / AI_LANDING_PAGE_SIZE))
+  // Clamp to a valid page so a stale page index (e.g. after a resync shrinks the list) still renders.
+  const aiLandingCurrentPage = Math.min(Math.max(1, aiLandingPage), aiLandingTotalPages)
+  const aiLandingPageStart = (aiLandingCurrentPage - 1) * AI_LANDING_PAGE_SIZE
+  const pagedAiLandingPages = useMemo(
+    () => sortedAiLandingPages.slice(aiLandingPageStart, aiLandingPageStart + AI_LANDING_PAGE_SIZE),
+    [sortedAiLandingPages, aiLandingPageStart],
+  )
 
   const sortedSocialReferrals = useMemo(() => {
     if (!traffic?.socialReferrals) return []
@@ -815,32 +829,62 @@ function ClickThroughActivity({ projectName }: { projectName: string }) {
                   <h3 className="text-sm font-semibold text-zinc-100">Known AI referrers — landing pages</h3>
                 </div>
                 <p className="text-xs text-zinc-500">
-                  {sortedAiLandingPages.length > 0 ? `${sortedAiLandingPages.length} rows` : 'No landing-page rows'}
+                  {sortedAiLandingPages.length > AI_LANDING_PAGE_SIZE
+                    ? `${aiLandingPageStart + 1}–${aiLandingPageStart + pagedAiLandingPages.length} of ${sortedAiLandingPages.length} rows`
+                    : sortedAiLandingPages.length > 0
+                      ? `${sortedAiLandingPages.length} rows`
+                      : 'No landing-page rows'}
                 </p>
               </div>
 
               {sortedAiLandingPages.length > 0 ? (
-                <div className="overflow-x-auto">
-                  <table className="w-full text-sm">
-                    <thead>
-                      <tr className="text-[10px] uppercase tracking-wider text-zinc-500">
-                        <SortHeader label="Landing Page" sortKey="landingPage" current={aiLandingSortKey} dir={aiLandingSortDir} onSort={handleAiLandingSort} align="left" />
-                        <SortHeader label="Source" sortKey="source" current={aiLandingSortKey} dir={aiLandingSortDir} onSort={handleAiLandingSort} align="left" />
-                        <th className="py-1 font-medium text-left">Attribution</th>
-                        <SortHeader label="Sessions" sortKey="sessions" current={aiLandingSortKey} dir={aiLandingSortDir} onSort={handleAiLandingSort} align="right" />
-                        <SortHeader label="Users" sortKey="users" current={aiLandingSortKey} dir={aiLandingSortDir} onSort={handleAiLandingSort} align="right" />
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {sortedAiLandingPages.map((row) => (
-                        <AiReferralLandingPageRow
-                          key={`${row.landingPage}:${row.source}:${row.medium}:${row.sourceDimension}`}
-                          row={row}
-                        />
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
+                <>
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="text-[10px] uppercase tracking-wider text-zinc-500">
+                          <SortHeader label="Landing Page" sortKey="landingPage" current={aiLandingSortKey} dir={aiLandingSortDir} onSort={handleAiLandingSort} align="left" />
+                          <SortHeader label="Source" sortKey="source" current={aiLandingSortKey} dir={aiLandingSortDir} onSort={handleAiLandingSort} align="left" />
+                          <th className="py-1 font-medium text-left">Attribution</th>
+                          <SortHeader label="Sessions" sortKey="sessions" current={aiLandingSortKey} dir={aiLandingSortDir} onSort={handleAiLandingSort} align="right" />
+                          <SortHeader label="Users" sortKey="users" current={aiLandingSortKey} dir={aiLandingSortDir} onSort={handleAiLandingSort} align="right" />
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {pagedAiLandingPages.map((row) => (
+                          <AiReferralLandingPageRow
+                            key={`${row.landingPage}:${row.source}:${row.medium}:${row.sourceDimension}`}
+                            row={row}
+                          />
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+
+                  {aiLandingTotalPages > 1 && (
+                    <div className="mt-3 flex items-center justify-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => setAiLandingPage(aiLandingCurrentPage - 1)}
+                        disabled={aiLandingCurrentPage <= 1}
+                        className="text-xs text-zinc-400 hover:text-zinc-200 disabled:opacity-40 disabled:hover:text-zinc-400 px-3 py-1 rounded-full border border-zinc-800 hover:border-zinc-700 disabled:hover:border-zinc-800 transition-colors"
+                      >
+                        Previous
+                      </button>
+                      <span className="text-xs text-zinc-500 tabular-nums">
+                        Page {aiLandingCurrentPage} of {aiLandingTotalPages}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => setAiLandingPage(aiLandingCurrentPage + 1)}
+                        disabled={aiLandingCurrentPage >= aiLandingTotalPages}
+                        className="text-xs text-zinc-400 hover:text-zinc-200 disabled:opacity-40 disabled:hover:text-zinc-400 px-3 py-1 rounded-full border border-zinc-800 hover:border-zinc-700 disabled:hover:border-zinc-800 transition-colors"
+                      >
+                        Next
+                      </button>
+                    </div>
+                  )}
+                </>
               ) : (
                 <div className="flex flex-col items-center justify-center py-8 text-center">
                   <p className="text-sm text-zinc-400 mb-2">No AI landing pages detected yet</p>

--- a/apps/web/src/components/project/ActivitySection.tsx
+++ b/apps/web/src/components/project/ActivitySection.tsx
@@ -785,7 +785,7 @@ export function ClickThroughActivity({ projectName }: { projectName: string }) {
               <div className="mb-4 flex items-end justify-between gap-3">
                 <div>
                   <p className="eyebrow eyebrow-soft">Detail</p>
-                  <h3 className="text-sm font-semibold text-zinc-100">Known AI referrers — sources detected</h3>
+                  <h3 className="text-sm font-semibold text-zinc-100">Known AI referrers by source</h3>
                 </div>
                 <p className="text-xs text-zinc-500">
                   {traffic.aiReferrals.length > 0 ? `${aiSourceCount} unique sources, ${traffic.aiReferrals.length} rows` : 'No source rows'}
@@ -826,7 +826,7 @@ export function ClickThroughActivity({ projectName }: { projectName: string }) {
               <div className="mb-4 flex items-end justify-between gap-3">
                 <div>
                   <p className="eyebrow eyebrow-soft">Detail</p>
-                  <h3 className="text-sm font-semibold text-zinc-100">Known AI referrers — landing pages</h3>
+                  <h3 className="text-sm font-semibold text-zinc-100">Known AI referrers by landing page</h3>
                 </div>
                 <p className="text-xs text-zinc-500">
                   {sortedAiLandingPages.length > AI_LANDING_PAGE_SIZE

--- a/apps/web/test/activity-section-pagination.test.tsx
+++ b/apps/web/test/activity-section-pagination.test.tsx
@@ -1,0 +1,175 @@
+import React from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, expect, onTestFinished, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+// Recharts needs a sized container (jsdom has none); stub it like the other
+// chart-bearing section tests so we assert on the textual layer, not the SVG.
+vi.mock('recharts', () => {
+  const passthrough = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>
+  return {
+    ResponsiveContainer: passthrough,
+    ComposedChart: passthrough,
+    BarChart: passthrough,
+    Bar: () => null,
+    Line: () => null,
+    Area: () => null,
+    XAxis: () => null,
+    YAxis: () => null,
+    CartesianGrid: () => null,
+    Tooltip: () => null,
+    Legend: () => null,
+    ReferenceArea: () => null,
+    Cell: () => null,
+  }
+})
+
+import { ClickThroughActivity } from '../src/components/project/ActivitySection.js'
+import type { ApiGaTrafficAiLandingPage } from '../src/api.js'
+import { mockFetch, jsonResponse } from './mock-fetch.js'
+
+afterEach(() => {
+  cleanup()
+})
+
+function emptyBucket() {
+  return { sessions: 0, sharePct: 0, sharePctDisplay: '0%' }
+}
+
+/** A full ApiGaTraffic fixture with a parametrizable set of AI landing-page rows. */
+function makeTraffic(aiReferralLandingPages: ApiGaTrafficAiLandingPage[]) {
+  return {
+    totalSessions: 0,
+    totalOrganicSessions: 0,
+    totalDirectSessions: 0,
+    totalUsers: 0,
+    topPages: [],
+    aiReferrals: [],
+    aiReferralLandingPages,
+    aiSessionsDeduped: 0,
+    aiUsersDeduped: 0,
+    aiSessionsBySession: 0,
+    aiUsersBySession: 0,
+    socialReferrals: [],
+    socialSessions: 0,
+    socialUsers: 0,
+    channelBreakdown: {
+      organic: emptyBucket(),
+      social: emptyBucket(),
+      direct: emptyBucket(),
+      ai: emptyBucket(),
+      other: emptyBucket(),
+    },
+    organicSharePct: 0,
+    aiSharePct: 0,
+    aiSharePctBySession: 0,
+    socialSharePct: 0,
+    directSharePct: 0,
+    organicSharePctDisplay: '0%',
+    aiSharePctDisplay: '0%',
+    aiSharePctBySessionDisplay: '0%',
+    socialSharePctDisplay: '0%',
+    directSharePctDisplay: '0%',
+    otherSessions: 0,
+    otherSharePct: 0,
+    otherSharePctDisplay: '0%',
+    lastSyncedAt: '2026-06-09T00:00:00.000Z',
+    periodStart: '2026-05-10',
+    periodEnd: '2026-06-09',
+  }
+}
+
+/** N AI landing-page rows with descending sessions so sort order is deterministic. */
+function makeLandingPages(count: number): ApiGaTrafficAiLandingPage[] {
+  return Array.from({ length: count }, (_, i) => ({
+    source: 'chatgpt.com',
+    medium: 'referral',
+    sourceDimension: 'session' as const,
+    landingPage: `/page-${String(i).padStart(3, '0')}`,
+    sessions: count - i,
+    users: count - i,
+  }))
+}
+
+function renderPanel(landingPages: ApiGaTrafficAiLandingPage[]) {
+  const restoreFetch = mockFetch((url) => {
+    const urlPath = url.split('?')[0]!
+    if (urlPath.endsWith('/projects/test-project/ga/status')) {
+      return jsonResponse({
+        connected: true,
+        propertyId: '123456',
+        clientEmail: 'svc@example.com',
+        lastSyncedAt: '2026-06-09T00:00:00.000Z',
+        createdAt: '2026-05-01T00:00:00.000Z',
+        updatedAt: '2026-06-09T00:00:00.000Z',
+      })
+    }
+    if (urlPath.endsWith('/projects/test-project/ga/traffic')) {
+      return jsonResponse(makeTraffic(landingPages))
+    }
+    if (urlPath.endsWith('/projects/test-project/ga/ai-referral-history')) return jsonResponse([])
+    if (urlPath.endsWith('/projects/test-project/ga/session-history')) return jsonResponse([])
+    if (urlPath.endsWith('/projects/test-project/ga/social-referral-history')) return jsonResponse([])
+    throw new Error(`Unexpected fetch: ${url}`)
+  })
+  onTestFinished(restoreFetch)
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ClickThroughActivity projectName="test-project" />
+    </QueryClientProvider>,
+  )
+}
+
+test('shows 50 landing-page rows per page and paginates the rest', async () => {
+  renderPanel(makeLandingPages(60))
+
+  // Page 1: first 50 rows render, the 51st does not.
+  await waitFor(() => expect(screen.getByText('1–50 of 60 rows')).toBeTruthy())
+  expect(screen.getByText('/page-000')).toBeTruthy()
+  expect(screen.getByText('/page-049')).toBeTruthy()
+  expect(screen.queryByText('/page-050')).toBeNull()
+
+  // Controls: Page 1 of 2, Previous disabled, Next enabled.
+  expect(screen.getByText('Page 1 of 2')).toBeTruthy()
+  const prev = screen.getByRole('button', { name: 'Previous' })
+  const next = screen.getByRole('button', { name: 'Next' })
+  expect(prev.hasAttribute('disabled')).toBe(true)
+  expect(next.hasAttribute('disabled')).toBe(false)
+
+  // Advance: page 2 shows the remaining 10 rows, Next is now disabled.
+  fireEvent.click(next)
+  await waitFor(() => expect(screen.getByText('51–60 of 60 rows')).toBeTruthy())
+  expect(screen.getByText('Page 2 of 2')).toBeTruthy()
+  expect(screen.getByText('/page-050')).toBeTruthy()
+  expect(screen.getByText('/page-059')).toBeTruthy()
+  expect(screen.queryByText('/page-049')).toBeNull()
+  expect(screen.getByRole('button', { name: 'Next' }).hasAttribute('disabled')).toBe(true)
+  expect(screen.getByRole('button', { name: 'Previous' }).hasAttribute('disabled')).toBe(false)
+})
+
+test('renders no pagination controls when there are 50 or fewer rows', async () => {
+  renderPanel(makeLandingPages(50))
+
+  await waitFor(() => expect(screen.getByText('50 rows')).toBeTruthy())
+  // No range caption and no pager for a single page.
+  expect(screen.queryByText('1–50 of 50 rows')).toBeNull()
+  expect(screen.queryByRole('button', { name: 'Next' })).toBeNull()
+  expect(screen.queryByRole('button', { name: 'Previous' })).toBeNull()
+  expect(screen.queryByText(/Page \d+ of/)).toBeNull()
+})
+
+test('changing the sort resets to page 1', async () => {
+  renderPanel(makeLandingPages(60))
+
+  // Jump to page 2.
+  await waitFor(() => expect(screen.getByText('Page 1 of 2')).toBeTruthy())
+  fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+  await waitFor(() => expect(screen.getByText('Page 2 of 2')).toBeTruthy())
+
+  // Re-sorting (click the "Landing Page" header) snaps back to page 1.
+  fireEvent.click(screen.getByRole('button', { name: /Landing Page/ }))
+  await waitFor(() => expect(screen.getByText('Page 1 of 2')).toBeTruthy())
+  expect(screen.getByText('1–50 of 60 rows')).toBeTruthy()
+})

--- a/apps/web/test/activity-section.test.tsx
+++ b/apps/web/test/activity-section.test.tsx
@@ -218,7 +218,7 @@ test('renders five-channel breakdown with disjoint Organic, Social, Direct, Know
   // The misleading old framing is gone: panel title "Attributable AI visits" must not appear
   expect(screen.queryByText('Attributable AI visits')).toBeNull()
 
-  expect(screen.getByText('Known AI referrers — landing pages')).toBeTruthy()
+  expect(screen.getByText('Known AI referrers by landing page')).toBeTruthy()
   const row = screen.getAllByText('/pricing')
     .map((cell) => cell.closest('tr') as HTMLElement | null)
     .find((candidate): candidate is HTMLElement => Boolean(candidate && within(candidate).queryByText('chatgpt.com')))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.75.0",
+  "version": "4.76.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.75.0",
+  "version": "4.76.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/commands/serve.ts
+++ b/packages/canonry/src/commands/serve.ts
@@ -48,7 +48,7 @@ export async function serveCommand(format: CliFormat = 'text'): Promise<void> {
   }
 
   // Same idea for ga_ai_referrals — landing_page_normalized was added in
-  // v46. Without this, the dashboard's "Known AI referrers — landing pages"
+  // v46. Without this, the dashboard's "Known AI referrers by landing page"
   // panel surfaces legacy rows as a synthetic '(not set)' bucket until the
   // user re-syncs.
   try {


### PR DESCRIPTION
The "Known AI referrers — landing pages" table in the Activity tab previously rendered every row at once (216+ on active projects); this adds client-side pagination at 50 rows per page with a Previous/Next pager, a "1–50 of N rows" range caption, and a reset to page 1 on re-sort. The pager is hidden at ≤50 rows and the page index is clamped so a shrinking GA4 resync can't strand an empty page. It's pure presentation over the already-fetched `aiReferralLandingPages` list, so there is no API/CLI parity impact. `ClickThroughActivity` is exported so the new `activity-section-pagination.test.tsx` (3 cases) can unit-test the panel in isolation, and the package version is bumped 4.75.0 → 4.76.0.