### PR TITLE
feat(ads): OpenAI Advertiser API read client (v4.77.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ packages/provider-cdp/           Chrome DevTools Protocol adapter
 packages/integration-google/     Google Search Console integration
 packages/integration-google-analytics/  Google Analytics 4 integration
 packages/integration-bing/       Bing Webmaster Tools integration
+packages/integration-openai-ads/  OpenAI Advertiser API (ChatGPT ads) integration
 packages/integration-wordpress/  WordPress integration
 docs/                            Architecture, roadmap, testing, ADRs
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.76.1",
+  "version": "4.77.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.77.0",
+  "version": "4.78.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.77.0",
+  "version": "4.78.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.76.1",
+  "version": "4.77.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/integration-openai-ads/AGENTS.md
+++ b/packages/integration-openai-ads/AGENTS.md
@@ -1,0 +1,52 @@
+# integration-openai-ads
+
+## Purpose
+
+OpenAI Advertiser API (ChatGPT ads) integration — typed read client for ad
+account, campaigns, ad groups, ads, and insights. The paid-surface counterpart
+to the organic answer-visibility data: ads render only in the ChatGPT consumer
+UI (never in API answers), so this client is the only window into the paid
+layer. See `plans/openai-ads-integration.md` for the full lane design.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `src/ads-client.ts` | API client — account, campaigns, ad groups, ads, insights |
+| `src/types.ts` | Response types (mirrored from captured live responses) and `OpenAiAdsApiError` |
+| `src/constants.ts` | API base URL, timeouts, pagination cap |
+| `src/index.ts` | Re-exports public API |
+| `test/fixtures.ts` | Sanitized copies of real captured responses — never invent shapes |
+
+## Patterns
+
+- **Bearer "SDK key" auth**: keys are minted in OpenAI Ads Manager and scoped
+  to one ad account (platform `sk-` keys are a different credential system —
+  they 401 unless granted ads scopes). Stored in `~/.canonry/config.yaml`.
+- **List envelope**: every list returns `{ object: 'list', data, first_id,
+  last_id, has_more }`. The client auto-paginates; the `after=` request param
+  follows the OpenAI list convention but has not been exercised against a
+  multi-page dataset yet — revisit if pagination misbehaves on large accounts.
+- **`fields[]` selection**: insights default to impressions only; richer
+  metrics require literal `fields[]=` query pairs with namespaced names
+  (`campaign.clicks`, `ad_group.spend`, `metadata.readable_time`, …). A wrong
+  field name returns a 400 whose message enumerates the valid catalog.
+- **Money units are mixed upstream**: budgets/bids are integer micros
+  (`daily_spend_limit_micros`, `max_bid_micros`) but insights `spend`/`cpc`
+  are decimal dollars. Consumers must normalize at ingest — this client
+  returns values as the API sends them.
+- **Vocabulary**: paid metrics are `paid` / `sponsored` — never reuse
+  `mentioned` / `cited` (those mean answer-text and source-list presence).
+
+## Common Mistakes
+
+- **Storing API keys in the database** — credentials belong in `~/.canonry/config.yaml`.
+- **Inventing fixture fields** — every fixture in `test/` mirrors a captured
+  live response (sanitized identifiers). When the API surface grows, capture
+  the real response first.
+- **Treating insights `spend` as micros** — it is decimal dollars.
+
+## See Also
+
+- `plans/openai-ads-integration.md` — phased lane design
+- `docs/roadmap.md` — "Paid Surface (ChatGPT Ads)" lane

--- a/packages/integration-openai-ads/CLAUDE.md
+++ b/packages/integration-openai-ads/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/integration-openai-ads/package.json
+++ b/packages/integration-openai-ads/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@ainyc/canonry-integration-openai-ads",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "license": "FSL-1.1-ALv2",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "types": "./src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "vitest run",
+    "lint": "eslint src/ test/"
+  },
+  "dependencies": {}
+}

