### PR TITLE
feat(gbp): capture owner-content profile fields from the Location resource

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.89.0",
+  "version": "4.90.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -861,6 +861,17 @@ export type GbpLocationDto = {
     websiteUri: string | null;
     placeId: string | null;
     mapsUri: string | null;
+    additionalCategories: Array<string>;
+    description: string | null;
+    serviceArea: {
+        [key: string]: unknown;
+    } | null;
+    regularHours: {
+        [key: string]: unknown;
+    } | null;
+    primaryPhone: string | null;
+    openStatus: string | null;
+    openingDate: string | null;
     selected: boolean;
     syncedAt: string | null;
     createdAt: string;
@@ -879,6 +890,17 @@ export type GbpLocationListResponse = {
         websiteUri: string | null;
         placeId: string | null;
         mapsUri: string | null;
+        additionalCategories: Array<string>;
+        description: string | null;
+        serviceArea: {
+            [key: string]: unknown;
+        } | null;
+        regularHours: {
+            [key: string]: unknown;
+        } | null;
+        primaryPhone: string | null;
+        openStatus: string | null;
+        openingDate: string | null;
         selected: boolean;
         syncedAt: string | null;
         createdAt: string;

--- a/packages/api-routes/src/google.ts
+++ b/packages/api-routes/src/google.ts
@@ -34,6 +34,7 @@ import {
   listAccounts as gbpListAccounts,
   listLocations as gbpListLocations,
   formatStorefrontAddress,
+  buildLocationProfileFields,
 } from '@ainyc/canonry-integration-google-business-profile'
 
 /**
@@ -1412,6 +1413,13 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
       websiteUri: row.websiteUri ?? null,
       placeId: row.placeId ?? null,
       mapsUri: row.mapsUri ?? null,
+      additionalCategories: row.additionalCategories ?? [],
+      description: row.description ?? null,
+      serviceArea: row.serviceArea ?? null,
+      regularHours: row.regularHours ?? null,
+      primaryPhone: row.primaryPhone ?? null,
+      openStatus: row.openStatus ?? null,
+      openingDate: row.openingDate ?? null,
       selected: Boolean(row.selected),
       syncedAt: row.syncedAt ?? null,
       createdAt: row.createdAt,
@@ -1550,6 +1558,9 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
           .from(gbpLocations)
           .where(and(eq(gbpLocations.projectId, project.id), eq(gbpLocations.locationName, remote.name)))
           .get()
+        // Owner-content profile fields (categories, description, hours, service
+        // area, phone, open state), derived once and applied to both branches.
+        const profile = buildLocationProfileFields(remote)
         if (existing) {
           tx.update(gbpLocations).set({
             accountName,
@@ -1559,6 +1570,7 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
             websiteUri: remote.websiteUri ?? null,
             placeId: remote.metadata?.placeId ?? null,
             mapsUri: remote.metadata?.mapsUri ?? null,
+            ...profile,
             updatedAt: now,
           }).where(eq(gbpLocations.id, existing.id)).run()
         } else {
@@ -1573,6 +1585,7 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
             websiteUri: remote.websiteUri ?? null,
             placeId: remote.metadata?.placeId ?? null,
             mapsUri: remote.metadata?.mapsUri ?? null,
+            ...profile,
             selected: selectAllNew,
             createdAt: now,
             updatedAt: now,

--- a/packages/api-routes/test/gbp.test.ts
+++ b/packages/api-routes/test/gbp.test.ts
@@ -124,7 +124,16 @@ describe('GBP routes (Phase 1)', () => {
 
   function mockGoogleResponses(opts: {
     accounts?: Array<{ name: string; accountName?: string }>
-    locations?: Array<{ name: string; title?: string; websiteUri?: string; categories?: { primaryCategory?: { displayName?: string } }; metadata?: { placeId?: string; mapsUri?: string } }>
+    locations?: Array<{
+      name: string; title?: string; websiteUri?: string
+      categories?: { primaryCategory?: { displayName?: string }; additionalCategories?: Array<{ displayName?: string }> }
+      profile?: { description?: string }
+      serviceArea?: Record<string, unknown>
+      regularHours?: Record<string, unknown>
+      phoneNumbers?: { primaryPhone?: string }
+      openInfo?: { status?: string; openingDate?: { year?: number; month?: number; day?: number } }
+      metadata?: { placeId?: string; mapsUri?: string }
+    }>
   }) {
     fetchSpy.mockImplementation((url: string) => {
       // Route on the exact hostname, not a substring of the full URL — a
@@ -216,6 +225,46 @@ describe('GBP routes (Phase 1)', () => {
       expect(two.mapsUri).toBeNull()
     })
 
+    it('persists the owner-content profile fields and surfaces them on the DTO', async () => {
+      const projectId = ctx.seedProject('hotels', 'hotels.example.com')
+      ctx.seedGbpConnection('hotels.example.com', 'valid-access-token')
+      mockGoogleResponses({
+        accounts: [{ name: 'accounts/123' }],
+        locations: [{
+          name: 'locations/1', title: 'AZ Coatings',
+          categories: {
+            primaryCategory: { displayName: 'Roofing contractor' },
+            additionalCategories: [{ displayName: 'Insulation contractor' }, { displayName: 'Waterproofing service' }],
+          },
+          profile: { description: 'Commercial roof restoration and protective coatings.' },
+          serviceArea: { businessType: 'CUSTOMER_LOCATION_ONLY' },
+          regularHours: { periods: [{ openDay: 'MONDAY' }] },
+          phoneNumbers: { primaryPhone: '(248) 925-7414' },
+          openInfo: { status: 'OPEN', openingDate: { year: 2021, month: 12, day: 1 } },
+        }],
+      })
+
+      const res = await ctx.app.inject({ method: 'POST', url: '/projects/hotels/gbp/locations/discover', payload: {} })
+      expect(res.statusCode).toBe(200)
+
+      // The DB row carries the structured owner content (JSON columns parsed back).
+      const row = ctx.db.select().from(gbpLocations).where(eq(gbpLocations.projectId, projectId)).all()[0]!
+      expect(row.additionalCategories).toEqual(['Insulation contractor', 'Waterproofing service'])
+      expect(row.description).toBe('Commercial roof restoration and protective coatings.')
+      expect(row.serviceArea).toEqual({ businessType: 'CUSTOMER_LOCATION_ONLY' })
+      expect(row.regularHours).toEqual({ periods: [{ openDay: 'MONDAY' }] })
+      expect(row.primaryPhone).toBe('(248) 925-7414')
+      expect(row.openStatus).toBe('OPEN')
+      expect(row.openingDate).toBe('2021-12-01')
+
+      // And the public location DTO surfaces them.
+      const dto = (res.json() as { locations: Array<Record<string, unknown>> }).locations[0]!
+      expect(dto.additionalCategories).toEqual(['Insulation contractor', 'Waterproofing service'])
+      expect(dto.description).toBe('Commercial roof restoration and protective coatings.')
+      expect(dto.primaryPhone).toBe('(248) 925-7414')
+      expect(dto.openStatus).toBe('OPEN')
+    })
+
     it('refreshes placeId on re-discover when Google later assigns one', async () => {
       const projectId = ctx.seedProject('hotels', 'hotels.example.com')
       ctx.seedGbpConnection('hotels.example.com', 'valid-access-token')
@@ -228,6 +277,70 @@ describe('GBP routes (Phase 1)', () => {
       mockGoogleResponses({ accounts: [{ name: 'accounts/123' }], locations: [{ name: 'locations/1', title: 'Hotel One', metadata: { placeId: 'ChIJlater' } }] })
       await ctx.app.inject({ method: 'POST', url: '/projects/hotels/gbp/locations/discover', payload: {} })
       expect(ctx.db.select().from(gbpLocations).where(eq(gbpLocations.projectId, projectId)).get()!.placeId).toBe('ChIJlater')
+    })
+
+    it('re-discover refreshes owner-content fields and clears ones Google no longer returns', async () => {
+      const projectId = ctx.seedProject('hotels', 'hotels.example.com')
+      ctx.seedGbpConnection('hotels.example.com', 'valid-access-token')
+      // First discover: a location with full owner content.
+      mockGoogleResponses({
+        accounts: [{ name: 'accounts/123' }],
+        locations: [{
+          name: 'locations/1', title: 'AZ Coatings',
+          categories: { primaryCategory: { displayName: 'Roofing contractor' }, additionalCategories: [{ displayName: 'Insulation contractor' }] },
+          profile: { description: 'Original description.' },
+          serviceArea: { businessType: 'CUSTOMER_LOCATION_ONLY' },
+          phoneNumbers: { primaryPhone: '(248) 925-7414' },
+          openInfo: { status: 'OPEN' },
+        }],
+      })
+      await ctx.app.inject({ method: 'POST', url: '/projects/hotels/gbp/locations/discover', payload: {} })
+
+      // Re-discover: description + open state CHANGED; additionalCategories,
+      // serviceArea, and phone REMOVED. Owner content is sync-not-merge (the
+      // last Google response wins), so removed fields must clear, not linger.
+      mockGoogleResponses({
+        accounts: [{ name: 'accounts/123' }],
+        locations: [{
+          name: 'locations/1', title: 'AZ Coatings',
+          categories: { primaryCategory: { displayName: 'Roofing contractor' } },
+          profile: { description: 'Updated description.' },
+          openInfo: { status: 'CLOSED_TEMPORARILY' },
+        }],
+      })
+      await ctx.app.inject({ method: 'POST', url: '/projects/hotels/gbp/locations/discover', payload: {} })
+
+      const row = ctx.db.select().from(gbpLocations).where(eq(gbpLocations.projectId, projectId)).get()!
+      // Changed fields refreshed:
+      expect(row.description).toBe('Updated description.')
+      expect(row.openStatus).toBe('CLOSED_TEMPORARILY')
+      // Removed fields cleared:
+      expect(row.additionalCategories).toEqual([])
+      expect(row.serviceArea).toBeNull()
+      expect(row.primaryPhone).toBeNull()
+    })
+
+    it('surfaces a pre-migration NULL owner-content row through the DTO defaults', async () => {
+      const projectId = ctx.seedProject('hotels', 'hotels.example.com')
+      ctx.seedGbpConnection('hotels.example.com', 'valid-access-token')
+      // A row written before migration v81 — the 7 owner-content columns are NULL.
+      const now = new Date().toISOString()
+      ctx.db.insert(gbpLocations).values({
+        id: 'loc-legacy', projectId, accountName: 'accounts/123', locationName: 'locations/9',
+        displayName: 'Legacy Location', selected: true, createdAt: now, updatedAt: now,
+      }).run()
+
+      const res = await ctx.app.inject({ method: 'GET', url: '/projects/hotels/gbp/locations' })
+      expect(res.statusCode).toBe(200)
+      const dto = (res.json() as { locations: Array<Record<string, unknown>> }).locations.find(l => l.locationName === 'locations/9')!
+      // The non-nullable array contract coalesces a NULL column to []; the rest stay null.
+      expect(dto.additionalCategories).toEqual([])
+      expect(dto.description).toBeNull()
+      expect(dto.serviceArea).toBeNull()
+      expect(dto.regularHours).toBeNull()
+      expect(dto.primaryPhone).toBeNull()
+      expect(dto.openStatus).toBeNull()
+      expect(dto.openingDate).toBeNull()
     })
 
     it('respects selectAllNew=false for newly-discovered locations', async () => {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.89.0",
+  "version": "4.90.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/contracts/src/gbp.ts
+++ b/packages/contracts/src/gbp.ts
@@ -40,6 +40,17 @@ export const gbpLocationDtoSchema = z.object({
   // the location is not on Maps). `placeId` is the join key to the Places API.
   placeId: z.string().nullable(),
   mapsUri: z.string().nullable(),
+  // Owner-authored profile content (Business Information v1 Location resource).
+  // These are the entity-anchor + qualifier signals AI answer engines weight:
+  // secondary categories, the business description, the service area + hours
+  // (stored verbatim as JSON), the primary phone, and the open state.
+  additionalCategories: z.array(z.string()),
+  description: z.string().nullable(),
+  serviceArea: z.record(z.string(), z.unknown()).nullable(),
+  regularHours: z.record(z.string(), z.unknown()).nullable(),
+  primaryPhone: z.string().nullable(),
+  openStatus: z.string().nullable(),
+  openingDate: z.string().nullable(),
   selected: z.boolean(),
   syncedAt: z.string().nullable(),
   createdAt: z.string(),

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1795,6 +1795,28 @@ export const MIGRATION_VERSIONS: ReadonlyArray<MigrationVersion> = [
       }
     },
   },
+  {
+    version: 81,
+    name: 'gbp-locations-owner-content',
+    statements: [],
+    run: (db) => {
+      if (!tableExists(db, 'gbp_locations')) return
+      const cols = [
+        'additional_categories',
+        'description',
+        'service_area',
+        'regular_hours',
+        'primary_phone',
+        'open_status',
+        'opening_date',
+      ]
+      for (const col of cols) {
+        if (!columnExists(db, 'gbp_locations', col)) {
+          db.run(sql.raw(`ALTER TABLE gbp_locations ADD COLUMN ${col} TEXT`))
+        }
+      }
+    },
+  },
 ]
 
 /**

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1003,6 +1003,16 @@ export const gbpLocations = sqliteTable('gbp_locations', {
   // rendered-listing data. Null when Google has not assigned a Place ID.
   placeId: text('place_id'),
   mapsUri: text('maps_uri'),
+  // Owner-authored profile content from the Business Information v1 Location
+  // resource — the entity-anchor + qualifier signals AI answer engines weight.
+  // `serviceArea` / `regularHours` are stored verbatim (presence + raw shape).
+  additionalCategories: text('additional_categories', { mode: 'json' }).$type<string[]>(),
+  description: text('description'),
+  serviceArea: text('service_area', { mode: 'json' }).$type<Record<string, unknown>>(),
+  regularHours: text('regular_hours', { mode: 'json' }).$type<Record<string, unknown>>(),
+  primaryPhone: text('primary_phone'),
+  openStatus: text('open_status'),
+  openingDate: text('opening_date'),
   selected: integer('selected', { mode: 'boolean' }).notNull().default(true),
   syncedAt: text('synced_at'),
   createdAt: text('created_at').notNull(),

--- a/packages/integration-google-business-profile/src/constants.ts
+++ b/packages/integration-google-business-profile/src/constants.ts
@@ -47,6 +47,15 @@ export const GBP_LOCATIONS_DEFAULT_READ_MASK = [
   'storefrontAddress',
   'websiteUri',
   'categories.primaryCategory.displayName',
+  // Owner-authored profile content — the entity-anchor and qualifier signals AI
+  // answer engines weight most. All ride the same Business Information v1
+  // Location resource canonry already reads (no new auth / API enablement).
+  'categories.additionalCategories.displayName',
+  'profile.description',
+  'serviceArea',
+  'regularHours',
+  'phoneNumbers',
+  'openInfo',
   'metadata.placeId',
   'metadata.mapsUri',
 ].join(',')

--- a/packages/integration-google-business-profile/src/index.ts
+++ b/packages/integration-google-business-profile/src/index.ts
@@ -1,8 +1,8 @@
 export * from './constants.js'
 export * from './types.js'
 export { listAccounts } from './accounts-client.js'
-export { listLocations, formatStorefrontAddress } from './locations-client.js'
-export type { ListLocationsOptions } from './locations-client.js'
+export { listLocations, formatStorefrontAddress, buildLocationProfileFields } from './locations-client.js'
+export type { ListLocationsOptions, LocationProfileFields } from './locations-client.js'
 export { fetchDailyMetrics, listMonthlyKeywords } from './performance-client.js'
 export type {
   GbpDailyMetricRow,

--- a/packages/integration-google-business-profile/src/locations-client.ts
+++ b/packages/integration-google-business-profile/src/locations-client.ts
@@ -5,7 +5,7 @@ import {
   GBP_MAX_PAGES,
 } from './constants.js'
 import { gbpFetchGet } from './http.js'
-import type { GbpFetchOptions, GbpLocation } from './types.js'
+import type { GbpDate, GbpFetchOptions, GbpLocation } from './types.js'
 
 interface ListLocationsResponse {
   locations?: GbpLocation[]
@@ -58,4 +58,57 @@ export function formatStorefrontAddress(loc: GbpLocation): string | null {
     addr.regionCode,
   ].filter((p): p is string => Boolean(p))
   return parts.length ? parts.join(', ') : null
+}
+
+/** The owner-content profile fields persisted onto a `gbp_locations` row. */
+export interface LocationProfileFields {
+  /** Secondary category display names (the primary stays in its own column). */
+  additionalCategories: string[]
+  /** Owner business description (`profile.description`), up to ~750 chars. */
+  description: string | null
+  /** Raw Service Area resource (SAB geo footprint), stored faithfully. */
+  serviceArea: Record<string, unknown> | null
+  /** Raw regular-hours resource, stored faithfully. */
+  regularHours: Record<string, unknown> | null
+  /** Primary phone number (NAP). */
+  primaryPhone: string | null
+  /** openInfo.status — OPEN / CLOSED_PERMANENTLY / CLOSED_TEMPORARILY. */
+  openStatus: string | null
+  /** openInfo.openingDate flattened to the precision Google gave (YYYY[-MM[-DD]]). */
+  openingDate: string | null
+}
+
+/**
+ * Derive the persisted owner-content profile fields from a Location resource.
+ * Centralizes the mapping so the discover insert + update branches stay in sync,
+ * and keeps the extraction unit-testable. `serviceArea` / `regularHours` are
+ * passed through verbatim (we record presence + the raw shape, not a reshape).
+ */
+export function buildLocationProfileFields(loc: GbpLocation): LocationProfileFields {
+  return {
+    additionalCategories: (loc.categories?.additionalCategories ?? [])
+      .map((c) => c.displayName)
+      .filter((n): n is string => Boolean(n)),
+    description: loc.profile?.description ?? null,
+    serviceArea: loc.serviceArea ?? null,
+    regularHours: loc.regularHours ?? null,
+    primaryPhone: loc.phoneNumbers?.primaryPhone ?? null,
+    openStatus: loc.openInfo?.status ?? null,
+    openingDate: formatOpeningDate(loc.openInfo?.openingDate),
+  }
+}
+
+/**
+ * Flatten a Google civil date to a string at the precision actually provided —
+ * year-only, year-month, or full date. Never fabricates a day/month Google
+ * omitted (a year-only opening date stays "2019", not "2019-01-01").
+ */
+function formatOpeningDate(date?: GbpDate): string | null {
+  if (!date?.year) return null
+  let out = String(date.year)
+  if (date.month) {
+    out += `-${String(date.month).padStart(2, '0')}`
+    if (date.day) out += `-${String(date.day).padStart(2, '0')}`
+  }
+  return out
 }

--- a/packages/integration-google-business-profile/src/types.ts
+++ b/packages/integration-google-business-profile/src/types.ts
@@ -29,6 +29,13 @@ export interface GbpLocationMetadata {
   mapsUri?: string
 }
 
+/** A Google "civil date": any of the components may be omitted (e.g. year-only). */
+export interface GbpDate {
+  year?: number
+  month?: number
+  day?: number
+}
+
 export interface GbpLocation {
   /** "locations/{n}" */
   name: string
@@ -39,6 +46,14 @@ export interface GbpLocation {
     primaryCategory?: { displayName?: string }
     additionalCategories?: { displayName?: string }[]
   }
+  // Owner-authored profile content. `serviceArea` / `regularHours` are stored
+  // faithfully as JSON (we surface presence, not a reshaped schema), so they are
+  // typed as passthrough objects rather than a brittle mirror of Google's shape.
+  profile?: { description?: string }
+  serviceArea?: Record<string, unknown>
+  regularHours?: Record<string, unknown>
+  phoneNumbers?: { primaryPhone?: string; additionalPhones?: string[] }
+  openInfo?: { status?: string; openingDate?: GbpDate }
   metadata?: GbpLocationMetadata
 }
 

--- a/packages/integration-google-business-profile/test/locations-client.test.ts
+++ b/packages/integration-google-business-profile/test/locations-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { listLocations, formatStorefrontAddress } from '../src/locations-client.js'
+import { listLocations, formatStorefrontAddress, buildLocationProfileFields } from '../src/locations-client.js'
 
 describe('listLocations', () => {
   const fetchSpy = vi.fn()
@@ -34,6 +34,21 @@ describe('listLocations', () => {
     expect(fields).toContain('title')
   })
 
+  it('requests the owner-content profile fields in the default readMask', async () => {
+    mockLocations([])
+    await listLocations('tok', 'accounts/1')
+    const url = new URL(fetchSpy.mock.calls[0]![0] as string)
+    const fields = (url.searchParams.get('readMask') ?? '').split(',')
+    // The owner-authored profile content AEO answer engines weight (categories,
+    // description, service area, hours, phone, open state) must be requested.
+    expect(fields).toContain('categories.additionalCategories.displayName')
+    expect(fields).toContain('profile.description')
+    expect(fields).toContain('serviceArea')
+    expect(fields).toContain('regularHours')
+    expect(fields).toContain('phoneNumbers')
+    expect(fields).toContain('openInfo')
+  })
+
   it('returns the placeId + mapsUri carried in a location metadata block', async () => {
     mockLocations([
       {
@@ -52,6 +67,55 @@ describe('listLocations', () => {
     mockLocations([{ name: 'locations/2', title: 'Off-Maps Location' }])
     const out = await listLocations('tok', 'accounts/1')
     expect(out[0]!.metadata?.placeId).toBeUndefined()
+  })
+})
+
+describe('buildLocationProfileFields', () => {
+  it('extracts the full owner-content profile from a populated location', () => {
+    const out = buildLocationProfileFields({
+      name: 'locations/1',
+      title: 'AZ Coatings',
+      categories: {
+        primaryCategory: { displayName: 'Roofing contractor' },
+        additionalCategories: [{ displayName: 'Insulation contractor' }, { displayName: 'Waterproofing service' }],
+      },
+      profile: { description: 'AZ Coatings specializes in commercial roof restoration.' },
+      serviceArea: { businessType: 'CUSTOMER_LOCATION_ONLY', places: { placeInfos: [{ placeName: 'Almont, MI' }] } },
+      regularHours: { periods: [{ openDay: 'MONDAY', openTime: { hours: 7 }, closeDay: 'MONDAY', closeTime: { hours: 18, minutes: 30 } }] },
+      phoneNumbers: { primaryPhone: '(248) 925-7414' },
+      openInfo: { status: 'OPEN', openingDate: { year: 2021, month: 12, day: 1 } },
+    })
+    expect(out.additionalCategories).toEqual(['Insulation contractor', 'Waterproofing service'])
+    expect(out.description).toBe('AZ Coatings specializes in commercial roof restoration.')
+    expect(out.serviceArea).toEqual({ businessType: 'CUSTOMER_LOCATION_ONLY', places: { placeInfos: [{ placeName: 'Almont, MI' }] } })
+    expect(out.regularHours).toEqual({ periods: [{ openDay: 'MONDAY', openTime: { hours: 7 }, closeDay: 'MONDAY', closeTime: { hours: 18, minutes: 30 } }] })
+    expect(out.primaryPhone).toBe('(248) 925-7414')
+    expect(out.openStatus).toBe('OPEN')
+    expect(out.openingDate).toBe('2021-12-01')
+  })
+
+  it('returns empty/null defaults for a bare location (no profile content)', () => {
+    const out = buildLocationProfileFields({ name: 'locations/2', title: 'Bare' })
+    expect(out.additionalCategories).toEqual([])
+    expect(out.description).toBeNull()
+    expect(out.serviceArea).toBeNull()
+    expect(out.regularHours).toBeNull()
+    expect(out.primaryPhone).toBeNull()
+    expect(out.openStatus).toBeNull()
+    expect(out.openingDate).toBeNull()
+  })
+
+  it('drops additional categories with no displayName and trims to the names', () => {
+    const out = buildLocationProfileFields({
+      name: 'locations/3',
+      categories: { additionalCategories: [{ displayName: 'Spa' }, {}, { displayName: 'Event venue' }] },
+    })
+    expect(out.additionalCategories).toEqual(['Spa', 'Event venue'])
+  })
+
+  it('formats a partial opening date (year only, year+month) without fabricating precision', () => {
+    expect(buildLocationProfileFields({ name: 'locations/4', openInfo: { openingDate: { year: 2019 } } }).openingDate).toBe('2019')
+    expect(buildLocationProfileFields({ name: 'locations/5', openInfo: { openingDate: { year: 2020, month: 3 } } }).openingDate).toBe('2020-03')
   })
 })
 

--- a/skills/canonry/references/google-business-profile.md
+++ b/skills/canonry/references/google-business-profile.md
@@ -2,7 +2,7 @@
 
 Canonry integrates with the Google Business Profile (GBP) API to surface local AEO signals: search-keyword impressions, daily performance metrics, hotel lodging attributes, and booking/reservation CTAs (plus reviews on the projects where Google has granted v4 access — see the gating section). This data feeds the local-AEO dashboard and the Aero analyst.
 
-> **Q&A is not available.** Google shut down the My Business Q&A API — it returns HTTP 501 `API_UNSUPPORTED`. There is no programmatic way to read or write profile Q&A. Don't plan around it.
+> **Q&A is not available.** Google **retired** the My Business Q&A API (`mybusinessqanda.googleapis.com`) on 2025-11-03, and began winding down the public Q&A section on profiles shortly after. There is no programmatic way to read or write profile Q&A. Don't plan around it.
 
 ## What Canonry Automates
 
@@ -68,7 +68,7 @@ In Cloud Console → APIs & Services → Library, enable:
 | **My Business Lodging API** | **Hotel attributes — required if working with lodging properties** |
 | **My Business Place Actions API** | **Booking / reservation CTAs — required if hotels or restaurants use them** |
 
-**Do NOT enable "My Business Q&A API"** — Google shut it down (HTTP 501 `API_UNSUPPORTED`). It's listed in some older setup docs but no longer functions.
+**Do NOT enable "My Business Q&A API"** — Google **retired** it on 2025-11-03. It's listed in some older setup docs but no longer functions.
 
 ### The legacy "Google My Business API" (v4 — reviews)
 
@@ -284,7 +284,7 @@ Validated against three live businesses of different types (a computer-support s
 | Lodging returns 200 with only `{ "name": ... }` | The lodging profile has no amenities filled in | Not an error — it's an AEO gap to flag to the operator |
 | Place action links empty | No CTAs configured | Set them up in the GBP UI; for many local businesses this is genuinely empty (an AEO gap) |
 | Reviews 403 `SERVICE_DISABLED` while v1 APIs work | Legacy v4 `mybusiness.googleapis.com` not enabled for this account/project | See "The legacy Google My Business API" above — enable via the approval-email shortcut as the approved account; can't be done via library or gcloud |
-| Q&A returns HTTP 501 `API_UNSUPPORTED` | Google shut down the Q&A API | Permanent — Q&A is not available programmatically |
+| Q&A API unreachable | Google retired the Q&A API on 2025-11-03 | Permanent. Q&A is not available programmatically |
 | Keyword impressions mostly `threshold` instead of `value` | Low-volume keywords are privacy-redacted by Google | Expected — even a busy hotel can be ~89% thresholded; tiny businesses are 100%. Surfaced as `thresholdedKeywordPct` in the summary |
 
 ## Related Files in This Skill


### PR DESCRIPTION
## Why

The GBP integration read performance telemetry plus a hotel-only amenity path, but ignored the **owner-authored profile content AI answer engines weight most**: secondary categories, the business description, the service area, hours, phone, and open state. All of it rides the **same Business Information v1 Location resource canonry already authenticates against** (`business.manage`, 300 QPM), so capturing it needs no new auth and no new API enablement. This is the highest-ROI step toward making the GBP surface representative.

## What

Extends the location read end-to-end:

- **Read mask + `GbpLocation` type** (`integration-google-business-profile`): adds `categories.additionalCategories.displayName`, `profile.description`, `serviceArea`, `regularHours`, `phoneNumbers`, `openInfo`.
- **`buildLocationProfileFields()`**: one extractor (secondary-category names, description, raw `serviceArea`/`regularHours` stored verbatim, primary phone, `openStatus`, and `openingDate` flattened to the precision Google gave — never fabricating a day/month). Shared by the discover insert + update branches so they can't drift.
- **`gbp_locations`**: 7 new columns (migration v81, idempotent ADD COLUMN) + `GbpLocationDto` fields + `rowToDto` mapping + regenerated SDK. The content now flows to `cnry gbp locations --format json`, the API, and the typed client.
- **Skill reference fix**: Q&A is **retired (2025-11-03)**, not "501 API_UNSUPPORTED".

Owner content is **sync-not-merge**: re-discover overwrites every field with Google's latest response (a removed description clears, matching the existing `placeId`/`websiteUri` behavior).

## Scope / follow-ups

This PR is the **capture + expose** layer. Deferred to a follow-up: the summary `profileCompleteness` rollup, the `category-thin` / `description-missing` insights (they need careful thresholds to avoid false positives), and a dedicated `cnry gbp profile` read.

## Tests (TDD)

Built test-first: read-mask + extractor unit tests (full, bare, partial-date, name-filtering), a discover round-trip (DB row + DTO), and — added after an adversarial review flagged the gaps — a re-discover refresh-and-clear test and a pre-migration NULL-row → DTO-defaults test. 6 packages + apps/web typecheck clean; lint clean; codegen drift gate green; full GBP test surface passing. Version bumped 4.89.0 → 4.90.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
