### PR TITLE
feat(agent): Aero operator-agent infra — injected remote-MCP, evidence-safe truncation, prompt-append

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.98.0",
+  "version": "4.99.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/AGENTS.md
+++ b/packages/canonry/AGENTS.md
@@ -277,6 +277,32 @@ config/env. This is a generic capability, no host names, no domain logic.
   `agent.state.tools`. `opts.connect` is the test injection point (the
   InMemory transport replaces the production StreamableHTTP transport).
 
+### Generic system-prompt append seam (OSS-D)
+
+`appendSystemPromptExtras(base, env?)` (`session.ts`) appends
+`AERO_SYSTEM_PROMPT_APPEND` (inline) and/or the contents of
+`AERO_SYSTEM_PROMPT_FILE` (a mounted file path) AFTER the base soul+SKILL
+prompt, separated by a divider. Empty by default => byte-identical. Generic, no
+product vocabulary. It lives inside `loadAeroSystemPrompt`, so it covers BOTH
+the one-shot `createAeroSession` default path and the registry (which builds on
+`loadAeroSystemPrompt`, then layers the `<memory>` block AFTER, so the appended
+rules frame the task and precede per-session memory). A `systemPromptOverride`
+(tests / explicit full control) deliberately bypasses it. A missing/unreadable
+file is skipped, never breaking the agent. The FILE variant exists so a multi-KB
+prompt is mounted, not crammed into a single `-e` arg.
+
+### Evidence-safe tool-result truncation (OSS-C)
+
+`truncateToolResult` (`mcp-to-agent-tool.ts`) renders a tool result under the
+20 KB cap WITHOUT cutting a row mid-structure. The previous guard blind-sliced
+the serialized JSON, which could split an array element halfway (invalid JSON)
+and silently drop a cited evidence row mid-object. Now: an object whose largest
+field is an array drops WHOLE trailing rows and stamps `__truncated` +
+`__omittedRows`; a top-level array is wrapped as `{ items, __truncated,
+__omittedRows }`; only a giant scalar with nothing structured to drop falls back
+to a marked string slice. Every retained row stays byte-intact; the programmatic
+`details` envelope is never trimmed, only the model-facing text.
+
 System prompt is composed from `skills/aero/soul.md` (identity/voice/values)
 + `skills/aero/SKILL.md` (task rules). Soul is prepended so identity frames
 the task instructions. Both files ship in `assets/agent-workspace/skills/aero/`.

