### PR TITLE
feat(agent): add DeepInfra as an agent LLM provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,7 +182,8 @@ the external-agent webhook path via `canonry agent attach <url>`.
   `AgentEvent`s to stdout. Supports `--provider claude|openai|gemini|zai|deepinfra`
   and `--format json`. `deepinfra` is a Western-hosted OpenAI-compatible host
   (GLM-5.2 / DeepSeek-V4-Flash); its key comes from `DEEPINFRA_TOKEN` or
-  `providers.deepinfra.apiKey`.
+  `providers.deepinfra.apiKey`, and `DEEPINFRA_BASE_URL` repoints the host at a
+  proxy (e.g. a LiteLLM gateway) — unset falls back to `api.deepinfra.com`.
 - **Dashboard:** the bottom command bar on every project-scoped route.
   SSE-streamed. Starter buttons cover the common ops (status, insights,
   last failed run, schedule).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,8 +179,10 @@ the external-agent webhook path via `canonry agent attach <url>`.
 ### Built-in Aero (native loop)
 
 - **CLI:** `canonry agent ask <project> "<prompt>"` — one-shot, streams
-  `AgentEvent`s to stdout. Supports `--provider claude|openai|gemini|zai`
-  and `--format json`.
+  `AgentEvent`s to stdout. Supports `--provider claude|openai|gemini|zai|deepinfra`
+  and `--format json`. `deepinfra` is a Western-hosted OpenAI-compatible host
+  (GLM-5.2 / DeepSeek-V4-Flash); its key comes from `DEEPINFRA_TOKEN` or
+  `providers.deepinfra.apiKey`.
 - **Dashboard:** the bottom command bar on every project-scoped route.
   SSE-streamed. Starter buttons cover the common ops (status, insights,
   last failed run, schedule).
@@ -253,7 +255,8 @@ Each check returns `status: ok | warn | fail | skipped`, a stable machine-readab
 | integrations | `traffic.source.recent-data` | project | Connected sources have crawler/AI-referral events in the last 7d (warn) or 30d (fail) |
 | integrations | `backlinks.source.connected` | project | At least one backlink source is set up — Common Crawl (`autoExtractBacklinks` + a `ready` release sync) OR Bing Webmaster (a connection for the domain); warns when a project has neither |
 | integrations | `content.winnability.coverage` | project | Discovery classification coverage for cited-surface domains behind the content winnability gate; warns when discovery has not classified the domains that make ownable/ceded decisions meaningful |
