### PR TITLE
fix(gsc): a Google permission error no longer logs the dashboard out

### DIFF
--- a/apps/web/src/api-aero.ts
+++ b/apps/web/src/api-aero.ts
@@ -76,11 +76,12 @@ export interface AeroTranscript {
 
 // Aero endpoints bypass apiFetch (the prompt endpoint needs the raw SSE stream
 // body, and the others share that file for cohesion), so they need their own
-// 401/403 → handleAuthExpired() trigger. Without this, a long-lived dashboard
+// 401 → handleAuthExpired() trigger. Without this, a long-lived dashboard
 // whose only active request is the agent stream wouldn't be kicked when its
-// session expires.
-function triggerAuthExpiredOn401Or403(status: number): void {
-  if (status === 401 || status === 403) {
+// session expires. Only 401 forces logout — a 403 is never a session expiry
+// (see the `heyClient` interceptor in api.ts for the full rationale).
+function triggerAuthExpiredOn401(status: number): void {
+  if (status === 401) {
     handleAuthExpired()
   }
 }
@@ -90,7 +91,7 @@ export async function fetchAeroTranscript(project: string): Promise<AeroTranscri
     credentials: 'include',
   })
   if (!res.ok) {
-    triggerAuthExpiredOn401Or403(res.status)
+    triggerAuthExpiredOn401(res.status)
     const body = await parseErrorBody(res)
     throw new ApiError(body.error?.message ?? `transcript fetch failed: ${res.status}`, res.status, body.error?.code)
   }
@@ -102,7 +103,7 @@ export async function fetchAgentProviders(project: string): Promise<AgentProvide
     credentials: 'include',
   })
   if (!res.ok) {
-    triggerAuthExpiredOn401Or403(res.status)
+    triggerAuthExpiredOn401(res.status)
     const body = await parseErrorBody(res)
     throw new ApiError(
       body.error?.message ?? `providers fetch failed: ${res.status}`,
@@ -119,7 +120,7 @@ export async function resetAeroTranscript(project: string): Promise<void> {
     credentials: 'include',
   })
   if (!res.ok) {
-    triggerAuthExpiredOn401Or403(res.status)
+    triggerAuthExpiredOn401(res.status)
     const body = await parseErrorBody(res)
     throw new ApiError(body.error?.message ?? `reset failed: ${res.status}`, res.status, body.error?.code)
   }
@@ -170,7 +171,7 @@ export async function promptAero({
     signal,
   })
   if (!res.ok || !res.body) {
-    triggerAuthExpiredOn401Or403(res.status)
+    triggerAuthExpiredOn401(res.status)
     const errBody = await parseErrorBody(res)
     throw new ApiError(errBody.error?.message ?? `prompt failed: ${res.status}`, res.status, errBody.error?.code)
   }

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -137,12 +137,21 @@ export type { GroundingSource }
 export class ApiError extends Error {
   readonly code: ErrorCode | 'UNKNOWN'
   readonly statusCode: number
+  /**
+   * Structured `error.details` from the API envelope, when present. Carries
+   * machine-readable remediation (e.g. a FORBIDDEN from a disabled Google API
+   * ships `{ reason: 'gsc-api-disabled', enableUrl, projectNumber }`) so a
+   * component can render a first-class "Action needed" affordance instead of a
+   * raw message.
+   */
+  readonly details?: Record<string, unknown>
 
-  constructor(message: string, statusCode: number, code?: ErrorCode) {
+  constructor(message: string, statusCode: number, code?: ErrorCode, details?: Record<string, unknown>) {
     super(message)
     this.name = 'ApiError'
     this.code = code ?? 'UNKNOWN'
     this.statusCode = statusCode
+    this.details = details
   }
 }
 
@@ -215,16 +224,16 @@ export function hasExplicitBrowserApiKey(): boolean {
 let _onAuthExpired: (() => void) | null = null
 
 /**
- * Register a handler to call when any API request returns 401 or 403.
- * Pass null to clear. Only one handler is active at a time.
+ * Register a handler to call when an API request returns 401 (session expired
+ * / invalid). Pass null to clear. Only one handler is active at a time.
  */
 export function setOnAuthExpired(handler: (() => void) | null): void {
   _onAuthExpired = handler
 }
 
 /**
- * Trigger the registered auth-expiry handler. Called automatically by
- * apiFetch / invokeWeb on 401/403 responses; also callable from tests.
+ * Trigger the registered auth-expiry handler. Called automatically on 401
+ * responses (never 403 — see the heyClient interceptor); also callable from tests.
  */
 export function handleAuthExpired(): void {
   _onAuthExpired?.()
@@ -253,10 +262,18 @@ export const heyClient = createHeyClient({
 // SDK call). Without this, hooks that bypass `invokeWeb` (e.g. components
 // using `useQuery(getApiV1...Options(...))`) would silently 401 and leave
 // the user staring at a broken dashboard instead of being kicked to login.
-// Skips /session/* routes — a 401 there means "wrong password," not
-// "your session expired."
+//
+// ONLY 401 forces logout. A 401 is the single status canonry's auth layer
+// emits for an invalid/expired session or API key — re-authenticating fixes
+// it. A 403 (FORBIDDEN) never means "your session expired": it's either a
+// missing scope or, more commonly, an upstream provider that forbade a proxied
+// call (e.g. Google Search Console returning 403 because the operator's GCP
+// project hasn't enabled the API). Logging out on those is wrong — re-login
+// changes nothing — and it produced the "connect GSC → instantly booted to
+// login" bug. Those surface to the calling component to render inline instead.
+// Skips /session/* — a 401 there means "wrong password," not "session expired."
 heyClient.interceptors.response.use((res, req) => {
-  if ((res.status === 401 || res.status === 403) && !req.url.includes('/api/v1/session')) {
+  if (res.status === 401 && !req.url.includes('/api/v1/session')) {
     handleAuthExpired()
   }
   return res
@@ -279,7 +296,7 @@ type SdkResult = {
 /**
  * Wrap a generated SDK call with `ApiError` mapping.
  *
- * 401/403 → `handleAuthExpired()` is handled by the `heyClient.interceptors.response`
+ * 401 → `handleAuthExpired()` is handled by the `heyClient.interceptors.response`
  * hook (declared at module top) so generated TanStack Query options get the
  * same redirect-on-expiry behavior. Don't dispatch it here too — that would
  * fire the handler twice for every expired-session request that flows through
@@ -291,23 +308,26 @@ async function invokeWeb<T>(call: () => Promise<SdkResult>): Promise<T> {
     const status = result.response.status
     let message = `API ${status}: ${result.response.statusText}`
     let code: ErrorCode | undefined
+    let details: Record<string, unknown> | undefined
     if (typeof result.error === 'object' && result.error !== null) {
       const inner = (result.error as { error?: unknown }).error
       if (typeof inner === 'string') {
         message = inner
       } else if (inner && typeof inner === 'object') {
-        const obj = inner as { message?: string; code?: string }
+        const obj = inner as { message?: string; code?: string; details?: Record<string, unknown> }
         if (obj.message) message = obj.message
         if (obj.code) code = obj.code as ErrorCode
+        if (obj.details) details = obj.details
       } else {
-        const flat = result.error as { message?: string; code?: string }
+        const flat = result.error as { message?: string; code?: string; details?: Record<string, unknown> }
         if (flat.message) message = flat.message
         if (flat.code) code = flat.code as ErrorCode
+        if (flat.details) details = flat.details
       }
     } else if (typeof result.error === 'string') {
       message = result.error
     }
-    throw new ApiError(message, status, code)
+    throw new ApiError(message, status, code, details)
   }
   if (result.response.status === 204) return undefined as T
   return result.data as T
@@ -335,10 +355,11 @@ async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
     const bodyText = await res.text()
     let message = `API ${res.status}: ${res.statusText}`
     let code: ErrorCode | undefined
+    let details: Record<string, unknown> | undefined
     if (bodyText) {
       try {
         const parsed = JSON.parse(bodyText) as {
-          error?: string | { message?: string; code?: string }
+          error?: string | { message?: string; code?: string; details?: Record<string, unknown> }
           message?: string
         }
         if (typeof parsed.error === 'string') {
@@ -346,6 +367,7 @@ async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
         } else if (parsed.error?.message) {
           message = parsed.error.message
           code = parsed.error.code as ErrorCode | undefined
+          details = parsed.error.details
         } else if (parsed.message) {
           message = parsed.message
         }
@@ -353,13 +375,14 @@ async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
         message = bodyText
       }
     }
-    // Don't trigger auth-expiry on the session endpoints themselves — those
-    // are the login/setup paths, and a 401 there means "wrong password", not
-    // "your session expired."
-    if ((res.status === 401 || res.status === 403) && !path.startsWith('/session')) {
+    // Only 401 forces logout — see the heyClient interceptor above for the full
+    // rationale. A 403 never means "session expired" (re-login can't fix a
+    // missing scope or an upstream provider 403), so it surfaces to the caller.
+    // Skip /session/* — a 401 there means "wrong password", not "session expired".
+    if (res.status === 401 && !path.startsWith('/session')) {
       handleAuthExpired()
     }
-    throw new ApiError(message, res.status, code)
+    throw new ApiError(message, res.status, code, details)
   }
   if (res.status === 204) {
     return undefined as T

--- a/apps/web/src/components/project/GscSection.tsx
+++ b/apps/web/src/components/project/GscSection.tsx
@@ -11,6 +11,9 @@ import { CHART_NEUTRAL, CHART_TONE, CHART_SERIES_COLORS } from '../shared/ChartP
 import { formatTimestamp, formatBooleanState, SearchMetric, SEARCH_METRIC_LABELS } from '../../lib/format-helpers.js'
 import { addToast } from '../../lib/toast-store.js'
 import { asyncHandler } from '../../lib/async-handler.js'
+import { extractApiErrorInfo } from '../../lib/extract-error-message.js'
+import { gscActionNeededFromError, type GscActionNeeded } from '../../lib/gsc-remediation.js'
+import { safeExternalUrl } from '../../lib/safe-url.js'
 import {
   fetchSettings,
   googleConnect,
@@ -178,7 +181,27 @@ export function GscSection({
   )
   const [requestingIndexing, setRequestingIndexing] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // First-class remediation for the self-hosted "I used my own OAuth client but
+  // never enabled the Search Console API" 403 — rendered as a one-click banner
+  // instead of a raw error string. Mutually exclusive with `error`.
+  const [actionNeeded, setActionNeeded] = useState<GscActionNeeded | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
+
+  // Classify a thrown GSC error: a recognized "Action needed" remediation
+  // (enable-API) renders as the amber banner; everything else is a plain inline
+  // error. Reading `details` works whether the throw was an ApiError (api.ts
+  // wrappers) or the raw envelope the generated SDK throws via fetchQuery.
+  function reportGscError(err: unknown, fallback: string) {
+    const info = extractApiErrorInfo(err)
+    const action = gscActionNeededFromError(info)
+    if (action) {
+      setActionNeeded(action)
+      setError(null)
+    } else {
+      setActionNeeded(null)
+      setError(info.message || fallback)
+    }
+  }
 
   const gscConn = connections.find((c) => c.connectionType === 'gsc')
   const hasHistoricalData = performance.length > 0 || inspections.length > 0 || deindexed.length > 0
@@ -201,9 +224,10 @@ export function GscSection({
       })
       setProperties(sites)
       setSelectedProperty(currentConn.propertyId ?? sites[0]?.siteUrl ?? '')
+      setActionNeeded(null)
     } catch (err) {
       setProperties([])
-      setError(err instanceof Error ? err.message : 'Failed to load Search Console properties')
+      reportGscError(err, 'Failed to load Search Console properties')
     } finally {
       setPropertiesLoading(false)
     }
@@ -612,6 +636,41 @@ export function GscSection({
         </div>
       </div>
 
+      {actionNeeded && (
+        <div className="mb-3 rounded-lg border border-amber-800/40 bg-amber-950/20 px-3 py-2.5 text-sm text-amber-200">
+          <div className="flex items-start justify-between gap-2">
+            <div>
+              <p className="font-medium text-amber-100">{actionNeeded.title}</p>
+              <p className="mt-0.5 text-amber-200/90">{actionNeeded.message}</p>
+              {(safeExternalUrl(actionNeeded.enableUrl) || safeExternalUrl(actionNeeded.indexingApiUrl)) && (
+                <div className="mt-2 flex flex-wrap gap-3">
+                  {safeExternalUrl(actionNeeded.enableUrl) && (
+                    <a
+                      href={safeExternalUrl(actionNeeded.enableUrl)!}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="font-medium text-amber-100 underline decoration-amber-500/50 underline-offset-2 hover:text-amber-50"
+                    >
+                      {'Enable Search Console API ↗'}
+                    </a>
+                  )}
+                  {safeExternalUrl(actionNeeded.indexingApiUrl) && (
+                    <a
+                      href={safeExternalUrl(actionNeeded.indexingApiUrl)!}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="font-medium text-amber-100 underline decoration-amber-500/50 underline-offset-2 hover:text-amber-50"
+                    >
+                      {'Enable Indexing API ↗'}
+                    </a>
+                  )}
+                </div>
+              )}
+            </div>
+            <button type="button" className="text-amber-400 hover:text-amber-200" onClick={() => setActionNeeded(null)}>×</button>
+          </div>
+        </div>
+      )}
       {error && (
         <div className="mb-3 rounded-lg border border-rose-800/40 bg-rose-950/20 px-3 py-2 text-sm text-rose-300">
           {error}

--- a/apps/web/src/lib/extract-error-message.ts
+++ b/apps/web/src/lib/extract-error-message.ts
@@ -1,9 +1,61 @@
 /**
+ * Structured view of an unknown thrown value from an API call.
+ *
+ * Two error shapes reach a component: an `ApiError` (Error subclass carrying
+ * `code` + `details`, thrown by the `api.ts` wrappers) and the raw envelope
+ * `{ error: { code, message, details } }` that the generated SDK throws when
+ * `throwOnError: true` (the path TanStack Query's `fetchQuery`/hooks take).
+ * This normalizes both so callers can branch on `code` / `details` without
+ * caring which path produced the error.
+ */
+export interface ApiErrorInfo {
+  message: string
+  code?: string
+  details?: Record<string, unknown>
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+/**
+ * Normalize an unknown thrown value into `{ message, code?, details? }`.
+ * Handles `ApiError` (duck-typed to avoid a circular import with api.ts), the
+ * raw `{ error: { … } }` SDK envelope, plain `Error`s, and strings.
+ */
+export function extractApiErrorInfo(error: unknown): ApiErrorInfo {
+  if (error instanceof Error) {
+    const e = error as Error & { code?: unknown; details?: unknown }
+    return {
+      message: error.message,
+      code: typeof e.code === 'string' ? e.code : undefined,
+      details: isRecord(e.details) ? e.details : undefined,
+    }
+  }
+  if (isRecord(error)) {
+    const inner = (error as { error?: unknown }).error
+    if (isRecord(inner)) {
+      return {
+        message: typeof inner.message === 'string' ? inner.message : 'Request failed',
+        code: typeof inner.code === 'string' ? inner.code : undefined,
+        details: isRecord(inner.details) ? inner.details : undefined,
+      }
+    }
+    if (typeof inner === 'string') return { message: inner }
+    const flatMessage = (error as { message?: unknown }).message
+    if (typeof flatMessage === 'string') return { message: flatMessage }
+  }
+  if (typeof error === 'string') return { message: error }
+  return { message: String(error) }
+}
+
+/**
  * Normalize an unknown thrown value into a human-readable message.
  *
  * Any `Error` (including subclasses such as the API client's `ApiError`)
- * yields its `.message`; anything else is coerced with `String()`.
+ * yields its `.message`; the raw `{ error: { message } }` SDK envelope yields
+ * its inner message; anything else is coerced with `String()`.
  */
 export function extractErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error)
+  return extractApiErrorInfo(error).message
 }

--- a/apps/web/src/lib/gsc-remediation.ts
+++ b/apps/web/src/lib/gsc-remediation.ts
@@ -1,0 +1,36 @@
+import type { ApiErrorInfo } from './extract-error-message.js'
+
+export interface GscActionNeeded {
+  title: string
+  message: string
+  /** Google Cloud "enable API" deep links, when the project number was parsed. */
+  enableUrl?: string
+  indexingApiUrl?: string
+  projectNumber?: string
+}
+
+/**
+ * When a Search Console call fails because the operator's own Google Cloud
+ * project hasn't enabled the Search Console API, the backend returns FORBIDDEN
+ * with `details.reason === 'gsc-api-disabled'` plus the enable deep links and
+ * GCP project number. Turn that into a first-class "Action needed" card so the
+ * setup flow can show a one-click remediation rather than a raw error string.
+ *
+ * Returns null for any other error (including the other GSC FORBIDDEN reasons,
+ * `gsc-reconnect` / `gsc-no-property-access`, whose self-explanatory messages
+ * render fine as a plain inline error) so the caller falls back to that path.
+ */
+export function gscActionNeededFromError(info: ApiErrorInfo): GscActionNeeded | null {
+  const d = info.details
+  if (info.code !== 'FORBIDDEN' || !d || d.reason !== 'gsc-api-disabled') return null
+  const projectNumber = typeof d.projectNumber === 'string' ? d.projectNumber : undefined
+  return {
+    title: 'Enable the Search Console API',
+    message:
+      `Your Google Cloud project${projectNumber ? ` (${projectNumber})` : ''} hasn't enabled the Search Console API. `
+      + 'Enable the Search Console API and the Indexing API, wait ~2–5 minutes, then retry.',
+    enableUrl: typeof d.enableUrl === 'string' ? d.enableUrl : undefined,
+    indexingApiUrl: typeof d.indexingApiUrl === 'string' ? d.indexingApiUrl : undefined,
+    projectNumber,
+  }
+}

--- a/apps/web/test/api-fetch-auth.test.ts
+++ b/apps/web/test/api-fetch-auth.test.ts
@@ -34,13 +34,17 @@ describe('apiFetch auth expiry', () => {
     expect(handler).toHaveBeenCalledOnce()
   })
 
-  test('calls auth expired handler on 403', async () => {
-    mockFetch(403, { error: 'Forbidden' })
+  test('does NOT call auth expired handler on 403 (forbidden ≠ session expiry)', async () => {
+    // A 403 is never a canonry session expiry — it's a missing scope or, far
+    // more often, an upstream provider 403 proxied through (e.g. Google Search
+    // Console returning 403 for a disabled API). Re-login can't fix it, so the
+    // dashboard must surface it inline, not boot the operator to login.
+    mockFetch(403, { error: { code: 'FORBIDDEN', message: 'Forbidden' } })
     const handler = vi.fn()
     setOnAuthExpired(handler)
 
     await expect(fetchProjects()).rejects.toThrow()
-    expect(handler).toHaveBeenCalledOnce()
+    expect(handler).not.toHaveBeenCalled()
   })
 
   test('does NOT call auth expired handler on 404', async () => {
@@ -128,13 +132,13 @@ describe('api-aero auth expiry', () => {
     expect(handler).toHaveBeenCalledOnce()
   })
 
-  test('fetchAeroTranscript triggers auth expiry on 403', async () => {
-    mockFetch(403, { error: 'Forbidden' })
+  test('fetchAeroTranscript does NOT trigger auth expiry on 403', async () => {
+    mockFetch(403, { error: { code: 'FORBIDDEN', message: 'Forbidden' } })
     const handler = vi.fn()
     setOnAuthExpired(handler)
 
     await expect(fetchAeroTranscript('demo')).rejects.toThrow()
-    expect(handler).toHaveBeenCalledOnce()
+    expect(handler).not.toHaveBeenCalled()
   })
 
   test('fetchAeroTranscript does NOT trigger auth expiry on 404', async () => {

--- a/apps/web/test/extract-error-message.test.ts
+++ b/apps/web/test/extract-error-message.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 
-import { extractErrorMessage } from '../src/lib/extract-error-message.js'
+import { extractErrorMessage, extractApiErrorInfo } from '../src/lib/extract-error-message.js'
 
 describe('extractErrorMessage', () => {
   test('returns the message of a plain Error', () => {
@@ -16,12 +16,58 @@ describe('extractErrorMessage', () => {
     expect(extractErrorMessage('plain string failure')).toBe('plain string failure')
   })
 
-  test('stringifies a non-error object', () => {
+  test('unwraps the raw API envelope the generated SDK throws', () => {
+    // throwOnError:true makes fetchQuery throw `{ error: { message } }` — not an
+    // Error — which previously stringified to "[object Object]" in the UI.
+    expect(extractErrorMessage({ error: { code: 'FORBIDDEN', message: 'GSC API not enabled' } })).toBe('GSC API not enabled')
+  })
+
+  test('unwraps a string-valued envelope error', () => {
+    expect(extractErrorMessage({ error: 'plain forbidden' })).toBe('plain forbidden')
+  })
+
+  test('stringifies a non-error object with no recognizable shape', () => {
     expect(extractErrorMessage({ nope: true })).toBe('[object Object]')
   })
 
   test('stringifies null and undefined', () => {
     expect(extractErrorMessage(null)).toBe('null')
     expect(extractErrorMessage(undefined)).toBe('undefined')
+  })
+})
+
+describe('extractApiErrorInfo', () => {
+  test('reads code + details off an Error subclass (ApiError)', () => {
+    class ApiError extends Error {
+      code = 'FORBIDDEN'
+      details = { reason: 'gsc-api-disabled', enableUrl: 'https://x' }
+    }
+    expect(extractApiErrorInfo(new ApiError('nope'))).toEqual({
+      message: 'nope',
+      code: 'FORBIDDEN',
+      details: { reason: 'gsc-api-disabled', enableUrl: 'https://x' },
+    })
+  })
+
+  test('reads code + details off the raw SDK envelope', () => {
+    expect(
+      extractApiErrorInfo({ error: { code: 'FORBIDDEN', message: 'disabled', details: { reason: 'gsc-api-disabled' } } }),
+    ).toEqual({ message: 'disabled', code: 'FORBIDDEN', details: { reason: 'gsc-api-disabled' } })
+  })
+
+  test('plain Error yields message only (no code/details)', () => {
+    expect(extractApiErrorInfo(new Error('boom'))).toEqual({ message: 'boom', code: undefined, details: undefined })
+  })
+
+  test('ignores non-object details', () => {
+    class ApiError extends Error {
+      code = 'FORBIDDEN'
+      details = 'not-an-object'
+    }
+    expect(extractApiErrorInfo(new ApiError('nope')).details).toBeUndefined()
+  })
+
+  test('falls back to String() for unrecognized values', () => {
+    expect(extractApiErrorInfo(42)).toEqual({ message: '42' })
   })
 })

--- a/apps/web/test/gsc-remediation.test.ts
+++ b/apps/web/test/gsc-remediation.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'vitest'
+
+import { gscActionNeededFromError } from '../src/lib/gsc-remediation.js'
+import type { ApiErrorInfo } from '../src/lib/extract-error-message.js'
+
+describe('gscActionNeededFromError', () => {
+  const disabled: ApiErrorInfo = {
+    message: 'the Google Search Console API is not enabled…',
+    code: 'FORBIDDEN',
+    details: {
+      reason: 'gsc-api-disabled',
+      projectNumber: '729411988784',
+      enableUrl: 'https://console.developers.google.com/apis/api/searchconsole.googleapis.com/overview?project=729411988784',
+      indexingApiUrl: 'https://console.developers.google.com/apis/api/indexing.googleapis.com/overview?project=729411988784',
+    },
+  }
+
+  test('builds a remediation card from the gsc-api-disabled FORBIDDEN', () => {
+    const card = gscActionNeededFromError(disabled)
+    expect(card).not.toBeNull()
+    expect(card!.title).toBe('Enable the Search Console API')
+    expect(card!.message).toContain('729411988784')
+    expect(card!.enableUrl).toBe(disabled.details!.enableUrl)
+    expect(card!.indexingApiUrl).toBe(disabled.details!.indexingApiUrl)
+    expect(card!.projectNumber).toBe('729411988784')
+  })
+
+  test('omits the project number from the message when not parsed', () => {
+    const card = gscActionNeededFromError({
+      ...disabled,
+      details: { reason: 'gsc-api-disabled' },
+    })
+    expect(card).not.toBeNull()
+    expect(card!.projectNumber).toBeUndefined()
+    expect(card!.message).not.toMatch(/\(\s*\)/) // no empty "()" left behind
+    expect(card!.enableUrl).toBeUndefined()
+  })
+
+  test('returns null for the other GSC FORBIDDEN reasons (plain inline error instead)', () => {
+    expect(gscActionNeededFromError({ message: 'reconnect', code: 'FORBIDDEN', details: { reason: 'gsc-reconnect' } })).toBeNull()
+    expect(
+      gscActionNeededFromError({ message: 'no access', code: 'FORBIDDEN', details: { reason: 'gsc-no-property-access' } }),
+    ).toBeNull()
+  })
+
+  test('returns null for a non-FORBIDDEN error', () => {
+    expect(gscActionNeededFromError({ message: 'boom', code: 'PROVIDER_ERROR', details: { reason: 'gsc-api-disabled' } })).toBeNull()
+  })
+
+  test('returns null when there are no details', () => {
+    expect(gscActionNeededFromError({ message: 'boom', code: 'FORBIDDEN' })).toBeNull()
+  })
+})

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -28,7 +28,18 @@ schema feature is **not** on the current roadmap — see root `AGENTS.md`
 canonry serve
 ```
 
-Opens at [http://localhost:4100](http://localhost:4100). No configuration needed.
+Opens at [http://127.0.0.1:4100](http://127.0.0.1:4100). No configuration needed.
+
+> **Use `127.0.0.1`, not `localhost`.** `canonry serve` binds the IPv4 loopback
+> `127.0.0.1` (override with `CANONRY_HOST`). On machines where `localhost`
+> resolves to the IPv6 loopback `::1` first, `http://localhost:4100` returns
+> *connection refused* even though the server is up — browse to
+> `http://127.0.0.1:4100` instead, or set `CANONRY_HOST=::1` to bind IPv6.
+
+> **Dashboard sessions are in-memory.** The dashboard password you set persists
+> in `~/.canonry/config.yaml`, but the logged-in *sessions* live in the server
+> process. Restarting `canonry serve` (or `canonry stop` / a crash) clears them,
+> so you'll be asked to sign in again after a restart. This is expected.
 
 ---
 

--- a/docs/google-search-console-setup.md
+++ b/docs/google-search-console-setup.md
@@ -256,12 +256,33 @@ The OAuth callback failed. Common causes:
 - The authorization code expired (they're single-use and expire in minutes)
 - Try connecting again — the code is generated fresh each time
 
-### `Search Console API not enabled`
+### `Search Console API not enabled` — connection succeeds, then every call returns 403
 
-Enable it at:
-```
-https://console.developers.google.com/apis/api/searchconsole.googleapis.com/overview?project=YOUR_PROJECT_ID
-```
+**Symptom:** the OAuth flow completes and the connection is stored, but opening the
+project immediately shows an **"Action needed — Enable the Search Console API"**
+banner (and, in the CLI, a `FORBIDDEN` with the message below). The first live call
+canonry makes — listing your Search Console properties — returns 403.
+
+**Cause:** when you use **your own** Google OAuth client, granting OAuth consent is
+**not** enough — the **Search Console API must also be enabled on that OAuth client's
+Google Cloud project.** OAuth authorizes the *account*; enabling the API authorizes the
+*project* to call it. They are separate steps, and the second is easy to miss.
+
+**Fix:** enable both APIs on the GCP project that owns your OAuth client, wait ~2–5
+minutes for the change to propagate, then retry:
+
+- **Search Console API** — required for all GSC features:
+  ```
+  https://console.developers.google.com/apis/api/searchconsole.googleapis.com/overview?project=YOUR_PROJECT_ID
+  ```
+- **Web Search Indexing API** — required only for the request-indexing feature:
+  ```
+  https://console.developers.google.com/apis/api/indexing.googleapis.com/overview?project=YOUR_PROJECT_ID
+  ```
+
+The dashboard banner deep-links straight to the enable page with your project number
+already filled in. The 403 does **not** log you out — a Google permission error is not
+a canonry session error, so your dashboard session stays valid while you fix it.
 
 ### `Indexing API returned 403`
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.76.1",
+  "version": "4.76.2",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/google.ts
+++ b/packages/api-routes/src/google.ts
@@ -186,6 +186,23 @@ function parseGscApiDisabled(
 }
 
 /**
+ * Recover the upstream HTTP status from a GoogleAuthError thrown by
+ * refreshAccessToken / exchangeCode. Those set `.statusCode` only for the 429
+ * rate-limit case; every other failure embeds the status in the message
+ * ("Token refresh failed (400): …"). We deliberately do NOT widen `.statusCode`
+ * at the throw site: the global error handler (index.ts) forwards any
+ * non-AppError's `.statusCode` as the HTTP response, so populating it would flip
+ * the UNWRAPPED GBP/GSC endpoints from a 500 to a raw upstream 4xx — and a
+ * leaked 401 would force a dashboard logout, the very bug this path prevents.
+ * Reading it back out here keeps the status confined to the wrapped GSC routes.
+ */
+function googleAuthErrorStatus(err: GoogleAuthError): number | null {
+  if (err.statusCode != null) return err.statusCode
+  const match = err.message.match(/failed \((\d{3})\)/)
+  return match ? Number(match[1]) : null
+}
+
+/**
  * Map a failure from a LIVE Google Search Console call into a canonry AppError.
  *
  * The GSC proxy routes (`/google/properties`, `/google/gsc/sitemaps`, …) are a
@@ -244,7 +261,7 @@ function gscErrorToAppError(err: unknown, context: string): AppError {
     // Token exchange/refresh failed. A 4xx (typically invalid_grant on a
     // revoked refresh token) is a non-retryable reconnect signal; a 429 is a
     // rate limit; anything else is treated as a transient upstream error.
-    const status = err.statusCode
+    const status = googleAuthErrorStatus(err)
     if (status === 429) return quotaExceeded('Google OAuth token refresh (rate limited)')
     if (status != null && status >= 400 && status < 500) {
       return forbidden(

--- a/packages/api-routes/src/google.ts
+++ b/packages/api-routes/src/google.ts
@@ -4,7 +4,7 @@ import type { FastifyInstance } from 'fastify'
 import { gscSearchData, gscUrlInspections, gscCoverageSnapshots, gbpLocations, gbpDailyMetrics, gbpKeywordImpressions, gbpKeywordMonthly, gbpPlaceActions, gbpLodgingSnapshots, gbpPlaceDetails, runs, projects, type DatabaseClient } from '@ainyc/canonry-db'
 import {
   validationError, notFound, normalizeProjectDomain, parseWindow, windowCutoff,
-  authRequired, quotaExceeded, providerError, escapeLikePattern,
+  authRequired, forbidden, quotaExceeded, providerError, escapeLikePattern, AppError,
   type GoogleConnectionType,
   gbpDiscoverRequestSchema, gbpLocationSelectionRequestSchema, gbpSyncRequestSchema,
   type GbpLocationDto, type GbpLocationListResponse, type GbpAccountListResponse,
@@ -24,6 +24,8 @@ import {
   GSC_SCOPE,
   INDEXING_SCOPE,
   INDEXING_API_DAILY_LIMIT,
+  GoogleApiError,
+  GoogleAuthError,
 } from '@ainyc/canonry-integration-google'
 import { GA4_SCOPE } from '@ainyc/canonry-integration-google-analytics'
 import {
@@ -153,6 +155,111 @@ async function getValidToken(
     connectionId: `${domain}:${connectionType}`,
     propertyId: conn.propertyId ?? null,
   }
+}
+
+/**
+ * When a self-hosted operator uses their own Google OAuth client, the single
+ * most common live-GSC failure is the Search Console API simply not being
+ * enabled on that OAuth client's Google Cloud project. Google returns a 403
+ * whose body names the GCP project number and a deep link to enable it. Detect
+ * that exact shape and lift the project number + enable links into structured
+ * fields so the dashboard can render a one-click "Action needed" remediation
+ * (and the CLI/agents get a machine-readable `reason`). Returns null when the
+ * 403 is some other forbidden (e.g. the account just lacks property access).
+ */
+function parseGscApiDisabled(
+  message: string,
+): { projectNumber: string | null; enableUrl: string; indexingApiUrl: string } | null {
+  if (!/accessNotConfigured|SERVICE_DISABLED|has not been used in project|is disabled/i.test(message)) {
+    return null
+  }
+  // Prefer the project number from Google's own enable URL; fall back to the
+  // "...in project <N>..." prose. Project numbers are bare integers.
+  const projectNumber = message.match(/[?&]project=(\d+)/)?.[1] ?? message.match(/project\s+(\d+)/i)?.[1] ?? null
+  const base = 'https://console.developers.google.com/apis/api'
+  const qs = projectNumber ? `?project=${projectNumber}` : ''
+  return {
+    projectNumber,
+    enableUrl: `${base}/searchconsole.googleapis.com/overview${qs}`,
+    indexingApiUrl: `${base}/indexing.googleapis.com/overview${qs}`,
+  }
+}
+
+/**
+ * Map a failure from a LIVE Google Search Console call into a canonry AppError.
+ *
+ * The GSC proxy routes (`/google/properties`, `/google/gsc/sitemaps`, …) are a
+ * gateway: canonry calls Google on the operator's behalf, so a Google failure
+ * is the UPSTREAM's fault, not a canonry-auth failure. The mapping is chosen so
+ * the HTTP status carries the right *actionability* signal to every client:
+ *
+ *   - A config problem that the operator must fix and that a retry will NOT
+ *     resolve (Search Console API not enabled, no property access, revoked
+ *     credentials) → `forbidden` (403, FORBIDDEN). Non-retryable → CLI exit
+ *     code 1 (user error). The dashboard renders these inline; it only forces
+ *     logout on a genuine canonry 401, never on a FORBIDDEN carrying a provider
+ *     message, so a Google permission error no longer boots the operator.
+ *   - A transient upstream failure a retry MIGHT fix (rate limit, 5xx) →
+ *     `quotaExceeded` (429) / `providerError` (502). Retryable → CLI exit 2.
+ *
+ * Crucially this NEVER returns 401: a leaked Google 401 would be
+ * indistinguishable from a canonry session expiry and would log the operator
+ * out. AppErrors raised before the network call (e.g. `notFound` /
+ * `validationError` from `getValidToken`) are genuine canonry-side errors and
+ * pass through unchanged.
+ */
+function gscErrorToAppError(err: unknown, context: string): AppError {
+  if (err instanceof AppError) return err
+
+  if (err instanceof GoogleApiError) {
+    if (err.status === 429) {
+      return quotaExceeded('Google Search Console API (rate limited; retries exhausted)')
+    }
+    if (err.status === 403) {
+      const disabled = parseGscApiDisabled(err.message)
+      if (disabled) {
+        const inProject = disabled.projectNumber ? ` (project ${disabled.projectNumber})` : ''
+        return forbidden(
+          `${context}: the Google Search Console API is not enabled for your Google Cloud project${inProject}. `
+            + `Enable the Search Console API and the Indexing API, wait ~2–5 minutes, then retry: ${disabled.enableUrl}`,
+          { reason: 'gsc-api-disabled', upstreamStatus: 403, ...disabled },
+        )
+      }
+      return forbidden(
+        `${context}: the connected Google account does not have access to a verified Search Console property `
+          + 'for this domain. Connect the account that owns the property.',
+        { reason: 'gsc-no-property-access', upstreamStatus: 403 },
+      )
+    }
+    if (err.status === 401) {
+      return forbidden(
+        `${context}: the Google connection has expired or was revoked. Reconnect Google Search Console.`,
+        { reason: 'gsc-reconnect', upstreamStatus: 401 },
+      )
+    }
+    return providerError(`${context}: ${err.message}`, { upstreamStatus: err.status })
+  }
+
+  if (err instanceof GoogleAuthError) {
+    // Token exchange/refresh failed. A 4xx (typically invalid_grant on a
+    // revoked refresh token) is a non-retryable reconnect signal; a 429 is a
+    // rate limit; anything else is treated as a transient upstream error.
+    const status = err.statusCode
+    if (status === 429) return quotaExceeded('Google OAuth token refresh (rate limited)')
+    if (status != null && status >= 400 && status < 500) {
+      return forbidden(
+        `${context}: the stored Google credentials are no longer valid (token refresh failed). `
+          + 'Reconnect Google Search Console.',
+        { reason: 'gsc-reconnect', upstreamStatus: status },
+      )
+    }
+    return providerError(
+      `${context}: ${err.message}. Reconnect Google Search Console if this persists.`,
+      status != null ? { upstreamStatus: status } : undefined,
+    )
+  }
+
+  return providerError(`${context}: ${err instanceof Error ? err.message : String(err)}`)
 }
 
 export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptions) {
@@ -487,9 +594,13 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
     const store = requireConnectionStore()
 
     const project = resolveProject(app.db, request.params.name)
-    const { accessToken } = await getValidToken(store, project.canonicalDomain, 'gsc', googleClientId, googleClientSecret)
-    const sites = await listSites(accessToken)
-    return { sites }
+    try {
+      const { accessToken } = await getValidToken(store, project.canonicalDomain, 'gsc', googleClientId, googleClientSecret)
+      const sites = await listSites(accessToken)
+      return { sites }
+    } catch (err) {
+      throw gscErrorToAppError(err, 'Failed to list Search Console properties')
+    }
   })
 
   // POST /projects/:name/google/gsc/sync
@@ -643,12 +754,16 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
       throw validationError('url is required')
     }
 
-    const { accessToken, propertyId } = await getValidToken(store, project.canonicalDomain, 'gsc', googleClientId, googleClientSecret)
-    if (!propertyId) {
-      throw validationError('No GSC property configured for this connection')
+    let result
+    try {
+      const { accessToken, propertyId } = await getValidToken(store, project.canonicalDomain, 'gsc', googleClientId, googleClientSecret)
+      if (!propertyId) {
+        throw validationError('No GSC property configured for this connection')
+      }
+      result = await gscInspectUrl(accessToken, url, propertyId)
+    } catch (err) {
+      throw gscErrorToAppError(err, 'Failed to inspect URL in Search Console')
     }
-
-    const result = await gscInspectUrl(accessToken, url, propertyId)
     const ir = result.inspectionResult
     const idx = ir.indexStatusResult
     const mob = ir.mobileUsabilityResult
@@ -957,13 +1072,17 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
     const store = requireConnectionStore()
 
     const project = resolveProject(app.db, request.params.name)
-    const { accessToken, propertyId } = await getValidToken(store, project.canonicalDomain, 'gsc', googleClientId, googleClientSecret)
-    if (!propertyId) {
-      throw validationError('No GSC property configured for this connection. Set one with "canonry google set-property".')
-    }
+    try {
+      const { accessToken, propertyId } = await getValidToken(store, project.canonicalDomain, 'gsc', googleClientId, googleClientSecret)
+      if (!propertyId) {
+        throw validationError('No GSC property configured for this connection. Set one with "canonry google set-property".')
+      }
 
-    const sitemaps = await listSitemaps(accessToken, propertyId)
-    return { sitemaps }
+      const sitemaps = await listSitemaps(accessToken, propertyId)
+      return { sitemaps }
+    } catch (err) {
+      throw gscErrorToAppError(err, 'Failed to list Search Console sitemaps')
+    }
   })
 
   // POST /projects/:name/google/gsc/discover-sitemaps
@@ -985,8 +1104,13 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
       throw validationError('No GSC property configured for this connection')
     }
 
-    const { accessToken } = await getValidToken(store, project.canonicalDomain, 'gsc', googleClientId, googleClientSecret)
-    const sitemaps = await listSitemaps(accessToken, conn.propertyId)
+    let sitemaps
+    try {
+      const { accessToken } = await getValidToken(store, project.canonicalDomain, 'gsc', googleClientId, googleClientSecret)
+      sitemaps = await listSitemaps(accessToken, conn.propertyId)
+    } catch (err) {
+      throw gscErrorToAppError(err, 'Failed to discover Search Console sitemaps')
+    }
 
     if (sitemaps.length === 0) {
       throw validationError('No sitemaps found for this GSC property. Submit a sitemap in Google Search Console first.')

--- a/packages/api-routes/test/google-properties-error.test.ts
+++ b/packages/api-routes/test/google-properties-error.test.ts
@@ -5,16 +5,18 @@ import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest'
 import Fastify from 'fastify'
 import { createClient, migrate, projects } from '@ainyc/canonry-db'
 import { AppError } from '@ainyc/canonry-contracts'
-// `GoogleApiError` is spread through from the real module by the mock below, so
-// this is the same class identity google.ts checks `instanceof` against.
-import { GoogleApiError } from '@ainyc/canonry-integration-google'
+// `GoogleApiError` / `GoogleAuthError` are spread through from the real module
+// by the mock below, so these are the same class identities google.ts checks
+// `instanceof` against.
+import { GoogleApiError, GoogleAuthError } from '@ainyc/canonry-integration-google'
 import { googleRoutes } from '../src/google.js'
 
 // Make the live GSC calls throwable on demand without touching the network.
-// `state.listError` is read inside the hoisted mock factory, so a test can set
-// the next thrown error before injecting a request. `importActual` keeps the
-// real error classes so `instanceof` in google.ts still matches what we throw.
-const state = vi.hoisted(() => ({ listError: null as Error | null }))
+// `state.listError` / `state.refreshError` are read inside the hoisted mock
+// factory, so a test can set the next thrown error before injecting a request.
+// `importActual` keeps the real error classes so `instanceof` in google.ts
+// still matches what we throw.
+const state = vi.hoisted(() => ({ listError: null as Error | null, refreshError: null as Error | null }))
 
 vi.mock('@ainyc/canonry-integration-google', async (importActual) => {
   const actual = await importActual<typeof import('@ainyc/canonry-integration-google')>()
@@ -24,10 +26,16 @@ vi.mock('@ainyc/canonry-integration-google', async (importActual) => {
       if (state.listError) throw state.listError
       return []
     }),
+    // Exercised only when the connection token is expired (see buildApp opts),
+    // which forces getValidToken down the refresh path.
+    refreshAccessToken: vi.fn(async () => {
+      if (state.refreshError) throw state.refreshError
+      return { access_token: 'refreshed-token', expires_in: 3600, token_type: 'Bearer', scope: '' }
+    }),
   }
 })
 
-function buildApp() {
+function buildApp(opts: { tokenExpiresAt?: string } = {}) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsc-properties-error-'))
   const db = createClient(path.join(tmpDir, 'test.db'))
   migrate(db)
@@ -52,15 +60,16 @@ function buildApp() {
     updatedAt: now,
   }).run()
 
-  // A connection whose access token is comfortably unexpired, so getValidToken
-  // returns it directly and never hits the (mocked-out) refresh path.
+  // A connection whose access token is comfortably unexpired by default, so
+  // getValidToken returns it directly and never hits the (mocked-out) refresh
+  // path. Pass `tokenExpiresAt` in the past to force the refresh path instead.
   const connection = {
     domain: 'proxter.com',
     connectionType: 'gsc' as const,
     propertyId: 'sc-domain:proxter.com',
     accessToken: 'fresh-access-token',
     refreshToken: 'refresh-token',
-    tokenExpiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    tokenExpiresAt: opts.tokenExpiresAt ?? new Date(Date.now() + 60 * 60 * 1000).toISOString(),
     scopes: ['https://www.googleapis.com/auth/webmasters.readonly'],
     createdAt: now,
     updatedAt: now,
@@ -100,6 +109,7 @@ describe('GET /projects/:name/google/properties — upstream Google failure mapp
 
   beforeEach(async () => {
     state.listError = null
+    state.refreshError = null
     const built = await buildApp()
     app = built.app
     tmpDir = built.tmpDir
@@ -192,5 +202,59 @@ describe('GET /projects/:name/google/properties — upstream Google failure mapp
       const res = await getProperties()
       expect(res.statusCode).not.toBe(401)
     }
+  })
+})
+
+describe('GET /projects/:name/google/properties — credential refresh failure mapping', () => {
+  let app: Awaited<ReturnType<typeof buildApp>>['app']
+  let tmpDir: string
+
+  beforeEach(async () => {
+    state.listError = null
+    state.refreshError = null
+    // An already-expired token forces getValidToken down the refresh path, so
+    // whatever `state.refreshError` holds is what the route has to map.
+    const built = await buildApp({ tokenExpiresAt: new Date(Date.now() - 60_000).toISOString() })
+    app = built.app
+    tmpDir = built.tmpDir
+    await app.ready()
+  })
+
+  afterEach(async () => {
+    await app.close()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  async function getProperties() {
+    return app.inject({ method: 'GET', url: '/projects/proxter/google/properties' })
+  }
+
+  // Regression guard: a revoked refresh token comes back as 400 invalid_grant.
+  // refreshAccessToken throws a GoogleAuthError WITHOUT a statusCode for that
+  // case (it only sets one for 429) — exactly as the real module does — so the
+  // mapper must recover 400 from the message and classify it as a non-retryable
+  // reconnect (403 gsc-reconnect) rather than a retryable 502, and never a 401.
+  it('maps a revoked refresh token (GoogleAuthError 400, no statusCode) to 403 FORBIDDEN gsc-reconnect', async () => {
+    state.refreshError = new GoogleAuthError('Token refresh failed (400): invalid_grant')
+    const res = await getProperties()
+    expect(res.statusCode).toBe(403)
+    const body = res.json() as { error: { code: string; message: string; details?: Record<string, unknown> } }
+    expect(body.error.code).toBe('FORBIDDEN')
+    expect(body.error.message).toMatch(/no longer valid/i)
+    expect(body.error.details).toMatchObject({ reason: 'gsc-reconnect', upstreamStatus: 400 })
+  })
+
+  it('maps an OAuth 429 refresh rate-limit to 429 QUOTA_EXCEEDED (retryable)', async () => {
+    state.refreshError = new GoogleAuthError('Google OAuth rate limit exceeded', 429)
+    const res = await getProperties()
+    expect(res.statusCode).toBe(429)
+    expect((res.json() as { error: { code: string } }).error.code).toBe('QUOTA_EXCEEDED')
+  })
+
+  it('maps a transient OAuth 5xx refresh failure (no statusCode) to 502 PROVIDER_ERROR (retryable)', async () => {
+    state.refreshError = new GoogleAuthError('Token refresh failed (503): backend error')
+    const res = await getProperties()
+    expect(res.statusCode).toBe(502)
+    expect((res.json() as { error: { code: string } }).error.code).toBe('PROVIDER_ERROR')
   })
 })

--- a/packages/api-routes/test/google-properties-error.test.ts
+++ b/packages/api-routes/test/google-properties-error.test.ts
@@ -1,0 +1,196 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest'
+import Fastify from 'fastify'
+import { createClient, migrate, projects } from '@ainyc/canonry-db'
+import { AppError } from '@ainyc/canonry-contracts'
+// `GoogleApiError` is spread through from the real module by the mock below, so
+// this is the same class identity google.ts checks `instanceof` against.
+import { GoogleApiError } from '@ainyc/canonry-integration-google'
+import { googleRoutes } from '../src/google.js'
+
+// Make the live GSC calls throwable on demand without touching the network.
+// `state.listError` is read inside the hoisted mock factory, so a test can set
+// the next thrown error before injecting a request. `importActual` keeps the
+// real error classes so `instanceof` in google.ts still matches what we throw.
+const state = vi.hoisted(() => ({ listError: null as Error | null }))
+
+vi.mock('@ainyc/canonry-integration-google', async (importActual) => {
+  const actual = await importActual<typeof import('@ainyc/canonry-integration-google')>()
+  return {
+    ...actual,
+    listSites: vi.fn(async () => {
+      if (state.listError) throw state.listError
+      return []
+    }),
+  }
+})
+
+function buildApp() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsc-properties-error-'))
+  const db = createClient(path.join(tmpDir, 'test.db'))
+  migrate(db)
+
+  const now = new Date().toISOString()
+  db.insert(projects).values({
+    id: 'proj_1',
+    name: 'proxter',
+    displayName: 'Proxter',
+    canonicalDomain: 'proxter.com',
+    ownedDomains: '[]',
+    country: 'US',
+    language: 'en',
+    tags: '[]',
+    labels: '{}',
+    providers: '["gemini"]',
+    locations: '[]',
+    defaultLocation: null,
+    configSource: 'api',
+    configRevision: 1,
+    createdAt: now,
+    updatedAt: now,
+  }).run()
+
+  // A connection whose access token is comfortably unexpired, so getValidToken
+  // returns it directly and never hits the (mocked-out) refresh path.
+  const connection = {
+    domain: 'proxter.com',
+    connectionType: 'gsc' as const,
+    propertyId: 'sc-domain:proxter.com',
+    accessToken: 'fresh-access-token',
+    refreshToken: 'refresh-token',
+    tokenExpiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    scopes: ['https://www.googleapis.com/auth/webmasters.readonly'],
+    createdAt: now,
+    updatedAt: now,
+  }
+
+  const app = Fastify()
+  app.decorate('db', db)
+  // Mirror the production global handler: AppError → its own status + envelope.
+  app.setErrorHandler((error, _request, reply) => {
+    if (error instanceof AppError) {
+      return reply.status(error.statusCode).send(error.toJSON())
+    }
+    throw error
+  })
+
+  app.register(googleRoutes, {
+    getGoogleAuthConfig: () => ({ clientId: 'client-id', clientSecret: 'client-secret' }),
+    googleConnectionStore: {
+      listConnections: (domain: string) => (domain === connection.domain ? [connection] : []),
+      getConnection: (domain: string, type: string) =>
+        domain === connection.domain && type === connection.connectionType ? connection : undefined,
+      upsertConnection: (c: typeof connection) => c,
+      updateConnection: (_d: string, _t: string, patch: Partial<typeof connection>) => {
+        Object.assign(connection, patch)
+        return connection
+      },
+      deleteConnection: () => true,
+    },
+    googleStateSecret: 'test-secret-32-bytes-long-enough!',
+  })
+  return { app, tmpDir }
+}
+
+describe('GET /projects/:name/google/properties — upstream Google failure mapping', () => {
+  let app: Awaited<ReturnType<typeof buildApp>>['app']
+  let tmpDir: string
+
+  beforeEach(async () => {
+    state.listError = null
+    const built = await buildApp()
+    app = built.app
+    tmpDir = built.tmpDir
+    await app.ready()
+  })
+
+  afterEach(async () => {
+    await app.close()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  async function getProperties() {
+    return app.inject({ method: 'GET', url: '/projects/proxter/google/properties' })
+  }
+
+  // The bug: a Google 403 (API not enabled) reached the dashboard, whose
+  // response interceptor treated ANY 403 as session expiry → the operator was
+  // booted the instant they connected Search Console. The backend half of the
+  // fix keeps it a FORBIDDEN (correct + non-retryable) but lifts the GCP project
+  // number + enable link into structured `details` so the UI can remediate; the
+  // frontend half (separate) stops logging out on a 403. The invariant enforced
+  // here is that this is NEVER a 401 (the only status that means "session
+  // invalid, re-login") and that config errors are non-retryable 403s.
+  it('maps a Google 403 (API not enabled) to 403 FORBIDDEN with structured remediation', async () => {
+    state.listError = new GoogleApiError(
+      'GSC API error (403): {"error":{"status":"PERMISSION_DENIED","message":"Google Search Console API has not been used in project 729411988784 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/searchconsole.googleapis.com/overview?project=729411988784 then retry.","errors":[{"reason":"accessNotConfigured"}]}}',
+      403,
+    )
+    const res = await getProperties()
+    expect(res.statusCode).toBe(403)
+    const body = res.json() as { error: { code: string; message: string; details?: Record<string, unknown> } }
+    expect(body.error.code).toBe('FORBIDDEN')
+    expect(body.error.message).toMatch(/not enabled/i)
+    // The dashboard reads these to render the one-click "Action needed" banner.
+    expect(body.error.details).toMatchObject({
+      reason: 'gsc-api-disabled',
+      projectNumber: '729411988784',
+      enableUrl: 'https://console.developers.google.com/apis/api/searchconsole.googleapis.com/overview?project=729411988784',
+      indexingApiUrl: 'https://console.developers.google.com/apis/api/indexing.googleapis.com/overview?project=729411988784',
+    })
+  })
+
+  it('maps a Google 403 (no property access) to 403 FORBIDDEN with a reconnect hint', async () => {
+    state.listError = new GoogleApiError('GSC API error (403): {"error":{"message":"User does not have sufficient permission"}}', 403)
+    const res = await getProperties()
+    expect(res.statusCode).toBe(403)
+    const body = res.json() as { error: { code: string; message: string; details?: Record<string, unknown> } }
+    expect(body.error.code).toBe('FORBIDDEN')
+    expect(body.error.message).toMatch(/does not have access/i)
+    expect(body.error.details).toMatchObject({ reason: 'gsc-no-property-access' })
+  })
+
+  it('maps a Google 401 (token revoked) to 403 FORBIDDEN, never 401', async () => {
+    state.listError = new GoogleApiError('Access token expired or revoked', 401)
+    const res = await getProperties()
+    // The critical invariant: NOT 401, so the dashboard never reads this as a
+    // canonry session expiry and never boots the operator.
+    expect(res.statusCode).toBe(403)
+    const body = res.json() as { error: { code: string; message: string; details?: Record<string, unknown> } }
+    expect(body.error.code).toBe('FORBIDDEN')
+    expect(body.error.message).toMatch(/expired or was revoked/i)
+    expect(body.error.details).toMatchObject({ reason: 'gsc-reconnect' })
+  })
+
+  it('maps a Google 429 to 429 QUOTA_EXCEEDED (retryable)', async () => {
+    state.listError = new GoogleApiError('Google API rate limit exceeded', 429)
+    const res = await getProperties()
+    expect(res.statusCode).toBe(429)
+    const body = res.json() as { error: { code: string } }
+    expect(body.error.code).toBe('QUOTA_EXCEEDED')
+  })
+
+  it('maps a transient Google 5xx to 502 PROVIDER_ERROR (retryable)', async () => {
+    state.listError = new GoogleApiError('GSC API error (503): backend unavailable', 503)
+    const res = await getProperties()
+    expect(res.statusCode).toBe(502)
+    expect((res.json() as { error: { code: string } }).error.code).toBe('PROVIDER_ERROR')
+  })
+
+  it('returns the property list unchanged on success', async () => {
+    state.listError = null
+    const res = await getProperties()
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ sites: [] })
+  })
+
+  it('never responds 401 for any upstream Google status (would falsely boot the operator)', async () => {
+    for (const status of [401, 403, 429, 500, 503]) {
+      state.listError = new GoogleApiError(`GSC API error (${status}): upstream`, status)
+      const res = await getProperties()
+      expect(res.statusCode).not.toBe(401)
+    }
+  })
+})

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.76.1",
+  "version": "4.76.2",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/test/google-commands.test.ts
+++ b/packages/canonry/test/google-commands.test.ts
@@ -197,7 +197,9 @@ describe('google CLI commands', () => {
 
     const { googleListSitemaps } = await import('../src/commands/google.js')
     try {
-      await expect(() => googleListSitemaps('test-proj', {})).rejects.toThrow('Access token expired or revoked')
+      // A Google 401 is mapped to a non-retryable FORBIDDEN with a reconnect
+      // hint (never a canonry 401, which would falsely read as session expiry).
+      await expect(() => googleListSitemaps('test-proj', {})).rejects.toThrow(/expired or was revoked\. Reconnect Google Search Console/)
     } finally {
       globalThis.fetch = originalFetch
     }
@@ -222,7 +224,7 @@ describe('google CLI commands', () => {
 
     const { googleDiscoverSitemaps } = await import('../src/commands/google.js')
     try {
-      await expect(() => googleDiscoverSitemaps('test-proj', { wait: false })).rejects.toThrow('Access token expired or revoked')
+      await expect(() => googleDiscoverSitemaps('test-proj', { wait: false })).rejects.toThrow(/expired or was revoked\. Reconnect Google Search Console/)
     } finally {
       globalThis.fetch = originalFetch
     }

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -66,8 +66,8 @@ export function authInvalid(): AppError {
   return new AppError('AUTH_INVALID', 'Invalid API key', 401)
 }
 
-export function forbidden(message = 'Forbidden'): AppError {
-  return new AppError('FORBIDDEN', message, 403)
+export function forbidden(message = 'Forbidden', details?: Record<string, unknown>): AppError {
+  return new AppError('FORBIDDEN', message, 403, details)
 }
 
 export function quotaExceeded(metric: string): AppError {


### PR DESCRIPTION
When canonry proxies Google Search Console, an upstream permission or credential error no longer logs the dashboard out: the frontend now treats only a 401 as session expiry, and the backend maps every Google failure to a 403/429/502 (never a 401 the UI would read as expiry).

- The "Search Console API not enabled" 403 now carries the GCP project number plus enable deep links, so the dashboard renders a one-click "Action needed" remediation banner and CLI/agents get a machine-readable `reason`.
- A revoked or expired Google refresh token now maps to a non-retryable 403 `gsc-reconnect` instead of a generic retryable 502 (the prior branch never fired because the HTTP status was not carried on the error; it is recovered inside the wrapped GSC path only, to avoid changing any other route).
- Adds backend upstream-error-mapping tests and frontend logout-behavior tests, refreshes the GSC setup docs, and bumps 4.76.1 → 4.76.2.
