### PR TITLE
feat(agent): disable thinking on DeepInfra cheap tiers

### DIFF
--- a/packages/canonry/src/agent/providers.ts
+++ b/packages/canonry/src/agent/providers.ts
@@ -347,7 +347,11 @@ export function resolveModelForCapability(
   // Custom OpenAI-compatible host (e.g. DeepInfra): the slug isn't in pi-ai's
   // catalog, so construct the model object directly against the host base URL.
   if (entry.openaiCompatible) {
-    return buildOpenAiCompatibleModel(entry, id) as Model<never>
+    // The single-shot cheap tiers (analyze/classify) don't need the model's
+    // reasoning trace; suppress it so they don't burn thinking tokens. The
+    // agent tier keeps the host's default thinking for its multi-step loop.
+    const suppressThinking = capability !== LlmCapabilities.agent
+    return buildOpenAiCompatibleModel(entry, id, suppressThinking) as Model<never>
   }
   const model = getModel(entry.piAiProvider as never, id as never) as Model<never> | undefined
   if (!model) {
@@ -368,6 +372,7 @@ export function resolveModelForCapability(
 export function buildOpenAiCompatibleModel(
   entry: AgentProviderEntry,
   id: string,
+  suppressThinking = false,
 ): Model<'openai-completions'> {
   const host = entry.openaiCompatible
   if (!host) {
@@ -378,6 +383,15 @@ export function buildOpenAiCompatibleModel(
   // LiteLLM gateway); an unset/empty env var falls back to the configured
   // constant, so the default self-hosted path is byte-for-byte unchanged.
   const baseUrl = (host.baseUrlEnvVar ? process.env[host.baseUrlEnvVar] : undefined) || host.baseUrl
+  // When the caller wants thinking off (the cheap single-shot tiers), pin GLM's
+  // chat-template thinking switch. With `thinkingFormat: 'qwen-chat-template'`
+  // and no request-time reasoning effort (the explain/classify callers pass
+  // none), pi-ai emits `chat_template_kwargs: { enable_thinking: false }` on
+  // DeepInfra's vLLM route. That branch requires `reasoning: true`, which the
+  // GLM tier sets — so the trace is suppressed at the request, not the model.
+  const compat: OpenAICompletionsCompat | undefined = suppressThinking
+    ? { ...host.compat, thinkingFormat: 'qwen-chat-template' }
+    : host.compat
   return {
     id,
     name: id,
@@ -389,7 +403,7 @@ export function buildOpenAiCompatibleModel(
     cost: meta.cost,
     contextWindow: meta.contextWindow,
     maxTokens: meta.maxTokens,
-    ...(host.compat ? { compat: host.compat } : {}),
+    ...(compat ? { compat } : {}),
   }
 }
 

--- a/packages/canonry/test/agent-providers.test.ts
+++ b/packages/canonry/test/agent-providers.test.ts
@@ -327,7 +327,7 @@ describe('deepinfra (custom OpenAI-compatible host)', () => {
     baseUrl: string
     reasoning: boolean
     cost: { input: number; output: number; cacheRead: number; cacheWrite: number }
-    compat?: { supportsDeveloperRole?: boolean; maxTokensField?: string }
+    compat?: { supportsDeveloperRole?: boolean; maxTokensField?: string; thinkingFormat?: string }
   }
 
   it('is registered, agent-only, and carries an openaiCompatible host config', () => {
@@ -362,6 +362,19 @@ describe('deepinfra (custom OpenAI-compatible host)', () => {
     const model = resolveModelForCapability('deepinfra', LlmCapabilities.agent) as unknown as CompletionsModel
     expect(model.compat?.supportsDeveloperRole).toBe(false)
     expect(model.compat?.maxTokensField).toBe('max_tokens')
+  })
+
+  it('suppresses thinking on the cheap tiers, not the agent tier', () => {
+    // agent → host default thinking (no thinkingFormat pin).
+    const agent = resolveModelForCapability('deepinfra', LlmCapabilities.agent) as unknown as CompletionsModel
+    expect(agent.compat?.thinkingFormat).toBeUndefined()
+    // analyze + classify → enable_thinking:false via GLM's chat-template switch,
+    // merged onto (not replacing) the base open-model compat profile.
+    for (const cap of [LlmCapabilities.analyze, LlmCapabilities.classify]) {
+      const model = resolveModelForCapability('deepinfra', cap) as unknown as CompletionsModel
+      expect(model.compat?.thinkingFormat).toBe('qwen-chat-template')
+      expect(model.compat?.maxTokensField).toBe('max_tokens')
+    }
   })
 
   it('applies per-slug known-model metadata and falls back for unknown slugs', () => {


### PR DESCRIPTION
Follow-up to #747 (GLM-5.2 on all DeepInfra tiers).

## What

The DeepInfra `analyze` and `classify` tiers run GLM-5.2 as single-shot calls (no tool loop), so the model's reasoning trace is wasted thinking tokens + latency. This suppresses thinking on those two tiers only. The `agent` tier is untouched and keeps the host's default thinking for its multi-step loop.

## How

`resolveModelForCapability` passes `suppressThinking = capability !== 'agent'` to `buildOpenAiCompatibleModel`, which for the cheap tiers merges `thinkingFormat: 'qwen-chat-template'` onto the host compat. Per pi-ai's `openai-completions` logic, with that format set and no request-time `reasoningEffort` (the explain/classify callers pass none), pi-ai emits `chat_template_kwargs: { enable_thinking: false }` on DeepInfra's vLLM route. The branch requires `reasoning: true`, which the GLM tier already sets, so thinking is suppressed at the request, not by faking the model as non-reasoning.

Scope is contained to the openai-compatible model builder, so catalog providers (claude/openai/gemini/zai) and the agent path are unaffected.

## Caveat (please smoke-test)

I could not runtime-verify the emission here (no DeepInfra key). The mechanism is read straight from pi-ai's source and DeepInfra runs vLLM (which documents `chat_template_kwargs`), so confidence is high, but before relying on it: run one `analyze` call against DeepInfra and confirm the request carries `chat_template_kwargs.enable_thinking: false`, the call succeeds (vLLM accepts the field), and the reasoning trace is gone.

## Verification

`agent-providers.test.ts` gains a test asserting analyze/classify carry `thinkingFormat: 'qwen-chat-template'` (merged onto the base compat) while agent does not: 38/38 pass. `typecheck` + `lint` clean. No version bump (33 lines, no API/contract change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
