### PR TITLE
feat(web): tokenize shell css primitives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,14 +19,16 @@ The web dashboard follows a dark, professional analytics aesthetic inspired by *
 - Current dark defaults: `bg-bg` = `zinc-950`; `bg-surface` = `zinc-900/30`;
   `bg-surface-subtle` = `zinc-900/20`; `bg-surface-hover` = `zinc-900/40`;
   `bg-surface-inset` = `zinc-800/60`; `border-default` =
-  `zinc-800/60`; `border-subtle` = `zinc-800/40`; `border-strong` =
-  `zinc-700`; `text-primary` = `zinc-50`; `text-secondary` =
-  `zinc-400`; `text-muted` = `zinc-500`; `text-faint` = `zinc-600`.
+  `zinc-800/60`; `border-subtle` = `zinc-800/40`; `border-base` =
+  `zinc-800`; `border-strong` = `zinc-700`; `text-primary` =
+  `zinc-50`; `text-heading` = `zinc-100`; `text-strong` = `zinc-200`;
+  `text-secondary` = `zinc-400`; `text-muted` = `zinc-500`;
+  `text-faint` = `zinc-600`.
 - Legacy literal palette utilities (`bg-zinc-*`, `text-zinc-*`,
   `border-zinc-*`, `emerald` / `amber` / `rose`) still exist in older code
   until the migration phases complete. Do not add new literal palette utilities
   for themeable UI; add or use a semantic token instead.
-- Font: **Geist Sans** (400–800 weights) for UI text, **Geist Mono** for code/numerics. Globally enabled OpenType features `cv11`, `ss01`, `ss03` for sharper i/l/I/0 disambiguation. Headings tighten tracking (`-0.015em`, `-0.02em` on h1). `text-zinc-50` primary, `text-zinc-400` secondary, `text-zinc-500`/`text-zinc-600` for labels.
+- Font: **Geist Sans** (400–800 weights) for UI text, **Geist Mono** for code/numerics. Globally enabled OpenType features `cv11`, `ss01`, `ss03` for sharper i/l/I/0 disambiguation. Headings tighten tracking (`-0.015em`, `-0.02em` on h1). Use `text-heading` / `text-strong` for heading and emphasized neutral text, `text-primary` for highest-contrast body text, `text-secondary` for supporting text, and `text-muted` / `text-faint` for labels.
 - Tone tokens: **positive** = emerald, **caution** = amber, **negative** = rose, **neutral** = zinc. Use `text-positive`, `border-positive`, `bg-positive-soft`, `fill-positive`, and the matching caution/negative/neutral utilities for new themeable tone work.
 - Provider identity colors in `ProviderBadge` encode which answer engine produced a signal. They are not semantic tone colors and stay literal unless the provider identity system changes.
 - No decorative background gradients. Keep it clean and flat.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,9 @@ The web dashboard follows a dark, professional analytics aesthetic inspired by *
   `@theme inline` block until the typography phase.
 - Current dark defaults: `bg-bg` = `zinc-950`; `bg-surface` = `zinc-900/30`;
   `bg-surface-subtle` = `zinc-900/20`; `bg-surface-hover` = `zinc-900/40`;
-  `bg-surface-inset` = `zinc-800/60`; `border-default` =
-  `zinc-800/60`; `border-subtle` = `zinc-800/40`; `border-base` =
+  `bg-surface-inset` = `zinc-800/60`; `bg-surface-inset-hover` =
+  `zinc-800/40`; `border-default` = `zinc-800/60`; `border-subtle` =
+  `zinc-800/40`; `border-base` =
   `zinc-800`; `border-strong` = `zinc-700`; `text-primary` =
   `zinc-50`; `text-heading` = `zinc-100`; `text-strong` = `zinc-200`;
   `text-secondary` = `zinc-400`; `text-muted` = `zinc-500`;

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -154,8 +154,9 @@ the full foundation is emitted while generated Tailwind utilities compile to
 New themeable UI code should use semantic utilities instead of literal palette
 classes: `bg-bg`, `bg-surface`, `bg-surface-subtle`,
 `bg-surface-hover`, `bg-surface-inset`, `border-default`,
