### PR TITLE
fix(vercel): guarantee the drain deadline always makes forward progress

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.75.0",
+  "version": "4.75.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/traffic.ts
+++ b/packages/api-routes/src/traffic.ts
@@ -1537,6 +1537,22 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
             'Vercel drain truncated dense one-second slice(s); ingested a sample and advanced past them',
           )
         }
+        if (drained.deadlineSkippedSliceCount > 0) {
+          // The drain hit its wall-clock budget while still narrowing a dense or
+          // slow slice at the window head and could not drain a single sub-window.
+          // Rather than freeze the cursor (which wedges the source — every retry
+          // re-hits the same head), it skipped past the head to guarantee forward
+          // progress. The skipped span was dropped undrained; surface it (never
+          // silent). The additive rollup keeps the rest of the window safe.
+          request.log.warn(
+            {
+              sourceId: sourceRow.id,
+              skippedSlices: drained.deadlineSkippedSliceCount,
+              sliceStarts: drained.deadlineSkippedSliceStartsMs.map((ms) => new Date(ms).toISOString()),
+            },
+            'Vercel drain could not narrow a dense/slow head slice within its budget; skipped past it to guarantee progress',
+          )
+        }
         allEvents = drained.events
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e)

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.75.0",
+  "version": "4.75.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/integration-vercel/AGENTS.md
+++ b/packages/integration-vercel/AGENTS.md
@@ -45,6 +45,13 @@ with **no in-app instrumentation** required on the user's Vercel project.
   burn the entire deadline with ZERO cursor progress and wedge permanently
   (every retry re-hits the same window). A small first span completes fast, the
   cursor advances, and partial progress is committed and resumed next run.
+  If the head is BOTH dense AND slow, even the small first span can't be narrowed
+  to a drainable floor before the budget elapses — so the **deadline path itself
+  guarantees progress**: on a zero-progress stop it skips past the head by the
+  initial span (recorded in `deadlineSkippedSliceCount` / `deadlineSkippedSliceStartsMs`,
+  surfaced via `warn`) rather than returning a start-equals-end window the route
+  must fail. Start-small reduces how often this fires; the skip makes the wedge
+  impossible regardless of upstream density or latency.
   The bisection floor is **one second** (`MIN_SUB_WINDOW_MS = 1_000`), small
   enough to drain real-world burst minutes (sites routinely hit 1000+ log
   pages in a single minute) without escalating to the floor-budget re-pull. A