--- a/packages/integration-openai-ads/src/ads-client.ts
+++ b/packages/integration-openai-ads/src/ads-client.ts
@@ -1,0 +1,169 @@
+import { OPENAI_ADS_API_BASE, OPENAI_ADS_MAX_PAGES, OPENAI_ADS_REQUEST_TIMEOUT_MS } from './constants.js'
+import type {
+  OpenAiAdsAccount,
+  OpenAiAdsAd,
+  OpenAiAdsAdGroup,
+  OpenAiAdsCampaign,
+  OpenAiAdsInsightRow,
+  OpenAiAdsInsightsOptions,
+  OpenAiAdsListResponse,
+} from './types.js'
+import { OpenAiAdsApiError, parseErrorEnvelope } from './types.js'
+
+function validateApiKey(apiKey: string): void {
+  if (!apiKey || typeof apiKey !== 'string' || apiKey.trim().length === 0) {
+    throw new OpenAiAdsApiError('API key is required and must be a non-empty string', 400)
+  }
+}
+
+function validateId(value: string, label: string): void {
+  if (!value || typeof value !== 'string' || value.trim().length === 0) {
+    throw new OpenAiAdsApiError(`${label} is required and must be a non-empty string`, 400)
+  }
+}
+
+function adsClientLog(level: 'info' | 'error', action: string, ctx?: Record<string, unknown>): void {
+  const entry: Record<string, unknown> = {
+    ts: new Date().toISOString(),
+    level,
+    module: 'OpenAiAdsClient',
+    action,
+    ...ctx,
+  }
+  if (entry.apiKey) entry.apiKey = '***'
+
+  const stream = level === 'error' ? process.stderr : process.stdout
+  stream.write(JSON.stringify(entry) + '\n')
+}
+
+// Query pairs are pre-encoded strings (e.g. 'fields[]=campaign.clicks').
+// The live API was exercised with literal bracket pairs, so the client sends
+// exactly that form rather than URLSearchParams' percent-encoded brackets.
+function buildUrl(path: string, queryPairs: readonly string[]): string {
+  const qs = queryPairs.join('&')
+  return qs ? `${OPENAI_ADS_API_BASE}/${path}?${qs}` : `${OPENAI_ADS_API_BASE}/${path}`
+}
+
+async function adsFetch<T>(apiKey: string, path: string, queryPairs: readonly string[] = []): Promise<T> {
+  const url = buildUrl(path, queryPairs)
+
+  const res = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    signal: AbortSignal.timeout(OPENAI_ADS_REQUEST_TIMEOUT_MS),
+  })
+
+  if (res.status === 401 || res.status === 403) {
+    const { code } = parseErrorEnvelope(await res.text())
+    adsClientLog('error', 'http.auth-failed', { path, httpStatus: res.status, code })
+    throw new OpenAiAdsApiError('OpenAI Ads API key is invalid or unauthorized', res.status, code)
+  }
+
+  if (res.status === 429) {
+    const { code } = parseErrorEnvelope(await res.text())
+    adsClientLog('error', 'http.rate-limited', { path, httpStatus: 429, code })
+    throw new OpenAiAdsApiError('OpenAI Ads API rate limit exceeded', 429, code)
+  }
+
+  if (!res.ok) {
+    const body = await res.text()
+    const { message, code } = parseErrorEnvelope(body)
+    adsClientLog('error', 'http.error', { path, httpStatus: res.status, code })
+    const detail = message ?? (body.length <= 500 ? body : `${body.slice(0, 500)}... [truncated]`)
+    throw new OpenAiAdsApiError(`OpenAI Ads API error (${res.status}): ${detail}`, res.status, code)
+  }
+
+  const text = await res.text()
+  try {
+    return JSON.parse(text) as T
+  } catch {
+    throw new OpenAiAdsApiError('OpenAI Ads API returned invalid JSON', 502)
+  }
+}
+
+// Every collection endpoint returns the same list envelope with
+// first_id/last_id/has_more (captured live). The `after=` request param
+// follows the OpenAI list convention; it has not been exercised against a
+// multi-page dataset yet — revisit if pagination misbehaves on large accounts.
+async function fetchAllPages<T>(apiKey: string, path: string, queryPairs: readonly string[]): Promise<T[]> {
+  const items: T[] = []
+  let after: string | null = null
+
+  for (let page = 0; page < OPENAI_ADS_MAX_PAGES; page++) {
+    const pairs: string[] = after ? [...queryPairs, `after=${encodeURIComponent(after)}`] : [...queryPairs]
+    const response: OpenAiAdsListResponse<T> = await adsFetch<OpenAiAdsListResponse<T>>(apiKey, path, pairs)
+    items.push(...response.data)
+    if (!response.has_more || !response.last_id) {
+      return items
+    }
+    after = response.last_id
+  }
+
+  adsClientLog('error', 'pagination.cap-reached', { path, pages: OPENAI_ADS_MAX_PAGES, items: items.length })
+  return items
+}
+
+function insightsPairs(opts?: OpenAiAdsInsightsOptions): string[] {
+  return (opts?.fields ?? []).map((field) => `fields[]=${encodeURIComponent(field)}`)
+}
+
+export async function getAdAccount(apiKey: string): Promise<OpenAiAdsAccount> {
+  validateApiKey(apiKey)
+  return adsFetch<OpenAiAdsAccount>(apiKey, 'ad_account')
+}
+
+export async function listCampaigns(apiKey: string): Promise<OpenAiAdsCampaign[]> {
+  validateApiKey(apiKey)
+  return fetchAllPages<OpenAiAdsCampaign>(apiKey, 'campaigns', [])
+}
+
+export async function listAdGroups(apiKey: string, campaignId: string): Promise<OpenAiAdsAdGroup[]> {
+  validateApiKey(apiKey)
+  validateId(campaignId, 'Campaign id')
+  return fetchAllPages<OpenAiAdsAdGroup>(apiKey, 'ad_groups', [`campaign_id=${encodeURIComponent(campaignId)}`])
+}
+
+export async function listAds(apiKey: string, adGroupId: string): Promise<OpenAiAdsAd[]> {
+  validateApiKey(apiKey)
+  validateId(adGroupId, 'Ad group id')
+  return fetchAllPages<OpenAiAdsAd>(apiKey, 'ads', [`ad_group_id=${encodeURIComponent(adGroupId)}`])
+}
+
+export async function getAdAccountInsights(
+  apiKey: string,
+  opts?: OpenAiAdsInsightsOptions,
+): Promise<OpenAiAdsInsightRow[]> {
+  validateApiKey(apiKey)
+  return fetchAllPages<OpenAiAdsInsightRow>(apiKey, 'ad_account/insights', insightsPairs(opts))
+}
+
+export async function getCampaignInsights(
+  apiKey: string,
+  campaignId: string,
+  opts?: OpenAiAdsInsightsOptions,
+): Promise<OpenAiAdsInsightRow[]> {
+  validateApiKey(apiKey)
+  validateId(campaignId, 'Campaign id')
+  return fetchAllPages<OpenAiAdsInsightRow>(
+    apiKey,
+    `campaigns/${encodeURIComponent(campaignId)}/insights`,
+    insightsPairs(opts),
+  )
+}
+
+export async function getAdGroupInsights(
+  apiKey: string,
+  adGroupId: string,
+  opts?: OpenAiAdsInsightsOptions,
+): Promise<OpenAiAdsInsightRow[]> {
+  validateApiKey(apiKey)
+  validateId(adGroupId, 'Ad group id')
+  return fetchAllPages<OpenAiAdsInsightRow>(
+    apiKey,
+    `ad_groups/${encodeURIComponent(adGroupId)}/insights`,
+    insightsPairs(opts),
+  )
+}