-`border-subtle`, `border-strong`, `text-primary`, `text-secondary`,
-`text-muted`, `text-faint`, plus tone utilities such as `text-positive`,
+`border-subtle`, `border-base`, `border-strong`, `text-primary`,
+`text-heading`, `text-strong`, `text-secondary`, `text-muted`,
+`text-faint`, plus tone utilities such as `text-positive`,
 `border-positive`, `bg-positive-soft`, and `fill-positive` (and the
 caution/negative/neutral variants).
 

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -153,7 +153,8 @@ the full foundation is emitted while generated Tailwind utilities compile to
 `var(--color-*)` and can be overridden at runtime.
 New themeable UI code should use semantic utilities instead of literal palette
 classes: `bg-bg`, `bg-surface`, `bg-surface-subtle`,
-`bg-surface-hover`, `bg-surface-inset`, `border-default`,
+`bg-surface-hover`, `bg-surface-inset`, `bg-surface-inset-hover`,
+`border-default`,
 `border-subtle`, `border-base`, `border-strong`, `text-primary`,
 `text-heading`, `text-strong`, `text-secondary`, `text-muted`,
 `text-faint`, plus tone utilities such as `text-positive`,

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -17,9 +17,12 @@
 
   --color-border: rgb(39 39 42 / 0.6);
   --color-border-subtle: rgb(39 39 42 / 0.4);
+  --color-border-base: var(--color-zinc-800);
   --color-border-strong: var(--color-zinc-700);
 
   --color-text-primary: var(--color-zinc-50);
+  --color-text-heading: var(--color-zinc-100);
+  --color-text-strong: var(--color-zinc-200);
   --color-text-secondary: var(--color-zinc-400);
   --color-text-muted: var(--color-zinc-500);
   --color-text-faint: var(--color-zinc-600);
@@ -84,12 +87,24 @@
   border-color: var(--color-border-subtle);
 }
 
