### PR TITLE
fix(traffic): classify WordPress feed/REST/XML-RPC polling as infra, not content

### DIFF
--- a/packages/contracts/src/traffic-path.ts
+++ b/packages/contracts/src/traffic-path.ts
@@ -40,6 +40,11 @@ export interface TrafficCrawlerSegments {
 // content read.
 const ROBOTS_BASENAMES = new Set(['robots.txt', 'llms.txt', 'llms-full.txt'])
 
+// Non-page infrastructure endpoints whose basename carries a document-like
+// extension, so the extension check below would otherwise call them `content`.
+// WordPress XML-RPC and cron are the common case.
+const INFRA_BASENAMES = new Set(['xmlrpc.php', 'wp-cron.php'])
+
 // Static-asset extensions. A crawler fetching these is pulling sub-resources,
 // not reading a page. Mirrors the set the issue calls out plus the common
 // remainder (fonts, modern image formats, media, source maps).
@@ -166,6 +171,16 @@ export function classifyTrafficPath(pathNormalized: string | null | undefined): 
   // Any `*.xml` / `*.xml.gz`, or one of the extensionless sitemap conventions.
   if (lower.endsWith('.xml') || lower.endsWith('.xml.gz')) return TrafficPathClasses.sitemap
   if (SITEMAP_BASENAME.test(basename)) return TrafficPathClasses.sitemap
+
+  // Non-page infrastructure endpoints that an extension or extensionless path
+  // would otherwise misclassify as `content`. WordPress is the common case:
+  // XML-RPC / cron (`xmlrpc.php`, `wp-cron.php`), the WP REST API
+  // (`/wp-json/...`), and RSS / comment feeds, which WordPress exposes at `/feed`
+  // and `/<path>/feed[/...]` with no file extension. These are polling and
+  // syndication, not a content crawl, so they go to the residual bucket.
+  if (INFRA_BASENAMES.has(basename)) return TrafficPathClasses.other
+  if (lower === '/wp-json' || lower.startsWith('/wp-json/')) return TrafficPathClasses.other
+  if (lower.endsWith('/feed') || lower.includes('/feed/')) return TrafficPathClasses.other
 
   // Extract the extension from the basename (ignore leading-dot dotfiles, where
   // the dot is at index 0 — those have no extension).

--- a/packages/contracts/test/traffic-path.test.ts
+++ b/packages/contracts/test/traffic-path.test.ts
@@ -97,6 +97,31 @@ describe('classifyTrafficPath', () => {
     expect(classifyTrafficPath('/report.xlsx')).toBe('other')
   })
 
+  it('routes WordPress infrastructure endpoints to other, not content', () => {
+    // XML-RPC and cron carry a .php document extension but are pure polling
+    expect(classifyTrafficPath('/xmlrpc.php')).toBe('other')
+    expect(classifyTrafficPath('/wp-cron.php')).toBe('other')
+    // WP REST API
+    expect(classifyTrafficPath('/wp-json')).toBe('other')
+    expect(classifyTrafficPath('/wp-json/wp/v2/posts')).toBe('other')
+    expect(classifyTrafficPath('/wp-json/wp/v2/pages/:id')).toBe('other')
+    expect(classifyTrafficPath('/wp-json/oembed/1.0/embed')).toBe('other')
+    // RSS / comment feeds: extensionless, at /feed and /<path>/feed[/...]
+    expect(classifyTrafficPath('/feed')).toBe('other')
+    expect(classifyTrafficPath('/feed/')).toBe('other')
+    expect(classifyTrafficPath('/blog/my-post/feed/')).toBe('other')
+    expect(classifyTrafficPath('/comments/feed/')).toBe('other')
+    expect(classifyTrafficPath('/feed/rss2/')).toBe('other')
+  })
+
+  it('does not over-match content slugs that merely contain "feed"', () => {
+    expect(classifyTrafficPath('/news-feed')).toBe('content')
+    expect(classifyTrafficPath('/feeds')).toBe('content')
+    expect(classifyTrafficPath('/feedback')).toBe('content')
+    expect(classifyTrafficPath('/blog/feed-reader-roundup')).toBe('content')
+    expect(classifyTrafficPath('/products/cattle-feed')).toBe('content')
+  })
+
   it('treats empty / missing paths as other (defensive fallback)', () => {
     expect(classifyTrafficPath('')).toBe('other')
     expect(classifyTrafficPath('   ')).toBe('other')
@@ -159,6 +184,21 @@ describe('segmentCrawlerHits', () => {
     expect(seg.content).toBe(0)
     expect(sumInfraHits(seg)).toBe(147)
     expect(seg.content + sumInfraHits(seg) + seg.other).toBe(147)
+  })
+
+  it('routes WordPress feed/api/xmlrpc polling to other, out of content', () => {
+    const seg = segmentCrawlerHits([
+      { pathNormalized: '/', hits: 10 },
+      { pathNormalized: '/blog/post/feed/', hits: 30 },
+      { pathNormalized: '/wp-json/wp/v2/pages/:id', hits: 25 },
+      { pathNormalized: '/xmlrpc.php', hits: 15 },
+      { pathNormalized: '/sitemap_index.xml', hits: 100 },
+    ])
+    expect(seg.content).toBe(10) // only the real page, not the WP infra
+    expect(seg.other).toBe(70) // feed + wp-json + xmlrpc
+    expect(seg.sitemap).toBe(100)
+    const total = 10 + 30 + 25 + 15 + 100
+    expect(seg.content + sumInfraHits(seg) + seg.other).toBe(total)
   })
 
   it('returns an all-zero breakdown for no rows', () => {

--- a/skills/canonry/references/server-side-traffic.md
+++ b/skills/canonry/references/server-side-traffic.md
@@ -264,7 +264,10 @@ therefore return, alongside the unchanged `crawlerHits` total:
 - `crawlerInfraHits` — sitemap + robots + asset fetches.
 - `crawlerSegments` — the full `{ content, sitemap, robots, asset, other }`
   breakdown; the five buckets sum to `crawlerHits`, and
-  `content + infra + other == crawlerHits`.
+  `content + infra + other == crawlerHits`. `other` captures non-page downloads
+  and feeds (PDF, CSV, RSS) plus WordPress polling endpoints that are not page
+  reads (`/feed`, `/<path>/feed`, `/wp-json/...`, `xmlrpc.php`, `wp-cron.php`), so
+  they stay out of `crawlerContentHits`.
 
 Each crawler row from `traffic events` also carries a `pathClass`
 (`content | sitemap | robots | asset | other`). The dashboard leads with the


### PR DESCRIPTION
## What

`classifyTrafficPath` (added in #720) classified WordPress infrastructure endpoints as `content`, which overstates the headline content-crawl figure on WordPress sites:

- RSS / comment feeds (`/feed`, `/<path>/feed[/...]`) are extensionless, so they fell through to `content`.
- The WP REST API (`/wp-json/...`) is extensionless.
- `xmlrpc.php` / `wp-cron.php` carry a `.php` document extension, so they hit the content branch.

These are polling and syndication, not page reads.

## Change

Route them to the `other` bucket, consistent with how `.rss` / `.atom` feeds are already classified. The fix is in the pure, read-time classifier, so it applies retroactively to all stored rollups with no schema change or backfill. The `content + infra + other == crawlerHits` invariant still holds.

Negative cases are included so content slugs that merely contain "feed" (`/news-feed`, `/feeds`, `/feedback`, `/blog/feed-reader-roundup`) stay `content`.

## Tests

- `classifyTrafficPath`: WordPress infra cases plus the negative slug cases.
- `segmentCrawlerHits`: a mixed WordPress source, asserting feed / REST / xmlrpc land in `other` and the `content + infra + other == total` invariant holds.

All 17 traffic-related test files pass (279 tests). No version bump (non-doc change is under the 100-line threshold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
