### PR TITLE
feat(providers): optional base URL for Gemini and OpenAI adapters

### DIFF
--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -38,7 +38,9 @@ Default: `gemini-2.5-flash`. Configurable via `GeminiConfig.model`.
 
 ## Custom Endpoint
 
-Optional. Set `GeminiConfig.baseUrl` — via the `GEMINI_BASE_URL` env var or `providers.gemini.baseUrl` in `~/.canonry/config.yaml` — to route requests through a proxy or gateway in front of the Gemini API. It maps to the SDK's `httpOptions.baseUrl` and applies to both AI Studio (API key) and Vertex AI auth. When unset, the SDK uses its default endpoint.
+Optional. Set `GeminiConfig.baseUrl` — via the `GEMINI_BASE_URL` env var or `providers.gemini.baseUrl` in `~/.canonry/config.yaml` — to route requests through a proxy or gateway in front of the Gemini API. It maps to the SDK's `httpOptions.baseUrl` and applies to both AI Studio (API key) and Vertex AI auth. When unset, the SDK uses its default endpoint. The same `baseUrl` is threaded into discovery's embeddings client (`embedQueries` → `createEmbedGenAI`), so a proxy captures both tracked-query sweeps and discovery embeddings. A path-prefix base URL (e.g. `https://proxy/gemini`) is preserved — the SDK appends the API path to it rather than swapping only the host.
+
+**Vertex caveat:** in Vertex AI mode the SDK builds Vertex-shaped request paths (`/v1/projects/.../locations/...`), so the proxy must expose a Vertex-compatible route — an AI Studio (`generativelanguage`-style) passthrough will not match.
 
 ## Grounding & Citation Detection
 

--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -36,6 +36,10 @@ Extracts analyst-relevant fields from the raw response:
 
 Default: `gemini-2.5-flash`. Configurable via `GeminiConfig.model`.
 
+## Custom Endpoint
+
+Optional. Set `GeminiConfig.baseUrl` — via the `GEMINI_BASE_URL` env var or `providers.gemini.baseUrl` in `~/.canonry/config.yaml` — to route requests through a proxy or gateway in front of the Gemini API. It maps to the SDK's `httpOptions.baseUrl` and applies to both AI Studio (API key) and Vertex AI auth. When unset, the SDK uses its default endpoint.
+
 ## Grounding & Citation Detection
 
 The provider uses Gemini's built-in **Google Search grounding** (`googleSearch` tool). When enabled, Gemini:

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -36,6 +36,10 @@ Extracts analyst-relevant fields from the raw response:
 
 Default: `gpt-5.4`. Configurable via `OpenAIConfig.model`.
 
+## Custom Endpoint
+
+Optional. Set `OpenAIConfig.baseUrl` — via the `OPENAI_BASE_URL` env var or `providers.openai.baseUrl` in `~/.canonry/config.yaml` — to route requests through a proxy or gateway in front of the OpenAI API. It maps to the SDK's `baseURL`. When unset, the SDK uses its default endpoint (`https://api.openai.com/v1`).
+
 ## Web Search & Citation Detection
 
 The provider uses OpenAI's **web search** tool (`web_search`, the current GA tool — released 2025-08-26 in the SDK as `web_search_2025_08_26`). When enabled, the Responses API:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.76.2",
