### PR TITLE
fix(gsc): report property-level totals so headline clicks/impressions match Google

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -36,6 +36,7 @@ erDiagram
   projects ||--o{ gbp_place_details : has
 
   projects ||--o{ gsc_search_data : has
+  projects ||--o{ gsc_daily_totals : has
   projects ||--o{ gsc_url_inspections : has
   projects ||--o{ gsc_coverage_snapshots : has
 
@@ -76,7 +77,8 @@ erDiagram
 | Table | Purpose |
 |-------|---------|
 | **google_connections** | OAuth credentials, domain-scoped. Unique: `(domain, connectionType)` |
-| **gsc_search_data** | GSC search analytics data synced per run |
+| **gsc_search_data** | GSC search analytics data synced per run (query × page × country × device × date) |
+| **gsc_daily_totals** | GSC property-level daily totals (no query/page dimensions). Headline clicks/impressions/CTR/position + daily trend source. Unique: `(project_id, date)` |
 | **gsc_url_inspections** | URL inspection results from GSC |
 | **gsc_coverage_snapshots** | Index coverage snapshots from GSC |
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.100.1",
+  "version": "4.101.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-routes/src/google.ts
+++ b/packages/api-routes/src/google.ts
@@ -12,6 +12,7 @@ import {
 } from '@ainyc/canonry-contracts'
 import { extractPlaceAmenities, type PlaceDetails } from '@ainyc/canonry-integration-google-places'
 import { buildGbpSummary } from './gbp-summary.js'
+import { readGscDailyTotals } from './gsc-totals.js'
 import { resolveProject, writeAuditLog } from './helpers.js'
 import {
   getAuthUrl,
@@ -706,8 +707,10 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
   })
 
   // GET /projects/:name/google/gsc/performance/daily
-  // Returns one row per date with clicks + impressions summed across every
-  // (query, page, country, device) tuple in the window, plus window totals.
+  // Returns one row per date with the property-level clicks + impressions for
+  // the window, plus window totals. Sourced from the un-dimensioned daily-totals
+  // table (matches Google's property total); falls back to summing the
+  // dimensioned `gsc_search_data` rows by date for projects not yet re-synced.
   // The chart and headline metrics in the dashboard render from this — never
   // recomputed from the paged /performance rows, which only cover one page.
   app.get<{
@@ -718,29 +721,47 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
     const { startDate, endDate } = request.query
     const cutoffDate = !startDate ? windowCutoff(parseWindow(request.query.window))?.slice(0, 10) ?? null : null
 
-    const conditions = [eq(gscSearchData.projectId, project.id)]
-    if (startDate) conditions.push(sql`${gscSearchData.date} >= ${startDate}`)
-    else if (cutoffDate) conditions.push(sql`${gscSearchData.date} >= ${cutoffDate}`)
-    if (endDate) conditions.push(sql`${gscSearchData.date} <= ${endDate}`)
+    // Prefer the property-level daily totals (match Google's property total —
+    // summing the dimensioned rows over-counts impressions and under-counts
+    // clicks). Fall back to summing `gsc_search_data` by date when the project
+    // has no daily-totals rows in the window (not yet re-synced).
+    const windowStart = startDate ?? cutoffDate ?? ''
+    const windowEnd = endDate ?? '9999-12-31'
+    const dailyTotals = readGscDailyTotals(app.db, project.id, windowStart, windowEnd)
 
-    const rows = app.db
-      .select({
-        date: gscSearchData.date,
-        clicks: sql<number>`COALESCE(SUM(${gscSearchData.clicks}), 0)`,
-        impressions: sql<number>`COALESCE(SUM(${gscSearchData.impressions}), 0)`,
-      })
-      .from(gscSearchData)
-      .where(and(...conditions))
-      .groupBy(gscSearchData.date)
-      .orderBy(gscSearchData.date)
-      .all()
+    let daily: { date: string; clicks: number; impressions: number; ctr: number }[]
+    if (dailyTotals.length > 0) {
+      daily = dailyTotals.map((d) => ({
+        date: d.date,
+        clicks: d.clicks,
+        impressions: d.impressions,
+        ctr: d.impressions > 0 ? d.clicks / d.impressions : 0,
+      }))
+    } else {
+      const conditions = [eq(gscSearchData.projectId, project.id)]
+      if (startDate) conditions.push(sql`${gscSearchData.date} >= ${startDate}`)
+      else if (cutoffDate) conditions.push(sql`${gscSearchData.date} >= ${cutoffDate}`)
+      if (endDate) conditions.push(sql`${gscSearchData.date} <= ${endDate}`)
 
-    const daily = rows.map((r) => ({
-      date: r.date,
-      clicks: r.clicks,
-      impressions: r.impressions,
-      ctr: r.impressions > 0 ? r.clicks / r.impressions : 0,
-    }))
+      const rows = app.db
+        .select({
+          date: gscSearchData.date,
+          clicks: sql<number>`COALESCE(SUM(${gscSearchData.clicks}), 0)`,
+          impressions: sql<number>`COALESCE(SUM(${gscSearchData.impressions}), 0)`,
+        })
+        .from(gscSearchData)
+        .where(and(...conditions))
+        .groupBy(gscSearchData.date)
+        .orderBy(gscSearchData.date)
+        .all()
+
+      daily = rows.map((r) => ({
+        date: r.date,
+        clicks: r.clicks,
+        impressions: r.impressions,
+        ctr: r.impressions > 0 ? r.clicks / r.impressions : 0,
+      }))
+    }
     const totalClicks = daily.reduce((sum, d) => sum + d.clicks, 0)
     const totalImpressions = daily.reduce((sum, d) => sum + d.impressions, 0)
     return {

--- a/packages/api-routes/src/google.ts
+++ b/packages/api-routes/src/google.ts
@@ -12,7 +12,7 @@ import {
 } from '@ainyc/canonry-contracts'
 import { extractPlaceAmenities, type PlaceDetails } from '@ainyc/canonry-integration-google-places'
 import { buildGbpSummary } from './gbp-summary.js'
-import { readGscDailyTotals } from './gsc-totals.js'
+import { mergeGscDailyTotalsWithFallback, readGscDailyTotals } from './gsc-totals.js'
 import { resolveProject, writeAuditLog } from './helpers.js'
 import {
   getAuthUrl,
@@ -721,47 +721,45 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
     const { startDate, endDate } = request.query
     const cutoffDate = !startDate ? windowCutoff(parseWindow(request.query.window))?.slice(0, 10) ?? null : null
 
-    // Prefer the property-level daily totals (match Google's property total —
-    // summing the dimensioned rows over-counts impressions and under-counts
-    // clicks). Fall back to summing `gsc_search_data` by date when the project
-    // has no daily-totals rows in the window (not yet re-synced).
+    // Prefer the property-level daily totals on dates where they exist (match
+    // Google's property total). Fall back to summing `gsc_search_data` for
+    // missing dates so upgraded installs do not shorten longer/custom windows
+    // after their first post-migration sync.
     const windowStart = startDate ?? cutoffDate ?? ''
     const windowEnd = endDate ?? '9999-12-31'
     const dailyTotals = readGscDailyTotals(app.db, project.id, windowStart, windowEnd)
 
-    let daily: { date: string; clicks: number; impressions: number; ctr: number }[]
-    if (dailyTotals.length > 0) {
-      daily = dailyTotals.map((d) => ({
-        date: d.date,
-        clicks: d.clicks,
-        impressions: d.impressions,
-        ctr: d.impressions > 0 ? d.clicks / d.impressions : 0,
-      }))
-    } else {
-      const conditions = [eq(gscSearchData.projectId, project.id)]
-      if (startDate) conditions.push(sql`${gscSearchData.date} >= ${startDate}`)
-      else if (cutoffDate) conditions.push(sql`${gscSearchData.date} >= ${cutoffDate}`)
-      if (endDate) conditions.push(sql`${gscSearchData.date} <= ${endDate}`)
+    const conditions = [eq(gscSearchData.projectId, project.id)]
+    if (startDate) conditions.push(sql`${gscSearchData.date} >= ${startDate}`)
+    else if (cutoffDate) conditions.push(sql`${gscSearchData.date} >= ${cutoffDate}`)
+    if (endDate) conditions.push(sql`${gscSearchData.date} <= ${endDate}`)
 
-      const rows = app.db
-        .select({
-          date: gscSearchData.date,
-          clicks: sql<number>`COALESCE(SUM(${gscSearchData.clicks}), 0)`,
-          impressions: sql<number>`COALESCE(SUM(${gscSearchData.impressions}), 0)`,
-        })
-        .from(gscSearchData)
-        .where(and(...conditions))
-        .groupBy(gscSearchData.date)
-        .orderBy(gscSearchData.date)
-        .all()
+    const dimensionedRows = app.db
+      .select({
+        date: gscSearchData.date,
+        clicks: sql<number>`COALESCE(SUM(${gscSearchData.clicks}), 0)`,
+        impressions: sql<number>`COALESCE(SUM(${gscSearchData.impressions}), 0)`,
+      })
+      .from(gscSearchData)
+      .where(and(...conditions))
+      .groupBy(gscSearchData.date)
+      .orderBy(gscSearchData.date)
+      .all()
 
-      daily = rows.map((r) => ({
+    const daily = mergeGscDailyTotalsWithFallback(
+      dailyTotals,
+      dimensionedRows.map((r) => ({
         date: r.date,
         clicks: r.clicks,
         impressions: r.impressions,
-        ctr: r.impressions > 0 ? r.clicks / r.impressions : 0,
-      }))
-    }
+        position: 0,
+      })),
+    ).map((d) => ({
+      date: d.date,
+      clicks: d.clicks,
+      impressions: d.impressions,
+      ctr: d.impressions > 0 ? d.clicks / d.impressions : 0,
+    }))
     const totalClicks = daily.reduce((sum, d) => sum + d.clicks, 0)
     const totalImpressions = daily.reduce((sum, d) => sum + d.impressions, 0)
     return {

--- a/packages/api-routes/src/gsc-totals.ts
+++ b/packages/api-routes/src/gsc-totals.ts
@@ -15,10 +15,8 @@ export interface GscDailyTotal {
  *
  * These rows come from the un-dimensioned (`dimensions: ['date']`) GSC sync and
  * are the CORRECT source for the headline clicks / impressions / CTR / position
- * and the daily trend — summing the dimensioned `gsc_search_data` rows does not
- * equal Google's property total. Returns an empty array when the project has no
- * daily-totals rows in the window (callers fall back to the dimensioned sum for
- * back-compat with projects that have not re-synced).
+ * and the daily trend on dates where they exist — summing the dimensioned
+ * `gsc_search_data` rows does not equal Google's property total.
  */
 export function readGscDailyTotals(
   db: DatabaseClient,
@@ -53,4 +51,14 @@ export function readGscDailyTotals(
       position: Number.isFinite(position) ? position : 0,
     }
   })
+}
+
+export function mergeGscDailyTotalsWithFallback(
+  propertyTotals: readonly GscDailyTotal[],
+  dimensionedFallback: readonly GscDailyTotal[],
+): GscDailyTotal[] {
+  const byDate = new Map<string, GscDailyTotal>()
+  for (const row of dimensionedFallback) byDate.set(row.date, row)
+  for (const row of propertyTotals) byDate.set(row.date, row)
+  return [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date))
 }

--- a/packages/api-routes/src/gsc-totals.ts
+++ b/packages/api-routes/src/gsc-totals.ts
@@ -1,0 +1,56 @@
+import { and, asc, eq, sql } from 'drizzle-orm'
+import { gscDailyTotals } from '@ainyc/canonry-db'
+import type { DatabaseClient } from '@ainyc/canonry-db'
+
+export interface GscDailyTotal {
+  date: string
+  clicks: number
+  impressions: number
+  position: number
+}
+
+/**
+ * Read the property-level daily GSC totals for a project over an inclusive
+ * `[startDate, endDate]` window, ordered by date ascending.
+ *
+ * These rows come from the un-dimensioned (`dimensions: ['date']`) GSC sync and
+ * are the CORRECT source for the headline clicks / impressions / CTR / position
+ * and the daily trend — summing the dimensioned `gsc_search_data` rows does not
+ * equal Google's property total. Returns an empty array when the project has no
+ * daily-totals rows in the window (callers fall back to the dimensioned sum for
+ * back-compat with projects that have not re-synced).
+ */
+export function readGscDailyTotals(
+  db: DatabaseClient,
+  projectId: string,
+  startDate: string,
+  endDate: string,
+): GscDailyTotal[] {
+  const rows = db
+    .select({
+      date: gscDailyTotals.date,
+      clicks: gscDailyTotals.clicks,
+      impressions: gscDailyTotals.impressions,
+      position: gscDailyTotals.position,
+    })
+    .from(gscDailyTotals)
+    .where(
+      and(
+        eq(gscDailyTotals.projectId, projectId),
+        sql`${gscDailyTotals.date} >= ${startDate}`,
+        sql`${gscDailyTotals.date} <= ${endDate}`,
+      ),
+    )
+    .orderBy(asc(gscDailyTotals.date))
+    .all()
+
+  return rows.map((r) => {
+    const position = Number(r.position)
+    return {
+      date: r.date,
+      clicks: r.clicks,
+      impressions: r.impressions,
+      position: Number.isFinite(position) ? position : 0,
+    }
+  })
+}

--- a/packages/api-routes/src/report.ts
+++ b/packages/api-routes/src/report.ts
@@ -65,7 +65,7 @@ import {
   smoothedRunDelta,
 } from '@ainyc/canonry-intelligence'
 import { loadDismissedTargetRefs } from './content.js'
-import { readGscDailyTotals } from './gsc-totals.js'
+import { mergeGscDailyTotalsWithFallback, readGscDailyTotals } from './gsc-totals.js'
 import { notProbeRun, resolveProject } from './helpers.js'
 import { renderReportHtml } from './report-renderer.js'
 import {
@@ -191,7 +191,7 @@ function buildGscSection(
   windowDays: number,
 ): ProjectReportDto['gsc'] {
   const allRows = db.select().from(gscSearchData).where(eq(gscSearchData.projectId, projectId)).all()
-  if (allRows.length === 0) return null
+  const allDailyTotals = readGscDailyTotals(db, projectId, '', '9999-12-31')
 
   // Constrain to the most recent `windowDays` of data so the GSC section
   // aligns with the GA section. GSC retains up to 16 months, but the report
@@ -200,16 +200,21 @@ function buildGscSection(
   // report should still cover a full window of real data.
   let maxDate = ''
   for (const r of allRows) if (r.date > maxDate) maxDate = r.date
+  for (const r of allDailyTotals) if (r.date > maxDate) maxDate = r.date
+  if (!maxDate) return null
+
   const startDate = windowStartDate(maxDate, windowDays)
   const rows = allRows.filter(r => r.date >= startDate && r.date <= maxDate)
-  if (rows.length === 0) return null
+  const dailyTotals = allDailyTotals.filter(r => r.date >= startDate && r.date <= maxDate)
+  if (rows.length === 0 && dailyTotals.length === 0) return null
 
   // Per-query / per-page aggregation stays on the dimensioned rows — these
-  // breakdowns are correct from `gsc_search_data`. Only the grand TOTALS and
-  // the daily trend move to the property-level table below.
+  // breakdowns are correct from `gsc_search_data`. The grand totals and daily
+  // trend prefer property-level rows per date, falling back to dimensioned rows
+  // for dates not yet covered by the new table.
   let dimensionedClicks = 0
   const queryAgg = new Map<string, { clicks: number; impressions: number; weightedPositionSum: number }>()
-  const dimensionedTrendAgg = new Map<string, { clicks: number; impressions: number }>()
+  const dimensionedTrendAgg = new Map<string, { clicks: number; impressions: number; weightedPositionSum: number }>()
 
   for (const r of rows) {
     dimensionedClicks += r.clicks
@@ -219,38 +224,32 @@ function buildGscSection(
     q.weightedPositionSum += safeNum(r.position) * r.impressions
     queryAgg.set(r.query, q)
 
-    const t = dimensionedTrendAgg.get(r.date) ?? { clicks: 0, impressions: 0 }
+    const t = dimensionedTrendAgg.get(r.date) ?? { clicks: 0, impressions: 0, weightedPositionSum: 0 }
     t.clicks += r.clicks
     t.impressions += r.impressions
+    t.weightedPositionSum += safeNum(r.position) * r.impressions
     dimensionedTrendAgg.set(r.date, t)
   }
 
-  // Property-level totals + daily trend. Prefer the un-dimensioned daily-totals
-  // table (matches Google's property total — summing the dimensioned rows
-  // over-counts impressions and under-counts clicks). Fall back to the
-  // dimensioned sums when the project has not re-synced (no daily-totals rows).
-  const dailyTotals = readGscDailyTotals(db, projectId, startDate, maxDate)
+  const dailySeries = mergeGscDailyTotalsWithFallback(
+    dailyTotals,
+    [...dimensionedTrendAgg.entries()].map(([date, agg]) => ({
+      date,
+      clicks: agg.clicks,
+      impressions: agg.impressions,
+      position: agg.impressions > 0 ? agg.weightedPositionSum / agg.impressions : 0,
+    })),
+  )
+
   let totalClicks = 0
   let totalImpressions = 0
   let weightedPositionSum = 0
-  let trend: { date: string; clicks: number; impressions: number }[]
-  if (dailyTotals.length > 0) {
-    for (const d of dailyTotals) {
-      totalClicks += d.clicks
-      totalImpressions += d.impressions
-      weightedPositionSum += d.position * d.impressions
-    }
-    trend = dailyTotals.map(d => ({ date: d.date, clicks: d.clicks, impressions: d.impressions }))
-  } else {
-    for (const r of rows) {
-      totalClicks += r.clicks
-      totalImpressions += r.impressions
-      weightedPositionSum += safeNum(r.position) * r.impressions
-    }
-    trend = [...dimensionedTrendAgg.entries()]
-      .map(([date, agg]) => ({ date, clicks: agg.clicks, impressions: agg.impressions }))
-      .sort((a, b) => a.date.localeCompare(b.date))
+  for (const d of dailySeries) {
+    totalClicks += d.clicks
+    totalImpressions += d.impressions
+    weightedPositionSum += d.position * d.impressions
   }
+  const trend = dailySeries.map(d => ({ date: d.date, clicks: d.clicks, impressions: d.impressions }))
 
   const ctr = totalImpressions > 0 ? totalClicks / totalImpressions : 0
   const avgPosition = totalImpressions > 0 ? weightedPositionSum / totalImpressions : 0

--- a/packages/api-routes/src/report.ts
+++ b/packages/api-routes/src/report.ts
@@ -65,6 +65,7 @@ import {
   smoothedRunDelta,
 } from '@ainyc/canonry-intelligence'
 import { loadDismissedTargetRefs } from './content.js'
+import { readGscDailyTotals } from './gsc-totals.js'
 import { notProbeRun, resolveProject } from './helpers.js'
 import { renderReportHtml } from './report-renderer.js'
 import {
@@ -203,26 +204,52 @@ function buildGscSection(
   const rows = allRows.filter(r => r.date >= startDate && r.date <= maxDate)
   if (rows.length === 0) return null
 
-  let totalClicks = 0
-  let totalImpressions = 0
-  let weightedPositionSum = 0
+  // Per-query / per-page aggregation stays on the dimensioned rows — these
+  // breakdowns are correct from `gsc_search_data`. Only the grand TOTALS and
+  // the daily trend move to the property-level table below.
+  let dimensionedClicks = 0
   const queryAgg = new Map<string, { clicks: number; impressions: number; weightedPositionSum: number }>()
-  const trendAgg = new Map<string, { clicks: number; impressions: number }>()
+  const dimensionedTrendAgg = new Map<string, { clicks: number; impressions: number }>()
 
   for (const r of rows) {
-    totalClicks += r.clicks
-    totalImpressions += r.impressions
-    weightedPositionSum += safeNum(r.position) * r.impressions
+    dimensionedClicks += r.clicks
     const q = queryAgg.get(r.query) ?? { clicks: 0, impressions: 0, weightedPositionSum: 0 }
     q.clicks += r.clicks
     q.impressions += r.impressions
     q.weightedPositionSum += safeNum(r.position) * r.impressions
     queryAgg.set(r.query, q)
 
-    const t = trendAgg.get(r.date) ?? { clicks: 0, impressions: 0 }
+    const t = dimensionedTrendAgg.get(r.date) ?? { clicks: 0, impressions: 0 }
     t.clicks += r.clicks
     t.impressions += r.impressions
-    trendAgg.set(r.date, t)
+    dimensionedTrendAgg.set(r.date, t)
+  }
+
+  // Property-level totals + daily trend. Prefer the un-dimensioned daily-totals
+  // table (matches Google's property total — summing the dimensioned rows
+  // over-counts impressions and under-counts clicks). Fall back to the
+  // dimensioned sums when the project has not re-synced (no daily-totals rows).
+  const dailyTotals = readGscDailyTotals(db, projectId, startDate, maxDate)
+  let totalClicks = 0
+  let totalImpressions = 0
+  let weightedPositionSum = 0
+  let trend: { date: string; clicks: number; impressions: number }[]
+  if (dailyTotals.length > 0) {
+    for (const d of dailyTotals) {
+      totalClicks += d.clicks
+      totalImpressions += d.impressions
+      weightedPositionSum += d.position * d.impressions
+    }
+    trend = dailyTotals.map(d => ({ date: d.date, clicks: d.clicks, impressions: d.impressions }))
+  } else {
+    for (const r of rows) {
+      totalClicks += r.clicks
+      totalImpressions += r.impressions
+      weightedPositionSum += safeNum(r.position) * r.impressions
+    }
+    trend = [...dimensionedTrendAgg.entries()]
+      .map(([date, agg]) => ({ date, clicks: agg.clicks, impressions: agg.impressions }))
+      .sort((a, b) => a.date.localeCompare(b.date))
   }
 
   const ctr = totalImpressions > 0 ? totalClicks / totalImpressions : 0
@@ -248,16 +275,16 @@ function buildGscSection(
     bucket.impressions += agg.impressions
     categoryAgg.set(cat, bucket)
   }
+  // Share is computed against the dimensioned click sum (the same source the
+  // per-category clicks come from) so the category shares stay internally
+  // consistent — the property total above is a different denominator.
   const categoryBreakdown = [...categoryAgg.entries()].map(([category, agg]) => ({
     category,
     clicks: agg.clicks,
     impressions: agg.impressions,
-    sharePct: totalClicks > 0 ? Math.round((agg.clicks / totalClicks) * 100) : 0,
+    sharePct: dimensionedClicks > 0 ? Math.round((agg.clicks / dimensionedClicks) * 100) : 0,
   })).sort((a, b) => b.clicks - a.clicks)
 
-  const trend = [...trendAgg.entries()]
-    .map(([date, agg]) => ({ date, clicks: agg.clicks, impressions: agg.impressions }))
-    .sort((a, b) => a.date.localeCompare(b.date))
   const periodStart = trend[0]?.date ?? ''
   const periodEnd = trend.at(-1)?.date ?? ''
 

--- a/packages/api-routes/test/db-dto-coverage.test.ts
+++ b/packages/api-routes/test/db-dto-coverage.test.ts
@@ -317,6 +317,10 @@ const COVERAGE: Record<string, CoverageEntry> = {
       createdAt: 'Row creation timestamp.',
     },
   },
+  gscDailyTotals: {
+    kind: 'internal-only',
+    reason: 'Property-level daily GSC totals (no query/page dims). Backing store for the report `gsc` headline/trend + the gsc performance/daily response; not exposed as a direct row DTO.',
+  },
   gscUrlInspections: {
     kind: 'dto',
     dto: gscUrlInspectionDtoSchema,

--- a/packages/api-routes/test/export-roundtrip.test.ts
+++ b/packages/api-routes/test/export-roundtrip.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { test, expect } from 'vitest'
 import Fastify from 'fastify'
-import { createClient, migrate } from '@ainyc/canonry-db'
+import { createClient, gscDailyTotals, migrate } from '@ainyc/canonry-db'
 import { apiRoutes } from '../src/index.js'
 
 function buildApp(opts?: { onProjectDeleted?: (projectId: string) => void }) {
@@ -15,7 +15,7 @@ function buildApp(opts?: { onProjectDeleted?: (projectId: string) => void }) {
   const app = Fastify()
   app.register(apiRoutes, { db, skipAuth: true, onProjectDeleted: opts?.onProjectDeleted })
 
-  return { app, tmpDir }
+  return { app, db, tmpDir }
 }
 
 test('project export includes schedule and notifications for round-tripping', async () => {
@@ -113,6 +113,46 @@ test('project delete invokes onProjectDeleted callback', async () => {
 
     expect(deleteRes.statusCode).toBe(204)
     expect(deletedProjectIds).toEqual([created.id])
+  } finally {
+    await app.close()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('project delete cascades gsc daily totals', async () => {
+  const { app, db, tmpDir } = buildApp()
+  await app.ready()
+
+  try {
+    const createRes = await app.inject({
+      method: 'PUT',
+      url: '/api/v1/projects/to-delete-gsc-totals',
+      payload: {
+        displayName: 'Delete GSC Totals',
+        canonicalDomain: 'example.com',
+        country: 'US',
+        language: 'en',
+      },
+    })
+    const created = JSON.parse(createRes.body) as { id: string }
+
+    db.insert(gscDailyTotals).values({
+      id: 'gsc-total-delete-test',
+      projectId: created.id,
+      date: '2026-04-30',
+      clicks: 12,
+      impressions: 500,
+      position: '9',
+      createdAt: new Date().toISOString(),
+    }).run()
+
+    const deleteRes = await app.inject({
+      method: 'DELETE',
+      url: '/api/v1/projects/to-delete-gsc-totals',
+    })
+
+    expect(deleteRes.statusCode).toBe(204)
+    expect(db.select().from(gscDailyTotals).all()).toEqual([])
   } finally {
     await app.close()
     fs.rmSync(tmpDir, { recursive: true, force: true })

--- a/packages/api-routes/test/google.test.ts
+++ b/packages/api-routes/test/google.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
 import Fastify from 'fastify'
-import { createClient, migrate, projects, runs, gscCoverageSnapshots, gscUrlInspections, gscSearchData } from '@ainyc/canonry-db'
+import { createClient, migrate, projects, runs, gscCoverageSnapshots, gscUrlInspections, gscSearchData, gscDailyTotals } from '@ainyc/canonry-db'
 import { AppError } from '@ainyc/canonry-contracts'
 import { googleRoutes } from '../src/google.js'
 
@@ -1515,5 +1515,47 @@ describe('googleRoutes: GET /projects/:name/google/gsc/performance/daily', () =>
       url: '/projects/nope/google/gsc/performance/daily',
     })
     expect(res.statusCode).toBe(404)
+  })
+
+  it('sources the daily series from gsc_daily_totals (property total), not the summed dimensioned rows', async () => {
+    // The seeded gsc_search_data sums to 20 clicks / 1350 impressions. Seed
+    // property-level daily totals for the same two dates with DIFFERENT figures
+    // and assert the endpoint returns those, proving it reads gsc_daily_totals.
+    const now = '2026-01-01T00:00:00.000Z'
+    context.db.insert(gscDailyTotals).values([
+      { id: crypto.randomUUID(), projectId, date: '2026-01-05', clicks: 25, impressions: 300, position: '4', createdAt: now },
+      { id: crypto.randomUUID(), projectId, date: '2026-01-06', clicks: 31, impressions: 900, position: '6', createdAt: now },
+    ]).run()
+
+    const res = await context.app.inject({
+      method: 'GET',
+      url: '/projects/perf/google/gsc/performance/daily',
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as { totals: { clicks: number; impressions: number; ctr: number; days: number }; daily: Array<{ date: string; clicks: number; impressions: number; ctr: number }> }
+
+    // Property totals — NOT the dimensioned sum (20 / 1350).
+    expect(body.daily).toEqual([
+      { date: '2026-01-05', clicks: 25, impressions: 300, ctr: 25 / 300 },
+      { date: '2026-01-06', clicks: 31, impressions: 900, ctr: 31 / 900 },
+    ])
+    expect(body.totals).toEqual({ clicks: 56, impressions: 1200, ctr: 56 / 1200, days: 2 })
+  })
+
+  it('falls back to summing gsc_search_data by date when no gsc_daily_totals rows exist in the window', async () => {
+    // No gsc_daily_totals seeded (only the dimensioned gsc_search_data from
+    // beforeEach), so the endpoint falls back to the per-date dimensioned sum.
+    const res = await context.app.inject({
+      method: 'GET',
+      url: '/projects/perf/google/gsc/performance/daily',
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as { totals: { clicks: number; impressions: number; ctr: number; days: number }; daily: Array<{ date: string; clicks: number; impressions: number; ctr: number }> }
+
+    expect(body.daily).toEqual([
+      { date: '2026-01-05', clicks: 10, impressions: 350, ctr: 10 / 350 },
+      { date: '2026-01-06', clicks: 10, impressions: 1000, ctr: 0.01 },
+    ])
+    expect(body.totals).toEqual({ clicks: 20, impressions: 1350, ctr: 20 / 1350, days: 2 })
   })
 })

--- a/packages/api-routes/test/google.test.ts
+++ b/packages/api-routes/test/google.test.ts
@@ -1558,4 +1558,53 @@ describe('googleRoutes: GET /projects/:name/google/gsc/performance/daily', () =>
     ])
     expect(body.totals).toEqual({ clicks: 20, impressions: 1350, ctr: 20 / 1350, days: 2 })
   })
+
+  it('uses daily totals per date without dropping dimensioned fallback dates from the same window', async () => {
+    const now = '2026-01-01T00:00:00.000Z'
+    context.db.insert(gscDailyTotals).values({
+      id: crypto.randomUUID(),
+      projectId,
+      date: '2026-01-06',
+      clicks: 31,
+      impressions: 900,
+      position: '6',
+      createdAt: now,
+    }).run()
+
+    const res = await context.app.inject({
+      method: 'GET',
+      url: '/projects/perf/google/gsc/performance/daily',
+    })
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as { totals: { clicks: number; impressions: number; ctr: number; days: number }; daily: Array<{ date: string; clicks: number; impressions: number; ctr: number }> }
+
+    expect(body.daily).toEqual([
+      { date: '2026-01-05', clicks: 10, impressions: 350, ctr: 10 / 350 },
+      { date: '2026-01-06', clicks: 31, impressions: 900, ctr: 31 / 900 },
+    ])
+    expect(body.totals).toEqual({ clicks: 41, impressions: 1250, ctr: 41 / 1250, days: 2 })
+  })
+
+  it('can return date-only daily totals when no dimensioned rows exist for the window', async () => {
+    const now = '2026-01-01T00:00:00.000Z'
+    context.db.insert(gscDailyTotals).values({
+      id: crypto.randomUUID(),
+      projectId,
+      date: '2026-02-01',
+      clicks: 12,
+      impressions: 500,
+      position: '9',
+      createdAt: now,
+    }).run()
+
+    const res = await context.app.inject({
+      method: 'GET',
+      url: '/projects/perf/google/gsc/performance/daily?startDate=2026-02-01&endDate=2026-02-01',
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({
+      totals: { clicks: 12, impressions: 500, ctr: 12 / 500, days: 1 },
+      daily: [{ date: '2026-02-01', clicks: 12, impressions: 500, ctr: 12 / 500 }],
+    })
+  })
 })

--- a/packages/api-routes/test/report.test.ts
+++ b/packages/api-routes/test/report.test.ts
@@ -611,6 +611,71 @@ describe('GET /api/v1/projects/:name/report', () => {
     expect(body.executiveSummary.gsc).toMatchObject({ clicks: 720, impressions: 46_325 })
   })
 
+  test('GSC headline totals merge daily totals with dimensioned fallback dates when coverage is partial', async () => {
+    const projectId = insertProject(ctx.db, 'gsc-partial-totals')
+    const syncRunId = insertRun(ctx.db, projectId, { kind: 'gsc-sync' })
+
+    ctx.db.insert(gscSearchData).values([
+      {
+        id: crypto.randomUUID(), projectId, syncRunId,
+        date: '2026-04-01', query: 'gsc-partial-totals brand',
+        page: 'https://gsc-partial-totals.example.com/a',
+        clicks: 400, impressions: 25_000, ctr: '0.016', position: '4',
+        createdAt: new Date().toISOString(),
+      },
+      {
+        id: crypto.randomUUID(), projectId, syncRunId,
+        date: '2026-04-30', query: 'industrial coatings',
+        page: 'https://gsc-partial-totals.example.com/b',
+        clicks: 320, impressions: 21_325, ctr: '0.015', position: '6',
+        createdAt: new Date().toISOString(),
+      },
+    ]).run()
+    ctx.db.insert(gscDailyTotals).values({
+      id: crypto.randomUUID(), projectId,
+      date: '2026-04-30', clicks: 482, impressions: 20_000, position: '6',
+      createdAt: new Date().toISOString(),
+    }).run()
+
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/gsc-partial-totals/report' })
+    const body = JSON.parse(res.body) as ProjectReportDto
+
+    expect(body.gsc).not.toBeNull()
+    expect(body.gsc!.periodStart).toBe('2026-04-01')
+    expect(body.gsc!.periodEnd).toBe('2026-04-30')
+    expect(body.gsc!.totalClicks).toBe(882)
+    expect(body.gsc!.totalImpressions).toBe(45_000)
+    expect(body.gsc!.trend).toEqual([
+      { date: '2026-04-01', clicks: 400, impressions: 25_000 },
+      { date: '2026-04-30', clicks: 482, impressions: 20_000 },
+    ])
+  })
+
+  test('GSC report can render property totals even when query/page rows are all anonymized away', async () => {
+    const projectId = insertProject(ctx.db, 'gsc-date-only')
+
+    ctx.db.insert(gscDailyTotals).values({
+      id: crypto.randomUUID(), projectId,
+      date: '2026-04-30', clicks: 12, impressions: 500, position: '9',
+      createdAt: new Date().toISOString(),
+    }).run()
+
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/gsc-date-only/report' })
+    const body = JSON.parse(res.body) as ProjectReportDto
+
+    expect(body.gsc).not.toBeNull()
+    expect(body.gsc!.periodStart).toBe('2026-04-30')
+    expect(body.gsc!.periodEnd).toBe('2026-04-30')
+    expect(body.gsc!.totalClicks).toBe(12)
+    expect(body.gsc!.totalImpressions).toBe(500)
+    expect(body.gsc!.avgPosition).toBe(9)
+    expect(body.gsc!.topQueries).toEqual([])
+    expect(body.gsc!.categoryBreakdown).toEqual([])
+    expect(body.executiveSummary.gsc).toMatchObject({ clicks: 12, impressions: 500 })
+  })
+
   test('GSC section trims to the most recent 30 days when older history is present', async () => {
     // GSC retains up to 16 months. The report only ever shows 30 days so it
     // stays aligned with the GA window. Older rows must be excluded from the

--- a/packages/api-routes/test/report.test.ts
+++ b/packages/api-routes/test/report.test.ts
@@ -14,6 +14,7 @@ import {
   querySnapshots,
   insights,
   gscSearchData,
+  gscDailyTotals,
   gscCoverageSnapshots,
   gaTrafficSnapshots,
   gaTrafficSummaries,
@@ -494,6 +495,120 @@ describe('GET /api/v1/projects/:name/report', () => {
       periodStart: '2026-04-01',
       periodEnd: '2026-04-30',
     })
+  })
+
+  test('GSC headline totals come from gsc_daily_totals (property total), not the summed dimensioned rows', async () => {
+    // The dimensioned `gsc_search_data` rows sum to 46,325 impressions / 720
+    // clicks (the page dimension over-counts impressions, dropped anonymized
+    // rare queries under-count clicks). The property total from GSC's UI is
+    // 37,100 / 982. When daily-totals rows are present, the headline must use
+    // them — NOT the summed dimensioned values.
+    const projectId = insertProject(ctx.db, 'gsc-property-total')
+    const syncRunId = insertRun(ctx.db, projectId, { kind: 'gsc-sync' })
+
+    // Dimensioned rows: two queries across two dates summing to 46,325 / 720.
+    ctx.db.insert(gscSearchData).values([
+      {
+        id: crypto.randomUUID(), projectId, syncRunId,
+        date: '2026-04-01', query: 'gsc-property-total brand',
+        page: 'https://gsc-property-total.example.com/a',
+        clicks: 400, impressions: 25_000, ctr: '0.016', position: '4',
+        createdAt: new Date().toISOString(),
+      },
+      {
+        id: crypto.randomUUID(), projectId, syncRunId,
+        date: '2026-04-30', query: 'industrial coatings',
+        page: 'https://gsc-property-total.example.com/b',
+        clicks: 320, impressions: 21_325, ctr: '0.015', position: '6',
+        createdAt: new Date().toISOString(),
+      },
+    ]).run()
+
+    // Property-level daily totals for the SAME window: 37,100 / 982.
+    ctx.db.insert(gscDailyTotals).values([
+      {
+        id: crypto.randomUUID(), projectId,
+        date: '2026-04-01', clicks: 500, impressions: 17_100, position: '4',
+        createdAt: new Date().toISOString(),
+      },
+      {
+        id: crypto.randomUUID(), projectId,
+        date: '2026-04-30', clicks: 482, impressions: 20_000, position: '6',
+        createdAt: new Date().toISOString(),
+      },
+    ]).run()
+
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/gsc-property-total/report' })
+    const body = JSON.parse(res.body) as ProjectReportDto
+
+    expect(body.gsc).not.toBeNull()
+    // Property total — NOT the dimensioned sum (46325 / 720).
+    expect(body.gsc!.totalImpressions).toBe(37_100)
+    expect(body.gsc!.totalClicks).toBe(982)
+    // CTR derived from the property totals.
+    expect(body.gsc!.ctr).toBeCloseTo(982 / 37_100, 10)
+    // Impression-weighted avg position from the daily rows:
+    // (4*17100 + 6*20000) / 37100.
+    expect(body.gsc!.avgPosition).toBeCloseTo((4 * 17_100 + 6 * 20_000) / 37_100, 10)
+    // Trend built from the daily totals.
+    expect(body.gsc!.trend).toEqual([
+      { date: '2026-04-01', clicks: 500, impressions: 17_100 },
+      { date: '2026-04-30', clicks: 482, impressions: 20_000 },
+    ])
+    // topQueries still come from gsc_search_data (the per-query breakdown).
+    expect(body.gsc!.topQueries.map(q => q.query).sort()).toEqual([
+      'gsc-property-total brand',
+      'industrial coatings',
+    ])
+    // executiveSummary mirrors the corrected property totals.
+    expect(body.executiveSummary.gsc).toMatchObject({ clicks: 982, impressions: 37_100 })
+  })
+
+  test('GSC headline totals fall back to the summed dimensioned rows when no gsc_daily_totals exist', async () => {
+    // Back-compat: a project that has not re-synced has no daily-totals rows,
+    // so the headline falls back to summing gsc_search_data (46,325 / 720).
+    const projectId = insertProject(ctx.db, 'gsc-fallback')
+    const syncRunId = insertRun(ctx.db, projectId, { kind: 'gsc-sync' })
+
+    ctx.db.insert(gscSearchData).values([
+      {
+        id: crypto.randomUUID(), projectId, syncRunId,
+        date: '2026-04-01', query: 'gsc-fallback brand',
+        page: 'https://gsc-fallback.example.com/a',
+        clicks: 400, impressions: 25_000, ctr: '0.016', position: '4',
+        createdAt: new Date().toISOString(),
+      },
+      {
+        id: crypto.randomUUID(), projectId, syncRunId,
+        date: '2026-04-30', query: 'industrial coatings',
+        page: 'https://gsc-fallback.example.com/b',
+        clicks: 320, impressions: 21_325, ctr: '0.015', position: '6',
+        createdAt: new Date().toISOString(),
+      },
+    ]).run()
+    // No gscDailyTotals rows seeded.
+
+    await ctx.app.ready()
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/projects/gsc-fallback/report' })
+    const body = JSON.parse(res.body) as ProjectReportDto
+
+    expect(body.gsc).not.toBeNull()
+    // Dimensioned sum (fallback): 46,325 impressions / 720 clicks.
+    expect(body.gsc!.totalImpressions).toBe(46_325)
+    expect(body.gsc!.totalClicks).toBe(720)
+    expect(body.gsc!.ctr).toBeCloseTo(720 / 46_325, 10)
+    // Trend falls back to the per-date dimensioned sum.
+    expect(body.gsc!.trend).toEqual([
+      { date: '2026-04-01', clicks: 400, impressions: 25_000 },
+      { date: '2026-04-30', clicks: 320, impressions: 21_325 },
+    ])
+    // topQueries still come from gsc_search_data.
+    expect(body.gsc!.topQueries.map(q => q.query).sort()).toEqual([
+      'gsc-fallback brand',
+      'industrial coatings',
+    ])
+    expect(body.executiveSummary.gsc).toMatchObject({ clicks: 720, impressions: 46_325 })
   })
 
   test('GSC section trims to the most recent 30 days when older history is present', async () => {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ainyc/canonry",
-  "version": "4.100.1",
+  "version": "4.101.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/gsc-sync.ts
+++ b/packages/canonry/src/gsc-sync.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto'
 import { eq, and, sql } from 'drizzle-orm'
 import type { DatabaseClient } from '@ainyc/canonry-db'
-import { runs, projects, gscSearchData, gscUrlInspections, gscCoverageSnapshots } from '@ainyc/canonry-db'
+import { runs, projects, gscSearchData, gscDailyTotals, gscUrlInspections, gscCoverageSnapshots } from '@ainyc/canonry-db'
 import {
   fetchSearchAnalytics,
   inspectUrl,
@@ -131,6 +131,45 @@ export async function executeGscSync(
         }).run()
       }
     }
+
+    // Property-level daily totals (no query/page dimensions). Summing the
+    // dimensioned rows above does NOT equal Google's property total: the `page`
+    // dimension over-counts impressions and the dropped anonymized rare queries
+    // under-count clicks. Fetch the un-dimensioned daily figure so the headline
+    // totals + daily trend match the GSC UI. Shares the main fetch's try block —
+    // a failure fails the sync, which is acceptable because the dimensioned data
+    // is already persisted and a re-sync recovers the totals.
+    const totalRows = await fetchSearchAnalytics(accessToken, propertyId, {
+      startDate,
+      endDate,
+      dimensions: ['date'],
+    })
+
+    db.delete(gscDailyTotals)
+      .where(
+        and(
+          eq(gscDailyTotals.projectId, projectId),
+          sql`${gscDailyTotals.date} >= ${startDate}`,
+          sql`${gscDailyTotals.date} <= ${endDate}`,
+        )
+      )
+      .run()
+
+    const dailyTotalsNow = new Date().toISOString()
+    for (const row of totalRows) {
+      const [date] = row.keys
+      db.insert(gscDailyTotals).values({
+        id: crypto.randomUUID(),
+        projectId,
+        date: date ?? '',
+        clicks: row.clicks,
+        impressions: row.impressions,
+        position: String(row.position),
+        createdAt: dailyTotalsNow,
+      }).run()
+    }
+
+    log.info('daily-totals.complete', { runId, projectId, rowCount: totalRows.length })
 
     // URL inspections — inspect top pages from the fetched data
     // Aggregate clicks per page, take top N

--- a/packages/canonry/test/gsc-sync-daily-totals.test.ts
+++ b/packages/canonry/test/gsc-sync-daily-totals.test.ts
@@ -1,0 +1,212 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { asc, eq } from 'drizzle-orm'
+import {
+  createClient,
+  migrate,
+  projects,
+  runs,
+  gscSearchData,
+  gscDailyTotals,
+} from '@ainyc/canonry-db'
+import type { CanonryConfig } from '../src/config.js'
+
+// --- mock the integration HTTP clients (no network in unit tests) ---
+const fetchSearchAnalyticsMock = vi.fn()
+const inspectUrlMock = vi.fn()
+const refreshAccessTokenMock = vi.fn()
+
+vi.mock('@ainyc/canonry-integration-google', async () => {
+  const actual = await vi.importActual<typeof import('@ainyc/canonry-integration-google')>(
+    '@ainyc/canonry-integration-google',
+  )
+  return {
+    ...actual,
+    fetchSearchAnalytics: (...a: unknown[]) => fetchSearchAnalyticsMock(...a),
+    inspectUrl: (...a: unknown[]) => inspectUrlMock(...a),
+    refreshAccessToken: (...a: unknown[]) => refreshAccessTokenMock(...a),
+  }
+})
+
+// Imported AFTER the mock is registered so the module picks up the mocked deps.
+const { executeGscSync } = await import('../src/gsc-sync.js')
+
+const DOMAIN = 'gjelina.example.com'
+const PROPERTY = 'sc-domain:gjelina.example.com'
+
+/** YYYY-MM-DD for `n` days before now — used so seeded dates land inside the
+ * sync window (`daysAgo(lag+1)` .. `daysAgo(lag+days)`, lag=3, days=30). */
+function daysAgo(n: number): string {
+  const d = new Date()
+  d.setDate(d.getDate() - n)
+  return d.toISOString().slice(0, 10)
+}
+
+function createTempDb() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-gsc-sync-test-'))
+  const db = createClient(path.join(tmpDir, 'test.db'))
+  migrate(db)
+  return { db, tmpDir }
+}
+
+function seedProject(db: ReturnType<typeof createClient>) {
+  const now = new Date().toISOString()
+  db.insert(projects).values({
+    id: 'proj_gsc',
+    name: 'gjelina',
+    displayName: 'Gjelina',
+    canonicalDomain: DOMAIN,
+    country: 'US',
+    language: 'en',
+    createdAt: now,
+    updatedAt: now,
+  }).run()
+}
+
+function seedRun(db: ReturnType<typeof createClient>, runId: string) {
+  db.insert(runs).values({
+    id: runId,
+    projectId: 'proj_gsc',
+    kind: 'gsc-sync',
+    status: 'queued',
+    trigger: 'manual',
+    createdAt: new Date().toISOString(),
+  }).run()
+}
+
+function testConfig(): CanonryConfig {
+  return {
+    google: {
+      clientId: 'cid',
+      clientSecret: 'csec',
+      connections: [
+        {
+          domain: DOMAIN,
+          connectionType: 'gsc',
+          accessToken: 'tok',
+          refreshToken: 'rt',
+          // Far-future expiry so the refresh branch (and saveConfigPatch) is skipped.
+          tokenExpiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+          propertyId: PROPERTY,
+          scopes: ['https://www.googleapis.com/auth/webmasters.readonly'],
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ],
+    },
+  } as unknown as CanonryConfig
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // No URL inspections (keeps the secondary inspection pass a no-op).
+  inspectUrlMock.mockResolvedValue({
+    inspectionResult: { indexStatusResult: { indexingState: 'INDEXING_ALLOWED' } },
+  })
+})
+
+describe('executeGscSync — gsc_daily_totals (property total)', () => {
+  test('stores property-level daily totals from the dimensions:[date] call', async () => {
+    const { db, tmpDir } = createTempDb()
+    try {
+      seedProject(db)
+      seedRun(db, 'run_1')
+
+      const earlyDate = daysAgo(20)
+      const lateDate = daysAgo(5)
+
+      // The dimensioned default call returns query×page×date rows that SUM to
+      // 46,325 impressions / 720 clicks. The dimensions:['date'] call returns
+      // the property total (37,100 / 982). The sync must store the latter in
+      // gsc_daily_totals and the former in gsc_search_data.
+      fetchSearchAnalyticsMock.mockImplementation(
+        (_token: string, _property: string, opts: { dimensions?: string[] }) => {
+          const isDateOnly = Array.isArray(opts.dimensions) && opts.dimensions.length === 1 && opts.dimensions[0] === 'date'
+          if (isDateOnly) {
+            return Promise.resolve([
+              { keys: [earlyDate], clicks: 500, impressions: 17_100, ctr: 500 / 17_100, position: 4 },
+              { keys: [lateDate], clicks: 482, impressions: 20_000, ctr: 482 / 20_000, position: 6 },
+            ])
+          }
+          // Dimensioned: query, page, country, device, date
+          return Promise.resolve([
+            { keys: ['gjelina brand', 'https://gjelina.example.com/a', 'usa', 'DESKTOP', earlyDate], clicks: 400, impressions: 25_000, ctr: 0.016, position: 4 },
+            { keys: ['venice hotel', 'https://gjelina.example.com/b', 'usa', 'MOBILE', lateDate], clicks: 320, impressions: 21_325, ctr: 0.015, position: 6 },
+          ])
+        },
+      )
+
+      await executeGscSync(db, 'run_1', 'proj_gsc', { config: testConfig() })
+
+      // The dimensions:['date'] call was made.
+      const dateOnlyCall = fetchSearchAnalyticsMock.mock.calls.find(
+        (c) => Array.isArray((c[2] as { dimensions?: string[] }).dimensions)
+          && (c[2] as { dimensions?: string[] }).dimensions!.length === 1
+          && (c[2] as { dimensions?: string[] }).dimensions![0] === 'date',
+      )
+      expect(dateOnlyCall).toBeDefined()
+
+      // gsc_daily_totals holds the property total (NOT the dimensioned sum).
+      const totals = db
+        .select()
+        .from(gscDailyTotals)
+        .where(eq(gscDailyTotals.projectId, 'proj_gsc'))
+        .orderBy(asc(gscDailyTotals.date))
+        .all()
+      expect(totals).toHaveLength(2)
+      expect(totals.map((t) => t.date)).toEqual([earlyDate, lateDate])
+      expect(totals.reduce((s, t) => s + t.impressions, 0)).toBe(37_100)
+      expect(totals.reduce((s, t) => s + t.clicks, 0)).toBe(982)
+      expect(totals[0]!.position).toBe('4')
+      expect(totals[1]!.position).toBe('6')
+
+      // gsc_search_data still holds the dimensioned rows (sum 46,325 / 720).
+      const dimensioned = db.select().from(gscSearchData).where(eq(gscSearchData.projectId, 'proj_gsc')).all()
+      expect(dimensioned).toHaveLength(2)
+      expect(dimensioned.reduce((s, r) => s + r.impressions, 0)).toBe(46_325)
+      expect(dimensioned.reduce((s, r) => s + r.clicks, 0)).toBe(720)
+
+      // Run completed.
+      const run = db.select().from(runs).where(eq(runs.id, 'run_1')).get()
+      expect(run!.status).toBe('completed')
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  test('re-sync replaces daily totals for the window (no duplicates)', async () => {
+    const { db, tmpDir } = createTempDb()
+    try {
+      seedProject(db)
+
+      const theDate = daysAgo(10)
+      fetchSearchAnalyticsMock.mockImplementation(
+        (_token: string, _property: string, opts: { dimensions?: string[] }) => {
+          const isDateOnly = Array.isArray(opts.dimensions) && opts.dimensions[0] === 'date' && opts.dimensions.length === 1
+          if (isDateOnly) {
+            return Promise.resolve([
+              { keys: [theDate], clicks: 10, impressions: 100, ctr: 0.1, position: 3 },
+            ])
+          }
+          return Promise.resolve([])
+        },
+      )
+
+      seedRun(db, 'run_a')
+      await executeGscSync(db, 'run_a', 'proj_gsc', { config: testConfig() })
+      seedRun(db, 'run_b')
+      await executeGscSync(db, 'run_b', 'proj_gsc', { config: testConfig() })
+
+      const totals = db.select().from(gscDailyTotals).where(eq(gscDailyTotals.projectId, 'proj_gsc')).all()
+      // One date in the window → exactly one row after two syncs (replace, not append).
+      expect(totals).toHaveLength(1)
+      expect(totals[0]!.date).toBe(theDate)
+      expect(totals[0]!.clicks).toBe(10)
+      expect(totals[0]!.impressions).toBe(100)
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/db/AGENTS.md
+++ b/packages/db/AGENTS.md
@@ -18,7 +18,7 @@ Drizzle ORM schema, migrations, and database client. SQLite locally (via better-
 
 - **Core domain**: projects, queries, competitors, runs, querySnapshots, auditLog
 - **Scheduling**: schedules, notifications, webhooks
-- **Integrations**: googleConnections (metadata only — credentials in config.yaml), gscData, urlInspections, gscCoverage, gscTraffic, bingConnections, bingUrlInspections, bingKeywordStats, ga4Connections (metadata only — credentials in config.yaml), ga4TrafficSnapshots, ga4AiReferrals, ga4Summaries, gaSocialReferrals
+- **Integrations**: googleConnections (metadata only — credentials in config.yaml), gscData, gscDailyTotals (property-level daily totals — headline/trend source), urlInspections, gscCoverage, gscTraffic, bingConnections, bingUrlInspections, bingKeywordStats, ga4Connections (metadata only — credentials in config.yaml), ga4TrafficSnapshots, ga4AiReferrals, ga4Summaries, gaSocialReferrals
 - **System**: apiKeys, usageCounters
 
 ## Patterns

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1905,7 +1905,7 @@ export const MIGRATION_VERSIONS: ReadonlyArray<MigrationVersion> = [
     statements: [
       `CREATE TABLE IF NOT EXISTS gsc_daily_totals (
         id           TEXT PRIMARY KEY,
-        project_id   TEXT NOT NULL,
+        project_id   TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
         date         TEXT NOT NULL,
         clicks       INTEGER NOT NULL,
         impressions  INTEGER NOT NULL,

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1899,6 +1899,23 @@ export const MIGRATION_VERSIONS: ReadonlyArray<MigrationVersion> = [
       `CREATE INDEX IF NOT EXISTS idx_agent_tool_events_status_created ON agent_tool_events(status, created_at)`,
     ],
   },
+  {
+    version: 86,
+    name: 'gsc-daily-totals',
+    statements: [
+      `CREATE TABLE IF NOT EXISTS gsc_daily_totals (
+        id           TEXT PRIMARY KEY,
+        project_id   TEXT NOT NULL,
+        date         TEXT NOT NULL,
+        clicks       INTEGER NOT NULL,
+        impressions  INTEGER NOT NULL,
+        position     TEXT NOT NULL,
+        created_at   TEXT NOT NULL
+      )`,
+      `CREATE UNIQUE INDEX IF NOT EXISTS idx_gsc_daily_totals_project_date ON gsc_daily_totals(project_id, date)`,
+      `CREATE INDEX IF NOT EXISTS idx_gsc_daily_totals_project ON gsc_daily_totals(project_id)`,
+    ],
+  },
 ]
 
 /**

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -221,6 +221,28 @@ export const gscSearchData = sqliteTable('gsc_search_data', {
   index('idx_gsc_search_run').on(table.syncRunId),
 ])
 
+// Property-level daily totals (no query/page/country/device dimensions). The
+// dimensioned `gsc_search_data` rows above OVER-count impressions (the `page`
+// dimension fans one SERP into N rows) and UNDER-count clicks (the `query`
+// dimension drops Google's anonymized rare queries), so summing them does not
+// equal Google's property total. This table stores the un-dimensioned daily
+// figure (`dimensions: ['date']`) so the headline totals + daily trend match
+// the GSC UI. Per-query / per-page breakdowns still read `gsc_search_data`.
+export const gscDailyTotals = sqliteTable('gsc_daily_totals', {
+  id: text('id').primaryKey(),
+  projectId: text('project_id').notNull(),
+  date: text('date').notNull(),
+  clicks: integer('clicks').notNull(),
+  impressions: integer('impressions').notNull(),
+  // Stored as a string like `gscSearchData.position` (parsed to a number on
+  // read). CTR is derived (clicks / impressions) and intentionally not stored.
+  position: text('position').notNull(),
+  createdAt: text('created_at').notNull(),
+}, (table) => [
+  uniqueIndex('idx_gsc_daily_totals_project_date').on(table.projectId, table.date),
+  index('idx_gsc_daily_totals_project').on(table.projectId),
+])
+
 export const gscUrlInspections = sqliteTable('gsc_url_inspections', {
   id: text('id').primaryKey(),
   projectId: text('project_id').notNull().references(() => projects.id, { onDelete: 'cascade' }),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -230,7 +230,7 @@ export const gscSearchData = sqliteTable('gsc_search_data', {
 // the GSC UI. Per-query / per-page breakdowns still read `gsc_search_data`.
 export const gscDailyTotals = sqliteTable('gsc_daily_totals', {
   id: text('id').primaryKey(),
-  projectId: text('project_id').notNull(),
+  projectId: text('project_id').notNull().references(() => projects.id, { onDelete: 'cascade' }),
   date: text('date').notNull(),
   clicks: integer('clicks').notNull(),
   impressions: integer('impressions').notNull(),


### PR DESCRIPTION
## What

The GSC headline clicks/impressions (report DTO, the `performance-daily` endpoint, and the daily trend) were computed by **summing the fully-dimensioned `gsc_search_data` rows** (query × page × country × device × date). That sum does not equal Google's property total:

- the `page` dimension fans out impressions (one SERP showing N of your pages counts as N), so impressions **over-count**;
- the `query` dimension drops Google's anonymized rare queries (and their clicks), so clicks **under-count**.

A property whose GSC UI showed 982 clicks / 37.1K impressions reported ~720 / ~46.3K.

## Change

- New `gsc_daily_totals` table (migration **v86**): un-dimensioned daily property totals.
- `gsc-sync` fetches `dimensions: ['date']` alongside the existing dimensioned pull and range-replaces the daily totals.
- `report.ts` and the `performance-daily` endpoint now source the headline clicks/impressions/CTR/position + daily trend from the new table, with a **fallback** to the previous dimensioned sum for projects that have not re-synced.
- Per-query / per-page breakdowns (topQueries, category breakdown, content-data) still read `gsc_search_data` — only the totals move.
- No DTO field renamed, so the report SPA and HTML render the corrected values with no copy change (report parity holds). No OpenAPI/codegen change.

## Tests

- Property-total vs dimensioned-sum (exact math), the fallback path, the sync write, and a no-duplicate re-sync.
- `pnpm typecheck` / `pnpm test` / `pnpm lint` green. Version bumped 4.100.1 → 4.101.0.

## Rollout

The corrected totals appear once each project re-syncs GSC (the daily data-refresh repopulates `gsc_daily_totals`); until then the fallback keeps the prior behavior, so there is no regression on un-synced projects.