### PR TITLE
feat: Add overview mention share trend

### DIFF
--- a/apps/web/src/components/project/VisibilityTrendSection.tsx
+++ b/apps/web/src/components/project/VisibilityTrendSection.tsx
@@ -95,6 +95,14 @@ function firstSeriesValue(rows: Array<Record<string, string | number | null>>, k
   return null
 }
 
+function competitorFrameKey(competitorDomains: readonly string[]): string {
+  return competitorDomains
+    .map(domain => domain.trim().toLowerCase())
+    .filter(Boolean)
+    .sort()
+    .join('\n')
+}
+
 /**
  * Single-select segmented control. A group of toggle buttons (`role="group"` +
  * `aria-pressed`), not a tab pattern: these switch the chart's series in place,
@@ -133,16 +141,23 @@ function Segmented<T extends string>({
   )
 }
 
-export function VisibilityTrendSection({ projectName }: { projectName: string }) {
+export function VisibilityTrendSection({
+  projectName,
+  competitorDomains = [],
+}: {
+  projectName: string
+  competitorDomains?: readonly string[]
+}) {
   const [window, setWindow] = useState<MetricsWindow>('all')
   const [metric, setMetric] = useState<MetricChoice>('mentioned')
   // Default to the per-engine breakdown: the blended line hides that engines
   // disagree wildly (a brand cited heavily by one engine and ignored by
   // another), which is the first thing an operator needs to see.
   const [mode, setMode] = useState<TrendSeriesMode>('byProvider')
+  const metricsFrameKey = useMemo(() => competitorFrameKey(competitorDomains), [competitorDomains])
 
   const metricsQuery = useQuery({
-    queryKey: ['analytics-metrics', projectName, window],
+    queryKey: ['analytics-metrics', projectName, window, metricsFrameKey],
     queryFn: () => fetchAnalyticsMetrics(projectName, window),
     staleTime: STATIC_VISIBILITY_STALE_MS,
   })
@@ -315,15 +330,17 @@ export function VisibilityTrendSection({ projectName }: { projectName: string })
 
 export function MentionShareTrendSection({
   projectName,
-  competitorCount,
+  competitorDomains,
 }: {
   projectName: string
-  competitorCount: number
+  competitorDomains: readonly string[]
 }) {
   const [window, setWindow] = useState<MetricsWindow>('all')
+  const metricsFrameKey = useMemo(() => competitorFrameKey(competitorDomains), [competitorDomains])
+  const competitorCount = competitorDomains.length
 
   const metricsQuery = useQuery({
-    queryKey: ['analytics-metrics', projectName, window],
+    queryKey: ['analytics-metrics', projectName, window, metricsFrameKey],
     queryFn: () => fetchAnalyticsMetrics(projectName, window),
     staleTime: STATIC_VISIBILITY_STALE_MS,
   })

--- a/apps/web/src/components/project/VisibilityTrendSection.tsx
+++ b/apps/web/src/components/project/VisibilityTrendSection.tsx
@@ -24,10 +24,12 @@ import { InfoTooltip } from '../shared/InfoTooltip.js'
 import { fetchAnalyticsMetrics } from '../../api.js'
 import { STATIC_VISIBILITY_STALE_MS } from '../../queries/query-client.js'
 import {
+  buildMentionShareTrendRows,
   buildTrendRows,
   CITED_KEY,
   formatQueryChangeCaption,
   latestSeriesValue,
+  MENTION_SHARE_KEY,
   MENTIONED_KEY,
   type MetricChoice,
   type TrendSeriesMode,
@@ -81,7 +83,16 @@ function seriesLabel(key: string): string {
 function seriesColor(key: string, index: number): string {
   if (key === CITED_KEY) return CHART_TONE.positive // emerald
   if (key === MENTIONED_KEY) return CHART_SERIES_COLORS[1]! // blue
+  if (key === MENTION_SHARE_KEY) return CHART_TONE.positive
   return providerSeriesColor(key, index)
+}
+
+function firstSeriesValue(rows: Array<Record<string, string | number | null>>, key: string): number | null {
+  for (const row of rows) {
+    const value = row[key]
+    if (typeof value === 'number' && Number.isFinite(value)) return value
+  }
+  return null
 }
 
 /**
@@ -296,6 +307,141 @@ export function VisibilityTrendSection({ projectName }: { projectName: string })
 
   return (
     <section className="visibility-trend">
+      {header}
+      {body}
+    </section>
+  )
+}
+
+export function MentionShareTrendSection({
+  projectName,
+  competitorCount,
+}: {
+  projectName: string
+  competitorCount: number
+}) {
+  const [window, setWindow] = useState<MetricsWindow>('all')
+
+  const metricsQuery = useQuery({
+    queryKey: ['analytics-metrics', projectName, window],
+    queryFn: () => fetchAnalyticsMetrics(projectName, window),
+    staleTime: STATIC_VISIBILITY_STALE_MS,
+  })
+  const data = metricsQuery.data ?? null
+  const error = metricsQuery.error
+  const trend = useMemo(() => (data ? buildMentionShareTrendRows(data) : null), [data])
+  const latestPct = trend ? latestSeriesValue(trend.rows, MENTION_SHARE_KEY) : null
+  const firstPct = trend ? firstSeriesValue(trend.rows, MENTION_SHARE_KEY) : null
+  const deltaPts = latestPct !== null && firstPct !== null && latestPct !== firstPct
+    ? round1(latestPct - firstPct)
+    : latestPct !== null && firstPct !== null
+      ? 0
+      : null
+
+  const header = (
+    <>
+      <div className="visibility-trend-head">
+        <div className="space-y-1">
+          <p className="eyebrow eyebrow-soft">Competitive trend</p>
+          <h2 className="visibility-trend-title">
+            Mention share over time
+            <InfoTooltip text="Of all answer-text brand mentions in each sweep bucket (you plus tracked competitors), the share that were you. Buckets with no brand mentions are not plotted." />
+          </h2>
+        </div>
+        {latestPct !== null && (
+          <div className="visibility-trend-current">
+            <span className="visibility-trend-current-dot" style={{ backgroundColor: CHART_TONE.positive }} aria-hidden="true" />
+            <span className="visibility-trend-current-label">Mention share</span>
+            <span className="visibility-trend-current-value">{latestPct}%</span>
+            {deltaPts !== null && (
+              <span
+                className={`visibility-trend-current-delta ${
+                  deltaPts > 0 ? 'text-emerald-400' : deltaPts < 0 ? 'text-rose-400' : 'text-zinc-500'
+                }`}
+              >
+                {deltaPts > 0 ? '+' : ''}{deltaPts.toFixed(1)} pts
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+      <div className="visibility-trend-controls">
+        <Segmented options={WINDOW_OPTIONS} value={window} onChange={setWindow} ariaLabel="Time window" className="sm:ml-auto" />
+      </div>
+    </>
+  )
+
+  let body: React.ReactNode
+  if (error) {
+    body = <p className="text-sm text-rose-400">{error instanceof Error ? error.message : String(error)}</p>
+  } else if (metricsQuery.isLoading && !data) {
+    body = <div className="visibility-trend-chart animate-pulse rounded-lg bg-zinc-900/40" aria-hidden="true" />
+  } else if (competitorCount === 0) {
+    body = <p className="text-sm text-zinc-400">Add tracked competitors to measure mention share over time.</p>
+  } else if (!data || !trend) {
+    body = null
+  } else if (!trend.hasData) {
+    body = <p className="text-sm text-zinc-400">No answer-text brand mentions for you or tracked competitors in this window yet.</p>
+  } else {
+    const caption = formatQueryChangeCaption(data.queryChanges)
+    const { rows, singleBucket } = trend
+    const srSummary = `Mention share across ${rows.length} ${rows.length === 1 ? 'sweep bucket' : 'sweep buckets'}. Latest ${latestPct}%${
+      deltaPts !== null ? `, ${deltaPts >= 0 ? 'up' : 'down'} ${Math.abs(deltaPts).toFixed(1)} points over the period` : ''
+    }.`
+    body = (
+      <>
+        <p className="sr-only">{srSummary}</p>
+        <div className="visibility-trend-chart">
+          <ResponsiveContainer width="100%" height="100%">
+            <ComposedChart data={rows} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
+              <CartesianGrid stroke={CHART_GRID_STROKE} vertical={false} />
+              <XAxis
+                dataKey="date"
+                tick={CHART_AXIS_TICK}
+                tickLine={false}
+                axisLine={{ stroke: CHART_AXIS_STROKE }}
+                tickFormatter={formatChartDateTick}
+                minTickGap={24}
+              />
+              <YAxis
+                domain={[0, 100]}
+                ticks={[0, 25, 50, 75, 100]}
+                tickFormatter={(v: number) => `${v}%`}
+                tick={CHART_AXIS_TICK}
+                tickLine={false}
+                axisLine={false}
+                width={40}
+              />
+              <RechartsTooltip
+                {...CHART_TOOLTIP_STYLE}
+                cursor={{ stroke: CHART_AXIS_STROKE, strokeWidth: 1 }}
+                labelFormatter={formatChartDateLabel}
+                formatter={(value) => [value == null ? 'no data' : `${value}%`, 'Mention share']}
+              />
+              <Line
+                type="monotone"
+                dataKey={MENTION_SHARE_KEY}
+                name={MENTION_SHARE_KEY}
+                stroke={CHART_TONE.positive}
+                strokeWidth={2.5}
+                dot={{ r: 2.5, fill: CHART_TONE.positive, strokeWidth: 0 }}
+                activeDot={{ r: 4, strokeWidth: 2, stroke: ACTIVE_DOT_RING }}
+                connectNulls
+                isAnimationActive={false}
+              />
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+        {singleBucket && (
+          <p className="visibility-trend-note">Only one competitive mention-share point so far. The trend line fills in after another sweep with brand mentions.</p>
+        )}
+        {caption && <p className="visibility-trend-note">{caption}</p>}
+      </>
+    )
+  }
+
+  return (
+    <section className="visibility-trend mention-share-trend">
       {header}
       {body}
     </section>

--- a/apps/web/src/lib/visibility-trend-helpers.ts
+++ b/apps/web/src/lib/visibility-trend-helpers.ts
@@ -12,6 +12,7 @@ import type { MetricTone } from '../view-models.js'
 /** Series keys for the two overall lines (overall mode plots both at once). */
 export const CITED_KEY = '__cited__'
 export const MENTIONED_KEY = '__mentioned__'