--- a/packages/integration-openai-ads/src/constants.ts
+++ b/packages/integration-openai-ads/src/constants.ts
@@ -1,0 +1,7 @@
+export const OPENAI_ADS_API_BASE = 'https://api.ads.openai.com/v1'
+
+export const OPENAI_ADS_REQUEST_TIMEOUT_MS = 30_000
+
+// Backstop against a pagination loop (e.g. a server that always returns
+// has_more=true). 100 pages is far beyond any observed account size.
+export const OPENAI_ADS_MAX_PAGES = 100

--- a/packages/integration-openai-ads/src/index.ts
+++ b/packages/integration-openai-ads/src/index.ts
@@ -1,0 +1,29 @@
+export {
+  getAdAccount,
+  listCampaigns,
+  listAdGroups,
+  listAds,
+  getAdAccountInsights,
+  getCampaignInsights,
+  getAdGroupInsights,
+} from './ads-client.js'
+export {
+  OpenAiAdsApiError,
+  parseErrorEnvelope,
+} from './types.js'
+export type {
+  OpenAiAdsAccount,
+  OpenAiAdsAd,
+  OpenAiAdsAdGroup,
+  OpenAiAdsBiddingConfig,
+  OpenAiAdsCampaign,
+  OpenAiAdsCampaignBudget,
+  OpenAiAdsCreative,
+  OpenAiAdsInsightRow,
+  OpenAiAdsInsightsOptions,
+  OpenAiAdsListResponse,
+  OpenAiAdsLocationTarget,
+  OpenAiAdsReviewState,
+  OpenAiAdsTargeting,
+} from './types.js'
+export { OPENAI_ADS_API_BASE, OPENAI_ADS_MAX_PAGES, OPENAI_ADS_REQUEST_TIMEOUT_MS } from './constants.js'

