### PR TITLE
feat(web): add design token foundation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,9 +11,24 @@ The web dashboard follows a dark, professional analytics aesthetic inspired by *
 - Pages use a `page-header` (title + subtitle + optional actions) followed by sections separated by `page-section-divider`.
 
 ### Color & Theme
-- Background: `bg-zinc-950`. Cards/surfaces: `bg-zinc-900/30` with `border-zinc-800/60`.
+- Use semantic color tokens for new dashboard code. `apps/web/src/styles.css`
+  registers color/chart tokens in a static, non-inline `@theme` block so the
+  full foundation is emitted and generated utilities still reference
+  runtime-overridable CSS variables. The font tokens stay in the existing
+  `@theme inline` block until the typography phase.
+- Current dark defaults: `bg-bg` = `zinc-950`; `bg-surface` = `zinc-900/30`;
+  `bg-surface-subtle` = `zinc-900/20`; `bg-surface-hover` = `zinc-900/40`;
+  `bg-surface-inset` = `zinc-800/60`; `border-default` =
+  `zinc-800/60`; `border-subtle` = `zinc-800/40`; `border-strong` =
+  `zinc-700`; `text-primary` = `zinc-50`; `text-secondary` =
+  `zinc-400`; `text-muted` = `zinc-500`; `text-faint` = `zinc-600`.
+- Legacy literal palette utilities (`bg-zinc-*`, `text-zinc-*`,
+  `border-zinc-*`, `emerald` / `amber` / `rose`) still exist in older code
+  until the migration phases complete. Do not add new literal palette utilities
+  for themeable UI; add or use a semantic token instead.
 - Font: **Geist Sans** (400–800 weights) for UI text, **Geist Mono** for code/numerics. Globally enabled OpenType features `cv11`, `ss01`, `ss03` for sharper i/l/I/0 disambiguation. Headings tighten tracking (`-0.015em`, `-0.02em` on h1). `text-zinc-50` primary, `text-zinc-400` secondary, `text-zinc-500`/`text-zinc-600` for labels.
-- Tone colors: **positive** = emerald, **caution** = amber, **negative** = rose, **neutral** = zinc.
+- Tone tokens: **positive** = emerald, **caution** = amber, **negative** = rose, **neutral** = zinc. Use `text-positive`, `border-positive`, `bg-positive-soft`, `fill-positive`, and the matching caution/negative/neutral utilities for new themeable tone work.
+- Provider identity colors in `ProviderBadge` encode which answer engine produced a signal. They are not semantic tone colors and stay literal unless the provider identity system changes.
 - No decorative background gradients. Keep it clean and flat.
 
 ### Components & Patterns
@@ -56,6 +71,7 @@ The web dashboard follows a dark, professional analytics aesthetic inspired by *
 
 - Import chart components and shared constants from `components/shared/ChartPrimitives.js`.
 - Use `CHART_TOOLTIP_STYLE`, `CHART_AXIS_TICK`, `CHART_GRID_STROKE`, `CHART_AXIS_STROKE`, and `CHART_SERIES_COLORS` for consistent styling.
+- Chart CSS variables (`--chart-series-*`, `--chart-tone-*`, `--chart-neutral-*`, `--chart-tooltip-*`, `--chart-grid`, `--chart-axis`) are registered in `styles.css`. Phase 4 bridges `ChartPrimitives.tsx` to these variables; until then, keep the JS constants and CSS token defaults in sync when touching chart colors.
 - Use `formatChartDateLabel` for tooltip labels and `formatChartDateTick` for axis ticks.
 - Custom SVG is allowed only for non-chart visualizations (gauges, sparklines, timelines) where Recharts is overkill.
 - If Recharts is missing a feature, extend `ChartPrimitives.tsx` rather than adding a second library.
@@ -63,6 +79,11 @@ The web dashboard follows a dark, professional analytics aesthetic inspired by *
 ### Report parity (Critical)
 
 **The downloadable HTML report (`canonry report` / `GET /report.html`) and the in-app SPA report view must stay perfectly aligned.** They are two renderers of the same `ProjectReportDto` — clients and agencies see one report. Any change to a section, label, headline, chart, tile, or order in `apps/web/src/pages/ReportPage.tsx` must ship the same change in `packages/api-routes/src/report-renderer.ts` in the same commit, and vice versa. Tile labels, eyebrows, titles, subtitles, action-card copy, and evidence-card titles must match verbatim across both. Update `packages/api-routes/test/report-renderer.test.ts` whenever client/agency strings change. See AGENTS.md "Report parity" for the full rule set.
