### PR TITLE
feat(ads): surface OpenAI conversion data on insights, summary, and status

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -118,11 +118,11 @@ Local-AEO signals. The OAuth connection reuses `google_connections` with `connec
 
 | Table | Purpose |
 |-------|---------|
-| **ads_connections** | One OpenAI ad-account connection per project (ad accounts are not domain-bound, so this keys on project like `ga_connections`). Metadata + sync state only — the Ads Manager "SDK key" lives in `~/.canonry/config.yaml`. |
+| **ads_connections** | One OpenAI ad-account connection per project (ad accounts are not domain-bound, so this keys on project like `ga_connections`). Metadata + sync state only — the Ads Manager "SDK key" lives in `~/.canonry/config.yaml`. `conversion_tracking_configured` is set on each sync from whether any synced campaign carries a `conversion_event_setting_ids` entry (the operator-readiness conversion gate reads it). |
 | **ads_campaigns** | Campaign snapshots, range-replaced per project on every `ads-sync`. Budgets are integer micros (`daily_spend_limit_micros` / `lifetime_spend_limit_micros`); `targeting` is the raw upstream JSON (geo includes/excludes). Ids are upstream ids (`cmpn_…`). |
 | **ads_ad_groups** | Ad-group snapshots. `context_hints` (JSON `string[]`) is the targeting primitive — entries are multi-line strings of newline-separated example queries; the paid/organic overlap matcher joins these against tracked queries. Cascades off `ads_campaigns`. |
 | **ads_ads** | Ad snapshots with the `chat_card` creative JSON and review status. Cascades off `ads_ad_groups`. |
-| **ads_insights_daily** | Daily paid-performance rollups, one row per `(level, entity, date)`. `spend_micros` is integer micros — the upstream insights API returns decimal dollars, normalized at ingest. Derived ratios (ctr/cpc) computed at read time. Upserts on conflict so re-syncing an in-progress day replaces. |
+| **ads_insights_daily** | Daily paid-performance rollups, one row per `(level, entity, date)`. `spend_micros` is integer micros — the upstream insights API returns decimal dollars, normalized at ingest. `conversions` is the integer conversion count (0 when the account has no conversion tracking). Derived ratios (ctr/cpc) computed at read time. Upserts on conflict so re-syncing an in-progress day replaces. |
 
 ### Server-Side Traffic Ingestion
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.95.0",
+  "version": "4.96.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -56,6 +56,7 @@ export type AdsConnectionStatusDto = {
     timezone?: string | null;
     status?: string | null;
     lastSyncedAt?: string | null;
+    conversionTrackingConfigured?: boolean;
 };
 
 export type AdsDisconnectResponse = {
@@ -70,6 +71,7 @@ export type AdsInsightsResponse = {
         impressions: number;
         clicks: number;
         spendMicros: number;
+        conversions: number;
         ctr: number | null;
         cpcMicros: number | null;
     }>;
@@ -92,6 +94,7 @@ export type AdsSummaryDto = {
         impressions: number;
         clicks: number;
         spendMicros: number;
+        conversions: number;
         ctr: number | null;
         cpcMicros: number | null;
     };

--- a/packages/api-routes/src/ads.ts
+++ b/packages/api-routes/src/ads.ts
@@ -71,6 +71,7 @@ function statusDto(row: ConnectionRow | undefined): AdsConnectionStatusDto {
     timezone: row.timezone,
     status: row.status,
     lastSyncedAt: row.lastSyncedAt,
+    conversionTrackingConfigured: row.conversionTrackingConfigured,
   }
 }
 
@@ -318,6 +319,7 @@ export async function adsRoutes(app: FastifyInstance, opts: AdsRoutesOptions): P
       impressions: row.impressions,
       clicks: row.clicks,
       spendMicros: row.spendMicros,
+      conversions: row.conversions,
       ctr: adsCtr(row.clicks, row.impressions),
       cpcMicros: adsCpcMicros(row.spendMicros, row.clicks),
     }))
@@ -352,12 +354,14 @@ export async function adsRoutes(app: FastifyInstance, opts: AdsRoutesOptions): P
     let impressions = 0
     let clicks = 0
     let spendMicros = 0
+    let conversions = 0
     let fromDate: string | null = null
     let toDate: string | null = null
     for (const insight of campaignInsights) {
       impressions += insight.impressions
       clicks += insight.clicks
       spendMicros += insight.spendMicros
+      conversions += insight.conversions
       if (fromDate === null || insight.date < fromDate) fromDate = insight.date
       if (toDate === null || insight.date > toDate) toDate = insight.date
     }
@@ -375,6 +379,7 @@ export async function adsRoutes(app: FastifyInstance, opts: AdsRoutesOptions): P
         impressions,
         clicks,
         spendMicros,
+        conversions,
         ctr: adsCtr(clicks, impressions),
         cpcMicros: adsCpcMicros(spendMicros, clicks),
       },

--- a/packages/api-routes/test/ads-routes.test.ts
+++ b/packages/api-routes/test/ads-routes.test.ts
@@ -88,7 +88,7 @@ function buildApp(overrides: { verifyShouldFail?: boolean } = {}) {
     db.insert(adsConnections).values({
       id: crypto.randomUUID(), projectId, adAccountId: 'adacct_aaa',
       displayName: 'Acme Exteriors, Inc', currencyCode: 'USD', timezone: 'America/Denver',
-      status: 'active', lastSyncedAt: NOW, createdAt: NOW, updatedAt: NOW,
+      status: 'active', conversionTrackingConfigured: true, lastSyncedAt: NOW, createdAt: NOW, updatedAt: NOW,
     }).run()
   }
 
@@ -112,12 +112,12 @@ function buildApp(overrides: { verifyShouldFail?: boolean } = {}) {
 
   function seedInsights(projectId: string) {
     const rows = [
-      { level: 'campaign', entityId: 'cmpn_bbb', date: '2026-06-09', impressions: 3326, clicks: 40, spendMicros: 90_450_000 },
-      { level: 'campaign', entityId: 'cmpn_bbb', date: '2026-06-10', impressions: 1736, clicks: 23, spendMicros: 39_280_000 },
+      { level: 'campaign', entityId: 'cmpn_bbb', date: '2026-06-09', impressions: 3326, clicks: 40, spendMicros: 90_450_000, conversions: 4 },
+      { level: 'campaign', entityId: 'cmpn_bbb', date: '2026-06-10', impressions: 1736, clicks: 23, spendMicros: 39_280_000, conversions: 2 },
       // subdivision of the campaign rows — must NOT be double-counted in summary totals
-      { level: 'ad_group', entityId: 'adgrp_ddd', date: '2026-06-10', impressions: 64, clicks: 1, spendMicros: 570_000 },
+      { level: 'ad_group', entityId: 'adgrp_ddd', date: '2026-06-10', impressions: 64, clicks: 1, spendMicros: 570_000, conversions: 1 },
       // zero-denominator edge: no clicks
-      { level: 'campaign', entityId: 'cmpn_bbb', date: '2026-06-08', impressions: 100, clicks: 0, spendMicros: 0 },
+      { level: 'campaign', entityId: 'cmpn_bbb', date: '2026-06-08', impressions: 100, clicks: 0, spendMicros: 0, conversions: 0 },
     ]
     for (const row of rows) {
       db.insert(adsInsightsDaily).values({ id: crypto.randomUUID(), projectId, syncRunId: null, ...row }).run()
@@ -192,6 +192,8 @@ describe('ads routes', () => {
     const body = JSON.parse(res.body) as Record<string, unknown>
     expect(body.connected).toBe(true)
     expect(body.lastSyncedAt).toBe(NOW)
+    // the seeded connection has conversion tracking configured
+    expect(body.conversionTrackingConfigured).toBe(true)
   })
 
   it('POST /ads/sync requires a connection, creates the run row, and fires the host callback', async () => {
@@ -261,6 +263,7 @@ describe('ads routes', () => {
     // $39.28 / 23 clicks = 1_707_826 micros; 23/1736 ctr
     expect(june10.cpcMicros).toBe(1_707_826)
     expect(june10.ctr).toBeCloseTo(23 / 1736, 8)
+    expect(june10.conversions).toBe(2)
 
     const june08 = body.rows.find((r) => r.date === '2026-06-08')!
     expect(june08.ctr).toBe(0)
@@ -303,7 +306,7 @@ describe('ads routes', () => {
       campaignCount: number
       adGroupCount: number
       adCount: number
-      totals: { impressions: number; clicks: number; spendMicros: number; ctr: number | null; cpcMicros: number | null }
+      totals: { impressions: number; clicks: number; spendMicros: number; conversions: number; ctr: number | null; cpcMicros: number | null }
       window: { from: string | null; to: string | null }
     }
     expect(body.connected).toBe(true)
@@ -315,6 +318,8 @@ describe('ads routes', () => {
     expect(body.totals.impressions).toBe(5162)
     expect(body.totals.clicks).toBe(63)
     expect(body.totals.spendMicros).toBe(129_730_000)
+    // conversions sum campaign rows only: 4+2+0 — the ad_group row's 1 is excluded
+    expect(body.totals.conversions).toBe(6)
     expect(body.totals.ctr).toBeCloseTo(63 / 5162, 8)
     expect(body.totals.cpcMicros).toBe(Math.round(129_730_000 / 63))
     expect(body.window).toEqual({ from: '2026-06-08', to: '2026-06-10' })

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.95.0",
+  "version": "4.96.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/ads-sync.ts
+++ b/packages/canonry/src/ads-sync.ts
@@ -23,8 +23,8 @@ import { createLogger } from './logger.js'
 
 const log = createLogger('AdsSync')
 
-const CAMPAIGN_INSIGHT_FIELDS = ['campaign.impressions', 'campaign.clicks', 'campaign.spend', 'metadata.readable_time']
-const AD_GROUP_INSIGHT_FIELDS = ['ad_group.impressions', 'ad_group.clicks', 'ad_group.spend', 'metadata.readable_time']
+const CAMPAIGN_INSIGHT_FIELDS = ['campaign.impressions', 'campaign.clicks', 'campaign.spend', 'campaign.conversions', 'metadata.readable_time']
+const AD_GROUP_INSIGHT_FIELDS = ['ad_group.impressions', 'ad_group.clicks', 'ad_group.spend', 'ad_group.conversions', 'metadata.readable_time']
 
 interface AdsSyncOptions {
   config: CanonryConfig
@@ -37,6 +37,7 @@ interface InsightUpsert {
   impressions: number
   clicks: number
   spendMicros: number
+  conversions: number
 }
 
 // The insights API returns spend/cpc as DECIMAL DOLLARS while budgets/bids
@@ -55,6 +56,7 @@ function toInsightUpserts(level: InsightUpsert['level'], entityId: string, rows:
       impressions: row.impressions ?? 0,
       clicks: row.clicks ?? 0,
       spendMicros: dollarsToMicros(row.spend ?? 0),
+      conversions: Math.round(row.conversions ?? 0),
     })
   }
   return upserts
@@ -131,6 +133,16 @@ export async function executeAdsSync(
       }
     }
 
+    // Conversion tracking is configured at the campaign level: a campaign
+    // carries one or more conversion_event_setting_ids once the operator wires
+    // up an OpenAI conversion pixel / CAPI event. Detect it from the full
+    // campaign list (the field rides the campaign object regardless of whether
+    // that campaign's insight fetch succeeded), so the account-level flag is
+    // not lost to a single failed per-campaign sync.
+    const conversionTrackingConfigured = campaigns.some(
+      (c) => (c.conversion_event_setting_ids?.length ?? 0) > 0,
+    )
+
     const insertNow = new Date().toISOString()
     db.transaction((tx) => {
       // Range-replace entity snapshots for the project. Deleting campaigns
@@ -204,6 +216,7 @@ export async function executeAdsSync(
             impressions: upsert.impressions,
             clicks: upsert.clicks,
             spendMicros: upsert.spendMicros,
+            conversions: upsert.conversions,
             syncRunId: runId,
           },
         }).run()
@@ -215,6 +228,7 @@ export async function executeAdsSync(
         currencyCode: account.currency_code,
         timezone: account.timezone,
         status: account.status,
+        conversionTrackingConfigured,
         lastSyncedAt: insertNow,
         updatedAt: insertNow,
       }).where(eq(adsConnections.projectId, projectId)).run()

--- a/packages/canonry/test/ads-sync.test.ts
+++ b/packages/canonry/test/ads-sync.test.ts
@@ -140,6 +140,9 @@ describe('executeAdsSync', () => {
     expect(campaignDay?.spendMicros).toBe(39_280_000)
     expect(campaignDay?.impressions).toBe(1736)
     expect(campaignDay?.clicks).toBe(23)
+    // No conversions field on the insight rows → defaults to 0 (the API omits
+    // it when the account has no conversion tracking).
+    expect(campaignDay?.conversions).toBe(0)
     const groupDay = insightRows.find((r) => r.level === 'ad_group')
     expect(groupDay?.entityId).toBe('adgrp_ddd')
     expect(groupDay?.spendMicros).toBe(570_000)
@@ -149,6 +152,50 @@ describe('executeAdsSync', () => {
     expect(conn?.currencyCode).toBe('USD')
     expect(conn?.status).toBe('active')
     expect(conn?.lastSyncedAt).toBeTruthy()
+    // CAMPAIGN carries an empty conversion_event_setting_ids → tracking off.
+    expect(conn?.conversionTrackingConfigured).toBe(false)
+  })
+
+  it('captures conversion counts and flags the connection when conversion tracking is configured', async () => {
+    const db = createTempDb()
+    seed(db)
+
+    // A conversion-tracking account: the campaign carries a configured event id
+    // and the insight rows return a conversions metric (fractional attribution
+    // figures round to the integer column).
+    const trackedCampaign = { ...CAMPAIGN, conversion_event_setting_ids: ['cevent_1111'] }
+    const trackedCampaignInsights = [
+      { id: 'r1', start_time: 1, end_time: 2, readable_time: '2026-06-09', impressions: 3326, clicks: 40, spend: 90.45, conversions: 5 },
+      { id: 'r2', start_time: 2, end_time: 3, readable_time: '2026-06-10', impressions: 1736, clicks: 23, spend: 39.28, conversions: 2.6 },
+    ]
+    const trackedGroupInsights = [
+      { id: 'r3', start_time: 2, end_time: 3, readable_time: '2026-06-10', impressions: 64, clicks: 1, spend: 0.57, conversions: 1 },
+    ]
+    globalThis.fetch = async (url: string | URL | Request) => {
+      const u = String(url)
+      const respond = (payload: unknown) => new Response(JSON.stringify(payload), { status: 200 })
+      if (u.endsWith('/ad_account')) return respond(ACCOUNT)
+      if (u.includes('/campaigns/cmpn_bbb/insights')) return respond(list(trackedCampaignInsights))
+      if (u.includes('/ad_groups/adgrp_ddd/insights')) return respond(list(trackedGroupInsights))
+      if (u.includes('/campaigns')) return respond(list([trackedCampaign]))
+      if (u.includes('/ad_groups?campaign_id=cmpn_bbb')) return respond(list([AD_GROUP]))
+      if (u.includes('/ads?ad_group_id=adgrp_ddd')) return respond(list([AD]))
+      throw new Error(`unexpected URL in test: ${u}`)
+    }
+
+    await executeAdsSync(db, 'run_1', 'proj_1', { config: testConfig() })
+
+    const insightRows = db.select().from(adsInsightsDaily).all()
+    const campaignJun9 = insightRows.find((r) => r.level === 'campaign' && r.date === '2026-06-09')
+    expect(campaignJun9?.conversions).toBe(5)
+    const campaignJun10 = insightRows.find((r) => r.level === 'campaign' && r.date === '2026-06-10')
+    // 2.6 attribution figure → rounds to 3 in the integer column.
+    expect(campaignJun10?.conversions).toBe(3)
+    const groupDay = insightRows.find((r) => r.level === 'ad_group')
+    expect(groupDay?.conversions).toBe(1)
+
+    const conn = db.select().from(adsConnections).where(eq(adsConnections.projectId, 'proj_1')).get()
+    expect(conn?.conversionTrackingConfigured).toBe(true)
   })
 
   it('is idempotent: a re-sync replaces snapshots and upserts insights without duplicating', async () => {

--- a/packages/contracts/src/ads.ts
+++ b/packages/contracts/src/ads.ts
@@ -20,6 +20,10 @@ export const adsConnectionStatusDtoSchema = z.object({
   timezone: z.string().nullable().optional(),
   status: z.string().nullable().optional(),
   lastSyncedAt: z.string().nullable().optional(),
+  /** Whether the ad account has OpenAI conversion tracking (pixel or CAPI) configured,
+   *  detected from synced campaigns carrying conversion_event_setting_ids. Optional:
+   *  only present when connected. */
+  conversionTrackingConfigured: z.boolean().optional(),
 })
 export type AdsConnectionStatusDto = z.infer<typeof adsConnectionStatusDtoSchema>
 
@@ -99,6 +103,10 @@ export const adsInsightRowDtoSchema = z.object({
   impressions: z.number().int(),
   clicks: z.number().int(),
   spendMicros: z.number().int(),
+  /** Conversion count for the row. 0 when conversion tracking is not configured.
+   *  Conversion VALUE (for ROAS) is a deliberate follow-up: the upstream value
+   *  field is not yet captured against a live conversion-tracking account. */
+  conversions: z.number().int(),
   /** clicks / impressions; null when impressions is 0. */
   ctr: z.number().nullable(),
   /** spendMicros / clicks, rounded to integer micros; null when clicks is 0. */
@@ -117,6 +125,7 @@ export const adsTotalsDtoSchema = z.object({
   impressions: z.number().int(),
   clicks: z.number().int(),
   spendMicros: z.number().int(),
+  conversions: z.number().int(),
   ctr: z.number().nullable(),
   cpcMicros: z.number().int().nullable(),
 })

--- a/packages/contracts/test/ads.test.ts
+++ b/packages/contracts/test/ads.test.ts
@@ -5,6 +5,7 @@ import {
   adsInsightRowDtoSchema,
   adsSummaryDtoSchema,
   adsCampaignDtoSchema,
+  adsConnectionStatusDtoSchema,
 } from '../src/ads.js'
 
 describe('adsCtr', () => {
@@ -35,9 +36,23 @@ describe('DTO schemas', () => {
   test('insight row accepts derived nulls for zero denominators', () => {
     const parsed = adsInsightRowDtoSchema.parse({
       level: 'campaign', entityId: 'cmpn_x', date: '2026-06-10',
-      impressions: 0, clicks: 0, spendMicros: 0, ctr: null, cpcMicros: null,
+      impressions: 0, clicks: 0, spendMicros: 0, conversions: 0, ctr: null, cpcMicros: null,
     })
     expect(parsed.ctr).toBeNull()
+    expect(parsed.conversions).toBe(0)
+  })
+
+  test('insight row requires an integer conversions count', () => {
+    // Missing → invalid (the field is required so a zero is always explicit).
+    expect(adsInsightRowDtoSchema.safeParse({
+      level: 'campaign', entityId: 'cmpn_x', date: '2026-06-10',
+      impressions: 10, clicks: 1, spendMicros: 1000, ctr: 0.1, cpcMicros: 1000,
+    }).success).toBe(false)
+    // Fractional → invalid (the column is an integer; rounding happens at ingest).
+    expect(adsInsightRowDtoSchema.safeParse({
+      level: 'campaign', entityId: 'cmpn_x', date: '2026-06-10',
+      impressions: 10, clicks: 1, spendMicros: 1000, conversions: 2.5, ctr: 0.1, cpcMicros: 1000,
+    }).success).toBe(false)
   })
 
   test('campaign DTO defaults nested collections', () => {
@@ -45,13 +60,28 @@ describe('DTO schemas', () => {
     expect(parsed.adGroups).toEqual([])
   })
 
-  test('summary requires window and totals', () => {
+  test('summary requires window and totals incl. conversions', () => {
     const ok = adsSummaryDtoSchema.safeParse({
       connected: true, campaignCount: 2, adGroupCount: 16, adCount: 20,
       window: { from: '2026-06-07', to: '2026-06-10' },
-      totals: { impressions: 18047, clicks: 235, spendMicros: 498_470_000, ctr: 0.013, cpcMicros: 2_121_148 },
+      totals: { impressions: 18047, clicks: 235, spendMicros: 498_470_000, conversions: 9, ctr: 0.013, cpcMicros: 2_121_148 },
     })
     expect(ok.success).toBe(true)
+    expect(ok.success && ok.data.totals.conversions).toBe(9)
+    // totals without conversions is now invalid (the field is required).
+    expect(adsSummaryDtoSchema.safeParse({
+      connected: true, campaignCount: 0, adGroupCount: 0, adCount: 0,
+      window: { from: null, to: null },
+      totals: { impressions: 0, clicks: 0, spendMicros: 0, ctr: null, cpcMicros: null },
+    }).success).toBe(false)
     expect(adsSummaryDtoSchema.safeParse({ connected: false }).success).toBe(false)
+  })
+
+  test('connection status carries an optional conversionTrackingConfigured flag', () => {
+    // Optional: a disconnected status omits it.
+    expect(adsConnectionStatusDtoSchema.parse({ connected: false }).conversionTrackingConfigured).toBeUndefined()
+    // Present when connected.
+    const parsed = adsConnectionStatusDtoSchema.parse({ connected: true, conversionTrackingConfigured: true })
+    expect(parsed.conversionTrackingConfigured).toBe(true)
   })
 })

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1834,6 +1834,14 @@ export const MIGRATION_VERSIONS: ReadonlyArray<MigrationVersion> = [
       `CREATE INDEX IF NOT EXISTS idx_gbp_attributes_loc ON gbp_attributes_snapshots(project_id, location_name, synced_at)`,
     ],
   },
+  {
+    version: 83,
+    name: 'ads-insights-conversions',
+    statements: [
+      `ALTER TABLE ads_insights_daily ADD COLUMN conversions INTEGER NOT NULL DEFAULT 0`,
+      `ALTER TABLE ads_connections ADD COLUMN conversion_tracking_configured INTEGER NOT NULL DEFAULT 0`,
+    ],
+  },
 ]
 
 /**

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1180,6 +1180,7 @@ export const adsConnections = sqliteTable('ads_connections', {
   timezone: text('timezone'),
   status: text('status'),
   lastSyncedAt: text('last_synced_at'),
+  conversionTrackingConfigured: integer('conversion_tracking_configured', { mode: 'boolean' }).notNull().default(false),
   createdAt: text('created_at').notNull(),
   updatedAt: text('updated_at').notNull(),
 }, (table) => [
@@ -1259,6 +1260,7 @@ export const adsInsightsDaily = sqliteTable('ads_insights_daily', {
   impressions: integer('impressions').notNull().default(0),
   clicks: integer('clicks').notNull().default(0),
   spendMicros: integer('spend_micros').notNull().default(0),
+  conversions: integer('conversions').notNull().default(0),
   syncRunId: text('sync_run_id').references(() => runs.id, { onDelete: 'set null' }),
 }, (table) => [
   uniqueIndex('uniq_ads_insights_daily').on(table.projectId, table.level, table.entityId, table.date),

--- a/packages/integration-openai-ads/src/types.ts
+++ b/packages/integration-openai-ads/src/types.ts
@@ -112,6 +112,9 @@ export interface OpenAiAdsInsightRow {
   impressions?: number
   clicks?: number
   spend?: number
+  /** Conversion count. Only present when requested via fields[] (campaign.conversions /
+   *  ad_group.conversions) and the account has conversion tracking configured. */
+  conversions?: number
   ctr?: number
   cpc?: number
   cpm?: number

--- a/packages/integration-openai-ads/test/fixtures.ts
+++ b/packages/integration-openai-ads/test/fixtures.ts
@@ -102,12 +102,18 @@ export const FIXTURE_INSIGHT_ROW_DEFAULT: OpenAiAdsInsightRow = {
   start_time: 1781071200,
 }
 
-// With fields[]= requested: clicks/ctr/cpc/spend appear; spend and cpc are
-// DECIMAL DOLLARS (not micros) in production responses.
+// With fields[]= requested: clicks/ctr/cpc/spend/conversions appear; spend and
+// cpc are DECIMAL DOLLARS (not micros) in production responses. `conversions` is
+// the documented campaign.conversions / ad_group.conversions field — present
+// only when the account has conversion tracking configured (this row models a
+// conversion-tracking account, matching FIXTURE_CAMPAIGN's non-empty
+// conversion_event_setting_ids); refresh the count from a live capture when one
+// is available.
 export const FIXTURE_INSIGHT_ROW_FULL: OpenAiAdsInsightRow = {
   id: 'start=1781071200:end=1781157600:entity_id=cmpn_0000000000000000000000000000bbbb',
   campaign_name: 'Homeowners Free Estimate',
   clicks: 23,
+  conversions: 4,
   cpc: 1.71,
   ctr: 0.0132,
   end_time: 1781157600,


### PR DESCRIPTION
## What

Extends the OpenAI ads integration to read and surface conversion data, the missing producer side of the operator-readiness conversion gate.

- Requests `campaign.conversions` / `ad_group.conversions` from the Advertiser Insights API and persists an integer conversion count on the daily paid-performance rollups (`ads_insights_daily.conversions`).
- Surfaces `conversions` on `GET /ads/insights` rows and on the `GET /ads/summary` campaign-level totals (campaign rows only, so ad-group subdivisions are never double-counted).
- Detects whether the connected account has conversion tracking configured from synced campaigns carrying `conversion_event_setting_ids`, stores it on the connection row, and returns it as `conversionTrackingConfigured` on `GET /ads/status`.

## Why

Downstream consumers gate the real-money budget recommendation on a trusted conversion signal, but the engine had no conversion surface at all. This is the additive producer half: it lights up the conversion count and the tracking-configured flag the readiness ladder consumes. All fields are additive (no path or method changes).

## Notes

- Schema migration v83 adds the two columns (idempotent `ALTER TABLE ADD COLUMN`).
- Fractional attribution figures are rounded to the integer column at ingest.
- Conversion value (for ROAS) is a deliberate follow-up: the upstream value field is not yet captured against a live conversion-tracking account, so this PR scopes to the conversion count only.
- SDK regenerated via `pnpm gen`; version bumped to 4.96.0.

## Tests

- Round-trip: conversion count flows insight row → rollup → DTO → summary totals; fractional rounds (2.6 → 3); zero default when the field is absent.
- Detection: `conversionTrackingConfigured` true when a campaign carries an event id, false when none do.
- Contract: `conversions` required and integer-only on the insight-row / totals DTOs; `conversionTrackingConfigured` optional on status.
- Route: status flag, summary campaign-only conversion sum, insights-row conversion.
- Full gate green: typecheck, lint (0 errors), 1988 tests across the changed packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)