--- a/packages/integration-openai-ads/src/types.ts
+++ b/packages/integration-openai-ads/src/types.ts
@@ -1,0 +1,160 @@
+// Types mirror OpenAI Advertiser API responses captured live on 2026-06-10.
+// Money units are mixed upstream and preserved as-is here: budgets/bids are
+// integer micros, insights spend/cpc are decimal dollars. Normalize at ingest.
+
+export interface OpenAiAdsListResponse<T> {
+  object: 'list'
+  data: T[]
+  first_id: string | null
+  last_id: string | null
+  has_more: boolean
+  count?: number
+}
+
+export interface OpenAiAdsReviewState {
+  status: string
+}
+
+export interface OpenAiAdsAccount {
+  id: string
+  status: string
+  name: string
+  currency_code: string
+  timezone: string
+  url: string | null
+  review?: OpenAiAdsReviewState
+  account_integrity_review?: unknown
+  preview_url?: string | null
+}
+
+export interface OpenAiAdsCampaignBudget {
+  daily_spend_limit_micros?: number
+  lifetime_spend_limit_micros?: number
+}
+
+export interface OpenAiAdsLocationTarget {
+  id: string
+  type: string
+  country_code: string | null
+  name: string | null
+  region_code: string | null
+}
+
+export interface OpenAiAdsTargeting {
+  locations?: {
+    include?: OpenAiAdsLocationTarget[]
+    exclude?: OpenAiAdsLocationTarget[]
+  }
+}
+
+export interface OpenAiAdsCampaign {
+  id: string
+  name: string
+  status: string
+  bidding_type: string | null
+  budget: OpenAiAdsCampaignBudget | null
+  conversion_event_setting_ids: string[] | null
+  description: string | null
+  start_time: number | null
+  end_time: number | null
+  landing_page_configuration: unknown
+  mode: string | null
+  targeting: OpenAiAdsTargeting | null
+  created_at: number
+  updated_at: number
+}
+
+export interface OpenAiAdsBiddingConfig {
+  billing_event_type: string | null
+  max_bid_micros: number | null
+}
+
+export interface OpenAiAdsAdGroup {
+  id: string
+  name: string
+  status: string
+  bidding_config: OpenAiAdsBiddingConfig | null
+  // Live format: each entry is a multi-line string of newline-separated
+  // example queries (typically one entry per ad group).
+  context_hints: string[]
+  description: string | null
+  product_set: unknown
+  created_at: number
+  updated_at: number
+}
+
+export interface OpenAiAdsCreative {
+  type: string
+  title?: string | null
+  body?: string | null
+  file_id?: string | null
+  target_url?: string | null
+}
+
+export interface OpenAiAdsAd {
+  id: string
+  name: string
+  status: string
+  creative: OpenAiAdsCreative | null
+  review?: OpenAiAdsReviewState
+  review_status?: string
+  created_at: number
+  updated_at: number
+}
+
+// One row per time bucket (daily granularity observed). Metric fields appear
+// only when requested via fields[]; default responses carry impressions only.
+export interface OpenAiAdsInsightRow {
+  id: string
+  start_time: number
+  end_time: number
+  readable_time?: string
+  impressions?: number
+  clicks?: number
+  spend?: number
+  ctr?: number
+  cpc?: number
+  cpm?: number
+  ad_account_name?: string
+  campaign_name?: string
+}
+
+export interface OpenAiAdsInsightsOptions {
+  // Namespaced field names, e.g. 'campaign.clicks', 'ad_group.spend',
+  // 'metadata.readable_time'. Invalid names get a 400 whose message
+  // enumerates the valid catalog.
+  fields?: string[]
+}
+
+interface OpenAiAdsErrorEnvelope {
+  error?: {
+    message?: string
+    type?: string
+    param?: string | null
+    code?: string | null
+  }
+}
+
+export class OpenAiAdsApiError extends Error {
+  readonly status: number
+  readonly code: string | null
+
+  constructor(message: string, status: number, code: string | null = null) {
+    super(message)
+    this.name = 'OpenAiAdsApiError'
+    this.status = status
+    this.code = code
+  }
+}
+
+export function parseErrorEnvelope(body: string): { message: string | null; code: string | null } {
+  try {
+    const parsed = JSON.parse(body) as OpenAiAdsErrorEnvelope
+    return {
+      message: parsed.error?.message ?? null,
+      code: parsed.error?.code ?? null,
+    }
+  } catch {
+    return { message: null, code: null }
+  }
+}