+@utility border-base {
+  border-color: var(--color-border-base);
+}
+
 @utility border-strong {
   border-color: var(--color-border-strong);
 }
 
 @utility text-primary {
   color: var(--color-text-primary);
+}
+
+@utility text-heading {
+  color: var(--color-text-heading);
+}
+
+@utility text-strong {
+  color: var(--color-text-strong);
 }
 
 @utility text-secondary {
@@ -170,7 +185,7 @@
 
 @layer base {
   * {
-    @apply border-zinc-800;
+    @apply border-base;
   }
 
   html {
@@ -186,7 +201,7 @@
   }
 
   body {
-    @apply min-h-screen bg-zinc-950 font-sans text-zinc-50 antialiased;
+    @apply min-h-screen bg-bg font-sans text-primary antialiased;
   }
 
   /* Headings: tighten tracking and gently bump weight so they read as
@@ -212,14 +227,14 @@
   }
 
   ::selection {
-    background: rgba(250, 250, 250, 0.12);
-    color: #fafafa;
+    background: color-mix(in oklab, var(--color-accent) 12%, transparent);
+    color: var(--color-accent);
   }
 }
 
 @layer components {
   .skip-link {
-    @apply absolute left-4 top-[-3rem] z-50 rounded-md bg-zinc-50 px-4 py-2 text-sm font-medium text-black transition-all focus:top-4;
+    @apply absolute left-4 top-[-3rem] z-50 rounded-md bg-accent px-4 py-2 text-sm font-medium text-accent-fg transition-all focus:top-4;
   }
 
   /* ── Layout shell: sidebar + topbar + content ── */
@@ -236,16 +251,16 @@
      the shell background + text: page content uses fixed Tailwind colors. */
   .app-shell-embed {
     @apply min-h-screen w-full;
-    background: var(--canonry-embed-bg, #09090b);
+    background: var(--canonry-embed-bg, var(--color-bg));
     color: var(--canonry-embed-fg, inherit);
   }
 
   .embed-view-unavailable {
-    @apply mx-auto max-w-6xl px-4 py-16 text-center text-sm text-zinc-500;
+    @apply mx-auto max-w-6xl px-4 py-16 text-center text-sm text-muted;
   }
 
   .sidebar {
-    @apply fixed inset-y-0 left-0 z-30 hidden w-56 flex-col border-r border-zinc-800/60 bg-zinc-950 lg:flex;
+    @apply fixed inset-y-0 left-0 z-30 hidden w-56 flex-col border-r border-default bg-bg lg:flex;
   }
 
   .sidebar-brand {
@@ -274,7 +289,7 @@
   }
 
   .brand-mark {
-    @apply text-[15px] font-semibold leading-none tracking-[-0.02em] text-zinc-100 no-underline;
+    @apply text-[15px] font-semibold leading-none tracking-[-0.02em] text-heading no-underline;
   }
 
   .brand-lockup-compact .brand-mark {
@@ -282,7 +297,7 @@
   }
 
   .brand-version {
-    @apply mt-0.5 font-mono text-[11px] tracking-tight text-zinc-500;
+    @apply mt-0.5 font-mono text-[11px] tracking-tight text-muted;
   }
 
   /* ── Update bubble ── */
@@ -408,15 +423,15 @@
   }
 
   .sidebar-section-title {
-    @apply mb-1 mt-5 px-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-zinc-600;
+    @apply mb-1 mt-5 px-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-faint;
   }
 
   .sidebar-link {
-    @apply flex items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-[13px] font-normal text-zinc-500 transition hover:bg-zinc-800/40 hover:text-zinc-300;
+    @apply flex items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-[13px] font-normal text-muted transition hover:bg-surface-hover hover:text-neutral;
   }
 
   .sidebar-link-active {
-    @apply bg-zinc-800/50 text-zinc-200 font-medium;
+    @apply bg-surface-inset text-strong font-medium;
   }
 
   .sidebar-icon {
@@ -424,11 +439,11 @@
   }
 
   .sidebar-project {
-    @apply flex items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-[13px] text-zinc-500 transition hover:bg-zinc-900 hover:text-zinc-200;
+    @apply flex items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-[13px] text-muted transition hover:bg-bg-elevated hover:text-strong;
   }
 
   .sidebar-project-active {
-    @apply text-zinc-200;
+    @apply text-strong;
   }
 
   .sidebar-dot {
@@ -448,11 +463,11 @@
   }
 
   .sidebar-footer {
-    @apply flex items-center gap-1 border-t border-zinc-800/60 px-4 py-3;
+    @apply flex items-center gap-1 border-t border-default px-4 py-3;
   }
 
   .sidebar-footer-icon {
-    @apply inline-flex size-7 items-center justify-center rounded-md text-zinc-500 transition hover:bg-zinc-800/40 hover:text-zinc-200;
+    @apply inline-flex size-7 items-center justify-center rounded-md text-muted transition hover:bg-surface-hover hover:text-strong;
   }
 
   .main-area {
@@ -468,7 +483,7 @@
   }
 
   .topbar {
-    @apply sticky top-0 z-20 flex items-center justify-between gap-4 border-b border-zinc-800/60 bg-zinc-950/95 px-4 py-2.5 backdrop-blur-sm md:px-6;
+    @apply sticky top-0 z-20 flex items-center justify-between gap-4 border-b border-default bg-bg/95 px-4 py-2.5 backdrop-blur-sm md:px-6;
   }
 
   .topbar-left {
@@ -480,7 +495,7 @@
   }
 
   .breadcrumb {
-    @apply hidden items-center gap-1.5 text-sm text-zinc-500 md:flex;
+    @apply hidden items-center gap-1.5 text-sm text-muted md:flex;
   }
 
   .breadcrumb-sep {
@@ -488,7 +503,7 @@
   }
 
   .breadcrumb-current {
-    @apply text-zinc-200;
+    @apply text-strong;
   }
 
   .topbar-actions {
@@ -508,7 +523,7 @@
   }
 
   .health-pill-checking {
-    @apply border-zinc-700 bg-zinc-900 text-zinc-400;
+    @apply border-strong bg-bg-elevated text-secondary;
   }
 
   .health-pill-error {
@@ -525,7 +540,7 @@
 
   /* mobile nav */
   .mobile-nav {
-    @apply fixed inset-0 z-40 hidden flex-col bg-zinc-950/98 p-4 pt-16 backdrop-blur-sm;
+    @apply fixed inset-0 z-40 hidden flex-col bg-bg/98 p-4 pt-16 backdrop-blur-sm;
   }
 
   .mobile-nav-open {
@@ -533,11 +548,11 @@
   }
 
   .mobile-nav-link {
-    @apply rounded-lg px-4 py-3 text-base font-medium text-zinc-400 transition hover:bg-zinc-900 hover:text-zinc-100;
+    @apply rounded-lg px-4 py-3 text-base font-medium text-secondary transition hover:bg-bg-elevated hover:text-heading;
   }
 
   .mobile-nav-link-active {
-    @apply bg-zinc-900 text-zinc-100;
+    @apply bg-bg-elevated text-heading;
   }
 
   .mobile-nav-close {
@@ -545,11 +560,11 @@
   }
 
   .mobile-nav-section {
-    @apply mt-4 border-t border-zinc-800 pt-4;
+    @apply mt-4 border-t border-base pt-4;
   }
 
   .mobile-nav-section-title {
-    @apply mb-2 px-4 text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-600;
+    @apply mb-2 px-4 text-[11px] font-semibold uppercase tracking-[0.16em] text-faint;
   }
 
   /* ── Page content ── */
@@ -573,11 +588,11 @@
   }
 
   .page-title {
-    @apply text-lg font-semibold tracking-[-0.02em] text-zinc-100;
+    @apply text-lg font-semibold tracking-[-0.02em] text-heading;
   }
 
   .page-subtitle {
-    @apply mt-0.5 text-[13px] font-normal text-zinc-500;
+    @apply mt-0.5 text-[13px] font-normal text-muted;
   }
 
   .page-header-right {
@@ -589,27 +604,27 @@
   }
 
   .tag {
-    @apply rounded-md border border-zinc-800 bg-zinc-900/50 px-2 py-0.5 text-[11px] font-medium text-zinc-400;
+    @apply rounded-md border border-base bg-bg-elevated/50 px-2 py-0.5 text-[11px] font-medium text-secondary;
   }
 
   /* ── Eyebrow / labels ── */
 
   .eyebrow {
-    @apply text-[11px] font-medium uppercase tracking-[0.18em] text-zinc-500;
+    @apply text-[11px] font-medium uppercase tracking-[0.18em] text-muted;
   }
 
   .eyebrow-soft {
-    @apply mb-1 text-[10px] font-medium uppercase tracking-[0.16em] text-zinc-600;
+    @apply mb-1 text-[10px] font-medium uppercase tracking-[0.16em] text-faint;
   }
 
   /* ── Typography ── */
 
   .lede {
-    @apply max-w-3xl text-sm leading-6 text-zinc-400;
+    @apply max-w-3xl text-sm leading-6 text-secondary;
   }
 
   .supporting-copy {
-    @apply text-sm leading-6 text-zinc-500;
+    @apply text-sm leading-6 text-muted;
   }
 
   .blocking-copy {
@@ -987,11 +1002,11 @@
   /* ── Metric cards (non-gauge) ── */
 
   .metric-card {
-    @apply flex flex-col rounded-xl border border-zinc-800/60 bg-zinc-900/30 px-4 py-5 min-w-0 overflow-visible;
+    @apply flex flex-col rounded-xl border border-default bg-surface px-4 py-5 min-w-0 overflow-visible;
   }
 
   .metric-card-eyebrow {
-    @apply text-[10px] font-medium uppercase tracking-[0.12em] text-zinc-500 flex items-center gap-1;
+    @apply text-[10px] font-medium uppercase tracking-[0.12em] text-muted flex items-center gap-1;
   }
 
   .metric-card-big-value {
@@ -1014,17 +1029,17 @@
   }
 
   .metric-card-detail {
-    @apply mt-2 text-[12px] text-zinc-400;
+    @apply mt-2 text-[12px] text-secondary;
   }
 
   .metric-card-sub {
-    @apply mt-1 text-[11px] leading-4 text-zinc-500;
+    @apply mt-1 text-[11px] leading-4 text-muted;
   }
 
   /* ── Surface cards ── */
 
   .surface-card {
-    @apply rounded-xl border border-zinc-800/60 bg-zinc-900/30 p-4;
+    @apply rounded-xl border border-default bg-surface p-4;
   }
 
   .compact-card {
@@ -1032,13 +1047,13 @@
   }
 
   .section-title-sm {
-    @apply text-sm font-semibold tracking-[-0.01em] text-zinc-200;
+    @apply text-sm font-semibold tracking-[-0.01em] text-strong;
   }
 
   .surface-card h2,
   .surface-card h3,
   .empty-card h1 {
-    @apply text-sm font-semibold tracking-[-0.01em] text-zinc-200;
+    @apply text-sm font-semibold tracking-[-0.01em] text-strong;
   }
 
   .empty-card {
@@ -1060,7 +1075,7 @@
   }
 
   .page-section-divider {
-    @apply mt-8 border-t border-zinc-800/40 pt-6;
+    @apply mt-8 border-t border-subtle pt-6;
   }
 
   /* Progressive disclosure keeps evidence and diagnostics available without

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -14,6 +14,7 @@
   --color-surface-subtle: rgb(24 24 27 / 0.2);
   --color-surface-hover: rgb(24 24 27 / 0.4);
   --color-surface-inset: rgb(39 39 42 / 0.6);
+  --color-surface-inset-hover: rgb(39 39 42 / 0.4);
 
   --color-border: rgb(39 39 42 / 0.6);
   --color-border-subtle: rgb(39 39 42 / 0.4);
@@ -427,7 +428,7 @@
   }
 
   .sidebar-link {
-    @apply flex items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-[13px] font-normal text-muted transition hover:bg-surface-hover hover:text-neutral;
+    @apply flex items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-[13px] font-normal text-muted transition hover:bg-surface-inset-hover hover:text-neutral;
   }
 
   .sidebar-link-active {
@@ -467,7 +468,7 @@
   }
 
   .sidebar-footer-icon {
-    @apply inline-flex size-7 items-center justify-center rounded-md text-muted transition hover:bg-surface-hover hover:text-strong;
+    @apply inline-flex size-7 items-center justify-center rounded-md text-muted transition hover:bg-surface-inset-hover hover:text-strong;
   }
 
   .main-area {

--- a/apps/web/test/design-tokens.test.ts
+++ b/apps/web/test/design-tokens.test.ts
@@ -61,6 +61,7 @@ test('semantic color utilities compile to runtime-overridable CSS variables', as
   const css = await compileAppStyles([
     'bg-bg',
     'bg-surface/50',
+    'bg-surface-inset-hover',
     'border-base',
     'border-default',
     'border-positive',
@@ -71,6 +72,8 @@ test('semantic color utilities compile to runtime-overridable CSS variables', as
 
   expect(css).toContain('.bg-bg')
   expect(css).toContain('background-color: var(--color-bg)')
+  expect(css).toContain('.bg-surface-inset-hover')
+  expect(css).toContain('background-color: var(--color-surface-inset-hover)')
   expect(css).toContain('.text-primary')
   expect(css).toContain('color: var(--color-text-primary)')
   expect(css).toContain('.text-heading')
@@ -102,4 +105,5 @@ test('shared stylesheet primitives consume semantic tokens', async () => {
   expect(ruleFor(css, '.surface-card')).toContain('border-color: var(--color-border)')
   expect(ruleFor(css, '.surface-card')).toContain('background-color: var(--color-surface)')
   expect(ruleFor(css, '.page-section-divider')).toContain('border-color: var(--color-border-subtle)')
+  expect(ruleFor(css, '.sidebar-link')).toContain('background-color: var(--color-surface-inset-hover)')
 })

--- a/apps/web/test/design-tokens.test.ts
+++ b/apps/web/test/design-tokens.test.ts
@@ -33,23 +33,73 @@ async function compileAppStyles(candidates: string[]) {
   return compiler.build(candidates)
 }
 
+function ruleFor(css: string, selector: string) {
+  const selectorStart = css.indexOf(`${selector} {`)
+  if (selectorStart === -1) {
+    throw new Error(`Could not find compiled rule for ${selector}`)
+  }
+
+  const openBrace = css.indexOf('{', selectorStart)
+  let depth = 0
+
+  for (let index = openBrace; index < css.length; index += 1) {
+    const char = css[index]
+    if (char === '{') {
+      depth += 1
+    } else if (char === '}') {
+      depth -= 1
+      if (depth === 0) {
+        return css.slice(openBrace + 1, index)
+      }
+    }
+  }
+
+  throw new Error(`Compiled rule for ${selector} was not closed`)
+}
+
 test('semantic color utilities compile to runtime-overridable CSS variables', async () => {
   const css = await compileAppStyles([
     'bg-bg',
     'bg-surface/50',
+    'border-base',
     'border-default',
     'border-positive',
+    'text-heading',
     'text-primary',
+    'text-strong',
   ])
 
   expect(css).toContain('.bg-bg')
   expect(css).toContain('background-color: var(--color-bg)')
   expect(css).toContain('.text-primary')
   expect(css).toContain('color: var(--color-text-primary)')
+  expect(css).toContain('.text-heading')
+  expect(css).toContain('color: var(--color-text-heading)')
+  expect(css).toContain('.text-strong')
+  expect(css).toContain('color: var(--color-text-strong)')
+  expect(css).toContain('.border-base')
+  expect(css).toContain('border-color: var(--color-border-base)')
   expect(css).toContain('.border-default')
   expect(css).toContain('border-color: var(--color-border)')
   expect(css).toContain('.border-positive')
   expect(css).toContain('border-color: var(--color-positive-border)')
   expect(css).toContain('--chart-series-1: #34d399')
   expect(css).toContain('color-mix(in oklab, var(--color-surface) 50%, transparent)')
+})
+
+test('shared stylesheet primitives consume semantic tokens', async () => {
+  const css = await compileAppStyles([])
+
+  expect(ruleFor(css, 'body')).toContain('background-color: var(--color-bg)')
+  expect(ruleFor(css, 'body')).toContain('color: var(--color-text-primary)')
+  expect(ruleFor(css, '.sidebar')).toContain('border-color: var(--color-border)')
+  expect(ruleFor(css, '.sidebar')).toContain('background-color: var(--color-bg)')
+  expect(ruleFor(css, '.topbar')).toContain('border-color: var(--color-border)')
+  expect(ruleFor(css, '.topbar')).toContain('var(--color-bg)')
+  expect(ruleFor(css, '.page-title')).toContain('color: var(--color-text-heading)')
+  expect(ruleFor(css, '.metric-card')).toContain('border-color: var(--color-border)')
+  expect(ruleFor(css, '.metric-card')).toContain('background-color: var(--color-surface)')
+  expect(ruleFor(css, '.surface-card')).toContain('border-color: var(--color-border)')
+  expect(ruleFor(css, '.surface-card')).toContain('background-color: var(--color-surface)')
+  expect(ruleFor(css, '.page-section-divider')).toContain('border-color: var(--color-border-subtle)')
 })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.104.1",
+  "version": "4.104.2",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.104.1",
+  "version": "4.104.2",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Summary
- Adds neutral semantic roles for exact existing shell contrast: `border-base`, `text-heading`, and `text-strong`.
- Migrates the CSS-only base, shell, page header, metric card, surface card, and divider primitives from literal zinc utilities to semantic token utilities.
- Extends the Tailwind compiler test to prove those shared stylesheet primitives compile through runtime-overridable CSS variables.
- Updates design-token guidance and bumps the package versions to `4.104.2`.

## Stack
- Stacked on #768 (`arberx/scope-issue-767`).

## Validation
- Red first: `corepack pnpm --filter @ainyc/canonry-web test -- apps/web/test/design-tokens.test.ts` failed on the legacy `body` zinc rule before implementation.
- `corepack pnpm --filter @ainyc/canonry-web typecheck`
- `corepack pnpm --filter @ainyc/canonry-web test`
- `corepack pnpm --filter @ainyc/canonry-web lint` (passes with existing warnings)
- `corepack pnpm --filter @ainyc/canonry-web build` (passes with existing large-chunk warning)
- `git diff --check`
- Local smoke: Vite served `http://localhost:4173/` with `200 OK`; built CSS emits the new runtime variables.
- In-app Browser smoke was attempted, but the browser runtime failed before navigation with `codex/sandbox-state-meta: sandboxCwd must be an absolute file URI: relative URL without a base`.