-| providers | `config.providers` | global | At least one provider key configured |
+| providers | `config.providers` | global | At least one answer-engine provider key configured |
+| providers | `config.agent-providers` | global | At least one agent LLM provider (claude / openai / gemini / zai / deepinfra) has a usable key — warns when none do (the built-in Aero agent can't run); skipped on deployments that don't run the agent |
 | agent | `agent.skills.installed` | global | Both bundled skills (`canonry`, `aero`) are present under `~/.claude/skills/` |
 | agent | `agent.skills.current` | global | Installed `~/.claude/skills/` trees are not behind the bundled build — warns when a newly shipped or upstream-updated file has not been picked up (skips when nothing is installed; local edits are reported but do not count as "behind") |
 

--- a/apps/web/src/components/shared/AeroBar.tsx
+++ b/apps/web/src/components/shared/AeroBar.tsx
@@ -864,6 +864,8 @@ function envVarHint(id: AgentProviderId): string {
       return 'GOOGLE_API_KEY'
     case 'zai':
       return 'ZAI_API_KEY'
+    case 'deepinfra':
+      return 'DEEPINFRA_TOKEN'
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.97.0",
+  "version": "4.98.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -6,13 +6,13 @@ export type ClientOptions = {
 
 export type AgentProvidersResponseDto = {
     providers: Array<{
-        id: 'claude' | 'openai' | 'gemini' | 'zai';
+        id: 'claude' | 'openai' | 'gemini' | 'zai' | 'deepinfra';
         label: string;
         defaultModel: string;
         configured: boolean;
         keySource: 'config' | 'env';
     }>;
-    defaultProvider: 'claude' | 'openai' | 'gemini' | 'zai';
+    defaultProvider: 'claude' | 'openai' | 'gemini' | 'zai' | 'deepinfra';
 };
 
 export type AdsCampaignListResponse = {

--- a/packages/api-routes/src/doctor.ts
+++ b/packages/api-routes/src/doctor.ts
@@ -9,6 +9,7 @@ import type { BingConnectionStore } from './bing.js'
 import type { WordpressConnectionStore } from './wordpress.js'
 import type { Ga4CredentialStore } from './ga.js'
 import type { ProviderSummaryEntry } from './settings.js'
+import type { AgentProviderOption } from '@ainyc/canonry-contracts'
 import { resolveProject } from './helpers.js'
 
 export interface DoctorRoutesOptions {
@@ -23,6 +24,8 @@ export interface DoctorRoutesOptions {
   /** Used to derive the redirect URI displayed by the redirect-uri check. */
   publicUrl?: string
   providerSummary?: ProviderSummaryEntry[]
+  /** Resolves agent LLM provider key status for the `config.agent-providers` check. See `DoctorContext.getAgentProviderSummary`. */
+  getAgentProviderSummary?: () => AgentProviderOption[]
   /**
    * Map of `traffic_sources.source_type` → adapter validator. Optional — the
    * generic `traffic.source.credentials` / `traffic.source.scopes` checks
@@ -69,6 +72,7 @@ export async function doctorRoutes(app: FastifyInstance, opts: DoctorRoutesOptio
       getPlacesConfig: opts.getPlacesConfig,
       redirectUri,
       providerSummary: opts.providerSummary,
+      getAgentProviderSummary: opts.getAgentProviderSummary,
       trafficSourceValidators: opts.trafficSourceValidators,
       runtimeStatePaths: opts.runtimeStatePaths,
       bundledSkills: opts.bundledSkills,
@@ -100,6 +104,7 @@ export async function doctorRoutes(app: FastifyInstance, opts: DoctorRoutesOptio
       getPlacesConfig: opts.getPlacesConfig,
       redirectUri,
       providerSummary: opts.providerSummary,
+      getAgentProviderSummary: opts.getAgentProviderSummary,
       trafficSourceValidators: opts.trafficSourceValidators,
       runtimeStatePaths: opts.runtimeStatePaths,
       bundledSkills: opts.bundledSkills,

--- a/packages/api-routes/src/doctor/checks/providers.ts
+++ b/packages/api-routes/src/doctor/checks/providers.ts
@@ -43,4 +43,54 @@ const providersConfiguredCheck: CheckDefinition = {
   },
 }
 
-export const PROVIDERS_CHECKS: readonly CheckDefinition[] = [providersConfiguredCheck]
+const agentProvidersConfiguredCheck: CheckDefinition = {
+  id: 'config.agent-providers',
+  category: CheckCategories.providers,
+  scope: CheckScopes.global,
+  title: 'Agent provider keys',
+  run: (ctx) => {
+    const summary = ctx.getAgentProviderSummary?.()
+    if (!summary) {
+      return {
+        status: CheckStatuses.skipped,
+        code: 'agent-providers.summary-unavailable',
+        summary: 'Agent provider summary is not available in this deployment.',
+        remediation: null,
+      }
+    }
+    const configured = summary.filter((entry) => entry.configured)
+    const total = summary.length
+    const details = {
+      configured: configured.map((entry) => entry.id),
+      providers: summary.map((entry) => ({
+        id: entry.id,
+        configured: entry.configured,
+        keySource: entry.keySource,
+      })),
+    }
+    if (configured.length === 0) {
+      return {
+        status: CheckStatuses.warn,
+        code: 'agent-providers.none-configured',
+        summary: 'No agent LLM provider has credentials configured — the built-in Aero agent cannot run.',
+        remediation:
+          'Add a key for one of the agent providers (claude, openai, gemini, zai, deepinfra) under ' +
+          '`providers.<name>.apiKey` in ~/.canonry/config.yaml, or export its env var ' +
+          '(e.g. ANTHROPIC_API_KEY, OPENAI_API_KEY, DEEPINFRA_TOKEN).',
+        details,
+      }
+    }
+    return {
+      status: CheckStatuses.ok,
+      code: 'agent-providers.configured',
+      summary: `${configured.length} of ${total} agent providers configured: ${configured.map((e) => e.id).join(', ')}.`,
+      remediation: null,
+      details,
+    }
+  },
+}
+
+export const PROVIDERS_CHECKS: readonly CheckDefinition[] = [
+  providersConfiguredCheck,
+  agentProvidersConfiguredCheck,
+]

--- a/packages/api-routes/src/doctor/types.ts
+++ b/packages/api-routes/src/doctor/types.ts
@@ -1,5 +1,5 @@
 import type { DatabaseClient } from '@ainyc/canonry-db'
-import type { BundledSkillSnapshot, CheckCategory, CheckResultDto, CheckScope, CheckStatus } from '@ainyc/canonry-contracts'
+import type { AgentProviderOption, BundledSkillSnapshot, CheckCategory, CheckResultDto, CheckScope, CheckStatus } from '@ainyc/canonry-contracts'
 import type { GoogleConnectionStore } from '../google.js'
 import type { BingConnectionStore } from '../bing.js'
 import type { WordpressConnectionStore } from '../wordpress.js'
@@ -56,6 +56,14 @@ export interface DoctorContext {
   /** Resolved redirect URI (publicUrl + /api/v1/google/callback) used by the OAuth flow. */
   redirectUri?: string
   providerSummary?: ProviderSummaryEntry[]
+  /**
+   * Resolves which agent LLM providers (claude / openai / gemini / zai /
+   * deepinfra) currently have a usable key, for the `config.agent-providers`
+   * check. A closure (not a snapshot) so it reflects keys added at runtime
+   * via the settings API. Wired by `canonry serve`; cloud deployments that
+   * don't run the built-in agent leave it undefined and the check `skipped`.
+   */
+  getAgentProviderSummary?: () => AgentProviderOption[]
   /**
    * Map of `traffic_sources.source_type` → adapter-specific validator. The
    * generic `traffic.source.credentials` / `traffic.source.scopes` checks

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -84,6 +84,8 @@ export interface ApiRoutesOptions {
   onRunCreated?: (runId: string, projectId: string, providers?: string[], location?: import('@ainyc/canonry-contracts').LocationContext | null) => void
   /** Provider configuration summary for settings endpoint */
   providerSummary?: ProviderSummaryEntry[]
+  /** Resolves agent LLM provider key status for the `config.agent-providers` doctor check. See `DoctorContext.getAgentProviderSummary`. */
+  getAgentProviderSummary?: () => import('@ainyc/canonry-contracts').AgentProviderOption[]
   /** Adapter metadata for provider validation */
   providerAdapters?: ProviderAdapterInfo[]
   /** Callback when a provider config is updated via API */
@@ -461,6 +463,7 @@ export async function apiRoutes(app: FastifyInstance, opts: ApiRoutesOptions) {
       getPlacesConfig: opts.getPlacesConfig,
       publicUrl: opts.publicUrl,
       providerSummary: opts.providerSummary,
+      getAgentProviderSummary: opts.getAgentProviderSummary,
       trafficSourceValidators: buildTrafficSourceValidators(opts),
       runtimeStatePaths: opts.runtimeStatePaths,
       bundledSkills: opts.bundledSkills,

--- a/packages/api-routes/test/doctor-other-checks.test.ts
+++ b/packages/api-routes/test/doctor-other-checks.test.ts
@@ -264,3 +264,44 @@ describe('config.providers', () => {
     expect(result.status).toBe('skipped')
   })
 })
+
+const agentProvidersCheck = PROVIDERS_CHECKS.find((c) => c.id === 'config.agent-providers')!
+
+function agentEntry(id: string, configured: boolean, keySource: 'config' | 'env' | null = null) {
+  return { id, label: id, defaultModel: 'm', configured, keySource }
+}
+
+describe('config.agent-providers', () => {
+  it('returns ok and reports the configured agent providers (incl. deepinfra)', () => {
+    const result = agentProvidersCheck.run({
+      db: {} as DoctorContext['db'],
+      project: null,
+      getAgentProviderSummary: () => [
+        agentEntry('claude', true, 'env'),
+        agentEntry('deepinfra', true, 'config'),
+        agentEntry('zai', false),
+      ],
+    })
+    expect(result.status).toBe('ok')
+    expect(result.code).toBe('agent-providers.configured')
+    expect(result.summary).toContain('deepinfra')
+    expect(result.details).toMatchObject({ configured: ['claude', 'deepinfra'] })
+  })
+
+  it('warns (not fails) when no agent provider has a key', () => {
+    const result = agentProvidersCheck.run({
+      db: {} as DoctorContext['db'],
+      project: null,
+      getAgentProviderSummary: () => [agentEntry('claude', false), agentEntry('deepinfra', false)],
+    })
+    expect(result.status).toBe('warn')
+    expect(result.code).toBe('agent-providers.none-configured')
+    expect(result.remediation).toMatch(/DEEPINFRA_TOKEN/)
+  })
+
+  it('skips when the agent provider summary is unavailable (e.g. cloud)', () => {
+    const result = agentProvidersCheck.run({ db: {} as DoctorContext['db'], project: null })
+    expect(result.status).toBe('skipped')
+    expect(result.code).toBe('agent-providers.summary-unavailable')
+  })
+})

--- a/packages/canonry/AGENTS.md
+++ b/packages/canonry/AGENTS.md
@@ -195,7 +195,10 @@ consume Canonry through the external-agent webhook.
 
 - **CLI**: `canonry agent ask <project> "<prompt>"` — one-shot turn. Streams
   `AgentEvent` lines to stdout (or JSON with `--format json`). Supports
-  `--provider claude|openai|gemini|zai` and `--model <id>`.
+  `--provider claude|openai|gemini|zai|deepinfra` and `--model <id>`. `zai` and
+  `deepinfra` are agent-only; `deepinfra` is an OpenAI-compatible host outside
+  pi-ai's catalog (`agent/providers.ts` builds a custom `openai-completions`
+  model against `https://api.deepinfra.com/v1/openai`; key from `DEEPINFRA_TOKEN`).
 - **Dashboard**: bottom command bar (`AeroBar`) on every project-scoped
   route. SSE-streamed via `POST /api/v1/projects/:name/agent/prompt`.
 - **Proactive**: `RunCoordinator` enqueues a synthesized `[system]` follow-up

--- a/packages/canonry/AGENTS.md
+++ b/packages/canonry/AGENTS.md
@@ -198,7 +198,8 @@ consume Canonry through the external-agent webhook.
   `--provider claude|openai|gemini|zai|deepinfra` and `--model <id>`. `zai` and
   `deepinfra` are agent-only; `deepinfra` is an OpenAI-compatible host outside
   pi-ai's catalog (`agent/providers.ts` builds a custom `openai-completions`
-  model against `https://api.deepinfra.com/v1/openai`; key from `DEEPINFRA_TOKEN`).
+  model against `https://api.deepinfra.com/v1/openai`; key from `DEEPINFRA_TOKEN`,
+  base URL overridable via `DEEPINFRA_BASE_URL` for proxy/LiteLLM-gateway routing).
 - **Dashboard**: bottom command bar (`AeroBar`) on every project-scoped
   route. SSE-streamed via `POST /api/v1/projects/:name/agent/prompt`.
 - **Proactive**: `RunCoordinator` enqueues a synthesized `[system]` follow-up

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.97.0",
+  "version": "4.98.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/agent/providers.ts
+++ b/packages/canonry/src/agent/providers.ts
@@ -1,4 +1,10 @@
-import { getEnvApiKey, getModel, type KnownProvider, type Model } from '@mariozechner/pi-ai'
+import {
+  getEnvApiKey,
+  getModel,
+  type KnownProvider,
+  type Model,
+  type OpenAICompletionsCompat,
+} from '@mariozechner/pi-ai'
 import {
   AGENT_PROVIDER_IDS,
   AgentProviderIds,
@@ -20,8 +26,9 @@ import {
  * metadata: pi-ai vendor mapping, per-capability models, priority, label.
  *
  * Intentionally does NOT list sweep-only providers (`perplexity`, `local`,
- * `cdp:chatgpt`) — they can't drive an agent loop. `zai` is agent-only
- * with no sweep adapter.
+ * `cdp:chatgpt`) — they can't drive an agent loop. `zai` and `deepinfra`
+ * are agent-only with no sweep adapter; `deepinfra` is an OpenAI-compatible
+ * host outside pi-ai's catalog (see `OpenAiCompatibleHost`).
  *
  * Model selection is two-dimensional: `(provider, capability) → modelId`.
  * Provider is configured by the user (API key + default); capability is
@@ -31,20 +38,73 @@ import {
  * exposes `defaultModel` as a shortcut to the `agent`-tier model for
  * backward-compatible callers (DTO + CLI display).
  */
+/**
+ * Per-model metadata used to build a `Model<'openai-completions'>` object
+ * for a custom OpenAI-compatible host that isn't in pi-ai's catalog. Costs
+ * are USD per 1M tokens (same unit pi-ai's `calculateCost` consumes);
+ * `contextWindow` / `maxTokens` feed pi-ai's overflow heuristics only.
+ */
+export interface OpenAiCompatibleModelMeta {
+  contextWindow: number
+  maxTokens: number
+  reasoning: boolean
+  cost: { input: number; output: number; cacheRead: number; cacheWrite: number }
+}
+
+/**
+ * Config for an OpenAI-compatible host (e.g. DeepInfra) that pi-ai can reach
+ * through its `openai-completions` API but does not ship in its model
+ * catalog. When an `AgentProviderEntry` carries this block, model resolution
+ * constructs a custom `Model<'openai-completions'>` pointed at `baseUrl`
+ * instead of looking the id up via `getModel`, and API-key resolution reads
+ * `apiKeyEnvVar` (pi-ai's `getEnvApiKey` doesn't know this host).
+ */
+export interface OpenAiCompatibleHost {
+  /** OpenAI-compatible completions base URL, e.g. `https://api.deepinfra.com/v1/openai`. */
+  baseUrl: string
+  /** Env var carrying the API key — pi-ai's `getEnvApiKey` has no entry for this host. */
+  apiKeyEnvVar: string
+  /**
+   * pi-ai compat overrides for the host's quirks. pi-ai auto-detects compat
+   * from the base URL for hosts it knows; an unknown host like DeepInfra
+   * falls back to the strict OpenAI profile, so we set the open-model
+   * profile explicitly. See `detectCompat` in pi-ai's openai-completions.
+   */
+  compat?: OpenAICompletionsCompat
+  /** Per-slug metadata for `org/Model` ids we ship as tiers; falls back to `defaultModelMeta`. */
+  knownModels: Record<string, OpenAiCompatibleModelMeta>
+  /** Metadata for user-supplied `--model` slugs not present in `knownModels`. */
+  defaultModelMeta: OpenAiCompatibleModelMeta
+}
+
 export interface AgentProviderEntry {
-  /** pi-ai vendor id — what `getModel(provider, id)` and `getEnvApiKey(provider)` accept. */
-  piAiProvider: KnownProvider
+  /**
+   * The `model.provider` string the agent loop passes to `getApiKey`. For
+   * pi-ai catalog providers this is the pi-ai vendor id (e.g. `anthropic`)
+   * that `getModel(provider, id)` / `getEnvApiKey(provider)` accept. For a
+   * custom OpenAI-compatible host (see `openaiCompatible`) it's the canonical
+   * `AgentProviderId` (e.g. `deepinfra`) — not a pi-ai catalog provider —
+   * which `resolveAgentId` maps back to the config/env key lookup.
+   */
+  piAiProvider: KnownProvider | string
   /** User-facing label shown in CLI help and dashboard pickers. */
   label: string
   /**
    * Default model when the caller doesn't specify one and didn't pass a
    * capability. Equals `PROVIDER_MODELS[id].agent` — the `agent`-tier
    * model is the historical default since Aero was the only consumer.
-   * Validated against pi-ai's catalog at module load.
+   * Validated against pi-ai's catalog at module load (catalog providers
+   * only; custom hosts validate that the model object builds).
    */
   defaultModel: string
   /** Lower = higher priority in auto-detect. Used when no `--provider` is passed. */
   autoDetectPriority: number
+  /**
+   * Present only for OpenAI-compatible hosts outside pi-ai's catalog. Drives
+   * custom model construction + env-var key resolution. Absent for pi-ai
+   * catalog providers (claude / openai / gemini / zai).
+   */
+  openaiCompatible?: OpenAiCompatibleHost
 }
 
 /**
@@ -65,6 +125,11 @@ export interface AgentProviderEntry {
  *     model. All three tiers point at flash.
  *   - Zai: glm-5.1 is the agent tier; glm-5.1-flash is the cheap tier
  *     for analyze + classify.
+ *   - DeepInfra: GLM-5.2 (Western-hosted open weights) is the agent tier;
+ *     DeepSeek-V4-Flash is the cheap tier for analyze + classify. These are
+ *     DeepInfra `org/Model` slugs, not pi-ai catalog ids — model resolution
+ *     builds a custom openai-completions model (see `buildOpenAiCompatibleModel`).
+ *     Serving is quantized (FP8/FP4); validate quality before production use.
  */
 export const PROVIDER_MODELS = {
   [AgentProviderIds.claude]: {
@@ -92,9 +157,20 @@ export const PROVIDER_MODELS = {
     [LlmCapabilities.analyze]: 'glm-5-turbo',
     [LlmCapabilities.classify]: 'glm-5-turbo',
   },
+  [AgentProviderIds.deepinfra]: {
+    // DeepInfra `org/Model` slugs. GLM-5.2 drives the agent loop; the much
+    // cheaper DeepSeek-V4-Flash fills analyze + classify. Resolved into a
+    // custom openai-completions model, not pi-ai's catalog.
+    [LlmCapabilities.agent]: 'zai-org/GLM-5.2',
+    [LlmCapabilities.analyze]: 'deepseek-ai/DeepSeek-V4-Flash',
+    [LlmCapabilities.classify]: 'deepseek-ai/DeepSeek-V4-Flash',
+  },
 } as const satisfies Record<AgentProviderId, Record<LlmCapability, string>>
 
-export const AGENT_PROVIDERS = {
+// Explicitly typed as the widened entry record (not `as const satisfies`) so
+// `AGENT_PROVIDERS[id].openaiCompatible` is visible on every member — the
+// const-narrowed union would only expose it on the one entry that sets it.
+export const AGENT_PROVIDERS: Record<AgentProviderId, AgentProviderEntry> = {
   [AgentProviderIds.claude]: {
     piAiProvider: 'anthropic',
     label: 'Anthropic (Claude)',
@@ -119,7 +195,58 @@ export const AGENT_PROVIDERS = {
     defaultModel: PROVIDER_MODELS[AgentProviderIds.zai][LlmCapabilities.agent],
     autoDetectPriority: 3,
   },
-} as const satisfies Record<AgentProviderId, AgentProviderEntry>
+  [AgentProviderIds.deepinfra]: {
+    // `piAiProvider` is the canonical id here (not a pi-ai vendor) — it's the
+    // `model.provider` string the agent loop hands to `getApiKey`, which
+    // `resolveAgentId` maps straight back to the deepinfra config/env key.
+    piAiProvider: AgentProviderIds.deepinfra,
+    label: 'DeepInfra (GLM / DeepSeek)',
+    defaultModel: PROVIDER_MODELS[AgentProviderIds.deepinfra][LlmCapabilities.agent],
+    autoDetectPriority: 4,
+    openaiCompatible: {
+      baseUrl: 'https://api.deepinfra.com/v1/openai',
+      apiKeyEnvVar: 'DEEPINFRA_TOKEN',
+      // DeepInfra serves open-weight models (GLM, DeepSeek) behind an
+      // OpenAI-compatible vLLM endpoint. pi-ai's `detectCompat` has no rule
+      // for api.deepinfra.com, so it would apply the strict OpenAI profile;
+      // we set the same open-model profile pi-ai uses for deepseek.com /
+      // cerebras / z.ai. `developer` role and `reasoning_effort` are
+      // OpenAI-platform-isms these models reject, `store` is response
+      // persistence DeepInfra doesn't implement, and DeepInfra documents
+      // `max_tokens` (not `max_completion_tokens`) on its OpenAI route.
+      compat: {
+        supportsStore: false,
+        supportsDeveloperRole: false,
+        supportsReasoningEffort: false,
+        maxTokensField: 'max_tokens',
+      },
+      // Best-effort metadata. Costs are USD/1M tokens (DeepInfra published
+      // rates: GLM-5.2 ~$0.95 in / $0.18 cached / $3.00 out; DeepSeek-V4-Flash
+      // ~$0.10 in / $0.20 out). Context/maxTokens only drive pi-ai overflow
+      // heuristics, not the wire limit.
+      knownModels: {
+        'zai-org/GLM-5.2': {
+          contextWindow: 131072,
+          maxTokens: 98304,
+          reasoning: true,
+          cost: { input: 0.95, output: 3.0, cacheRead: 0.18, cacheWrite: 0 },
+        },
+        'deepseek-ai/DeepSeek-V4-Flash': {
+          contextWindow: 131072,
+          maxTokens: 32768,
+          reasoning: false,
+          cost: { input: 0.1, output: 0.2, cacheRead: 0, cacheWrite: 0 },
+        },
+      },
+      defaultModelMeta: {
+        contextWindow: 131072,
+        maxTokens: 32768,
+        reasoning: false,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      },
+    },
+  },
+}
 
 /**
  * Backwards-compatible alias for the canonical `AgentProviderId`. Existing
@@ -187,7 +314,10 @@ export function resolveModelForProvider(
  * mid-tier for synthesis) without hand-coding model names at every
  * call site.
  *
- * Throws if the model isn't in pi-ai's catalog.
+ * For a pi-ai catalog provider, throws if the model isn't in pi-ai's
+ * catalog. For a custom OpenAI-compatible host (`entry.openaiCompatible`,
+ * e.g. DeepInfra) the model is constructed directly — any slug is accepted
+ * and forwarded to the host, which validates it at request time.
  */
 export function resolveModelForCapability(
   provider: AgentProviderId,
@@ -196,6 +326,11 @@ export function resolveModelForCapability(
 ): Model<never> {
   const entry = AGENT_PROVIDERS[provider]
   const id = modelIdOverride ?? PROVIDER_MODELS[provider][capability]
+  // Custom OpenAI-compatible host (e.g. DeepInfra): the slug isn't in pi-ai's
+  // catalog, so construct the model object directly against the host base URL.
+  if (entry.openaiCompatible) {
+    return buildOpenAiCompatibleModel(entry, id) as Model<never>
+  }
   const model = getModel(entry.piAiProvider as never, id as never) as Model<never> | undefined
   if (!model) {
     throw new Error(
@@ -204,6 +339,36 @@ export function resolveModelForCapability(
     )
   }
   return model
+}
+
+/**
+ * Build a `Model<'openai-completions'>` for a custom OpenAI-compatible host.
+ * pi-ai's `streamSimple` dispatches on `model.api`, hits `model.baseUrl`, and
+ * passes `model.provider` to the agent loop's `getApiKey` callback — so the
+ * canonical id in `entry.piAiProvider` lands back in our key resolver.
+ */
+export function buildOpenAiCompatibleModel(
+  entry: AgentProviderEntry,
+  id: string,
+): Model<'openai-completions'> {
+  const host = entry.openaiCompatible
+  if (!host) {
+    throw new Error(`buildOpenAiCompatibleModel called for non-custom provider '${entry.piAiProvider}'`)
+  }
+  const meta = host.knownModels[id] ?? host.defaultModelMeta
+  return {
+    id,
+    name: id,
+    api: 'openai-completions',
+    provider: entry.piAiProvider,
+    baseUrl: host.baseUrl,
+    reasoning: meta.reasoning,
+    input: ['text'],
+    cost: meta.cost,
+    contextWindow: meta.contextWindow,
+    maxTokens: meta.maxTokens,
+    ...(host.compat ? { compat: host.compat } : {}),
+  }
 }
 
 /**
@@ -264,9 +429,26 @@ export function resolveApiKeySource(
   const entry = AGENT_PROVIDERS[id]
   const fromConfig = config.providers?.[id]?.apiKey
   if (fromConfig) return { key: fromConfig, source: 'config' }
-  const fromEnv = getEnvApiKey(entry.piAiProvider)
+  // Custom hosts (DeepInfra) aren't in pi-ai's env-var map — read their
+  // documented env var directly. Catalog providers fall back to pi-ai.
+  const fromEnv = entry.openaiCompatible
+    ? process.env[entry.openaiCompatible.apiKeyEnvVar]
+    : getEnvApiKey(entry.piAiProvider)
   if (fromEnv) return { key: fromEnv, source: 'env' }
   return undefined
+}
+
+/**
+ * The environment variable an operator sets to supply this provider's key,
+ * shown in onboarding hints. Custom hosts carry their own var (DeepInfra →
+ * `DEEPINFRA_TOKEN`); catalog providers derive it from the pi-ai vendor id
+ * (`anthropic` → `ANTHROPIC_API_KEY`), matching pi-ai's `getEnvApiKey` map.
+ */
+export function agentProviderApiKeyEnvVar(id: AgentProviderId): string {
+  const entry = AGENT_PROVIDERS[id]
+  return entry.openaiCompatible
+    ? entry.openaiCompatible.apiKeyEnvVar
+    : `${entry.piAiProvider.toUpperCase()}_API_KEY`
 }
 
 /**

--- a/packages/canonry/src/agent/providers.ts
+++ b/packages/canonry/src/agent/providers.ts
@@ -41,8 +41,11 @@ import {
 /**
  * Per-model metadata used to build a `Model<'openai-completions'>` object
  * for a custom OpenAI-compatible host that isn't in pi-ai's catalog. Costs
- * are USD per 1M tokens (same unit pi-ai's `calculateCost` consumes);
- * `contextWindow` / `maxTokens` feed pi-ai's overflow heuristics only.
+ * are USD per 1M tokens (same unit pi-ai's `calculateCost` consumes).
+ * `contextWindow` / `maxTokens` are descriptive capability metadata — Aero's
+ * compaction fires on a fixed token budget (`COMPACTION_TOKEN_THRESHOLD`) and
+ * pi-agent-core's loop never reads `model.contextWindow`, so the value here
+ * does not gate compaction; keep it accurate for documentation + cost display.
  */
 export interface OpenAiCompatibleModelMeta {
   contextWindow: number
@@ -62,6 +65,13 @@ export interface OpenAiCompatibleModelMeta {
 export interface OpenAiCompatibleHost {
   /** OpenAI-compatible completions base URL, e.g. `https://api.deepinfra.com/v1/openai`. */
   baseUrl: string
+  /**
+   * Optional env var that overrides `baseUrl` at model-construction time. Lets
+   * a proxied deployment (e.g. a LiteLLM gateway that injects the upstream key
+   * out-of-container) repoint the host without a rebuild. Unset / empty env →
+   * the `baseUrl` constant is used, so the default self-hosted path is unchanged.
+   */
+  baseUrlEnvVar?: string
   /** Env var carrying the API key — pi-ai's `getEnvApiKey` has no entry for this host. */
   apiKeyEnvVar: string
   /**
@@ -205,6 +215,7 @@ export const AGENT_PROVIDERS: Record<AgentProviderId, AgentProviderEntry> = {
     autoDetectPriority: 4,
     openaiCompatible: {
       baseUrl: 'https://api.deepinfra.com/v1/openai',
+      baseUrlEnvVar: 'DEEPINFRA_BASE_URL',
       apiKeyEnvVar: 'DEEPINFRA_TOKEN',
       // DeepInfra serves open-weight models (GLM, DeepSeek) behind an
       // OpenAI-compatible vLLM endpoint. pi-ai's `detectCompat` has no rule
@@ -222,22 +233,26 @@ export const AGENT_PROVIDERS: Record<AgentProviderId, AgentProviderEntry> = {
       },
       // Best-effort metadata. Costs are USD/1M tokens (DeepInfra published
       // rates: GLM-5.2 ~$0.95 in / $0.18 cached / $3.00 out; DeepSeek-V4-Flash
-      // ~$0.10 in / $0.20 out). Context/maxTokens only drive pi-ai overflow
-      // heuristics, not the wire limit.
+      // ~$0.10 in / $0.20 out). contextWindow is DeepInfra's 1M (fp4) serving
+      // window for both models; it's descriptive (see OpenAiCompatibleModelMeta),
+      // so it documents the real window rather than gating compaction.
       knownModels: {
         'zai-org/GLM-5.2': {
-          contextWindow: 131072,
+          contextWindow: 1_048_576,
           maxTokens: 98304,
           reasoning: true,
           cost: { input: 0.95, output: 3.0, cacheRead: 0.18, cacheWrite: 0 },
         },
         'deepseek-ai/DeepSeek-V4-Flash': {
-          contextWindow: 131072,
+          contextWindow: 1_048_576,
           maxTokens: 32768,
           reasoning: false,
           cost: { input: 0.1, output: 0.2, cacheRead: 0, cacheWrite: 0 },
         },
       },
+      // Fallback for arbitrary `--model` slugs we don't ship as tiers. cost is
+      // 0, so an unknown slug isn't cost-tracked by pi-ai's `calculateCost`;
+      // contextWindow stays conservative since we can't know the slug's window.
       defaultModelMeta: {
         contextWindow: 131072,
         maxTokens: 32768,
@@ -356,12 +371,16 @@ export function buildOpenAiCompatibleModel(
     throw new Error(`buildOpenAiCompatibleModel called for non-custom provider '${entry.piAiProvider}'`)
   }
   const meta = host.knownModels[id] ?? host.defaultModelMeta
+  // A proxied deployment can repoint the host via `baseUrlEnvVar` (e.g. a
+  // LiteLLM gateway); an unset/empty env var falls back to the configured
+  // constant, so the default self-hosted path is byte-for-byte unchanged.
+  const baseUrl = (host.baseUrlEnvVar ? process.env[host.baseUrlEnvVar] : undefined) || host.baseUrl
   return {
     id,
     name: id,
     api: 'openai-completions',
     provider: entry.piAiProvider,
-    baseUrl: host.baseUrl,
+    baseUrl,
     reasoning: meta.reasoning,
     input: ['text'],
     cost: meta.cost,

--- a/packages/canonry/src/agent/recommendation-explainer.ts
+++ b/packages/canonry/src/agent/recommendation-explainer.ts
@@ -20,7 +20,7 @@ import type {
 } from '@ainyc/canonry-api-routes'
 import type { CanonryConfig } from '../config.js'
 import {
-  AGENT_PROVIDERS,
+  agentProviderApiKeyEnvVar,
   agentProvidersByPriority,
   coerceAgentProvider,
   resolveApiKeyFor,
@@ -159,9 +159,7 @@ function pickExplainProvider(
   for (const provider of agentProvidersByPriority()) {
     if (resolveApiKeyFor(provider, config)) return provider
   }
-  const hints = agentProvidersByPriority()
-    .map((p) => `${AGENT_PROVIDERS[p].piAiProvider.toUpperCase()}_API_KEY`)
-    .join(' / ')
+  const hints = agentProvidersByPriority().map(agentProviderApiKeyEnvVar).join(' / ')
   throw providerError(
     `No LLM provider configured. Add an API key in ~/.canonry/config.yaml or set one of: ${hints}.`,
   )

--- a/packages/canonry/src/agent/session.ts
+++ b/packages/canonry/src/agent/session.ts
@@ -6,7 +6,7 @@ import { registerBuiltInApiProviders, type Model } from '@mariozechner/pi-ai'
 import type { ApiClient } from '../client.js'
 import type { CanonryConfig } from '../config.js'
 import {
-  AGENT_PROVIDERS,
+  agentProviderApiKeyEnvVar,
   agentProvidersByPriority,
   getAgentProvider,
   resolveApiKeyFor,
@@ -72,9 +72,7 @@ export function loadAeroSystemPrompt(pkgDir?: string): string {
 
 function missingProviderMessage(): string {
   const configHints = agentProvidersByPriority().join(', ')
-  const envHints = agentProvidersByPriority()
-    .map((p) => `${AGENT_PROVIDERS[p].piAiProvider.toUpperCase()}_API_KEY`)
-    .join(' / ')
+  const envHints = agentProvidersByPriority().map(agentProviderApiKeyEnvVar).join(' / ')
   return (
     `No agent LLM provider configured. Add an API key for one of: ${configHints} in ` +
     `~/.canonry/config.yaml, or export ${envHints}.`

--- a/packages/canonry/src/mcp/tool-registry.ts
+++ b/packages/canonry/src/mcp/tool-registry.ts
@@ -276,7 +276,7 @@ const contentTargetsInputSchema = z.object({
 const contentBriefInputSchema = z.object({
   project: projectNameSchema,
   targetRef: z.string().min(1).describe('Stable target ref from canonry_content_targets. The target must be ownable; ceded targets are rejected.'),
-  provider: z.string().optional().describe('Optional provider override (claude|openai|gemini|zai).'),
+  provider: z.string().optional().describe('Optional provider override (claude|openai|gemini|zai|deepinfra).'),
   model: z.string().optional().describe('Optional model override within the chosen provider.'),
   forceRefresh: z.boolean().optional().describe('Force a fresh synthesis even if a cached brief exists.'),
 })

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -95,6 +95,7 @@ import { Notifier } from './notifier.js'
 import { IntelligenceService } from './intelligence-service.js'
 import { RunCoordinator } from './run-coordinator.js'
 import { SessionRegistry } from './agent/session-registry.js'
+import { buildAgentProvidersResponse } from './agent/providers.js'
 import { registerAgentRoutes } from './agent/agent-routes.js'
 import { createRecommendationExplainer, createRecommendationBriefSynthesizer, RECOMMENDATION_BRIEF_PROMPT_VERSION } from './agent/recommendation-explainer.js'
 import { ApiClient } from './client.js'
@@ -1312,6 +1313,9 @@ export async function createServer(opts: {
     },
     getGoogleAuthConfig: () => getGoogleAuthConfig(opts.config),
     getPlacesConfig: () => getPlacesConfig(opts.config),
+    // Resolved fresh each call so a key added at runtime (settings API) shows
+    // up immediately in the `config.agent-providers` doctor check.
+    getAgentProviderSummary: () => buildAgentProvidersResponse(opts.config).providers,
     googleConnectionStore,
     googleStateSecret,
     publicUrl: opts.config.publicUrl,

--- a/packages/canonry/test/agent-providers.test.ts
+++ b/packages/canonry/test/agent-providers.test.ts
@@ -5,6 +5,7 @@ import {
   AGENT_PROVIDERS,
   AgentProviders,
   PROVIDER_MODELS,
+  agentProviderApiKeyEnvVar,
   agentProvidersByPriority,
   buildAgentProvidersResponse,
   coerceAgentProvider,
@@ -34,10 +35,18 @@ describe('agent provider registry', () => {
     }
   })
 
-  it('every registered default model resolves against pi-ai at runtime', () => {
+  it('every registered default model resolves at runtime', () => {
     expect(() => validateAgentProviderRegistry()).not.toThrow()
     for (const provider of listAgentProviders()) {
       const entry = getAgentProvider(provider)
+      if (entry.openaiCompatible) {
+        // Custom OpenAI-compatible host (e.g. DeepInfra) — not in pi-ai's
+        // catalog. Resolve via the builder and assert it points at the host.
+        const model = resolveModelForCapability(provider, LlmCapabilities.agent)
+        expect((model as { id?: string }).id).toBe(entry.defaultModel)
+        expect((model as { baseUrl?: string }).baseUrl).toBe(entry.openaiCompatible.baseUrl)
+        continue
+      }
       const model = getModel(entry.piAiProvider as never, entry.defaultModel as never)
       expect(model, `pi-ai missing ${entry.piAiProvider}/${entry.defaultModel}`).toBeDefined()
     }
@@ -228,11 +237,18 @@ describe('PROVIDER_MODELS capability tiers', () => {
     }
   })
 
-  it('every (provider, capability) pair resolves to a real pi-ai model', () => {
+  it('every (provider, capability) pair resolves to a model', () => {
     for (const provider of listAgentProviders()) {
       for (const capability of LLM_CAPABILITIES) {
         const entry = getAgentProvider(provider)
         const modelId = PROVIDER_MODELS[provider][capability]
+        if (entry.openaiCompatible) {
+          // Custom host: the builder constructs the model from the slug
+          // (no pi-ai catalog entry to look up).
+          const model = resolveModelForCapability(provider, capability)
+          expect((model as { id?: string }).id).toBe(modelId)
+          continue
+        }
         const model = getModel(entry.piAiProvider as never, modelId as never)
         expect(
           model,
@@ -298,5 +314,110 @@ describe('resolveModelForCapability', () => {
     const viaProvider = resolveModelForProvider('claude', overrideId)
     const viaCapability = resolveModelForCapability('claude', LlmCapabilities.agent, overrideId)
     expect((viaProvider as { id?: string }).id).toBe((viaCapability as { id?: string }).id)
+  })
+})
+
+describe('deepinfra (custom OpenAI-compatible host)', () => {
+  // DeepInfra is agent-only, has no pi-ai catalog entry, and resolves models
+  // by constructing a custom openai-completions object pointed at its base URL.
+  type CompletionsModel = {
+    id: string
+    api: string
+    provider: string
+    baseUrl: string
+    reasoning: boolean
+    cost: { input: number; output: number; cacheRead: number; cacheWrite: number }
+    compat?: { supportsDeveloperRole?: boolean; maxTokensField?: string }
+  }
+
+  it('is registered, agent-only, and carries an openaiCompatible host config', () => {
+    expect(listAgentProviders()).toContain('deepinfra')
+    const entry = getAgentProvider('deepinfra')
+    expect(entry.piAiProvider).toBe('deepinfra')
+    expect(entry.openaiCompatible?.baseUrl).toBe('https://api.deepinfra.com/v1/openai')
+    expect(entry.openaiCompatible?.apiKeyEnvVar).toBe('DEEPINFRA_TOKEN')
+  })
+
+  it('agent tier is GLM-5.2; analyze + classify share the cheaper DeepSeek tier', () => {
+    expect(PROVIDER_MODELS.deepinfra[LlmCapabilities.agent]).toBe('zai-org/GLM-5.2')
+    expect(PROVIDER_MODELS.deepinfra[LlmCapabilities.analyze]).toBe('deepseek-ai/DeepSeek-V4-Flash')
+    expect(PROVIDER_MODELS.deepinfra[LlmCapabilities.classify]).toBe('deepseek-ai/DeepSeek-V4-Flash')
+    // defaultModel mirrors the agent tier (covered generically elsewhere too).
+    expect(getAgentProvider('deepinfra').defaultModel).toBe('zai-org/GLM-5.2')
+  })
+
+  it('builds an openai-completions model pointed at DeepInfra for every capability', () => {
+    for (const capability of LLM_CAPABILITIES) {
+      const model = resolveModelForCapability('deepinfra', capability) as unknown as CompletionsModel
+      expect(model.api).toBe('openai-completions')
+      // model.provider is what the agent loop hands back to getApiKey — must
+      // be the canonical id so the deepinfra key resolver fires.
+      expect(model.provider).toBe('deepinfra')
+      expect(model.baseUrl).toBe('https://api.deepinfra.com/v1/openai')
+      expect(model.id).toBe(PROVIDER_MODELS.deepinfra[capability])
+    }
+  })
+
+  it('applies the open-model compat profile (no developer role, max_tokens field)', () => {
+    const model = resolveModelForCapability('deepinfra', LlmCapabilities.agent) as unknown as CompletionsModel
+    expect(model.compat?.supportsDeveloperRole).toBe(false)
+    expect(model.compat?.maxTokensField).toBe('max_tokens')
+  })
+
+  it('applies per-slug known-model metadata and falls back for unknown slugs', () => {
+    // GLM-5.2 is a known model → its published cost/reasoning metadata.
+    const glm = resolveModelForCapability('deepinfra', LlmCapabilities.agent) as unknown as CompletionsModel
+    expect(glm.reasoning).toBe(true)
+    expect(glm.cost.input).toBe(0.95)
+    expect(glm.cost.output).toBe(3.0)
+    // An arbitrary user --model override falls back to defaultModelMeta (cost 0).
+    const custom = resolveModelForCapability(
+      'deepinfra',
+      LlmCapabilities.agent,
+      'meta-llama/Llama-4-Maverick',
+    ) as unknown as CompletionsModel
+    expect(custom.id).toBe('meta-llama/Llama-4-Maverick')
+    expect(custom.cost.input).toBe(0)
+  })
+
+  it('resolves the key from DEEPINFRA_TOKEN env (not DEEPINFRA_API_KEY), config wins', () => {
+    expect(agentProviderApiKeyEnvVar('deepinfra')).toBe('DEEPINFRA_TOKEN')
+    // Catalog providers still derive their var from the pi-ai vendor id.
+    expect(agentProviderApiKeyEnvVar('claude')).toBe('ANTHROPIC_API_KEY')
+
+    const priorToken = process.env.DEEPINFRA_TOKEN
+    const priorApiKey = process.env.DEEPINFRA_API_KEY
+    process.env.DEEPINFRA_TOKEN = 'from-token'
+    process.env.DEEPINFRA_API_KEY = 'wrong-var'
+    try {
+      // The wrong-named var is ignored; DEEPINFRA_TOKEN is read.
+      expect(resolveApiKeySource('deepinfra', {})).toEqual({ key: 'from-token', source: 'env' })
+      // Config still beats env.
+      expect(
+        resolveApiKeySource('deepinfra', { providers: { deepinfra: { apiKey: 'cfg' } } }),
+      ).toEqual({ key: 'cfg', source: 'config' })
+    } finally {
+      if (priorToken === undefined) delete process.env.DEEPINFRA_TOKEN
+      else process.env.DEEPINFRA_TOKEN = priorToken
+      if (priorApiKey === undefined) delete process.env.DEEPINFRA_API_KEY
+      else process.env.DEEPINFRA_API_KEY = priorApiKey
+    }
+  })
+
+  it('surfaces deepinfra in the providers response, configured via DEEPINFRA_TOKEN', () => {
+    const prior = process.env.DEEPINFRA_TOKEN
+    process.env.DEEPINFRA_TOKEN = 'tok'
+    try {
+      const res = buildAgentProvidersResponse({})
+      const di = res.providers.find((p) => p.id === 'deepinfra')
+      expect(di).toBeDefined()
+      expect(di?.label).toBe('DeepInfra (GLM / DeepSeek)')
+      expect(di?.defaultModel).toBe('zai-org/GLM-5.2')
+      expect(di?.configured).toBe(true)
+      expect(di?.keySource).toBe('env')
+    } finally {
+      if (prior === undefined) delete process.env.DEEPINFRA_TOKEN
+      else process.env.DEEPINFRA_TOKEN = prior
+    }
   })
 })

--- a/packages/canonry/test/agent-providers.test.ts
+++ b/packages/canonry/test/agent-providers.test.ts
@@ -420,4 +420,37 @@ describe('deepinfra (custom OpenAI-compatible host)', () => {
       else process.env.DEEPINFRA_TOKEN = prior
     }
   })
+
+  it("reports DeepInfra's real 1M (fp4) context window for the shipped tiers", () => {
+    // GLM-5.2 and DeepSeek-V4-Flash both serve at 1,048,576 on DeepInfra.
+    for (const capability of LLM_CAPABILITIES) {
+      const model = resolveModelForCapability('deepinfra', capability) as unknown as { contextWindow: number }
+      expect(model.contextWindow).toBe(1_048_576)
+    }
+    // An unknown user --model slug keeps the conservative fallback window.
+    const custom = resolveModelForCapability(
+      'deepinfra',
+      LlmCapabilities.agent,
+      'meta-llama/Llama-4-Maverick',
+    ) as unknown as { contextWindow: number }
+    expect(custom.contextWindow).toBe(131072)
+  })
+
+  it('repoints baseUrl via DEEPINFRA_BASE_URL when set, else uses the constant', () => {
+    const DEFAULT = 'https://api.deepinfra.com/v1/openai'
+    const baseUrlOf = () =>
+      (resolveModelForCapability('deepinfra', LlmCapabilities.agent) as unknown as CompletionsModel).baseUrl
+    const prior = process.env.DEEPINFRA_BASE_URL
+    delete process.env.DEEPINFRA_BASE_URL
+    try {
+      expect(baseUrlOf()).toBe(DEFAULT) // unset → constant
+      process.env.DEEPINFRA_BASE_URL = 'https://proxy.internal/v1/openai'
+      expect(baseUrlOf()).toBe('https://proxy.internal/v1/openai') // set → proxy override
+      process.env.DEEPINFRA_BASE_URL = ''
+      expect(baseUrlOf()).toBe(DEFAULT) // empty string falls back to the constant
+    } finally {
+      if (prior === undefined) delete process.env.DEEPINFRA_BASE_URL
+      else process.env.DEEPINFRA_BASE_URL = prior
+    }
+  })
 })

--- a/packages/contracts/src/agent.ts
+++ b/packages/contracts/src/agent.ts
@@ -14,7 +14,7 @@ export type { AgentProviderId } from './providers.js'
  * in the OpenAPI components — the SDK needs that to emit a string-union
  * type instead of a bare `string`.
  */
-export const agentProviderIdSchema = z.enum(['claude', 'openai', 'gemini', 'zai'])
+export const agentProviderIdSchema = z.enum(['claude', 'openai', 'gemini', 'zai', 'deepinfra'])
 
 export const agentProviderOptionDtoSchema = z.object({
   /** Stable identifier — what clients pass back as `provider` on the prompt endpoint. */

--- a/packages/contracts/src/providers.ts
+++ b/packages/contracts/src/providers.ts
@@ -9,12 +9,14 @@
  *   Perplexity is an answer engine; `local` is an OpenAI-compatible local
  *   LLM; `cdp:chatgpt` is a browser-automation adapter.
  * - `AgentProviderIds`  — LLM backends that can drive the Aero conversation
- *   loop (tool-calling + streaming). Subset of ProviderIds plus `zai`
- *   (agent-only, no sweep adapter).
+ *   loop (tool-calling + streaming). Subset of ProviderIds plus `zai` and
+ *   `deepinfra` (both agent-only, no sweep adapter).
  *
  * Agent-side code maps these to pi-ai's vendor names (e.g. `claude` →
  * pi-ai's `anthropic`) inside `packages/canonry/src/agent/providers.ts`.
- * External consumers only see the canonical IDs here.
+ * `deepinfra` is an OpenAI-compatible host with no pi-ai catalog entry —
+ * the agent registry constructs a custom `openai-completions` model pointed
+ * at its base URL. External consumers only see the canonical IDs here.
  */
 
 export const ProviderIds = {
@@ -25,6 +27,7 @@ export const ProviderIds = {
   local: 'local',
   cdpChatgpt: 'cdp:chatgpt',
   zai: 'zai',
+  deepinfra: 'deepinfra',
 } as const
 
 export type ProviderId = (typeof ProviderIds)[keyof typeof ProviderIds]
@@ -48,13 +51,17 @@ export const SWEEP_PROVIDER_IDS: readonly SweepProviderId[] = Object.values(Swee
 /**
  * Providers that can drive the built-in Aero agent loop. Perplexity / local /
  * cdp:chatgpt are excluded (answer engine, unreliable tool-calling, browser
- * scraper respectively). `zai` is agent-only.
+ * scraper respectively). `zai` and `deepinfra` are agent-only — both serve
+ * open-weight models (GLM, DeepSeek) but have no answer-visibility sweep
+ * adapter (no live web-search grounding), so they stay out of SweepProviderIds.
+ * `deepinfra` is a Western-hosted (US/EU) OpenAI-compatible endpoint.
  */
 export const AgentProviderIds = {
   claude: ProviderIds.claude,
   openai: ProviderIds.openai,
   gemini: ProviderIds.gemini,
   zai: ProviderIds.zai,
+  deepinfra: ProviderIds.deepinfra,
 } as const
 
 export type AgentProviderId = (typeof AgentProviderIds)[keyof typeof AgentProviderIds]

--- a/skills/canonry/references/canonry-cli.md
+++ b/skills/canonry/references/canonry-cli.md
@@ -631,6 +631,7 @@ cnry agent ask <project> "<prompt>" --provider anthropic --model claude-opus-4-7
 cnry agent ask <project> "<prompt>" --provider zai      --model glm-5.1
 cnry agent ask <project> "<prompt>" --provider openai
 cnry agent ask <project> "<prompt>" --provider google
+cnry agent ask <project> "<prompt>" --provider deepinfra --model zai-org/GLM-5.2   # Western-hosted GLM/DeepSeek (key: DEEPINFRA_TOKEN)
 
 # Restrict the tool surface. Default is --scope all (full read+write surface).
 # --scope read-only matches the dashboard bar default so pasted "Copy as CLI"
@@ -651,9 +652,12 @@ cnry agent memory forget <project> --key <k>
 ```
 
 **Provider detection order** when `--provider` is omitted: `anthropic` →
-`openai` → `google` → `zai`, whichever has an API key present first
-(from `~/.canonry/config.yaml` providers block, or the matching env var
-`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` / `ZAI_API_KEY`).
+`openai` → `google` → `zai` → `deepinfra`, whichever has an API key present
+first (from `~/.canonry/config.yaml` providers block, or the matching env var
+`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` / `ZAI_API_KEY` /
+`DEEPINFRA_TOKEN`). `deepinfra` (GLM-5.2 / DeepSeek-V4-Flash) is a
+Western-hosted OpenAI-compatible host — useful when the agent / analyze /
+classify tiers must avoid PRC-hosted GLM (`zai`).
 
 Conversations **persist per project** — `cnry agent ask` continues the
 same rolling thread each invocation. Reset with `cnry agent reset <project>`


### PR DESCRIPTION
Adds DeepInfra as a fifth Aero agent provider — a Western-hosted, OpenAI-compatible host serving open-weight models (GLM-5.2 for the agent tier, DeepSeek-V4-Flash for the cheaper analyze/classify tiers). Since DeepInfra has no pi-ai catalog entry, the agent registry now builds a custom `openai-completions` model pointed at its base URL (with an explicit open-model compat profile) and resolves the key from `DEEPINFRA_TOKEN` or `providers.deepinfra.apiKey`. A new `config.agent-providers` doctor check warns when no agent provider has a usable key, surfaced through the existing CLI/MCP doctor surface. It threads `deepinfra` through the contracts enums, generated client types, the `AeroBar` provider picker, docs, and the CLI skill reference, with provider/doctor tests and a minor version bump (4.97.0 → 4.98.0).