--- a/packages/integration-openai-ads/test/ads-client.test.ts
+++ b/packages/integration-openai-ads/test/ads-client.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  getAdAccount,
+  listCampaigns,
+  listAdGroups,
+  listAds,
+  getAdAccountInsights,
+  getCampaignInsights,
+  getAdGroupInsights,
+} from '../src/ads-client.js'
+import { OPENAI_ADS_API_BASE } from '../src/constants.js'
+import {
+  FIXTURE_AD_ACCOUNT,
+  FIXTURE_AD_GROUP,
+  FIXTURE_AD,
+  FIXTURE_CAMPAIGN,
+  FIXTURE_ERROR_401,
+  FIXTURE_ERROR_BAD_FIELDS,
+  FIXTURE_ERROR_MISSING_PARAM,
+  FIXTURE_INSIGHT_ROW_DEFAULT,
+  FIXTURE_INSIGHT_ROW_FULL,
+  makeListResponse,
+} from './fixtures.js'
+
+let originalFetch: typeof globalThis.fetch
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+function mockFetchOnce(payload: unknown, status = 200) {
+  const calls: Array<{ url: string; init?: RequestInit }> = []
+  globalThis.fetch = async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(url), init })
+    return new Response(JSON.stringify(payload), { status })
+  }
+  return calls
+}
+
+describe('getAdAccount', () => {
+  it('sends a Bearer Authorization header and parses the account', async () => {
+    const calls = mockFetchOnce(FIXTURE_AD_ACCOUNT)
+
+    const account = await getAdAccount('test-key')
+
+    expect(calls.length).toBe(1)
+    expect(calls[0]!.url).toBe(`${OPENAI_ADS_API_BASE}/ad_account`)
+    const headers = calls[0]!.init?.headers as Record<string, string>
+    expect(headers.Authorization).toBe('Bearer test-key')
+    expect(account.id).toBe(FIXTURE_AD_ACCOUNT.id)
+    expect(account.currency_code).toBe('USD')
+    expect(account.timezone).toBe('America/Denver')
+  })
+
+  it('throws OpenAiAdsApiError with the upstream code on 401', async () => {
+    mockFetchOnce(FIXTURE_ERROR_401, 401)
+
+    await expect(() => getAdAccount('bad-key')).rejects.toMatchObject({
+      name: 'OpenAiAdsApiError',
+      status: 401,
+      code: 'invalid_api_key',
+    })
+    mockFetchOnce(FIXTURE_ERROR_401, 401)
+    await expect(() => getAdAccount('bad-key')).rejects.toThrow(/invalid or unauthorized/)
+  })
+
+  it('throws a rate-limit error on 429', async () => {
+    mockFetchOnce({ error: { message: 'Too many requests', type: 'rate_limit_error', param: null, code: null } }, 429)
+
+    await expect(() => getAdAccount('key')).rejects.toMatchObject({ status: 429 })
+    mockFetchOnce({ error: { message: 'Too many requests', type: 'rate_limit_error', param: null, code: null } }, 429)
+    await expect(() => getAdAccount('key')).rejects.toThrow(/rate limit/)
+  })
+
+  it('throws a 502-style error on invalid JSON', async () => {
+    globalThis.fetch = async () => new Response('<html>gateway</html>', { status: 200 })
+
+    await expect(() => getAdAccount('key')).rejects.toMatchObject({ status: 502 })
+  })
+
+  it('rejects an empty API key before calling fetch', async () => {
+    const calls = mockFetchOnce(FIXTURE_AD_ACCOUNT)
+
+    await expect(() => getAdAccount('')).rejects.toMatchObject({ status: 400 })
+    expect(calls.length).toBe(0)
+  })
+})
+
+describe('listCampaigns', () => {
+  it('parses the list envelope and returns the campaigns', async () => {
+    mockFetchOnce(makeListResponse([FIXTURE_CAMPAIGN]))
+
+    const campaigns = await listCampaigns('test-key')
+
+    expect(campaigns.length).toBe(1)
+    expect(campaigns[0]!.id).toBe(FIXTURE_CAMPAIGN.id)
+    // budgets are integer micros upstream — assert the unit survives untouched
+    expect(campaigns[0]!.budget?.daily_spend_limit_micros).toBe(150000000)
+    expect(campaigns[0]!.targeting?.locations?.include?.[0]?.country_code).toBe('US')
+  })
+
+  it('follows cursor pagination via after= until has_more is false', async () => {
+    const page1 = makeListResponse([{ ...FIXTURE_CAMPAIGN, id: 'cmpn_page1' }], {
+      has_more: true,
+      last_id: 'cmpn_page1',
+    })
+    const page2 = makeListResponse([{ ...FIXTURE_CAMPAIGN, id: 'cmpn_page2' }])
+    const urls: string[] = []
+    let call = 0
+    globalThis.fetch = async (url: string | URL | Request) => {
+      urls.push(String(url))
+      call += 1
+      return new Response(JSON.stringify(call === 1 ? page1 : page2), { status: 200 })
+    }
+
+    const campaigns = await listCampaigns('test-key')
+
+    expect(campaigns.map((c) => c.id)).toEqual(['cmpn_page1', 'cmpn_page2'])
+    expect(urls.length).toBe(2)
+    expect(urls[0]).not.toContain('after=')
+    expect(urls[1]).toContain('after=cmpn_page1')
+  })
+
+  it('stops when has_more is false even though last_id is set', async () => {
+    const calls = mockFetchOnce(makeListResponse([FIXTURE_CAMPAIGN]))
+
+    await listCampaigns('test-key')
+
+    expect(calls.length).toBe(1)
+  })
+})
+
+describe('listAdGroups', () => {
+  it('requires campaign_id in the query and preserves context_hints verbatim', async () => {
+    const calls = mockFetchOnce(makeListResponse([FIXTURE_AD_GROUP]))
+
+    const adGroups = await listAdGroups('test-key', 'cmpn_abc')
+
+    expect(calls[0]!.url).toBe(`${OPENAI_ADS_API_BASE}/ad_groups?campaign_id=cmpn_abc`)
+    expect(adGroups[0]!.context_hints).toEqual(FIXTURE_AD_GROUP.context_hints)
+    // live format: one multi-line string of newline-separated example queries
+    expect(adGroups[0]!.context_hints[0]).toContain('\n')
+    expect(adGroups[0]!.bidding_config?.max_bid_micros).toBe(2000000)
+  })
+
+  it('rejects an empty campaign id before calling fetch', async () => {
+    const calls = mockFetchOnce(makeListResponse([FIXTURE_AD_GROUP]))
+
+    await expect(() => listAdGroups('test-key', '')).rejects.toMatchObject({ status: 400 })
+    expect(calls.length).toBe(0)
+  })
+
+  it('surfaces the upstream missing-parameter error envelope', async () => {
+    mockFetchOnce(FIXTURE_ERROR_MISSING_PARAM, 400)
+
+    await expect(() => listAdGroups('test-key', 'cmpn_abc')).rejects.toMatchObject({
+      status: 400,
+      code: 'missing_required_parameter',
+    })
+  })
+})
+
+describe('listAds', () => {
+  it('requires ad_group_id in the query and parses the chat_card creative', async () => {
+    const calls = mockFetchOnce(makeListResponse([FIXTURE_AD]))
+
+    const ads = await listAds('test-key', 'adgrp_abc')
+
+    expect(calls[0]!.url).toBe(`${OPENAI_ADS_API_BASE}/ads?ad_group_id=adgrp_abc`)
+    expect(ads[0]!.creative?.type).toBe('chat_card')
+    expect(ads[0]!.creative?.target_url).toContain('utm_source=chatgpt')
+    expect(ads[0]!.review_status).toBe('approved')
+  })
+})
+
+describe('insights', () => {
+  it('returns default rows (impressions only) when no fields are requested', async () => {
+    const calls = mockFetchOnce(makeListResponse([FIXTURE_INSIGHT_ROW_DEFAULT]))
+
+    const rows = await getAdAccountInsights('test-key')
+
+    expect(calls[0]!.url).toBe(`${OPENAI_ADS_API_BASE}/ad_account/insights`)
+    expect(rows[0]!.impressions).toBe(2061)
+    expect(rows[0]!.clicks).toBeUndefined()
+  })
+
+  it('serializes fields as literal fields[]= pairs in request order', async () => {
+    const calls = mockFetchOnce(makeListResponse([FIXTURE_INSIGHT_ROW_FULL]))
+
+    const rows = await getCampaignInsights('test-key', 'cmpn_abc', {
+      fields: ['campaign.impressions', 'campaign.clicks', 'campaign.spend', 'metadata.readable_time'],
+    })
+
+    // The live API was exercised with literal bracket pairs — keep them
+    // unencoded so the client sends exactly what was verified.
+    expect(calls[0]!.url).toBe(
+      `${OPENAI_ADS_API_BASE}/campaigns/cmpn_abc/insights?fields[]=campaign.impressions&fields[]=campaign.clicks&fields[]=campaign.spend&fields[]=metadata.readable_time`,
+    )
+    // spend/cpc are decimal dollars upstream — assert they pass through untouched
+    expect(rows[0]!.spend).toBe(39.28)
+    expect(rows[0]!.cpc).toBe(1.71)
+    expect(rows[0]!.readable_time).toBe('2026-06-10')
+  })
+
+  it('supports ad-group-level insights', async () => {
+    const calls = mockFetchOnce(
+      makeListResponse([{ ...FIXTURE_INSIGHT_ROW_FULL, id: 'start=1:end=2:entity_id=adgrp_abc' }]),
+    )
+
+    await getAdGroupInsights('test-key', 'adgrp_abc', { fields: ['ad_group.impressions'] })
+
+    expect(calls[0]!.url).toBe(`${OPENAI_ADS_API_BASE}/ad_groups/adgrp_abc/insights?fields[]=ad_group.impressions`)
+  })
+
+  it('surfaces the invalid-fields 400 with its catalog message', async () => {
+    mockFetchOnce(FIXTURE_ERROR_BAD_FIELDS, 400)
+
+    await expect(() =>
+      getCampaignInsights('test-key', 'cmpn_abc', { fields: ['impressions'] }),
+    ).rejects.toThrow(/Each value in fields must be one of/)
+  })
+
+  it('paginates insights like every other list', async () => {
+    const page1 = makeListResponse([{ ...FIXTURE_INSIGHT_ROW_FULL, id: 'row-1' }], {
+      has_more: true,
+      last_id: 'row-1',
+    })
+    const page2 = makeListResponse([{ ...FIXTURE_INSIGHT_ROW_FULL, id: 'row-2' }])
+    const urls: string[] = []
+    let call = 0
+    globalThis.fetch = async (url: string | URL | Request) => {
+      urls.push(String(url))
+      call += 1
+      return new Response(JSON.stringify(call === 1 ? page1 : page2), { status: 200 })
+    }
+
+    const rows = await getAdAccountInsights('test-key', { fields: ['ad_account.id'] })
+
+    expect(rows.map((r) => r.id)).toEqual(['row-1', 'row-2'])
+    expect(urls[1]).toContain('fields[]=ad_account.id')
+    expect(urls[1]).toContain('after=row-1')
+  })
+})

