### PR TITLE
feat(agent): run GLM-5.2 on all DeepInfra tiers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,7 +181,7 @@ the external-agent webhook path via `canonry agent attach <url>`.
 - **CLI:** `canonry agent ask <project> "<prompt>"` — one-shot, streams
   `AgentEvent`s to stdout. Supports `--provider claude|openai|gemini|zai|deepinfra`
   and `--format json`. `deepinfra` is a Western-hosted OpenAI-compatible host
-  (GLM-5.2 / DeepSeek-V4-Flash); its key comes from `DEEPINFRA_TOKEN` or
+  (GLM-5.2); its key comes from `DEEPINFRA_TOKEN` or
   `providers.deepinfra.apiKey`, and `DEEPINFRA_BASE_URL` repoints the host at a
   proxy (e.g. a LiteLLM gateway) — unset falls back to `api.deepinfra.com`.
 - **Dashboard:** the bottom command bar on every project-scoped route.

--- a/packages/canonry/src/agent/providers.ts
+++ b/packages/canonry/src/agent/providers.ts
@@ -135,11 +135,13 @@ export interface AgentProviderEntry {
  *     model. All three tiers point at flash.
  *   - Zai: glm-5.1 is the agent tier; glm-5.1-flash is the cheap tier
  *     for analyze + classify.
- *   - DeepInfra: GLM-5.2 (Western-hosted open weights) is the agent tier;
- *     DeepSeek-V4-Flash is the cheap tier for analyze + classify. These are
- *     DeepInfra `org/Model` slugs, not pi-ai catalog ids — model resolution
- *     builds a custom openai-completions model (see `buildOpenAiCompatibleModel`).
- *     Serving is quantized (FP8/FP4); validate quality before production use.
+ *   - DeepInfra: GLM-5.2 (Western-hosted, Sonnet-class open weights) on all
+ *     three tiers. At ~$0.95/$3.00 per 1M it undercuts the Claude analyze
+ *     (Sonnet) and classify (Haiku) tiers it replaces, so the cheaper tiers
+ *     take no quality hit. These are DeepInfra `org/Model` slugs, not pi-ai
+ *     catalog ids — model resolution builds a custom openai-completions model
+ *     (see `buildOpenAiCompatibleModel`). Serving is quantized (FP8/FP4);
+ *     validate quality before production use.
  */
 export const PROVIDER_MODELS = {
   [AgentProviderIds.claude]: {
@@ -168,12 +170,13 @@ export const PROVIDER_MODELS = {
     [LlmCapabilities.classify]: 'glm-5-turbo',
   },
   [AgentProviderIds.deepinfra]: {
-    // DeepInfra `org/Model` slugs. GLM-5.2 drives the agent loop; the much
-    // cheaper DeepSeek-V4-Flash fills analyze + classify. Resolved into a
-    // custom openai-completions model, not pi-ai's catalog.
+    // DeepInfra `org/Model` slugs. GLM-5.2 (Sonnet-class) on all three tiers —
+    // it undercuts the Claude tiers it replaces, so the cheaper tiers take no
+    // quality hit. Resolved into a custom openai-completions model, not pi-ai's
+    // catalog.
     [LlmCapabilities.agent]: 'zai-org/GLM-5.2',
-    [LlmCapabilities.analyze]: 'deepseek-ai/DeepSeek-V4-Flash',
-    [LlmCapabilities.classify]: 'deepseek-ai/DeepSeek-V4-Flash',
+    [LlmCapabilities.analyze]: 'zai-org/GLM-5.2',
+    [LlmCapabilities.classify]: 'zai-org/GLM-5.2',
   },
 } as const satisfies Record<AgentProviderId, Record<LlmCapability, string>>
 

--- a/packages/canonry/test/agent-providers.test.ts
+++ b/packages/canonry/test/agent-providers.test.ts
@@ -338,10 +338,10 @@ describe('deepinfra (custom OpenAI-compatible host)', () => {
     expect(entry.openaiCompatible?.apiKeyEnvVar).toBe('DEEPINFRA_TOKEN')
   })
 
-  it('agent tier is GLM-5.2; analyze + classify share the cheaper DeepSeek tier', () => {
+  it('runs GLM-5.2 on all three tiers (agent, analyze, classify)', () => {
     expect(PROVIDER_MODELS.deepinfra[LlmCapabilities.agent]).toBe('zai-org/GLM-5.2')
-    expect(PROVIDER_MODELS.deepinfra[LlmCapabilities.analyze]).toBe('deepseek-ai/DeepSeek-V4-Flash')
-    expect(PROVIDER_MODELS.deepinfra[LlmCapabilities.classify]).toBe('deepseek-ai/DeepSeek-V4-Flash')
+    expect(PROVIDER_MODELS.deepinfra[LlmCapabilities.analyze]).toBe('zai-org/GLM-5.2')
+    expect(PROVIDER_MODELS.deepinfra[LlmCapabilities.classify]).toBe('zai-org/GLM-5.2')
     // defaultModel mirrors the agent tier (covered generically elsewhere too).
     expect(getAgentProvider('deepinfra').defaultModel).toBe('zai-org/GLM-5.2')
   })
@@ -422,7 +422,7 @@ describe('deepinfra (custom OpenAI-compatible host)', () => {
   })
 
   it("reports DeepInfra's real 1M (fp4) context window for the shipped tiers", () => {
-    // GLM-5.2 and DeepSeek-V4-Flash both serve at 1,048,576 on DeepInfra.
+    // All three tiers run GLM-5.2, which serves at 1,048,576 (fp4) on DeepInfra.
     for (const capability of LLM_CAPABILITIES) {
       const model = resolveModelForCapability('deepinfra', capability) as unknown as { contextWindow: number }
       expect(model.contextWindow).toBe(1_048_576)

--- a/skills/canonry/references/canonry-cli.md
+++ b/skills/canonry/references/canonry-cli.md
@@ -655,7 +655,7 @@ cnry agent memory forget <project> --key <k>
 `openai` → `google` → `zai` → `deepinfra`, whichever has an API key present
 first (from `~/.canonry/config.yaml` providers block, or the matching env var
 `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` / `ZAI_API_KEY` /
-`DEEPINFRA_TOKEN`). `deepinfra` (GLM-5.2 / DeepSeek-V4-Flash) is a
+`DEEPINFRA_TOKEN`). `deepinfra` (GLM-5.2) is a
 Western-hosted OpenAI-compatible host — useful when the agent / analyze /
 classify tiers must avoid PRC-hosted GLM (`zai`).
 


### PR DESCRIPTION
## What

Set the DeepInfra agent provider to **GLM-5.2 on all three tiers** (agent, analyze, classify). Previously agent ran GLM-5.2 while analyze/classify ran `deepseek-ai/DeepSeek-V4-Flash`.

| Tier | Before | After |
|---|---|---|
| agent | `zai-org/GLM-5.2` | `zai-org/GLM-5.2` |
| analyze | `deepseek-ai/DeepSeek-V4-Flash` | `zai-org/GLM-5.2` |
| classify | `deepseek-ai/DeepSeek-V4-Flash` | `zai-org/GLM-5.2` |

## Why GLM-5.2 everywhere (and not a cheaper tier)

GLM-5.2 is Sonnet-class, and on DeepInfra it costs **$0.95 / $3.00** per 1M. That is cheaper than *both* Claude tiers it replaces:

- analyze was Claude Sonnet ($3 / $15)
- classify was Claude Haiku ($1 / $5)

So moving analyze/classify to the flagship GLM-5.2 raises quality on those tiers while still costing less than the Claude defaults they came from. There was no cost reason to drop to a weaker model.

## Notes

- Slug `zai-org/GLM-5.2` confirmed live on deepinfra.com (org prefix is `zai-org`, not OpenRouter's `z-ai`).
- `knownModels` already carries GLM-5.2 metadata; `DeepSeek-V4-Flash` stays a known `--model` override target since DeepInfra still hosts it. Provider label stays `DeepInfra (GLM / DeepSeek)`.
- GLM-5.2 defaults to thinking-on at DeepInfra. A later change can pass `chat_template_kwargs.enable_thinking: false` if the classify tier should skip thinking tokens.

## Verification

`agent-providers.test.ts` updated: 37/37 pass. `typecheck` + `lint` clean. No version bump (35 lines, no API/contract/codegen change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
