### PR TITLE
feat(insights): add --type / --severity / --limit filters to insights

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.93.0",
+  "version": "4.94.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -8106,6 +8106,18 @@ export type GetApiV1ProjectsByNameInsightsData = {
          * Filter by run ID.
          */
         runId?: string;
+        /**
+         * Filter by insight type. Exact match, or a trailing `*` for a prefix (e.g. `gbp-*`).
+         */
+        type?: string;
+        /**
+         * Minimum severity (low|medium|high|critical); e.g. `high` returns high + critical.
+         */
+        severity?: string;
+        /**
+         * Cap the number of (newest-first) insights returned.
+         */
+        limit?: string;
     };
     url: '/api/v1/projects/{name}/insights';
 };

--- a/packages/api-routes/src/intelligence.ts
+++ b/packages/api-routes/src/intelligence.ts
@@ -1,8 +1,21 @@
-import { eq, desc, and, inArray } from 'drizzle-orm'
+import { eq, desc, and, inArray, like } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import { groupRunsByCreatedAt, insights, healthSnapshots, runs } from '@ainyc/canonry-db'
-import { notFound, RunKinds, RunStatuses, type InsightDto, type HealthSnapshotDto } from '@ainyc/canonry-contracts'
+import { notFound, validationError, RunKinds, RunStatuses, type InsightDto, type HealthSnapshotDto } from '@ainyc/canonry-contracts'
 import { notProbeRun, resolveProject } from './helpers.js'