--- a/packages/integration-vercel/src/drain.ts
+++ b/packages/integration-vercel/src/drain.ts
@@ -134,6 +134,18 @@ export interface DrainVercelTrafficEventsResult {
   /** Epoch-ms start of each truncated floor slice, for operator logging. */
   truncatedSliceStartsMs: number[]
   /**
+   * Count of head slices the drain SKIPPED past undrained because the wall-clock
+   * deadline elapsed while it was still narrowing a dense or slow slice at the
+   * window start down to a drainable floor. Distinct from `truncatedSliceCount`
+   * (those slices WERE pulled, just sampled): a deadline-skipped slice was never
+   * drained at all — the drain advanced the cursor past it so the source can
+   * never wedge on an un-narrowable head. Non-zero means that head span was
+   * dropped; the caller should surface it.
+   */
+  deadlineSkippedSliceCount: number
+  /** Epoch-ms start of each deadline-skipped head slice, for operator logging. */
+  deadlineSkippedSliceStartsMs: number[]
+  /**
    * Furthest instant (epoch ms) the drain fully completed. Equals `endDate` on
    * a normal full drain; on a `deadlineReached` stop it is the last cleanly
    * drained sub-window boundary, so `[startDate, drainedThroughMs]` is complete
@@ -255,6 +267,12 @@ async function resolveRetainedStart(
  * cost: an additive caller commits the partial window and resumes next run, so a
  * dense or slow window converges over several syncs instead of one unbounded
  * grind. (One in-flight pull can overrun the deadline; the bound is approximate.)
+ * Crucially, the deadline ALWAYS yields forward progress: if the budget elapsed
+ * while still narrowing the head without completing one sub-window (a dense or
+ * slow slice at the window start), the drain skips past that head span — counted
+ * in `deadlineSkippedSliceCount` — rather than returning a start-equals-end
+ * window the caller must fail. Without this a single un-narrowable head wedges
+ * the source forever, since every retry re-pulls the same start.
  */
 export async function drainVercelTrafficEvents(
   options: DrainVercelTrafficEventsOptions,
@@ -266,7 +284,7 @@ export async function drainVercelTrafficEvents(
   const events: NormalizedTrafficRequest[] = []
   const seenEventIds = new Set<string>()
   if (endMs <= startMs) {
-    return { events, subWindowCount: 0, effectiveStartMs: startMs, retentionClamped: false, truncatedSliceCount: 0, truncatedSliceStartsMs: [], drainedThroughMs: startMs, deadlineReached: false }
+    return { events, subWindowCount: 0, effectiveStartMs: startMs, retentionClamped: false, truncatedSliceCount: 0, truncatedSliceStartsMs: [], deadlineSkippedSliceCount: 0, deadlineSkippedSliceStartsMs: [], drainedThroughMs: startMs, deadlineReached: false }
   }
 
   let cursorMs = startMs
@@ -282,14 +300,33 @@ export async function drainVercelTrafficEvents(
   let truncatedSliceCount = 0
   let deadlineReached = false
   const truncatedSliceStartsMs: number[] = []
+  const deadlineSkippedSliceStartsMs: number[] = []
 
   while (cursorMs < endMs) {
     // Wall-clock budget: stop before starting another sub-window once the
-    // deadline passes. `cursorMs` is the last fully-drained boundary, so the
-    // caller can commit `[startMs, cursorMs]` and resume from there next run
+    // deadline passes. Normally `cursorMs` is the last fully-drained boundary,
+    // so the caller commits `[startMs, cursorMs]` and resumes there next run
     // rather than letting one sync grind the whole window unbounded.
     if (options.deadlineMs !== undefined && now() >= options.deadlineMs) {
       deadlineReached = true
+      // Guarantee forward progress. If the run actually attempted pulls
+      // (`subWindowCount > 0`) but burned its whole budget narrowing the head
+      // without completing a single sub-window — a dense or slow slice at the
+      // window start that could not be reduced to a drainable floor in time —
+      // `cursorMs` is still at the (post-retention-clamp) start. Returning that
+      // wedges the source: the additive caller can't advance `lastSyncedAt`, so
+      // every retry re-hits the same head forever. Skip past the head by the
+      // initial span (the chunk first attempted, now known not to drain in one
+      // pass) so the cursor always advances; the skipped span is dropped
+      // (recorded here, surfaced by the caller — never silent) and the next run
+      // resumes past it. The `subWindowCount > 0` guard matters: if the budget
+      // was already spent before the first pull, nothing has been tried, so
+      // skipping could drop drainable data — leave the cursor put and let the
+      // caller retry with a fresh budget instead.
+      if (cursorMs === effectiveStartMs && subWindowCount > 0 && cursorMs < endMs) {
+        deadlineSkippedSliceStartsMs.push(cursorMs)
+        cursorMs = Math.min(effectiveStartMs + INITIAL_SUB_WINDOW_MS, endMs)
+      }
       break
     }
     if (subWindowCount >= options.maxSubWindows) {
@@ -406,5 +443,5 @@ export async function drainVercelTrafficEvents(
     }
   }
 
-  return { events, subWindowCount, effectiveStartMs, retentionClamped, truncatedSliceCount, truncatedSliceStartsMs, drainedThroughMs: cursorMs, deadlineReached }
+  return { events, subWindowCount, effectiveStartMs, retentionClamped, truncatedSliceCount, truncatedSliceStartsMs, deadlineSkippedSliceCount: deadlineSkippedSliceStartsMs.length, deadlineSkippedSliceStartsMs, drainedThroughMs: cursorMs, deadlineReached }
 }

--- a/packages/integration-vercel/test/drain.test.ts
+++ b/packages/integration-vercel/test/drain.test.ts
@@ -427,4 +427,33 @@ describe('drainVercelTrafficEvents', () => {
     expect(result.drainedThroughMs).toBeGreaterThan(0)
     expect(result.events.length).toBeGreaterThan(0)
   })
+
+  test('skips past an un-narrowable head slice when the deadline trips mid-narrowing, instead of wedging', async () => {
+    // The gjelina wedge that start-small alone did NOT fix: a head slice that is
+    // both dense AND slow. Every span overflows (hasMore always true), so the
+    // drain only ever halves — it never completes a sub-window — and the budget
+    // elapses while still narrowing, before it can reach the drainable floor.
+    // Returning zero progress (drainedThroughMs == startDate) makes the caller
+    // fail and re-pull the identical head forever: a permanent wedge. Instead the
+    // drain skips past the head so the cursor always advances.
+    const pull = vi.fn(async () => page([], true)) // every span overflows, always
+    let tick = 0
+    const result = await drainVercelTrafficEvents({
+      ...baseOptions,
+      pull,
+      startDate: 0,
+      endDate: 24 * HOUR,
+      deadlineMs: 3, // trips after a couple of halvings, well before the 1s floor
+      now: () => (tick += 1),
+    })
+    expect(result.deadlineReached).toBe(true)
+    // Forward progress is guaranteed: the cursor advanced past the head by the
+    // initial span rather than staying at startDate (which is what wedged it).
+    expect(result.drainedThroughMs).toBe(5 * MINUTE)
+    expect(result.deadlineSkippedSliceCount).toBe(1)
+    expect(result.deadlineSkippedSliceStartsMs).toEqual([0])
+    // The head was skipped undrained, not sampled — distinct from truncation.
+    expect(result.events).toEqual([])
+    expect(result.truncatedSliceCount).toBe(0)
+  })
 })


### PR DESCRIPTION
## What
The Vercel `request-logs` drain now guarantees forward progress when its wall-clock deadline elapses, so a dense-and-slow slice at the window head can no longer permanently wedge a traffic source.

## Why
The drain narrows an overflowing span down to a 1-second floor (where it samples-and-advances). If a slice at the **window head** is both dense and slow, the deadline can elapse while the drain is still narrowing it, before it completes a single sub-window. It then returned `drainedThroughMs == startMs`; the route failed the sync ("exceeded its budget without completing any sub-window") and `lastSyncedAt` never advanced, so every subsequent sync re-pulled the identical head and the source stayed frozen. `start-small` (#686) made this rarer but could not eliminate it against a slow upstream.

## Fix
On a zero-progress deadline stop, and only after at least one pull was attempted, the drain skips past the head by the initial span rather than returning a zero-width window. The cursor always advances, so the source can never permanently wedge. The skipped span is dropped undrained but recorded (`deadlineSkippedSliceCount` / `deadlineSkippedSliceStartsMs`) and surfaced by the route via `warn` (never silent). The `subWindowCount > 0` guard preserves the "deadline already passed before the first pull -> make no progress" behaviour, so untried, possibly-drainable data is never skipped.

## Tests
- New regression: a head that always overflows (dense) with the clock tripping mid-narrowing (slow) now advances past the head (`deadlineSkippedSliceCount === 1`, `drainedThroughMs > startMs`) instead of returning zero progress.
- All existing drain + traffic-route tests pass (20 + 98), typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
