### PR TITLE
Record Aero tool telemetry

### DIFF
--- a/packages/api-routes/test/db-dto-coverage.test.ts
+++ b/packages/api-routes/test/db-dto-coverage.test.ts
@@ -528,6 +528,10 @@ const COVERAGE: Record<string, CoverageEntry> = {
     kind: 'internal-only',
     reason: 'Internal LLM token/cache/cost ledger for prompt-cache tuning; not exposed as a public DTO.',
   },
+  agentToolEvents: {
+    kind: 'internal-only',
+    reason: 'Internal Aero tool-call ledger for long-session observability; not exposed as a public DTO.',
+  },
   agentSessions: {
     kind: 'internal-only',
     reason: 'Aero session state (transcript + queue). Exposed via the agent transcript composite, not as a direct row DTO.',

--- a/packages/canonry/src/agent/session.ts
+++ b/packages/canonry/src/agent/session.ts
@@ -25,6 +25,7 @@ import {
   recordLlmUsageEvent,
 } from './llm-usage.js'
 import { splitAeroAnthropicSystemCachePayload } from './prompt-cache.js'
+import { createAeroToolUsageHooks } from './tool-usage.js'
 
 export type { SupportedAgentProvider } from './providers.js'
 export { AgentProviders, listAgentProviders, coerceAgentProvider } from './providers.js'
@@ -171,6 +172,14 @@ export function createAeroSession(opts: AeroSessionOptions): Agent {
   const stateTools = toolScope === 'read-only' ? buildReadTools(toolCtx) : buildAllTools(toolCtx)
   const defaultTools = [...stateTools, ...buildSkillDocTools()]
   const tools = opts.tools ?? defaultTools
+  const toolUsageHooks = opts.db
+    ? createAeroToolUsageHooks({
+        db: opts.db,
+        projectId: opts.projectId,
+        agentSessionId: opts.agentSessionId,
+        metadata: { projectName: opts.projectName },
+      })
+    : {}
 
   const agent = new Agent({
     initialState: {
@@ -182,6 +191,7 @@ export function createAeroSession(opts: AeroSessionOptions): Agent {
     streamFn: opts.streamFn,
     sessionId: buildAeroProviderSessionId(opts),
     onPayload: splitAeroAnthropicSystemCachePayload,
+    ...toolUsageHooks,
     getApiKey: buildApiKeyResolver(opts.config),
   })
 

--- a/packages/canonry/src/agent/tool-usage.ts
+++ b/packages/canonry/src/agent/tool-usage.ts
@@ -1,0 +1,123 @@
+import crypto from 'node:crypto'
+import { agentToolEvents, type DatabaseClient } from '@ainyc/canonry-db'
+import type { AgentOptions } from '@mariozechner/pi-agent-core'
+import type { ImageContent, TextContent } from '@mariozechner/pi-ai'
+
+export const AeroToolEventStatuses = {
+  success: 'success',
+  error: 'error',
+} as const
+
+function jsonBytes(value: unknown): number {
+  try {
+    return Buffer.byteLength(JSON.stringify(value), 'utf8')
+  } catch {
+    return 0
+  }
+}
+
+function nonNegativeInteger(value: number | undefined): number {
+  if (!Number.isFinite(value) || value === undefined || value <= 0) return 0
+  return Math.round(value)
+}
+
+function resultTextChars(content: readonly (TextContent | ImageContent)[]): number {
+  let total = 0
+  for (const block of content) {
+    if (block.type === 'text') {
+      total += block.text.length
+    } else {
+      total += block.data.length
+    }
+  }
+  return total
+}
+
+export interface CreateAeroToolUsageHooksArgs {
+  db: DatabaseClient
+  projectId?: string
+  agentSessionId?: string
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Durable, best-effort tool-call telemetry for long Aero sessions. The hooks
+ * are observational only: they never block, rewrite, or fail the tool result.
+ */
+export function createAeroToolUsageHooks(
+  args: CreateAeroToolUsageHooksArgs,
+): Pick<AgentOptions, 'beforeToolCall' | 'afterToolCall'> {
+  const startedAt = new Map<string, number>()
+
+  return {
+    beforeToolCall: async ({ toolCall }) => {
+      startedAt.set(toolCall.id, Date.now())
+      return undefined
+    },
+    afterToolCall: async ({ assistantMessage, toolCall, args: toolArgs, result, isError, context }) => {
+      const start = startedAt.get(toolCall.id)
+      startedAt.delete(toolCall.id)
+      recordAgentToolEvent({
+        db: args.db,
+        projectId: args.projectId,
+        agentSessionId: args.agentSessionId,
+        toolCallId: toolCall.id,
+        toolName: toolCall.name,
+        assistantResponseId: assistantMessage.responseId,
+        provider: assistantMessage.provider,
+        model: assistantMessage.model,
+        status: isError ? AeroToolEventStatuses.error : AeroToolEventStatuses.success,
+        durationMs: start === undefined ? 0 : Date.now() - start,
+        argsBytes: jsonBytes(toolArgs),
+        resultTextChars: resultTextChars(result.content),
+        resultBytes: jsonBytes(result),
+        metadata: {
+          ...args.metadata,
+          toolCount: context.tools?.length ?? 0,
+        },
+      })
+      return undefined
+    },
+  }
+}
+
+interface RecordAgentToolEventArgs {
+  db: DatabaseClient
+  projectId?: string
+  agentSessionId?: string
+  toolCallId: string
+  toolName: string
+  assistantResponseId?: string
+  provider?: string
+  model?: string
+  status: string
+  durationMs?: number
+  argsBytes?: number
+  resultTextChars?: number
+  resultBytes?: number
+  metadata?: Record<string, unknown>
+}
+
+export function recordAgentToolEvent(args: RecordAgentToolEventArgs): void {
+  try {
+    args.db.insert(agentToolEvents).values({
+      id: crypto.randomUUID(),
+      projectId: args.projectId,
+      agentSessionId: args.agentSessionId,
+      toolCallId: args.toolCallId,
+      toolName: args.toolName,
+      assistantResponseId: args.assistantResponseId,
+      provider: args.provider,
+      model: args.model,
+      status: args.status,
+      durationMs: nonNegativeInteger(args.durationMs),
+      argsBytes: nonNegativeInteger(args.argsBytes),
+      resultTextChars: nonNegativeInteger(args.resultTextChars),
+      resultBytes: nonNegativeInteger(args.resultBytes),
+      metadata: args.metadata,
+      createdAt: new Date().toISOString(),
+    }).run()
+  } catch {
+    // Tool telemetry is diagnostic only; do not fail or modify the tool result.
+  }
+}

--- a/packages/canonry/test/agent-session-registry.test.ts
+++ b/packages/canonry/test/agent-session-registry.test.ts
@@ -8,17 +8,20 @@ import {
   migrate,
   projects,
   agentSessions,
+  agentToolEvents,
   llmUsageEvents,
   parseJsonColumn,
   type DatabaseClient,
 } from '@ainyc/canonry-db'
 import {
   fauxAssistantMessage,
+  fauxToolCall,
   registerFauxProvider,
   type FauxProviderRegistration,
 } from '@mariozechner/pi-ai'
 import { eq } from 'drizzle-orm'
-import type { AgentMessage } from '@mariozechner/pi-agent-core'
+import { Type } from '@sinclair/typebox'
+import type { AgentMessage, AgentTool } from '@mariozechner/pi-agent-core'
 import { MemorySources } from '@ainyc/canonry-contracts'
 import { SessionRegistry } from '../src/agent/session-registry.js'
 import { canonryMcpTools } from '../src/mcp/tool-registry.js'
@@ -186,6 +189,62 @@ describe('SessionRegistry', () => {
     expect(usageRows[0].metadata).toMatchObject({
       projectName: 'demo',
       toolCount: AERO_READ_TOOL_COUNT,
+    })
+  })
+
+  it('records per-tool telemetry tied to the durable Aero session', async () => {
+    const projectId = insertProject(db, 'demo')
+    const registry = new SessionRegistry({ db, client: stubClient(), config: stubConfig() })
+    const agent = registry.getOrCreate('demo')
+    const row = db.select().from(agentSessions).where(eq(agentSessions.projectId, projectId)).get()
+    expect(row).toBeDefined()
+
+    const tool: AgentTool = {
+      name: 'canonry_test_status',
+      label: 'Test status',
+      description: 'Returns a compact test status payload.',
+      parameters: Type.Object({ section: Type.String() }),
+      execute: async (_toolCallId, params) => {
+        const section = (params as { section: string }).section
+        return {
+          content: [{ type: 'text', text: `section=${section}; status=ok` }],
+          details: { ok: true, section, rows: [{ id: 'r1', value: 42 }] },
+        }
+      },
+    }
+
+    agent.state.model = faux.getModel()
+    agent.state.tools = [tool]
+    faux.setResponses([
+      fauxAssistantMessage(
+        fauxToolCall('canonry_test_status', { section: 'ads' }, { id: 'tool-call-1' }),
+        { stopReason: 'toolUse', responseId: 'resp-tool-1' },
+      ),
+      fauxAssistantMessage('Tool complete.'),
+    ])
+
+    await agent.prompt('Check the ads status.')
+    await agent.waitForIdle()
+
+    const toolRows = db.select().from(agentToolEvents).where(eq(agentToolEvents.projectId, projectId)).all()
+    expect(toolRows).toHaveLength(1)
+    expect(toolRows[0]).toMatchObject({
+      projectId,
+      agentSessionId: row!.id,
+      toolCallId: 'tool-call-1',
+      toolName: 'canonry_test_status',
+      assistantResponseId: 'resp-tool-1',
+      provider: 'faux',
+      model: 'faux-model',
+      status: 'success',
+    })
+    expect(toolRows[0].durationMs).toBeGreaterThanOrEqual(0)
+    expect(toolRows[0].argsBytes).toBeGreaterThan(0)
+    expect(toolRows[0].resultTextChars).toBeGreaterThan(0)
+    expect(toolRows[0].resultBytes).toBeGreaterThan(0)
+    expect(toolRows[0].metadata).toMatchObject({
+      projectName: 'demo',
+      toolCount: 1,
     })
   })
 

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1872,6 +1872,33 @@ export const MIGRATION_VERSIONS: ReadonlyArray<MigrationVersion> = [
       `CREATE INDEX IF NOT EXISTS idx_llm_usage_run_created ON llm_usage_events(run_id, created_at)`,
     ],
   },
+  {
+    version: 85,
+    name: 'agent-tool-events',
+    statements: [
+      `CREATE TABLE IF NOT EXISTS agent_tool_events (
+        id                    TEXT PRIMARY KEY,
+        project_id            TEXT REFERENCES projects(id) ON DELETE CASCADE,
+        agent_session_id      TEXT REFERENCES agent_sessions(id) ON DELETE SET NULL,
+        tool_call_id          TEXT NOT NULL,
+        tool_name             TEXT NOT NULL,
+        assistant_response_id TEXT,
+        provider              TEXT,
+        model                 TEXT,
+        status                TEXT NOT NULL,
+        duration_ms           INTEGER NOT NULL DEFAULT 0,
+        args_bytes            INTEGER NOT NULL DEFAULT 0,
+        result_text_chars     INTEGER NOT NULL DEFAULT 0,
+        result_bytes          INTEGER NOT NULL DEFAULT 0,
+        metadata              TEXT,
+        created_at            TEXT NOT NULL
+      )`,
+      `CREATE INDEX IF NOT EXISTS idx_agent_tool_events_project_created ON agent_tool_events(project_id, created_at)`,
+      `CREATE INDEX IF NOT EXISTS idx_agent_tool_events_session_created ON agent_tool_events(agent_session_id, created_at)`,
+      `CREATE INDEX IF NOT EXISTS idx_agent_tool_events_tool_created ON agent_tool_events(tool_name, created_at)`,
+      `CREATE INDEX IF NOT EXISTS idx_agent_tool_events_status_created ON agent_tool_events(status, created_at)`,
+    ],
+  },
 ]
 
 /**

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -694,6 +694,34 @@ export const llmUsageEvents = sqliteTable('llm_usage_events', {
   index('idx_llm_usage_run_created').on(table.runId, table.createdAt),
 ])
 
+/**
+ * Append-only internal tool-call ledger for long-running Aero sessions. It
+ * lets operators see tool fan-out, failures, latency, and result size without
+ * replaying the transcript or scraping SSE events.
+ */
+export const agentToolEvents = sqliteTable('agent_tool_events', {
+  id: text('id').primaryKey(),
+  projectId: text('project_id').references(() => projects.id, { onDelete: 'cascade' }),
+  agentSessionId: text('agent_session_id').references(() => agentSessions.id, { onDelete: 'set null' }),
+  toolCallId: text('tool_call_id').notNull(),
+  toolName: text('tool_name').notNull(),
+  assistantResponseId: text('assistant_response_id'),
+  provider: text('provider'),
+  model: text('model'),
+  status: text('status').notNull(),
+  durationMs: integer('duration_ms').notNull().default(0),
+  argsBytes: integer('args_bytes').notNull().default(0),
+  resultTextChars: integer('result_text_chars').notNull().default(0),
+  resultBytes: integer('result_bytes').notNull().default(0),
+  metadata: text('metadata', { mode: 'json' }).$type<Record<string, unknown>>(),
+  createdAt: text('created_at').notNull(),
+}, (table) => [
+  index('idx_agent_tool_events_project_created').on(table.projectId, table.createdAt),
+  index('idx_agent_tool_events_session_created').on(table.agentSessionId, table.createdAt),
+  index('idx_agent_tool_events_tool_created').on(table.toolName, table.createdAt),
+  index('idx_agent_tool_events_status_created').on(table.status, table.createdAt),
+])
+
 // --- Server-side traffic ingestion ---
 // Per-source connection metadata. Credentials live in ~/.canonry/config.yaml,
 // not here. `archived_at` retains the row after a host migration so historical


### PR DESCRIPTION
## Summary
- add an internal `agent_tool_events` ledger for Aero tool-call observability
- wire pi-agent `beforeToolCall` / `afterToolCall` hooks to record tool latency, status, args/result size, provider/model, and session context
- cover the new table with migration parity, DTO coverage, and a faux-provider tool-call test

## Stack
- Base PR: #751 (`ax/aero-prompt-cache-foundation`)
- This PR should be reviewed against `ax/aero-prompt-cache-foundation`, not `main`

## Validation
- `corepack pnpm exec vitest run --project canonry packages/canonry/test/agent-session-registry.test.ts`
- `corepack pnpm exec vitest run --project db packages/db/test/migration-parity.test.ts`
- `corepack pnpm exec vitest run --project api-routes packages/api-routes/test/db-dto-coverage.test.ts`
- `corepack pnpm --filter @ainyc/canonry typecheck`
- `corepack pnpm --filter @ainyc/canonry-db typecheck`
- `corepack pnpm --filter @ainyc/canonry-api-routes typecheck`
- `corepack pnpm --filter @ainyc/canonry-db lint`
- `corepack pnpm --filter @ainyc/canonry lint -- src/agent/session.ts src/agent/tool-usage.ts test/agent-session-registry.test.ts` (passes with existing 114 warnings)
- commit hook ran `pnpm -r run lint` (passes with existing warning baseline)
