### PR TITLE
fix(gbp): request `categories` whole in locations readMask (fixes discover 400)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.91.0",
+  "version": "4.91.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.91.0",
+  "version": "4.91.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/integration-google-business-profile/src/constants.ts
+++ b/packages/integration-google-business-profile/src/constants.ts
@@ -46,11 +46,15 @@ export const GBP_LOCATIONS_DEFAULT_READ_MASK = [
   'title',
   'storefrontAddress',
   'websiteUri',
-  'categories.primaryCategory.displayName',
+  // Request `categories` WHOLE, not a nested sub-path. The Business Information
+  // locations.list readMask rejects a nested path into the REPEATED
+  // `additionalCategories` array ("Invalid field mask provided", HTTP 400 —
+  // verified against the live API), so we ask for the full `categories` object
+  // (it carries primaryCategory + additionalCategories displayNames + serviceTypes).
+  'categories',
   // Owner-authored profile content — the entity-anchor and qualifier signals AI
   // answer engines weight most. All ride the same Business Information v1
   // Location resource canonry already reads (no new auth / API enablement).
-  'categories.additionalCategories.displayName',
   'profile.description',
   'serviceArea',
   'regularHours',

--- a/packages/integration-google-business-profile/test/locations-client.test.ts
+++ b/packages/integration-google-business-profile/test/locations-client.test.ts
@@ -41,7 +41,11 @@ describe('listLocations', () => {
     const fields = (url.searchParams.get('readMask') ?? '').split(',')
     // The owner-authored profile content AEO answer engines weight (categories,
     // description, service area, hours, phone, open state) must be requested.
-    expect(fields).toContain('categories.additionalCategories.displayName')
+    // `categories` is requested WHOLE: the locations.list readMask rejects a
+    // nested path into the repeated `additionalCategories` array (400), so the
+    // nested form must never be used.
+    expect(fields).toContain('categories')
+    expect(fields).not.toContain('categories.additionalCategories.displayName')
     expect(fields).toContain('profile.description')
     expect(fields).toContain('serviceArea')
     expect(fields).toContain('regularHours')


### PR DESCRIPTION
fix(gbp): request `categories` whole in the locations readMask (was a 400)

#724's expanded readMask added `categories.additionalCategories.displayName`,
but the Business Information locations.list API rejects a nested path into the
REPEATED additionalCategories array ("Invalid field mask provided", HTTP 400),
which broke `gbp locations discover` for every GBP project in production. (Metric
and keyword sync were unaffected — they operate on already-discovered locations,
not listLocations.) The mocked unit tests could not catch it because the mock
does not validate the readMask against the API.

Request `categories` WHOLE instead; it carries primaryCategory +
additionalCategories displayNames (verified against the live API, which then
returns the real owner content). The test now asserts `categories` is requested
and the invalid nested form is never used.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)