### PR TITLE
fix(web): show AI user-fetch count in traffic sync toast

### DIFF
--- a/apps/web/src/pages/TrafficSourceDetailPage.tsx
+++ b/apps/web/src/pages/TrafficSourceDetailPage.tsx
@@ -301,7 +301,7 @@ export function TrafficSourceDetailPage() {
     try {
       const result = await sync.mutateAsync({ sinceMinutes: 60 })
       setSyncResult(
-        `Pulled ${result.pulledEvents} entries · ${result.crawlerHits} crawler · ${result.aiReferralHits} AI referral · ${result.unknownHits} unknown`,
+        `Pulled ${result.pulledEvents} entries · ${result.crawlerHits} crawler · ${result.aiUserFetchHits} AI user fetch · ${result.aiReferralHits} AI referral · ${result.unknownHits} unknown`,
       )
     } catch (e) {
       setSyncError(extractErrorMessage(e))

--- a/apps/web/src/queries/server-traffic.ts
+++ b/apps/web/src/queries/server-traffic.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { useMutation, useQuery, useQueryClient, type QueryClient } from '@tanstack/react-query'
 
-import type { TrafficSourceStatus } from '@ainyc/canonry-contracts'
+import type { TrafficEventKind, TrafficSourceStatus } from '@ainyc/canonry-contracts'
 import { TrafficSourceStatuses } from '@ainyc/canonry-contracts'
 import {
   getApiV1ProjectsByNameTrafficEventsOptions,
@@ -39,7 +39,7 @@ export function toneFromTrafficSourceStatus(status: TrafficSourceStatus): Metric
 }
 
 export interface ServerTrafficEventsFilters {
-  kind?: 'all' | 'crawler' | 'ai-referral'
+  kind?: TrafficEventKind | 'all'
   sourceId?: string
   sinceMinutes?: number
   limit?: number


### PR DESCRIPTION
Investigated suspected WordPress/aggregator hit overcounting and verified the ingestion + rollup pipeline counts each request exactly once (plugin write, forward-only cursor, rollup, and cross-sync dedup are all sound and covered by passing tests) — no double-counting bug. Two display-only fixes surfaced during that trace:

- **Sync toast:** the "Sync now" result omitted `aiUserFetchHits`, so a sync that pulled only AI user-fetch hits (e.g. ChatGPT-User) read `0 crawler · 0 AI referral · 0 unknown` and the pulled events appeared to vanish — now shown in canonical order (crawler · AI user fetch · AI referral · unknown).
- **Filter type:** widened `ServerTrafficEventsFilters.kind` to the `TrafficEventKind` contract union so `'ai-user-fetch'` is a valid filter value (runtime already passed it through).

No counting logic changed — UI-only.