+
+### Theme Migration Tests
+
+- `apps/web/test/design-tokens.test.ts` compiles `styles.css` with Tailwind's compiler and asserts semantic utilities such as `bg-bg`, `bg-surface/50`, `border-default`, and `text-primary` resolve through CSS variables. This is the build assertion that guards against accidentally putting color tokens in `@theme inline` and confirms chart-only tokens are emitted before the chart bridge uses them.
+- `apps/web/test/dashboard-class-baseline.test.tsx` SSR-renders representative routes and snapshots stable component class lists. Use it as a fast migration tripwire before browser visual checks. The suite runs in jsdom; jsdom cannot compute Tailwind v4's modern CSS output (`@layer`, `@property`, `color-mix`) reliably, so computed-style coverage lives at the Tailwind compiler-output level here.
 
 ### Don'ts
 - Don't use hero grids with large descriptive text blocks on the project page. Keep headers compact.

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -8,6 +8,7 @@ Vite SPA (React 19 + TanStack Router/Query + Tailwind CSS 4) for the analytics d
 
 | File | Role |
 |------|------|
+| `src/styles.css` | Tailwind v4 entrypoint, global component classes, semantic color/chart tokens |
 | `src/api.ts` | `apiFetch<T>()` wrapper, `ApiError` class, all API call functions, `getEmbedConfig()` (#716 — reads `window.__CANONRY_CONFIG__.embed`, returns the block when enabled else `null`; `typeof window` guarded for SSR) |
 | `src/embed.ts` | Read-only embed mode (#716) presentational helpers: `embedViewIdForPath(pathname)` (coarse route→view-id map for the allowlist) and `embedThemeStyle(theme)` (allowlisted `--canonry-embed-*` CSS custom properties with per-value strict color-regex sanitization — CSS-injection guard) |
 | `src/router/routes.tsx` | TanStack Router route tree |
@@ -143,6 +144,36 @@ PRs rather than rolling into tooling work.
 ```typescript
 import { CHART_TOOLTIP_STYLE, CHART_AXIS_TICK, CHART_SERIES_COLORS } from '../shared/ChartPrimitives'
 ```
+
+### Design tokens
+
+`src/styles.css` keeps font tokens in the existing `@theme inline` block, but
+color and chart tokens live in a separate static, non-inline `@theme` block so
+the full foundation is emitted while generated Tailwind utilities compile to
+`var(--color-*)` and can be overridden at runtime.
+New themeable UI code should use semantic utilities instead of literal palette
+classes: `bg-bg`, `bg-surface`, `bg-surface-subtle`,
+`bg-surface-hover`, `bg-surface-inset`, `border-default`,
+`border-subtle`, `border-strong`, `text-primary`, `text-secondary`,
+`text-muted`, `text-faint`, plus tone utilities such as `text-positive`,
+`border-positive`, `bg-positive-soft`, and `fill-positive` (and the
+caution/negative/neutral variants).
+
+Legacy `zinc` / `emerald` / `amber` / `rose` utilities are still present until
+the migration phases finish. Do not add new literal palette utilities for
+themeable UI. The fixed provider identity palettes in `ProviderBadge` remain
+literal because they encode the engine, not semantic tone.
+
+Token migration guardrails:
+
+- `test/design-tokens.test.ts` compiles the stylesheet with Tailwind and proves
+  semantic utilities reference CSS variables, including opacity modifiers like
+  `bg-surface/50`, and that chart-only tokens are emitted before the chart
+  bridge consumes them.
+- `test/dashboard-class-baseline.test.tsx` SSR-renders representative routes and
+  snapshots stable class lists for later migration PRs. jsdom cannot compute
+  Tailwind v4 `@layer` / `@property` / `color-mix` output reliably, so the
+  computed-style spot check is the Tailwind compiler-output assertion.
 
 ### Component organization
 

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -6,6 +6,168 @@
   --font-mono: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
 
+@theme static {
+  --color-bg: var(--color-zinc-950);
+  --color-bg-elevated: var(--color-zinc-900);
+
+  --color-surface: rgb(24 24 27 / 0.3);
+  --color-surface-subtle: rgb(24 24 27 / 0.2);
+  --color-surface-hover: rgb(24 24 27 / 0.4);
+  --color-surface-inset: rgb(39 39 42 / 0.6);
+
+  --color-border: rgb(39 39 42 / 0.6);
+  --color-border-subtle: rgb(39 39 42 / 0.4);
+  --color-border-strong: var(--color-zinc-700);
+
+  --color-text-primary: var(--color-zinc-50);
+  --color-text-secondary: var(--color-zinc-400);
+  --color-text-muted: var(--color-zinc-500);
+  --color-text-faint: var(--color-zinc-600);
+
+  --color-accent: var(--color-zinc-50);
+  --color-accent-fg: var(--color-zinc-950);
+
+  --color-positive-text: var(--color-emerald-300);
+  --color-positive-border: rgb(16 185 129 / 0.25);
+  --color-positive-bg-soft: rgb(16 185 129 / 0.1);
+  --color-positive-fill: #34d399;
+
+  --color-caution-text: var(--color-amber-300);
+  --color-caution-border: rgb(245 158 11 / 0.3);
+  --color-caution-bg-soft: rgb(245 158 11 / 0.1);
+  --color-caution-fill: #fbbf24;
+
+  --color-negative-text: var(--color-rose-300);
+  --color-negative-border: rgb(244 63 94 / 0.25);
+  --color-negative-bg-soft: rgb(244 63 94 / 0.1);
+  --color-negative-fill: #fb7185;
+
+  --color-neutral-text: var(--color-zinc-300);
+  --color-neutral-border: rgb(63 63 70 / 0.45);
+  --color-neutral-bg-soft: rgb(63 63 70 / 0.2);
+  --color-neutral-fill: var(--color-zinc-400);
+
+  --color-ring: rgb(113 113 122 / 0.5);
+  --color-ring-accent: rgb(251 191 36 / 0.6);
+
+  --chart-series-1: #34d399;
+  --chart-series-2: #60a5fa;
+  --chart-series-3: #f472b6;
+  --chart-series-4: #facc15;
+  --chart-series-5: #a78bfa;
+  --chart-series-6: #fb923c;
+  --chart-series-7: #22d3ee;
+  --chart-series-8: #f87171;
+  --chart-tone-positive: #34d399;
+  --chart-tone-positive-deep: #10b981;
+  --chart-tone-caution: #fbbf24;
+  --chart-tone-negative: #fb7185;
+  --chart-tone-neutral: #a1a1aa;
+  --chart-neutral-text: #a1a1aa;
+  --chart-neutral-text-dim: #71717a;
+  --chart-neutral-text-faint: #52525b;
+  --chart-neutral-surface: #27272a;
+  --chart-neutral-grid-line: rgb(255 255 255 / 0.06);
+  --chart-tooltip-bg: #18181b;
+  --chart-tooltip-border: #3f3f46;
+  --chart-tooltip-label: #e4e4e7;
+  --chart-tooltip-item: #a1a1aa;
+  --chart-grid: #27272a;
+  --chart-axis: #27272a;
+}
+
+@utility border-default {
+  border-color: var(--color-border);
+}
+
+@utility border-subtle {
+  border-color: var(--color-border-subtle);
+}
+
+@utility border-strong {
+  border-color: var(--color-border-strong);
+}
+
+@utility text-primary {
+  color: var(--color-text-primary);
+}
+
+@utility text-secondary {
+  color: var(--color-text-secondary);
+}
+
+@utility text-muted {
+  color: var(--color-text-muted);
+}
+
+@utility text-faint {
+  color: var(--color-text-faint);
+}
+
+@utility text-positive {
+  color: var(--color-positive-text);
+}
+
+@utility text-caution {
+  color: var(--color-caution-text);
+}
+
+@utility text-negative {
+  color: var(--color-negative-text);
+}
+
+@utility text-neutral {
+  color: var(--color-neutral-text);
+}
+
+@utility border-positive {
+  border-color: var(--color-positive-border);
+}
+
+@utility border-caution {
+  border-color: var(--color-caution-border);
+}
+
+@utility border-negative {
+  border-color: var(--color-negative-border);
+}
+
+@utility border-neutral {
+  border-color: var(--color-neutral-border);
+}
+
+@utility bg-positive-soft {
+  background-color: var(--color-positive-bg-soft);
+}
+
+@utility bg-caution-soft {
+  background-color: var(--color-caution-bg-soft);
+}
+
+@utility bg-negative-soft {
+  background-color: var(--color-negative-bg-soft);
+}
+
+@utility bg-neutral-soft {
+  background-color: var(--color-neutral-bg-soft);
+}
+
+@utility fill-positive {
+  fill: var(--color-positive-fill);
+}
+
+@utility fill-caution {
+  fill: var(--color-caution-fill);
+}
+
+@utility fill-negative {
+  fill: var(--color-negative-fill);
+}
+
+@utility fill-neutral {
+  fill: var(--color-neutral-fill);
+}
+
 @layer base {
   * {
     @apply border-zinc-800;

--- a/apps/web/test/dashboard-class-baseline.test.tsx
+++ b/apps/web/test/dashboard-class-baseline.test.tsx
@@ -1,0 +1,93 @@
+import { beforeAll, expect, test } from 'vitest'
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { RouterProvider } from '@tanstack/react-router'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import { DashboardProvider } from '../src/contexts/dashboard-context.js'
+import { createDashboardFixture } from '../src/mock-data.js'
+import { createAppRouter } from '../src/router/router.js'
+import { preloadAllLazyRoutes } from '../src/router/routes.js'
+
+beforeAll(async () => {
+  await preloadAllLazyRoutes()
+})
+
+async function renderRoute(pathname: string): Promise<string> {
+  const fixture = createDashboardFixture({})
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const router = createAppRouter(queryClient, { initialEntries: [pathname] })
+  await router.load()
+
+  return renderToStaticMarkup(
+    <QueryClientProvider client={queryClient}>
+      <DashboardProvider value={{ dashboard: fixture.dashboard, health: fixture.health }}>
+        <RouterProvider router={router} />
+      </DashboardProvider>
+    </QueryClientProvider>,
+  )
+}
+
+function classFor(html: string, selector: string): string {
+  const doc = new DOMParser().parseFromString(html, 'text/html')
+  const element = doc.querySelector(selector)
+  if (!element) {
+    const classes = [...doc.querySelectorAll('[class]')]
+      .map((candidate) => candidate.getAttribute('class') ?? '')
+      .filter((className) => className.includes('page') || className.includes('surface') || className.includes('metric'))
+      .slice(0, 80)
+      .join('\n')
+    throw new Error(`Missing element for selector: ${selector}\nRendered classes:\n${classes}`)
+  }
+  return element.getAttribute('class') ?? ''
+}
+
+test('overview route keeps the dark dashboard class baseline stable', async () => {
+  const html = await renderRoute('/')
+
+  expect({
+    appShell: classFor(html, '.app-shell'),
+    sidebar: classFor(html, '.sidebar'),
+    topbar: classFor(html, '.topbar'),
+    pageShell: classFor(html, '.page-shell'),
+    pageContainer: classFor(html, '.page-container'),
+    pageHeader: classFor(html, '.page-header'),
+    pageTitle: classFor(html, '.page-title'),
+    firstSurface: classFor(html, '.surface-card'),
+    firstHealthPill: classFor(html, '.health-pill'),
+  }).toMatchInlineSnapshot(`
+    {
+      "appShell": "app-shell ",
+      "firstHealthPill": "health-pill health-pill-ok",
+      "firstSurface": "rounded-xl border border-zinc-800 bg-zinc-950/75 shadow-[0_0_0_1px_rgba(255,255,255,0.01)] surface-card compact-card",
+      "pageContainer": "page-container",
+      "pageHeader": "page-header",
+      "pageShell": "page-shell",
+      "pageTitle": "page-title",
+      "sidebar": "sidebar",
+      "topbar": "topbar",
+    }
+  `)
+})
+
+test('project route keeps the core metric and evidence class baseline stable', async () => {
+  const html = await renderRoute('/projects/Citypoint%20Dental%20NYC')
+
+  expect({
+    pageContainer: classFor(html, '.page-container'),
+    pageHeader: classFor(html, '.page-header'),
+    pageTitle: classFor(html, '.page-title'),
+    firstSectionDivider: classFor(html, '.page-section-divider'),
+    firstMetricFill: classFor(html, '.metric-card-bar-fill'),
+    evidenceDisclosure: classFor(html, '#evidence-section'),
+  }).toMatchInlineSnapshot(`
+    {
+      "evidenceDisclosure": "overview-disclosure page-section-divider scroll-mt-24",
+      "firstMetricFill": "metric-card-bar-fill progress-fill-positive",
+      "firstSectionDivider": "page-section-divider",
+      "pageContainer": "page-container",
+      "pageHeader": "page-header",
+      "pageTitle": "page-title",
+    }
+  `)
+})

--- a/apps/web/test/design-tokens.test.ts
+++ b/apps/web/test/design-tokens.test.ts
@@ -1,0 +1,55 @@
+import { readFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+
+import { compile } from 'tailwindcss'
+import { expect, test } from 'vitest'
+
+const stylesPath = resolve(import.meta.dirname, '../src/styles.css')
+const tailwindRoot = resolve(import.meta.dirname, '../node_modules/tailwindcss')
+
+async function loadTailwindStylesheet(id: string) {
+  if (id !== 'tailwindcss' && !id.startsWith('tailwindcss/')) {
+    throw new Error(`Unexpected stylesheet import: ${id}`)
+  }
+
+  const filename = id === 'tailwindcss'
+    ? 'index.css'
+    : `${id.slice('tailwindcss/'.length)}.css`
+  const path = resolve(tailwindRoot, filename)
+  return {
+    path,
+    base: dirname(path),
+    content: await readFile(path, 'utf8'),
+  }
+}
+
+async function compileAppStyles(candidates: string[]) {
+  const compiler = await compile(await readFile(stylesPath, 'utf8'), {
+    from: stylesPath,
+    base: dirname(stylesPath),
+    loadStylesheet: loadTailwindStylesheet,
+  })
+
+  return compiler.build(candidates)
+}
+
+test('semantic color utilities compile to runtime-overridable CSS variables', async () => {
+  const css = await compileAppStyles([
+    'bg-bg',
+    'bg-surface/50',
+    'border-default',
+    'border-positive',
+    'text-primary',
+  ])
+
+  expect(css).toContain('.bg-bg')
+  expect(css).toContain('background-color: var(--color-bg)')
+  expect(css).toContain('.text-primary')
+  expect(css).toContain('color: var(--color-text-primary)')
+  expect(css).toContain('.border-default')
+  expect(css).toContain('border-color: var(--color-border)')
+  expect(css).toContain('.border-positive')
+  expect(css).toContain('border-color: var(--color-positive-border)')
+  expect(css).toContain('--chart-series-1: #34d399')
+  expect(css).toContain('color-mix(in oklab, var(--color-surface) 50%, transparent)')
+})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.104.0",
+  "version": "4.104.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.104.0",
+  "version": "4.104.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Summary

Phase 1 for #767. Adds the web dashboard design-token foundation without migrating existing consumers yet.

- registers semantic color, tone, ring, and chart tokens in a static non-inline Tailwind `@theme` block
- exposes semantic utility aliases for the next migration slices
- adds compiler-level token assertions and SSR class-list baselines
- documents the new token rules in the root and web agent guidance
- bumps the root and publishable package versions to `4.104.1`

## Validation

- `corepack pnpm --filter @ainyc/canonry-web typecheck`
- `corepack pnpm --filter @ainyc/canonry-web test`
- `corepack pnpm --filter @ainyc/canonry-web lint` (0 errors, existing warnings)
- `corepack pnpm --filter @ainyc/canonry-web build` (existing large-chunk warning)
- commit hook `pnpm -r run lint` (0 errors, existing warnings)
- `git diff --check`

## Notes

Browser smoke was attempted against Vite on `localhost:4173`, but the in-app browser runtime failed before navigation with `sandboxCwd must be an absolute file URI`. The production web build verifies the Tailwind/Vite pipeline and the bundle contains the emitted chart tokens.