--- a/packages/canonry/AGENTS.md
+++ b/packages/canonry/AGENTS.md
@@ -76,6 +76,7 @@ The publishable npm package (`@ainyc/canonry`). Bundles the CLI, local Fastify s
 | `src/agent/token-counter.ts` | `estimateMessageTokens` / `estimateTranscriptTokens` — chars/4 heuristic handling user/assistant/toolResult content shapes. Used only to decide when to compact, not to enforce provider limits. |
 | `src/agent/tools.ts` | Thin wrapper around `mcp-to-agent-tool.ts` — `buildReadTools(ctx)` and `buildAllTools(ctx)` delegate to `buildMcpAgentTools(canonryMcpTools, ctx)`. Adding a new tool to `mcp/tool-registry.ts` automatically exposes it to Aero — no separate registration in this file. |
 | `src/agent/mcp-to-agent-tool.ts` | Adapter that converts every `CanonryMcpTool` into a pi-agent-core `AgentTool`. Strips `project` from the LLM-visible schema and injects `ctx.projectName` at call time. `AERO_EXCLUDED_MCP_TOOLS` lists tools that ride the registry but should not reach Aero (e.g. `canonry_agent_clear` — Aero must not erase the operator's transcript). |
+| `src/agent/remote-mcp.ts` | `loadExternalMcpTools(servers, opts)`, the injected remote-MCP load path. For each configured `{ url, token, label? }` it connects to a REMOTE MCP server over the FROZEN transport (bearer-gated MCP Streamable HTTP, `connectStreamableHttp`), `listTools()`, and adapts each tool into an `AgentTool` (mirroring `mcp-to-agent-tool.ts`). Read-only filter: a remote tool is adopted ONLY when `annotations.readOnlyHint === true` AND its name is not in the local `AERO_EXCLUDED_MCP_TOOLS` set. Fail-soft: a server that fails to connect/list is logged and skipped, never throwing the whole load; no servers configured returns `[]`. The transport is the contract a remote MCP server must speak (see "Injected remote-MCP load path" below). |
 | `src/agent/skill-tools.ts` | 2 skill-doc tools (`list_skill_docs`, `read_skill_doc`) — progressive disclosure of bundled reference playbooks. Ride in every scope. |
 | `src/agent/skill-paths.ts` | `resolveAeroSkillDir` — finds the on-disk `skills/aero/` (prod/dev/repo candidate paths) for the prompt loader and skill-doc tools |
 | `src/agent/agent-routes.ts` | Fastify routes — `GET/DELETE transcript` + `POST prompt` (SSE) for the dashboard Aero bar |
@@ -239,6 +240,42 @@ Tool surface has two layers:
   Ride in every scope. `SKILL.md` stays lightweight; detailed playbooks
   (workflows, regression diagnosis, reporting templates, integrations) load
   on-demand via slug.
+- **Injected remote MCP tools** (`src/agent/remote-mcp.ts`), read-only tools
+  loaded from external MCP servers configured via `config.externalMcpServers`
+  (or the `CANONRY_EXTERNAL_MCP` env var, a JSON array of `{ url, token, label? }`).
+  Loaded once per `SessionRegistry` lifetime (cached promise) and merged into
+  each session's tool list in `acquireForTurn`, after local-scope alignment.
+  See "Injected remote-MCP load path" below for the frozen transport + filter.
+
+### Injected remote-MCP load path (OSS-A)
+
+Aero can load tools from a REMOTE, externally-hosted MCP server injected via
+config/env. This is a generic capability, no host names, no domain logic.
+
+- **Frozen transport (the contract a remote MCP server must speak):**
+  **token-gated MCP Streamable HTTP**, `StreamableHTTPClientTransport` from
+  `@modelcontextprotocol/sdk/client/streamableHttp.js`, with the bearer token
+  carried in the transport's request headers (`Authorization: Bearer <token>`).
+  SSE is legacy and is NOT used. The remote server is platform/external code,
+  never co-located in the OSS container; the injected env carries only
+  `{ url, token, label? }` and Aero connects out. Per-tenant isolation is the
+  token's responsibility (scoped server-side), NOT the container boundary.
+- **Read-only filter (always applied):** a remote tool is adopted ONLY when it
+  is read-only, keyed off the MCP `annotations.readOnlyHint === true` flag -
+  AND its name is not in `remote-mcp.ts`'s `AERO_EXCLUDED_MCP_TOOLS`. Write
+  tools and excluded tools never reach Aero.
+- **Resilience:** a server that fails to connect or list its tools is logged
+  and skipped; one bad server never aborts the whole load. No servers
+  configured returns `[]` (default path is byte-identical to today).
+- **Config:** `CanonryConfig.externalMcpServers?: ExternalMcpServerConfig[]`
+  (`config.ts`), parsed from `CANONRY_EXTERNAL_MCP` (env wins over config.yaml)
+  by `parseExternalMcpEnv`. Malformed/non-array/entry-missing-url-or-token
+  values are ignored fail-soft.
+- **Seam:** `loadExternalMcpTools(servers, opts)` is the async load function.
+  `createAeroSession` stays synchronous; the registry awaits the load in its
+  already-async `acquireForTurn` and merges the returned tools into
+  `agent.state.tools`. `opts.connect` is the test injection point (the
+  InMemory transport replaces the production StreamableHTTP transport).
 
 System prompt is composed from `skills/aero/soul.md` (identity/voice/values)
 + `skills/aero/SKILL.md` (task rules). Soul is prepended so identity frames

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.98.0",
+  "version": "4.99.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/agent/mcp-to-agent-tool.ts
+++ b/packages/canonry/src/agent/mcp-to-agent-tool.ts
@@ -4,15 +4,92 @@ import type { ApiClient } from '../client.js'
 import type { CanonryMcpTool } from '../mcp/tool-registry.js'
 
 const MAX_TOOL_RESULT_CHARS = 20_000
+const TRUNCATION_NOTE = '... (truncated — result too large)'
 
-function truncate(json: string): string {
-  if (json.length <= MAX_TOOL_RESULT_CHARS) return json
-  return json.slice(0, MAX_TOOL_RESULT_CHARS) + '\n... (truncated — result too large)'
+/** Pretty JSON, exactly what the model reads in the tool-result text. */
+function serializeResult(value: unknown): string {
+  return JSON.stringify(value, null, 2)
+}
+
+/** The object key whose array value serializes largest (the one worth trimming). */
+function largestArrayKey(obj: Record<string, unknown>): string | undefined {
+  let best: string | undefined
+  let bestLen = -1
+  for (const [k, v] of Object.entries(obj)) {
+    if (!Array.isArray(v)) continue
+    const len = serializeResult(v).length
+    if (len > bestLen) {
+      bestLen = len
+      best = k
+    }
+  }
+  return best
+}
+
+/** Drop WHOLE trailing rows until `render(kept)` fits the cap (or nothing is left). */
+function trimRowsToFit(rows: readonly unknown[], render: (kept: unknown[]) => string): unknown[] {
+  let kept = rows.slice()
+  while (kept.length > 0 && render(kept).length > MAX_TOOL_RESULT_CHARS) {
+    kept = kept.slice(0, -1)
+  }
+  return kept
+}
+
+/**
+ * Render a tool result as JSON text under the size cap WITHOUT cutting a row
+ * mid-structure. The previous behavior blind-sliced the serialized string,
+ * which could split an array element halfway, hand the model invalid JSON, and
+ * silently drop a cited evidence row mid-object. Structure-aware instead:
+ *  - object whose largest field is an array: drop WHOLE trailing rows from that
+ *    array until it fits, stamping `__truncated` + `__omittedRows` on the object;
+ *  - top-level array: same, wrapped as `{ items, __truncated, __omittedRows }`;
+ *  - any other still-oversized value (a giant scalar / string with nothing
+ *    structured to drop): a marked string slice, the last resort.
+ * Every RETAINED row stays byte-intact and the structured output stays parseable
+ * JSON. Only the model-facing text is trimmed; the programmatic `details`
+ * envelope is never touched.
+ */
+export function truncateToolResult(details: unknown): string {
+  const full = serializeResult(details)
+  if (full.length <= MAX_TOOL_RESULT_CHARS) return full
+
+  // Top-level array: trim whole elements, wrap with the marker (always fits, an
+  // empty `items` is tiny).
+  if (Array.isArray(details)) {
+    const kept = trimRowsToFit(details, (rows) =>
+      serializeResult({ items: rows, __truncated: true, __omittedRows: details.length - rows.length }),
+    )
+    return serializeResult({ items: kept, __truncated: true, __omittedRows: details.length - kept.length })
+  }
+
+  // Object whose largest field is an array (the ads-artifact shape): trim that
+  // array by whole rows, keep every other field intact.
+  if (details && typeof details === 'object') {
+    const obj = details as Record<string, unknown>
+    const arrayKey = largestArrayKey(obj)
+    if (arrayKey) {
+      const rows = obj[arrayKey] as unknown[]
+      const kept = trimRowsToFit(rows, (r) =>
+        serializeResult({ ...obj, [arrayKey]: r, __truncated: true, __omittedRows: rows.length - r.length }),
+      )
+      const out = serializeResult({
+        ...obj,
+        [arrayKey]: kept,
+        __truncated: true,
+        __omittedRows: rows.length - kept.length,
+      })
+      // Falls through to the last resort only when the non-array fields ALONE
+      // already blow the cap (nothing structured left to drop).
+      if (out.length <= MAX_TOOL_RESULT_CHARS) return out
+    }
+  }
+
+  return full.slice(0, MAX_TOOL_RESULT_CHARS) + '\n' + TRUNCATION_NOTE
 }
 
 function textResult<T>(details: T): AgentToolResult<T> {
   return {
-    content: [{ type: 'text', text: truncate(JSON.stringify(details, null, 2)) }],
+    content: [{ type: 'text', text: truncateToolResult(details) }],
     details,
   }
 }

--- a/packages/canonry/src/agent/remote-mcp.ts
+++ b/packages/canonry/src/agent/remote-mcp.ts
@@ -1,0 +1,197 @@
+import { Type, type TSchema } from '@sinclair/typebox'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import type { AgentTool, AgentToolResult } from '@mariozechner/pi-agent-core'
+import { createLogger } from '../logger.js'
+import type { ExternalMcpServerConfig } from '../config.js'
+
+const log = createLogger('RemoteMcp')
+
+/**
+ * FROZEN TRANSPORT CONTRACT (OSS-A).
+ *
+ * Aero loads tools from an injected REMOTE MCP server over MCP Streamable
+ * HTTP (`StreamableHTTPClientTransport`), authenticating with a bearer
+ * token carried in the transport's request headers
+ * (`Authorization: Bearer <token>`). This is the single transport a remote
+ * MCP server must speak to be loadable here. SSE is legacy and is NOT used.
+ *
+ * The server is remote platform-hosted code, never co-located in the OSS
+ * container. The injected config carries only `{ url, token, label? }`; Aero
+ * connects out. Per-tenant isolation is the responsibility of the token
+ * (scoped server-side), not the container boundary.
+ *
+ * Safety filter (always applied): a remote tool is adapted into an AgentTool
+ * ONLY when it is read-only (`annotations.readOnlyHint === true`) AND its name
+ * is not in `AERO_EXCLUDED_MCP_TOOLS`. A server that fails to connect is
+ * logged and skipped; it never throws the whole load.
+ */
+
+/**
+ * Remote MCP tool names that must never reach Aero even when a server
+ * advertises them as read-only. Distinct from the local-registry exclusion
+ * set in `mcp-to-agent-tool.ts`: this guards tools that arrive over the wire
+ * from an external server we do not own.
+ */
+export const AERO_EXCLUDED_MCP_TOOLS: ReadonlySet<string> = new Set<string>([])
+
+/** Max characters of a remote tool result we hand back to the model. */
+const MAX_TOOL_RESULT_CHARS = 20_000
+
+function truncate(text: string): string {
+  if (text.length <= MAX_TOOL_RESULT_CHARS) return text
+  return text.slice(0, MAX_TOOL_RESULT_CHARS) + '\n... (truncated, result too large)'
+}
+
+/** Shape of a single tool entry returned by the MCP SDK `client.listTools()`. */
+interface RemoteToolDescriptor {
+  name: string
+  description?: string
+  inputSchema?: unknown
+  annotations?: {
+    title?: string
+    readOnlyHint?: boolean
+  }
+}
+
+/**
+ * A minimal MCP client surface, just the two methods the adapter needs.
+ * Lets tests inject an InMemory-connected client without the production
+ * StreamableHTTP transport, while production uses the real SDK `Client`.
+ */
+export interface RemoteMcpClient {
+  listTools(): Promise<{ tools: RemoteToolDescriptor[] }>
+  callTool(params: { name: string; arguments?: Record<string, unknown> }): Promise<unknown>
+}
+
+export interface LoadExternalMcpToolsOptions {
+  /**
+   * Test seam: connect to a server config and return a ready MCP client.
+   * Defaults to `connectStreamableHttp` (the frozen production transport).
+   */
+  connect?: (server: ExternalMcpServerConfig) => Promise<RemoteMcpClient>
+  /** Override the read-only exclusion set (tests). Defaults to `AERO_EXCLUDED_MCP_TOOLS`. */
+  excluded?: ReadonlySet<string>
+}
+
+/**
+ * Build the production MCP client for one server: a `StreamableHTTPClientTransport`
+ * pointed at `server.url` with the bearer token in its request headers. This is
+ * the frozen transport contract, bearer-gated MCP Streamable HTTP.
+ */
+export async function connectStreamableHttp(
+  server: ExternalMcpServerConfig,
+): Promise<RemoteMcpClient> {
+  const transport = new StreamableHTTPClientTransport(new URL(server.url), {
+    requestInit: {
+      headers: { Authorization: `Bearer ${server.token}` },
+    },
+  })
+  const client = new Client(
+    { name: 'canonry-aero', version: '1.0.0' },
+    { capabilities: {} },
+  )
+  await client.connect(transport)
+  return client as unknown as RemoteMcpClient
+}
+
+/** True when a remote tool is read-only per its MCP annotations. */
+function isReadOnly(tool: RemoteToolDescriptor): boolean {
+  return tool.annotations?.readOnlyHint === true
+}
+
+/**
+ * Adapt one remote read-only MCP tool into a pi-agent-core `AgentTool`. Mirrors
+ * the AgentTool shape produced by `mcp-to-agent-tool.ts` (name/label/description/
+ * parameters/execute). The remote tool's JSON Schema is wrapped in `Type.Unsafe`
+ * so pi-agent-core's TSchema-typed `parameters` accepts it without conversion;
+ * `execute` forwards the validated args to `client.callTool` and returns the
+ * remote result under the 20 KB truncation guard.
+ *
+ * No `project` stripping/injection here (unlike the local adapter): a remote
+ * server defines its own argument surface and we never inject a canonry project
+ * id into a tool we do not own.
+ */
+function adaptRemoteTool(client: RemoteMcpClient, tool: RemoteToolDescriptor): AgentTool {
+  const parameters = Type.Unsafe<Record<string, unknown>>(
+    (tool.inputSchema ?? { type: 'object', properties: {} }) as object,
+  ) as TSchema
+
+  const execute = async (
+    _toolCallId: string,
+    params: Record<string, unknown>,
+  ): Promise<AgentToolResult<unknown>> => {
+    const result = await client.callTool({ name: tool.name, arguments: params })
+    return {
+      content: [{ type: 'text', text: truncate(JSON.stringify(result, null, 2)) }],
+      details: result,
+    }
+  }
+
+  return {
+    name: tool.name,
+    label: tool.annotations?.title ?? tool.name,
+    description: tool.description ?? '',
+    parameters,
+    execute,
+  } as AgentTool
+}
+
+/**
+ * Connect to each configured external MCP server, discover its tools, and
+ * adapt every read-only, non-excluded tool into an AgentTool for Aero.
+ *
+ * Resilient by design: a server that fails to connect or list its tools is
+ * logged and skipped, one bad server never aborts the whole load. No servers
+ * configured returns `[]`.
+ *
+ * The frozen transport (bearer-gated Streamable HTTP) is constructed in
+ * `connectStreamableHttp`; tests inject `opts.connect` to supply an
+ * InMemory-connected client instead.
+ */
+export async function loadExternalMcpTools(
+  servers: readonly ExternalMcpServerConfig[] | undefined,
+  opts: LoadExternalMcpToolsOptions = {},
+): Promise<AgentTool[]> {
+  if (!servers || servers.length === 0) return []
+  const connect = opts.connect ?? connectStreamableHttp
+  const excluded = opts.excluded ?? AERO_EXCLUDED_MCP_TOOLS
+
+  const tools: AgentTool[] = []
+  for (const server of servers) {
+    const label = server.label ?? server.url
+    let client: RemoteMcpClient
+    try {
+      client = await connect(server)
+    } catch (err) {
+      log.error('external-mcp.connect-failed', {
+        label,
+        error: err instanceof Error ? err.message : String(err),
+      })
+      continue
+    }
+
+    let listed: { tools: RemoteToolDescriptor[] }
+    try {
+      listed = await client.listTools()
+    } catch (err) {
+      log.error('external-mcp.list-failed', {
+        label,
+        error: err instanceof Error ? err.message : String(err),
+      })
+      continue
+    }
+
+    for (const tool of listed.tools) {
+      if (excluded.has(tool.name)) continue
+      if (!isReadOnly(tool)) continue
+      tools.push(adaptRemoteTool(client, tool))
+    }
+    log.info('external-mcp.loaded', {
+      label,
+      discovered: listed.tools.length,
+      adopted: tools.length,
+    })
+  }
+  return tools
+}

--- a/packages/canonry/src/agent/session-registry.ts
+++ b/packages/canonry/src/agent/session-registry.ts
@@ -6,7 +6,7 @@ import {
   projects,
   type DatabaseClient,
 } from '@ainyc/canonry-db'
-import type { Agent, AgentMessage } from '@mariozechner/pi-agent-core'
+import type { Agent, AgentMessage, AgentTool } from '@mariozechner/pi-agent-core'
 import type { Api, Model } from '@mariozechner/pi-ai'
 import { agentBusy, AgentProviderIds } from '@ainyc/canonry-contracts'
 import { createLogger } from '../logger.js'
@@ -23,6 +23,7 @@ import {
 import { getAgentProvider } from './providers.js'
 import { buildSkillDocTools } from './skill-tools.js'
 import { buildAllTools, buildReadTools } from './tools.js'
+import { loadExternalMcpTools } from './remote-mcp.js'
 import { loadRecentForHydrate } from './memory-store.js'
 import { compactMessages, shouldCompact } from './compaction.js'
 
@@ -107,10 +108,57 @@ export class SessionRegistry {
    * awaits the same promise instead of kicking off a duplicate LLM call.
    */
   private readonly compactions = new Map<string, Promise<void>>()
+  /**
+   * Read-only tools loaded once from the injected remote MCP servers (OSS-A).
+   * The server set is static config, so we connect + adapt a single time and
+   * cache the promise; every session merges the same AgentTool list. Resolves
+   * to `[]` when no servers are configured or all fail to connect (the load is
+   * fail-soft and never throws).
+   */
+  private externalToolsPromise?: Promise<AgentTool[]>
   private readonly opts: SessionRegistryOptions
 
   constructor(opts: SessionRegistryOptions) {
     this.opts = opts
+  }
+
+  /**
+   * Lazily load + cache the injected remote MCP tools. The seam OSS-A exposes:
+   * `loadExternalMcpTools` connects to each configured server over the frozen
+   * bearer-gated Streamable HTTP transport, lists tools, and adapts the
+   * read-only, non-excluded ones into AgentTools. Cached so we connect once per
+   * registry lifetime regardless of how many projects or turns run.
+   */
+  private loadExternalTools(): Promise<AgentTool[]> {
+    if (!this.externalToolsPromise) {
+      this.externalToolsPromise = loadExternalMcpTools(this.opts.config.externalMcpServers).catch(
+        (err) => {
+          log.error('external-mcp.load-failed', {
+            error: err instanceof Error ? err.message : String(err),
+          })
+          return []
+        },
+      )
+    }
+    return this.externalToolsPromise
+  }
+
+  /**
+   * Append the cached external MCP tools to the live agent's tool list, idempotently.
+   * Called after scope/model alignment in `acquireForTurn` (which rebuilds
+   * `state.tools` from the local registry), so the remote read-only tools ride
+   * alongside the local ones for the upcoming turn. No-op when none are configured.
+   */
+  private async mergeExternalTools(agent: Agent): Promise<void> {
+    const external = await this.loadExternalTools()
+    if (external.length === 0) return
+    // `acquireForTurn` aligns scope (which sets state.tools) before calling
+    // this, so the live agent always has its local tool list populated here.
+    const current = agent.state.tools
+    const present = new Set(current.map((t) => t.name))
+    const additions = external.filter((t) => !present.has(t.name))
+    if (additions.length === 0) return
+    agent.state.tools = [...current, ...additions]
   }
 
   /** Read-only access to the config snapshot the registry was built with. */
@@ -291,6 +339,9 @@ export class SessionRegistry {
     if (preferences?.provider || preferences?.modelId) {
       this.alignModel(projectName, agent, preferences)
     }
+    // Merge injected remote MCP read-only tools (OSS-A) AFTER scope alignment,
+    // which rebuilds state.tools from the local registry. Idempotent + fail-soft.
+    await this.mergeExternalTools(agent)
     await this.maybeCompact(projectName, agent)
     return agent
   }

--- a/packages/canonry/src/agent/session.ts
+++ b/packages/canonry/src/agent/session.ts
@@ -65,9 +65,44 @@ export function loadAeroSystemPrompt(pkgDir?: string): string {
   const skillDir = resolveAeroSkillDir(pkgDir)
   const skillBody = fs.readFileSync(path.join(skillDir, 'SKILL.md'), 'utf-8')
   const soulPath = path.join(skillDir, 'soul.md')
-  if (!fs.existsSync(soulPath)) return skillBody
-  const soulBody = fs.readFileSync(soulPath, 'utf-8')
-  return `${soulBody.trimEnd()}\n\n---\n\n${skillBody}`
+  const base = fs.existsSync(soulPath)
+    ? `${fs.readFileSync(soulPath, 'utf-8').trimEnd()}\n\n---\n\n${skillBody}`
+    : skillBody
+  return appendSystemPromptExtras(base)
+}
+
+/**
+ * Generic system-prompt APPEND seam (OSS-D). Appends `AERO_SYSTEM_PROMPT_APPEND`
+ * (inline) and/or the contents of `AERO_SYSTEM_PROMPT_FILE` (a file path) AFTER
+ * the base soul+SKILL prompt, separated by a divider. Empty by default, so a
+ * default install is byte-identical. Generic: carries no product vocabulary.
+ *
+ * Lives inside `loadAeroSystemPrompt` so it covers BOTH the one-shot
+ * `createAeroSession` default path AND the registry (which builds on
+ * `loadAeroSystemPrompt`, then layers the dynamic `<memory>` block AFTER, so the
+ * appended rules frame the task and sit before per-session memory). A
+ * `systemPromptOverride` (tests / explicit full control) deliberately bypasses
+ * this. A missing or unreadable file is skipped, never breaking the agent. The
+ * FILE variant exists so a multi-KB prompt is mounted as a file rather than
+ * crammed into a single `-e` env arg. Exported for tests.
+ */
+export function appendSystemPromptExtras(
+  base: string,
+  env: Record<string, string | undefined> = process.env,
+): string {
+  const inline = env.AERO_SYSTEM_PROMPT_APPEND?.trim()
+  let fileBody = ''
+  const filePath = env.AERO_SYSTEM_PROMPT_FILE?.trim()
+  if (filePath) {
+    try {
+      fileBody = fs.readFileSync(filePath, 'utf-8').trim()
+    } catch {
+      fileBody = ''
+    }
+  }
+  const extras = [inline, fileBody].filter((s): s is string => !!s && s.length > 0)
+  if (extras.length === 0) return base
+  return `${base.trimEnd()}\n\n---\n\n${extras.join('\n\n')}`
 }
 
 function missingProviderMessage(): string {

--- a/packages/canonry/src/config.ts
+++ b/packages/canonry/src/config.ts
@@ -184,6 +184,22 @@ export interface VercelTrafficConfigEntry {
   connections?: VercelTrafficConnectionConfigEntry[]
 }
 
+/**
+ * One injected remote MCP server Aero loads read-only tools from (OSS-A).
+ * Generic shape: `{ url, token, label? }`. The transport is bearer-gated MCP
+ * Streamable HTTP (the contract is frozen in `agent/remote-mcp.ts`). The
+ * server is remote, never co-located in the OSS container; per-tenant
+ * isolation is the token's responsibility, not the container boundary.
+ */
+export interface ExternalMcpServerConfig {
+  /** Streamable HTTP endpoint of the remote MCP server. */
+  url: string
+  /** Bearer token sent as `Authorization: Bearer <token>`. */
+  token: string
+  /** Optional human label used in logs. Defaults to `url`. */
+  label?: string
+}
+
 export interface AgentConfigEntry {
   /**
    * Agent mode. `'disabled'` turns the built-in Aero agent OFF entirely — the
@@ -252,6 +268,10 @@ export interface CanonryConfig {
   lastKnownLatestVersion?: string
   // Agent layer configuration (reserved — native loop TBD)
   agent?: AgentConfigEntry
+  // Injected remote MCP servers Aero loads read-only tools from (OSS-A).
+  // Parsed from config.yaml or the CANONRY_EXTERNAL_MCP env var (JSON array).
+  // Generic capability: no host names or ads logic baked in.
+  externalMcpServers?: ExternalMcpServerConfig[]
   // Google Places API config (supplemental GBP lodging data — #648)
   places?: PlacesConfigEntry
   // Read-only embed mode (#716) — opt-in chromeless render + frame-ancestors
@@ -373,7 +393,47 @@ export function loadConfig(): CanonryConfig {
     }
   }
 
+  // Honor CANONRY_EXTERNAL_MCP, a JSON array of injected remote MCP servers
+  // Aero loads read-only tools from (OSS-A). Env wins over config.yaml so a
+  // container can inject servers without a config file. Malformed JSON or a
+  // non-array value is ignored (logged-free, fail-soft) so a bad env var never
+  // blocks startup.
+  const parsedExternalMcp = parseExternalMcpEnv(process.env.CANONRY_EXTERNAL_MCP)
+  if (parsedExternalMcp) {
+    parsed.externalMcpServers = parsedExternalMcp
+  }
+
   return parsed
+}
+
+/**
+ * Parse the `CANONRY_EXTERNAL_MCP` env var into a validated list of remote MCP
+ * server configs. Accepts a JSON array of `{ url, token, label? }`. Returns
+ * undefined when the value is absent, empty, malformed, or carries no entry
+ * with both a `url` and a `token`, the caller leaves `config.externalMcpServers`
+ * untouched in that case.
+ */
+export function parseExternalMcpEnv(raw: string | undefined): ExternalMcpServerConfig[] | undefined {
+  const trimmed = raw?.trim()
+  if (!trimmed) return undefined
+  let value: unknown
+  try {
+    value = JSON.parse(trimmed)
+  } catch {
+    return undefined
+  }
+  if (!Array.isArray(value)) return undefined
+  const servers: ExternalMcpServerConfig[] = []
+  for (const entry of value) {
+    if (!entry || typeof entry !== 'object') continue
+    const candidate = entry as Record<string, unknown>
+    const url = typeof candidate.url === 'string' ? candidate.url.trim() : ''
+    const token = typeof candidate.token === 'string' ? candidate.token : ''
+    if (!url || !token) continue
+    const label = typeof candidate.label === 'string' ? candidate.label : undefined
+    servers.push({ url, token, ...(label ? { label } : {}) })
+  }
+  return servers.length > 0 ? servers : undefined
 }
 
 /**

--- a/packages/canonry/test/agent-remote-mcp.test.ts
+++ b/packages/canonry/test/agent-remote-mcp.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from 'vitest'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import {
+  loadExternalMcpTools,
+  connectStreamableHttp,
+  type RemoteMcpClient,
+} from '../src/agent/remote-mcp.js'
+import { parseExternalMcpEnv, type ExternalMcpServerConfig } from '../src/config.js'
+
+const READ_TOOL = 'demo_read_artifact'
+const WRITE_TOOL = 'demo_write_thing'
+const EXCLUDED_TOOL = 'demo_excluded_tool'
+const KNOWN_ARTIFACT = { reasonCode: 'R7', value: 42 }
+
+/**
+ * Stand up an in-process MCP server exposing three tools:
+ *   - a read-only tool (readOnlyHint: true) that returns a known artifact
+ *   - a write tool (readOnlyHint: false)
+ *   - a tool whose NAME is in the exclusion set passed to the loader
+ * Connect a real MCP SDK Client to it over an InMemory transport pair and
+ * return the client. This exercises the same `listTools` / `callTool` path the
+ * production StreamableHTTP client uses, without standing up an HTTP server.
+ */
+async function makeInMemoryServerClient(): Promise<RemoteMcpClient> {
+  const server = new McpServer({ name: 'demo-remote', version: '1.0.0' })
+
+  server.registerTool(
+    READ_TOOL,
+    {
+      description: 'Read a known artifact (read-only).',
+      inputSchema: {},
+      annotations: { readOnlyHint: true, title: 'Read artifact' },
+    },
+    async () => ({
+      content: [{ type: 'text', text: JSON.stringify(KNOWN_ARTIFACT) }],
+    }),
+  )
+
+  server.registerTool(
+    WRITE_TOOL,
+    {
+      description: 'A mutating tool that must never reach Aero.',
+      inputSchema: {},
+      annotations: { readOnlyHint: false },
+    },
+    async () => ({ content: [{ type: 'text', text: 'wrote' }] }),
+  )
+
+  // Excluded tool is ALSO read-only, proves the exclusion filter is independent
+  // of the read-only filter (a read-only tool can still be excluded by name).
+  server.registerTool(
+    EXCLUDED_TOOL,
+    {
+      description: 'Read-only but excluded by name.',
+      inputSchema: {},
+      annotations: { readOnlyHint: true },
+    },
+    async () => ({ content: [{ type: 'text', text: 'should-not-load' }] }),
+  )
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  await server.connect(serverTransport)
+
+  const client = new Client({ name: 'test-aero', version: '1.0.0' }, { capabilities: {} })
+  await client.connect(clientTransport)
+  return client as unknown as RemoteMcpClient
+}
+
+const SERVER: ExternalMcpServerConfig = { url: 'http://remote.invalid/mcp', token: 'tok_abc', label: 'demo' }
+
+describe('loadExternalMcpTools', () => {
+  it('discovers + calls a read-only tool, returning its artifact', async () => {
+    const tools = await loadExternalMcpTools([SERVER], {
+      connect: makeInMemoryServerClient,
+      excluded: new Set([EXCLUDED_TOOL]),
+    })
+
+    const readTool = tools.find((t) => t.name === READ_TOOL)
+    expect(readTool, 'read-only tool should be discovered').toBeDefined()
+
+    const result = await readTool!.execute('call-1', {})
+    // The adapter returns the raw MCP callTool envelope under `details`. The
+    // tool's known artifact rides inside that envelope's first text block.
+    const details = result.details as { content: Array<{ type: string; text: string }> }
+    expect(JSON.parse(details.content[0].text)).toEqual(KNOWN_ARTIFACT)
+    // And the model-facing content is the serialized envelope (carrying the artifact).
+    const text = result.content.find((c) => c.type === 'text') as { text: string } | undefined
+    expect(text?.text).toContain('reasonCode')
+    expect(text?.text).toContain('R7')
+  })
+
+  it('filters OUT the write tool (not read-only)', async () => {
+    const tools = await loadExternalMcpTools([SERVER], {
+      connect: makeInMemoryServerClient,
+      excluded: new Set([EXCLUDED_TOOL]),
+    })
+    expect(tools.map((t) => t.name)).not.toContain(WRITE_TOOL)
+  })
+
+  it('filters OUT the excluded tool even though it is read-only', async () => {
+    const tools = await loadExternalMcpTools([SERVER], {
+      connect: makeInMemoryServerClient,
+      excluded: new Set([EXCLUDED_TOOL]),
+    })
+    expect(tools.map((t) => t.name)).not.toContain(EXCLUDED_TOOL)
+  })
+
+  it('only the read-only, non-excluded tool survives the filter', async () => {
+    const tools = await loadExternalMcpTools([SERVER], {
+      connect: makeInMemoryServerClient,
+      excluded: new Set([EXCLUDED_TOOL]),
+    })
+    expect(tools.map((t) => t.name)).toEqual([READ_TOOL])
+  })
+
+  it('returns [] when no servers are configured', async () => {
+    expect(await loadExternalMcpTools(undefined)).toEqual([])
+    expect(await loadExternalMcpTools([])).toEqual([])
+  })
+
+  it('skips a server that fails to connect (never throws the whole load)', async () => {
+    const tools = await loadExternalMcpTools(
+      [
+        { url: 'http://bad.invalid/mcp', token: 't1', label: 'bad' },
+        SERVER,
+      ],
+      {
+        connect: async (server) => {
+          if (server.label === 'bad') throw new Error('connection refused')
+          return makeInMemoryServerClient()
+        },
+        excluded: new Set([EXCLUDED_TOOL]),
+      },
+    )
+    // The good server's read tool still loads; the bad one is skipped silently.
+    expect(tools.map((t) => t.name)).toEqual([READ_TOOL])
+  })
+})
+
+describe('connectStreamableHttp (frozen transport)', () => {
+  it('constructs a StreamableHTTPClientTransport with the bearer header', async () => {
+    // We do not actually connect (no server at the URL); we only assert that the
+    // production path builds the bearer-gated Streamable HTTP transport. The
+    // transport is constructed lazily inside connectStreamableHttp, so we probe
+    // the SDK transport directly with the same options the loader uses.
+    const transport = new StreamableHTTPClientTransport(new URL(SERVER.url), {
+      requestInit: { headers: { Authorization: `Bearer ${SERVER.token}` } },
+    })
+    // The transport stores requestInit privately; assert via its constructed shape.
+    const requestInit = (transport as unknown as { _requestInit?: RequestInit })._requestInit
+    expect(requestInit?.headers).toEqual({ Authorization: 'Bearer tok_abc' })
+    await transport.close()
+
+    // And assert the production helper is callable + uses StreamableHTTP: it
+    // should reject (no real server) rather than fall back to any other transport.
+    await expect(connectStreamableHttp(SERVER)).rejects.toBeDefined()
+  })
+})
+
+describe('parseExternalMcpEnv (CANONRY_EXTERNAL_MCP)', () => {
+  it('parses a JSON array of {url, token, label}', () => {
+    const parsed = parseExternalMcpEnv(
+      JSON.stringify([{ url: 'http://a/mcp', token: 't1', label: 'a' }, { url: 'http://b/mcp', token: 't2' }]),
+    )
+    expect(parsed).toEqual([
+      { url: 'http://a/mcp', token: 't1', label: 'a' },
+      { url: 'http://b/mcp', token: 't2' },
+    ])
+  })
+
+  it('drops entries missing a url or token', () => {
+    const parsed = parseExternalMcpEnv(
+      JSON.stringify([{ url: 'http://a/mcp' }, { token: 't2' }, { url: 'http://c/mcp', token: 't3' }]),
+    )
+    expect(parsed).toEqual([{ url: 'http://c/mcp', token: 't3' }])
+  })
+
+  it('returns undefined for absent / empty / malformed / non-array input', () => {
+    expect(parseExternalMcpEnv(undefined)).toBeUndefined()
+    expect(parseExternalMcpEnv('')).toBeUndefined()
+    expect(parseExternalMcpEnv('   ')).toBeUndefined()
+    expect(parseExternalMcpEnv('{not json')).toBeUndefined()
+    expect(parseExternalMcpEnv(JSON.stringify({ url: 'x', token: 'y' }))).toBeUndefined()
+    expect(parseExternalMcpEnv(JSON.stringify([{ url: 'x' }]))).toBeUndefined()
+  })
+})

--- a/packages/canonry/test/agent-system-prompt-append.test.ts
+++ b/packages/canonry/test/agent-system-prompt-append.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { appendSystemPromptExtras } from '../src/agent/session.js'
+
+const tmpFiles: string[] = []
+function writeTmp(contents: string): string {
+  const p = path.join(os.tmpdir(), `aero-append-${Math.random().toString(36).slice(2)}.md`)
+  fs.writeFileSync(p, contents, 'utf-8')
+  tmpFiles.push(p)
+  return p
+}
+afterEach(() => {
+  for (const p of tmpFiles.splice(0)) fs.rmSync(p, { force: true })
+})
+
+describe('appendSystemPromptExtras (OSS-D)', () => {
+  it('is byte-identical to the base when no append env is set', () => {
+    expect(appendSystemPromptExtras('BASE', {})).toBe('BASE')
+    // An all-whitespace inline value collapses to empty => base unchanged.
+    expect(appendSystemPromptExtras('BASE  ', { AERO_SYSTEM_PROMPT_APPEND: '   ' })).toBe('BASE  ')
+  })
+
+  it('appends the inline AERO_SYSTEM_PROMPT_APPEND after a divider', () => {
+    expect(appendSystemPromptExtras('BASE', { AERO_SYSTEM_PROMPT_APPEND: 'ADS RULES' })).toBe(
+      'BASE\n\n---\n\nADS RULES',
+    )
+  })
+
+  it('appends the contents of AERO_SYSTEM_PROMPT_FILE', () => {
+    const file = writeTmp('FILE RULES')
+    expect(appendSystemPromptExtras('BASE', { AERO_SYSTEM_PROMPT_FILE: file })).toBe(
+      'BASE\n\n---\n\nFILE RULES',
+    )
+  })
+
+  it('appends inline then file when both are set', () => {
+    const file = writeTmp('FROM FILE')
+    expect(
+      appendSystemPromptExtras('BASE', { AERO_SYSTEM_PROMPT_APPEND: 'INLINE', AERO_SYSTEM_PROMPT_FILE: file }),
+    ).toBe('BASE\n\n---\n\nINLINE\n\nFROM FILE')
+  })
+
+  it('skips a missing file without throwing (delivery never breaks on a bad path)', () => {
+    expect(appendSystemPromptExtras('BASE', { AERO_SYSTEM_PROMPT_FILE: '/no/such/aero/append/file.md' })).toBe(
+      'BASE',
+    )
+  })
+
+  it('trims the base trailing whitespace only when an append is present', () => {
+    expect(appendSystemPromptExtras('BASE\n\n', { AERO_SYSTEM_PROMPT_APPEND: 'X' })).toBe('BASE\n\n---\n\nX')
+  })
+})

--- a/packages/canonry/test/agent-tool-truncation.test.ts
+++ b/packages/canonry/test/agent-tool-truncation.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { truncateToolResult } from '../src/agent/mcp-to-agent-tool.js'
+
+const CAP = 20_000
+
+/** A row carrying a unique, recognizable marker so the test can prove no row is
+ *  split mid-content (every retained row's reasonCode survives intact). */
+function evidenceRow(i: number) {
+  return { id: `action-${i}`, reasonCode: `R${i}`, evidence: 'x'.repeat(60) }
+}
+
+describe('truncateToolResult (OSS-C)', () => {
+  it('is byte-identical to pretty JSON for a sub-cap result', () => {
+    const details = { summary: { total: 2 }, actions: [evidenceRow(0), evidenceRow(1)] }
+    expect(truncateToolResult(details)).toBe(JSON.stringify(details, null, 2))
+  })
+
+  it('trims an oversized object by WHOLE rows of its largest array, never mid-row', () => {
+    const actions = Array.from({ length: 600 }, (_, i) => evidenceRow(i))
+    const details = { summary: { total: actions.length }, actions }
+    const out = truncateToolResult(details)
+
+    // Still valid, parseable JSON (the old blind slice produced invalid JSON).
+    const parsed = JSON.parse(out) as {
+      summary: { total: number }
+      actions: Array<{ id: string; reasonCode: string; evidence: string }>
+      __truncated: boolean
+      __omittedRows: number
+    }
+
+    expect(out.length).toBeLessThanOrEqual(CAP)
+    expect(parsed.__truncated).toBe(true)
+    // Non-array fields are preserved intact.
+    expect(parsed.summary).toEqual({ total: 600 })
+    // Kept rows are a PREFIX of the original, each byte-intact (reasonCode survives).
+    expect(parsed.actions.length).toBeGreaterThan(0)
+    parsed.actions.forEach((row, i) => expect(row).toEqual(actions[i]))
+    // The omitted count is exact: kept + omitted === original.
+    expect(parsed.actions.length + parsed.__omittedRows).toBe(actions.length)
+    expect(parsed.__omittedRows).toBeGreaterThan(0)
+  })
+
+  it('wraps + trims an oversized TOP-LEVEL array with an omitted marker', () => {
+    const rows = Array.from({ length: 600 }, (_, i) => evidenceRow(i))
+    const out = truncateToolResult(rows)
+    const parsed = JSON.parse(out) as {
+      items: Array<{ id: string; reasonCode: string }>
+      __truncated: boolean
+      __omittedRows: number
+    }
+    expect(out.length).toBeLessThanOrEqual(CAP)
+    expect(parsed.__truncated).toBe(true)
+    parsed.items.forEach((row, i) => expect(row).toEqual(rows[i]))
+    expect(parsed.items.length + parsed.__omittedRows).toBe(rows.length)
+  })
+
+  it('falls back to a marked string slice for an oversized scalar with nothing to drop', () => {
+    const giant = 'y'.repeat(CAP + 5_000)
+    const out = truncateToolResult(giant)
+    expect(out.length).toBeLessThanOrEqual(CAP + 50)
+    expect(out).toContain('truncated')
+  })
+})


### PR DESCRIPTION
Three independent, generic Aero-agent capabilities that the canonry-platform operator-agent work builds on. No ads or product logic, no host names. Each is its own commit; they ride one `CANONRY_IMAGE` bump together.

### Commits
- **OSS-A — injected remote-MCP load path** (`Closes #739`). `loadExternalMcpTools` lets Aero connect to optional REMOTE read-only MCP servers (config/env `CANONRY_EXTERNAL_MCP`) over a **frozen transport: bearer-gated MCP Streamable HTTP**. Read-only filter (`annotations.readOnlyHint === true` + exclusion set), fail-soft per server, merged into the session in `acquireForTurn`. No servers configured => byte-identical.
- **OSS-C — evidence-safe tool-result truncation** (`Closes #741`). `truncateToolResult` replaces the blind 20KB `slice` with structure-aware whole-row dropping + a `{ __truncated, __omittedRows }` marker, so a large tool result never splits a row mid-JSON or silently drops a cited evidence row. Only the model-facing text is trimmed; `details` is untouched. Sub-cap output byte-identical.
- **OSS-D — generic system-prompt append seam** (`Closes #742`). `appendSystemPromptExtras` appends `AERO_SYSTEM_PROMPT_APPEND` / `AERO_SYSTEM_PROMPT_FILE` after soul+SKILL inside `loadAeroSystemPrompt` (so it covers the one-shot and registry paths, before the `<memory>` block). Empty by default => byte-identical.

### Notes
- A 4th spike (a generic agent base-URL override) was **dropped**: it is superseded by the first-class DeepInfra provider in #744. The one residual idea (a base-URL override so a proxy can front the agent) folds into #744.
- Version 4.99.0 (sits above #744's 4.98.0; whichever lands second rebases the bump).
- Full canonry suite green (152 files), typecheck + lint clean. New tests: `agent-remote-mcp`, `agent-tool-truncation`, `agent-system-prompt-append`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)