### PR TITLE
feat(web,report): name-based project URLs and configurable report period

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ canonry visibility-stats <project> --since 2026-06-01 --until 2026-06-30 --forma
 canonry apply <file...>                          # multi-doc YAML + multiple files
 canonry export <project>
 canonry report <project>                         # client-facing AEO report → canonry-report-<project>-YYYY-MM-DD.html
+canonry report <project> --period 7              # window (7|14|30|90, default 30): scopes GSC/GA/server-activity + the period-over-period deltas
 canonry report <project> --output dist/aeo.html
 canonry report <project> --format json           # raw report payload to stdout
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -566,8 +566,8 @@ export function RootLayout() {
                 return (
                   <Link
                     key={projectVm.project.id}
-                    to="/projects/$projectId"
-                    params={{ projectId: projectVm.project.id }}
+                    to="/projects/$projectName"
+                    params={{ projectName: projectVm.project.name }}
                     className="sidebar-project"
                     activeProps={{ className: 'sidebar-project sidebar-project-active' }}
                   >
@@ -691,8 +691,8 @@ export function RootLayout() {
               {safeDashboard.projects.map((projectVm) => (
                 <Link
                   key={projectVm.project.id}
-                  to="/projects/$projectId"
-                  params={{ projectId: projectVm.project.id }}
+                  to="/projects/$projectName"
+                  params={{ projectName: projectVm.project.name }}
                   className="mobile-nav-link"
                 >
                   {projectVm.project.name}

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1418,9 +1418,10 @@ function parseFilenameFromContentDisposition(header: string | null): string | nu
 // Blob download — keep raw fetch so we can read the binary body + parse
 // the Content-Disposition filename. The generated SDK would JSON-parse the
 // response and discard the binary payload.
-export async function downloadReportHtml(project: string, audience: ReportAudience = 'agency'): Promise<void> {
+export async function downloadReportHtml(project: string, audience: ReportAudience = 'agency', period?: number): Promise<void> {
   const key = getApiKey()
   const params = new URLSearchParams({ audience })
+  if (period !== undefined) params.set('period', String(period))
   const res = await fetch(`${API_BASE}/projects/${encodeURIComponent(project)}/report.html?${params.toString()}`, {
     credentials: 'same-origin',
     headers: key ? { Authorization: `Bearer ${key}` } : {},

--- a/apps/web/src/build-dashboard.ts
+++ b/apps/web/src/build-dashboard.ts
@@ -814,7 +814,7 @@ function buildAttentionItems(projectCenters: ProjectCommandCenterVm[]) {
         title: `${pc.project.displayName || pc.project.name} lost citations`,
         detail: `${lostEvidence.length} quer${lostEvidence.length > 1 ? 'ies' : 'y'} lost citation.`,
         actionLabel: 'Open project',
-        href: `/projects/${pc.project.id}`,
+        href: `/projects/${encodeURIComponent(pc.project.name)}`,
       })
     }
 

--- a/apps/web/src/components/shared/AeroBar.tsx
+++ b/apps/web/src/components/shared/AeroBar.tsx
@@ -1235,11 +1235,11 @@ function TypingIndicator() {
  * when we're on a project-scoped route. Keeps the bar hidden on overview /
  * settings / setup pages where there's no project context to ask about.
  *
- * The `/projects/$projectId` route carries the project's UUID, not its
- * name. Aero's server routes (and the whole agent-first API surface) key
- * off the project name, so we resolve UUID → name via the cached project
- * list before rendering. Accepts a name in the URL slot too — harmless
- * fallback if the route ever changes to use slugs.
+ * The `/projects/$projectName` route carries the project's name. Aero's
+ * server routes (and the whole agent-first API surface) key off the name,
+ * so we use the URL segment directly. A UUID is still accepted in the slot
+ * too — a harmless fallback for legacy links that resolves id → name via
+ * the cached project list before rendering.
  */
 export function AeroBarHost() {
   const location = useLocation()

--- a/apps/web/src/pages/OverviewPage.tsx
+++ b/apps/web/src/pages/OverviewPage.tsx
@@ -21,8 +21,8 @@ function OverviewProjectCard({
 }) {
   return (
     <Link
-      to="/projects/$projectId"
-      params={{ projectId: project.project.id }}
+      to="/projects/$projectName"
+      params={{ projectName: project.project.name }}
       className="project-row cursor-pointer"
     >
       <div className="project-row-chart">

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -1530,20 +1530,22 @@ function SuggestedQueriesCard({
  * pre-refactor code path.
  */
 export function ProjectPage(props: { tab: ProjectPageTab }) {
-  const { projectId } = useParams({ from: '/projects/$projectId' })
-  // Resolve project name: prefer the SSR/test fixture (synchronous, no
-  // query needed); otherwise hit the shared `/projects` cache that
-  // `useDashboardOverview` populates.
+  const { projectName: routeIdentifier } = useParams({ from: '/projects/$projectName' })
+  // The URL carries the project name (the canonical identifier). Match by name
+  // first; fall back to matching by id so a legacy UUID-shaped URL that wasn't
+  // caught by the route-level redirect (e.g. cold cache, SSR) still resolves.
+  // Prefer the SSR/test fixture (synchronous, no query needed); otherwise hit
+  // the shared `/projects` cache that `useDashboardOverview` populates.
   const contextDashboard = useInitialDashboard()
   const nameFromContext = contextDashboard?.dashboard.projects.find(
-    p => p.project.id === projectId,
+    p => p.project.name === routeIdentifier || p.project.id === routeIdentifier,
   )?.project.name ?? null
   const projectsListQuery = useQuery({
     ...getApiV1ProjectsOptions({ client: heyClient }),
     enabled: !nameFromContext,
   })
   const lookupProjectName = nameFromContext
-    ?? projectsListQuery.data?.find(p => p.id === projectId)?.name
+    ?? projectsListQuery.data?.find(p => p.name === routeIdentifier || p.id === routeIdentifier)?.name
     ?? null
   const {
     commandCenter: model,
@@ -1553,8 +1555,8 @@ export function ProjectPage(props: { tab: ProjectPageTab }) {
   const isLoading = (!nameFromContext && projectsListQuery.isLoading) || dashboardLoading
 
   // Not-found state: both context and the projects-list query resolved
-  // (loading is done), but neither could match the URL's projectId to a
-  // known project name. Render the explicit not-found rather than the
+  // (loading is done), but neither could match the URL's identifier to a
+  // known project. Render the explicit not-found rather than the
   // indefinite skeleton so the user can navigate away.
   const isNotFound = !lookupProjectName
     && !nameFromContext
@@ -1566,7 +1568,7 @@ export function ProjectPage(props: { tab: ProjectPageTab }) {
       <div className="page-container">
         <Card className="surface-card empty-card">
           <h1>Project not found</h1>
-          <p>Could not find a project with ID "{projectId}".</p>
+          <p>Could not find a project named "{routeIdentifier}".</p>
           <Button asChild>
             <Link to="/">Return to overview</Link>
           </Button>
@@ -1807,7 +1809,7 @@ function ProjectPageContent({
   // `if (!model)` branch removed — the wrapper guarantees `model` is set
   // by the time we render `ProjectPageContent`. The wrapper also owns the
   // "project not found" state (when both context and /projects list have
-  // resolved but neither matched the URL's projectId).
+  // resolved but neither matched the URL's identifier).
 
   async function handleTriggerRun() {
     try {
@@ -2006,7 +2008,7 @@ function ProjectPageContent({
   // underline on the bar's hairline. Low-frequency sections (Report) live in a
   // trailing "More" overflow; Settings is split out at the far right (universal
   // convention). "Local Presence" only appears once GBP is connected.
-  const projectTabBase = `/projects/${model.project.id}`
+  const projectTabBase = `/projects/${encodeURIComponent(model.project.name)}`
   const projectTabItems: ProjectTabItem[] = [
     { key: 'overview', label: 'Overview', href: projectTabBase },
     { key: 'search-console', label: 'Search Engines', href: `${projectTabBase}/search-console` },

--- a/apps/web/src/pages/ProjectsPage.tsx
+++ b/apps/web/src/pages/ProjectsPage.tsx
@@ -85,7 +85,7 @@ export function ProjectsPage() {
       setCountry('US')
       setLanguage('en')
       setShowForm(false)
-      void navigate({ to: '/projects/$projectId', params: { projectId: project.id } })
+      void navigate({ to: '/projects/$projectName', params: { projectName: project.name } })
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create project')
     } finally {
@@ -210,11 +210,11 @@ export function ProjectsPage() {
               {projects.map((p) => {
                 const latestRun = p.recentRuns[0]
                 return (
-                  <tr key={p.project.id} className="cursor-pointer" onClick={() => { void navigate({ to: '/projects/$projectId', params: { projectId: p.project.id } }) }}>
+                  <tr key={p.project.id} className="cursor-pointer" onClick={() => { void navigate({ to: '/projects/$projectName', params: { projectName: p.project.name } }) }}>
                     <td>
                       <Link
-                        to="/projects/$projectId"
-                        params={{ projectId: p.project.id }}
+                        to="/projects/$projectName"
+                        params={{ projectName: p.project.name }}
                         className="text-zinc-100 font-medium hover:underline"
                         onClick={(e) => e.stopPropagation()}
                       >

--- a/apps/web/src/pages/ReportPage.tsx
+++ b/apps/web/src/pages/ReportPage.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, keepPreviousData } from '@tanstack/react-query'
 import { Download } from 'lucide-react'
 import type {
   ProjectReportDto,
   ReportActionPlanItem,
   ReportAudience,
   ReportInsight,
+  ReportPeriodDays,
 } from '@ainyc/canonry-contracts'
 import {
   contentActionLabel,
@@ -15,6 +16,8 @@ import {
   formatAverageDelta,
   formatDeltaCopy,
   formatWindowCountDelta,
+  REPORT_DEFAULT_PERIOD_DAYS,
+  REPORT_PERIOD_OPTIONS,
   reportActionCategoryLabel,
   reportActionTone,
   reportConfidenceLabel,
@@ -71,16 +74,20 @@ function formatLocationLabel(location: NonNullable<ProjectReportDto['meta']['loc
 export function ReportPage({ projectName }: { projectName: string }) {
   const [downloading, setDownloading] = useState(false)
   const [downloadError, setDownloadError] = useState<string | null>(null)
+  const [period, setPeriod] = useState<ReportPeriodDays>(REPORT_DEFAULT_PERIOD_DAYS)
 
-  const reportQuery = useQuery(
-    getApiV1ProjectsByNameReportOptions({ client: heyClient, path: { name: projectName } }),
-  )
+  const reportQuery = useQuery({
+    ...getApiV1ProjectsByNameReportOptions({ client: heyClient, path: { name: projectName }, query: { period } }),
+    // Keep the current report on screen while a new period loads so the
+    // toggle and content don't flash to a full-page skeleton on every switch.
+    placeholderData: keepPreviousData,
+  })
 
   async function handleDownload() {
     setDownloading(true)
     setDownloadError(null)
     try {
-      await downloadReportHtml(projectName, 'client')
+      await downloadReportHtml(projectName, 'client', period)
     } catch (err) {
       const message = err instanceof ApiError ? err.message : err instanceof Error ? err.message : 'Download failed'
       setDownloadError(message)
@@ -114,11 +121,13 @@ export function ReportPage({ projectName }: { projectName: string }) {
             {report.meta.location
               ? ` · Location: ${formatLocationLabel(report.meta.location)}`
               : ' · No location set'}
+            {' · '}Last {report.meta.periodDays} days
             {' · '}Generated {formatDate(report.meta.generatedAt)}
           </p>
           {downloadError && <p className="mt-2 text-xs text-rose-400">{downloadError}</p>}
         </div>
-        <div className="page-header-right">
+        <div className="page-header-right flex flex-col items-end gap-2">
+          <PeriodToggle period={period} onChange={setPeriod} />
           <Button
             variant="secondary"
             size="sm"
@@ -140,12 +149,51 @@ export function ReportPage({ projectName }: { projectName: string }) {
   )
 }
 
+// Time-window selector. Re-fetches the report scoped to the chosen window
+// (the API recomputes every section + comparison for it). Pill/filter-chip
+// styling per the design system.
+function PeriodToggle({
+  period,
+  onChange,
+}: {
+  period: ReportPeriodDays
+  onChange: (p: ReportPeriodDays) => void
+}) {
+  return (
+    <div
+      className="inline-flex items-center gap-0.5 rounded-full border border-zinc-800/60 bg-zinc-900/40 p-0.5"
+      role="group"
+      aria-label="Report time period"
+    >
+      {REPORT_PERIOD_OPTIONS.map((opt) => {
+        const active = opt === period
+        return (
+          <button
+            key={opt}
+            type="button"
+            onClick={() => onChange(opt)}
+            aria-pressed={active}
+            className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+              active ? 'bg-zinc-200 text-zinc-900' : 'text-zinc-400 hover:text-zinc-100'
+            }`}
+          >
+            {opt}d
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
 // Section heading for the server-side AI visibility view. Mirrors the
 // HTML renderer's `serverActivityHeading('client', …)` per the
 // report-parity rule — eyebrow, title, and subtitle must match verbatim.
 const SERVER_ACTIVITY_TITLE = 'AI Visibility — Server-Side'
 const SERVER_ACTIVITY_EYEBROW_CLIENT = 'AI engine attention'
-const SERVER_ACTIVITY_INTRO_HAS_DATA = 'What AI engines actually do in your server logs over the last 7 days — the other half of citations.'
+// Window-aware so the copy honors the selected report period; must match the
+// HTML renderer's `serverActivityHeading` intro verbatim.
+const serverActivityIntroHasData = (periodDays: number): string =>
+  `What AI engines actually do in your server logs over the last ${periodDays} days — the other half of citations.`
 const SERVER_ACTIVITY_INTRO_NO_DATA = 'Live telemetry from your server logs.'
 
 /**
@@ -181,10 +229,12 @@ function ServerActivityClientView({ report }: { report: ProjectReportDto }) {
       sa.verifiedCrawlerHits.prior + sa.unverifiedCrawlerHits.prior,
     ),
   }
-  const crawlerDelta = formatDeltaCopy(crawlerRequests, 'requests')
+  const windowDays = report.meta.periodDays
+  const priorWindowLabel = `vs prior ${windowDays} days`
+  const crawlerDelta = formatDeltaCopy(crawlerRequests, 'requests', priorWindowLabel)
   const crawlerSubtitle = `${formatNumber(sa.verifiedCrawlerHits.current)} verified · ${formatNumber(sa.unverifiedCrawlerHits.current)} unverified${crawlerDelta ? ` · ${crawlerDelta}` : ''}`
-  const userFetchDelta = formatDeltaCopy(sa.aiUserFetchHits, 'requests')
-  const referralDelta = formatDeltaCopy(sa.referralArrivals, 'sessions')
+  const userFetchDelta = formatDeltaCopy(sa.aiUserFetchHits, 'requests', priorWindowLabel)
+  const referralDelta = formatDeltaCopy(sa.referralArrivals, 'sessions', priorWindowLabel)
   // For the client view we cap at the top 5 entries — agencies see the full breakdown in the HTML report.
   const topOperators = sa.byOperator
     .filter(o => o.verifiedHits > 0 || o.unverifiedHits > 0 || o.userFetchHits > 0 || o.referralArrivals > 0)
@@ -195,7 +245,7 @@ function ServerActivityClientView({ report }: { report: ProjectReportDto }) {
       <SectionHeading
         eyebrow={SERVER_ACTIVITY_EYEBROW_CLIENT}
         title={SERVER_ACTIVITY_TITLE}
-        subtitle={SERVER_ACTIVITY_INTRO_HAS_DATA}
+        subtitle={serverActivityIntroHasData(windowDays)}
       />
       <div className="grid gap-3 sm:grid-cols-3">
         <Metric
@@ -222,8 +272,8 @@ function ServerActivityClientView({ report }: { report: ProjectReportDto }) {
               <thead>
                 <tr>
                   <th>AI tool</th>
-                  <th>Bot requests (7d)</th>
-                  <th>User fetches (7d)</th>
+                  <th>Bot requests ({windowDays}d)</th>
+                  <th>User fetches ({windowDays}d)</th>
                   <th>Referral sessions</th>
                 </tr>
               </thead>
@@ -671,8 +721,6 @@ function ClientEvidenceSection({ report }: { report: ProjectReportDto }) {
 
 // ─── Section: What's Changed ───────────────────────────────────────────────
 
-const WHATS_CHANGED_PERIOD_DAYS = 14
-
 function deltaTone(direction: 'up' | 'down' | 'flat'): MetricTone {
   if (direction === 'up') return 'positive'
   if (direction === 'down') return 'negative'
@@ -730,10 +778,12 @@ function TrafficDeltaTile({
   label,
   delta,
   countLabel,
+  comparisonWindowDays,
 }: {
   label: string
   delta: ProjectReportDto['whatsChanged']['gscClicksDelta']
   countLabel: string
+  comparisonWindowDays: number
 }) {
   if (!delta) {
     return (
@@ -750,7 +800,7 @@ function TrafficDeltaTile({
     : 'text-zinc-100'
   // Shared "smart %" formatter — same helper the HTML renderer calls, so both
   // surfaces emit byte-identical copy per the report-parity rule.
-  const deltaText = formatWindowCountDelta(delta, countLabel, `vs prior ${WHATS_CHANGED_PERIOD_DAYS} days`)
+  const deltaText = formatWindowCountDelta(delta, countLabel, `vs prior ${comparisonWindowDays} days`)
   return (
     <div className="rounded-xl border border-zinc-800/60 bg-zinc-900/30 px-4 py-3">
       <p className="eyebrow-soft">{label}</p>
@@ -896,8 +946,8 @@ function WhatsChangedSection({ report, audience }: { report: ProjectReportDto; a
         <RateDeltaTile label={isClient ? 'AI links to your website' : 'Citation rate'} delta={w.citationRate} unit="%" />
         <RateDeltaTile label={isClient ? 'AI mentions your name' : 'Mention rate'} delta={w.mentionRate} unit="%" />
         <RateDeltaTile label={isClient ? 'Questions AI answered with you' : 'Cited queries'} delta={w.citedQueryCount} unit="count" />
-        <TrafficDeltaTile label={isClient ? 'Visitors from Google' : 'GSC clicks'} delta={w.gscClicksDelta} countLabel={isClient ? 'visits' : 'clicks'} />
-        <TrafficDeltaTile label={isClient ? 'Visitors from AI tools' : 'AI referral sessions'} delta={w.aiReferralsDelta} countLabel={isClient ? 'visits' : 'sessions'} />
+        <TrafficDeltaTile label={isClient ? 'Visitors from Google' : 'GSC clicks'} delta={w.gscClicksDelta} countLabel={isClient ? 'visits' : 'clicks'} comparisonWindowDays={w.comparisonWindowDays} />
+        <TrafficDeltaTile label={isClient ? 'Visitors from AI tools' : 'AI referral sessions'} delta={w.aiReferralsDelta} countLabel={isClient ? 'visits' : 'sessions'} comparisonWindowDays={w.comparisonWindowDays} />
       </div>
       <ProviderMovementsTable movements={w.providerMovements} audience={audience} />
       <WinsLossesTable insights={w.wins} heading={isClient ? 'What got better' : 'Wins'} emptyMessage={isClient ? 'No new wins this period.' : 'No new gains in the latest check.'} audience={audience} />

--- a/apps/web/src/pages/SetupPage.tsx
+++ b/apps/web/src/pages/SetupPage.tsx
@@ -96,7 +96,6 @@ export function SetupPage() {
   const [language, setLanguage] = useState('en')
   const [autoExtractBacklinks, setAutoExtractBacklinks] = useState(false)
   const [createdProjectName, setCreatedProjectName] = useState<string | null>(null)
-  const [createdProjectId, setCreatedProjectId] = useState<string | null>(null)
   const [projectError, setProjectError] = useState<string | null>(null)
   const [projectSaving, setProjectSaving] = useState(false)
 
@@ -172,7 +171,6 @@ export function SetupPage() {
         autoExtractBacklinks,
       })
       setCreatedProjectName(slug)
-      setCreatedProjectId(project.id)
       addToast({
         title: 'Project created',
         detail: `${project.displayName || project.name} is ready for setup.`,
@@ -651,7 +649,7 @@ export function SetupPage() {
                 </div>
                 <div className="setup-nav">
                   <span />
-                  <Button type="button" variant="outline" onClick={() => { void navigate({ to: createdProjectId ? `/projects/${createdProjectId}` : '/' }) }}>
+                  <Button type="button" variant="outline" onClick={() => { void navigate({ to: createdProjectName ? `/projects/${encodeURIComponent(createdProjectName)}` : '/' }) }}>
                     Watch on project page
                   </Button>
                 </div>
@@ -661,7 +659,7 @@ export function SetupPage() {
                 <p className="text-rose-400">Sweep failed. Inspect the run on the project page for the provider error and retry from there.</p>
                 <div className="setup-nav">
                   <span />
-                  <Button type="button" onClick={() => { void navigate({ to: createdProjectId ? `/projects/${createdProjectId}` : '/' }) }}>
+                  <Button type="button" onClick={() => { void navigate({ to: createdProjectName ? `/projects/${encodeURIComponent(createdProjectName)}` : '/' }) }}>
                     Open project
                   </Button>
                 </div>
@@ -694,7 +692,7 @@ export function SetupPage() {
                 </p>
                 <div className="setup-nav">
                   <span />
-                  <Button type="button" onClick={() => { void navigate({ to: createdProjectId ? `/projects/${createdProjectId}` : '/' }) }}>
+                  <Button type="button" onClick={() => { void navigate({ to: createdProjectName ? `/projects/${encodeURIComponent(createdProjectName)}` : '/' }) }}>
                     Open project dashboard →
                   </Button>
                 </div>

--- a/apps/web/src/router/routes.tsx
+++ b/apps/web/src/router/routes.tsx
@@ -14,7 +14,7 @@ import { ProjectsPage } from '../pages/ProjectsPage.js'
 import { SetupPage } from '../pages/SetupPage.js'
 import { NotFoundPage } from '../pages/NotFoundPage.js'
 import { heyClient } from '../api.js'
-import { getApiV1ProjectsQueryKey } from '@ainyc/canonry-api-client/react-query'
+import { getApiV1ProjectsQueryKey, getApiV1ProjectsOptions } from '@ainyc/canonry-api-client/react-query'
 
 // `lazyRouteComponent` (not React.lazy) handles route-level code splitting
 // in TanStack Router. The key advantage over `React.lazy` + `Suspense` is
@@ -100,11 +100,50 @@ export const projectsRoute = createRoute({
   component: ProjectsPage,
 })
 
+// Project URLs key off the human-readable project name (a kebab-case slug),
+// not the opaque UUID — `/projects/acme-co/report` instead of
+// `/projects/<uuid>/report`. The API already resolves projects by name, so
+// the name is the canonical identifier across the whole surface.
+const PROJECT_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 // Layout route for project tabs — renders Outlet to pass through to sub-routes
 export const projectLayoutRoute = createRoute({
   getParentRoute: () => rootRoute,
-  path: '/projects/$projectId',
+  path: '/projects/$projectName',
   component: () => <Outlet />,
+  // Legacy compatibility: project URLs used to carry the UUID. When an old
+  // UUID-shaped segment arrives (e.g. a stale bookmark), resolve it to the
+  // current name and redirect to the clean URL, preserving the tab sub-path.
+  // Name-shaped segments skip the lookup entirely — zero overhead on the
+  // common path.
+  beforeLoad: async ({ context, params, location }) => {
+    const segment = params.projectName
+    if (!PROJECT_UUID_RE.test(segment)) return
+    // Read the already-loaded projects list synchronously (the sidebar /
+    // overview populate it); only fetch if it's genuinely absent.
+    let projects = context.queryClient.getQueryData(
+      getApiV1ProjectsQueryKey({ client: heyClient }),
+    ) as Array<{ id: string; name: string }> | undefined
+    if (!projects) {
+      try {
+        projects = await context.queryClient.ensureQueryData(getApiV1ProjectsOptions({ client: heyClient }))
+      } catch {
+        // Best-effort: if the list can't be resolved (auth/network), don't
+        // block navigation — ProjectPage resolves the id itself or shows
+        // its not-found state.
+        return
+      }
+    }
+    const match = projects.find((p) => p.id === segment)
+    if (!match) return
+    throw redirect({
+      to: location.pathname.replace(
+        `/projects/${segment}`,
+        `/projects/${encodeURIComponent(match.name)}`,
+      ),
+      replace: true,
+    })
+  },
 })
 
 export const projectOverviewRoute = createRoute({

--- a/apps/web/test/router.test.tsx
+++ b/apps/web/test/router.test.tsx
@@ -49,9 +49,36 @@ test('/projects renders the projects page', async () => {
   expect(container.querySelector('.page-title')?.textContent).toBe('Projects')
 })
 
-test('/projects/$id renders the project page', async () => {
+test('/projects/$name resolves a project by its name', async () => {
+  const { container } = await renderRoute('/projects/Citypoint%20Dental%20NYC')
+  expect(container.innerHTML).toMatch(/Citypoint Dental NYC/)
+})
+
+test('/projects/$id still resolves a legacy id-based URL', async () => {
   const { container } = await renderRoute('/projects/project_citypoint')
   expect(container.innerHTML).toMatch(/Citypoint Dental NYC/)
+})
+
+test('a legacy UUID project URL redirects to the clean name URL', async () => {
+  const fixture = createDashboardFixture()
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const uuid = '11111111-2222-4333-8444-555555555555'
+  const project = { ...fixture.dashboard.projects[0]!.project, id: uuid, name: 'acme-co' }
+  // Pre-seed the projects cache so the route-level redirect can resolve id → name
+  queryClient.setQueryData(projectsCacheKey, [project])
+  const router = createAppRouter(queryClient, { initialEntries: [`/projects/${uuid}/report`] })
+  await router.load()
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <DashboardProvider value={{ dashboard: fixture.dashboard, health: fixture.health }}>
+        <RouterProvider router={router} />
+      </DashboardProvider>
+    </QueryClientProvider>,
+  )
+
+  // The UUID-shaped segment is swapped for the name; the /report tab is preserved.
+  expect(router.state.location.pathname).toBe('/projects/acme-co/report')
 })
 
 test('/runs renders the runs page', async () => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.96.0",
+  "version": "4.97.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -1672,6 +1672,7 @@ export type ProjectReportDto = {
         }>;
         periodStart: string | null;
         periodEnd: string | null;
+        periodDays: number;
     };
     executiveSummary: {
         citationRate: number;
@@ -1958,6 +1959,7 @@ export type ProjectReportDto = {
             direction: 'up' | 'down' | 'flat';
             window?: number;
         } | null;
+        comparisonWindowDays: number;
         providerMovements: Array<{
             provider: string;
             current: number;
@@ -8230,7 +8232,12 @@ export type GetApiV1ProjectsByNameReportData = {
          */
         name: string;
     };
-    query?: never;
+    query?: {
+        /**
+         * Report window in days — one of 7, 14, 30, 90 (default 30). Scopes the GSC, GA4, and server-side AI activity sections and the period-over-period comparisons to this window.
+         */
+        period?: 7 | 14 | 30 | 90;
+    };
     url: '/api/v1/projects/{name}/report';
 };
 
@@ -8265,6 +8272,10 @@ export type GetApiV1ProjectsByNameReportHtmlData = {
          * HTML report audience mode. Defaults to agency.
          */
         audience?: 'agency' | 'client';
+        /**
+         * Report window in days — one of 7, 14, 30, 90 (default 30). Scopes the GSC, GA4, and server-side AI activity sections and the period-over-period comparisons to this window.
+         */
+        period?: 7 | 14 | 30 | 90;
     };
     url: '/api/v1/projects/{name}/report.html';
 };

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -227,6 +227,14 @@ const analyticsWindowParameter: OpenApiParameter = {
   schema: { type: 'string', enum: ['7d', '30d', '90d', 'all'] },
 }
 
+const reportPeriodQueryParameter: OpenApiParameter = {
+  name: 'period',
+  in: 'query',
+  description:
+    'Report window in days — one of 7, 14, 30, 90 (default 30). Scopes the GSC, GA4, and server-side AI activity sections and the period-over-period comparisons to this window.',
+  schema: { type: 'integer', enum: [7, 14, 30, 90] },
+}
+
 const sinceQueryParameter: OpenApiParameter = {
   name: 'since',
   in: 'query',
@@ -2976,7 +2984,7 @@ const routeCatalog: OpenApiOperation[] = [
     tags: ['report'],
     description:
       'Bundles every section the canonry-report HTML output needs (executive summary, client summary, agency diagnostics, action plan, citation scorecard, competitor landscape — citation + mention landscapes, AI citation sources, GSC, GA4, social/AI referrals, indexing health, citations trend, insights, and recommended next steps) into a single canonical JSON payload. Backs `canonry report <project>` and MCP report reads.',
-    parameters: [nameParameter],
+    parameters: [nameParameter, reportPeriodQueryParameter],
     responses: {
       200: jsonResponse('Report returned.', 'ProjectReportDto'),
       404: errorResponse('Project not found.'),
@@ -2989,7 +2997,7 @@ const routeCatalog: OpenApiOperation[] = [
     tags: ['report'],
     description:
       'Server-rendered self-contained HTML version of the project report. Same data as `/projects/{name}/report` (JSON), rendered through the canonry HTML report renderer in agency or client mode. Returns `text/html` with `Content-Disposition: attachment` so browsers download it as `canonry-report-<project>-<audience>-YYYY-MM-DD.html`. Open in a browser and Print → Save as PDF for a PDF copy.',
-    parameters: [nameParameter, reportAudienceQueryParameter],
+    parameters: [nameParameter, reportAudienceQueryParameter, reportPeriodQueryParameter],
     responses: {
       200: { description: 'HTML report returned.', content: { 'text/html': { schema: { type: 'string' } } } },
       404: errorResponse('Project not found.'),

--- a/packages/api-routes/src/report-renderer.ts
+++ b/packages/api-routes/src/report-renderer.ts
@@ -1209,21 +1209,20 @@ function renderTrafficDeltaTile(
   label: string,
   delta: ProjectReportDto['whatsChanged']['gscClicksDelta'],
   countLabel: string,
+  comparisonWindowDays: number,
 ): string {
   if (!delta) {
     return `<div class="metric"><div class="label">${escapeHtml(label)}</div><div class="value">—</div><div class="delta">Not enough trend data</div></div>`
   }
   // Shared "smart %" formatter: big prior base → signed %, small base →
   // rounded absolute delta with the count label. Same helper the SPA calls.
-  const deltaText = formatWindowCountDelta(delta, countLabel, `vs prior ${WHATS_CHANGED_PERIOD_DAYS} days`)
+  const deltaText = formatWindowCountDelta(delta, countLabel, `vs prior ${comparisonWindowDays} days`)
   return `<div class="metric">
     <div class="label">${escapeHtml(label)}</div>
     <div class="value ${deltaToneClass(delta.direction)}">${formatNumber(delta.current)} <span style="font-size:14px;font-weight:500;">${deltaArrow(delta.direction)}</span></div>
     <div class="delta">${deltaText}</div>
   </div>`
 }
-
-const WHATS_CHANGED_PERIOD_DAYS = 14
 
 function renderProviderMovements(
   movements: ProjectReportDto['whatsChanged']['providerMovements'],
@@ -1303,8 +1302,8 @@ function renderWhatsChanged(report: ProjectReportDto, audience: ReportAudience):
     ${renderRateDeltaTile(isClient ? 'AI links to your website' : 'Citation rate', w.citationRate, '%')}
     ${renderRateDeltaTile(isClient ? 'AI mentions your name' : 'Mention rate', w.mentionRate, '%')}
     ${renderRateDeltaTile(isClient ? 'Questions AI answered with you' : 'Cited queries', w.citedQueryCount, 'count')}
-    ${renderTrafficDeltaTile(isClient ? 'Visitors from Google' : 'GSC clicks', w.gscClicksDelta, isClient ? 'visits' : 'clicks')}
-    ${renderTrafficDeltaTile(isClient ? 'Visitors from AI tools' : 'AI referral sessions', w.aiReferralsDelta, isClient ? 'visits' : 'sessions')}
+    ${renderTrafficDeltaTile(isClient ? 'Visitors from Google' : 'GSC clicks', w.gscClicksDelta, isClient ? 'visits' : 'clicks', w.comparisonWindowDays)}
+    ${renderTrafficDeltaTile(isClient ? 'Visitors from AI tools' : 'AI referral sessions', w.aiReferralsDelta, isClient ? 'visits' : 'sessions', w.comparisonWindowDays)}
   </div>`
   const movements = renderProviderMovements(w.providerMovements, audience)
   const winsHeading = isClient ? 'What got better' : 'Wins'
@@ -1856,7 +1855,7 @@ function renderAiReferrals(report: ProjectReportDto): string {
 // Section heading metadata for "AI Visibility — Server-Side". The SPA and
 // HTML must render the SAME eyebrow/title/intro per audience — see the
 // report-parity rule in `AGENTS.md`.
-function serverActivityHeading(audience: ReportAudience, hasData: boolean): {
+function serverActivityHeading(audience: ReportAudience, hasData: boolean, windowDays: number): {
   id: string
   eyebrow: string
   title: string
@@ -1869,7 +1868,7 @@ function serverActivityHeading(audience: ReportAudience, hasData: boolean): {
     title: 'AI Visibility — Server-Side',
     intro: isClient
       ? hasData
-        ? 'What AI engines actually do in your server logs over the last 7 days — the other half of citations.'
+        ? `What AI engines actually do in your server logs over the last ${windowDays} days — the other half of citations.`
         : 'Live telemetry from your server logs.'
       : 'What AI engines actually do in your server logs — direct evidence, complementary to citations (which measure what they say).',
   }
@@ -1878,6 +1877,11 @@ function serverActivityHeading(audience: ReportAudience, hasData: boolean): {
 function renderServerActivity(report: ProjectReportDto, audience: ReportAudience): string {
   const sa = report.serverActivity
   const isClient = audience === 'client'
+  // The server-activity headline + daily trend span the report window, and the
+  // prior comparison covers the equal-length window before it.
+  const windowDays = report.meta.periodDays
+  const windowLabel = `${windowDays}d`
+  const priorWindowLabel = `vs prior ${windowDays} days`
   // Client view stays silent when no source is connected — surfacing a
   // "connect a Cloud Run source" call-to-action to a client who has no
   // technical access produces noise. Agency view shows the prompt because
@@ -1885,13 +1889,13 @@ function renderServerActivity(report: ProjectReportDto, audience: ReportAudience
   if (!sa) {
     if (isClient) return ''
     return section(
-      serverActivityHeading('agency', false),
+      serverActivityHeading('agency', false, windowDays),
       renderEmpty('Connect a server-side traffic source to surface what AI engines do directly in your server logs — distinct from GA4 click-throughs.'),
     )
   }
   if (!sa.hasData) {
     return section(
-      serverActivityHeading(audience, false),
+      serverActivityHeading(audience, false, windowDays),
       renderEmpty(isClient
         ? 'Your server-side traffic source is connected. Numbers will appear after the next sync.'
         : 'Source connected — collecting your first data. Numbers will appear after the next sync.'),
@@ -1899,7 +1903,7 @@ function renderServerActivity(report: ProjectReportDto, audience: ReportAudience
   }
 
   const formatDelta = (d: { current: number; prior: number; deltaPct: number | null }, suffix: string) => {
-    const copy = formatDeltaCopy(d, suffix)
+    const copy = formatDeltaCopy(d, suffix, priorWindowLabel)
     if (!copy) return ''
     return `<span class="tone-${deltaTone(d.deltaPct)}">${escapeHtml(copy)}</span>`
   }
@@ -1934,7 +1938,7 @@ function renderServerActivity(report: ProjectReportDto, audience: ReportAudience
     </tr>`).join('')
 
     return section(
-      serverActivityHeading('client', true),
+      serverActivityHeading('client', true, windowDays),
       `<div class="metric-grid">
         <div class="metric">
           <div class="label">AI bot requests observed</div>
@@ -1954,7 +1958,7 @@ function renderServerActivity(report: ProjectReportDto, audience: ReportAudience
       </div>
       ${clientOperatorRows ? `<div class="chart-card"><h3>By AI tool</h3>
         <table class="report-table">
-          <thead><tr><th>AI tool</th><th class="numeric">Bot requests (7d)</th><th class="numeric">User fetches (7d)</th><th class="numeric">Referral sessions</th></tr></thead>
+          <thead><tr><th>AI tool</th><th class="numeric">Bot requests (${windowLabel})</th><th class="numeric">User fetches (${windowLabel})</th><th class="numeric">Referral sessions</th></tr></thead>
           <tbody>${clientOperatorRows}</tbody>
         </table>
         <p class="meta">Bot requests are bulk crawl (GPTBot, PerplexityBot, …). User fetches are on-demand reads triggered by real users inside an AI surface (ChatGPT-User, Perplexity-User, …). Verified means the request came from an IP the operator publishes as its own; unverified means the user-agent matched but the IP is not in a published range. User-fetch totals count both, since many genuine user fetches come from outside any published range.</p>
@@ -2004,30 +2008,30 @@ function renderServerActivity(report: ProjectReportDto, audience: ReportAudience
     ? renderLineChart(
         sa.dailyTrend.map(d => ({ x: d.date, y: d.verifiedCrawlerHits, label: d.date.slice(5) })),
         COLORS.series[1]!,
-        'Verified crawler hits over time (last 14 days)',
+        `Verified crawler hits over time (last ${windowDays} days)`,
       )
     : ''
 
   return section(
-    serverActivityHeading('agency', true),
+    serverActivityHeading('agency', true, windowDays),
     `<div class="metric-grid">
       <div class="metric">
-        <div class="label">Verified crawler hits (7d)</div>
+        <div class="label">Verified crawler hits (${windowLabel})</div>
         <div class="value">${formatNumber(sa.verifiedCrawlerHits.current)}</div>
         <div class="subtitle">${formatDelta(sa.verifiedCrawlerHits, 'hits')}</div>
       </div>
       <div class="metric">
-        <div class="label">Unverified crawler hits (7d)</div>
+        <div class="label">Unverified crawler hits (${windowLabel})</div>
         <div class="value">${formatNumber(sa.unverifiedCrawlerHits.current)}</div>
         <div class="subtitle">${formatDelta(sa.unverifiedCrawlerHits, 'hits')}</div>
       </div>
       <div class="metric">
-        <div class="label">AI user-fetch hits (7d)</div>
+        <div class="label">AI user-fetch hits (${windowLabel})</div>
         <div class="value">${formatNumber(sa.aiUserFetchHits.current)}</div>
         <div class="subtitle">${formatDelta(sa.aiUserFetchHits, 'hits')}</div>
       </div>
       <div class="metric">
-        <div class="label">AI-referral sessions (7d)</div>
+        <div class="label">AI-referral sessions (${windowLabel})</div>
         <div class="value">${formatNumber(sa.referralArrivals.current)}</div>
         <div class="subtitle">${formatDelta(sa.referralArrivals, 'sessions')}</div>
       </div>
@@ -2036,12 +2040,12 @@ function renderServerActivity(report: ProjectReportDto, audience: ReportAudience
     ${operatorRows ? `<div class="chart-card"><h3>Per AI operator</h3>
       <p class="meta">Verified means the request's source IP falls inside the operator's published range. Unverified bots claim the user-agent but the IP is not in a published range, so it could be the real bot or an imitator. User fetches are on-demand reads from an AI surface on behalf of a real user (ChatGPT-User, Perplexity-User, …), disjoint from bulk crawl and counted whether or not the IP can be verified.</p>
       <table class="report-table">
-        <thead><tr><th>Operator</th><th class="numeric">Verified hits</th><th class="numeric">Unverified</th><th class="numeric">User fetches</th><th class="numeric">Referral sessions</th><th class="numeric">7d delta</th></tr></thead>
+        <thead><tr><th>Operator</th><th class="numeric">Verified hits</th><th class="numeric">Unverified</th><th class="numeric">User fetches</th><th class="numeric">Referral sessions</th><th class="numeric">${windowLabel} delta</th></tr></thead>
         <tbody>${operatorRows}</tbody>
       </table>
     </div>` : ''}
     ${pathRows ? `<div class="chart-card"><h3>Top crawled paths</h3>
-      <p class="meta">Pages AI bots fetched most often (verified only, last 7d).</p>
+      <p class="meta">Pages AI bots fetched most often (verified only, last ${windowLabel}).</p>
       <table class="report-table">
         <thead><tr><th>Path</th><th class="numeric">Verified hits</th><th class="numeric">Distinct operators</th></tr></thead>
         <tbody>${pathRows}</tbody>
@@ -2644,7 +2648,7 @@ export function renderReportHtml(report: ProjectReportDto, opts: RenderReportHtm
   <header class="header">
     <div class="eyebrow">AI Visibility Report</div>
     <h1>${escapeHtml(report.meta.project.displayName)}</h1>
-    <div class="subtitle">${escapeHtml(report.meta.project.canonicalDomain)} · ${escapeHtml(report.meta.project.country)} / ${escapeHtml(report.meta.project.language.toUpperCase())}${renderHeaderLocationFragment(report.meta.location)} · Generated ${formatDate(report.meta.generatedAt)}</div>
+    <div class="subtitle">${escapeHtml(report.meta.project.canonicalDomain)} · ${escapeHtml(report.meta.project.country)} / ${escapeHtml(report.meta.project.language.toUpperCase())}${renderHeaderLocationFragment(report.meta.location)} · Last ${report.meta.periodDays} days · Generated ${formatDate(report.meta.generatedAt)}</div>
   </header>
   ${sections}
   <footer class="footer">Generated by <a href="https://canonry.ai">canonry</a> · ${escapeHtml(formatIsoDate(report.meta.generatedAt))}</footer>

--- a/packages/api-routes/src/report.ts
+++ b/packages/api-routes/src/report.ts
@@ -30,6 +30,8 @@ import {
   deltaPercent,
   effectiveBrandNames,
   getProviderLocationHandling,
+  parseReportPeriodDays,
+  reportComparisonWindowDays,
   validationError,
   type CitationsTrendPoint,
   type CompetitorRow,
@@ -81,16 +83,10 @@ const TOP_CAMPAIGN_LIMIT = 10
 // Keeps a months-old undismissed regression from cluttering today's
 // report while still surfacing alerts that recur within recent history.
 const INSIGHT_LOOKBACK_RUNS = 5
-// Trailing window for GSC and GA report sections. Anchored on the most
-// recent date present in each dataset (not "today") so reports remain
-// usable when a sync hasn't run for a few days; the two sections may end
-// on slightly different dates but always span the same number of days.
-const REPORT_WINDOW_DAYS = 30
-
-// Server-side AI visibility section windows (last-7d headline + 7d prior for delta + 14d trend).
-const SERVER_ACTIVITY_HEADLINE_DAYS = 7
-const SERVER_ACTIVITY_TREND_DAYS = 14
 const SERVER_ACTIVITY_TOP_PATHS_LIMIT = 10
+// GA4 precomputes deduplicated window summaries only for these keys; any other
+// requested window falls back to summing per-page snapshots.
+const GA_WINDOW_SUMMARY_KEYS: Record<number, string> = { 7: '7d', 30: '30d', 90: '90d' }
 
 // Returns the inclusive start-date string (YYYY-MM-DD) for a window of
 // `windowDays` ending on `endDate`. `endDate` must already be YYYY-MM-DD.
@@ -191,18 +187,19 @@ function buildGscSection(
   projectBrandNames: readonly string[],
   canonicalDomain: string,
   trackedQueries: string[],
+  windowDays: number,
 ): ProjectReportDto['gsc'] {
   const allRows = db.select().from(gscSearchData).where(eq(gscSearchData.projectId, projectId)).all()
   if (allRows.length === 0) return null
 
-  // Constrain to the most recent REPORT_WINDOW_DAYS of data so the GSC
-  // section aligns with the GA section. GSC retains up to 16 months, but the
-  // report only ever shows 30 days. Anchor on the latest date in the dataset
-  // rather than "today" — when GSC sync is a few days behind the report
-  // should still cover a full 30-day window of real data.
+  // Constrain to the most recent `windowDays` of data so the GSC section
+  // aligns with the GA section. GSC retains up to 16 months, but the report
+  // only ever shows the selected window. Anchor on the latest date in the
+  // dataset rather than "today" — when GSC sync is a few days behind the
+  // report should still cover a full window of real data.
   let maxDate = ''
   for (const r of allRows) if (r.date > maxDate) maxDate = r.date
-  const startDate = windowStartDate(maxDate, REPORT_WINDOW_DAYS)
+  const startDate = windowStartDate(maxDate, windowDays)
   const rows = allRows.filter(r => r.date >= startDate && r.date <= maxDate)
   if (rows.length === 0) return null
 
@@ -292,21 +289,26 @@ function buildGscSection(
   }
 }
 
-function buildGaSection(db: DatabaseClient, projectId: string): ProjectReportDto['ga'] {
-  // Prefer the dedicated 30-day window summary so totalUsers reflects the
-  // deduplicated count from GA4 (summing per-page snapshots overcounts users
-  // who landed on multiple pages — that's exactly what this table fixes).
-  const windowSummary = db
-    .select()
-    .from(gaTrafficWindowSummaries)
-    .where(
-      and(
-        eq(gaTrafficWindowSummaries.projectId, projectId),
-        eq(gaTrafficWindowSummaries.windowKey, '30d'),
-      ),
-    )
-    .limit(1)
-    .get()
+function buildGaSection(db: DatabaseClient, projectId: string, windowDays: number): ProjectReportDto['ga'] {
+  // Prefer the dedicated window summary whose key matches the requested window
+  // so totalUsers reflects the deduplicated count from GA4 (summing per-page
+  // snapshots overcounts users who landed on multiple pages — that's exactly
+  // what this table fixes). GA4 precomputes 7d/30d/90d only; any other window
+  // (e.g. 14d) has no summary and falls back to the snapshot sums below.
+  const gaWindowKey = GA_WINDOW_SUMMARY_KEYS[windowDays]
+  const windowSummary = gaWindowKey
+    ? db
+        .select()
+        .from(gaTrafficWindowSummaries)
+        .where(
+          and(
+            eq(gaTrafficWindowSummaries.projectId, projectId),
+            eq(gaTrafficWindowSummaries.windowKey, gaWindowKey),
+          ),
+        )
+        .limit(1)
+        .get()
+    : undefined
 
   // Fallback when window summaries haven't been backfilled yet — the older
   // gaTrafficSummaries table still holds aggregate totals.
@@ -329,11 +331,11 @@ function buildGaSection(db: DatabaseClient, projectId: string): ProjectReportDto
   if (!windowSummary && !fallbackSummary && allSnapshotRows.length === 0) return null
 
   // Match the GSC section: filter per-page snapshots to the most recent
-  // REPORT_WINDOW_DAYS so the landing-page table and channel mix describe the
-  // same window the headline totals do.
+  // `windowDays` so the landing-page table and channel mix describe the same
+  // window the headline totals do.
   let snapshotMaxDate = ''
   for (const r of allSnapshotRows) if (r.date > snapshotMaxDate) snapshotMaxDate = r.date
-  const snapshotStartDate = snapshotMaxDate ? windowStartDate(snapshotMaxDate, REPORT_WINDOW_DAYS) : ''
+  const snapshotStartDate = snapshotMaxDate ? windowStartDate(snapshotMaxDate, windowDays) : ''
   const snapshotRows = snapshotStartDate
     ? allSnapshotRows.filter(r => r.date >= snapshotStartDate && r.date <= snapshotMaxDate)
     : allSnapshotRows
@@ -392,9 +394,9 @@ function buildGaSection(db: DatabaseClient, projectId: string): ProjectReportDto
     }
   }
 
-  // Period reflects whichever totals source was used. Window summary is the
-  // authoritative 30d span; otherwise we report the snapshot-derived window
-  // (which is also 30 days), with the legacy summary as a final fallback.
+  // Period reflects whichever totals source was used. The window summary is the
+  // authoritative span for its key; otherwise we report the snapshot-derived
+  // window (the same `windowDays`), with the legacy summary as a final fallback.
   const periodStart = windowSummary?.periodStart
     ?? (snapshotStartDate || fallbackSummary?.periodStart || '')
   const periodEnd = windowSummary?.periodEnd
@@ -576,7 +578,7 @@ function nonSubresourceReferralPathCondition() {
  * operator's published range, while claimed-unverified hits are surfaced
  * separately so a real crawl burst still shows activity.
  */
-function buildServerActivity(db: DatabaseClient, projectId: string): ProjectReportDto['serverActivity'] {
+function buildServerActivity(db: DatabaseClient, projectId: string, windowDays: number): ProjectReportDto['serverActivity'] {
   // 1. Bail if no traffic source is connected at all.
   // Treat archived sources as "not connected" — we don't want to surface
   // historical data for a host migration the user has moved past.
@@ -594,9 +596,11 @@ function buildServerActivity(db: DatabaseClient, projectId: string): ProjectRepo
 
   const now = new Date()
   const headlineEnd = now.toISOString()
-  const headlineStartMs = now.getTime() - SERVER_ACTIVITY_HEADLINE_DAYS * 24 * 60 * 60_000
-  const priorStartMs = headlineStartMs - SERVER_ACTIVITY_HEADLINE_DAYS * 24 * 60 * 60_000
-  const trendStartMs = now.getTime() - SERVER_ACTIVITY_TREND_DAYS * 24 * 60 * 60_000
+  // Uniform window: the headline + daily trend span the selected window, and
+  // the prior comparison covers the equal-length window immediately before it.
+  const headlineStartMs = now.getTime() - windowDays * 24 * 60 * 60_000
+  const priorStartMs = headlineStartMs - windowDays * 24 * 60 * 60_000
+  const trendStartMs = headlineStartMs
 
   const headlineStart = new Date(headlineStartMs).toISOString()
   const priorStart = new Date(priorStartMs).toISOString()
@@ -879,7 +883,7 @@ function buildServerActivity(db: DatabaseClient, projectId: string): ProjectRepo
     distinctProducts: Number(r.products),
   }))
 
-  // 7. Daily trend (last 14d) — bucket tsHour to YYYY-MM-DD via SQLite SUBSTR.
+  // 7. Daily trend (spans the selected window) — bucket tsHour to YYYY-MM-DD via SQLite SUBSTR.
   const crawlerTrendRows = db
     .select({
       date: sql<string>`SUBSTR(${crawlerEventsHourly.tsHour}, 1, 10)`,
@@ -1699,14 +1703,6 @@ function buildAgencyDiagnostics(input: ReportActionPlanInput & {
   }
 }
 
-// 14-day half-window for period-over-period traffic deltas (last 14 days vs
-// the 14 days before that). Anchored on the trend tail so a stale sync still
-// produces meaningful comparisons; below 28 points we return null instead of
-// inventing motion. The choice of 14 (not 7) smooths weekday seasonality
-// without dropping all the way back into the noise floor of single-day swings.
-const WHATS_CHANGED_PERIOD_DAYS = 14
-const WHATS_CHANGED_MIN_TREND_POINTS = WHATS_CHANGED_PERIOD_DAYS * 2
-
 // Real-movement thresholds for the per-run rate deltas. Tighter values
 // (and the point-to-point comparison they replaced) flipped tone arrows
 // on every run because a single query bouncing in/out of cited on a
@@ -1725,12 +1721,19 @@ function rateDirection(delta: number, threshold = 0.5): 'up' | 'down' | 'flat' {
   return 'flat'
 }
 
+// Period-over-period traffic delta: the most recent `halfWindow` days of the
+// trend vs the `halfWindow` days before that. `halfWindow` is the report
+// window split in two, so the comparison always covers the full selected
+// window. Anchored on the trend tail so a stale sync still produces a
+// meaningful comparison; below `halfWindow * 2` points we return null instead
+// of inventing motion on a partial prior window.
 function periodOverPeriodDelta(
   trend: ReadonlyArray<{ date: string; value: number }>,
+  halfWindow: number,
 ): ReportRateDelta | null {
-  if (trend.length < WHATS_CHANGED_MIN_TREND_POINTS) return null
-  const tail = trend.slice(-WHATS_CHANGED_PERIOD_DAYS)
-  const prior = trend.slice(-WHATS_CHANGED_PERIOD_DAYS * 2, -WHATS_CHANGED_PERIOD_DAYS)
+  if (trend.length < halfWindow * 2) return null
+  const tail = trend.slice(-halfWindow)
+  const prior = trend.slice(-halfWindow * 2, -halfWindow)
   const current = tail.reduce((s, p) => s + p.value, 0)
   const priorTotal = prior.reduce((s, p) => s + p.value, 0)
   const deltaAbs = current - priorTotal
@@ -1749,6 +1752,7 @@ function buildWhatsChangedHeadline(
   aiReferrals: ReportRateDelta | null,
   enoughHistory: boolean,
   trendLength: number,
+  comparisonWindowDays: number,
 ): string {
   if (!enoughHistory) {
     return `Building baseline (${trendLength} of ${MIN_TREND_POINTS} checks completed). Trends appear after a few more checks.`
@@ -1767,10 +1771,10 @@ function buildWhatsChangedHeadline(
   }
   if (aiReferrals && aiReferrals.direction !== 'flat') {
     const arrow = aiReferrals.direction === 'up' ? '↑' : '↓'
-    parts.push(`AI referrals ${arrow}${Math.abs(aiReferrals.deltaAbs)} sessions vs prior 14 days`)
+    parts.push(`AI referrals ${arrow}${Math.abs(aiReferrals.deltaAbs)} sessions vs prior ${comparisonWindowDays} days`)
   } else if (gscClicks && gscClicks.direction !== 'flat') {
     const arrow = gscClicks.direction === 'up' ? '↑' : '↓'
-    parts.push(`GSC clicks ${arrow}${Math.abs(gscClicks.deltaAbs)} vs prior 14 days`)
+    parts.push(`GSC clicks ${arrow}${Math.abs(gscClicks.deltaAbs)} vs prior ${comparisonWindowDays} days`)
   }
   return parts.length > 0 ? `${parts.join(' · ')}.` : 'No meaningful movement vs the prior period.'
 }
@@ -1780,8 +1784,9 @@ function buildWhatsChanged(input: {
   gsc: ProjectReportDto['gsc']
   aiReferrals: ProjectReportDto['aiReferrals']
   insights: ReportInsight[]
+  comparisonWindowDays: number
 }): WhatsChangedSection {
-  const { citationsTrend, gsc, aiReferrals, insights: insightList } = input
+  const { citationsTrend, gsc, aiReferrals, insights: insightList, comparisonWindowDays } = input
   const baseline = isTrendBaseline(citationsTrend)
   const latest = citationsTrend.at(-1)
   const prior = citationsTrend.length >= 2 ? citationsTrend.at(-2) : null
@@ -1835,10 +1840,10 @@ function buildWhatsChanged(input: {
   }
 
   const gscClicksDelta = gsc
-    ? periodOverPeriodDelta(gsc.trend.map(t => ({ date: t.date, value: t.clicks })))
+    ? periodOverPeriodDelta(gsc.trend.map(t => ({ date: t.date, value: t.clicks })), comparisonWindowDays)
     : null
   const aiReferralsDelta = aiReferrals
-    ? periodOverPeriodDelta(aiReferrals.trend.map(t => ({ date: t.date, value: t.sessions })))
+    ? periodOverPeriodDelta(aiReferrals.trend.map(t => ({ date: t.date, value: t.sessions })), comparisonWindowDays)
     : null
 
   const wins = insightList
@@ -1854,6 +1859,7 @@ function buildWhatsChanged(input: {
     aiReferralsDelta,
     enoughHistory,
     citationsTrend.length,
+    comparisonWindowDays,
   )
 
   return {
@@ -1864,15 +1870,17 @@ function buildWhatsChanged(input: {
     citedQueryCount,
     gscClicksDelta,
     aiReferralsDelta,
+    comparisonWindowDays,
     providerMovements,
     wins,
     regressions,
   }
 }
 
-function buildProjectReport(db: DatabaseClient, projectName: string): ProjectReportDto {
+function buildProjectReport(db: DatabaseClient, projectName: string, periodDays: number): ProjectReportDto {
   const project = resolveProject(db, projectName)
   const queryLookup = loadQueryLookup(db, project.id)
+  const comparisonWindowDays = reportComparisonWindowDays(periodDays)
 
   const allRuns = db
     .select()
@@ -1939,11 +1947,12 @@ function buildProjectReport(db: DatabaseClient, projectName: string): ProjectRep
     projectBrandNames,
     project.canonicalDomain,
     trackedQueries,
+    periodDays,
   )
-  const gaSection = buildGaSection(db, project.id)
+  const gaSection = buildGaSection(db, project.id, periodDays)
   const socialSection = buildSocialReferrals(db, project.id)
   const aiReferralsSection = buildAiReferrals(db, project.id)
-  const serverActivitySection = buildServerActivity(db, project.id)
+  const serverActivitySection = buildServerActivity(db, project.id, periodDays)
   const indexingHealthSection = buildIndexingHealth(db, project.id)
   const citationsTrend = buildCitationsTrend(db, project.id, queryLookup, latestRunLocation)
   const insightList = buildInsightList(db, project.id, latestRunLocation)
@@ -1975,6 +1984,7 @@ function buildProjectReport(db: DatabaseClient, projectName: string): ProjectRep
     gsc: gscSection,
     aiReferrals: aiReferralsSection,
     insights: insightList,
+    comparisonWindowDays,
   })
 
   // Headline rate is per-query — see buildCitationsTrend for the rationale.
@@ -2133,6 +2143,7 @@ function buildProjectReport(db: DatabaseClient, projectName: string): ProjectRep
       providerLocationHandling,
       periodStart,
       periodEnd,
+      periodDays,
     },
     executiveSummary,
     citationScorecard,
@@ -2174,14 +2185,16 @@ function reportFilenameFor(
 }
 
 export async function reportRoutes(app: FastifyInstance) {
-  app.get<{ Params: { name: string } }>('/projects/:name/report', async (request, reply) => {
-    const dto = buildProjectReport(app.db, request.params.name)
+  app.get<{ Params: { name: string }; Querystring: { period?: string } }>('/projects/:name/report', async (request, reply) => {
+    const periodDays = parseReportPeriodDays(request.query.period)
+    const dto = buildProjectReport(app.db, request.params.name, periodDays)
     return reply.send(dto)
   })
 
-  app.get<{ Params: { name: string }; Querystring: { audience?: string } }>('/projects/:name/report.html', async (request, reply) => {
+  app.get<{ Params: { name: string }; Querystring: { audience?: string; period?: string } }>('/projects/:name/report.html', async (request, reply) => {
     const audience = parseReportAudience(request.query.audience)
-    const dto = buildProjectReport(app.db, request.params.name)
+    const periodDays = parseReportPeriodDays(request.query.period)
+    const dto = buildProjectReport(app.db, request.params.name, periodDays)
     const html = renderReportHtml(dto, { audience })
     const filename = reportFilenameFor(dto.meta.project, dto.meta.generatedAt, audience)
     reply.header('Content-Type', 'text/html; charset=utf-8')

--- a/packages/api-routes/test/report-renderer.test.ts
+++ b/packages/api-routes/test/report-renderer.test.ts
@@ -18,6 +18,7 @@ function emptyReport(): ProjectReportDto {
       providerLocationHandling: [],
       periodStart: null,
       periodEnd: null,
+      periodDays: 30,
     },
     executiveSummary: {
       citationRate: 0,
@@ -52,6 +53,7 @@ function emptyReport(): ProjectReportDto {
       citedQueryCount: null,
       gscClicksDelta: null,
       aiReferralsDelta: null,
+      comparisonWindowDays: 15,
       providerMovements: [],
       wins: [],
       regressions: [],
@@ -124,6 +126,11 @@ function richReport(): ProjectReportDto {
       ],
       periodStart: '2026-04-01T00:00:00Z',
       periodEnd: '2026-04-30T00:00:00Z',
+      // Deliberately distinct from whatsChanged.comparisonWindowDays below so
+      // these tests prove the server-activity labels read meta.periodDays while
+      // the what's-changed traffic-delta labels read comparisonWindowDays —
+      // independent wiring, not a shared constant.
+      periodDays: 7,
     },
     executiveSummary: {
       citationRate: 65,
@@ -299,6 +306,7 @@ function richReport(): ProjectReportDto {
       citedQueryCount: null,
       gscClicksDelta: null,
       aiReferralsDelta: null,
+      comparisonWindowDays: 14,
       providerMovements: [],
       wins: [],
       regressions: [],

--- a/packages/api-routes/test/report.test.ts
+++ b/packages/api-routes/test/report.test.ts
@@ -1651,7 +1651,8 @@ describe('serverActivity (AI visibility — server-side)', () => {
     // prior window (d-10): 50 verified — 100% increase
     insertCrawler(projectId, sourceId, { tsHour: isoMinusDays(10), hits: 50 })
     await ctx.app.ready()
-    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/delta-pct/report' })
+    // period=7 makes the headline window 7d and the prior comparison the 7d before.
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/delta-pct/report?period=7' })
     const sa = (JSON.parse(res.body) as ProjectReportDto).serverActivity!
     expect(sa.verifiedCrawlerHits.current).toBe(100)
     expect(sa.verifiedCrawlerHits.prior).toBe(50)
@@ -1720,17 +1721,32 @@ describe('serverActivity (AI visibility — server-side)', () => {
     ])
   })
 
-  test('events outside the 14-day trend window are excluded', async () => {
+  test('events outside the trend window are excluded', async () => {
     const projectId = insertProject(ctx.db, 'trend-window')
     const sourceId = insertTrafficSource(projectId)
     insertCrawler(projectId, sourceId, { tsHour: isoMinusDays(2), hits: 7 })
     insertCrawler(projectId, sourceId, { tsHour: isoMinusDays(20), hits: 999 })
     await ctx.app.ready()
-    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/trend-window/report' })
+    // period=14 → the daily trend spans the last 14 days; the d-20 event is outside it.
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/trend-window/report?period=14' })
     const sa = (JSON.parse(res.body) as ProjectReportDto).serverActivity!
     // 999 is older than 14d — must not appear in dailyTrend
     const totalTrendHits = sa.dailyTrend.reduce((acc, d) => acc + d.verifiedCrawlerHits, 0)
     expect(totalTrendHits).toBe(7)
+  })
+
+  test('period widens the server-activity window: events 30d back roll into one window', async () => {
+    const projectId = insertProject(ctx.db, 'period-widens')
+    const sourceId = insertTrafficSource(projectId)
+    // Two events at d-1 and d-10. At period=7 they split (current vs prior);
+    // at period=30 both land in the current window with an empty prior.
+    insertCrawler(projectId, sourceId, { tsHour: isoMinusDays(1), hits: 100 })
+    insertCrawler(projectId, sourceId, { tsHour: isoMinusDays(10), hits: 50 })
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/period-widens/report?period=30' })
+    const sa = (JSON.parse(res.body) as ProjectReportDto).serverActivity!
+    expect(sa.verifiedCrawlerHits.current).toBe(150)
+    expect(sa.verifiedCrawlerHits.prior).toBe(0)
   })
 })
 
@@ -1783,5 +1799,70 @@ describe('GET /api/v1/projects/:name/report.html', () => {
     const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/bad-audience/report.html?audience=internal' })
     expect(res.statusCode).toBe(400)
     expect(JSON.parse(res.body).error.code).toBe('VALIDATION_ERROR')
+  })
+})
+
+describe('report period (configurable window)', () => {
+  async function getMeta(project: string, query = ''): Promise<ProjectReportDto> {
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: `/api/v1/projects/${project}/report${query}` })
+    expect(res.statusCode).toBe(200)
+    return JSON.parse(res.body) as ProjectReportDto
+  }
+
+  test('defaults to a 30-day window with a 15-day comparison half-window', async () => {
+    insertProject(ctx.db, 'period-default')
+    const body = await getMeta('period-default')
+    expect(body.meta.periodDays).toBe(30)
+    expect(body.whatsChanged.comparisonWindowDays).toBe(15)
+  })
+
+  test('comparisonWindowDays is floor(periodDays / 2) for every option', async () => {
+    insertProject(ctx.db, 'period-half')
+    for (const [period, half] of [[7, 3], [14, 7], [30, 15], [90, 45]] as const) {
+      const body = await getMeta('period-half', `?period=${period}`)
+      expect(body.meta.periodDays).toBe(period)
+      expect(body.whatsChanged.comparisonWindowDays).toBe(half)
+    }
+  })
+
+  test('rejects a period outside the allowed set', async () => {
+    insertProject(ctx.db, 'period-bad')
+    await ctx.app.ready()
+    for (const bad of ['15', '0', '-7', 'abc', '30.5']) {
+      const res = await ctx.app.inject({ method: 'GET', url: `/api/v1/projects/period-bad/report?period=${bad}` })
+      expect(res.statusCode).toBe(400)
+      expect(JSON.parse(res.body).error.code).toBe('VALIDATION_ERROR')
+    }
+  })
+
+  test('GSC headline window scales with the selected period', async () => {
+    const projectId = insertProject(ctx.db, 'period-gsc')
+    const syncRunId = insertRun(ctx.db, projectId, { kind: 'gsc-sync' })
+    const baseRow = {
+      projectId,
+      syncRunId,
+      query: 'period topic',
+      page: 'https://period-gsc.example.com/',
+      ctr: '0.05',
+      position: '5',
+      createdAt: new Date().toISOString(),
+    }
+    // Anchored on the latest date (2026-04-30): 04-28 is within 7 days, 04-10 is not.
+    ctx.db.insert(gscSearchData).values([
+      { id: crypto.randomUUID(), ...baseRow, date: '2026-04-30', clicks: 10, impressions: 100 },
+      { id: crypto.randomUUID(), ...baseRow, date: '2026-04-28', clicks: 5, impressions: 50 },
+      { id: crypto.randomUUID(), ...baseRow, date: '2026-04-10', clicks: 100, impressions: 1000 },
+    ]).run()
+
+    // periodStart reflects the earliest data point inside the window (the
+    // window boundary for period=7 is 04-24, but the earliest row is 04-28).
+    const sevenDay = await getMeta('period-gsc', '?period=7')
+    expect(sevenDay.gsc!.totalClicks).toBe(15) // 04-30 + 04-28 only — 04-10 excluded
+    expect(sevenDay.gsc!.periodStart).toBe('2026-04-28')
+
+    const thirtyDay = await getMeta('period-gsc', '?period=30')
+    expect(thirtyDay.gsc!.totalClicks).toBe(115) // all three rows fall in the 30-day window
+    expect(thirtyDay.gsc!.periodStart).toBe('2026-04-10')
   })
 })

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.96.0",
+  "version": "4.97.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/cli-commands/report.ts
+++ b/packages/canonry/src/cli-commands/report.ts
@@ -2,14 +2,23 @@ import { runReportCommand } from '../commands/report.js'
 import type { CliCommandSpec } from '../cli-dispatch.js'
 import { getString, requireProject } from '../cli-command-helpers.js'
 import { usageError } from '../cli-error.js'
-import type { ReportAudience } from '@ainyc/canonry-contracts'
+import { REPORT_PERIOD_OPTIONS, type ReportAudience, type ReportPeriodDays } from '@ainyc/canonry-contracts'
 
-const USAGE = 'canonry report <project> [--audience agency|client] [--output <path>] [--format json]'
+const USAGE = 'canonry report <project> [--audience agency|client] [--period 7|14|30|90] [--output <path>] [--format json]'
 
 function parseAudience(value: string | undefined): ReportAudience | undefined {
   if (value === undefined) return undefined
   if (value === 'agency' || value === 'client') return value
   throw usageError(`Error: --audience must be "agency" or "client"\n\nUsage: ${USAGE}`)
+}
+
+function parsePeriod(value: string | undefined): ReportPeriodDays | undefined {
+  if (value === undefined) return undefined
+  const n = Number(value)
+  if (Number.isInteger(n) && (REPORT_PERIOD_OPTIONS as readonly number[]).includes(n)) {
+    return n as ReportPeriodDays
+  }
+  throw usageError(`Error: --period must be one of ${REPORT_PERIOD_OPTIONS.join(', ')}\n\nUsage: ${USAGE}`)
 }
 
 export const REPORT_CLI_COMMANDS: readonly CliCommandSpec[] = [
@@ -18,6 +27,7 @@ export const REPORT_CLI_COMMANDS: readonly CliCommandSpec[] = [
     usage: USAGE,
     options: {
       audience: { type: 'string' },
+      period: { type: 'string' },
       output: { type: 'string', short: 'o' },
     },
     run: async (input) => {
@@ -25,6 +35,7 @@ export const REPORT_CLI_COMMANDS: readonly CliCommandSpec[] = [
       await runReportCommand(project, {
         format: input.format,
         audience: parseAudience(getString(input.values, 'audience')),
+        period: parsePeriod(getString(input.values, 'period')),
         output: getString(input.values, 'output'),
       })
     },

--- a/packages/canonry/src/client.ts
+++ b/packages/canonry/src/client.ts
@@ -97,6 +97,7 @@ import type {
   ProjectSearchResponseDto,
   DoctorReportDto,
   ProjectReportDto,
+  ReportPeriodDays,
   TrafficSourceDto,
   TrafficSourceDetailDto,
   TrafficSourceListResponse,
@@ -780,9 +781,13 @@ export class ApiClient {
     )
   }
 
-  async getReport(project: string): Promise<ProjectReportDto> {
+  async getReport(project: string, opts?: { period?: ReportPeriodDays }): Promise<ProjectReportDto> {
     return this.invoke<ProjectReportDto>(() =>
-      getApiV1ProjectsByNameReport({ client: this.heyClient, path: { name: project } }),
+      getApiV1ProjectsByNameReport({
+        client: this.heyClient,
+        path: { name: project },
+        ...(opts?.period !== undefined && { query: { period: opts.period } }),
+      }),
     )
   }
 

--- a/packages/canonry/src/commands/report.ts
+++ b/packages/canonry/src/commands/report.ts
@@ -3,12 +3,14 @@ import path from 'node:path'
 import { createApiClient } from '../client.js'
 import { renderReportHtml } from '@ainyc/canonry-api-routes'
 import { isMachineFormat, type CliFormat } from '../cli-error.js'
-import type { ReportAudience } from '@ainyc/canonry-contracts'
+import type { ReportAudience, ReportPeriodDays } from '@ainyc/canonry-contracts'
 
 export interface RunReportCommandOptions {
   format?: CliFormat
   /** Render audience for HTML output. JSON always prints the full canonical DTO. */
   audience?: ReportAudience
+  /** Report window in days (7/14/30/90). Omitted → server default (30). */
+  period?: ReportPeriodDays
   /** Override the output path. Default: `<cwd>/canonry-report-<project>-<audience>-<YYYY-MM-DD>.html`. */
   output?: string
 }
@@ -23,7 +25,7 @@ export async function runReportCommand(
   opts: RunReportCommandOptions = {},
 ): Promise<void> {
   const client = createApiClient()
-  const report = await client.getReport(project)
+  const report = await client.getReport(project, opts.period !== undefined ? { period: opts.period } : undefined)
   const audience = opts.audience ?? 'agency'
 
   if (isMachineFormat(opts.format)) {

--- a/packages/canonry/src/mcp/tool-registry.ts
+++ b/packages/canonry/src/mcp/tool-registry.ts
@@ -18,6 +18,7 @@ import {
   projectUpsertRequestSchema,
   runTriggerRequestSchema,
   backlinkSourceSchema,
+  reportPeriodSchema,
   schedulableRunKindSchema,
   scheduleUpsertRequestSchema,
   trafficConnectCloudRunRequestSchema,
@@ -515,13 +516,16 @@ export const canonryMcpTools = [
     name: 'canonry_report',
     title: 'Get aggregated AEO report',
     description:
-      'Returns the full canonical AEO report bundle for a project — executive summary, client summary, agency diagnostics, action plan, per-query × per-provider citation matrix, competitor landscape, AI citation sources, GSC/GA4 performance, social and AI referrals, indexing health, citations trend, prioritized insights, and recommended next steps. Same payload `canonry report <project>` consumes to render audience-specific HTML.',
+      'Returns the full canonical AEO report bundle for a project — executive summary, client summary, agency diagnostics, action plan, per-query × per-provider citation matrix, competitor landscape, AI citation sources, GSC/GA4 performance, social and AI referrals, indexing health, citations trend, prioritized insights, and recommended next steps. Same payload `canonry report <project>` consumes to render audience-specific HTML. Pass `period` (7/14/30/90 days, default 30) to scope the GSC/GA4/server-activity sections and the period-over-period comparisons.',
     access: 'read',
     tier: 'monitoring',
-    inputSchema: projectInputSchema,
+    inputSchema: z.object({
+      project: projectNameSchema,
+      period: reportPeriodSchema.optional(),
+    }),
     annotations: readAnnotations(),
     openApiOperations: ['GET /api/v1/projects/{name}/report'],
-    handler: (client, input) => client.getReport(input.project),
+    handler: (client, input) => client.getReport(input.project, input.period !== undefined ? { period: input.period } : undefined),
   }),
   defineTool({
     name: 'canonry_analytics_metrics',

--- a/packages/canonry/test/report-command.test.ts
+++ b/packages/canonry/test/report-command.test.ts
@@ -20,6 +20,7 @@ function makeReport(): ProjectReportDto {
       providerLocationHandling: [],
       periodStart: null,
       periodEnd: null,
+      periodDays: 30,
     },
     executiveSummary: {
       citationRate: 0,
@@ -53,6 +54,7 @@ function makeReport(): ProjectReportDto {
       citedQueryCount: null,
       gscClicksDelta: null,
       aiReferralsDelta: null,
+      comparisonWindowDays: 15,
       providerMovements: [],
       wins: [],
       regressions: [],
@@ -151,6 +153,18 @@ describe('runReportCommand', () => {
     expect(html).toContain('AI Visibility Report')
     expect(html).toContain('id="client-summary"')
     expect(html).not.toContain('id="citation-scorecard"')
+  })
+
+  it('forwards --period to the API client', async () => {
+    getReportMock.mockResolvedValue(makeReport())
+    await runReportCommand('demo', { format: 'json', period: 7 })
+    expect(getReportMock).toHaveBeenCalledWith('demo', { period: 7 })
+  })
+
+  it('omits the period query entirely when no --period is given', async () => {
+    getReportMock.mockResolvedValue(makeReport())
+    await runReportCommand('demo', { format: 'json' })
+    expect(getReportMock).toHaveBeenCalledWith('demo', undefined)
   })
 
   it('--format json prints the raw report JSON to stdout, no file written', async () => {

--- a/packages/contracts/src/report.ts
+++ b/packages/contracts/src/report.ts
@@ -14,6 +14,50 @@ import {
   contentSourceRowDtoSchema,
   contentGapRowDtoSchema,
 } from './content.js'
+import { validationError } from './errors.js'
+
+/**
+ * Selectable report time windows, in days. Every time-windowed section of the
+ * report (GSC, GA4, server-side AI activity, the citations trend) scopes to the
+ * chosen window, and the period-over-period comparisons split it in half. The
+ * SPA renders these as a toggle, the CLI exposes `--period`, and the API takes
+ * a `period` query param — all validated against this single source of truth.
+ */
+export const REPORT_PERIOD_OPTIONS = [7, 14, 30, 90] as const
+export type ReportPeriodDays = (typeof REPORT_PERIOD_OPTIONS)[number]
+/** Preserves the historical GSC/GA window so existing reports are unchanged by default. */
+export const REPORT_DEFAULT_PERIOD_DAYS: ReportPeriodDays = 30
+
+/**
+ * Zod schema for a report window — the MCP `canonry_report` tool input. Kept in
+ * lockstep with `REPORT_PERIOD_OPTIONS` by `report.test.ts`.
+ */
+export const reportPeriodSchema = z
+  .union([z.literal(7), z.literal(14), z.literal(30), z.literal(90)])
+  .describe('Report window in days (7, 14, 30, or 90). Defaults to 30 when omitted.')
+
+function isReportPeriodDays(n: number): n is ReportPeriodDays {
+  return (REPORT_PERIOD_OPTIONS as readonly number[]).includes(n)
+}
+
+/**
+ * Parse a raw `period` query/flag value into a valid window. Absent → the
+ * default; present-but-invalid → a `validationError` (serialized as 400 by the
+ * API's global handler, mapped to a CliError exit code by the client).
+ */
+export function parseReportPeriodDays(value: string | number | undefined | null): ReportPeriodDays {
+  if (value === undefined || value === null || value === '') return REPORT_DEFAULT_PERIOD_DAYS
+  const n = typeof value === 'number' ? value : Number(value)
+  if (!Number.isInteger(n) || !isReportPeriodDays(n)) {
+    throw validationError(`"period" must be one of ${REPORT_PERIOD_OPTIONS.join(', ')}`)
+  }
+  return n
+}
+
+/** The period-over-period half-window for a given report window. */
+export function reportComparisonWindowDays(periodDays: number): number {
+  return Math.max(1, Math.floor(periodDays / 2))
+}
 
 const providerLocationTreatmentSchema = z.enum([
   'prompt',
@@ -80,6 +124,13 @@ export const reportMetaSchema = z.object({
   periodStart: z.string().nullable(),
   /** Latest data point referenced by the report (ISO date). */
   periodEnd: z.string().nullable(),
+  /**
+   * The selected report window, in days (one of `REPORT_PERIOD_OPTIONS`).
+   * Every time-windowed section scopes to this many days; renderers read it to
+   * label the window ("Last 30 days", "(30d)"). Defaults to
+   * `REPORT_DEFAULT_PERIOD_DAYS` when no `period` is requested.
+   */
+  periodDays: z.number().int().positive(),
 })
 
 export type ReportMeta = z.infer<typeof reportMetaSchema>
@@ -596,16 +647,25 @@ export const whatsChangedSectionSchema = z.object({
   /** Cited query count delta vs the prior completed run. Null when no prior run. */
   citedQueryCount: reportRateDeltaSchema.nullable(),
   /**
-   * GSC clicks delta — last 14 days of `gsc.trend` vs the 14 days before
-   * that. Null when GSC isn't connected or fewer than 28 trend points exist.
+   * GSC clicks delta — the most recent `comparisonWindowDays` of `gsc.trend`
+   * vs the `comparisonWindowDays` before that. Null when GSC isn't connected
+   * or fewer than `comparisonWindowDays * 2` trend points exist.
    */
   gscClicksDelta: reportRateDeltaSchema.nullable(),
   /**
-   * AI referral sessions delta — last 14 days of `aiReferrals.trend` vs the
-   * 14 days before that. Null when AI referrals aren't tracked or fewer
-   * than 28 trend points exist.
+   * AI referral sessions delta — the most recent `comparisonWindowDays` of
+   * `aiReferrals.trend` vs the `comparisonWindowDays` before that. Null when
+   * AI referrals aren't tracked or fewer than `comparisonWindowDays * 2`
+   * trend points exist.
    */
   aiReferralsDelta: reportRateDeltaSchema.nullable(),
+  /**
+   * The period-over-period half-window in days used for `gscClicksDelta` and
+   * `aiReferralsDelta` — `floor(meta.periodDays / 2)`. Renderers label those
+   * deltas "vs prior {comparisonWindowDays} days" off this single value so the
+   * SPA and HTML stay verbatim-identical.
+   */
+  comparisonWindowDays: z.number().int().positive(),
   /**
    * Per-provider citation rate movements (latest run vs prior run). Empty
    * when no prior run. Sorted by |deltaAbs| desc — providers with the

--- a/packages/contracts/test/report-period.test.ts
+++ b/packages/contracts/test/report-period.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'vitest'
+import {
+  REPORT_DEFAULT_PERIOD_DAYS,
+  REPORT_PERIOD_OPTIONS,
+  parseReportPeriodDays,
+  reportComparisonWindowDays,
+  reportPeriodSchema,
+} from '../src/report.js'
+
+describe('REPORT_PERIOD_OPTIONS', () => {
+  test('exposes the selectable windows and a 30-day default', () => {
+    expect([...REPORT_PERIOD_OPTIONS]).toEqual([7, 14, 30, 90])
+    expect(REPORT_DEFAULT_PERIOD_DAYS).toBe(30)
+    expect(REPORT_PERIOD_OPTIONS).toContain(REPORT_DEFAULT_PERIOD_DAYS)
+  })
+})
+
+describe('parseReportPeriodDays', () => {
+  test('absent values fall back to the default', () => {
+    expect(parseReportPeriodDays(undefined)).toBe(30)
+    expect(parseReportPeriodDays(null)).toBe(30)
+    expect(parseReportPeriodDays('')).toBe(30)
+  })
+
+  test('accepts each valid option as string or number', () => {
+    for (const opt of REPORT_PERIOD_OPTIONS) {
+      expect(parseReportPeriodDays(String(opt))).toBe(opt)
+      expect(parseReportPeriodDays(opt)).toBe(opt)
+    }
+  })
+
+  test('rejects values outside the allowed set with a validation error', () => {
+    for (const bad of ['15', '0', '-7', 'abc', '30.5', 31, 8]) {
+      expect(() => parseReportPeriodDays(bad)).toThrowError(
+        expect.objectContaining({ code: 'VALIDATION_ERROR' }),
+      )
+    }
+  })
+})
+
+describe('reportComparisonWindowDays', () => {
+  test('is floor(periodDays / 2) for every option', () => {
+    expect(reportComparisonWindowDays(7)).toBe(3)
+    expect(reportComparisonWindowDays(14)).toBe(7)
+    expect(reportComparisonWindowDays(30)).toBe(15)
+    expect(reportComparisonWindowDays(90)).toBe(45)
+  })
+
+  test('never drops below 1 even on a tiny window', () => {
+    expect(reportComparisonWindowDays(1)).toBe(1)
+    expect(reportComparisonWindowDays(0)).toBe(1)
+  })
+})
+
+describe('reportPeriodSchema', () => {
+  test('accepts exactly REPORT_PERIOD_OPTIONS — no drift', () => {
+    for (const opt of REPORT_PERIOD_OPTIONS) {
+      expect(reportPeriodSchema.parse(opt)).toBe(opt)
+    }
+    for (const bad of [15, 0, 8, 60, 31]) {
+      expect(reportPeriodSchema.safeParse(bad).success).toBe(false)
+    }
+  })
+})

--- a/skills/canonry/references/canonry-cli.md
+++ b/skills/canonry/references/canonry-cli.md
@@ -153,6 +153,7 @@ Summary: `Mentioned: X / Y` (primary) and `Cited: X / Y` (secondary) are reporte
 
 ```bash
 cnry report <project>                          # write canonry-report-<project>-YYYY-MM-DD.html
+cnry report <project> --period 14              # time window: 7|14|30|90 days (default 30) — scopes GSC/GA/server-activity + period-over-period deltas
 cnry report <project> --output dist/aeo.html   # custom path
 cnry report <project> --format json            # raw report payload to stdout
 ```


### PR DESCRIPTION
Two independent changes on this branch.

**Name-based project URLs** — project routes now key off the project name (a kebab slug) instead of the opaque UUID (e.g. `/projects/acme-co/report`); legacy UUID-shaped URLs redirect to the clean name URL while preserving the tab sub-path, and `ProjectPage`/`AeroBarHost` still resolve a stale id as a fallback.

**Configurable report period** — a 7/14/30/90-day selector (default 30) scopes the GSC, GA4, and server-side AI activity sections plus the period-over-period deltas, wired end-to-end through the API (`?period`), CLI (`--period`), MCP (`canonry_report`), and both the SPA and HTML renderers in parity. Adds tests across contracts, api-routes, and the CLI; bumps to 4.97.0.