### PR TITLE
fix(gbp): re-stamp lodging snapshot syncedAt on unchanged re-fetch

### DIFF
--- a/packages/canonry/src/gbp-sync.ts
+++ b/packages/canonry/src/gbp-sync.ts
@@ -308,8 +308,13 @@ export async function executeGbpSync(
               }).run()
             }
 
-            // Lodging: append a new snapshot only when the profile changed
-            // (hotel attributes change rarely — don't store a row per sync).
+            // Lodging: append a new snapshot when the profile changed (hotel
+            // attributes change rarely — don't store a row per sync); otherwise
+            // re-stamp the latest snapshot's `syncedAt` so it records this
+            // fetch. Lodging is re-fetched every sync and has no cadence gate,
+            // so without this touch a stable-but-just-re-verified profile keeps
+            // the first-observed timestamp and reads as stale in `gbp lodging` /
+            // `gbp summary`. Mirrors the Places enrichment touch below.
             if (lodging !== null && lodgingChanged) {
               tx.insert(gbpLodgingSnapshots).values({
                 id: crypto.randomUUID(),
@@ -321,6 +326,11 @@ export async function executeGbpSync(
                 syncedAt: insertNow,
                 syncRunId: runId,
               }).run()
+            } else if (lodging !== null && latestLodging) {
+              tx.update(gbpLodgingSnapshots)
+                .set({ syncedAt: insertNow, syncRunId: runId })
+                .where(eq(gbpLodgingSnapshots.id, latestLodging.id))
+                .run()
             }
 
             // Places: append a new rendered-listing snapshot when the Place

--- a/packages/canonry/test/gbp-sync.test.ts
+++ b/packages/canonry/test/gbp-sync.test.ts
@@ -12,8 +12,10 @@ import {
   gbpKeywordImpressions,
   gbpKeywordMonthly,
   gbpPlaceDetails,
+  gbpLodgingSnapshots,
 } from '@ainyc/canonry-db'
 import { hashPlaceDetails } from '@ainyc/canonry-integration-google-places'
+import { hashLodging, countPopulatedGroups } from '@ainyc/canonry-integration-google-business-profile'
 import { executeGbpSync } from '../src/gbp-sync.js'
 import type { CanonryConfig } from '../src/config.js'
 
@@ -427,6 +429,88 @@ describe('executeGbpSync — Places enrichment (#648)', () => {
       // Metrics/keywords/lodging succeeded → run completes; Places error swallowed.
       expect(db.select().from(runs).where(eq(runs.id, 'run_1')).get()!.status).toBe('completed')
       expect(placeRows(db)).toHaveLength(0)
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('executeGbpSync — lodging snapshot freshness', () => {
+  const LODGING = { name: `${LOCATION}/lodging`, pools: { pool: true } }
+
+  function lodgingRows(db: ReturnType<typeof createClient>) {
+    return db.select().from(gbpLodgingSnapshots).where(eq(gbpLodgingSnapshots.projectId, 'proj_gbp')).all()
+  }
+
+  test('an unchanged lodging re-fetch re-stamps the latest snapshot (no new row, syncedAt advances)', async () => {
+    const { db, tmpDir } = createTempDb()
+    try {
+      seedProject(db)
+      getLodgingMock.mockResolvedValue(LODGING)
+
+      // Existing snapshot 30 days old whose content matches what the fetch
+      // returns, so the sync finds the lodging profile UNCHANGED — the common
+      // steady state (hotel attributes change rarely). Before the touch this
+      // row kept its 30-day-old syncedAt and read as stale.
+      const oldSyncedAt = new Date(Date.now() - 30 * 86_400_000).toISOString()
+      db.insert(gbpLodgingSnapshots).values({
+        id: 'seed_lodging',
+        projectId: 'proj_gbp',
+        locationName: LOCATION,
+        contentHash: hashLodging(LODGING),
+        attributes: LODGING,
+        populatedGroupCount: countPopulatedGroups(LODGING),
+        syncedAt: oldSyncedAt,
+        syncRunId: null,
+      }).run()
+
+      seedRun(db, 'run_1')
+      await executeGbpSync(db, 'run_1', 'proj_gbp', { config: testConfig() })
+
+      const rows = lodgingRows(db)
+      expect(rows).toHaveLength(1)                  // unchanged → no duplicate row
+      expect(rows[0]!.id).toBe('seed_lodging')       // same row, touched in place
+      expect(rows[0]!.syncRunId).toBe('run_1')       // re-stamped by this run
+      // Freshness advanced: the row no longer reads as 30 days stale.
+      expect(new Date(rows[0]!.syncedAt).getTime()).toBeGreaterThan(new Date(oldSyncedAt).getTime())
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  test('changed lodging content appends a new snapshot (snapshot-on-change preserved)', async () => {
+    const { db, tmpDir } = createTempDb()
+    try {
+      seedProject(db)
+
+      getLodgingMock.mockResolvedValue(LODGING)
+      seedRun(db, 'run_1')
+      await executeGbpSync(db, 'run_1', 'proj_gbp', { config: testConfig() })
+      expect(lodgingRows(db)).toHaveLength(1)
+
+      // Different attributes → a new content hash → a new snapshot row, so the
+      // touch must not swallow a genuine change.
+      getLodgingMock.mockResolvedValue({ ...LODGING, services: { roomService: true } })
+      seedRun(db, 'run_2')
+      await executeGbpSync(db, 'run_2', 'proj_gbp', { config: testConfig() })
+      expect(lodgingRows(db)).toHaveLength(2)
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  test('first-ever lodging sync inserts a snapshot (no prior row to touch)', async () => {
+    const { db, tmpDir } = createTempDb()
+    try {
+      seedProject(db)
+      getLodgingMock.mockResolvedValue(LODGING)
+
+      seedRun(db, 'run_1')
+      await executeGbpSync(db, 'run_1', 'proj_gbp', { config: testConfig() })
+
+      const rows = lodgingRows(db)
+      expect(rows).toHaveLength(1)
+      expect(rows[0]!.syncRunId).toBe('run_1')
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Problem

`executeGbpSync` re-fetches the GBP lodging (hotel attributes) resource on every sync, but the snapshot table is append-on-change: a new `gbp_lodging_snapshots` row is inserted only when the content hash differs. On an unchanged re-fetch the latest snapshot's `syncedAt` was never advanced, so a stable hotel profile kept the timestamp from when its content was *first observed*. `gbp lodging` and `gbp summary` surface that timestamp as a freshness signal, so a profile that was re-verified today but last changed weeks ago reads as stale.

The parallel Places-enrichment snapshot in the same transaction already handles this: on unchanged content it re-stamps the existing row's `syncedAt` (the "touch" branch). Lodging was missing the symmetric touch.

## Fix

When lodging is unchanged and a prior snapshot exists, re-stamp that row's `syncedAt`/`syncRunId` to the current sync, mirroring the Places touch. `syncedAt` now consistently means "last confirmed" across both snapshot surfaces.

- No new row on an unchanged re-fetch (snapshot-on-change preserved).
- No schema change, no migration (existing columns only).
- All four consumers read the latest row via `orderBy desc(syncedAt) limit 1` and none diff by it, so advancing the latest row's timestamp forward is safe.

## Tests

Added a `lodging snapshot freshness` suite to `gbp-sync.test.ts`:
- unchanged re-fetch touches in place (no duplicate row, `syncedAt` advances, `syncRunId` re-stamped),
- changed content still appends a new snapshot,
- the first-ever sync still inserts.

`gbp-sync.test.ts` 14/14 pass; typecheck + lint clean. No version bump (96 lines changed, under the 100-line threshold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