--- a/packages/integration-openai-ads/test/fixtures.ts
+++ b/packages/integration-openai-ads/test/fixtures.ts
@@ -1,0 +1,165 @@
+// Fixtures mirror REAL OpenAI Advertiser API responses captured live on
+// 2026-06-10 (curl against an active ad account). Identifiers, names, URLs,
+// and copy are sanitized; field names, nesting, envelope shape, value types,
+// and unit quirks (micros vs decimal dollars) are verbatim from production.
+// Never add a field here that has not been observed in a captured response.
+
+import type {
+  OpenAiAdsAccount,
+  OpenAiAdsAd,
+  OpenAiAdsAdGroup,
+  OpenAiAdsCampaign,
+  OpenAiAdsInsightRow,
+  OpenAiAdsListResponse,
+} from '../src/types.js'
+
+export const FIXTURE_AD_ACCOUNT: OpenAiAdsAccount = {
+  id: 'adacct_0000000000000000000000000000aaaa',
+  status: 'active',
+  account_integrity_review: {
+    details: {
+      decision: 'allowed',
+      reason: 'Low risk: established business with an official site and third-party validation.',
+      status_updated_at: '2026-06-03T18:57:34.397908+00:00',
+    },
+    review: { status: 'approved' },
+  },
+  currency_code: 'USD',
+  name: 'Acme Exteriors, Inc',
+  preview_url: 'https://bzrcdn.openai.com/0000000000000000.png',
+  review: { status: 'approved' },
+  timezone: 'America/Denver',
+  url: 'https://acme-exteriors.example/',
+}
+
+export const FIXTURE_CAMPAIGN: OpenAiAdsCampaign = {
+  id: 'cmpn_0000000000000000000000000000bbbb',
+  created_at: 1780770653,
+  status: 'active',
+  bidding_type: 'clicks',
+  budget: { daily_spend_limit_micros: 150000000 },
+  conversion_event_setting_ids: ['0000000000000000000000000000cccc'],
+  description: null,
+  end_time: null,
+  landing_page_configuration: null,
+  mode: null,
+  name: 'Homeowners Free Estimate',
+  start_time: 1780770127,
+  targeting: {
+    locations: {
+      include: [
+        { id: '1000232', type: 'country', country_code: 'US', name: 'United States', region_code: null },
+        { id: '1000037', type: 'country', country_code: 'CA', name: 'Canada', region_code: null },
+      ],
+    },
+  },
+  updated_at: 1780868842,
+}
+
+export const FIXTURE_AD_GROUP: OpenAiAdsAdGroup = {
+  id: 'adgrp_0000000000000000000000000000dddd',
+  created_at: 1780770657,
+  status: 'active',
+  bidding_config: {
+    billing_event_type: 'click',
+    max_bid_micros: 2000000,
+  },
+  // Live format: ONE multi-line string of newline-separated example queries —
+  // not one hint per array element, and not prose descriptions.
+  context_hints: [
+    'how much does a new deck cost for my house\nhow much material do I need for a deck\nwhat size deck fits my yard\ncomposite vs wood deck for my home\nhow many boards do I need for a deck\nmeasure my yard to plan materials',
+  ],
+  description: null,
+  name: 'Deck Project Planning',
+  product_set: null,
+  updated_at: 1780864410,
+}
+
+export const FIXTURE_AD: OpenAiAdsAd = {
+  id: 'ad_0000000000000000000000000000eeee',
+  created_at: 1780770662,
+  status: 'active',
+  creative: {
+    type: 'chat_card',
+    body: 'Know how much material you need, from a free measurement.',
+    file_id: 'file_0000000000000000000000000000ffff',
+    target_url: 'https://lp.acme-exteriors.example/free-estimate?utm_source=chatgpt&utm_medium=cpc',
+    title: 'Free Estimate For Materials',
+  },
+  name: 'HO Deck - Materials',
+  review: { status: 'approved' },
+  review_status: 'approved',
+  updated_at: 1781139491,
+}
+
+// Default insights response (no fields[] requested) carries impressions only.
+export const FIXTURE_INSIGHT_ROW_DEFAULT: OpenAiAdsInsightRow = {
+  id: 'start=1781071200:end=1781157600:entity_id=adacct_0000000000000000000000000000aaaa',
+  ad_account_name: 'Acme Exteriors, Inc',
+  end_time: 1781157600,
+  impressions: 2061,
+  readable_time: '2026-06-10',
+  start_time: 1781071200,
+}
+
+// With fields[]= requested: clicks/ctr/cpc/spend appear; spend and cpc are
+// DECIMAL DOLLARS (not micros) in production responses.
+export const FIXTURE_INSIGHT_ROW_FULL: OpenAiAdsInsightRow = {
+  id: 'start=1781071200:end=1781157600:entity_id=cmpn_0000000000000000000000000000bbbb',
+  campaign_name: 'Homeowners Free Estimate',
+  clicks: 23,
+  cpc: 1.71,
+  ctr: 0.0132,
+  end_time: 1781157600,
+  impressions: 1736,
+  readable_time: '2026-06-10',
+  spend: 39.28,
+  start_time: 1781071200,
+}
+
+export function makeListResponse<T>(
+  data: T[],
+  overrides: Partial<Omit<OpenAiAdsListResponse<T>, 'data'>> = {},
+): OpenAiAdsListResponse<T> {
+  const ids = data as Array<{ id?: string }>
+  return {
+    object: 'list',
+    data,
+    first_id: ids[0]?.id ?? null,
+    last_id: ids[ids.length - 1]?.id ?? null,
+    has_more: false,
+    ...overrides,
+  }
+}
+
+// Real 401 body (no/invalid Authorization), captured verbatim.
+export const FIXTURE_ERROR_401 = {
+  error: {
+    message: 'Missing or invalid SDK key in Authorization header.',
+    type: 'invalid_request_error',
+    param: null,
+    code: 'invalid_api_key',
+  },
+}
+
+// Real 400 body for a list endpoint missing its required parent filter.
+export const FIXTURE_ERROR_MISSING_PARAM = {
+  error: {
+    message: "Missing required parameter: 'campaign_id'.",
+    type: 'invalid_request_error',
+    param: 'campaign_id',
+    code: 'missing_required_parameter',
+  },
+}
+
+// Real 400 body for an invalid fields[] name — the message enumerates the
+// valid catalog (truncated here; structure verbatim, code is null upstream).
+export const FIXTURE_ERROR_BAD_FIELDS = {
+  error: {
+    message:
+      '400: Each value in fields must be one of: ad_account.id, campaign.clicks, campaign.impressions, campaign.spend, metadata.readable_time',
+    type: 'server_error',
+    param: null,
+    code: null,
+  },
+}