+export const MENTION_SHARE_KEY = '__mentionShare__'
 
 export type TrendSeriesMode = 'overall' | 'byProvider'
 
@@ -72,6 +73,25 @@ export function buildTrendRows(
     return row
   })
   return { rows, series, hasData, singleBucket }
+}
+
+export function buildMentionShareTrendRows(dto: BrandMetricsDto): TrendData {
+  const rows: TrendRow[] = dto.buckets.map(b => {
+    const mentionShare = (b as { mentionShare?: BrandMetricsDto['buckets'][number]['mentionShare'] }).mentionShare
+    return {
+      date: b.startDate,
+      [MENTION_SHARE_KEY]: mentionShare?.rate == null ? null : toPercent(mentionShare.rate),
+    }
+  })
+  const plottedValues = rows
+    .map(row => row[MENTION_SHARE_KEY])
+    .filter((v): v is number => typeof v === 'number' && Number.isFinite(v))
+  return {
+    rows,
+    series: [MENTION_SHARE_KEY],
+    hasData: plottedValues.length > 0,
+    singleBucket: plottedValues.length === 1,
+  }
 }
 
 /**

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -1681,6 +1681,7 @@ function ProjectPageContent({
 }) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
+  const competitorDomains = useMemo(() => model.competitors.map(c => c.domain), [model.competitors])
   // "Local Presence" is always shown — GbpSection renders a setup guide when no
   // Google Business Profile is connected, so the tab is the entry point to
   // connecting one rather than being hidden until after connection.
@@ -2219,11 +2220,11 @@ function ProjectPageContent({
       {tab === 'overview' ? (
         <>
           <section className="page-section-divider">
-            <VisibilityTrendSection projectName={model.project.name} />
+            <VisibilityTrendSection projectName={model.project.name} competitorDomains={competitorDomains} />
           </section>
 
           <section className="page-section-divider">
-            <MentionShareTrendSection projectName={model.project.name} competitorCount={model.competitors.length} />
+            <MentionShareTrendSection projectName={model.project.name} competitorDomains={competitorDomains} />
           </section>
 
           <OverviewBrief

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -21,7 +21,7 @@ import { GscSection } from '../components/project/GscSection.js'
 import { GbpSection } from '../components/project/GbpSection.js'
 import { BacklinksSection } from '../components/project/BacklinksSection.js'
 import { CitationVisibilitySection } from '../components/project/CitationVisibilitySection.js'
-import { VisibilityTrendSection } from '../components/project/VisibilityTrendSection.js'
+import { MentionShareTrendSection, VisibilityTrendSection } from '../components/project/VisibilityTrendSection.js'
 import { DiscoverySection } from '../components/project/DiscoverySection.js'
 import { TechnicalAeoSection } from '../components/project/TechnicalAeoSection.js'
 import { ReportPage } from './ReportPage.js'
@@ -1906,6 +1906,7 @@ function ProjectPageContent({
       const existingDomains = existing.map(c => c.domain)
       const merged = [...new Set([...existingDomains, domain])]
       await apiSetCompetitors(projectName, merged)
+      await queryClient.invalidateQueries({ queryKey: ['analytics-metrics', projectName] })
       void refetch()
       setNewCompetitorDomain('')
       setAddingCompetitor(false)
@@ -1917,6 +1918,7 @@ function ProjectPageContent({
   async function handleRemoveCompetitor(domain: string) {
     try {
       await apiRemoveCompetitors(projectName, [domain])
+      await queryClient.invalidateQueries({ queryKey: ['analytics-metrics', projectName] })
       void refetch()
     } catch (err) {
       addToast({
@@ -2216,30 +2218,20 @@ function ProjectPageContent({
 
       {tab === 'overview' ? (
         <>
+          <section className="page-section-divider">
+            <VisibilityTrendSection projectName={model.project.name} />
+          </section>
+
+          <section className="page-section-divider">
+            <MentionShareTrendSection projectName={model.project.name} competitorCount={model.competitors.length} />
+          </section>
+
           <OverviewBrief
             model={model}
             sweepRunning={hasActiveVisibilitySweep}
             onJumpToEvidence={() => focusOverviewSection('evidence-section', true)}
             onJumpToActions={() => focusOverviewSection('action-queue')}
           />
-
-          <section id="action-queue" className="page-section-divider scroll-mt-24 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500/60" tabIndex={-1}>
-            <div className="section-head section-head-inline">
-              <div>
-                <p className="eyebrow eyebrow-soft">Action queue</p>
-                <h2>What needs your attention</h2>
-              </div>
-            </div>
-            <InsightSignals
-              insights={model.insights}
-              suggestedQueries={model.suggestedQueries}
-              projectName={projectName}
-            />
-          </section>
-
-          <section className="page-section-divider">
-            <VisibilityTrendSection projectName={model.project.name} />
-          </section>
 
           <section className="page-section-divider">
             <div className="section-head section-head-inline">
@@ -2475,6 +2467,20 @@ function ProjectPageContent({
               ))}
             </div>
           </OverviewDisclosure>
+
+          <section id="action-queue" className="page-section-divider scroll-mt-24 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500/60" tabIndex={-1}>
+            <div className="section-head section-head-inline">
+              <div>
+                <p className="eyebrow eyebrow-soft">Action queue</p>
+                <h2>What needs your attention</h2>
+              </div>
+            </div>
+            <InsightSignals
+              insights={model.insights}
+              suggestedQueries={model.suggestedQueries}
+              projectName={projectName}
+            />
+          </section>
 
         </>
       ) : tab === 'settings' ? (

--- a/apps/web/test/visibility-trend-helpers.test.ts
+++ b/apps/web/test/visibility-trend-helpers.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect } from 'vitest'
 import type { BrandMetricsDto } from '@ainyc/canonry-contracts'
 import {
+  buildMentionShareTrendRows,
   buildTrendRows,
   trendToTone,
   formatQueryChangeCaption,
   latestSeriesValue,
   CITED_KEY,
+  MENTION_SHARE_KEY,
   MENTIONED_KEY,
 } from '../src/lib/visibility-trend-helpers.js'
 
@@ -23,6 +25,7 @@ function bucket(date: string, byProvider: BrandMetricsDto['buckets'][number]['by
     queryCount: 4,
     mentionRate: rates.mentionRate,
     mentionedCount: 1,
+    mentionShare: { rate: 0.6, projectMentionSnapshots: 3, competitorMentionSnapshots: 2 },
     byProvider,
   }
 }
@@ -122,6 +125,32 @@ describe('buildTrendRows — data flags', () => {
   it('flags a single bucket', () => {
     const res = buildTrendRows(dto([bucket('2026-04-01', { gemini: provider(0.5, 0.5) })]), 'cited', 'overall')
     expect(res.hasData).toBe(true)
+    expect(res.singleBucket).toBe(true)
+  })
+})
+
+describe('buildMentionShareTrendRows', () => {
+  it('plots bucket mention share as percentages', () => {
+    const d = dto([
+      { ...bucket('2026-04-01', { gemini: provider(0.25, 0.1) }), mentionShare: { rate: 0.25, projectMentionSnapshots: 1, competitorMentionSnapshots: 3 } },
+      { ...bucket('2026-04-08', { gemini: provider(0.5, 0.4) }), mentionShare: { rate: 0.75, projectMentionSnapshots: 3, competitorMentionSnapshots: 1 } },
+    ])
+
+    const res = buildMentionShareTrendRows(d)
+    expect(res.series).toEqual([MENTION_SHARE_KEY])
+    expect(res.rows.map(r => r[MENTION_SHARE_KEY])).toEqual([25, 75])
+    expect(res.hasData).toBe(true)
+  })
+
+  it('emits null when a bucket has no competitive brand mentions', () => {
+    const d = dto([
+      { ...bucket('2026-04-01', { gemini: provider(0.25, 0.1) }), mentionShare: { rate: null, projectMentionSnapshots: 0, competitorMentionSnapshots: 0 } },
+      { ...bucket('2026-04-08', { gemini: provider(0.5, 0.4) }), mentionShare: { rate: 0.5, projectMentionSnapshots: 1, competitorMentionSnapshots: 1 } },
+    ])
+
+    const res = buildMentionShareTrendRows(d)
+    expect(res.rows[0]![MENTION_SHARE_KEY]).toBeNull()
+    expect(res.rows[1]![MENTION_SHARE_KEY]).toBe(50)
     expect(res.singleBucket).toBe(true)
   })
 })

--- a/apps/web/test/visibility-trend-section.test.tsx
+++ b/apps/web/test/visibility-trend-section.test.tsx
@@ -70,11 +70,11 @@ function renderSection() {
   )
 }
 
-function renderMentionShareSection(competitorCount = 1) {
+function renderMentionShareSection(competitorDomains: readonly string[] = ['competitor.com']) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
     <QueryClientProvider client={queryClient}>
-      <MentionShareTrendSection projectName="test-project" competitorCount={competitorCount} />
+      <MentionShareTrendSection projectName="test-project" competitorDomains={competitorDomains} />
     </QueryClientProvider>,
   )
 }
@@ -174,9 +174,43 @@ test('prompts for competitors before rendering mention-share history', async () 
   })
   onTestFinished(restore)
 
-  renderMentionShareSection(0)
+  renderMentionShareSection([])
 
   await waitFor(() => {
     expect(screen.getByText(/Add tracked competitors/)).toBeTruthy()
+  })
+})
+
+test('refetches mention-share metrics when the competitor frame changes', async () => {
+  const requests: string[] = []
+  const restore = mockFetch((url) => {
+    const path = url.split('?')[0]!
+    if (path.endsWith('/projects/test-project/analytics/metrics')) {
+      requests.push(url)
+      return jsonResponse(metricsDto(TWO_BUCKETS))
+    }
+    throw new Error(`Unexpected fetch: ${url}`)
+  })
+  onTestFinished(restore)
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const view = render(
+    <QueryClientProvider client={queryClient}>
+      <MentionShareTrendSection projectName="test-project" competitorDomains={['competitor.com']} />
+    </QueryClientProvider>,
+  )
+
+  await waitFor(() => {
+    expect(requests).toHaveLength(1)
+  })
+
+  view.rerender(
+    <QueryClientProvider client={queryClient}>
+      <MentionShareTrendSection projectName="test-project" competitorDomains={['competitor.com', 'new-rival.com']} />
+    </QueryClientProvider>,
+  )
+
+  await waitFor(() => {
+    expect(requests).toHaveLength(2)
   })
 })

--- a/apps/web/test/visibility-trend-section.test.tsx
+++ b/apps/web/test/visibility-trend-section.test.tsx
@@ -27,7 +27,7 @@ vi.mock('recharts', () => {
   }
 })
 
-import { VisibilityTrendSection } from '../src/components/project/VisibilityTrendSection.js'
+import { MentionShareTrendSection, VisibilityTrendSection } from '../src/components/project/VisibilityTrendSection.js'
 import { mockFetch, jsonResponse } from './mock-fetch.js'
 
 function provider(citationRate: number, mentionRate: number) {
@@ -50,11 +50,13 @@ const TWO_BUCKETS = [
   {
     startDate: '2026-04-01', endDate: '2026-04-08',
     citationRate: 0.25, cited: 1, total: 4, queryCount: 4, mentionRate: 0.5, mentionedCount: 2,
+    mentionShare: { rate: 0.25, projectMentionSnapshots: 1, competitorMentionSnapshots: 3 },
     byProvider: { gemini: provider(0.25, 0.5), openai: provider(0.5, 0.25) },
   },
   {
     startDate: '2026-04-08', endDate: '2026-04-15',
     citationRate: 0.75, cited: 3, total: 4, queryCount: 4, mentionRate: 0.5, mentionedCount: 2,
+    mentionShare: { rate: 0.75, projectMentionSnapshots: 3, competitorMentionSnapshots: 1 },
     byProvider: { gemini: provider(0.75, 0.5) },
   },
 ]
@@ -64,6 +66,15 @@ function renderSection() {
   return render(
     <QueryClientProvider client={queryClient}>
       <VisibilityTrendSection projectName="test-project" />
+    </QueryClientProvider>,
+  )
+}
+
+function renderMentionShareSection(competitorCount = 1) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MentionShareTrendSection projectName="test-project" competitorCount={competitorCount} />
     </QueryClientProvider>,
   )
 }
@@ -133,5 +144,39 @@ test('shows an empty state when there are no buckets yet', async () => {
 
   await waitFor(() => {
     expect(screen.getByText(/Run a sweep to start tracking/)).toBeTruthy()
+  })
+})
+
+test('renders mention-share trend from bucket metrics', async () => {
+  const restore = mockFetch((url) => {
+    const path = url.split('?')[0]!
+    if (path.endsWith('/projects/test-project/analytics/metrics')) {
+      return jsonResponse(metricsDto(TWO_BUCKETS))
+    }
+    throw new Error(`Unexpected fetch: ${url}`)
+  })
+  onTestFinished(restore)
+
+  renderMentionShareSection()
+
+  expect(await screen.findByText('Mention share over time')).toBeTruthy()
+  expect(await screen.findByText('75%')).toBeTruthy()
+  expect(screen.getByRole('button', { name: 'All' })).toBeTruthy()
+})
+
+test('prompts for competitors before rendering mention-share history', async () => {
+  const restore = mockFetch((url) => {
+    const path = url.split('?')[0]!
+    if (path.endsWith('/projects/test-project/analytics/metrics')) {
+      return jsonResponse(metricsDto(TWO_BUCKETS))
+    }
+    throw new Error(`Unexpected fetch: ${url}`)
+  })
+  onTestFinished(restore)
+
+  renderMentionShareSection(0)
+
+  await waitFor(() => {
+    expect(screen.getByText(/Add tracked competitors/)).toBeTruthy()
   })
 })

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -342,6 +342,11 @@ export type BrandMetricsDto = {
         queryCount: number;
         mentionRate: number;
         mentionedCount: number;
+        mentionShare: {
+            rate: number | null;
+            projectMentionSnapshots: number;
+            competitorMentionSnapshots: number;
+        };
         byProvider: {
             [key: string]: {
                 citationRate: number;

--- a/packages/api-routes/src/analytics.ts
+++ b/packages/api-routes/src/analytics.ts
@@ -2,7 +2,7 @@ import { and, eq, desc, inArray } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
 import { filterTrackedSnapshots, groupRunsByCreatedAt, pickGroupRepresentative, querySnapshots, runs, queries, competitors, domainClassifications, parseJsonColumn } from '@ainyc/canonry-db'
 import {
-  AI_PROVIDER_INFRA_DOMAINS, categorizeSource, categoryLabel, CitationStates,
+  AI_PROVIDER_INFRA_DOMAINS, brandLabelFromDomain, categorizeSource, categoryLabel, CitationStates,
   classifySurfaceFromCategory, surfaceClassFromCompetitorType, surfaceClassLabel,
   effectiveDomains, normalizeProjectDomain, parseWindow, windowCutoff, validationError,
 } from '@ainyc/canonry-contracts'
@@ -12,6 +12,7 @@ import type {
   SourceCategory, SourceCategoryCount, ProviderMetric, QueryChangeEvent,
   RankedSourceList, SourceRankEntry, SurfaceClass, SurfaceClassCount,
 } from '@ainyc/canonry-contracts'
+import { buildMentionShare } from '@ainyc/canonry-intelligence'
 import { notProbeRun, resolveProject, resolveSnapshotAnswerMentioned } from './helpers.js'
 
 export async function analyticsRoutes(app: FastifyInstance) {
@@ -77,6 +78,15 @@ export async function analyticsRoutes(app: FastifyInstance) {
       .where(eq(queries.projectId, project.id))
       .all()
     const queryCreatedAt = new Map(projectQueries.map(q => [q.id, q.createdAt]))
+    const mentionShareCompetitors = app.db
+      .select({ domain: competitors.domain })
+      .from(competitors)
+      .where(eq(competitors.projectId, project.id))
+      .all()
+      .map(c => ({
+        domain: c.domain,
+        brandTokens: [brandLabelFromDomain(c.domain)].filter(t => t.length >= 3),
+      }))
 
     // Overall metrics
     const overall = computeProviderMetric(allSnapshots)
@@ -93,7 +103,7 @@ export async function analyticsRoutes(app: FastifyInstance) {
     const latest = new Date(projectRuns[projectRuns.length - 1]!.createdAt)
     const spanDays = Math.max(1, Math.ceil((latest.getTime() - earliest.getTime()) / 86_400_000))
     const bucketSize = bucketSizeForSpan(spanDays)
-    const buckets = computeBuckets(allSnapshots, projectRuns, bucketSize, queryCreatedAt)
+    const buckets = computeBuckets(allSnapshots, projectRuns, bucketSize, queryCreatedAt, mentionShareCompetitors)
 
     // Trends
     const trend = computeTrend(buckets, 'citationRate')
@@ -482,7 +492,13 @@ interface SnapshotLike {
   provider: string
   citationState: string
   resolvedMentioned: boolean
+  answerText: string | null
   createdAt: string
+}
+
+interface MentionShareCompetitorInput {
+  domain: string
+  brandTokens: string[]
 }
 
 function computeProviderMetric(snapshots: SnapshotLike[]): ProviderMetric {
@@ -503,6 +519,7 @@ function computeBuckets(
   projectRuns: Array<{ createdAt: string }>,
   bucketDays: number,
   queryCreatedAt?: Map<string, string>,
+  mentionShareCompetitors: MentionShareCompetitorInput[] = [],
 ): TimeBucket[] {
   if (projectRuns.length === 0) return []
 
@@ -557,6 +574,7 @@ function computeBuckets(
         queryCount,
         mentionRate: metric.mentionRate,
         mentionedCount: metric.mentionedCount,
+        mentionShare: computeMentionShareBucketMetric(usable, mentionShareCompetitors),
         byProvider,
       })
     }
@@ -565,6 +583,31 @@ function computeBuckets(
   }
 
   return buckets
+}
+
+function computeMentionShareBucketMetric(
+  snapshots: SnapshotLike[],
+  mentionShareCompetitors: MentionShareCompetitorInput[],
+): TimeBucket['mentionShare'] {
+  if (mentionShareCompetitors.length === 0) {
+    return { rate: null, projectMentionSnapshots: 0, competitorMentionSnapshots: 0 }
+  }
+
+  const result = buildMentionShare(
+    snapshots.map(s => ({
+      projectMentioned: s.resolvedMentioned,
+      answerText: s.answerText,
+    })),
+    { competitors: mentionShareCompetitors },
+  )
+  const projectMentionSnapshots = result.breakdown.projectMentionSnapshots
+  const competitorMentionSnapshots = result.breakdown.competitorMentionSnapshots
+  const denominator = projectMentionSnapshots + competitorMentionSnapshots
+  return {
+    rate: denominator > 0 ? round4(projectMentionSnapshots / denominator) : null,
+    projectMentionSnapshots,
+    competitorMentionSnapshots,
+  }
 }
 
 function computeQueryChanges(

--- a/packages/api-routes/test/analytics.test.ts
+++ b/packages/api-routes/test/analytics.test.ts
@@ -53,6 +53,13 @@ describe('analytics routes', () => {
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     }).run()
+    db.insert(competitors).values({
+      id: crypto.randomUUID(),
+      projectId,
+      domain: 'competitor.com',
+      provenance: 'manual',
+      createdAt: new Date().toISOString(),
+    }).run()
 
     // Seed: queries
     const q1Id = crypto.randomUUID()
@@ -212,6 +219,23 @@ describe('analytics routes', () => {
         expect(bucket.mentionRate).toBeGreaterThanOrEqual(0)
         expect(typeof bucket.mentionedCount).toBe('number')
       }
+    })
+
+    it('returns mention-share metrics for each bucket from answer-text brand mentions', async () => {
+      const res = await app.inject({ method: 'GET', url: '/api/v1/projects/test-site/analytics/metrics' })
+      expect(res.statusCode).toBe(200)
+      const body = JSON.parse(res.payload)
+      expect(body.buckets.length).toBeGreaterThan(0)
+
+      const latest = body.buckets[body.buckets.length - 1]
+      // The fixture cites competitor.com in sources, but the answer prose only
+      // names Example.com. Mention share must follow answer-text mentions, not
+      // citation overlap.
+      expect(latest.mentionShare).toMatchObject({
+        rate: 1,
+        projectMentionSnapshots: 1,
+        competitorMentionSnapshots: 0,
+      })
     })
 
     it('supports window parameter', async () => {

--- a/packages/contracts/src/analytics.ts
+++ b/packages/contracts/src/analytics.ts
@@ -25,6 +25,15 @@ export const providerMetricSchema = z.object({
 })
 export type ProviderMetric = z.infer<typeof providerMetricSchema>
 
+/** Mention-share metric for one time bucket. Null rate means the competitive
+ *  frame had no brand mentions in that bucket, so the share is undefined. */
+export const mentionShareBucketMetricSchema = z.object({
+  rate: z.number().nullable(),
+  projectMentionSnapshots: z.number().int().nonnegative(),
+  competitorMentionSnapshots: z.number().int().nonnegative(),
+})
+export type MentionShareBucketMetric = z.infer<typeof mentionShareBucketMetricSchema>
+
 /**
  * One time bucket of the citation/mention trend. `byProvider` carries the
  * same metrics computed per provider over the bucket's normalized snapshot
@@ -39,6 +48,7 @@ export const timeBucketSchema = z.object({
   queryCount: z.number().int(),
   mentionRate: z.number(),
   mentionedCount: z.number().int(),
+  mentionShare: mentionShareBucketMetricSchema,
   byProvider: z.record(z.string(), providerMetricSchema),
 })
 export type TimeBucket = z.infer<typeof timeBucketSchema>

--- a/packages/contracts/test/analytics.test.ts
+++ b/packages/contracts/test/analytics.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
+  mentionShareBucketMetricSchema,
   providerMetricSchema,
   timeBucketSchema,
   brandMetricsDtoSchema,
@@ -27,6 +28,7 @@ const bucket = {
   queryCount: 2,
   mentionRate: 0.75,
   mentionedCount: 3,
+  mentionShare: { rate: 0.6, projectMentionSnapshots: 3, competitorMentionSnapshots: 2 },
   byProvider: {
     gemini: providerMetric,
     openai: { citationRate: 0.5, cited: 1, total: 2, mentionRate: 0.5, mentionedCount: 1 },
@@ -41,6 +43,21 @@ describe('providerMetricSchema', () => {
   it('rejects a missing field', () => {
     const { mentionRate: _mentionRate, ...partial } = providerMetric
     expect(() => providerMetricSchema.parse(partial)).toThrow()
+  })
+})
+
+describe('mentionShareBucketMetricSchema', () => {
+  it('round-trips a bucket-level mention share metric', () => {
+    expect(() => mentionShareBucketMetricSchema.parse(bucket.mentionShare)).not.toThrow()
+  })
+
+  it('allows null rate when no competitive brand mentions exist', () => {
+    const parsed = mentionShareBucketMetricSchema.parse({
+      rate: null,
+      projectMentionSnapshots: 0,
+      competitorMentionSnapshots: 0,
+    })
+    expect(parsed.rate).toBeNull()
   })
 })
 


### PR DESCRIPTION
## Summary
- Reorder the overview dashboard so the trend chart leads and the action queue moves to the bottom.
- Add a mention share over time graph below the trend chart, backed by `analytics/metrics` bucket data.
- Add contract/API/generated-client support for per-bucket mention share, including the no-competitor `rate: null` case and cache invalidation when competitors change.

## Validation
- `corepack pnpm exec vitest run packages/contracts/test/analytics.test.ts packages/api-routes/test/analytics.test.ts apps/web/test/visibility-trend-helpers.test.ts apps/web/test/visibility-trend-section.test.tsx --environment jsdom`
- `corepack pnpm --filter @ainyc/canonry-contracts run typecheck`
- `corepack pnpm --filter @ainyc/canonry-api-routes run typecheck`
- `corepack pnpm --filter @ainyc/canonry-web run typecheck`
- `corepack pnpm --filter @ainyc/canonry-api-client run typecheck`
- `corepack pnpm --filter @ainyc/canonry-api-client run gen:check`
- `corepack pnpm --filter @ainyc/canonry-web run lint`
- Commit hook: `pnpm -r run lint` passed with existing warnings only