### PR TITLE
feat(report): smart-percentage deltas for client report metric cards

### DIFF
--- a/apps/web/src/pages/ReportPage.tsx
+++ b/apps/web/src/pages/ReportPage.tsx
@@ -12,7 +12,9 @@ import {
   dedupeReportActions,
   dedupeReportOpportunities,
   deltaPercent,
+  formatAverageDelta,
   formatDeltaCopy,
+  formatWindowCountDelta,
   reportActionCategoryLabel,
   reportActionTone,
   reportConfidenceLabel,
@@ -702,11 +704,15 @@ function RateDeltaTile({
     )
   }
   const valueSuffix = unit === '%' ? '%' : ''
-  const sign = delta.deltaAbs > 0 ? '+' : ''
   const tone = deltaTone(delta.direction)
   const toneClass = tone === 'positive' ? 'text-emerald-400'
     : tone === 'negative' ? 'text-rose-400'
     : 'text-zinc-100'
+  // unit='%' keeps its percentage-point copy; unit='count' routes through the
+  // shared "smart %" formatter so the SPA and HTML stay byte-identical.
+  const deltaText = unit === '%'
+    ? `${delta.deltaAbs > 0 ? '+' : ''}${delta.deltaAbs.toFixed(1)}% vs ${delta.prior}%`
+    : formatAverageDelta(delta)
   return (
     <div className="rounded-xl border border-zinc-800/60 bg-zinc-900/30 px-4 py-3">
       <p className="eyebrow-soft">{label}</p>
@@ -714,7 +720,7 @@ function RateDeltaTile({
         {delta.current}{valueSuffix} <span className="text-sm font-medium">{deltaArrow(delta.direction)}</span>
       </p>
       <p className="mt-1 text-[11px] text-zinc-500">
-        {sign}{unit === '%' ? delta.deltaAbs.toFixed(1) : delta.deltaAbs}{valueSuffix} vs {delta.prior}{valueSuffix}
+        {deltaText}
       </p>
     </div>
   )
@@ -738,11 +744,13 @@ function TrafficDeltaTile({
       </div>
     )
   }
-  const sign = delta.deltaAbs > 0 ? '+' : ''
   const tone = deltaTone(delta.direction)
   const toneClass = tone === 'positive' ? 'text-emerald-400'
     : tone === 'negative' ? 'text-rose-400'
     : 'text-zinc-100'
+  // Shared "smart %" formatter — same helper the HTML renderer calls, so both
+  // surfaces emit byte-identical copy per the report-parity rule.
+  const deltaText = formatWindowCountDelta(delta, countLabel, `vs prior ${WHATS_CHANGED_PERIOD_DAYS} days`)
   return (
     <div className="rounded-xl border border-zinc-800/60 bg-zinc-900/30 px-4 py-3">
       <p className="eyebrow-soft">{label}</p>
@@ -750,7 +758,7 @@ function TrafficDeltaTile({
         {formatNumber(delta.current)} <span className="text-sm font-medium">{deltaArrow(delta.direction)}</span>
       </p>
       <p className="mt-1 text-[11px] text-zinc-500">
-        {sign}{formatNumber(delta.deltaAbs)} {countLabel} vs prior {WHATS_CHANGED_PERIOD_DAYS} days
+        {deltaText}
       </p>
     </div>
   )

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.95.0",
+  "version": "4.96.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -1919,6 +1919,7 @@ export type ProjectReportDto = {
             current: number;
             prior: number;
             deltaAbs: number;
+            deltaPct: number | null;
             direction: 'up' | 'down' | 'flat';
             window?: number;
         } | null;
@@ -1926,6 +1927,7 @@ export type ProjectReportDto = {
             current: number;
             prior: number;
             deltaAbs: number;
+            deltaPct: number | null;
             direction: 'up' | 'down' | 'flat';
             window?: number;
         } | null;
@@ -1933,6 +1935,7 @@ export type ProjectReportDto = {
             current: number;
             prior: number;
             deltaAbs: number;
+            deltaPct: number | null;
             direction: 'up' | 'down' | 'flat';
             window?: number;
         } | null;
@@ -1940,6 +1943,7 @@ export type ProjectReportDto = {
             current: number;
             prior: number;
             deltaAbs: number;
+            deltaPct: number | null;
             direction: 'up' | 'down' | 'flat';
             window?: number;
         } | null;
@@ -1947,6 +1951,7 @@ export type ProjectReportDto = {
             current: number;
             prior: number;
             deltaAbs: number;
+            deltaPct: number | null;
             direction: 'up' | 'down' | 'flat';
             window?: number;
         } | null;

--- a/packages/api-routes/src/report-renderer.ts
+++ b/packages/api-routes/src/report-renderer.ts
@@ -18,12 +18,14 @@ import {
   dedupeReportOpportunities,
   deltaPercent,
   deltaTone,
+  formatAverageDelta,
   formatDate,
   formatDateRange,
   formatDeltaCopy,
   formatIsoDate,
   formatNumber,
   formatRatio,
+  formatWindowCountDelta,
   reportActionCategoryLabel,
   reportActionTone,
   reportConfidenceLabel,
@@ -1190,8 +1192,12 @@ function renderRateDeltaTile(
     return `<div class="metric"><div class="label">${escapeHtml(label)}</div><div class="value">—</div><div class="delta">No prior data</div></div>`
   }
   const valueSuffix = unit === '%' ? '%' : ''
-  const deltaSign = delta.deltaAbs > 0 ? '+' : ''
-  const deltaText = `${deltaSign}${delta.deltaAbs.toFixed(unit === '%' ? 1 : 0)}${valueSuffix} vs ${delta.prior}${valueSuffix}`
+  // unit='%' keeps its percentage-point copy; unit='count' routes through the
+  // shared "smart %" formatter (big base → %, small base → rounded raw delta)
+  // so the SPA and HTML stay byte-identical per the report-parity rule.
+  const deltaText = unit === '%'
+    ? `${delta.deltaAbs > 0 ? '+' : ''}${delta.deltaAbs.toFixed(1)}% vs ${delta.prior}%`
+    : formatAverageDelta(delta)
   return `<div class="metric">
     <div class="label">${escapeHtml(label)}</div>
     <div class="value ${deltaToneClass(delta.direction)}">${delta.current}${valueSuffix} <span style="font-size:14px;font-weight:500;">${deltaArrow(delta.direction)}</span></div>
@@ -1207,8 +1213,9 @@ function renderTrafficDeltaTile(
   if (!delta) {
     return `<div class="metric"><div class="label">${escapeHtml(label)}</div><div class="value">—</div><div class="delta">Not enough trend data</div></div>`
   }
-  const deltaSign = delta.deltaAbs > 0 ? '+' : ''
-  const deltaText = `${deltaSign}${formatNumber(delta.deltaAbs)} ${countLabel} vs prior ${WHATS_CHANGED_PERIOD_DAYS} days`
+  // Shared "smart %" formatter: big prior base → signed %, small base →
+  // rounded absolute delta with the count label. Same helper the SPA calls.
+  const deltaText = formatWindowCountDelta(delta, countLabel, `vs prior ${WHATS_CHANGED_PERIOD_DAYS} days`)
   return `<div class="metric">
     <div class="label">${escapeHtml(label)}</div>
     <div class="value ${deltaToneClass(delta.direction)}">${formatNumber(delta.current)} <span style="font-size:14px;font-weight:500;">${deltaArrow(delta.direction)}</span></div>

--- a/packages/api-routes/src/report.ts
+++ b/packages/api-routes/src/report.ts
@@ -1738,6 +1738,7 @@ function periodOverPeriodDelta(
     current,
     prior: priorTotal,
     deltaAbs,
+    deltaPct: deltaPercent(current, priorTotal),
     direction: rateDirection(deltaAbs, 0),
   }
 }

--- a/packages/api-routes/test/report-renderer.test.ts
+++ b/packages/api-routes/test/report-renderer.test.ts
@@ -750,6 +750,59 @@ describe('renderReportHtml', () => {
     expect(clientHtml).toContain('Up 100% vs prior 7 days (6 sessions)')
   })
 
+  // Locks in the "smart %" rule for the What's-changed count + traffic tiles.
+  // Both surfaces call the SAME shared contracts helpers (formatAverageDelta /
+  // formatWindowCountDelta), so the HTML asserted here is byte-identical to the
+  // SPA subtitle. The gjelina-shaped values: cited-query count averages ~3.3
+  // (small base → rounded raw delta) while GSC clicks total ~382 over the prior
+  // window (large base → percentage).
+  test('whatsChanged count + traffic tiles use the smart-% rule', () => {
+    const report = richReport()
+    report.whatsChanged = {
+      ...report.whatsChanged,
+      enoughHistory: true,
+      // Small base (< MIN_PCT_BASE): rounded raw delta vs prior, never a float,
+      // never a misleading % on a tiny base. Fixes the +0.33333… float bug.
+      citedQueryCount: { current: 3.7, prior: 3.3, deltaAbs: 0.33333333333333304, deltaPct: 10, direction: 'flat', window: 3 },
+      // Large base (>= MIN_PCT_BASE): signed percentage, no "visits" word.
+      gscClicksDelta: { current: 328, prior: 382, deltaAbs: -54, deltaPct: -14, direction: 'down' },
+    }
+
+    const clientHtml = renderReportHtml(report, { audience: 'client' })
+    // Questions answered (cited-query count) → rounded raw delta in the visible
+    // tile subtitle, never the unrounded float. (The raw DTO is still embedded
+    // in the hydration <script>, so we assert the rendered .delta div, not the
+    // whole document.)
+    expect(clientHtml).toContain('Questions AI answered with you')
+    expect(clientHtml).toContain('<div class="delta">+0.3 vs 3.3</div>')
+    // The visible subtitle never shows the unrounded float copy.
+    expect(clientHtml).not.toContain('<div class="delta">+0.33333')
+    // Visitors from Google (GSC clicks) → percentage, not an absolute count.
+    expect(clientHtml).toContain('Visitors from Google')
+    expect(clientHtml).toContain('<div class="delta">-14% vs prior 14 days</div>')
+    expect(clientHtml).not.toContain('-54 visits')
+
+    const agencyHtml = renderReportHtml(report, { audience: 'agency' })
+    expect(agencyHtml).toContain('Cited queries')
+    expect(agencyHtml).toContain('<div class="delta">+0.3 vs 3.3</div>')
+    expect(agencyHtml).toContain('GSC clicks')
+    expect(agencyHtml).toContain('<div class="delta">-14% vs prior 14 days</div>')
+  })
+
+  // Small-base path for the traffic tile too: when the prior window total is
+  // below MIN_PCT_BASE the tile shows a rounded absolute count with the label.
+  test('whatsChanged traffic tile falls back to a rounded count on a small base', () => {
+    const report = richReport()
+    report.whatsChanged = {
+      ...report.whatsChanged,
+      enoughHistory: true,
+      gscClicksDelta: { current: 14, prior: 10, deltaAbs: 4, deltaPct: 40, direction: 'up' },
+    }
+    const clientHtml = renderReportHtml(report, { audience: 'client' })
+    expect(clientHtml).toContain('<div class="delta">+4 visits vs prior 14 days</div>')
+    expect(clientHtml).not.toContain('+40% vs prior 14 days')
+  })
+
   test('client view of empty server-activity uses the friendly heading, not "Section 10"', () => {
     const report = richReport()
     report.serverActivity = {

--- a/packages/api-routes/test/report.test.ts
+++ b/packages/api-routes/test/report.test.ts
@@ -858,6 +858,8 @@ describe('GET /api/v1/projects/:name/report', () => {
     expect(body.whatsChanged.citationRate!.current).toBe(25)
     expect(body.whatsChanged.citationRate!.prior).toBe(0)
     expect(body.whatsChanged.citationRate!.deltaAbs).toBe(25)
+    // prior is 0 → percentage undefined → deltaPct null.
+    expect(body.whatsChanged.citationRate!.deltaPct).toBeNull()
     expect(body.whatsChanged.citationRate!.direction).toBe('up')
     expect(body.whatsChanged.citationRate!.window).toBe(2)
     // citedQueryCount: tail avg 0.5, prior avg 0, delta 0.5 — exactly at
@@ -865,6 +867,8 @@ describe('GET /api/v1/projects/:name/report', () => {
     // (a single-query bump is not yet a trend on a 2-query basket).
     expect(body.whatsChanged.citedQueryCount!.current).toBe(0.5)
     expect(body.whatsChanged.citedQueryCount!.prior).toBe(0)
+    // prior 0 → deltaPct null → the smart-% rule renders the raw rounded delta.
+    expect(body.whatsChanged.citedQueryCount!.deltaPct).toBeNull()
     expect(body.whatsChanged.citedQueryCount!.direction).toBe('flat')
     expect(body.whatsChanged.providerMovements.length).toBe(1)
     expect(body.whatsChanged.providerMovements[0]!.provider).toBe('gemini')

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.95.0",
+  "version": "4.96.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/contracts/src/formatting.ts
+++ b/packages/contracts/src/formatting.ts
@@ -92,3 +92,58 @@ export function formatDeltaCopy(d: DeltaWindow, suffix: string, windowLabel = 'v
   if (d.deltaPct < 0) return `Down ${Math.abs(d.deltaPct)}% ${windowLabel} (${formatNumber(d.prior)} ${suffix})`
   return `Flat ${windowLabel} (${formatNumber(d.prior)} ${suffix})`
 }
+
+/**
+ * Smart-percent base threshold. When the PRIOR-window value is at least this
+ * large, a delta is expressed as a percentage; below it, a raw rounded delta
+ * is shown instead so a tiny base never produces a misleading percentage
+ * (e.g. "+50%" off a base of 2). Same rule the Discord orchestrator uses.
+ */
+export const MIN_PCT_BASE = 30
+
+/** Round to one decimal place: round1(0.3333) → 0.3, round1(3.3333) → 3.3. */
+function round1(value: number): number {
+  return Math.round(value * 10) / 10
+}
+
+/**
+ * "Smart %" subtitle for an AVERAGE metric (e.g. cited-query count averaged
+ * over a rolling window). When the prior average is a large-enough base
+ * (`prior >= MIN_PCT_BASE`) and a percentage is computable, render the signed
+ * percent — otherwise fall back to a clean rounded raw delta vs the prior
+ * average. `deltaPct` is already signed (negative = down); we only add a '+'
+ * for positive values.
+ *
+ * Pure. Shared by the report SPA and HTML renderer so both surfaces produce
+ * byte-identical copy per the report-parity rule.
+ */
+export function formatAverageDelta(d: { deltaAbs: number; prior: number; deltaPct: number | null }): string {
+  if (d.prior >= MIN_PCT_BASE && d.deltaPct !== null) {
+    const sign = d.deltaPct > 0 ? '+' : ''
+    return `${sign}${d.deltaPct}% vs prior`
+  }
+  const sign = d.deltaAbs > 0 ? '+' : ''
+  return `${sign}${round1(d.deltaAbs)} vs ${round1(d.prior)}`
+}
+
+/**
+ * "Smart %" subtitle for a WINDOW-COUNT metric (e.g. GSC clicks summed over a
+ * trailing window vs the prior window). When the prior total is a large-enough
+ * base and a percentage is computable, render the signed percent followed by
+ * the window label; otherwise render a rounded absolute delta with the count
+ * label (`visits`, `clicks`, …) and the window label.
+ *
+ * Pure. Shared by the report SPA and HTML renderer.
+ */
+export function formatWindowCountDelta(
+  d: { deltaAbs: number; prior: number; deltaPct: number | null },
+  countLabel: string,
+  windowLabel: string,
+): string {
+  if (d.prior >= MIN_PCT_BASE && d.deltaPct !== null) {
+    const sign = d.deltaPct > 0 ? '+' : ''
+    return `${sign}${d.deltaPct}% ${windowLabel}`
+  }
+  const sign = d.deltaAbs > 0 ? '+' : ''
+  return `${sign}${formatNumber(Math.round(d.deltaAbs))} ${countLabel} ${windowLabel}`
+}

--- a/packages/contracts/src/report.ts
+++ b/packages/contracts/src/report.ts
@@ -543,6 +543,13 @@ export const reportRateDeltaSchema = z.object({
   /** Absolute delta (current − prior). Negative = decrease. */
   deltaAbs: z.number(),
   /**
+   * Signed percent change vs `prior`, rounded to a whole number. Null when
+   * `prior <= 0` (percentage undefined). Renderers route count/traffic tiles
+   * through the "smart %" rule — percentage when the prior base is large
+   * enough (`MIN_PCT_BASE`), otherwise a rounded raw delta.
+   */
+  deltaPct: z.number().nullable(),
+  /**
    * Direction tag for tone mapping. Threshold is metric-specific (3pp for
    * rates, 0.5 for counts) so small noise lands as 'flat' rather than
    * flipping up/down each run.

--- a/packages/contracts/test/formatting.test.ts
+++ b/packages/contracts/test/formatting.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, test } from 'vitest'
 import {
+  MIN_PCT_BASE,
   deltaPercent,
   deltaTone,
+  formatAverageDelta,
   formatDate,
   formatDateRange,
   formatDeltaCopy,
   formatIsoDate,
   formatNumber,
   formatRatio,
+  formatWindowCountDelta,
   parseInclusiveEndMs,
 } from '../src/formatting.js'
 
@@ -163,6 +166,76 @@ describe('formatDeltaCopy', () => {
   test('windowLabel can be overridden', () => {
     expect(formatDeltaCopy({ current: 200, prior: 100, deltaPct: 100 }, 'hits', 'vs prior 30 days'))
       .toBe('Up 100% vs prior 30 days (100 hits)')
+  })
+})
+
+describe('formatAverageDelta', () => {
+  test('large base renders a signed percentage vs prior', () => {
+    expect(formatAverageDelta({ deltaAbs: 4.2, prior: 30, deltaPct: 14 })).toBe('+14% vs prior')
+  })
+
+  test('large base with a negative delta keeps the sign from deltaPct', () => {
+    expect(formatAverageDelta({ deltaAbs: -6, prior: 50, deltaPct: -12 })).toBe('-12% vs prior')
+  })
+
+  test(`base below MIN_PCT_BASE (${MIN_PCT_BASE}) falls back to a rounded raw delta`, () => {
+    // The float-parity case: 0.33333333333333304 → 0.3, 3.3333 → 3.3.
+    expect(formatAverageDelta({ deltaAbs: 0.33333333333333304, prior: 3.3333, deltaPct: 10 }))
+      .toBe('+0.3 vs 3.3')
+  })
+
+  test('small-base negative delta omits the plus sign', () => {
+    expect(formatAverageDelta({ deltaAbs: -0.5, prior: 2, deltaPct: -20 })).toBe('-0.5 vs 2')
+  })
+
+  test('zero prior (deltaPct null) takes the raw branch even though prior < MIN_PCT_BASE', () => {
+    expect(formatAverageDelta({ deltaAbs: 0.5, prior: 0, deltaPct: null })).toBe('+0.5 vs 0')
+  })
+
+  test('large base but null deltaPct still falls back to the raw branch', () => {
+    // prior >= MIN_PCT_BASE but no computable percentage — never render "%".
+    expect(formatAverageDelta({ deltaAbs: 5, prior: 40, deltaPct: null })).toBe('+5 vs 40')
+  })
+
+  test('zero delta on a small base renders without a sign', () => {
+    expect(formatAverageDelta({ deltaAbs: 0, prior: 3.3, deltaPct: 0 })).toBe('0 vs 3.3')
+  })
+})
+
+describe('formatWindowCountDelta', () => {
+  test('large base renders a signed percentage with the window label, no count word', () => {
+    expect(formatWindowCountDelta({ deltaAbs: -54, prior: 382, deltaPct: -14 }, 'visits', 'vs prior 14 days'))
+      .toBe('-14% vs prior 14 days')
+  })
+
+  test('large base positive delta gets a plus sign', () => {
+    expect(formatWindowCountDelta({ deltaAbs: 60, prior: 300, deltaPct: 20 }, 'clicks', 'vs prior 14 days'))
+      .toBe('+20% vs prior 14 days')
+  })
+
+  test(`base below MIN_PCT_BASE (${MIN_PCT_BASE}) falls back to a rounded absolute delta with the count label`, () => {
+    expect(formatWindowCountDelta({ deltaAbs: 4, prior: 10, deltaPct: 40 }, 'visits', 'vs prior 14 days'))
+      .toBe('+4 visits vs prior 14 days')
+  })
+
+  test('small-base negative delta omits the plus sign and rounds', () => {
+    expect(formatWindowCountDelta({ deltaAbs: -2.6, prior: 5, deltaPct: -52 }, 'clicks', 'vs prior 14 days'))
+      .toBe('-3 clicks vs prior 14 days')
+  })
+
+  test('zero prior (deltaPct null) takes the count branch', () => {
+    expect(formatWindowCountDelta({ deltaAbs: 7, prior: 0, deltaPct: null }, 'visits', 'vs prior 14 days'))
+      .toBe('+7 visits vs prior 14 days')
+  })
+
+  test('large base but null deltaPct falls back to the count branch', () => {
+    expect(formatWindowCountDelta({ deltaAbs: -10, prior: 100, deltaPct: null }, 'visits', 'vs prior 14 days'))
+      .toBe('-10 visits vs prior 14 days')
+  })
+
+  test('large count deltas abbreviate via formatNumber', () => {
+    expect(formatWindowCountDelta({ deltaAbs: 1500, prior: 20, deltaPct: 7500 }, 'visits', 'vs prior 14 days'))
+      .toBe('+1.5K visits vs prior 14 days')
   })
 })
 

--- a/packages/intelligence/src/smoothed-delta.ts
+++ b/packages/intelligence/src/smoothed-delta.ts
@@ -14,6 +14,8 @@
  * a value extractor; this helper does the windowing math.
  */
 
+import { deltaPercent } from '@ainyc/canonry-contracts'
+
 export interface SmoothedRunDelta {
   /** Average of the most recent `window` points, rounded to 1 decimal. */
   current: number
@@ -22,6 +24,10 @@ export interface SmoothedRunDelta {
   /** Unrounded `current - prior` average. Caller compares against a
    *  threshold (e.g. 3pp for rates) to decide up/down/flat. */
   deltaAbs: number
+  /** Signed percent change of `current` vs `prior` (rounded averages),
+   *  rounded to a whole number. Null when `prior <= 0`. Renderers route
+   *  count tiles through the "smart %" rule with this. */
+  deltaPct: number | null
   /** How many points went into each side of the average. 1 = point-to-point
    *  (only 2–3 runs in history); higher = real smoothing. Renderers use
    *  this to label "vs prior N checks" vs "since last check". */
@@ -55,10 +61,13 @@ export function smoothedRunDelta<T>(
   const sum = (arr: readonly T[]): number => arr.reduce((s, p) => s + valueFn(p), 0)
   const currentAvg = sum(tail) / tail.length
   const priorAvg = sum(prior) / prior.length
+  const current = roundTo1Decimal(currentAvg)
+  const prior_ = roundTo1Decimal(priorAvg)
   return {
-    current: roundTo1Decimal(currentAvg),
-    prior: roundTo1Decimal(priorAvg),
+    current,
+    prior: prior_,
     deltaAbs: currentAvg - priorAvg,
+    deltaPct: deltaPercent(current, prior_),
     window,
   }
 }

--- a/packages/intelligence/test/smoothed-delta.test.ts
+++ b/packages/intelligence/test/smoothed-delta.test.ts
@@ -13,7 +13,19 @@ describe('smoothedRunDelta', () => {
   it('falls back to window=1 (point-to-point) with exactly 2 points', () => {
     // Equivalent to the legacy `latest - prior` delta.
     const result = smoothedRunDelta<Point>([v(50), v(60)], p => p.value)
-    expect(result).toEqual({ current: 60, prior: 50, deltaAbs: 10, window: 1 })
+    // deltaPct = round((60-50)/50 * 100) = 20.
+    expect(result).toEqual({ current: 60, prior: 50, deltaAbs: 10, deltaPct: 20, window: 1 })
+  })
+
+  it('computes deltaPct from the rounded averages; null when prior is zero', () => {
+    // Large enough base → a real percentage off the rounded prior average.
+    const climbing = smoothedRunDelta<Point>([v(40), v(50), v(60), v(70)], p => p.value)
+    // prior = 45, current = 65 → round((65-45)/45 * 100) = round(44.44) = 44.
+    expect(climbing?.deltaPct).toBe(44)
+    // Prior average of 0 → percentage undefined → null.
+    const fromZero = smoothedRunDelta<Point>([v(0), v(0), v(5)], p => p.value)
+    expect(fromZero?.prior).toBe(0)
+    expect(fromZero?.deltaPct).toBeNull()
   })
 
   it('keeps window=1 with 3 points (need 4 to fit window=2 without overlap)', () => {


### PR DESCRIPTION
## What
The client report's two movement cards rendered raw deltas:
- **Questions answered** (`citedQueryCount`) showed a long unrounded float, e.g. `+0.33333333333333304 vs 3.3` — and worse, a **SPA/HTML parity bug**: the SPA rendered the raw float while the HTML rounded to 0 decimals (`+0 vs 3.3`), so the two surfaces disagreed.
- **Visitors from Google** (`gscClicksDelta`) showed an absolute count, e.g. `-54 visits vs prior 14 days`.

Both now use a shared **"smart %"** rule (`MIN_PCT_BASE = 30`): when the prior base is large enough, render a signed percentage; when it's small, render a clean rounded delta — so a tiny base never produces a misleading percent (e.g. `+50%` off a base of 2), and the float is gone.

| Card | Before | After |
|---|---|---|
| Questions answered (small base) | `+0.33333333333333304 vs 3.3` (SPA) / `+0 vs 3.3` (HTML) | `+0.3 vs 3.3` (identical) |
| Visitors from Google (large base) | `-54 visits vs prior 14 days` | `-14% vs prior 14 days` |

## How
- `deltaPct: number | null` added to `reportRateDeltaSchema` (computed in the API via `deltaPercent(current, prior)`; SDK regenerated — no codegen drift). Keeps the calc in the DTO, not the renderers.
- Shared `formatAverageDelta` / `formatWindowCountDelta` + `MIN_PCT_BASE` in `@ainyc/canonry-contracts`, called by **both** `apps/web/src/pages/ReportPage.tsx` and `packages/api-routes/src/report-renderer.ts` (same helpers, same `WHATS_CHANGED_PERIOD_DAYS = 14`), so the subtitle strings are byte-identical per the report-parity rule.
- Percentage-point (rate) tiles are unchanged — only the count and traffic tiles route through the smart rule.

## Tests
- `contracts/test/formatting.test.ts` — exact-string cases for both helpers: big base → %, small base → rounded delta, zero base (`prior=0` → `deltaPct=null` → raw), negatives, and the specific float case → `+0.3 vs 3.3`.
- `report-renderer.test.ts` / `report.test.ts` / `smoothed-delta.test.ts` updated for the new subtitles + `deltaPct`.

typecheck + lint (0 errors) + full test suite green; codegen byte-stable. Version 4.95.0 → 4.96.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)