--- a/packages/integration-openai-ads/tsconfig.json
+++ b/packages/integration-openai-ads/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -445,6 +445,8 @@ importers:
         specifier: workspace:*
         version: link:../contracts
 
+  packages/integration-openai-ads: {}
+
   packages/integration-traffic:
     dependencies:
       '@ainyc/canonry-contracts':

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -38,6 +38,7 @@ const NODE_PACKAGES = [
   'integration-google-analytics',
   'integration-google-business-profile',
   'integration-google-places',
+  'integration-openai-ads',
   'integration-traffic',
   'integration-vercel',
   'integration-wordpress',


### PR DESCRIPTION
## What

New private workspace package `@ainyc/canonry-integration-openai-ads`: a typed read client for the OpenAI Advertiser API (`api.ads.openai.com/v1`). Covers ad account, campaigns, ad groups, ads, and account/campaign/ad-group insights. PR 2 of the lane planned in `plans/openai-ads-integration.md` (#693); nothing imports it yet — wiring (run kind, routes, CLI, MCP) lands in the next stacked PR.

## How

TDD against fixtures that mirror real captured API responses (sanitized identifiers, verbatim shapes):

- Bearer "SDK key" auth; 401/403/429 and error-envelope mapping with upstream `code` preserved
- List envelope (`object/data/first_id/last_id/has_more`) with cursor pagination; the `after=` request param follows the OpenAI list convention and is documented as unverified against multi-page datasets
- Insights metric selection via literal `fields[]=` pairs with namespaced names (the form exercised live)
- Upstream money units preserved as-is: budgets/bids in integer micros, insights spend/cpc in decimal dollars; normalization is deliberately deferred to ingest

## Tests

17 unit tests (auth header, envelope parsing, pagination, fields serialization, context_hints passthrough, error codes, client-side validation). `pnpm vitest run --project integration-openai-ads`, package lint + typecheck, and workspace typecheck/lint all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)