### PR TITLE
Add Aero prompt cache telemetry

### DIFF
--- a/packages/api-routes/test/db-dto-coverage.test.ts
+++ b/packages/api-routes/test/db-dto-coverage.test.ts
@@ -524,6 +524,10 @@ const COVERAGE: Record<string, CoverageEntry> = {
     kind: 'internal-only',
     reason: 'Internal rate-limit / quota counters; never exposed.',
   },
+  llmUsageEvents: {
+    kind: 'internal-only',
+    reason: 'Internal LLM token/cache/cost ledger for prompt-cache tuning; not exposed as a public DTO.',
+  },
   agentSessions: {
     kind: 'internal-only',
     reason: 'Aero session state (transcript + queue). Exposed via the agent transcript composite, not as a direct row DTO.',

--- a/packages/canonry/src/agent/llm-usage.ts
+++ b/packages/canonry/src/agent/llm-usage.ts
@@ -1,0 +1,69 @@
+import crypto from 'node:crypto'
+import { llmUsageEvents, type DatabaseClient } from '@ainyc/canonry-db'
+import type { AssistantMessage } from '@mariozechner/pi-ai'
+
+export const AeroLlmUsageFeatures = {
+  turn: 'aero.turn',
+} as const
+
+export const AERO_PROMPT_FAMILY = 'aero'
+export const AERO_PROMPT_VERSION = 'aero-system-v1'
+
+/**
+ * One dollar = 100 cents = 100,000 millicents. pi-ai returns USD floats;
+ * telemetry persists integer millicents for cheap sums and stable audits.
+ */
+function dollarsToMillicents(dollars: number): number {
+  if (!Number.isFinite(dollars) || dollars <= 0) return 0
+  return Math.round(dollars * 100_000)
+}
+
+function nonNegativeInteger(value: number | undefined): number {
+  if (!Number.isFinite(value) || value === undefined || value <= 0) return 0
+  return Math.round(value)
+}
+
+export interface RecordLlmUsageEventArgs {
+  db: DatabaseClient
+  projectId?: string
+  runId?: string
+  agentSessionId?: string
+  feature: string
+  promptFamily?: string
+  promptVersion?: string
+  message: AssistantMessage
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Best-effort append-only usage telemetry. This must never break an agent turn:
+ * the Anthropic/OpenAI dashboards are advisory, but the operator chat is user-facing.
+ */
+export function recordLlmUsageEvent(args: RecordLlmUsageEventArgs): void {
+  try {
+    const usage = args.message.usage
+    const now = new Date().toISOString()
+    args.db.insert(llmUsageEvents).values({
+      id: crypto.randomUUID(),
+      projectId: args.projectId,
+      runId: args.runId,
+      agentSessionId: args.agentSessionId,
+      feature: args.feature,
+      provider: args.message.provider,
+      model: args.message.model,
+      responseId: args.message.responseId,
+      inputTokens: nonNegativeInteger(usage.input),
+      outputTokens: nonNegativeInteger(usage.output),
+      cacheReadTokens: nonNegativeInteger(usage.cacheRead),
+      cacheWriteTokens: nonNegativeInteger(usage.cacheWrite),
+      totalTokens: nonNegativeInteger(usage.totalTokens),
+      costMillicents: dollarsToMillicents(usage.cost.total),
+      promptFamily: args.promptFamily,
+      promptVersion: args.promptVersion,
+      metadata: args.metadata,
+      createdAt: now,
+    }).run()
+  } catch {
+    // Usage telemetry is diagnostic only; do not fail the agent on DB errors.
+  }
+}

--- a/packages/canonry/src/agent/prompt-cache.ts
+++ b/packages/canonry/src/agent/prompt-cache.ts
@@ -1,0 +1,95 @@
+import type { Api, Model } from '@mariozechner/pi-ai'
+
+const AERO_MEMORY_SEPARATOR = '\n\n---\n\n'
+const AERO_MEMORY_BLOCK_PREFIX = `${AERO_MEMORY_SEPARATOR}<memory>\n`
+
+interface TextSystemBlock {
+  type: 'text'
+  text: string
+  cache_control?: unknown
+  [key: string]: unknown
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function isTextSystemBlock(value: unknown): value is TextSystemBlock {
+  return isRecord(value) && value.type === 'text' && typeof value.text === 'string'
+}
+
+export interface SplitAeroSystemPrompt {
+  basePrompt: string
+  memoryBlock?: string
+}
+
+/**
+ * SessionRegistry appends dynamic project memory as:
+ *
+ *   <base prompt>
+ *   ---
+ *   <memory>...</memory>
+ *
+ * Keep that dynamic block outside the cached system breakpoint so Anthropic can
+ * reuse the stable Aero prompt even as project memory changes.
+ */
+export function splitAeroHydratedSystemPrompt(systemPrompt: string): SplitAeroSystemPrompt {
+  const idx = systemPrompt.lastIndexOf(AERO_MEMORY_BLOCK_PREFIX)
+  if (idx < 0) return { basePrompt: systemPrompt }
+  return {
+    basePrompt: systemPrompt.slice(0, idx).trimEnd(),
+    memoryBlock: systemPrompt.slice(idx + AERO_MEMORY_SEPARATOR.length),
+  }
+}
+
+/**
+ * pi-ai emits one Anthropic system text block with cache_control. When that
+ * block contains hydrated memory, replace it with two blocks:
+ *   1. stable Aero base prompt, still cacheable
+ *   2. dynamic memory block, not cacheable
+ *
+ * Return undefined when the payload should be left unchanged, matching pi-ai's
+ * onPayload convention.
+ */
+export function splitAeroAnthropicSystemCachePayload(
+  payload: unknown,
+  model: Model<Api>,
+): unknown | undefined {
+  if (model.api !== 'anthropic-messages') return undefined
+  if (!isRecord(payload) || !Array.isArray(payload.system)) return undefined
+
+  let changed = false
+  const nextSystem: unknown[] = []
+
+  for (const block of payload.system) {
+    if (!isTextSystemBlock(block)) {
+      nextSystem.push(block)
+      continue
+    }
+
+    const split = splitAeroHydratedSystemPrompt(block.text)
+    if (!split.memoryBlock) {
+      nextSystem.push(block)
+      continue
+    }
+
+    const memoryBlock: TextSystemBlock = {
+      ...block,
+      text: split.memoryBlock,
+    }
+    delete memoryBlock.cache_control
+
+    nextSystem.push({
+      ...block,
+      text: split.basePrompt,
+    })
+    nextSystem.push(memoryBlock)
+    changed = true
+  }
+
+  if (!changed) return undefined
+  return {
+    ...payload,
+    system: nextSystem,
+  }
+}

--- a/packages/canonry/src/agent/session-registry.ts
+++ b/packages/canonry/src/agent/session-registry.ts
@@ -210,6 +210,9 @@ export class SessionRegistry {
         systemPromptOverride: this.buildHydratedSystemPrompt(projectId, row.systemPrompt),
         initialMessages: persistedMessages,
         toolScope: preferences?.toolScope,
+        db: this.opts.db,
+        projectId,
+        agentSessionId: row.id,
       })
       this.scopes.set(projectName, preferences?.toolScope ?? 'all')
       this.projectIds.set(projectName, projectId)
@@ -226,6 +229,7 @@ export class SessionRegistry {
 
     const { provider, modelId } = resolveSessionProviderAndModel(this.opts.config, preferences)
     const systemPrompt = loadAeroSystemPrompt()
+    const sessionId = crypto.randomUUID()
 
     const agent = createAeroSession({
       projectName,
@@ -237,11 +241,15 @@ export class SessionRegistry {
       // notes if they were seeded via CLI/API before the first prompt.
       systemPromptOverride: this.buildHydratedSystemPrompt(projectId, systemPrompt),
       toolScope: preferences?.toolScope,
+      db: this.opts.db,
+      projectId,
+      agentSessionId: sessionId,
     })
     this.scopes.set(projectName, preferences?.toolScope ?? 'all')
     this.projectIds.set(projectName, projectId)
 
     this.insertRow({
+      id: sessionId,
       projectId,
       // Persist the raw (unhydrated) prompt so the DB remains canonical —
       // the `<memory>` block is rebuilt from the notes table on every load.
@@ -646,6 +654,7 @@ export class SessionRegistry {
   }
 
   private insertRow(params: {
+    id?: string
     projectId: string
     systemPrompt: string
     provider?: SupportedAgentProvider
@@ -658,7 +667,7 @@ export class SessionRegistry {
     this.opts.db
       .insert(agentSessions)
       .values({
-        id: crypto.randomUUID(),
+        id: params.id ?? crypto.randomUUID(),
         projectId: params.projectId,
         systemPrompt: params.systemPrompt,
         modelProvider: params.provider ?? params.modelProvider ?? AgentProviderIds.claude,

--- a/packages/canonry/src/agent/session.ts
+++ b/packages/canonry/src/agent/session.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import { Agent } from '@mariozechner/pi-agent-core'
 import type { AgentOptions, AgentTool } from '@mariozechner/pi-agent-core'
 import { registerBuiltInApiProviders, type Model } from '@mariozechner/pi-ai'
+import type { DatabaseClient } from '@ainyc/canonry-db'
 import type { ApiClient } from '../client.js'
 import type { CanonryConfig } from '../config.js'
 import {
@@ -17,6 +18,13 @@ import {
 import { resolveAeroSkillDir } from './skill-paths.js'
 import { buildSkillDocTools } from './skill-tools.js'
 import { buildAllTools, buildReadTools } from './tools.js'
+import {
+  AERO_PROMPT_FAMILY,
+  AERO_PROMPT_VERSION,
+  AeroLlmUsageFeatures,
+  recordLlmUsageEvent,
+} from './llm-usage.js'
+import { splitAeroAnthropicSystemCachePayload } from './prompt-cache.js'
 
 export type { SupportedAgentProvider } from './providers.js'
 export { AgentProviders, listAgentProviders, coerceAgentProvider } from './providers.js'
@@ -52,6 +60,10 @@ export interface AeroSessionOptions {
   toolScope?: 'all' | 'read-only'
   /** Seed initial transcript. Used by the registry when rehydrating a persisted session. */
   initialMessages?: import('@mariozechner/pi-agent-core').AgentMessage[]
+  /** Optional telemetry context. When present, assistant turn usage is appended to llm_usage_events. */
+  db?: DatabaseClient
+  projectId?: string
+  agentSessionId?: string
 }
 
 export { resolveAeroSkillDir } from './skill-paths.js'
@@ -137,6 +149,10 @@ export function buildApiKeyResolver(
   return (piAiProvider: string) => resolveApiKeyFor(piAiProvider, config)
 }
 
+function buildAeroProviderSessionId(opts: AeroSessionOptions): string {
+  return `canonry:aero:${opts.agentSessionId ?? opts.projectId ?? opts.projectName}`
+}
+
 export function createAeroSession(opts: AeroSessionOptions): Agent {
   const systemPrompt = opts.systemPromptOverride ?? loadAeroSystemPrompt()
 
@@ -156,7 +172,7 @@ export function createAeroSession(opts: AeroSessionOptions): Agent {
   const defaultTools = [...stateTools, ...buildSkillDocTools()]
   const tools = opts.tools ?? defaultTools
 
-  return new Agent({
+  const agent = new Agent({
     initialState: {
       systemPrompt,
       model,
@@ -164,8 +180,30 @@ export function createAeroSession(opts: AeroSessionOptions): Agent {
       ...(opts.initialMessages ? { messages: opts.initialMessages } : {}),
     },
     streamFn: opts.streamFn,
+    sessionId: buildAeroProviderSessionId(opts),
+    onPayload: splitAeroAnthropicSystemCachePayload,
     getApiKey: buildApiKeyResolver(opts.config),
   })
+
+  const telemetryDb = opts.db
+  if (telemetryDb) {
+    agent.subscribe((event) => {
+      if (event.type !== 'turn_end') return
+      if (event.message.role !== 'assistant') return
+      recordLlmUsageEvent({
+        db: telemetryDb,
+        projectId: opts.projectId,
+        agentSessionId: opts.agentSessionId,
+        feature: AeroLlmUsageFeatures.turn,
+        promptFamily: AERO_PROMPT_FAMILY,
+        promptVersion: AERO_PROMPT_VERSION,
+        message: event.message,
+        metadata: { projectName: opts.projectName, toolCount: agent.state.tools.length },
+      })
+    })
+  }
+
+  return agent
 }
 
 /** Exposed so the registry can persist the chosen provider/model without re-running detection. */

--- a/packages/canonry/test/agent-prompt-cache.test.ts
+++ b/packages/canonry/test/agent-prompt-cache.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import type { Api, Model } from '@mariozechner/pi-ai'
+import {
+  splitAeroAnthropicSystemCachePayload,
+  splitAeroHydratedSystemPrompt,
+} from '../src/agent/prompt-cache.js'
+
+const anthropicModel = {
+  id: 'claude-opus-4-7',
+  name: 'Claude Opus 4.7',
+  api: 'anthropic-messages',
+  provider: 'anthropic',
+  baseUrl: 'https://api.anthropic.com',
+  reasoning: false,
+  input: ['text'],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 200000,
+  maxTokens: 32000,
+} as Model<Api>
+
+const openAiModel = {
+  ...anthropicModel,
+  api: 'openai-responses',
+  provider: 'openai',
+} as Model<Api>
+
+describe('Aero Anthropic prompt cache payload split', () => {
+  it('splits hydrated memory out of the stable system prompt', () => {
+    const prompt = 'You are Aero.\n\n---\n\n<memory>\n- [user] goal: ads\n</memory>'
+
+    expect(splitAeroHydratedSystemPrompt(prompt)).toEqual({
+      basePrompt: 'You are Aero.',
+      memoryBlock: '<memory>\n- [user] goal: ads\n</memory>',
+    })
+  })
+
+  it('keeps cache_control on the stable system block and removes it from dynamic memory', () => {
+    const payload = {
+      model: 'claude-opus-4-7',
+      system: [
+        {
+          type: 'text',
+          text: 'You are Aero.\n\n---\n\n<memory>\n- [user] goal: ads\n</memory>',
+          cache_control: { type: 'ephemeral' },
+        },
+      ],
+      messages: [{ role: 'user', content: 'status' }],
+    }
+
+    const out = splitAeroAnthropicSystemCachePayload(payload, anthropicModel)
+    const changed = out as { system: Array<Record<string, unknown>> }
+
+    expect(changed.system).toHaveLength(2)
+    expect(changed.system[0]).toMatchObject({
+      type: 'text',
+      text: 'You are Aero.',
+      cache_control: { type: 'ephemeral' },
+    })
+    expect(changed.system[1]).toMatchObject({
+      type: 'text',
+      text: '<memory>\n- [user] goal: ads\n</memory>',
+    })
+    expect(changed.system[1].cache_control).toBeUndefined()
+  })
+
+  it('leaves non-Anthropic payloads unchanged', () => {
+    const payload = {
+      system: [
+        {
+          type: 'text',
+          text: 'You are Aero.\n\n---\n\n<memory>\n- [user] goal: ads\n</memory>',
+          cache_control: { type: 'ephemeral' },
+        },
+      ],
+    }
+
+    expect(splitAeroAnthropicSystemCachePayload(payload, openAiModel)).toBeUndefined()
+  })
+})

--- a/packages/canonry/test/agent-session-registry.test.ts
+++ b/packages/canonry/test/agent-session-registry.test.ts
@@ -8,6 +8,7 @@ import {
   migrate,
   projects,
   agentSessions,
+  llmUsageEvents,
   parseJsonColumn,
   type DatabaseClient,
 } from '@ainyc/canonry-db'
@@ -134,6 +135,58 @@ describe('SessionRegistry', () => {
     const row = db.select().from(agentSessions).where(eq(agentSessions.projectId, projectId)).get()
     const persisted = parseJsonColumn<AgentMessage[]>(row!.messages, [])
     expect(persisted).toHaveLength(inMemoryCount)
+  })
+
+  it('records per-turn LLM usage tied to the durable Aero session', async () => {
+    const projectId = insertProject(db, 'demo')
+    const registry = new SessionRegistry({ db, client: stubClient(), config: stubConfig() })
+    const agent = registry.getOrCreate('demo')
+    const row = db.select().from(agentSessions).where(eq(agentSessions.projectId, projectId)).get()
+    expect(row).toBeDefined()
+
+    agent.state.model = faux.getModel()
+    faux.setResponses([fauxAssistantMessage('Usage recorded.')])
+
+    await agent.prompt('Status update please')
+    await agent.waitForIdle()
+
+    const usageRows = db.select().from(llmUsageEvents).where(eq(llmUsageEvents.projectId, projectId)).all()
+    expect(usageRows).toHaveLength(1)
+    expect(usageRows[0]).toMatchObject({
+      projectId,
+      agentSessionId: row!.id,
+      feature: 'aero.turn',
+      provider: 'faux',
+      model: 'faux-model',
+      promptFamily: 'aero',
+      promptVersion: 'aero-system-v1',
+    })
+    expect(usageRows[0].inputTokens).toBeGreaterThan(0)
+    expect(usageRows[0].outputTokens).toBeGreaterThan(0)
+    expect(usageRows[0].cacheWriteTokens).toBeGreaterThan(0)
+    expect(usageRows[0].metadata).toMatchObject({
+      projectName: 'demo',
+      toolCount: AERO_ALL_TOOL_COUNT,
+    })
+  })
+
+  it('records LLM usage with the current hot-session tool count after scope alignment', async () => {
+    const projectId = insertProject(db, 'demo')
+    const registry = new SessionRegistry({ db, client: stubClient(), config: stubConfig() })
+    const agent = await registry.acquireForTurn('demo', { toolScope: 'read-only' })
+
+    agent.state.model = faux.getModel()
+    faux.setResponses([fauxAssistantMessage('Read-only usage recorded.')])
+
+    await agent.prompt('Status update please')
+    await agent.waitForIdle()
+
+    const usageRows = db.select().from(llmUsageEvents).where(eq(llmUsageEvents.projectId, projectId)).all()
+    expect(usageRows).toHaveLength(1)
+    expect(usageRows[0].metadata).toMatchObject({
+      projectName: 'demo',
+      toolCount: AERO_READ_TOOL_COUNT,
+    })
   })
 
   it('hydrates an evicted session from the DB and surfaces persisted queue as pending', () => {

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1842,6 +1842,36 @@ export const MIGRATION_VERSIONS: ReadonlyArray<MigrationVersion> = [
       `ALTER TABLE ads_connections ADD COLUMN conversion_tracking_configured INTEGER NOT NULL DEFAULT 0`,
     ],
   },
+  {
+    version: 84,
+    name: 'llm-usage-events',
+    statements: [
+      `CREATE TABLE IF NOT EXISTS llm_usage_events (
+        id                  TEXT PRIMARY KEY,
+        project_id          TEXT REFERENCES projects(id) ON DELETE CASCADE,
+        run_id              TEXT REFERENCES runs(id) ON DELETE SET NULL,
+        agent_session_id    TEXT REFERENCES agent_sessions(id) ON DELETE SET NULL,
+        feature             TEXT NOT NULL,
+        provider            TEXT NOT NULL,
+        model               TEXT NOT NULL,
+        response_id         TEXT,
+        input_tokens        INTEGER NOT NULL DEFAULT 0,
+        output_tokens       INTEGER NOT NULL DEFAULT 0,
+        cache_read_tokens   INTEGER NOT NULL DEFAULT 0,
+        cache_write_tokens  INTEGER NOT NULL DEFAULT 0,
+        total_tokens        INTEGER NOT NULL DEFAULT 0,
+        cost_millicents     INTEGER NOT NULL DEFAULT 0,
+        prompt_family       TEXT,
+        prompt_version      TEXT,
+        metadata            TEXT,
+        created_at          TEXT NOT NULL
+      )`,
+      `CREATE INDEX IF NOT EXISTS idx_llm_usage_project_created ON llm_usage_events(project_id, created_at)`,
+      `CREATE INDEX IF NOT EXISTS idx_llm_usage_feature_created ON llm_usage_events(feature, created_at)`,
+      `CREATE INDEX IF NOT EXISTS idx_llm_usage_session_created ON llm_usage_events(agent_session_id, created_at)`,
+      `CREATE INDEX IF NOT EXISTS idx_llm_usage_run_created ON llm_usage_events(run_id, created_at)`,
+    ],
+  },
 ]
 
 /**

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -663,6 +663,37 @@ export const agentMemory = sqliteTable('agent_memory', {
   index('idx_agent_memory_project_updated').on(table.projectId, table.updatedAt),
 ])
 
+/**
+ * Append-only internal LLM usage ledger. `usage_counters` is intentionally
+ * aggregate-only; prompt-cache tuning needs per-call token and cache component
+ * rows grouped by feature/provider/model/session.
+ */
+export const llmUsageEvents = sqliteTable('llm_usage_events', {
+  id: text('id').primaryKey(),
+  projectId: text('project_id').references(() => projects.id, { onDelete: 'cascade' }),
+  runId: text('run_id').references(() => runs.id, { onDelete: 'set null' }),
+  agentSessionId: text('agent_session_id').references(() => agentSessions.id, { onDelete: 'set null' }),
+  feature: text('feature').notNull(),
+  provider: text('provider').notNull(),
+  model: text('model').notNull(),
+  responseId: text('response_id'),
+  inputTokens: integer('input_tokens').notNull().default(0),
+  outputTokens: integer('output_tokens').notNull().default(0),
+  cacheReadTokens: integer('cache_read_tokens').notNull().default(0),
+  cacheWriteTokens: integer('cache_write_tokens').notNull().default(0),
+  totalTokens: integer('total_tokens').notNull().default(0),
+  costMillicents: integer('cost_millicents').notNull().default(0),
+  promptFamily: text('prompt_family'),
+  promptVersion: text('prompt_version'),
+  metadata: text('metadata', { mode: 'json' }).$type<Record<string, unknown>>(),
+  createdAt: text('created_at').notNull(),
+}, (table) => [
+  index('idx_llm_usage_project_created').on(table.projectId, table.createdAt),
+  index('idx_llm_usage_feature_created').on(table.feature, table.createdAt),
+  index('idx_llm_usage_session_created').on(table.agentSessionId, table.createdAt),
+  index('idx_llm_usage_run_created').on(table.runId, table.createdAt),
+])
+
 // --- Server-side traffic ingestion ---
 // Per-source connection metadata. Credentials live in ~/.canonry/config.yaml,
 // not here. `archived_at` retains the row after a host migration so historical


### PR DESCRIPTION
## Summary
- split Aero's hydrated Anthropic system prompt so the stable base prompt remains cacheable while project memory stays dynamic
- persist best-effort Aero LLM usage telemetry, including cache read/write tokens and prompt family/version
- add the `llm_usage_events` table plus migration/DTO coverage and focused tests

## Validation
- `corepack pnpm exec vitest run --project canonry packages/canonry/test/agent-prompt-cache.test.ts packages/canonry/test/agent-session-registry.test.ts`
- `corepack pnpm exec vitest run --project db packages/db/test/migration-parity.test.ts`
- `corepack pnpm exec vitest run --project api-routes packages/api-routes/test/db-dto-coverage.test.ts`
- `corepack pnpm --filter @ainyc/canonry typecheck`
- `corepack pnpm --filter @ainyc/canonry-db typecheck`
- `corepack pnpm --filter @ainyc/canonry-api-routes typecheck`
- `corepack pnpm --filter @ainyc/canonry-db lint`
- `corepack pnpm --filter @ainyc/canonry lint -- src/agent/session.ts src/agent/session-registry.ts src/agent/llm-usage.ts src/agent/prompt-cache.ts test/agent-prompt-cache.test.ts test/agent-session-registry.test.ts` (passes with existing 114 warnings)
- commit hook ran `pnpm -r run lint` (passes with existing warning baseline)
