### PR TITLE
fix(web): fill URL column width in technical-AEO per-page table

### DIFF
--- a/apps/web/src/components/project/TechnicalAeoSection.tsx
+++ b/apps/web/src/components/project/TechnicalAeoSection.tsx
@@ -439,7 +439,7 @@ export function TechnicalAeoSection({ projectName }: { projectName: string }) {
                   <tr>
                     <th className="text-right">Score</th>
                     <th>Status</th>
-                    <th>URL</th>
+                    <th className="w-full">URL</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -451,7 +451,7 @@ export function TechnicalAeoSection({ projectName }: { projectName: string }) {
                           : <span className={scoreTextClass(p.overallScore)}>{p.overallScore}</span>}
                       </td>
                       <td>{p.status === 'error' ? <ToneBadge tone="negative">Error</ToneBadge> : <ToneBadge tone={scoreTone(p.overallScore)}>{statusLabel(p.overallScore)}</ToneBadge>}</td>
-                      <td className="max-w-0">
+                      <td className="w-full max-w-0">
                         <a href={p.url} target="_blank" rel="noreferrer" className="block truncate text-zinc-300 hover:text-zinc-100" title={p.status === 'error' ? p.error ?? p.url : p.url}>
                           {p.url}
                         </a>


### PR DESCRIPTION
Fixes the wasted space on the right-hand side of the Technical AEO **Per-page breakdown** table.

The URL cell was capped at `max-w-0` without `w-full`, so in the 3-column `w-full` table the leftover horizontal space collapsed into the Status column — leaving a large empty gap and pushing the URLs to the far right. Adding `w-full` to the URL header/cell makes that column absorb the remaining width (left-aligned, truncating at the edge) while Score/Status shrink to content. Inner `truncate` link is unchanged, so long URLs still ellipsize. Verified live against a real audit (`ainyc`, 29 pages): the three columns now sit together and the URL fills the row.