### PR TITLE
feat(agent): add kill-switch to disable the built-in Aero agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,10 @@ in the environment (env wins; `CANONRY_AGENT_DISABLED=0` forces it back on even
 when config disables). Resolved by `resolveAgentEnabled` in
 `packages/canonry/src/agent-config.ts`. This only affects the agent — data
 syncs, intelligence, and notifications are unchanged. Use it when the proactive
-analysis is unused and you want to stop the per-run agent LLM cost.
+analysis is unused and you want to stop the per-run agent LLM cost. This
+silences only the *automatic* per-run agent stream; the on-demand `analyze`-tier
+calls (the recommendation `explain` / `brief` routes — Sonnet) still bill when a
+user explicitly requests them, since those are not part of the agent loop.
 
 ### External agents (webhook)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,6 +198,18 @@ Key files:
 - `packages/canonry/src/agent/agent-routes.ts` — Fastify SSE endpoints
 - `apps/web/src/components/shared/AeroBar.tsx` — dashboard UI
 
+### Disabling Aero
+
+Aero is on by default. To turn the built-in agent OFF entirely — no proactive
+auto-wake on run completion, no `SessionRegistry`, and the interactive agent
+routes (`/projects/:name/agent/*`) plus `canonry agent ask` not served — set
+`agent.mode: 'disabled'` in `~/.canonry/config.yaml`, or `CANONRY_AGENT_DISABLED=1`
+in the environment (env wins; `CANONRY_AGENT_DISABLED=0` forces it back on even
+when config disables). Resolved by `resolveAgentEnabled` in
+`packages/canonry/src/agent-config.ts`. This only affects the agent — data
+syncs, intelligence, and notifications are unchanged. Use it when the proactive
+analysis is unused and you want to stop the per-run agent LLM cost.
+
 ### External agents (webhook)
 
 `canonry agent attach <project> --url <webhook-url>` registers a webhook for

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.94.0",
+  "version": "4.95.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/AGENTS.md
+++ b/packages/canonry/AGENTS.md
@@ -31,6 +31,7 @@ The publishable npm package (`@ainyc/canonry`). Bundles the CLI, local Fastify s
 | `src/mcp/cli.ts` | `canonry-mcp` stdio entrypoint — parses `--read-only`, `--eager`, `--scope`, plus `CANONRY_MCP_*` env. `resolveEffectiveScope()` best-effort probes `GET /keys/self` at startup and forces `read-only` when the configured key is read-only (auto-restricts the catalog to read tools; falls back to the flag scope on any probe failure). |
 | `src/server.ts` | Fastify server setup — mounts api-routes, serves SPA, registers providers. Read-only embed mode (#716): resolves `resolveEmbedConfig(process.env, config)` at boot; when enabled, `injectConfig` appends an `embed` block to `window.__CANONRY_CONFIG__` and the single `sendSpaDocument` chokepoint (used by `serveIndex` AND the deep-link `setNotFoundHandler` fallback) emits `Content-Security-Policy: frame-ancestors …` (fail-closed to `'none'`). When embed is off, the injected config + headers are byte-for-byte unchanged. `createServer` opts take an optional `assetsDir` override (default = bundled `assets/`) so integration tests can point at a temp `index.html`. |
 | `src/embed.ts` | `resolveEmbedConfig(env, config)` — resolves embed mode (#716) from `CANONRY_EMBED` / `CANONRY_EMBED_ORIGINS` / `CANONRY_EMBED_VIEWS` layered over config.yaml `embed:` (env over config, mirroring basePath). Delegates origin normalization + the `frame-ancestors` value + the client block to the pure helpers in `@ainyc/canonry-contracts` (`normalizeFrameOrigin` / `parseOriginList` / `frameAncestorsHeaderValue` / `buildEmbedClientConfig`). `enabled` is decoupled from origins so `--embed` without origins fails closed; an empty views list collapses to `undefined` (= all views). Serve/start flags: `--embed`, `--embed-allow-origin <origin>…`, `--embed-view <view>…` (in `cli-commands/system.ts` → env via `applyServerEnv`; `start` forwards them through `buildServeForwardArgs` in `commands/daemon.ts`). |
+| `src/agent-config.ts` | `resolveAgentEnabled(env, config)` — the Aero kill-switch. Resolves whether the built-in agent runs from `CANONRY_AGENT_DISABLED` env layered over `agent.mode: 'disabled'` in `config.yaml` (env over config; `=1`/`true` off, `=0`/`false` force on). `server.ts` reads it once at boot and guards the three Aero wiring points: the `SessionRegistry`, the proactive run-completion wake, and the interactive agent routes. Does not touch data syncs / intelligence / notifications. |
 | `src/job-runner.ts` | In-process job runner for visibility sweeps |
 | `src/provider-registry.ts` | `ProviderRegistry` — manages provider adapters |
 | `src/scheduler.ts` | Cron-based schedule runner (kinds: `answer-visibility`, `traffic-sync`, `gbp-sync`, `data-refresh`, `backlinks-sync`, `site-audit`, `ads-sync`; the `onDataRefreshRequested` callback fans out to every connected integration, `onBacklinksSyncRequested` re-probes Common Crawl + syncs the workspace release when a newer rolling window appears, and `onSiteAuditRequested` runs the Technical AEO sitemap crawl — skipped when one is already in flight) |
@@ -241,6 +242,17 @@ the task instructions. Both files ship in `assets/agent-workspace/skills/aero/`.
 The `<memory>` hydrate block is appended at session-build time by
 `SessionRegistry.buildHydratedSystemPrompt` — the DB row keeps the raw
 (unhydrated) prompt so every new session sees the latest notes.
+
+### Disabling Aero
+
+Aero is enabled by default. Set `agent.mode: 'disabled'` in
+`~/.canonry/config.yaml` (or `CANONRY_AGENT_DISABLED=1` in the environment;
+env wins, `=0` forces it back on) to turn the agent OFF entirely — the
+proactive auto-wake on `run.completed`, the `SessionRegistry`, and the
+interactive agent routes + `canonry agent ask` are all skipped. `server.ts`
+resolves this once at boot via `resolveAgentEnabled(process.env, config)`
+(`src/agent-config.ts`) and guards the three Aero wiring points. Data syncs,
+intelligence, and notifications are unaffected.
 
 ### External agents (webhook lifecycle)
 

--- a/packages/canonry/AGENTS.md
+++ b/packages/canonry/AGENTS.md
@@ -252,7 +252,9 @@ proactive auto-wake on `run.completed`, the `SessionRegistry`, and the
 interactive agent routes + `canonry agent ask` are all skipped. `server.ts`
 resolves this once at boot via `resolveAgentEnabled(process.env, config)`
 (`src/agent-config.ts`) and guards the three Aero wiring points. Data syncs,
-intelligence, and notifications are unaffected.
+intelligence, and notifications are unaffected. Note it stops only the
+*automatic* per-run agent stream — the on-demand `analyze`-tier recommendation
+`explain` / `brief` routes (Sonnet) still bill on explicit user action.
 
 ### External agents (webhook lifecycle)
 

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.94.0",
+  "version": "4.95.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/agent-config.ts
+++ b/packages/canonry/src/agent-config.ts
@@ -1,0 +1,27 @@
+import type { CanonryConfig } from './config.js'
+
+/**
+ * Resolve whether the built-in Aero agent is enabled, from the environment
+ * layered over `~/.canonry/config.yaml` (env over config, mirroring
+ * `resolveEmbedConfig` in embed.ts).
+ *
+ * Disabling turns OFF the entire agent subsystem: the proactive auto-wake on
+ * `run.completed`, the `SessionRegistry`, and the interactive agent routes
+ * (`/projects/:name/agent/*`) plus the `canonry agent ask` CLI (a thin client
+ * of those routes). It does NOT touch data syncs, intelligence, or
+ * notifications — only the agent.
+ *
+ *  - `CANONRY_AGENT_DISABLED` is authoritative when set and non-empty: `'1'` /
+ *    `'true'` (case-insensitive) disable the agent; any other value (including
+ *    `'0'` / `'false'`) forces it ON, so the env can re-enable an agent that
+ *    config disabled.
+ *  - otherwise `config.agent?.mode === 'disabled'` disables it.
+ *  - default (no env, no config) — enabled.
+ */
+export function resolveAgentEnabled(env: NodeJS.ProcessEnv, config: CanonryConfig): boolean {
+  const raw = env.CANONRY_AGENT_DISABLED?.trim()
+  if (raw) {
+    return !(raw === '1' || raw.toLowerCase() === 'true')
+  }
+  return config.agent?.mode !== 'disabled'
+}

--- a/packages/canonry/src/config.ts
+++ b/packages/canonry/src/config.ts
@@ -185,7 +185,15 @@ export interface VercelTrafficConfigEntry {
 }
 
 export interface AgentConfigEntry {
-  /** Agent mode. Only 'disabled' is valid until the native loop ships. */
+  /**
+   * Agent mode. `'disabled'` turns the built-in Aero agent OFF entirely — the
+   * proactive auto-wake on run completion does not fire, the `SessionRegistry`
+   * is not constructed, and the interactive agent routes (`/projects/:name/
+   * agent/*`) plus the `canonry agent ask` CLI (a thin client of those routes)
+   * are not served. Absent (the default) leaves Aero enabled. Resolved, with
+   * the `CANONRY_AGENT_DISABLED` env override, by `resolveAgentEnabled` in
+   * agent-config.ts.
+   */
   mode?: 'disabled'
 }
 

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -21,6 +21,7 @@ import { perplexityAdapter } from '@ainyc/canonry-provider-perplexity'
 import { authInvalid, authRequired, validationError, buildEmbedClientConfig, frameAncestorsHeaderValue, CcReleaseSyncStatuses, RunKinds, RunStatuses, RunTriggers, type ProviderAdapter } from '@ainyc/canonry-contracts'
 import type { CanonryConfig, ProviderConfigEntry } from './config.js'
 import { resolveEmbedConfig } from './embed.js'
+import { resolveAgentEnabled } from './agent-config.js'
 import { saveConfigPatch, loadConfig, getConfigPath } from './config.js'
 import { getPlacesConfig } from './places-config.js'
 import {
@@ -459,11 +460,20 @@ export async function createServer(opts: {
   // loadConfig() so tests that set CANONRY_CONFIG_DIR after spawning the
   // server don't fail at construction time.
   const aeroClient = new ApiClient(opts.config.apiUrl, opts.config.apiKey, { skipProbe: true })
-  const sessionRegistry = new SessionRegistry({
-    db: opts.db,
-    client: aeroClient,
-    config: opts.config,
-  })
+  // Built-in Aero agent kill-switch. When disabled (config `agent.mode:
+  // 'disabled'` or env CANONRY_AGENT_DISABLED=1) we skip the SessionRegistry,
+  // the proactive wake on run completion, and the interactive agent routes —
+  // the data/intelligence/notification pipeline is unaffected. `aeroClient`
+  // itself stays: the scheduler callbacks below reuse it (data-refresh,
+  // traffic, backlinks), which is unrelated to Aero.
+  const agentEnabled = resolveAgentEnabled(process.env, opts.config)
+  const sessionRegistry = agentEnabled
+    ? new SessionRegistry({
+        db: opts.db,
+        client: aeroClient,
+        config: opts.config,
+      })
+    : undefined
 
   const runCoordinator = new RunCoordinator(
     opts.db,
@@ -471,6 +481,8 @@ export async function createServer(opts: {
     intelligenceService,
     (runId, projectId, result) => notifier.dispatchInsightWebhooks(runId, projectId, result),
     async (ctx) => {
+      // Aero kill-switch: never wake the agent on run completion when disabled.
+      if (!sessionRegistry) return
       const project = opts.db
         .select({ name: projects.name })
         .from(projects)
@@ -1294,6 +1306,8 @@ export async function createServer(opts: {
     // Local-only Aero agent routes. Registered here so they inherit api-routes'
     // auth plugin — bare `registerAgentRoutes(app, ...)` would skip auth.
     registerAuthenticatedRoutes: async (scope) => {
+      // Aero kill-switch: don't serve the interactive agent routes when disabled.
+      if (!sessionRegistry) return
       registerAgentRoutes(scope, { db: opts.db, sessionRegistry })
     },
     getGoogleAuthConfig: () => getGoogleAuthConfig(opts.config),

--- a/packages/canonry/test/agent-config.test.ts
+++ b/packages/canonry/test/agent-config.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { resolveAgentEnabled } from '../src/agent-config.js'
+import type { CanonryConfig } from '../src/config.js'
+
+function cfg(agent?: CanonryConfig['agent']): CanonryConfig {
+  return {
+    apiUrl: 'http://localhost:4100',
+    database: ':memory:',
+    apiKey: 'cnry_test',
+    ...(agent ? { agent } : {}),
+  } as CanonryConfig
+}
+
+describe('resolveAgentEnabled', () => {
+  it('defaults to enabled with no env and no config', () => {
+    expect(resolveAgentEnabled({}, cfg())).toBe(true)
+  })
+
+  it('config agent.mode "disabled" disables', () => {
+    expect(resolveAgentEnabled({}, cfg({ mode: 'disabled' }))).toBe(false)
+  })
+
+  it('CANONRY_AGENT_DISABLED=1 disables (no config)', () => {
+    expect(resolveAgentEnabled({ CANONRY_AGENT_DISABLED: '1' }, cfg())).toBe(false)
+  })
+
+  it('CANONRY_AGENT_DISABLED=true disables (case-insensitive)', () => {
+    expect(resolveAgentEnabled({ CANONRY_AGENT_DISABLED: 'TRUE' }, cfg())).toBe(false)
+  })
+
+  it('CANONRY_AGENT_DISABLED=0 forces enabled, overriding a config disable', () => {
+    expect(resolveAgentEnabled({ CANONRY_AGENT_DISABLED: '0' }, cfg({ mode: 'disabled' }))).toBe(true)
+  })
+
+  it('CANONRY_AGENT_DISABLED=false forces enabled, overriding a config disable', () => {
+    expect(resolveAgentEnabled({ CANONRY_AGENT_DISABLED: 'false' }, cfg({ mode: 'disabled' }))).toBe(true)
+  })
+
+  it('empty / whitespace env falls through to config', () => {
+    expect(resolveAgentEnabled({ CANONRY_AGENT_DISABLED: '   ' }, cfg({ mode: 'disabled' }))).toBe(false)
+    expect(resolveAgentEnabled({ CANONRY_AGENT_DISABLED: '' }, cfg())).toBe(true)
+  })
+})

--- a/packages/canonry/test/server-agent-disabled.test.ts
+++ b/packages/canonry/test/server-agent-disabled.test.ts
@@ -9,6 +9,21 @@ import type { CanonryConfig } from '../src/config.js'
 
 const AGENT_ENV = ['CANONRY_AGENT_DISABLED'] as const
 
+// Every route mounted by registerAgentRoutes. The kill-switch gates all of
+// them through a single guard, so the test asserts the whole surface flips —
+// not just the two probed before. Payloads are intentionally empty: when the
+// agent is enabled, POST /prompt and the memory mutations 400 on validation
+// *before* any LLM turn fires, so the parity loop never spends.
+const AGENT_ROUTES: ReadonlyArray<readonly [string, string, unknown?]> = [
+  ['GET', '/api/v1/projects/acme/agent/transcript'],
+  ['DELETE', '/api/v1/projects/acme/agent/transcript'],
+  ['GET', '/api/v1/projects/acme/agent/providers'],
+  ['POST', '/api/v1/projects/acme/agent/prompt', { prompt: '' }],
+  ['GET', '/api/v1/projects/acme/agent/memory'],
+  ['PUT', '/api/v1/projects/acme/agent/memory', {}],
+  ['DELETE', '/api/v1/projects/acme/agent/memory', {}],
+] as const
+
 interface Built {
   app: Awaited<ReturnType<typeof createServer>>
   apiKey: string
@@ -52,6 +67,16 @@ async function seedProject(app: Built['app'], apiKey: string, name: string): Pro
   expect(res.statusCode).toBe(201)
 }
 
+function inject(app: Built['app'], apiKey: string, route: readonly [string, string, unknown?]) {
+  const [method, url, payload] = route
+  return app.inject({
+    method: method as 'GET' | 'POST' | 'PUT' | 'DELETE',
+    url,
+    headers: { authorization: `Bearer ${apiKey}` },
+    ...(payload !== undefined ? { payload } : {}),
+  })
+}
+
 describe('Aero agent kill-switch', () => {
   const saved: Record<string, string | undefined> = {}
 
@@ -69,58 +94,56 @@ describe('Aero agent kill-switch', () => {
     }
   })
 
-  it('enabled (default): the agent transcript route is served (200 for a real project)', async () => {
+  it('enabled (default): the full agent route surface is served', async () => {
     const { app, apiKey, cleanup } = await buildServer()
     try {
       await seedProject(app, apiKey, 'acme')
-      const res = await app.inject({
+
+      const transcript = await app.inject({
         method: 'GET',
         url: '/api/v1/projects/acme/agent/transcript',
         headers: { authorization: `Bearer ${apiKey}` },
       })
-      expect(res.statusCode).toBe(200)
-      expect(JSON.parse(res.body).messages).toEqual([])
+      expect(transcript.statusCode).toBe(200)
+      expect(JSON.parse(transcript.body).messages).toEqual([])
+
+      // Parity with the disabled case: every gated route is mounted (not 404)
+      // when the agent is on. Empty bodies keep POST /prompt + memory mutations
+      // at a 400 validation error rather than running an agent turn.
+      for (const route of AGENT_ROUTES) {
+        const res = await inject(app, apiKey, route)
+        expect(res.statusCode, `enabled ${route[0]} ${route[1]} should be mounted`).not.toBe(404)
+      }
     } finally {
       await cleanup()
     }
   })
 
-  it('config agent.mode "disabled": agent routes are NOT served (404 for a real project)', async () => {
+  it('config agent.mode "disabled": every agent route is gone (404 for a real project)', async () => {
     const { app, apiKey, cleanup } = await buildServer({ mode: 'disabled' })
     try {
       // The project EXISTS, so a 404 proves the route was never registered
-      // (not a project-not-found 404).
+      // (not a project-not-found 404). All 7 routes ride the single gate.
       await seedProject(app, apiKey, 'acme')
-      const auth = { authorization: `Bearer ${apiKey}` }
-
-      const transcript = await app.inject({ method: 'GET', url: '/api/v1/projects/acme/agent/transcript', headers: auth })
-      expect(transcript.statusCode).toBe(404)
-
-      // The SSE prompt route — the one that spends on Opus — is gone too.
-      const prompt = await app.inject({
-        method: 'POST',
-        url: '/api/v1/projects/acme/agent/prompt',
-        headers: auth,
-        payload: { prompt: 'hi' },
-      })
-      expect(prompt.statusCode).toBe(404)
+      for (const route of AGENT_ROUTES) {
+        const res = await inject(app, apiKey, route)
+        expect(res.statusCode, `disabled ${route[0]} ${route[1]} should 404`).toBe(404)
+      }
     } finally {
       await cleanup()
     }
   })
 
-  it('CANONRY_AGENT_DISABLED=1 overrides config and disables the routes', async () => {
+  it('CANONRY_AGENT_DISABLED=1 overrides config and removes every agent route', async () => {
     process.env.CANONRY_AGENT_DISABLED = '1'
     // config does NOT disable — env must win.
     const { app, apiKey, cleanup } = await buildServer()
     try {
       await seedProject(app, apiKey, 'acme')
-      const res = await app.inject({
-        method: 'GET',
-        url: '/api/v1/projects/acme/agent/transcript',
-        headers: { authorization: `Bearer ${apiKey}` },
-      })
-      expect(res.statusCode).toBe(404)
+      for (const route of AGENT_ROUTES) {
+        const res = await inject(app, apiKey, route)
+        expect(res.statusCode, `env-disabled ${route[0]} ${route[1]} should 404`).toBe(404)
+      }
     } finally {
       await cleanup()
     }

--- a/packages/canonry/test/server-agent-disabled.test.ts
+++ b/packages/canonry/test/server-agent-disabled.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import os from 'node:os'
+import fs from 'node:fs'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import { createClient, migrate, type DatabaseClient } from '@ainyc/canonry-db'
+import { createServer } from '../src/server.js'
+import type { CanonryConfig } from '../src/config.js'
+
+const AGENT_ENV = ['CANONRY_AGENT_DISABLED'] as const
+
+interface Built {
+  app: Awaited<ReturnType<typeof createServer>>
+  apiKey: string
+  cleanup: () => Promise<void>
+}
+
+async function buildServer(agent?: CanonryConfig['agent']): Promise<Built> {
+  const tmpDir = path.join(os.tmpdir(), `canonry-agent-disabled-${crypto.randomUUID()}`)
+  fs.mkdirSync(tmpDir, { recursive: true })
+  const dbPath = path.join(tmpDir, 'test.db')
+  const db: DatabaseClient = createClient(dbPath)
+  migrate(db)
+
+  const apiKey = `cnry_${crypto.randomBytes(16).toString('hex')}`
+  const config: CanonryConfig = {
+    apiUrl: 'http://localhost:4100',
+    database: dbPath,
+    apiKey,
+    providers: {},
+    ...(agent ? { agent } : {}),
+  }
+
+  const app = await createServer({ config, db, logger: false })
+  return {
+    app,
+    apiKey,
+    cleanup: async () => {
+      await app.close()
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    },
+  }
+}
+
+async function seedProject(app: Built['app'], apiKey: string, name: string): Promise<void> {
+  const res = await app.inject({
+    method: 'PUT',
+    url: `/api/v1/projects/${name}`,
+    headers: { authorization: `Bearer ${apiKey}` },
+    payload: { displayName: name, canonicalDomain: `${name}.example.com`, country: 'US', language: 'en' },
+  })
+  expect(res.statusCode).toBe(201)
+}
+
+describe('Aero agent kill-switch', () => {
+  const saved: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    for (const key of AGENT_ENV) {
+      saved[key] = process.env[key]
+      delete process.env[key]
+    }
+  })
+
+  afterEach(() => {
+    for (const key of AGENT_ENV) {
+      if (saved[key] === undefined) delete process.env[key]
+      else process.env[key] = saved[key]
+    }
+  })
+
+  it('enabled (default): the agent transcript route is served (200 for a real project)', async () => {
+    const { app, apiKey, cleanup } = await buildServer()
+    try {
+      await seedProject(app, apiKey, 'acme')
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/v1/projects/acme/agent/transcript',
+        headers: { authorization: `Bearer ${apiKey}` },
+      })
+      expect(res.statusCode).toBe(200)
+      expect(JSON.parse(res.body).messages).toEqual([])
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('config agent.mode "disabled": agent routes are NOT served (404 for a real project)', async () => {
+    const { app, apiKey, cleanup } = await buildServer({ mode: 'disabled' })
+    try {
+      // The project EXISTS, so a 404 proves the route was never registered
+      // (not a project-not-found 404).
+      await seedProject(app, apiKey, 'acme')
+      const auth = { authorization: `Bearer ${apiKey}` }
+
+      const transcript = await app.inject({ method: 'GET', url: '/api/v1/projects/acme/agent/transcript', headers: auth })
+      expect(transcript.statusCode).toBe(404)
+
+      // The SSE prompt route — the one that spends on Opus — is gone too.
+      const prompt = await app.inject({
+        method: 'POST',
+        url: '/api/v1/projects/acme/agent/prompt',
+        headers: auth,
+        payload: { prompt: 'hi' },
+      })
+      expect(prompt.statusCode).toBe(404)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('CANONRY_AGENT_DISABLED=1 overrides config and disables the routes', async () => {
+    process.env.CANONRY_AGENT_DISABLED = '1'
+    // config does NOT disable — env must win.
+    const { app, apiKey, cleanup } = await buildServer()
+    try {
+      await seedProject(app, apiKey, 'acme')
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/v1/projects/acme/agent/transcript',
+        headers: { authorization: `Bearer ${apiKey}` },
+      })
+      expect(res.statusCode).toBe(404)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('CANONRY_AGENT_DISABLED=0 forces the agent ON even when config disables it', async () => {
+    process.env.CANONRY_AGENT_DISABLED = '0'
+    const { app, apiKey, cleanup } = await buildServer({ mode: 'disabled' })
+    try {
+      await seedProject(app, apiKey, 'acme')
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/v1/projects/acme/agent/transcript',
+        headers: { authorization: `Bearer ${apiKey}` },
+      })
+      expect(res.statusCode).toBe(200)
+    } finally {
+      await cleanup()
+    }
+  })
+})


### PR DESCRIPTION
## What
Adds a first-class, reversible kill-switch to disable canonry's built-in **Aero** agent entirely, via the already-reserved `agent.mode: 'disabled'` config field or a new `CANONRY_AGENT_DISABLED` environment variable (env over config, mirroring embed mode).

When disabled, `createServer` skips:
- the `SessionRegistry`,
- the proactive auto-wake that fires Aero after every `run.completed`, and
- the interactive agent routes (`/projects/:name/agent/*`) and `canonry agent ask` (a thin client of those routes).

**Unaffected:** data syncs, intelligence, notifications, and external-agent webhooks (`canonry agent attach` — these are notification routes, not part of `registerAgentRoutes`). Default behaviour is unchanged: Aero stays enabled unless explicitly turned off.

## Why
Aero wakes unprompted after every run completion and runs an LLM turn to analyse it. On an instance with scheduled data-refresh / sync runs, that produces a recurring per-run agent LLM cost even when nobody consumes the proactive analysis, and there was previously no way to turn it off short of editing the code. This adds a supported off switch.

## How it works
`resolveAgentEnabled(env, config)` (new `packages/canonry/src/agent-config.ts`): `CANONRY_AGENT_DISABLED` is authoritative when set (`1`/`true` → off, anything else incl. `0`/`false` → forced on); otherwise `config.agent.mode === 'disabled'` disables; default enabled. `server.ts` resolves it once at boot and guards the three Aero wiring points.

## Tests
- `agent-config.test.ts` — 8 cases for the resolver (config, env, precedence, edge/whitespace values).
- `server-agent-disabled.test.ts` — end-to-end via `createServer`: the agent routes return **404 when disabled** (config and env paths) and **200 when enabled**, with a seeded project so the 404 proves route-gating rather than project-not-found.
- Existing `server-embed` boot tests still pass (default path unchanged).

typecheck + lint (0 errors) + tests all green. Version bumped 4.94.0 → 4.95.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)