+  "version": "4.77.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.76.2",
+  "version": "4.77.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/discovery-run.ts
+++ b/packages/canonry/src/discovery-run.ts
@@ -197,7 +197,7 @@ function buildDefaultDeps(registry: ProviderRegistry): DiscoveryDeps {
     },
     async embed(queries: string[]): Promise<number[][]> {
       if (cfg.apiKey) {
-        return embedQueries(queries, { apiKey: cfg.apiKey })
+        return embedQueries(queries, { apiKey: cfg.apiKey, baseUrl: cfg.baseUrl })
       }
       // Vertex-mode embeddings need a Vertex-aware client; this is outside
       // PR 1's scope. Throw early with a clear remediation so we don't

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -126,14 +126,16 @@ const adapterMap = Object.fromEntries(
   API_ADAPTERS.map(a => [a.name, a]),
 ) as Record<string, ProviderAdapter>
 
-function summarizeProviderConfig(
-  provider: string,
-  config: ProviderConfigEntry | undefined,
-) {
+function summarizeProviderConfig(config: ProviderConfigEntry | undefined) {
   return {
     configured: Boolean(config?.apiKey || config?.baseUrl),
     model: config?.model ?? null,
-    baseUrl: provider === 'local' ? config?.baseUrl ?? null : null,
+    // baseUrl is surfaced for ALL providers, not just local — gemini/openai now
+    // honor a custom endpoint, so repointing one must show in the settings
+    // summary AND produce an audit diff. Omitting it for API providers would let
+    // an endpoint redirect (a credential-exfiltration vector on a box where the
+    // provider key is the carrier) happen with no audit trail.
+    baseUrl: config?.baseUrl ?? null,
     quota: { ...(config?.quota ?? DEFAULT_QUOTA) },
   }
 }
@@ -1412,7 +1414,7 @@ export async function createServer(opts: {
       // Update config and persist
       if (!opts.config.providers) opts.config.providers = {}
       const existing = opts.config.providers[name]
-      const beforeConfig = summarizeProviderConfig(name, existing)
+      const beforeConfig = summarizeProviderConfig(existing)
       const mergedQuota = incomingQuota
         ? { ...(existing?.quota ?? DEFAULT_QUOTA), ...incomingQuota }
         : existing?.quota
@@ -1459,7 +1461,7 @@ export async function createServer(opts: {
         }
       }
 
-      const afterConfig = summarizeProviderConfig(name, opts.config.providers[name])
+      const afterConfig = summarizeProviderConfig(opts.config.providers[name])
       if (JSON.stringify(beforeConfig) !== JSON.stringify(afterConfig)) {
         const diff = JSON.stringify({
           before: existing ? beforeConfig : null,

--- a/packages/canonry/test/index.test.ts
+++ b/packages/canonry/test/index.test.ts
@@ -1008,6 +1008,102 @@ describe('canonry', () => {
     }
   })
 
+  it('settings/providers audits a baseUrl (endpoint) change for an API provider', async () => {
+    const tmpDir = path.join(os.tmpdir(), `canonry-provider-baseurl-${crypto.randomUUID()}`)
+    fs.mkdirSync(tmpDir, { recursive: true })
+
+    vi.stubEnv('CANONRY_CONFIG_DIR', tmpDir)
+
+    const dbPath = path.join(tmpDir, 'test.db')
+    const db = createClient(dbPath)
+    migrate(db)
+
+    const rawKey = `cnry_${crypto.randomBytes(16).toString('hex')}`
+    const keyHash = crypto.createHash('sha256').update(rawKey).digest('hex')
+    db.insert(apiKeys).values({
+      id: crypto.randomUUID(),
+      name: 'test',
+      keyHash,
+      keyPrefix: rawKey.slice(0, 9),
+      scopes: ['*'],
+      createdAt: new Date().toISOString(),
+    }).run()
+
+    const app = await createServer({
+      config: {
+        apiUrl: 'http://localhost:4100',
+        database: dbPath,
+        apiKey: rawKey,
+        providers: {
+          gemini: {
+            apiKey: 'g-key',
+            model: 'gemini-2.5-flash',
+            quota: { maxConcurrency: 2, maxRequestsPerMinute: 10, maxRequestsPerDay: 1000 },
+          },
+        },
+      },
+      db,
+      logger: false,
+    })
+
+    try {
+      const createProjectRes = await app.inject({
+        method: 'PUT',
+        url: '/api/v1/projects/test-project',
+        headers: { authorization: `Bearer ${rawKey}` },
+        payload: {
+          displayName: 'Test Project',
+          canonicalDomain: 'example.com',
+          country: 'US',
+          language: 'en',
+          providers: ['gemini'],
+        },
+      })
+      expect(createProjectRes.statusCode).toBe(201)
+
+      // Repoint ONLY the endpoint (same key, same model). Before the fix this
+      // produced no diff — gemini's baseUrl was dropped from the summary — so a
+      // silent endpoint redirect left no audit trail.
+      const res = await app.inject({
+        method: 'PUT',
+        url: '/api/v1/settings/providers/gemini',
+        headers: { authorization: `Bearer ${rawKey}` },
+        payload: {
+          apiKey: 'g-key',
+          baseUrl: 'https://proxy.example.com',
+        },
+      })
+      expect(res.statusCode).toBe(200)
+
+      const config = loadConfig()
+      expect(config.providers?.gemini?.baseUrl).toBe('https://proxy.example.com')
+
+      const historyRes = await app.inject({
+        method: 'GET',
+        url: '/api/v1/projects/test-project/history',
+        headers: { authorization: `Bearer ${rawKey}` },
+      })
+      expect(historyRes.statusCode).toBe(200)
+      const historyEntries = JSON.parse(historyRes.body) as Array<{
+        action: string
+        entityType: string
+        entityId: string | null
+        diff: { before: { baseUrl: string | null } | null; after: { baseUrl: string | null } }
+      }>
+      const providerHistory = historyEntries.find(
+        entry => entry.action === 'provider.updated' && entry.entityType === 'provider',
+      )
+      // The endpoint repoint MUST be audited.
+      expect(providerHistory).toBeDefined()
+      expect(providerHistory!.entityId).toBe('gemini')
+      expect(providerHistory!.diff.before?.baseUrl ?? null).toBeNull()
+      expect(providerHistory!.diff.after.baseUrl).toBe('https://proxy.example.com')
+    } finally {
+      await app.close()
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
   it('SPA deep-link serves index.html with <base href> so relative assets resolve', async () => {
     const tmpDir = path.join(os.tmpdir(), `canonry-spa-base-${crypto.randomUUID()}`)
     fs.mkdirSync(tmpDir, { recursive: true })

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -11,6 +11,7 @@ const envSchema = z.object({
   // Gemini
   GEMINI_API_KEY: z.string().optional(),
   GEMINI_MODEL: z.string().optional(),
+  GEMINI_BASE_URL: z.string().optional(),
   GEMINI_MAX_CONCURRENCY: z.coerce.number().int().positive().default(2),
   GEMINI_MAX_REQUESTS_PER_MINUTE: z.coerce.number().int().positive().default(10),
   GEMINI_MAX_REQUESTS_PER_DAY: z.coerce.number().int().positive().default(1000),
@@ -21,6 +22,7 @@ const envSchema = z.object({
   // OpenAI
   OPENAI_API_KEY: z.string().optional(),
   OPENAI_MODEL: z.string().optional(),
+  OPENAI_BASE_URL: z.string().optional(),
   OPENAI_MAX_CONCURRENCY: z.coerce.number().int().positive().default(2),
   OPENAI_MAX_REQUESTS_PER_MINUTE: z.coerce.number().int().positive().default(10),
   OPENAI_MAX_REQUESTS_PER_DAY: z.coerce.number().int().positive().default(1000),
@@ -45,6 +47,12 @@ const envSchema = z.object({
 export interface ProviderEnvConfig {
   apiKey: string
   model?: string
+  /**
+   * Custom API endpoint (e.g. a proxy in front of the provider API). Sourced
+   * from `GEMINI_BASE_URL` / `OPENAI_BASE_URL`; threaded into the adapter's
+   * SDK client. Undefined when unset — the SDK uses its default endpoint.
+   */
+  baseUrl?: string
   quota: ProviderQuotaPolicy
   vertexProject?: string
   vertexRegion?: string
@@ -101,11 +109,13 @@ const bootstrapEnvSchema = z.object({
   CANONRY_DATABASE_PATH: z.string().optional(),
   GEMINI_API_KEY: z.string().optional(),
   GEMINI_MODEL: z.string().optional(),
+  GEMINI_BASE_URL: z.string().optional(),
   GEMINI_VERTEX_PROJECT: z.string().optional(),
   GEMINI_VERTEX_REGION: z.string().optional(),
   GEMINI_VERTEX_CREDENTIALS: z.string().optional(),
   OPENAI_API_KEY: z.string().optional(),
   OPENAI_MODEL: z.string().optional(),
+  OPENAI_BASE_URL: z.string().optional(),
   ANTHROPIC_API_KEY: z.string().optional(),
   ANTHROPIC_MODEL: z.string().optional(),
   PERPLEXITY_API_KEY: z.string().optional(),
@@ -126,6 +136,7 @@ export function getPlatformEnv(source: NodeJS.ProcessEnv): PlatformEnv {
     providers.gemini = {
       apiKey: parsed.GEMINI_API_KEY ?? '',
       model: parsed.GEMINI_MODEL,
+      baseUrl: parsed.GEMINI_BASE_URL,
       quota: providerQuotaPolicySchema.parse({
         maxConcurrency: parsed.GEMINI_MAX_CONCURRENCY,
         maxRequestsPerMinute: parsed.GEMINI_MAX_REQUESTS_PER_MINUTE,
@@ -141,6 +152,7 @@ export function getPlatformEnv(source: NodeJS.ProcessEnv): PlatformEnv {
     providers.openai = {
       apiKey: parsed.OPENAI_API_KEY,
       model: parsed.OPENAI_MODEL,
+      baseUrl: parsed.OPENAI_BASE_URL,
       quota: providerQuotaPolicySchema.parse({
         maxConcurrency: parsed.OPENAI_MAX_CONCURRENCY,
         maxRequestsPerMinute: parsed.OPENAI_MAX_REQUESTS_PER_MINUTE,
@@ -199,6 +211,7 @@ export function getBootstrapEnv(
     providers.gemini = {
       apiKey: parsed.GEMINI_API_KEY ?? '',
       model: parsed.GEMINI_MODEL || 'gemini-2.5-flash',
+      baseUrl: parsed.GEMINI_BASE_URL,
       quota: providerQuotaPolicySchema.parse({
         maxConcurrency: 2,
         maxRequestsPerMinute: 10,
@@ -214,6 +227,7 @@ export function getBootstrapEnv(
     providers.openai = {
       apiKey: parsed.OPENAI_API_KEY,
       model: parsed.OPENAI_MODEL || 'gpt-5.4',
+      baseUrl: parsed.OPENAI_BASE_URL,
       quota: providerQuotaPolicySchema.parse({
         maxConcurrency: 2,
         maxRequestsPerMinute: 10,

--- a/packages/config/test/provider-base-url.test.ts
+++ b/packages/config/test/provider-base-url.test.ts
@@ -1,0 +1,37 @@
+import { test, expect } from 'vitest'
+
+import { getBootstrapEnv, getPlatformEnv } from '../src/index.js'
+
+const baseEnv = { GEMINI_API_KEY: 'g', OPENAI_API_KEY: 'o' } as NodeJS.ProcessEnv
+
+test('getBootstrapEnv threads GEMINI_BASE_URL / OPENAI_BASE_URL into provider configs', () => {
+  const env = getBootstrapEnv({
+    ...baseEnv,
+    GEMINI_BASE_URL: 'https://gemini-proxy.example.com',
+    OPENAI_BASE_URL: 'https://openai-proxy.example.com',
+  })
+  expect(env.providers.gemini?.baseUrl).toBe('https://gemini-proxy.example.com')
+  expect(env.providers.openai?.baseUrl).toBe('https://openai-proxy.example.com')
+})
+
+test('getBootstrapEnv leaves provider baseUrl undefined when the env var is unset', () => {
+  const env = getBootstrapEnv(baseEnv)
+  expect(env.providers.gemini?.baseUrl).toBeUndefined()
+  expect(env.providers.openai?.baseUrl).toBeUndefined()
+})
+
+test('getPlatformEnv threads GEMINI_BASE_URL / OPENAI_BASE_URL into provider configs', () => {
+  const env = getPlatformEnv({
+    ...baseEnv,
+    GEMINI_BASE_URL: 'https://gemini-proxy.example.com',
+    OPENAI_BASE_URL: 'https://openai-proxy.example.com',
+  } as NodeJS.ProcessEnv)
+  expect(env.providers.gemini?.baseUrl).toBe('https://gemini-proxy.example.com')
+  expect(env.providers.openai?.baseUrl).toBe('https://openai-proxy.example.com')
+})
+
+test('getPlatformEnv leaves provider baseUrl undefined when the env var is unset', () => {
+  const env = getPlatformEnv(baseEnv)
+  expect(env.providers.gemini?.baseUrl).toBeUndefined()
+  expect(env.providers.openai?.baseUrl).toBeUndefined()
+})

--- a/packages/provider-gemini/src/adapter.ts
+++ b/packages/provider-gemini/src/adapter.ts
@@ -15,10 +15,11 @@ import {
 } from './normalize.js'
 import type { GeminiConfig } from './types.js'
 
-function toGeminiConfig(config: ProviderConfig): GeminiConfig {
+export function toGeminiConfig(config: ProviderConfig): GeminiConfig {
   return {
     apiKey: config.apiKey ?? '',
     model: config.model,
+    baseUrl: config.baseUrl,
     quotaPolicy: config.quotaPolicy,
     vertexProject: config.vertexProject,
     vertexRegion: config.vertexRegion,

--- a/packages/provider-gemini/src/embeddings.ts
+++ b/packages/provider-gemini/src/embeddings.ts
@@ -18,6 +18,11 @@ export interface EmbedQueriesOptions {
   apiKey: string
   model?: string
   outputDimensionality?: number
+  /**
+   * Custom API endpoint (e.g. a proxy in front of the Gemini API). Maps to the
+   * SDK's `httpOptions.baseUrl`. When unset, the SDK uses its default endpoint.
+   */
+  baseUrl?: string
   /** Override client — used for tests and Vertex-mode adapters that bypass the default GenAI SDK. */
   client?: EmbedClient
 }
@@ -30,7 +35,7 @@ export async function embedQueries(
   if (!options.apiKey && !options.client) {
     throw new Error('embedQueries: missing apiKey')
   }
-  const client = options.client ?? createGeminiEmbedClient(options.apiKey)
+  const client = options.client ?? createGeminiEmbedClient(options.apiKey, options.baseUrl)
   return client.embedBatch(queries, {
     model: options.model ?? DEFAULT_EMBED_MODEL,
     taskType: CLUSTERING_TASK_TYPE,
@@ -61,8 +66,18 @@ export function extractEmbeddingVectors(
   })
 }
 
-function createGeminiEmbedClient(apiKey: string): EmbedClient {
-  const genai = new GoogleGenAI({ apiKey })
+/**
+ * Construct the embeddings GenAI client, threading an optional `baseUrl` (e.g.
+ * a proxy in front of the Gemini API) into the SDK's `httpOptions.baseUrl`.
+ * Mirrors `createClient` in `normalize.ts` so discovery embeddings honor the
+ * same configured endpoint as tracked-query sweeps.
+ */
+export function createEmbedGenAI(apiKey: string, baseUrl?: string): GoogleGenAI {
+  return new GoogleGenAI({ apiKey, ...(baseUrl ? { httpOptions: { baseUrl } } : {}) })
+}
+
+function createGeminiEmbedClient(apiKey: string, baseUrl?: string): EmbedClient {
+  const genai = createEmbedGenAI(apiKey, baseUrl)
   return {
     async embedBatch(queries, opts) {
       const response = await genai.models.embedContent({

--- a/packages/provider-gemini/src/normalize.ts
+++ b/packages/provider-gemini/src/normalize.ts
@@ -32,8 +32,11 @@ function resolveModel(config: GeminiConfig): string {
 /**
  * Create a GoogleGenAI client — works for both AI Studio (apiKey) and
  * Vertex AI (project + location + optional service account credentials).
+ * A configured `baseUrl` (e.g. a proxy in front of the API) is threaded into
+ * the SDK's `httpOptions.baseUrl` for both auth modes.
  */
-function createClient(config: GeminiConfig): GoogleGenAI {
+export function createClient(config: GeminiConfig): GoogleGenAI {
+  const httpOptions = config.baseUrl ? { httpOptions: { baseUrl: config.baseUrl } } : {}
   if (isVertexConfig(config)) {
     return new GoogleGenAI({
       vertexai: true,
@@ -42,9 +45,10 @@ function createClient(config: GeminiConfig): GoogleGenAI {
       ...(config.vertexCredentials
         ? { googleAuthOptions: { keyFilename: config.vertexCredentials } }
         : {}),
+      ...httpOptions,
     })
   }
-  return new GoogleGenAI({ apiKey: config.apiKey })
+  return new GoogleGenAI({ apiKey: config.apiKey, ...httpOptions })
 }
 
 export function validateConfig(config: GeminiConfig): GeminiHealthcheckResult {

--- a/packages/provider-gemini/src/types.ts
+++ b/packages/provider-gemini/src/types.ts
@@ -6,6 +6,11 @@ export interface GeminiConfig {
   apiKey: string
   quotaPolicy: ProviderQuotaPolicy
   model?: string
+  /**
+   * Custom API endpoint (e.g. a proxy in front of the Gemini API). Maps to the
+   * SDK's `httpOptions.baseUrl`. When unset, the SDK uses its default endpoint.
+   */
+  baseUrl?: string
   /** Vertex AI GCP project ID — when set, uses Vertex AI instead of AI Studio */
   vertexProject?: string
   /** Vertex AI region (default: "us-central1") */

--- a/packages/provider-gemini/test/base-url.test.ts
+++ b/packages/provider-gemini/test/base-url.test.ts
@@ -30,6 +30,11 @@ test('createClient leaves httpOptions unset when no baseUrl is configured', () =
   expect(internals(client).httpOptions).toBeUndefined()
 })
 
+test('createClient treats an empty-string baseUrl as unset', () => {
+  const client = createClient({ apiKey: 'k', quotaPolicy, baseUrl: '' })
+  expect(internals(client).httpOptions).toBeUndefined()
+})
+
 test('createClient threads baseUrl into httpOptions for Vertex AI mode', () => {
   const client = createClient({
     apiKey: '',

--- a/packages/provider-gemini/test/base-url.test.ts
+++ b/packages/provider-gemini/test/base-url.test.ts
@@ -1,0 +1,105 @@
+import { test, expect, vi } from 'vitest'
+
+import { createClient } from '../src/normalize.js'
+import { createEmbedGenAI, embedQueries } from '../src/embeddings.js'
+import { toGeminiConfig } from '../src/adapter.js'
+
+const quotaPolicy = { maxConcurrency: 2, maxRequestsPerMinute: 10, maxRequestsPerDay: 1000 }
+
+// The SDK stores `httpOptions` as a runtime property (TS `private`, not `#private`),
+// so we read it back off the real constructed instance.
+type ClientInternals = { httpOptions?: { baseUrl?: string }; vertexai?: boolean }
+const internals = (client: unknown) => client as ClientInternals
+
+function requestUrl(input: unknown): string {
+  if (typeof input === 'string') return input
+  if (input instanceof URL) return input.href
+  if (input instanceof Request) return input.url
+  return String(input)
+}
+
+// --- SDK seam: createClient threads baseUrl into the real GoogleGenAI client ---
+
+test('createClient threads baseUrl into httpOptions.baseUrl (AI Studio mode)', () => {
+  const client = createClient({ apiKey: 'k', quotaPolicy, baseUrl: 'https://proxy.example.com' })
+  expect(internals(client).httpOptions?.baseUrl).toBe('https://proxy.example.com')
+})
+
+test('createClient leaves httpOptions unset when no baseUrl is configured', () => {
+  const client = createClient({ apiKey: 'k', quotaPolicy })
+  expect(internals(client).httpOptions).toBeUndefined()
+})
+
+test('createClient threads baseUrl into httpOptions for Vertex AI mode', () => {
+  const client = createClient({
+    apiKey: '',
+    quotaPolicy,
+    vertexProject: 'proj',
+    vertexRegion: 'us-central1',
+    baseUrl: 'https://proxy.example.com',
+  })
+  expect(internals(client).vertexai).toBe(true)
+  expect(internals(client).httpOptions?.baseUrl).toBe('https://proxy.example.com')
+})
+
+// --- Embeddings seam: discovery's embed client honors the same baseUrl ---
+
+test('createEmbedGenAI threads baseUrl into httpOptions.baseUrl', () => {
+  const client = createEmbedGenAI('k', 'https://proxy.example.com')
+  expect(internals(client).httpOptions?.baseUrl).toBe('https://proxy.example.com')
+})
+
+test('createEmbedGenAI leaves httpOptions unset when no baseUrl is configured', () => {
+  const client = createEmbedGenAI('k')
+  expect(internals(client).httpOptions).toBeUndefined()
+})
+
+// --- Wire guard: a path-prefix baseUrl (LiteLLM passthrough) is preserved, not host-swapped ---
+
+test('createClient preserves the baseUrl path prefix when building sweep request URLs', async () => {
+  const calls: string[] = []
+  vi.stubGlobal('fetch', async (input: unknown) => {
+    calls.push(requestUrl(input))
+    return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } })
+  })
+  try {
+    const client = createClient({ apiKey: 'tenant-virtual-key', quotaPolicy, baseUrl: 'https://proxy.example.com/gemini' })
+    await client.models.generateContent({ model: 'gemini-2.5-flash', contents: 'ping' }).catch(() => {})
+    expect(calls[0]).toMatch(/^https:\/\/proxy\.example\.com\/gemini\/.*:generateContent/)
+  } finally {
+    vi.unstubAllGlobals()
+  }
+})
+
+test('embedQueries preserves the baseUrl path prefix when building embed request URLs', async () => {
+  const calls: string[] = []
+  vi.stubGlobal('fetch', async (input: unknown) => {
+    calls.push(requestUrl(input))
+    return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } })
+  })
+  try {
+    // The stub body fails embedding extraction; only the requested URL matters.
+    await embedQueries(['ping'], { apiKey: 'tenant-virtual-key', baseUrl: 'https://proxy.example.com/gemini' }).catch(() => {})
+    // `:embedContent` (single) or `:batchEmbedContents` (batch) — either way the prefix must survive.
+    expect(calls[0]).toMatch(/^https:\/\/proxy\.example\.com\/gemini\/.*[eE]mbed/)
+  } finally {
+    vi.unstubAllGlobals()
+  }
+})
+
+// --- Mapping guard: ProviderConfig.baseUrl must survive the adapter mapping ---
+
+test('toGeminiConfig carries ProviderConfig.baseUrl into the adapter config', () => {
+  const mapped = toGeminiConfig({
+    provider: 'gemini',
+    apiKey: 'k',
+    baseUrl: 'https://proxy.example.com',
+    quotaPolicy,
+  })
+  expect(mapped.baseUrl).toBe('https://proxy.example.com')
+})
+
+test('toGeminiConfig leaves baseUrl undefined when ProviderConfig has none', () => {
+  const mapped = toGeminiConfig({ provider: 'gemini', apiKey: 'k', quotaPolicy })
+  expect(mapped.baseUrl).toBeUndefined()
+})

--- a/packages/provider-openai/src/adapter.ts
+++ b/packages/provider-openai/src/adapter.ts
@@ -15,10 +15,11 @@ import {
 } from './normalize.js'
 import type { OpenAIConfig } from './types.js'
 
-function toOpenAIConfig(config: ProviderConfig): OpenAIConfig {
+export function toOpenAIConfig(config: ProviderConfig): OpenAIConfig {
   return {
     apiKey: config.apiKey ?? '',
     model: config.model,
+    baseUrl: config.baseUrl,
     quotaPolicy: config.quotaPolicy,
   }
 }

--- a/packages/provider-openai/src/normalize.ts
+++ b/packages/provider-openai/src/normalize.ts
@@ -12,6 +12,18 @@ import type {
 
 const DEFAULT_MODEL = 'gpt-5.4'
 
+/**
+ * Construct the OpenAI SDK client, threading a configured `baseUrl` (e.g. a
+ * proxy in front of the API) into the SDK's `baseURL`. When unset, the SDK
+ * falls back to its default endpoint.
+ */
+export function createClient(config: OpenAIConfig): OpenAI {
+  return new OpenAI({
+    apiKey: config.apiKey,
+    ...(config.baseUrl ? { baseURL: config.baseUrl } : {}),
+  })
+}
+
 export function validateConfig(config: OpenAIConfig): OpenAIHealthcheckResult {
   if (!config.apiKey || config.apiKey.length === 0) {
     return { ok: false, provider: 'openai', message: 'missing api key' }
@@ -29,7 +41,7 @@ export async function healthcheck(config: OpenAIConfig): Promise<OpenAIHealthche
   if (!validation.ok) return validation
 
   try {
-    const client = new OpenAI({ apiKey: config.apiKey })
+    const client = createClient(config)
     const response = await withRetry(() =>
       client.responses.create({
         model: config.model ?? DEFAULT_MODEL,
@@ -55,7 +67,7 @@ export async function healthcheck(config: OpenAIConfig): Promise<OpenAIHealthche
 
 export async function executeTrackedQuery(input: OpenAITrackedQueryInput): Promise<OpenAIRawResult> {
   const model = input.config.model ?? DEFAULT_MODEL
-  const client = new OpenAI({ apiKey: input.config.apiKey })
+  const client = createClient(input.config)
 
   const webSearchTool: Record<string, unknown> = { type: 'web_search' }
   if (input.location) {
@@ -285,7 +297,7 @@ function extractDomainFromUri(uri: string): string | null {
 
 export async function generateText(prompt: string, config: OpenAIConfig): Promise<string> {
   const model = config.model ?? DEFAULT_MODEL
-  const client = new OpenAI({ apiKey: config.apiKey })
+  const client = createClient(config)
   const response = await withRetry(() =>
     client.responses.create({
       model,

--- a/packages/provider-openai/src/types.ts
+++ b/packages/provider-openai/src/types.ts
@@ -6,6 +6,11 @@ export interface OpenAIConfig {
   apiKey: string
   quotaPolicy: ProviderQuotaPolicy
   model?: string
+  /**
+   * Custom API endpoint (e.g. a proxy in front of the OpenAI API). Maps to the
+   * SDK's `baseURL`. When unset, the SDK uses its default endpoint.
+   */
+  baseUrl?: string
 }
 
 export interface OpenAIHealthcheckResult {

--- a/packages/provider-openai/test/base-url.test.ts
+++ b/packages/provider-openai/test/base-url.test.ts
@@ -1,0 +1,70 @@
+import { test, expect, vi } from 'vitest'
+
+import { createClient } from '../src/normalize.js'
+import { toOpenAIConfig } from '../src/adapter.js'
+
+const quotaPolicy = { maxConcurrency: 2, maxRequestsPerMinute: 10, maxRequestsPerDay: 1000 }
+
+function requestUrl(input: unknown): string {
+  if (typeof input === 'string') return input
+  if (input instanceof URL) return input.href
+  if (input instanceof Request) return input.url
+  return String(input)
+}
+
+// --- SDK seam: createClient threads baseUrl into the real OpenAI client ---
+
+test('createClient threads a configured baseUrl into the SDK baseURL', () => {
+  const client = createClient({ apiKey: 'k', quotaPolicy, baseUrl: 'https://proxy.example.com/v1' })
+  expect(client.baseURL).toBe('https://proxy.example.com/v1')
+})
+
+test('createClient falls back to the OpenAI default endpoint when baseUrl is unset', () => {
+  const client = createClient({ apiKey: 'k', quotaPolicy })
+  expect(client.baseURL).toBe('https://api.openai.com/v1')
+})
+
+test('createClient treats an empty-string baseUrl as unset', () => {
+  const client = createClient({ apiKey: 'k', quotaPolicy, baseUrl: '' })
+  expect(client.baseURL).toBe('https://api.openai.com/v1')
+})
+
+// --- Wire guard: a path-prefix baseUrl (LiteLLM passthrough) is preserved, not host-swapped ---
+
+test('createClient preserves the baseUrl path prefix when building request URLs', async () => {
+  const calls: string[] = []
+  // Stub before constructing — the SDK captures globalThis.fetch at construction.
+  vi.stubGlobal('fetch', async (input: unknown) => {
+    calls.push(requestUrl(input))
+    return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } })
+  })
+  try {
+    const client = createClient({
+      apiKey: 'tenant-virtual-key',
+      quotaPolicy,
+      baseUrl: 'https://proxy.example.com/openai_passthrough/v1',
+    })
+    // The stub body isn't a valid Responses payload; only the requested URL matters.
+    await client.responses.create({ model: 'gpt-5.4', input: 'ping' }).catch(() => {})
+    expect(calls[0]).toBe('https://proxy.example.com/openai_passthrough/v1/responses')
+  } finally {
+    vi.unstubAllGlobals()
+  }
+})
+
+// --- Mapping guard: ProviderConfig.baseUrl must survive the adapter mapping ---
+
+test('toOpenAIConfig carries ProviderConfig.baseUrl into the adapter config', () => {
+  const mapped = toOpenAIConfig({
+    provider: 'openai',
+    apiKey: 'k',
+    baseUrl: 'https://proxy.example.com/v1',
+    quotaPolicy,
+  })
+  expect(mapped.baseUrl).toBe('https://proxy.example.com/v1')
+})
+
+test('toOpenAIConfig leaves baseUrl undefined when ProviderConfig has none', () => {
+  const mapped = toOpenAIConfig({ provider: 'openai', apiKey: 'k', quotaPolicy })
+  expect(mapped.baseUrl).toBeUndefined()
+})


### PR DESCRIPTION
Adds an optional `baseUrl` to the Gemini and OpenAI providers so requests can route through a proxy or gateway (e.g. a LiteLLM passthrough), sourced from `GEMINI_BASE_URL` / `OPENAI_BASE_URL` env vars or `providers.<name>.baseUrl` in `config.yaml`.

- **Wiring:** threads `baseUrl` into the OpenAI SDK `baseURL` and js-genai `httpOptions.baseUrl` across both Gemini auth modes (AI Studio + Vertex), consolidating OpenAI client construction into one `createClient`.
- **Discovery embeddings:** the Gemini embed client now honors the same `baseUrl`, so discovery no longer bypasses the proxy.
- **Path-prefix safe:** a prefixed base URL (e.g. `<proxy>/gemini`, `<proxy>/openai_passthrough/v1`) is preserved on the wire rather than host-swapped — locked in by tests asserting the final request URL.
- Adds config/env parsing, provider docs, tests (config + both providers), and a minor version bump (4.76.2 → 4.77.0).