### PR TITLE
fix(gbp): refresh profiles during sync

### DIFF
--- a/packages/canonry/src/gbp-sync.ts
+++ b/packages/canonry/src/gbp-sync.ts
@@ -5,6 +5,9 @@ import { runs, projects, gbpLocations, gbpDailyMetrics, gbpKeywordImpressions, g
 import { buildRunErrorFromMessages, serializeRunError } from '@ainyc/canonry-contracts'
 import { refreshAccessToken } from '@ainyc/canonry-integration-google'
 import {
+  listLocations,
+  formatStorefrontAddress,
+  buildLocationProfileFields,
   fetchDailyMetrics,
   listMonthlyKeywords,
   listPlaceActionLinks,
@@ -42,6 +45,8 @@ const KEYWORD_TREND_MONTHS = 3
 // Drop monthly keyword rows older than this many months so the accumulate
 // table stays bounded.
 const KEYWORD_HISTORY_RETENTION_MONTHS = 18
+
+type GbpLocationRow = typeof gbpLocations.$inferSelect
 
 function daysAgo(n: number): Date {
   const d = new Date()
@@ -123,6 +128,7 @@ export async function executeGbpSync(
     if (locationRows.length === 0) {
       throw new Error('No selected GBP locations to sync. Discover and select locations first.')
     }
+    locationRows = await refreshSelectedLocationProfiles(db, projectId, accessToken, locationRows)
 
     const daysOfMetrics = opts.daysOfMetrics ?? DEFAULT_DAYS_OF_METRICS
     const monthsOfKeywords = opts.monthsOfKeywords ?? DEFAULT_MONTHS_OF_KEYWORDS
@@ -403,4 +409,52 @@ export async function executeGbpSync(
 // records the trailing window via periodStart / periodEnd (both YYYY-MM).
 function monthKey(m: { year: number; month: number }): string {
   return `${m.year}-${String(m.month).padStart(2, '0')}`
+}
+
+async function refreshSelectedLocationProfiles(
+  db: DatabaseClient,
+  projectId: string,
+  accessToken: string,
+  locationRows: GbpLocationRow[],
+): Promise<GbpLocationRow[]> {
+  const byAccount = new Map<string, GbpLocationRow[]>()
+  for (const row of locationRows) {
+    const accountRows = byAccount.get(row.accountName) ?? []
+    accountRows.push(row)
+    byAccount.set(row.accountName, accountRows)
+  }
+
+  const refreshedRows = new Map<string, GbpLocationRow>()
+  for (const [accountName, accountRows] of byAccount.entries()) {
+    const remoteLocations = await listLocations(accessToken, accountName)
+    const remoteByName = new Map(remoteLocations.map((loc) => [loc.name, loc]))
+    const missing = accountRows.filter((row) => !remoteByName.has(row.locationName))
+    if (missing.length > 0) {
+      throw new Error(`Selected GBP location(s) no longer appear under ${accountName}: ${missing.map((row) => row.locationName).join(', ')}. Run "canonry gbp locations discover" to refresh the selection.`)
+    }
+
+    const updatedAt = new Date().toISOString()
+    for (const row of accountRows) {
+      const remote = remoteByName.get(row.locationName)!
+      const profile = buildLocationProfileFields(remote)
+      const update = {
+        accountName,
+        displayName: remote.title ?? row.displayName,
+        primaryCategoryDisplayName: remote.categories?.primaryCategory?.displayName ?? null,
+        storefrontAddress: formatStorefrontAddress(remote),
+        websiteUri: remote.websiteUri ?? null,
+        placeId: remote.metadata?.placeId ?? null,
+        mapsUri: remote.metadata?.mapsUri ?? null,
+        ...profile,
+        updatedAt,
+      }
+      db.update(gbpLocations)
+        .set(update)
+        .where(and(eq(gbpLocations.projectId, projectId), eq(gbpLocations.id, row.id)))
+        .run()
+      refreshedRows.set(row.id, { ...row, ...update })
+    }
+  }
+
+  return locationRows.map((row) => refreshedRows.get(row.id) ?? row)
 }

--- a/packages/canonry/test/gbp-sync.test.ts
+++ b/packages/canonry/test/gbp-sync.test.ts
@@ -15,11 +15,12 @@ import {
   gbpLodgingSnapshots,
 } from '@ainyc/canonry-db'
 import { hashPlaceDetails } from '@ainyc/canonry-integration-google-places'
-import { hashLodging, countPopulatedGroups } from '@ainyc/canonry-integration-google-business-profile'
+import { hashLodging, countPopulatedGroups, type GbpLocation } from '@ainyc/canonry-integration-google-business-profile'
 import { executeGbpSync } from '../src/gbp-sync.js'
 import type { CanonryConfig } from '../src/config.js'
 
 // --- mock the integration HTTP clients (no network in unit tests) ---
+const listLocationsMock = vi.fn()
 const fetchDailyMetricsMock = vi.fn()
 const listMonthlyKeywordsMock = vi.fn()
 const listPlaceActionLinksMock = vi.fn()
@@ -33,6 +34,7 @@ vi.mock('@ainyc/canonry-integration-google-business-profile', async () => {
   )
   return {
     ...actual,
+    listLocations: (...a: unknown[]) => listLocationsMock(...a),
     fetchDailyMetrics: (...a: unknown[]) => fetchDailyMetricsMock(...a),
     listMonthlyKeywords: (...a: unknown[]) => listMonthlyKeywordsMock(...a),
     listPlaceActionLinks: (...a: unknown[]) => listPlaceActionLinksMock(...a),
@@ -71,7 +73,18 @@ function createTempDb() {
   return { db, tmpDir }
 }
 
-function seedProject(db: ReturnType<typeof createClient>, opts: { placeId?: string } = {}) {
+function listedLocation(opts: { placeId?: string | null; description?: string | null } = {}): GbpLocation {
+  return {
+    name: LOCATION,
+    title: 'Gjelina Venice',
+    profile: opts.description === undefined || opts.description === null
+      ? undefined
+      : { description: opts.description },
+    metadata: opts.placeId ? { placeId: opts.placeId, mapsUri: `https://maps.google.com/?q=${opts.placeId}` } : undefined,
+  }
+}
+
+function seedProject(db: ReturnType<typeof createClient>, opts: { placeId?: string; description?: string | null } = {}) {
   const now = new Date().toISOString()
   db.insert(projects).values({
     id: 'proj_gbp',
@@ -90,10 +103,12 @@ function seedProject(db: ReturnType<typeof createClient>, opts: { placeId?: stri
     locationName: LOCATION,
     displayName: 'Gjelina Venice',
     placeId: opts.placeId ?? null,
+    description: opts.description ?? null,
     selected: true,
     createdAt: now,
     updatedAt: now,
   }).run()
+  listLocationsMock.mockResolvedValue([listedLocation({ placeId: opts.placeId ?? null, description: opts.description ?? null })])
 }
 
 function seedRun(db: ReturnType<typeof createClient>, runId: string) {
@@ -134,6 +149,7 @@ function testConfig(): CanonryConfig {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  listLocationsMock.mockResolvedValue([listedLocation()])
   fetchDailyMetricsMock.mockResolvedValue([])
   listPlaceActionLinksMock.mockResolvedValue([])
   getLodgingMock.mockResolvedValue(null)
@@ -150,6 +166,49 @@ beforeEach(() => {
       return Promise.resolve([{ keyword: 'venice beach hotel', valueCount: 999, valueThreshold: null }])
     },
   )
+})
+
+describe('executeGbpSync — selected location profile refresh', () => {
+  test('refreshes owner profile fields from the Business Information API during sync', async () => {
+    const { db, tmpDir } = createTempDb()
+    try {
+      seedProject(db, { description: null })
+      listLocationsMock.mockResolvedValue([{
+        ...listedLocation({ description: 'Fresh owner description.' }),
+        categories: {
+          primaryCategory: { displayName: 'Restaurant' },
+          additionalCategories: [{ displayName: 'Hotel' }],
+        },
+        storefrontAddress: {
+          addressLines: ['1429 Abbot Kinney Blvd'],
+          locality: 'Venice',
+          administrativeArea: 'CA',
+          postalCode: '90291',
+          regionCode: 'US',
+        },
+        websiteUri: 'https://gjelina.example.com',
+        phoneNumbers: { primaryPhone: '+1 310-555-1212' },
+        openInfo: { status: 'OPEN', openingDate: { year: 2008 } },
+      }])
+      seedRun(db, 'run_1')
+
+      await executeGbpSync(db, 'run_1', 'proj_gbp', { config: testConfig() })
+
+      expect(listLocationsMock).toHaveBeenCalledWith('tok', 'accounts/1')
+      const row = db.select().from(gbpLocations).where(eq(gbpLocations.id, 'loc_1')).get()
+      expect(row!.description).toBe('Fresh owner description.')
+      expect(row!.primaryCategoryDisplayName).toBe('Restaurant')
+      expect(row!.additionalCategories).toEqual(['Hotel'])
+      expect(row!.storefrontAddress).toBe('1429 Abbot Kinney Blvd, Venice, CA, 90291, US')
+      expect(row!.websiteUri).toBe('https://gjelina.example.com')
+      expect(row!.primaryPhone).toBe('+1 310-555-1212')
+      expect(row!.openStatus).toBe('OPEN')
+      expect(row!.openingDate).toBe('2008')
+      expect(row!.syncedAt).toBeTruthy()
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('executeGbpSync — keyword monthly accumulate', () => {


### PR DESCRIPTION
## What
- Refresh selected GBP location profile fields from the Business Information API at the start of `gbp-sync`.
- Keep `gbp_locations.syncedAt` tied to the successful per-location sync transaction, so failed locations are not analyzed as covered by the run.
- Add a regression test that verifies a stale empty description is replaced during sync.

## Why
PR #729 added `gbp-description-missing`, but the signal read `gbp_locations.description` while `gbp-sync` only refreshed performance, place action, lodging, and Places data. A location whose owner description was fixed in Google could keep re-emitting a stale missing-description insight until the operator manually rediscovered locations.

## Validation
- `pnpm exec vitest run --project canonry gbp-sync.test.ts intelligence-service-gbp.test.ts`
- `pnpm --filter @ainyc/canonry typecheck`
- `pnpm --filter @ainyc/canonry lint`
- Commit hook ran repo lint and passed with existing warnings.