+
+// Severity ordering for the insights `severity` filter (a MINIMUM-level gate:
+// `--severity high` returns high + critical). Mirrors InsightDto['severity'].
+const SEVERITY_RANK: Record<InsightDto['severity'], number> = { low: 0, medium: 1, high: 2, critical: 3 }
+
+/** Severities at or above `min`, or throw a validation error for an unknown level. */
+function severitiesAtOrAbove(min: string): InsightDto['severity'][] {
+  const floor = SEVERITY_RANK[min as InsightDto['severity']]
+  if (floor === undefined) {
+    throw validationError(`Invalid severity "${min}". Use one of: low, medium, high, critical.`)
+  }
+  return (Object.keys(SEVERITY_RANK) as InsightDto['severity'][]).filter((s) => SEVERITY_RANK[s] >= floor)
+}
 
 function emptyHealthSnapshot(projectId: string): HealthSnapshotDto {
   return {
@@ -145,16 +158,43 @@ function aggregateHealthSnapshots(
 }
 
 export async function intelligenceRoutes(app: FastifyInstance) {
-  // GET /projects/:name/insights — list insights for a project
+  // GET /projects/:name/insights — list insights for a project.
+  // Filters (all optional, AND-combined): `type` matches an exact insight type
+  // or, with a trailing `*`, a prefix (e.g. `gbp-*`); `severity` is a MINIMUM
+  // level (`high` returns high + critical); `limit` caps the (newest-first)
+  // result. Server-side so an agent gets exactly what it needs in one call.
   app.get<{
     Params: { name: string }
-    Querystring: { dismissed?: string; runId?: string }
+    Querystring: { dismissed?: string; runId?: string; type?: string; severity?: string; limit?: string }
   }>('/projects/:name/insights', async (request, reply) => {
     const project = resolveProject(app.db, request.params.name)
 
     const conditions = [eq(insights.projectId, project.id)]
     if (request.query.runId) {
       conditions.push(eq(insights.runId, request.query.runId))
+    }
+    const typeFilter = request.query.type?.trim()
+    if (typeFilter) {
+      // Insight types are a server-controlled enum of safe identifiers (no LIKE
+      // metacharacters), so a raw prefix is sufficient for the `gbp-*` form.
+      conditions.push(
+        typeFilter.endsWith('*')
+          ? like(insights.type, `${typeFilter.slice(0, -1)}%`)
+          : eq(insights.type, typeFilter),
+      )
+    }
+    const severityFilter = request.query.severity?.trim()
+    if (severityFilter) {
+      conditions.push(inArray(insights.severity, severitiesAtOrAbove(severityFilter)))
+    }
+
+    let limit: number | undefined
+    if (request.query.limit !== undefined) {
+      const parsed = Number(request.query.limit)
+      if (!Number.isInteger(parsed) || parsed < 1) {
+        throw validationError(`Invalid limit "${request.query.limit}". Use a positive integer.`)
+      }
+      limit = parsed
     }
 
     const rows = app.db
@@ -166,9 +206,10 @@ export async function intelligenceRoutes(app: FastifyInstance) {
 
     const showDismissed = request.query.dismissed === 'true'
 
-    const result: InsightDto[] = rows
+    let result: InsightDto[] = rows
       .filter(r => showDismissed || !r.dismissed)
       .map(mapInsightRow)
+    if (limit !== undefined) result = result.slice(0, limit)
 
     return reply.send(result)
   })

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -2929,6 +2929,9 @@ const routeCatalog: OpenApiOperation[] = [
       nameParameter,
       { name: 'dismissed', in: 'query', description: 'Include dismissed insights (true/false).', schema: stringSchema },
       { name: 'runId', in: 'query', description: 'Filter by run ID.', schema: stringSchema },
+      { name: 'type', in: 'query', description: 'Filter by insight type. Exact match, or a trailing `*` for a prefix (e.g. `gbp-*`).', schema: stringSchema },
+      { name: 'severity', in: 'query', description: 'Minimum severity (low|medium|high|critical); e.g. `high` returns high + critical.', schema: stringSchema },
+      { name: 'limit', in: 'query', description: 'Cap the number of (newest-first) insights returned.', schema: stringSchema },
     ],
     responses: {
       // TODO: Add `InsightDto` Zod schema in contracts.

--- a/packages/api-routes/test/insights-filters.test.ts
+++ b/packages/api-routes/test/insights-filters.test.ts
@@ -1,0 +1,102 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import Fastify from 'fastify'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createClient, migrate, insights, projects } from '@ainyc/canonry-db'
+import { apiRoutes } from '../src/index.js'
+import type { ApiRoutesOptions } from '../src/index.js'
+import type { InsightDto } from '@ainyc/canonry-contracts'
+
+const cleanups: Array<() => void> = []
+afterEach(() => { for (const fn of cleanups.splice(0)) fn() })
+
+// Five insights with distinct types/severities + ascending createdAt so the
+// newest-first ordering (and `limit`) is deterministic. One is dismissed.
+function buildApp() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-insights-filters-'))
+  const db = createClient(path.join(tmpDir, 'test.db'))
+  migrate(db)
+  const app = Fastify()
+  app.register(apiRoutes, { db, skipAuth: true } satisfies ApiRoutesOptions)
+
+  const projectId = crypto.randomUUID()
+  db.insert(projects).values({
+    id: projectId, name: 'demo', displayName: 'Demo', canonicalDomain: 'demo.example.com',
+    country: 'US', language: 'en', createdAt: '2026-06-01T00:00:00.000Z', updatedAt: '2026-06-01T00:00:00.000Z',
+  }).run()
+
+  const ins = (type: string, severity: string, t: string, dismissed = false) => ({
+    id: crypto.randomUUID(), projectId, runId: null, type, severity,
+    title: `${type} title`, query: 'q', provider: 'test', recommendation: null, cause: null,
+    dismissed, createdAt: t,
+  })
+  db.insert(insights).values([
+    ins('regression', 'critical', '2026-06-10T00:00:01.000Z'),
+    ins('gbp-keyword-drop', 'high', '2026-06-10T00:00:02.000Z'),
+    ins('gbp-cta-gap', 'medium', '2026-06-10T00:00:03.000Z'),
+    ins('gbp-description-missing', 'low', '2026-06-10T00:00:04.000Z'),
+    ins('gain', 'low', '2026-06-10T00:00:05.000Z'),
+    ins('gbp-metric-drop', 'medium', '2026-06-10T00:00:06.000Z', true), // dismissed
+  ]).run()
+
+  cleanups.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }))
+  return { app }
+}
+
+async function list(app: ReturnType<typeof buildApp>['app'], qs: string) {
+  const res = await app.inject({ method: 'GET', url: `/api/v1/projects/demo/insights${qs}` })
+  return { status: res.statusCode, body: res.json() as InsightDto[] }
+}
+
+describe('GET /insights filters', () => {
+  it('returns all non-dismissed insights with no filter', async () => {
+    const { app } = buildApp()
+    const { body } = await list(app, '')
+    expect(body.map((i) => i.type).sort()).toEqual(['gain', 'gbp-cta-gap', 'gbp-description-missing', 'gbp-keyword-drop', 'regression'])
+  })
+
+  it('--type exact returns only that type', async () => {
+    const { app } = buildApp()
+    const { body } = await list(app, '?type=gbp-keyword-drop')
+    expect(body.map((i) => i.type)).toEqual(['gbp-keyword-drop'])
+  })
+
+  it('--type prefix (gbp-*) returns only the gbp family (excludes dismissed)', async () => {
+    const { app } = buildApp()
+    const { body } = await list(app, '?type=gbp-*')
+    expect(body.map((i) => i.type).sort()).toEqual(['gbp-cta-gap', 'gbp-description-missing', 'gbp-keyword-drop'])
+  })
+
+  it('--severity is a minimum level (high returns high + critical)', async () => {
+    const { app } = buildApp()
+    const { body } = await list(app, '?severity=high')
+    expect(body.map((i) => i.severity).sort()).toEqual(['critical', 'high'])
+  })
+
+  it('--limit caps the newest-first result', async () => {
+    const { app } = buildApp()
+    const { body } = await list(app, '?limit=2')
+    // Newest two non-dismissed: gain (…05) then gbp-description-missing (…04).
+    expect(body.map((i) => i.type)).toEqual(['gain', 'gbp-description-missing'])
+  })
+
+  it('combines type + severity', async () => {
+    const { app } = buildApp()
+    const { body } = await list(app, '?type=gbp-*&severity=medium')
+    expect(body.map((i) => i.type).sort()).toEqual(['gbp-cta-gap', 'gbp-keyword-drop'])
+  })
+
+  it('rejects an invalid severity with 400', async () => {
+    const { app } = buildApp()
+    const { status } = await list(app, '?severity=urgent')
+    expect(status).toBe(400)
+  })
+
+  it('rejects a non-positive / non-integer limit with 400', async () => {
+    const { app } = buildApp()
+    expect((await list(app, '?limit=0')).status).toBe(400)
+    expect((await list(app, '?limit=abc')).status).toBe(400)
+  })
+})

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.93.0",
+  "version": "4.94.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/cli-commands/intelligence.ts
+++ b/packages/canonry/src/cli-commands/intelligence.ts
@@ -9,17 +9,23 @@ import { getBoolean, requireProject, requirePositional, getString, parseIntegerO
 export const INTELLIGENCE_CLI_COMMANDS: readonly CliCommandSpec[] = [
   {
     path: ['insights'],
-    usage: 'canonry insights <project> [--dismissed] [--run-id <id>] [--format json]',
+    usage: 'canonry insights <project> [--type <type|prefix*>] [--severity <low|medium|high|critical>] [--limit <n>] [--dismissed] [--run-id <id>] [--format json]',
     options: {
       dismissed: { type: 'boolean' },
       'run-id': { type: 'string' },
+      type: { type: 'string' },
+      severity: { type: 'string' },
+      limit: { type: 'string' },
     },
     run: async (input) => {
-      const usage = 'canonry insights <project> [--dismissed] [--run-id <id>] [--format json]'
+      const usage = 'canonry insights <project> [--type <type|prefix*>] [--severity <low|medium|high|critical>] [--limit <n>] [--dismissed] [--run-id <id>] [--format json]'
       const project = requireProject(input, 'insights', usage)
       const dismissed = input.values.dismissed === true
       const runId = getString(input.values, 'run-id')
-      await listInsights(project, { dismissed, runId, format: input.format })
+      const type = getString(input.values, 'type')
+      const severity = getString(input.values, 'severity')
+      const limit = parseIntegerOption(input, 'limit', { message: 'limit must be an integer', usage, command: 'insights' })
+      await listInsights(project, { dismissed, runId, type, severity, limit, format: input.format })
     },
   },
   {

--- a/packages/canonry/src/client.ts
+++ b/packages/canonry/src/client.ts
@@ -2189,7 +2189,7 @@ export class ApiClient {
 
   // ── Intelligence ────────────────────────────────────────────────────────
 
-  async getInsights(project: string, opts?: { dismissed?: boolean; runId?: string }): Promise<InsightDto[]> {
+  async getInsights(project: string, opts?: { dismissed?: boolean; runId?: string; type?: string; severity?: string; limit?: number }): Promise<InsightDto[]> {
     return this.invoke<InsightDto[]>(() =>
       getApiV1ProjectsByNameInsights({
         client: this.heyClient,
@@ -2197,6 +2197,9 @@ export class ApiClient {
         query: {
           dismissed: opts?.dismissed ? 'true' : undefined,
           runId: opts?.runId,
+          type: opts?.type,
+          severity: opts?.severity,
+          limit: opts?.limit !== undefined ? String(opts.limit) : undefined,
         } as never,
       }),
     )

--- a/packages/canonry/src/commands/insights.ts
+++ b/packages/canonry/src/commands/insights.ts
@@ -4,10 +4,16 @@ import { emitJsonl } from '../cli-output.js'
 
 export async function listInsights(
   project: string,
-  opts: { dismissed?: boolean; runId?: string; format?: string },
+  opts: { dismissed?: boolean; runId?: string; type?: string; severity?: string; limit?: number; format?: string },
 ): Promise<void> {
   const client = createApiClient()
-  const insights = await client.getInsights(project, { dismissed: opts.dismissed, runId: opts.runId })
+  const insights = await client.getInsights(project, {
+    dismissed: opts.dismissed,
+    runId: opts.runId,
+    type: opts.type,
+    severity: opts.severity,
+    limit: opts.limit,
+  })
 
   if (opts.format === 'json') {
     console.log(JSON.stringify(insights, null, 2))

--- a/skills/canonry/references/canonry-cli.md
+++ b/skills/canonry/references/canonry-cli.md
@@ -232,6 +232,10 @@ cnry schedule set <project> --kind site-audit --preset weekly   # keep it fresh
 
 ```bash
 cnry insights <project>                        # list active insights (regressions, gains, opportunities)
+cnry insights <project> --type gbp-*           # filter by insight type; trailing * = prefix (e.g. only GBP insights)
+cnry insights <project> --type gbp-description-missing   # exact type match
+cnry insights <project> --severity high        # minimum severity (high returns high + critical)
+cnry insights <project> --limit 10             # cap to the newest N
 cnry insights <project> --dismissed            # include dismissed insights
 cnry insights <project> --format json          # JSON output
 cnry insights dismiss <project> <id>           # dismiss an insight


### PR DESCRIPTION
## What
Server-side filters on `GET /projects/{name}/insights` and `cnry insights`:

| Flag | Behavior |
|---|---|
| `--type <type\|prefix*>` | exact match, or a trailing `*` for a prefix (e.g. `gbp-*`) |
| `--severity <low\|medium\|high\|critical>` | a MINIMUM level (`high` returns high + critical) |
| `--limit <n>` | cap the newest-first result |

Invalid severity / non-positive limit return `400`.

## Why
Filtering insights previously meant `cnry insights <p> --format json` piped through `python`/`grep` to keep only the `gbp-*` types or a severity, which is the exact anti-pattern `AGENTS.md` calls out: an agent should get what it needs in one call. Now `cnry insights gjelina-hotel --type 'gbp-*' --severity high` returns exactly that, server-side, no post-processing.

## Changes
- `intelligence.ts`: type (exact/prefix), severity (min-level via a rank helper), limit on the route
- `openapi.ts`: the three query params; regenerated `@ainyc/canonry-api-client`
- CLI: `--type` / `--severity` / `--limit` on `cnry insights`, threaded through the client
- test: 8 cases (exact, prefix, min-severity, limit, combined, invalid severity 400, invalid limit 400)
- skill CLI reference updated

Minor bump to 4.94.0. Default human table is unchanged (already shows severity/type/title).

🤖 Generated with [Claude Code](https://claude.com/claude-code)