### PR TITLE
fix(web): project page finds its latest run via the project-scoped runs endpoint

### DIFF
--- a/apps/web/src/queries/run-invalidations.ts
+++ b/apps/web/src/queries/run-invalidations.ts
@@ -48,6 +48,12 @@ export function invalidateQueriesForRunKind(
   // below for the surgical per-domain invalidations.
   void queryClient.invalidateQueries({ queryKey: getApiV1RunsQueryKey({ client: heyClient }) })
   void queryClient.invalidateQueries({ queryKey: getApiV1ProjectsQueryKey({ client: heyClient }) })
+  // The project page's runs list uses the PROJECT-SCOPED runs endpoint
+  // (`getApiV1ProjectsByNameRuns`), not the global `/runs` list above, so it
+  // must be invalidated too or the page won't refresh after a run completes.
+  // `getApiV1ProjectsByNameRuns` matches only the runs sub-endpoint (there is
+  // no per-project run-detail op), so the prefix is safe (not greedy).
+  invalidateByOpPrefix(queryClient, 'getApiV1ProjectsByNameRuns')
 
   switch (kind) {
     case RunKinds['answer-visibility']:

--- a/apps/web/src/queries/use-project-dashboard.ts
+++ b/apps/web/src/queries/use-project-dashboard.ts
@@ -13,7 +13,7 @@ import {
 } from '../api.js'
 import {
   getApiV1ProjectsByNameOptions,
-  getApiV1RunsOptions,
+  getApiV1ProjectsByNameRunsOptions,
 } from '@ainyc/canonry-api-client/react-query'
 import { buildProjectCommandCenter } from '../build-dashboard.js'
 import type { ProjectData } from '../build-dashboard.js'
@@ -70,10 +70,15 @@ export function useProjectDashboard(projectName: string | null | undefined) {
     refetchOnWindowFocus: 'always',
   })
 
-  // Project-scoped runs list (still kind-filtered so the cap doesn't bite
-  // here either). We then narrow client-side to this project's runs.
+  // Project-scoped runs list. MUST be the per-project endpoint, not the global
+  // `/runs` list: that global list is capped to the most recent runs across ALL
+  // projects, so a project that has gone quiet while others keep sweeping falls
+  // off it entirely. Filtering that capped list to the project then yields an
+  // empty `latestRunIds`, and the per-query views render blank even though the
+  // project has plenty of (older) runs. The per-project endpoint always returns
+  // this project's own runs, so the latest sweep is found regardless of cadence.
   const runsQuery = useQuery({
-    ...getApiV1RunsOptions({ client: heyClient, query: { kind: 'answer-visibility' } }),
+    ...getApiV1ProjectsByNameRunsOptions({ client: heyClient, path: { name: projectName ?? '' }, query: { kind: 'answer-visibility' } }),
     enabled: !!projectName,
     staleTime: RUNS_STALE_MS,
     refetchOnWindowFocus: 'always',

--- a/apps/web/test/run-invalidations.test.ts
+++ b/apps/web/test/run-invalidations.test.ts
@@ -52,6 +52,14 @@ test('always invalidates the shared runs and projects operations', () => {
   expect(exactKeyOpIds).toContain('getApiV1Projects')
 })
 
+test('invalidates the project-scoped runs list so the project page refreshes after a run', () => {
+  // The project page reads its runs from `getApiV1ProjectsByNameRuns` (NOT the
+  // globally-capped `/runs` list), so this op must be invalidated on a run or
+  // a quiet project's page would never pick up its new sweep.
+  invalidateQueriesForRunKind(queryClient, RunKinds['answer-visibility'], 'demo')
+  expect(predicateMatches('getApiV1ProjectsByNameRuns')).toBe(true)
+})
+
 test('invalidates GSC operations for gsc-sync runs', () => {
   invalidateQueriesForRunKind(queryClient, RunKinds['gsc-sync'], 'demo')
   expect(predicateMatches('getApiV1ProjectsByNameGoogleGscCoverage')).toBe(true)


### PR DESCRIPTION
## What
The project page derived the project's latest answer-visibility run by filtering the **global** `/runs?kind=answer-visibility` list, which is capped to the most-recent runs across all projects. A project that goes quiet while others keep sweeping falls off that list, so `latestRunIds` computes empty and the per-query views render blank, even though the project has many (older) runs.

Concretely: a project last swept 33 days ago showed no queries on its page, while three actively-swept projects filled the capped list (8 runs, oldest 12 days, none from the quiet project).

## Fix
- `use-project-dashboard.ts`: read runs from the project-scoped `GET /projects/:name/runs` endpoint instead of the global list. It always returns the project's own runs, so the latest sweep is found regardless of cadence. (The comment already claimed it was project-scoped; the code wasn't.)
- `run-invalidations.ts`: also invalidate the `getApiV1ProjectsByNameRuns` key on run completion (the page uses it now), so the page still refreshes after a run.
- test: lock in that a run invalidates the project-scoped runs list.

## Verify
`GET /projects/<quiet-project>/runs?kind=answer-visibility` returns all 65 of its runs including the 33-day-old sweep; the global list returned only the 8 most-recent, none from the quiet project.

Frontend-only, 27 lines, no version bump. The `/projects/:name/runs` endpoint already exists. Note: the portfolio hooks (`use-dashboard-overview`) still use the global list by design for the cross-project recent-activity feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)