### PR TITLE
Add Aero ads operator profile

### DIFF
--- a/apps/web/src/api-aero.ts
+++ b/apps/web/src/api-aero.ts
@@ -127,6 +127,7 @@ export async function resetAeroTranscript(project: string): Promise<void> {
 }
 
 export type AeroToolScope = 'read-only' | 'all'
+export type AeroToolProfile = 'default' | 'ads-operator'
 
 export interface PromptAeroArgs {
   project: string
@@ -140,6 +141,8 @@ export interface PromptAeroArgs {
    * tools like run_sweep and dismiss_insight; `all` enables the full set.
    */
   scope?: AeroToolScope
+  /** Optional narrower tool profile for specialized workflows. */
+  profile?: AeroToolProfile
   signal?: AbortSignal
   onEvent: (event: AeroEvent) => void
 }
@@ -156,6 +159,7 @@ export async function promptAero({
   provider,
   modelId,
   scope,
+  profile,
   signal,
   onEvent,
 }: PromptAeroArgs): Promise<void> {
@@ -163,6 +167,7 @@ export async function promptAero({
   if (provider) body.provider = provider
   if (modelId) body.modelId = modelId
   if (scope) body.scope = scope
+  if (profile) body.profile = profile
   const res = await fetch(`${API_BASE}/projects/${encodeURIComponent(project)}/agent/prompt`, {
     method: 'POST',
     credentials: 'include',

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -84,6 +84,8 @@ Some write tools compose existing API calls rather than using a native atomic en
 
 `canonry_project_upsert` and `canonry_apply_config` use PUT semantics — fields omitted from the request are reset to their defaults. Pass the full intended project shape. `canonry_apply_config` accepts one project document per call; loop on the client side for multi-project configs.
 
+The built-in Aero agent consumes the same MCP-derived local tool registry, then may apply an agent profile. The `ads-operator` profile is intentionally narrower than the full MCP catalog and adds one Aero-only context-packing helper, `canonry_ads_operator_context`, that bundles existing public reads for long-session efficiency. It is not an MCP tool because it introduces no new public capability; agents that need the same data outside Aero should call the existing project overview, ads, doctor, and memory tools directly.
+
 ## Progressive Tool Discovery
 
 The full 80-tool API catalog costs roughly 17k tokens of definitions every session. Most sessions touch a handful of tools, so `canonry-mcp` defaults to a small **core tier** (~10 tools, ~3k tokens) and registers the rest on demand via `notifications/tools/list_changed`.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.100.1",
+  "version": "4.101.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -4167,7 +4167,7 @@ export const canonryLocalRouteCatalog: OpenApiOperation[] = [
     path: '/api/v1/projects/{name}/agent/prompt',
     summary: 'Send a prompt to Aero and stream events back as SSE',
     description:
-      'Posts a prompt into the project\'s Aero session and streams `AgentEvent` frames as `text/event-stream`. Each frame is `data: <JSON>\\n\\n`. The server brackets the stream with `{"type":"stream_open"}` and `{"type":"stream_close"}` control frames; `{"type":"error","message":"..."}` surfaces in-stream failures without collapsing the stream. Returns 409 `AGENT_BUSY` if another turn is already in flight for this project. Body field `scope` accepts "all" | "read-only"; omitted defaults to "read-only" (safe dashboard surface). The CLI passes "all" to keep write tools available.',
+      'Posts a prompt into the project\'s Aero session and streams `AgentEvent` frames as `text/event-stream`. Each frame is `data: <JSON>\\n\\n`. The server brackets the stream with `{"type":"stream_open"}` and `{"type":"stream_close"}` control frames; `{"type":"error","message":"..."}` surfaces in-stream failures without collapsing the stream. Returns 409 `AGENT_BUSY` if another turn is already in flight for this project. Body field `scope` accepts "all" | "read-only"; omitted defaults to "read-only" (safe dashboard surface). Body field `profile` accepts "default" | "ads-operator"; omitted keeps the default full Canonry operator surface. The CLI passes "all" to keep write tools available.',
     tags: ['agent'],
     parameters: [nameParameter],
     requestBody: {
@@ -4192,6 +4192,11 @@ export const canonryLocalRouteCatalog: OpenApiOperation[] = [
                 type: 'string',
                 enum: ['all', 'read-only'],
                 description: 'Tool surface scope. Default "read-only". Set "all" to enable write tools.',
+              },
+              profile: {
+                type: 'string',
+                enum: ['default', 'ads-operator'],
+                description: 'Tool profile. Default "default". Set "ads-operator" to use the narrower ads SaaS operator surface plus the ads context tool.',
               },
             },
           },

--- a/packages/canonry/AGENTS.md
+++ b/packages/canonry/AGENTS.md
@@ -240,11 +240,23 @@ Tool surface has two layers:
   Ride in every scope. `SKILL.md` stays lightweight; detailed playbooks
   (workflows, regression diagnosis, reporting templates, integrations) load
   on-demand via slug.
+- **Aero tool profiles** (`src/agent/tools.ts`) — the default profile exposes
+  the full local MCP-derived tool surface for the requested scope. The
+  `ads-operator` profile narrows local state tools to an explicit typed
+  allow-list for ads operations and prepends `canonry_ads_operator_context`, an
+  Aero-only context-packing helper that composes existing project overview,
+  ads, doctor, and memory reads through `ApiClient`. It does not expose a new
+  capability outside Aero; promote it to API/CLI/MCP only if operators need
+  that exact bundle as a public contract rather than as a long-session prompt
+  optimization.
 - **Injected remote MCP tools** (`src/agent/remote-mcp.ts`), read-only tools
   loaded from external MCP servers configured via `config.externalMcpServers`
   (or the `CANONRY_EXTERNAL_MCP` env var, a JSON array of `{ url, token, label? }`).
   Loaded once per `SessionRegistry` lifetime (cached promise) and merged into
-  each session's tool list in `acquireForTurn`, after local-scope alignment.
+  each session's tool list in `acquireForTurn`, after local-scope/profile
+  alignment. This is intentional: profile narrowing applies to the local
+  Canonry tools, while injected remote tools are separately accepted only when
+  their MCP annotations mark them read-only.
   See "Injected remote-MCP load path" below for the frozen transport + filter.
 
 ### Injected remote-MCP load path (OSS-A)

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.100.1",
+  "version": "4.101.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/agent/agent-routes.ts
+++ b/packages/canonry/src/agent/agent-routes.ts
@@ -18,6 +18,13 @@ import {
 import type { AgentEvent, AgentMessage } from '@mariozechner/pi-agent-core'
 import type { SessionRegistry } from './session-registry.js'
 import type { SupportedAgentProvider } from './session.js'
+import {
+  AeroToolProfiles,
+  AeroToolScopes,
+  isAeroToolProfile,
+  type AeroToolProfile,
+  type AeroToolScope,
+} from './tools.js'
 import { buildAgentProvidersResponse } from './providers.js'
 import {
   COMPACTION_KEY_PREFIX,
@@ -25,6 +32,14 @@ import {
   listMemoryEntries,
   upsertMemoryEntry,
 } from './memory-store.js'
+
+type AgentPromptBody = Partial<{
+  prompt: string
+  provider?: SupportedAgentProvider
+  modelId?: string
+  scope?: AeroToolScope
+  profile?: AeroToolProfile
+}>
 
 export interface AgentRoutesOptions {
   db: DatabaseClient
@@ -102,15 +117,11 @@ export function registerAgentRoutes(app: FastifyInstance, opts: AgentRoutesOptio
 
   app.post<{
     Params: { name: string }
-    Body: {
-      prompt: string
-      provider?: SupportedAgentProvider
-      modelId?: string
-      scope?: 'all' | 'read-only'
-    }
+    Body: AgentPromptBody
   }>('/projects/:name/agent/prompt', async (request, reply) => {
     const project = resolveProject(opts.db, request.params.name)
-    const promptText = (request.body?.prompt ?? '').trim()
+    const body = request.body as unknown as AgentPromptBody | undefined
+    const promptText = (body?.prompt ?? '').trim()
     if (!promptText) throw validationError('"prompt" is required')
 
     // Tool-scope policy:
@@ -120,16 +131,20 @@ export function registerAgentRoutes(app: FastifyInstance, opts: AgentRoutesOptio
     //     full tool surface the operator invoked the command with.
     // Any authenticated caller can pass `scope` — the gate is about blast
     // radius for interactive UI, not authorization.
-    const requestedScope = request.body?.scope === 'all' ? 'all' : 'read-only'
+    const requestedScope = body?.scope === AeroToolScopes.all ? AeroToolScopes.all : AeroToolScopes.readOnly
+    const requestedProfile = isAeroToolProfile(body?.profile)
+      ? body.profile
+      : AeroToolProfiles.default
 
     // acquireForTurn serializes per project: the busy check runs BEFORE any
     // scope / model mutation, so a second request against a busy Agent
     // throws `AGENT_BUSY` (409) without swapping out the in-flight turn's
     // tools or model. Safe to call concurrently from CLI + dashboard.
     const agent = await opts.sessionRegistry.acquireForTurn(project.name, {
-      provider: request.body?.provider,
-      modelId: request.body?.modelId,
+      provider: body?.provider,
+      modelId: body?.modelId,
       toolScope: requestedScope,
+      toolProfile: requestedProfile,
     })
 
     reply.raw.writeHead(200, {

--- a/packages/canonry/src/agent/mcp-to-agent-tool.ts
+++ b/packages/canonry/src/agent/mcp-to-agent-tool.ts
@@ -1,7 +1,12 @@
 import { Type, type TSchema } from '@sinclair/typebox'
 import type { AgentTool, AgentToolResult } from '@mariozechner/pi-agent-core'
 import type { ApiClient } from '../client.js'
-import type { CanonryMcpTool } from '../mcp/tool-registry.js'
+import {
+  CanonryMcpToolNames,
+  type CanonryMcpRegistryTool,
+  type CanonryMcpTool,
+  type CanonryMcpToolName,
+} from '../mcp/tool-registry.js'
 
 const MAX_TOOL_RESULT_CHARS = 20_000
 const TRUNCATION_NOTE = '... (truncated — result too large)'
@@ -179,13 +184,15 @@ export function mcpToAgentTool(
  * exposed to the built-in Aero agent. Aero clearing its own conversation is
  * a foot-gun (it would erase the user's context mid-turn).
  */
-export const AERO_EXCLUDED_MCP_TOOLS: ReadonlySet<string> = new Set([
-  'canonry_agent_clear',
+export const AERO_EXCLUDED_MCP_TOOLS: ReadonlySet<CanonryMcpToolName> = new Set([
+  CanonryMcpToolNames.canonry_agent_clear,
 ])
 
 export interface BuildMcpAgentToolsOptions {
   /** Filter to read-only tools when true. */
   readOnly?: boolean
+  /** Optional allow-list for profile-specific tool surfaces. */
+  includeNames?: ReadonlySet<CanonryMcpToolName>
 }
 
 /**
@@ -195,12 +202,13 @@ export interface BuildMcpAgentToolsOptions {
  * registration is required.
  */
 export function buildMcpAgentTools(
-  registry: readonly CanonryMcpTool[],
+  registry: readonly CanonryMcpRegistryTool[],
   ctx: AgentMcpAdapterContext,
   opts: BuildMcpAgentToolsOptions = {},
 ): AgentTool[] {
   return registry
     .filter((tool) => !AERO_EXCLUDED_MCP_TOOLS.has(tool.name))
+    .filter((tool) => (opts.includeNames ? opts.includeNames.has(tool.name) : true))
     .filter((tool) => (opts.readOnly ? tool.access === 'read' : true))
     .map((tool) => mcpToAgentTool(tool, ctx))
 }

--- a/packages/canonry/src/agent/session-registry.ts
+++ b/packages/canonry/src/agent/session-registry.ts
@@ -22,7 +22,13 @@ import {
 } from './session.js'
 import { getAgentProvider } from './providers.js'
 import { buildSkillDocTools } from './skill-tools.js'
-import { buildAllTools, buildReadTools } from './tools.js'
+import {
+  AeroToolProfiles,
+  buildAeroStateTools,
+  type AeroToolProfile,
+  AeroToolScopes,
+  type AeroToolScope,
+} from './tools.js'
 import { loadExternalMcpTools } from './remote-mcp.js'
 import { loadRecentForHydrate } from './memory-store.js'
 import { compactMessages, shouldCompact } from './compaction.js'
@@ -39,7 +45,9 @@ export interface SessionPreferences {
   provider?: SupportedAgentProvider
   modelId?: string
   /** Pass 'read-only' to build a session that exposes only read tools. Default 'all'. */
-  toolScope?: 'all' | 'read-only'
+  toolScope?: AeroToolScope
+  /** Optional profile that narrows tools for a workflow. Default 'default'. */
+  toolProfile?: AeroToolProfile
 }
 
 interface AgentSessionRow {
@@ -99,7 +107,9 @@ export class SessionRegistry {
   private readonly live = new Map<string, Agent>()
   private readonly pending = new Map<string, AgentMessage[]>()
   /** Last tool scope used on the live Agent for a project. Read in getOrCreate to know when to swap. */
-  private readonly scopes = new Map<string, 'all' | 'read-only'>()
+  private readonly scopes = new Map<string, AeroToolScope>()
+  /** Last profile used on the live Agent for a project. Paired with scopes when rebuilding tools. */
+  private readonly profiles = new Map<string, AeroToolProfile>()
   /** Cached resolved project id per project name, used so alignScope can rebuild tool context without a DB roundtrip. */
   private readonly projectIds = new Map<string, string>()
   /**
@@ -210,11 +220,13 @@ export class SessionRegistry {
         systemPromptOverride: this.buildHydratedSystemPrompt(projectId, row.systemPrompt),
         initialMessages: persistedMessages,
         toolScope: preferences?.toolScope,
+        toolProfile: preferences?.toolProfile,
         db: this.opts.db,
         projectId,
         agentSessionId: row.id,
       })
-      this.scopes.set(projectName, preferences?.toolScope ?? 'all')
+      this.scopes.set(projectName, preferences?.toolScope ?? AeroToolScopes.all)
+      this.profiles.set(projectName, preferences?.toolProfile ?? AeroToolProfiles.default)
       this.projectIds.set(projectName, projectId)
 
       if (queued.length > 0) {
@@ -241,11 +253,13 @@ export class SessionRegistry {
       // notes if they were seeded via CLI/API before the first prompt.
       systemPromptOverride: this.buildHydratedSystemPrompt(projectId, systemPrompt),
       toolScope: preferences?.toolScope,
+      toolProfile: preferences?.toolProfile,
       db: this.opts.db,
       projectId,
       agentSessionId: sessionId,
     })
-    this.scopes.set(projectName, preferences?.toolScope ?? 'all')
+    this.scopes.set(projectName, preferences?.toolScope ?? AeroToolScopes.all)
+    this.profiles.set(projectName, preferences?.toolProfile ?? AeroToolProfiles.default)
     this.projectIds.set(projectName, projectId)
 
     this.insertRow({
@@ -329,8 +343,9 @@ export class SessionRegistry {
    * Busy-check runs FIRST, before any state mutation — if two requests race
    * on the same project, one gets the 409 and the other's in-flight turn is
    * untouched. Only after confirming idle do we:
-   *   - align `state.tools` to the requested scope (CLI full vs dashboard
-   *     read-only share the same cached Agent; each request re-scopes it).
+   *   - align `state.tools` to the requested scope/profile (CLI full vs
+   *     dashboard read-only share the same cached Agent; each request
+   *     re-scopes it).
    *   - align `state.model` when the caller passes `provider` or `modelId`,
    *     honoring `--provider` / `--model` on hot sessions (not just on
    *     fresh/hydrated construction).
@@ -343,7 +358,10 @@ export class SessionRegistry {
     if (agent.state.isStreaming) {
       throw agentBusy(projectName)
     }
-    this.alignScope(projectName, agent, preferences?.toolScope ?? 'all')
+    this.alignToolSurface(projectName, agent, {
+      scope: preferences?.toolScope ?? AeroToolScopes.all,
+      profile: preferences?.toolProfile ?? AeroToolProfiles.default,
+    })
     if (preferences?.provider || preferences?.modelId) {
       this.alignModel(projectName, agent, preferences)
     }
@@ -414,16 +432,25 @@ export class SessionRegistry {
     }
   }
 
-  private alignScope(projectName: string, agent: Agent, wantScope: 'all' | 'read-only'): void {
-    if (this.scopes.get(projectName) === wantScope) return
+  private alignToolSurface(
+    projectName: string,
+    agent: Agent,
+    want: { scope: AeroToolScope; profile: AeroToolProfile },
+  ): void {
+    if (
+      this.scopes.get(projectName) === want.scope &&
+      this.profiles.get(projectName) === want.profile
+    ) {
+      return
+    }
     const projectId = this.projectIds.get(projectName) ?? this.resolveProjectId(projectName)
     this.projectIds.set(projectName, projectId)
     const toolCtx = { client: this.opts.client, projectName }
     // Mirror createAeroSession: skill-doc tools ride in every scope.
-    const stateTools =
-      wantScope === 'read-only' ? buildReadTools(toolCtx) : buildAllTools(toolCtx)
+    const stateTools = buildAeroStateTools(toolCtx, want)
     agent.state.tools = [...stateTools, ...buildSkillDocTools()]
-    this.scopes.set(projectName, wantScope)
+    this.scopes.set(projectName, want.scope)
+    this.profiles.set(projectName, want.profile)
   }
 
   private alignModel(
@@ -516,11 +543,12 @@ export class SessionRegistry {
         // escalate a read-only dashboard session to the full write surface.
         // Default to 'read-only' when no scope has been set yet, since drains
         // are system-triggered and should fail closed.
-        const scope = this.scopes.get(projectName) ?? 'read-only'
+        const scope = this.scopes.get(projectName) ?? AeroToolScopes.readOnly
+        const profile = this.profiles.get(projectName) ?? AeroToolProfiles.default
         // acquireForTurn does the busy check in the registry — if the agent
         // is mid-stream we leave pending alone and let `agent_end` drain
         // hook pick it up. Pi's AppError surfaces as `AGENT_BUSY`.
-        agent = await this.acquireForTurn(projectName, { toolScope: scope })
+        agent = await this.acquireForTurn(projectName, { toolScope: scope, toolProfile: profile })
       } catch (err) {
         if ((err as { code?: string }).code === 'AGENT_BUSY') return
         throw err
@@ -557,6 +585,7 @@ export class SessionRegistry {
     this.live.delete(projectName)
     this.pending.delete(projectName)
     this.scopes.delete(projectName)
+    this.profiles.delete(projectName)
     this.projectIds.delete(projectName)
   }
 

--- a/packages/canonry/src/agent/session.ts
+++ b/packages/canonry/src/agent/session.ts
@@ -17,7 +17,13 @@ import {
 } from './providers.js'
 import { resolveAeroSkillDir } from './skill-paths.js'
 import { buildSkillDocTools } from './skill-tools.js'
-import { buildAllTools, buildReadTools } from './tools.js'
+import {
+  AeroToolProfiles,
+  AeroToolScopes,
+  buildAeroStateTools,
+  type AeroToolProfile,
+  type AeroToolScope,
+} from './tools.js'
 import {
   AERO_PROMPT_FAMILY,
   AERO_PROMPT_VERSION,
@@ -58,7 +64,9 @@ export interface AeroSessionOptions {
    * exposes only the read tools — used by the dashboard bar where we don't
    * yet have a confirmation UX for destructive/additive actions.
    */
-  toolScope?: 'all' | 'read-only'
+  toolScope?: AeroToolScope
+  /** Optional profile that narrows the tool surface for specific operator workflows. */
+  toolProfile?: AeroToolProfile
   /** Seed initial transcript. Used by the registry when rehydrating a persisted session. */
   initialMessages?: import('@mariozechner/pi-agent-core').AgentMessage[]
   /** Optional telemetry context. When present, assistant turn usage is appended to llm_usage_events. */
@@ -162,14 +170,15 @@ export function createAeroSession(opts: AeroSessionOptions): Agent {
 
   const model = resolveAeroModel(provider, opts.modelId)
 
-  const toolScope = opts.toolScope ?? 'all'
+  const toolScope = opts.toolScope ?? AeroToolScopes.all
+  const toolProfile = opts.toolProfile ?? AeroToolProfiles.default
   const toolCtx = {
     client: opts.client,
     projectName: opts.projectName,
   }
   // Skill-doc tools ride in both scopes — they're pure reads of bundled
   // assets, no project state involved.
-  const stateTools = toolScope === 'read-only' ? buildReadTools(toolCtx) : buildAllTools(toolCtx)
+  const stateTools = buildAeroStateTools(toolCtx, { scope: toolScope, profile: toolProfile })
   const defaultTools = [...stateTools, ...buildSkillDocTools()]
   const tools = opts.tools ?? defaultTools
   const toolUsageHooks = opts.db

--- a/packages/canonry/src/agent/tools.ts
+++ b/packages/canonry/src/agent/tools.ts
@@ -1,7 +1,17 @@
-import type { AgentTool } from '@mariozechner/pi-agent-core'
+import { Type, type TSchema } from '@sinclair/typebox'
+import type { AgentTool, AgentToolResult } from '@mariozechner/pi-agent-core'
+import type {
+  AdsCampaignListResponse,
+  AdsInsightsResponse,
+  ProjectOverviewDto,
+} from '@ainyc/canonry-contracts'
 import type { ApiClient } from '../client.js'
-import { canonryMcpTools } from '../mcp/tool-registry.js'
-import { buildMcpAgentTools } from './mcp-to-agent-tool.js'
+import {
+  CanonryMcpToolNames,
+  canonryMcpTools,
+  type CanonryMcpToolName,
+} from '../mcp/tool-registry.js'
+import { buildMcpAgentTools, truncateToolResult } from './mcp-to-agent-tool.js'
 
 /**
  * Context Aero tools close over so the LLM can never target a different
@@ -11,6 +21,271 @@ import { buildMcpAgentTools } from './mcp-to-agent-tool.js'
 export interface ToolContext {
   client: ApiClient
   projectName: string
+}
+
+export const AeroToolScopes = Object.freeze({
+  all: 'all',
+  readOnly: 'read-only',
+} as const)
+
+export const AERO_TOOL_SCOPES = [
+  AeroToolScopes.all,
+  AeroToolScopes.readOnly,
+] as const
+export type AeroToolScope = typeof AERO_TOOL_SCOPES[number]
+
+export const AeroToolProfiles = Object.freeze({
+  default: 'default',
+  adsOperator: 'ads-operator',
+} as const)
+
+export const AERO_TOOL_PROFILES = [
+  AeroToolProfiles.default,
+  AeroToolProfiles.adsOperator,
+] as const
+export type AeroToolProfile = typeof AERO_TOOL_PROFILES[number]
+
+export function isAeroToolProfile(value: string | undefined): value is AeroToolProfile {
+  return value !== undefined && (AERO_TOOL_PROFILES as readonly string[]).includes(value)
+}
+
+export const AeroAgentToolNames = Object.freeze({
+  adsOperatorContext: 'canonry_ads_operator_context',
+} as const)
+export type AeroAgentToolName = typeof AeroAgentToolNames[keyof typeof AeroAgentToolNames]
+
+export const AERO_ADS_OPERATOR_CONTEXT_TOOL_NAME: AeroAgentToolName = AeroAgentToolNames.adsOperatorContext
+
+export const AERO_ADS_OPERATOR_MCP_TOOL_NAMES: ReadonlySet<CanonryMcpToolName> = new Set([
+  CanonryMcpToolNames.canonry_project_get,
+  CanonryMcpToolNames.canonry_project_overview,
+  CanonryMcpToolNames.canonry_search,
+  CanonryMcpToolNames.canonry_doctor,
+  CanonryMcpToolNames.canonry_analytics_metrics,
+  CanonryMcpToolNames.canonry_analytics_sources,
+  CanonryMcpToolNames.canonry_runs_list,
+  CanonryMcpToolNames.canonry_runs_latest,
+  CanonryMcpToolNames.canonry_run_get,
+  CanonryMcpToolNames.canonry_insights_list,
+  CanonryMcpToolNames.canonry_insight_get,
+  CanonryMcpToolNames.canonry_health_latest,
+  CanonryMcpToolNames.canonry_queries_list,
+  CanonryMcpToolNames.canonry_competitors_list,
+  CanonryMcpToolNames.canonry_schedule_get,
+  CanonryMcpToolNames.canonry_memory_list,
+  CanonryMcpToolNames.canonry_memory_set,
+  CanonryMcpToolNames.canonry_memory_forget,
+  CanonryMcpToolNames.canonry_run_trigger,
+  CanonryMcpToolNames.canonry_ads_status,
+  CanonryMcpToolNames.canonry_ads_campaigns,
+  CanonryMcpToolNames.canonry_ads_insights,
+  CanonryMcpToolNames.canonry_ads_summary,
+  CanonryMcpToolNames.canonry_ads_sync,
+])
+
+interface ToolBuildOptions {
+  scope?: AeroToolScope
+  profile?: AeroToolProfile
+}
+
+interface ContextSection<T> {
+  status: 'ok' | 'error'
+  data?: T
+  error?: string
+}
+
+interface AdsOperatorContextParams {
+  /** Lookback window for paid rollup rows. Default 30d. */
+  windowDays?: number
+  /** Max campaign snapshots to include. Default 8. */
+  campaignLimit?: number
+  /** Max paid rollup rows to include per level. Default 40. */
+  insightRowLimit?: number
+}
+
+function toolResult<T>(details: T): AgentToolResult<T> {
+  return {
+    content: [{ type: 'text', text: truncateToolResult(details) }],
+    details,
+  }
+}
+
+async function readSection<T>(fn: () => Promise<T>): Promise<ContextSection<T>> {
+  try {
+    return { status: 'ok', data: await fn() }
+  } catch (err) {
+    return {
+      status: 'error',
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}
+
+function clampInteger(value: unknown, fallback: number, min: number, max: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
+  return Math.max(min, Math.min(max, Math.trunc(value)))
+}
+
+function isoDateDaysAgo(days: number): string {
+  const d = new Date(Date.now() - (days - 1) * 24 * 60 * 60 * 1000)
+  return d.toISOString().slice(0, 10)
+}
+
+function todayIsoDate(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+function compactOverview(overview: Partial<ProjectOverviewDto>) {
+  return {
+    project: overview.project,
+    contextLabel: overview.contextLabel,
+    dateRangeLabel: overview.dateRangeLabel,
+    latestRun: overview.latestRun,
+    health: overview.health,
+    scores: overview.scores,
+    queryCounts: overview.queryCounts,
+    providers: overview.providers,
+    citationMovement: overview.citationMovement,
+    mentionMovement: overview.mentionMovement,
+    movementComparison: overview.movementComparison,
+    topInsights: overview.topInsights?.slice(0, 5) ?? [],
+    attentionItems: overview.attentionItems?.slice(0, 8) ?? [],
+    competitors: overview.competitors?.slice(0, 12) ?? [],
+  }
+}
+
+function compactCampaigns(response: AdsCampaignListResponse, limit: number) {
+  return {
+    campaignCount: response.campaigns.length,
+    campaigns: response.campaigns.slice(0, limit).map((campaign) => ({
+      id: campaign.id,
+      name: campaign.name,
+      status: campaign.status,
+      biddingType: campaign.biddingType,
+      dailySpendLimitMicros: campaign.dailySpendLimitMicros,
+      lifetimeSpendLimitMicros: campaign.lifetimeSpendLimitMicros,
+      adGroupCount: campaign.adGroups.length,
+      adGroups: campaign.adGroups.slice(0, 8).map((group) => ({
+        id: group.id,
+        name: group.name,
+        status: group.status,
+        billingEventType: group.billingEventType,
+        maxBidMicros: group.maxBidMicros,
+        contextHintCount: group.contextHints.length,
+        contextHints: group.contextHints.slice(0, 3),
+        adCount: group.ads.length,
+        ads: group.ads.slice(0, 4).map((ad) => ({
+          id: ad.id,
+          name: ad.name,
+          status: ad.status,
+          reviewStatus: ad.reviewStatus,
+          creative: ad.creative
+            ? {
+                type: ad.creative.type,
+                title: ad.creative.title,
+                body: ad.creative.body,
+                targetUrl: ad.creative.targetUrl,
+              }
+            : ad.creative,
+        })),
+      })),
+    })),
+  }
+}
+
+function compactInsights(response: AdsInsightsResponse, rowLimit: number) {
+  return {
+    currencyCode: response.currencyCode,
+    rowCount: response.rows.length,
+    rows: response.rows.slice(-rowLimit),
+  }
+}
+
+function buildAdsOperatorContextTool(ctx: ToolContext): AgentTool {
+  return {
+    name: AERO_ADS_OPERATOR_CONTEXT_TOOL_NAME,
+    label: 'Get ads operator context',
+    description:
+      'One-call Aero context pack for ads operations. Reads the project overview, ads connection, paid summary, bounded campaign snapshots, recent paid rollups, ads doctor checks, and recent Aero memory. Use before diagnosing ChatGPT ads performance or planning the next operator action.',
+    parameters: Type.Object({
+      windowDays: Type.Optional(Type.Integer({
+        minimum: 1,
+        maximum: 90,
+        description: 'Lookback window for paid rollup rows. Default 30 days.',
+      })),
+      campaignLimit: Type.Optional(Type.Integer({
+        minimum: 1,
+        maximum: 25,
+        description: 'Max campaign snapshots to include. Default 8.',
+      })),
+      insightRowLimit: Type.Optional(Type.Integer({
+        minimum: 1,
+        maximum: 100,
+        description: 'Max paid rollup rows to include per level. Default 40.',
+      })),
+    }) as TSchema,
+    execute: async (_toolCallId, rawParams): Promise<AgentToolResult<unknown>> => {
+      const params = rawParams as AdsOperatorContextParams
+      const windowDays = clampInteger(params.windowDays, 30, 1, 90)
+      const campaignLimit = clampInteger(params.campaignLimit, 8, 1, 25)
+      const insightRowLimit = clampInteger(params.insightRowLimit, 40, 1, 100)
+      const from = isoDateDaysAgo(windowDays)
+      const to = todayIsoDate()
+
+      const [
+        overview,
+        adsStatus,
+        adsSummary,
+        campaigns,
+        campaignInsights,
+        adGroupInsights,
+        doctor,
+        memory,
+      ] = await Promise.all([
+        readSection(() => ctx.client.getProjectOverview(ctx.projectName)),
+        readSection(() => ctx.client.getAdsStatus(ctx.projectName)),
+        readSection(() => ctx.client.getAdsSummary(ctx.projectName)),
+        readSection(async () => compactCampaigns(await ctx.client.getAdsCampaigns(ctx.projectName), campaignLimit)),
+        readSection(async () =>
+          compactInsights(
+            await ctx.client.getAdsInsights(ctx.projectName, { level: 'campaign', from, to }),
+            insightRowLimit,
+          ),
+        ),
+        readSection(async () =>
+          compactInsights(
+            await ctx.client.getAdsInsights(ctx.projectName, { level: 'ad_group', from, to }),
+            insightRowLimit,
+          ),
+        ),
+        readSection(() => ctx.client.runDoctor({ project: ctx.projectName, checkIds: ['ads.*'] })),
+        readSection(async () => {
+          const result = await ctx.client.listAgentMemory(ctx.projectName)
+          return { entries: result.entries.slice(0, 10) }
+        }),
+      ])
+
+      return toolResult({
+        project: ctx.projectName,
+        generatedAt: new Date().toISOString(),
+        window: { days: windowDays, from, to },
+        overview: overview.status === 'ok' && overview.data
+          ? { status: 'ok' as const, data: compactOverview(overview.data) }
+          : overview,
+        ads: {
+          status: adsStatus,
+          summary: adsSummary,
+          campaigns,
+          insights: {
+            campaign: campaignInsights,
+            adGroup: adGroupInsights,
+          },
+        },
+        doctor,
+        memory,
+      })
+    },
+  } as AgentTool
 }
 
 /**
@@ -29,4 +304,24 @@ export function buildReadTools(ctx: ToolContext): AgentTool[] {
  */
 export function buildAllTools(ctx: ToolContext): AgentTool[] {
   return buildMcpAgentTools(canonryMcpTools, ctx)
+}
+
+export function buildAdsOperatorTools(
+  ctx: ToolContext,
+  opts: Pick<ToolBuildOptions, 'scope'> = {},
+): AgentTool[] {
+  const mcpTools = buildMcpAgentTools(canonryMcpTools, ctx, {
+    readOnly: opts.scope === AeroToolScopes.readOnly,
+    includeNames: AERO_ADS_OPERATOR_MCP_TOOL_NAMES,
+  })
+  return [buildAdsOperatorContextTool(ctx), ...mcpTools]
+}
+
+export function buildAeroStateTools(ctx: ToolContext, opts: ToolBuildOptions = {}): AgentTool[] {
+  const scope = opts.scope ?? AeroToolScopes.all
+  const profile = opts.profile ?? AeroToolProfiles.default
+  if (profile === AeroToolProfiles.adsOperator) {
+    return buildAdsOperatorTools(ctx, { scope })
+  }
+  return scope === AeroToolScopes.readOnly ? buildReadTools(ctx) : buildAllTools(ctx)
 }

--- a/packages/canonry/src/cli-commands/agent.ts
+++ b/packages/canonry/src/cli-commands/agent.ts
@@ -1,5 +1,5 @@
 import { agentAttach, agentDetach } from '../commands/agent.js'
-import { agentAsk, type AgentAskScope } from '../commands/agent-ask.js'
+import { agentAsk, type AgentAskProfile, type AgentAskScope } from '../commands/agent-ask.js'
 import { agentProviders } from '../commands/agent-providers.js'
 import { agentTranscript, agentTranscriptReset } from '../commands/agent-transcript.js'
 import {
@@ -8,6 +8,7 @@ import {
   agentMemorySet,
 } from '../commands/agent-memory.js'
 import { coerceAgentProvider, listAgentProviders } from '../agent/session.js'
+import { AERO_TOOL_PROFILES, isAeroToolProfile } from '../agent/tools.js'
 import type { CliCommandSpec } from '../cli-dispatch.js'
 import { getString, requireProject, requireStringOption, stringOption } from '../cli-command-helpers.js'
 import { usageError } from '../cli-error.js'
@@ -17,14 +18,15 @@ const AGENT_ASK_SCOPES: readonly AgentAskScope[] = ['all', 'read-only']
 export const AGENT_CLI_COMMANDS: readonly CliCommandSpec[] = [
   {
     path: ['agent', 'ask'],
-    usage: `canonry agent ask <project> "<prompt>" [--provider ${listAgentProviders().join('|')}] [--model <id>] [--scope all|read-only] [--format json]`,
+    usage: `canonry agent ask <project> "<prompt>" [--provider ${listAgentProviders().join('|')}] [--model <id>] [--scope all|read-only] [--profile default|ads-operator] [--format json]`,
     options: {
       provider: stringOption(),
       model: stringOption(),
       scope: stringOption(),
+      profile: stringOption(),
     },
     run: async (input) => {
-      const usage = `canonry agent ask <project> "<prompt>" [--provider ${listAgentProviders().join('|')}] [--model <id>] [--scope all|read-only] [--format json]`
+      const usage = `canonry agent ask <project> "<prompt>" [--provider ${listAgentProviders().join('|')}] [--model <id>] [--scope all|read-only] [--profile default|ads-operator] [--format json]`
       const project = requireProject(input, 'agent.ask', usage)
       const prompt = input.positionals.slice(1).join(' ').trim()
       if (!prompt) {
@@ -60,12 +62,25 @@ export const AGENT_CLI_COMMANDS: readonly CliCommandSpec[] = [
           },
         })
       }
+      const profileInput = getString(input.values, 'profile')
+      if (profileInput && !isAeroToolProfile(profileInput)) {
+        throw usageError(`Error: --profile must be one of: ${AERO_TOOL_PROFILES.join(', ')}\nUsage: ${usage}`, {
+          message: `--profile must be one of: ${AERO_TOOL_PROFILES.join(', ')}`,
+          details: {
+            command: 'agent.ask',
+            usage,
+            profile: profileInput,
+            validProfiles: AERO_TOOL_PROFILES,
+          },
+        })
+      }
       await agentAsk({
         project,
         prompt,
         provider: coerceAgentProvider(providerInput),
         modelId: getString(input.values, 'model'),
         scope: scopeInput as AgentAskScope | undefined,
+        profile: profileInput as AgentAskProfile | undefined,
         format: input.format,
       })
     },

--- a/packages/canonry/src/commands/agent-ask.ts
+++ b/packages/canonry/src/commands/agent-ask.ts
@@ -8,6 +8,7 @@ import {
 } from '../cli-error.js'
 import { createApiClient } from '../client.js'
 import type { SupportedAgentProvider } from '../agent/session.js'
+import type { AeroToolProfile } from '../agent/tools.js'
 
 /**
  * Coerce the raw format flag while preserving `jsonl`. `agent ask` streams an
@@ -22,6 +23,7 @@ function toFormat(raw?: string): CliFormat {
 }
 
 export type AgentAskScope = 'all' | 'read-only'
+export type AgentAskProfile = AeroToolProfile
 
 export interface AgentAskOptions {
   project: string
@@ -29,6 +31,7 @@ export interface AgentAskOptions {
   provider?: SupportedAgentProvider
   modelId?: string
   scope?: AgentAskScope
+  profile?: AgentAskProfile
   format?: string
 }
 
@@ -66,6 +69,7 @@ export async function agentAsk(opts: AgentAskOptions): Promise<void> {
         provider: opts.provider,
         modelId: opts.modelId,
         scope: opts.scope ?? 'all',
+        ...(opts.profile ? { profile: opts.profile } : {}),
       },
       controller.signal,
     )

--- a/packages/canonry/src/mcp/tool-registry.ts
+++ b/packages/canonry/src/mcp/tool-registry.ts
@@ -44,8 +44,11 @@ import type { CanonryMcpTier } from './toolkits.js'
 
 export type McpToolAccess = 'read' | 'write'
 
-export interface CanonryMcpTool<TSchema extends z.ZodTypeAny = z.ZodTypeAny> {
-  name: string
+export interface CanonryMcpTool<
+  TSchema extends z.ZodTypeAny = z.ZodTypeAny,
+  TName extends string = string,
+> {
+  name: TName
   title: string
   description: string
   access: McpToolAccess
@@ -69,9 +72,9 @@ const writeAnnotations = (opts: { idempotentHint: boolean; destructiveHint?: boo
   ...(opts.openWorldHint ? { openWorldHint: opts.openWorldHint } : {}),
 })
 
-function defineTool<TSchema extends z.ZodTypeAny>(
-  tool: Omit<CanonryMcpTool<TSchema>, 'inputJsonSchema'>,
-): CanonryMcpTool<TSchema> {
+function defineTool<TSchema extends z.ZodTypeAny, TName extends string>(
+  tool: Omit<CanonryMcpTool<TSchema, TName>, 'inputJsonSchema'>,
+): CanonryMcpTool<TSchema, TName> {
   return {
     ...tool,
     inputJsonSchema: toJsonSchema(tool.inputSchema, tool.name),
@@ -1855,3 +1858,8 @@ export const canonryMcpTools = [
 export const CANONRY_MCP_TOOL_COUNT = canonryMcpTools.length
 export const CANONRY_MCP_READ_TOOL_COUNT = canonryMcpTools.filter(tool => tool.access === 'read').length
 export const CANONRY_MCP_CORE_TOOL_COUNT = canonryMcpTools.filter(tool => tool.tier === 'core').length
+export type CanonryMcpRegistryTool = typeof canonryMcpTools[number]
+export type CanonryMcpToolName = CanonryMcpRegistryTool['name']
+export const CanonryMcpToolNames = Object.freeze(
+  Object.fromEntries(canonryMcpTools.map((tool) => [tool.name, tool.name])),
+) as { readonly [K in CanonryMcpToolName]: K }

--- a/packages/canonry/test/agent-ask-scope.test.ts
+++ b/packages/canonry/test/agent-ask-scope.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import crypto from 'node:crypto'
 import { agentAsk } from '../src/commands/agent-ask.js'
+import { AeroToolProfiles, AeroToolScopes, type AeroToolProfile, type AeroToolScope } from '../src/agent/tools.js'
 
 /**
  * The dashboard AeroBar can run in `read-only` mode; the CLI defaults to
@@ -42,7 +43,7 @@ describe('agent ask scope parity', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true })
   })
 
-  async function captureScope(askScope: 'all' | 'read-only' | undefined): Promise<string> {
+  async function captureBody(opts: { scope?: AeroToolScope; profile?: AeroToolProfile }): Promise<string> {
     let captured = ''
     globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
@@ -57,22 +58,32 @@ describe('agent ask scope parity', () => {
       return new Response('not found', { status: 404 })
     }) as typeof globalThis.fetch
 
-    await agentAsk({ project: 'demo', prompt: 'hi', scope: askScope })
+    await agentAsk({ project: 'demo', prompt: 'hi', scope: opts.scope, profile: opts.profile })
     return captured
   }
 
   it('omitted scope defaults to "all" so CLI turns keep write capability', async () => {
-    const body = await captureScope(undefined)
-    expect(JSON.parse(body)).toMatchObject({ scope: 'all' })
+    const body = await captureBody({})
+    expect(JSON.parse(body)).toMatchObject({ scope: AeroToolScopes.all })
   })
 
   it('--scope read-only is forwarded to the server', async () => {
-    const body = await captureScope('read-only')
-    expect(JSON.parse(body)).toMatchObject({ scope: 'read-only' })
+    const body = await captureBody({ scope: AeroToolScopes.readOnly })
+    expect(JSON.parse(body)).toMatchObject({ scope: AeroToolScopes.readOnly })
   })
 
   it('--scope all is forwarded to the server', async () => {
-    const body = await captureScope('all')
-    expect(JSON.parse(body)).toMatchObject({ scope: 'all' })
+    const body = await captureBody({ scope: AeroToolScopes.all })
+    expect(JSON.parse(body)).toMatchObject({ scope: AeroToolScopes.all })
+  })
+
+  it('--profile ads-operator is forwarded to the server', async () => {
+    const body = await captureBody({ profile: AeroToolProfiles.adsOperator })
+    expect(JSON.parse(body)).toMatchObject({ scope: AeroToolScopes.all, profile: AeroToolProfiles.adsOperator })
+  })
+
+  it('omitted profile stays omitted so the server default remains authoritative', async () => {
+    const body = await captureBody({})
+    expect(JSON.parse(body)).not.toHaveProperty('profile')
   })
 })

--- a/packages/canonry/test/agent-session-registry.test.ts
+++ b/packages/canonry/test/agent-session-registry.test.ts
@@ -24,8 +24,14 @@ import { Type } from '@sinclair/typebox'
 import type { AgentMessage, AgentTool } from '@mariozechner/pi-agent-core'
 import { MemorySources } from '@ainyc/canonry-contracts'
 import { SessionRegistry } from '../src/agent/session-registry.js'
-import { canonryMcpTools } from '../src/mcp/tool-registry.js'
+import { CanonryMcpToolNames, canonryMcpTools } from '../src/mcp/tool-registry.js'
 import { AERO_EXCLUDED_MCP_TOOLS } from '../src/agent/mcp-to-agent-tool.js'
+import {
+  AERO_ADS_OPERATOR_CONTEXT_TOOL_NAME,
+  AERO_ADS_OPERATOR_MCP_TOOL_NAMES,
+  AeroToolProfiles,
+  AeroToolScopes,
+} from '../src/agent/tools.js'
 import type { ApiClient } from '../src/client.js'
 import type { CanonryConfig } from '../src/config.js'
 
@@ -39,6 +45,21 @@ const AERO_READ_TOOL_COUNT =
   SKILL_DOC_TOOL_COUNT
 const AERO_ALL_TOOL_COUNT =
   canonryMcpTools.filter((t) => !AERO_EXCLUDED_MCP_TOOLS.has(t.name)).length + SKILL_DOC_TOOL_COUNT
+const AERO_ADS_OPERATOR_READ_TOOL_COUNT =
+  canonryMcpTools.filter(
+    (t) =>
+      t.access === 'read' &&
+      AERO_ADS_OPERATOR_MCP_TOOL_NAMES.has(t.name) &&
+      !AERO_EXCLUDED_MCP_TOOLS.has(t.name),
+  ).length +
+  1 +
+  SKILL_DOC_TOOL_COUNT
+const AERO_ADS_OPERATOR_ALL_TOOL_COUNT =
+  canonryMcpTools.filter(
+    (t) => AERO_ADS_OPERATOR_MCP_TOOL_NAMES.has(t.name) && !AERO_EXCLUDED_MCP_TOOLS.has(t.name),
+  ).length +
+  1 +
+  SKILL_DOC_TOOL_COUNT
 
 function stubClient(): ApiClient {
   return {} as unknown as ApiClient
@@ -176,7 +197,7 @@ describe('SessionRegistry', () => {
   it('records LLM usage with the current hot-session tool count after scope alignment', async () => {
     const projectId = insertProject(db, 'demo')
     const registry = new SessionRegistry({ db, client: stubClient(), config: stubConfig() })
-    const agent = await registry.acquireForTurn('demo', { toolScope: 'read-only' })
+    const agent = await registry.acquireForTurn('demo', { toolScope: AeroToolScopes.readOnly })
 
     agent.state.model = faux.getModel()
     faux.setResponses([fauxAssistantMessage('Read-only usage recorded.')])
@@ -428,7 +449,7 @@ describe('SessionRegistry', () => {
     // session would leak into the next prompt after the reset.
     insertProject(db, 'demo')
     const registry = new SessionRegistry({ db, client: stubClient(), config: stubConfig() })
-    registry.getOrCreate('demo', { toolScope: 'read-only' })
+    registry.getOrCreate('demo', { toolScope: AeroToolScopes.readOnly })
 
     registry.queueFollowUp('demo', {
       role: 'user',
@@ -439,7 +460,7 @@ describe('SessionRegistry', () => {
     expect(registry.isLive('demo')).toBe(true)
     expect(
       (registry as unknown as { scopes: Map<string, string> }).scopes.get('demo'),
-    ).toBe('read-only')
+    ).toBe(AeroToolScopes.readOnly)
 
     registry.reset('demo')
 
@@ -491,7 +512,7 @@ describe('SessionRegistry', () => {
     // a system-triggered proactive drain.
     insertProject(db, 'demo')
     const registry = new SessionRegistry({ db, client: stubClient(), config: stubConfig() })
-    const agent = registry.getOrCreate('demo', { toolScope: 'read-only' })
+    const agent = registry.getOrCreate('demo', { toolScope: AeroToolScopes.readOnly })
     agent.state.model = faux.getModel()
     faux.setResponses([fauxAssistantMessage('Acknowledged.')])
 
@@ -506,6 +527,34 @@ describe('SessionRegistry', () => {
     await registry.drainNow('demo')
 
     expect(agent.state.tools.length).toBe(AERO_READ_TOOL_COUNT)
+  })
+
+  it('drainNow preserves an ads-operator profile and does not widen back to the default profile', async () => {
+    insertProject(db, 'demo')
+    const registry = new SessionRegistry({ db, client: stubClient(), config: stubConfig() })
+    const agent = registry.getOrCreate('demo', {
+      toolScope: AeroToolScopes.readOnly,
+      toolProfile: AeroToolProfiles.adsOperator,
+    })
+    agent.state.model = faux.getModel()
+    faux.setResponses([fauxAssistantMessage('Acknowledged.')])
+
+    expect(agent.state.tools.map((t) => t.name)).toContain(AERO_ADS_OPERATOR_CONTEXT_TOOL_NAME)
+    expect(agent.state.tools.length).toBe(AERO_ADS_OPERATOR_READ_TOOL_COUNT)
+
+    registry.queueFollowUp('demo', {
+      role: 'user',
+      content: '[system] run.completed',
+      timestamp: Date.now(),
+    } as unknown as AgentMessage)
+
+    await registry.drainNow('demo')
+
+    const names = agent.state.tools.map((t) => t.name)
+    expect(names).toContain(AERO_ADS_OPERATOR_CONTEXT_TOOL_NAME)
+    expect(names).toContain(CanonryMcpToolNames.canonry_ads_summary)
+    expect(names).not.toContain(CanonryMcpToolNames.canonry_ads_sync)
+    expect(agent.state.tools.length).toBe(AERO_ADS_OPERATOR_READ_TOOL_COUNT)
   })
 
   it('drainNow defaults to read-only when no session scope is set yet', async () => {
@@ -636,7 +685,7 @@ describe('SessionRegistry', () => {
 
     let caught: unknown
     try {
-      await registry.acquireForTurn('demo', { toolScope: 'read-only' })
+      await registry.acquireForTurn('demo', { toolScope: AeroToolScopes.readOnly })
     } catch (err) {
       caught = err
     }
@@ -653,9 +702,38 @@ describe('SessionRegistry', () => {
     const agent = registry.getOrCreate('demo')
     expect(agent.state.tools.length).toBe(AERO_ALL_TOOL_COUNT)
 
-    await registry.acquireForTurn('demo', { toolScope: 'read-only' })
+    await registry.acquireForTurn('demo', { toolScope: AeroToolScopes.readOnly })
 
     expect(agent.state.tools.length).toBe(AERO_READ_TOOL_COUNT)
+  })
+
+  it('acquireForTurn aligns tool profile on cached agents when idle', async () => {
+    insertProject(db, 'demo')
+    const registry = new SessionRegistry({ db, client: stubClient(), config: stubConfig() })
+    const agent = registry.getOrCreate('demo')
+    expect(agent.state.tools.length).toBe(AERO_ALL_TOOL_COUNT)
+
+    await registry.acquireForTurn('demo', {
+      toolScope: AeroToolScopes.readOnly,
+      toolProfile: AeroToolProfiles.adsOperator,
+    })
+
+    const readOnlyNames = agent.state.tools.map((t) => t.name)
+    expect(readOnlyNames).toContain(AERO_ADS_OPERATOR_CONTEXT_TOOL_NAME)
+    expect(readOnlyNames).toContain(CanonryMcpToolNames.canonry_ads_summary)
+    expect(readOnlyNames).not.toContain(CanonryMcpToolNames.canonry_ads_sync)
+    expect(agent.state.tools.length).toBe(AERO_ADS_OPERATOR_READ_TOOL_COUNT)
+
+    await registry.acquireForTurn('demo', {
+      toolScope: AeroToolScopes.all,
+      toolProfile: AeroToolProfiles.adsOperator,
+    })
+
+    const fullNames = agent.state.tools.map((t) => t.name)
+    expect(fullNames).toContain(AERO_ADS_OPERATOR_CONTEXT_TOOL_NAME)
+    expect(fullNames).toContain(CanonryMcpToolNames.canonry_ads_sync)
+    expect(fullNames).not.toContain(CanonryMcpToolNames.canonry_schedule_set)
+    expect(agent.state.tools.length).toBe(AERO_ADS_OPERATOR_ALL_TOOL_COUNT)
   })
 
   it('acquireForTurn swaps model on cached agents when preferences change', async () => {

--- a/packages/canonry/test/agent-tools.test.ts
+++ b/packages/canonry/test/agent-tools.test.ts
@@ -1,13 +1,18 @@
 import { describe, it, expect } from 'vitest'
 import type { AgentTool } from '@mariozechner/pi-agent-core'
-import { canonryMcpTools } from '../src/mcp/tool-registry.js'
+import { CanonryMcpToolNames, canonryMcpTools } from '../src/mcp/tool-registry.js'
 import {
   AERO_EXCLUDED_MCP_TOOLS,
   buildMcpAgentTools,
   mcpToAgentTool,
 } from '../src/agent/mcp-to-agent-tool.js'
 import {
+  AERO_ADS_OPERATOR_CONTEXT_TOOL_NAME,
+  AERO_ADS_OPERATOR_MCP_TOOL_NAMES,
+  AeroToolScopes,
+  buildAdsOperatorTools,
   buildAllTools,
+  buildAeroStateTools,
   buildReadTools,
   type ToolContext,
 } from '../src/agent/tools.js'
@@ -25,6 +30,84 @@ function recordingClient(calls: CallLog[]): ApiClient {
         const method = String(property)
         calls.push({ method, args })
         if (method === 'getProject') return { name: args[0], canonicalDomain: 'demo.example.com' }
+        if (method === 'getProjectOverview') {
+          return {
+            project: { name: args[0], canonicalDomain: 'demo.example.com' },
+            latestRun: null,
+            health: null,
+            scores: {},
+            queryCounts: {},
+            providers: [],
+            citationMovement: {},
+            mentionMovement: {},
+            movementComparison: {},
+            topInsights: [],
+            attentionItems: [],
+            competitors: [],
+            contextLabel: 'All locations',
+            dateRangeLabel: 'All time',
+          }
+        }
+        if (method === 'getAdsStatus') return { connected: true, adAccountId: 'acct_1', lastSyncedAt: '2026-06-28T00:00:00Z' }
+        if (method === 'getAdsSummary') {
+          return {
+            connected: true,
+            displayName: 'Demo ads',
+            currencyCode: 'USD',
+            lastSyncedAt: '2026-06-28T00:00:00Z',
+            campaignCount: 1,
+            adGroupCount: 1,
+            adCount: 1,
+            window: { from: '2026-06-01', to: '2026-06-28' },
+            totals: { impressions: 100, clicks: 10, spendMicros: 1_000_000, conversions: 1, ctr: 0.1, cpcMicros: 100_000 },
+          }
+        }
+        if (method === 'getAdsCampaigns') {
+          return {
+            campaigns: [{
+              id: 'camp_1',
+              name: 'High intent',
+              status: 'active',
+              biddingType: 'cpc',
+              dailySpendLimitMicros: 5_000_000,
+              lifetimeSpendLimitMicros: null,
+              adGroups: [{
+                id: 'ag_1',
+                campaignId: 'camp_1',
+                name: 'Branded alternatives',
+                status: 'active',
+                billingEventType: 'click',
+                maxBidMicros: 250_000,
+                contextHints: ['best demo software\ncanonry alternative'],
+                ads: [{
+                  id: 'ad_1',
+                  adGroupId: 'ag_1',
+                  name: 'Primary',
+                  status: 'active',
+                  reviewStatus: 'approved',
+                  creative: { title: 'Demo', body: 'Try demo', targetUrl: 'https://demo.example.com' },
+                }],
+              }],
+            }],
+          }
+        }
+        if (method === 'getAdsInsights') {
+          return {
+            currencyCode: 'USD',
+            rows: [{
+              level: args[1]?.level ?? 'campaign',
+              entityId: 'camp_1',
+              date: '2026-06-28',
+              impressions: 100,
+              clicks: 10,
+              spendMicros: 1_000_000,
+              conversions: 1,
+              ctr: 0.1,
+              cpcMicros: 100_000,
+            }],
+          }
+        }
+        if (method === 'runDoctor') return { status: 'ok', checks: [] }
         if (method === 'listProjects') return []
         if (method === 'listAgentMemory') return { entries: [] }
         if (method === 'setAgentMemory') return { status: 'ok', entry: { id: 'm1', key: 'pref', value: 'note', source: 'aero', createdAt: '', updatedAt: '' } }
@@ -50,12 +133,12 @@ describe('buildAllTools', () => {
     const expectedCount = canonryMcpTools.filter((t) => !AERO_EXCLUDED_MCP_TOOLS.has(t.name)).length
 
     expect(tools).toHaveLength(expectedCount)
-    expect(tools.map((t) => t.name)).not.toContain('canonry_agent_clear')
+    expect(tools.map((t) => t.name)).not.toContain(CanonryMcpToolNames.canonry_agent_clear)
     // Spot-check that every other tool from the registry is exposed.
-    expect(tools.map((t) => t.name)).toContain('canonry_project_overview')
-    expect(tools.map((t) => t.name)).toContain('canonry_run_trigger')
-    expect(tools.map((t) => t.name)).toContain('canonry_memory_list')
-    expect(tools.map((t) => t.name)).toContain('canonry_memory_set')
+    expect(tools.map((t) => t.name)).toContain(CanonryMcpToolNames.canonry_project_overview)
+    expect(tools.map((t) => t.name)).toContain(CanonryMcpToolNames.canonry_run_trigger)
+    expect(tools.map((t) => t.name)).toContain(CanonryMcpToolNames.canonry_memory_list)
+    expect(tools.map((t) => t.name)).toContain(CanonryMcpToolNames.canonry_memory_set)
   })
 })
 
@@ -70,15 +153,107 @@ describe('buildReadTools', () => {
     expect(tools).toHaveLength(expectedReads.length)
     expect(tools.every((t) => expectedReads.some((r) => r.name === t.name))).toBe(true)
     // Read scope must not include any write-only tool.
-    expect(tools.map((t) => t.name)).not.toContain('canonry_run_trigger')
-    expect(tools.map((t) => t.name)).not.toContain('canonry_memory_set')
+    expect(tools.map((t) => t.name)).not.toContain(CanonryMcpToolNames.canonry_run_trigger)
+    expect(tools.map((t) => t.name)).not.toContain(CanonryMcpToolNames.canonry_memory_set)
+  })
+})
+
+describe('buildAdsOperatorTools', () => {
+  it('adds the one-call context tool and narrows read-only mode to the ads operator allow-list', () => {
+    const calls: CallLog[] = []
+    const tools = buildAdsOperatorTools(ctxFor(recordingClient(calls)), { scope: AeroToolScopes.readOnly })
+    const names = tools.map((t) => t.name)
+    const expectedReads = canonryMcpTools.filter(
+      (t) =>
+        t.access === 'read' &&
+        AERO_ADS_OPERATOR_MCP_TOOL_NAMES.has(t.name) &&
+        !AERO_EXCLUDED_MCP_TOOLS.has(t.name),
+    )
+
+    expect(tools).toHaveLength(expectedReads.length + 1)
+    expect(names[0]).toBe(AERO_ADS_OPERATOR_CONTEXT_TOOL_NAME)
+    expect(names).toContain(CanonryMcpToolNames.canonry_project_overview)
+    expect(names).toContain(CanonryMcpToolNames.canonry_ads_summary)
+    expect(names).toContain(CanonryMcpToolNames.canonry_memory_list)
+    expect(names).not.toContain(CanonryMcpToolNames.canonry_ads_sync)
+    expect(names).not.toContain(CanonryMcpToolNames.canonry_run_trigger)
+    expect(names).not.toContain(CanonryMcpToolNames.canonry_memory_set)
+    expect(names).not.toContain(CanonryMcpToolNames.canonry_queries_replace)
+  })
+
+  it('keeps only selected write tools when full scope is requested', () => {
+    const calls: CallLog[] = []
+    const tools = buildAdsOperatorTools(ctxFor(recordingClient(calls)), { scope: AeroToolScopes.all })
+    const names = tools.map((t) => t.name)
+
+    expect(names).toContain(CanonryMcpToolNames.canonry_ads_sync)
+    expect(names).toContain(CanonryMcpToolNames.canonry_run_trigger)
+    expect(names).toContain(CanonryMcpToolNames.canonry_memory_set)
+    expect(names).toContain(CanonryMcpToolNames.canonry_memory_forget)
+    expect(names).not.toContain(CanonryMcpToolNames.canonry_schedule_set)
+    expect(names).not.toContain(CanonryMcpToolNames.canonry_queries_replace)
+    expect(names).not.toContain(CanonryMcpToolNames.canonry_traffic_connect_cloud_run)
+  })
+
+  it('keeps the full-scope local profile inside the explicit ads operator allow-list', () => {
+    const calls: CallLog[] = []
+    const tools = buildAdsOperatorTools(ctxFor(recordingClient(calls)), { scope: AeroToolScopes.all })
+    const allowedNames = new Set<string>([
+      AERO_ADS_OPERATOR_CONTEXT_TOOL_NAME,
+      ...AERO_ADS_OPERATOR_MCP_TOOL_NAMES,
+    ])
+
+    expect(tools.map((t) => t.name).filter((name) => !allowedNames.has(name))).toEqual([])
+  })
+
+  it('executes the context tool as a bounded composite read', async () => {
+    const calls: CallLog[] = []
+    const tools = buildAdsOperatorTools(ctxFor(recordingClient(calls)), { scope: AeroToolScopes.readOnly })
+    const contextTool = tools.find((t) => t.name === AERO_ADS_OPERATOR_CONTEXT_TOOL_NAME)!
+
+    const result = await contextTool.execute('call-1', { windowDays: 14, campaignLimit: 1, insightRowLimit: 1 })
+
+    expect(result.details).toMatchObject({
+      project: 'demo',
+      window: { days: 14 },
+      overview: { status: 'ok' },
+      ads: {
+        status: { status: 'ok' },
+        summary: { status: 'ok' },
+      },
+      doctor: { status: 'ok' },
+      memory: { status: 'ok' },
+    })
+    expect(calls.map((c) => c.method)).toEqual([
+      'getProjectOverview',
+      'getAdsStatus',
+      'getAdsSummary',
+      'getAdsCampaigns',
+      'getAdsInsights',
+      'getAdsInsights',
+      'runDoctor',
+      'listAgentMemory',
+    ])
+    expect((result.content[0] as { text: string }).text).toContain('High intent')
+  })
+})
+
+describe('buildAeroStateTools', () => {
+  it('keeps the default profile equivalent to the existing read/full builders', () => {
+    const calls: CallLog[] = []
+    const ctx = ctxFor(recordingClient(calls))
+
+    expect(buildAeroStateTools(ctx, { scope: AeroToolScopes.readOnly }).map((t) => t.name))
+      .toEqual(buildReadTools(ctx).map((t) => t.name))
+    expect(buildAeroStateTools(ctx, { scope: AeroToolScopes.all }).map((t) => t.name))
+      .toEqual(buildAllTools(ctx).map((t) => t.name))
   })
 })
 
 describe('mcpToAgentTool', () => {
   it('strips the top-level project property from the LLM-visible schema', () => {
     const calls: CallLog[] = []
-    const overview = canonryMcpTools.find((t) => t.name === 'canonry_project_overview')!
+    const overview = canonryMcpTools.find((t) => t.name === CanonryMcpToolNames.canonry_project_overview)!
     const tool = mcpToAgentTool(overview, { client: recordingClient(calls), projectName: 'demo' })
 
     const props = jsonSchemaProperties(tool) ?? {}
@@ -89,7 +264,7 @@ describe('mcpToAgentTool', () => {
 
   it('injects ctx.projectName into the handler call when the schema had project', async () => {
     const calls: CallLog[] = []
-    const overview = canonryMcpTools.find((t) => t.name === 'canonry_project_overview')!
+    const overview = canonryMcpTools.find((t) => t.name === CanonryMcpToolNames.canonry_project_overview)!
     const tool = mcpToAgentTool(overview, { client: recordingClient(calls), projectName: 'demo' })
 
     await tool.execute('call-1', {})
@@ -100,7 +275,7 @@ describe('mcpToAgentTool', () => {
 
   it('passes through schemas that do not carry a project field', () => {
     const calls: CallLog[] = []
-    const projectsList = canonryMcpTools.find((t) => t.name === 'canonry_projects_list')!
+    const projectsList = canonryMcpTools.find((t) => t.name === CanonryMcpToolNames.canonry_projects_list)!
     const tool = mcpToAgentTool(projectsList, { client: recordingClient(calls), projectName: 'demo' })
 
     // Empty input schema has no `project` to strip; the schema stays unchanged.
@@ -110,7 +285,7 @@ describe('mcpToAgentTool', () => {
 
   it('injects projectName for multi-arg tools (memory set)', async () => {
     const calls: CallLog[] = []
-    const memorySet = canonryMcpTools.find((t) => t.name === 'canonry_memory_set')!
+    const memorySet = canonryMcpTools.find((t) => t.name === CanonryMcpToolNames.canonry_memory_set)!
     const tool = mcpToAgentTool(memorySet, { client: recordingClient(calls), projectName: 'demo' })
 
     await tool.execute('call-1', { key: 'pref', value: 'be terse' })
@@ -122,7 +297,7 @@ describe('mcpToAgentTool', () => {
 
   it('wraps the handler result in an AgentToolResult envelope', async () => {
     const calls: CallLog[] = []
-    const memoryList = canonryMcpTools.find((t) => t.name === 'canonry_memory_list')!
+    const memoryList = canonryMcpTools.find((t) => t.name === CanonryMcpToolNames.canonry_memory_list)!
     const tool = mcpToAgentTool(memoryList, { client: recordingClient(calls), projectName: 'demo' })
 
     const result = await tool.execute('call-1', {})
@@ -141,6 +316,42 @@ describe('buildMcpAgentTools', () => {
       (t) => t.access === 'read' && !AERO_EXCLUDED_MCP_TOOLS.has(t.name),
     )
     expect(reads).toHaveLength(expectedReads.length)
+  })
+
+  it('respects an explicit tool-name allow-list', () => {
+    const calls: CallLog[] = []
+    const tools = buildMcpAgentTools(
+      canonryMcpTools,
+      { client: recordingClient(calls), projectName: 'demo' },
+      {
+        includeNames: new Set([
+          CanonryMcpToolNames.canonry_project_overview,
+          CanonryMcpToolNames.canonry_ads_sync,
+        ]),
+      },
+    )
+
+    expect(tools.map((t) => t.name)).toEqual([
+      CanonryMcpToolNames.canonry_project_overview,
+      CanonryMcpToolNames.canonry_ads_sync,
+    ])
+  })
+
+  it('applies readOnly after the allow-list', () => {
+    const calls: CallLog[] = []
+    const tools = buildMcpAgentTools(
+      canonryMcpTools,
+      { client: recordingClient(calls), projectName: 'demo' },
+      {
+        readOnly: true,
+        includeNames: new Set([
+          CanonryMcpToolNames.canonry_project_overview,
+          CanonryMcpToolNames.canonry_ads_sync,
+        ]),
+      },
+    )
+
+    expect(tools.map((t) => t.name)).toEqual([CanonryMcpToolNames.canonry_project_overview])
   })
 
   it('excludes Aero-blacklisted tools', () => {


### PR DESCRIPTION
## Summary
- add a typed Aero tool profile option and CLI/API prompt plumbing for `ads-operator`
- add an Aero-only `canonry_ads_operator_context` composite tool for bounded ads/operator context
- keep read-only sessions write-free while allowing selected writes in full-scope ads profile

## Validation
- `corepack pnpm exec vitest run --project canonry packages/canonry/test/agent-tools.test.ts packages/canonry/test/agent-session-registry.test.ts packages/canonry/test/agent-ask-scope.test.ts`
- `corepack pnpm run typecheck`
- `corepack pnpm --filter @ainyc/canonry-api-client gen:check`
- `corepack pnpm run test`
- `corepack pnpm run lint` (passes with existing warnings)
