### PR TITLE
fix(agent): route the gemini agent provider through GEMINI_BASE_URL for proxied tenants

### DIFF
--- a/packages/canonry/src/agent/providers.ts
+++ b/packages/canonry/src/agent/providers.ts
@@ -360,6 +360,25 @@ export function resolveModelForCapability(
         `Verify PROVIDER_MODELS[${provider}][${capability}] against the installed @mariozechner/pi-ai catalog.`,
     )
   }
+  // Proxied deployments run the agent with a per-tenant LiteLLM virtual key and
+  // provider-native passthrough base URLs (the same GEMINI_BASE_URL the answer
+  // sweep already uses). pi-ai's native google vendor sends the key as the
+  // `x-goog-api-key` header, which a LiteLLM `/gemini` passthrough swaps for the
+  // real platform key — but only the agent's request must traverse the proxy,
+  // and the native model carries the host's default baseUrl, so the call goes
+  // direct to Google with the (invalid) virtual key. Repoint it via the env var.
+  // Two care points: pi-ai reads baseUrl off the SHARED singleton registry Model,
+  // so clone before overriding; and pi-ai's google client blanks the API version
+  // when a custom baseUrl is set, then appends `/models/{id}:...`, so the override
+  // must already carry `/v1beta`. Gemini only: OPENAI_BASE_URL etc. are also set
+  // in a proxied container (for the sweep) and would wrongly redirect those native
+  // agents. An unset GEMINI_BASE_URL leaves the default Google host untouched, so
+  // non-proxied installs are byte-for-byte unchanged.
+  if (provider === AgentProviderIds.gemini && process.env.GEMINI_BASE_URL) {
+    const base = process.env.GEMINI_BASE_URL.replace(/\/+$/, '')
+    const baseUrl = base.endsWith('/v1beta') ? base : `${base}/v1beta`
+    return { ...model, baseUrl }
+  }
   return model
 }
 

--- a/packages/canonry/test/agent-providers.test.ts
+++ b/packages/canonry/test/agent-providers.test.ts
@@ -317,6 +317,58 @@ describe('resolveModelForCapability', () => {
   })
 })
 
+describe('resolveModelForCapability: gemini proxy base URL override', () => {
+  const PRIOR = process.env.GEMINI_BASE_URL
+  function withGeminiBaseUrl<T>(value: string | undefined, fn: () => T): T {
+    if (value === undefined) delete process.env.GEMINI_BASE_URL
+    else process.env.GEMINI_BASE_URL = value
+    try {
+      return fn()
+    } finally {
+      if (PRIOR === undefined) delete process.env.GEMINI_BASE_URL
+      else process.env.GEMINI_BASE_URL = PRIOR
+    }
+  }
+  const baseUrlOf = (m: unknown) => (m as { baseUrl?: string }).baseUrl
+  const geminiAgentId = PROVIDER_MODELS.gemini[LlmCapabilities.agent]
+
+  it('repoints the gemini agent model at GEMINI_BASE_URL and appends /v1beta', () => {
+    withGeminiBaseUrl('http://172.17.0.1:4610/gemini', () => {
+      const model = resolveModelForCapability('gemini', LlmCapabilities.agent)
+      expect(baseUrlOf(model)).toBe('http://172.17.0.1:4610/gemini/v1beta')
+    })
+  })
+
+  it('does not double-append /v1beta and trims a trailing slash', () => {
+    withGeminiBaseUrl('http://host/gemini/v1beta/', () => {
+      expect(baseUrlOf(resolveModelForCapability('gemini', LlmCapabilities.agent))).toBe('http://host/gemini/v1beta')
+    })
+  })
+
+  it('never mutates the shared pi-ai registry Model (clones, not in place)', () => {
+    const before = baseUrlOf(getModel('google' as never, geminiAgentId as never))
+    withGeminiBaseUrl('http://172.17.0.1:4610/gemini', () => {
+      resolveModelForCapability('gemini', LlmCapabilities.agent)
+    })
+    const after = baseUrlOf(getModel('google' as never, geminiAgentId as never))
+    expect(after).toBe(before)
+    expect(after ?? '').not.toContain('172.17.0.1')
+  })
+
+  it('leaves the default Google host untouched when GEMINI_BASE_URL is unset', () => {
+    withGeminiBaseUrl(undefined, () => {
+      const fromRegistry = baseUrlOf(getModel('google' as never, geminiAgentId as never))
+      expect(baseUrlOf(resolveModelForCapability('gemini', LlmCapabilities.agent))).toBe(fromRegistry)
+    })
+  })
+
+  it('does not redirect other native providers (openai) when only GEMINI_BASE_URL is set', () => {
+    withGeminiBaseUrl('http://172.17.0.1:4610/gemini', () => {
+      expect(baseUrlOf(resolveModelForCapability('openai', LlmCapabilities.agent)) ?? '').not.toContain('172.17.0.1')
+    })
+  })
+})
+
 describe('deepinfra (custom OpenAI-compatible host)', () => {
   // DeepInfra is agent-only, has no pi-ai catalog entry, and resolves models
   // by constructing a custom openai-completions object pointed at its base URL.


### PR DESCRIPTION
## Problem

pi-ai's native `google` vendor builds from the static model registry with a hardcoded host (`generativelanguage.googleapis.com`). In a **proxied** deployment (LiteLLM gateway, per-tenant virtual keys), the answer-visibility **sweep** routes through `GEMINI_BASE_URL` and works, but the **agent** path had no baseUrl wiring, so Aero's gemini calls go DIRECT to Google with the per-tenant virtual key and Google returns `400 "API key not valid"`. Only `deepinfra` (the `openaiCompatible` host) could traverse the proxy; the native gemini agent could not.

## Fix

`resolveModelForCapability` clones the gemini agent `Model` and overrides its `baseUrl` from `GEMINI_BASE_URL` when set, appending `/v1beta` (pi-ai's google client blanks the API version once a custom baseUrl is set, then appends `/models/{id}:...`). The key rides the `x-goog-api-key` header, which a LiteLLM `/gemini` passthrough swaps for the real platform key.

- **Scoped to gemini** so `OPENAI_BASE_URL` (also set in a proxied container for the sweep) does not redirect the native openai agent.
- **Clones, never mutates** because `getModel` returns the shared singleton registry object.
- **Unset `GEMINI_BASE_URL` is a no-op**, so non-proxied installs are byte-for-byte unchanged.

## Validation

- New tests (5): override applies + `/v1beta` append, no double-append + trailing-slash trim, registry object not mutated, default host untouched when unset, openai not redirected. `agent-providers.test.ts` 43/43 pass; typecheck + lint clean.
- Live: a virtual-key call to `/gemini/v1beta/models/<id>:streamGenerateContent` through the LiteLLM `/gemini` passthrough returns 200.

No version bump (under the 100-line threshold). Activation is purely an image bump on the consuming platform, which already injects `GEMINI_BASE_URL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)