### PR TITLE
feat(web): bridge ChartPrimitives to CSS chart tokens (#767 phase 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ The web dashboard follows a dark, professional analytics aesthetic inspired by *
 
 - Import chart components and shared constants from `components/shared/ChartPrimitives.js`.
 - Use `CHART_TOOLTIP_STYLE`, `CHART_AXIS_TICK`, `CHART_GRID_STROKE`, `CHART_AXIS_STROKE`, and `CHART_SERIES_COLORS` for consistent styling.
-- Chart CSS variables (`--chart-series-*`, `--chart-tone-*`, `--chart-neutral-*`, `--chart-tooltip-*`, `--chart-grid`, `--chart-axis`) are registered in `styles.css`. Phase 4 bridges `ChartPrimitives.tsx` to these variables; until then, keep the JS constants and CSS token defaults in sync when touching chart colors.
+- Chart CSS variables (`--chart-series-*`, `--chart-tone-*`, `--chart-neutral-*`, `--chart-tooltip-*`, `--chart-grid`, `--chart-axis`) are registered in `styles.css` and consumed by `ChartPrimitives.tsx`: every Recharts color constant is `var(--chart-*, <hex fallback>)`, so the default dark render is unchanged and a theme can override the ramp at runtime. `test/chart-primitives.test.ts` locks each JS fallback to its CSS default (no two-source drift). Gauges/sparklines share the same `--chart-tone-*` / `--chart-neutral-grid-line` tokens so they can't drift from the charts. `PROVIDER_SERIES_COLORS` stays literal — it encodes engine identity, not tone. Never do string math (slice/alpha-concat) on these constants; a `var()` string would break.
 - Use `formatChartDateLabel` for tooltip labels and `formatChartDateTick` for axis ticks.
 - Custom SVG is allowed only for non-chart visualizations (gauges, sparklines, timelines) where Recharts is overkill.
 - If Recharts is missing a feature, extend `ChartPrimitives.tsx` rather than adding a second library.

--- a/apps/web/src/components/shared/ChartPrimitives.tsx
+++ b/apps/web/src/components/shared/ChartPrimitives.tsx
@@ -46,34 +46,41 @@ export const CHART_TOOLTIP_STYLE: {
   itemStyle: CSSProperties
 } = {
   contentStyle: {
-    backgroundColor: '#18181b',
-    border: '1px solid #3f3f46',
+    backgroundColor: 'var(--chart-tooltip-bg, #18181b)',
+    border: '1px solid var(--chart-tooltip-border, #3f3f46)',
     borderRadius: 8,
     fontSize: 12,
   },
-  labelStyle: { color: '#e4e4e7' },
-  itemStyle: { color: '#a1a1aa' },
+  labelStyle: { color: 'var(--chart-tooltip-label, #e4e4e7)' },
+  itemStyle: { color: 'var(--chart-tooltip-item, #a1a1aa)' },
 }
 
 /** Standard axis tick styling. */
-export const CHART_AXIS_TICK = { fill: '#71717a', fontSize: 11 } as const
+export const CHART_AXIS_TICK = { fill: 'var(--chart-neutral-text-dim, #71717a)', fontSize: 11 } as const
 
 /** Standard grid line color. */
-export const CHART_GRID_STROKE = '#27272a'
+export const CHART_GRID_STROKE = 'var(--chart-grid, #27272a)'
 
 /** Standard axis line stroke. */
-export const CHART_AXIS_STROKE = '#27272a'
+export const CHART_AXIS_STROKE = 'var(--chart-axis, #27272a)'
 
-/** Palette for multi-series charts (up to 8 series). */
+/**
+ * Palette for multi-series charts (up to 8 series). Each entry bridges to the
+ * `--chart-series-N` CSS token (registered in styles.css) with the original hex
+ * as the fallback, so the default dark render is unchanged and a theme can
+ * override the ramp at runtime. Recharts passes these straight to SVG
+ * fill/stroke, which resolve CSS variables. NEVER do string math on these
+ * (slice/alpha-concat) — a `var(...)` string would break.
+ */
 export const CHART_SERIES_COLORS = [
-  '#34d399', // emerald-400
-  '#60a5fa', // blue-400
-  '#f472b6', // pink-400
-  '#facc15', // yellow-400
-  '#a78bfa', // violet-400
-  '#fb923c', // orange-400
-  '#22d3ee', // cyan-400
-  '#f87171', // red-400
+  'var(--chart-series-1, #34d399)', // emerald-400
+  'var(--chart-series-2, #60a5fa)', // blue-400
+  'var(--chart-series-3, #f472b6)', // pink-400
+  'var(--chart-series-4, #facc15)', // yellow-400
+  'var(--chart-series-5, #a78bfa)', // violet-400
+  'var(--chart-series-6, #fb923c)', // orange-400
+  'var(--chart-series-7, #22d3ee)', // cyan-400
+  'var(--chart-series-8, #f87171)', // red-400
 ] as const
 
 /**
@@ -102,11 +109,11 @@ export function providerSeriesColor(provider: string, fallbackIndex = 0): string
  * the documented palette in DESIGN.md.
  */
 export const CHART_NEUTRAL = {
-  text: '#a1a1aa',      // zinc-400 — primary axis labels
-  textDim: '#71717a',   // zinc-500 — secondary text
-  textFaint: '#52525b', // zinc-600 — faintest text, track lines
-  surface: '#27272a',   // zinc-800 — area fill, track surface
-  gridLine: 'rgba(255, 255, 255, 0.06)',
+  text: 'var(--chart-neutral-text, #a1a1aa)',           // zinc-400 — primary axis labels
+  textDim: 'var(--chart-neutral-text-dim, #71717a)',    // zinc-500 — secondary text
+  textFaint: 'var(--chart-neutral-text-faint, #52525b)', // zinc-600 — faintest text, track lines
+  surface: 'var(--chart-neutral-surface, #27272a)',     // zinc-800 — area fill, track surface
+  gridLine: 'var(--chart-neutral-grid-line, rgb(255 255 255 / 0.06))',
 } as const
 
 /**
@@ -116,11 +123,11 @@ export const CHART_NEUTRAL = {
  * (large donut arcs); use the base variant for sparklines and gauges.
  */
 export const CHART_TONE = {
-  positive: '#34d399',     // emerald-400 — gauge fill, sparkline positive
-  positiveDeep: '#10b981', // emerald-500 — donut arc weight
-  caution: '#fbbf24',      // amber-400
-  negative: '#fb7185',     // rose-400
-  neutral: '#a1a1aa',      // zinc-400
+  positive: 'var(--chart-tone-positive, #34d399)',          // emerald-400 — gauge fill, sparkline positive
+  positiveDeep: 'var(--chart-tone-positive-deep, #10b981)', // emerald-500 — donut arc weight
+  caution: 'var(--chart-tone-caution, #fbbf24)',            // amber-400
+  negative: 'var(--chart-tone-negative, #fb7185)',          // rose-400
+  neutral: 'var(--chart-tone-neutral, #a1a1aa)',            // zinc-400
 } as const
 
 /** Parse a date string that may be a date-only ("2026-03-15") or full ISO timestamp. */

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -101,9 +101,9 @@
   --color-info-500: var(--color-sky-500);
   --color-info-950: var(--color-sky-950);
 
-  /* Effect colors — gauge/sparkline track, scrollbar thumb, panel/drop
-     shadows, the caution glow, and the light hover overlay. */
-  --color-track: rgb(255 255 255 / 0.06);
+  /* Effect colors — scrollbar thumb, panel/drop shadows, the caution glow, and
+     the light hover overlay. (Gauge/sparkline strokes + track consume the shared
+     --chart-tone-* / --chart-neutral-grid-line tokens registered below.) */
   --color-scrollbar-thumb: rgb(113 113 122 / 0.3);
   --color-shadow-drop: rgb(8 11 15 / 0.34);
   --color-shadow-panel: rgb(0 0 0 / 0.32);
@@ -709,7 +709,7 @@
 
   .gauge-bg {
     fill: none;
-    stroke: var(--color-track);
+    stroke: var(--chart-neutral-grid-line);
   }
 
   .gauge-fill {
@@ -725,19 +725,19 @@
   }
 
   .gauge-fill-positive {
-    stroke: var(--color-positive-400);
+    stroke: var(--chart-tone-positive);
   }
 
   .gauge-fill-caution {
-    stroke: var(--color-caution-400);
+    stroke: var(--chart-tone-caution);
   }
 
   .gauge-fill-negative {
-    stroke: var(--color-negative-400);
+    stroke: var(--chart-tone-negative);
   }
 
   .gauge-fill-neutral {
-    stroke: var(--color-mono-400);
+    stroke: var(--chart-tone-neutral);
   }
 
   .gauge-center {
@@ -1434,24 +1434,24 @@
   }
 
   .sparkline-guide {
-    stroke: var(--color-track);
+    stroke: var(--chart-neutral-grid-line);
     stroke-width: 1;
   }
 
   .sparkline-positive polyline {
-    stroke: var(--color-positive-400);
+    stroke: var(--chart-tone-positive);
   }
 
   .sparkline-caution polyline {
-    stroke: var(--color-caution-400);
+    stroke: var(--chart-tone-caution);
   }
 
   .sparkline-negative polyline {
-    stroke: var(--color-negative-400);
+    stroke: var(--chart-tone-negative);
   }
 
   .sparkline-neutral polyline {
-    stroke: var(--color-mono-400);
+    stroke: var(--chart-tone-neutral);
   }
 
   /* ── Grids ── */

--- a/apps/web/test/chart-primitives.test.ts
+++ b/apps/web/test/chart-primitives.test.ts
@@ -1,0 +1,99 @@
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+import { describe, expect, test } from 'vitest'
+
+import {
+  CHART_AXIS_STROKE,
+  CHART_AXIS_TICK,
+  CHART_GRID_STROKE,
+  CHART_NEUTRAL,
+  CHART_SERIES_COLORS,
+  CHART_TONE,
+  CHART_TOOLTIP_STYLE,
+  PROVIDER_SERIES_COLORS,
+} from '../src/components/shared/ChartPrimitives'
+
+const stylesPath = resolve(import.meta.dirname, '../src/styles.css')
+
+// Pull the leading `var(--name, fallback)` out of a value string. Handles a
+// prefix (`1px solid var(...)`) and a fallback that itself contains parens
+// (`rgba(...)`) by matching balanced parens.
+function parseVar(value: string): { name: string; fallback: string } {
+  const start = value.indexOf('var(')
+  expect(start, `expected a var() in "${value}"`).toBeGreaterThanOrEqual(0)
+  let depth = 0
+  let end = -1
+  for (let i = start + 3; i < value.length; i += 1) {
+    if (value[i] === '(') depth += 1
+    else if (value[i] === ')') {
+      depth -= 1
+      if (depth === 0) {
+        end = i
+        break
+      }
+    }
+  }
+  expect(end, `unbalanced var() in "${value}"`).toBeGreaterThan(0)
+  const inner = value.slice(start + 4, end)
+  const comma = inner.indexOf(',')
+  expect(comma, `var() has no fallback in "${value}"`).toBeGreaterThan(0)
+  return { name: inner.slice(0, comma).trim(), fallback: inner.slice(comma + 1).trim() }
+}
+
+async function chartTokenDefaults(): Promise<Map<string, string>> {
+  const css = await readFile(stylesPath, 'utf8')
+  const map = new Map<string, string>()
+  for (const m of css.matchAll(/(--chart-[a-z0-9-]+):([^;]+);/g)) {
+    map.set(m[1]!, m[2]!.trim())
+  }
+  return map
+}
+
+// Every JS constant that Recharts consumes, paired with the --chart-* token it
+// must bridge to.
+const BRIDGED: Array<[string, string]> = [
+  [CHART_TOOLTIP_STYLE.contentStyle.backgroundColor as string, '--chart-tooltip-bg'],
+  [CHART_TOOLTIP_STYLE.contentStyle.border as string, '--chart-tooltip-border'],
+  [CHART_TOOLTIP_STYLE.labelStyle.color as string, '--chart-tooltip-label'],
+  [CHART_TOOLTIP_STYLE.itemStyle.color as string, '--chart-tooltip-item'],
+  [CHART_AXIS_TICK.fill, '--chart-neutral-text-dim'],
+  [CHART_GRID_STROKE, '--chart-grid'],
+  [CHART_AXIS_STROKE, '--chart-axis'],
+  [CHART_NEUTRAL.text, '--chart-neutral-text'],
+  [CHART_NEUTRAL.textDim, '--chart-neutral-text-dim'],
+  [CHART_NEUTRAL.textFaint, '--chart-neutral-text-faint'],
+  [CHART_NEUTRAL.surface, '--chart-neutral-surface'],
+  [CHART_NEUTRAL.gridLine, '--chart-neutral-grid-line'],
+  [CHART_TONE.positive, '--chart-tone-positive'],
+  [CHART_TONE.positiveDeep, '--chart-tone-positive-deep'],
+  [CHART_TONE.caution, '--chart-tone-caution'],
+  [CHART_TONE.negative, '--chart-tone-negative'],
+  [CHART_TONE.neutral, '--chart-tone-neutral'],
+  ...CHART_SERIES_COLORS.map((c, i): [string, string] => [c, `--chart-series-${i + 1}`]),
+]
+
+describe('ChartPrimitives ↔ CSS chart tokens', () => {
+  test('every Recharts constant bridges to its --chart-* token', () => {
+    for (const [value, token] of BRIDGED) {
+      const { name } = parseVar(value)
+      expect(name).toBe(token)
+    }
+  })
+
+  test('each JS fallback matches the CSS token default (no two-source drift)', async () => {
+    const defaults = await chartTokenDefaults()
+    for (const [value, token] of BRIDGED) {
+      const { name, fallback } = parseVar(value)
+      expect(defaults.has(name), `${name} missing from styles.css @theme`).toBe(true)
+      expect(fallback, `${token} fallback drifted from its CSS default`).toBe(defaults.get(name))
+    }
+  })
+
+  test('provider identity colors stay fixed literal hex (not themeable)', () => {
+    // ProviderBadge identity encodes WHICH engine, not tone — must not bridge.
+    for (const hex of Object.values(PROVIDER_SERIES_COLORS)) {
+      expect(hex).toMatch(/^#[0-9a-f]{6}$/i)
+    }
+  })
+})

--- a/apps/web/test/design-tokens.test.ts
+++ b/apps/web/test/design-tokens.test.ts
@@ -156,9 +156,11 @@ test('neutral, tone, and info scale utilities compile through CSS variables', as
 test('gauge, highlight, and effect primitives consume tokens', async () => {
   const css = await compileAppStyles([])
 
-  expect(ruleFor(css, '.gauge-bg')).toContain('stroke: var(--color-track)')
-  expect(ruleFor(css, '.gauge-fill-positive')).toContain('stroke: var(--color-positive-400)')
-  expect(ruleFor(css, '.gauge-fill-neutral')).toContain('stroke: var(--color-mono-400)')
+  // gauges/sparklines consume the CHART tone tokens (shared with ChartPrimitives,
+  // Phase 4) so they can't drift from the charts
+  expect(ruleFor(css, '.gauge-bg')).toContain('stroke: var(--chart-neutral-grid-line)')
+  expect(ruleFor(css, '.gauge-fill-positive')).toContain('stroke: var(--chart-tone-positive)')
+  expect(ruleFor(css, '.gauge-fill-neutral')).toContain('stroke: var(--chart-tone-neutral)')
   expect(ruleFor(css, '.answer-highlight-brand')).toContain('var(--color-positive-400)')
   expect(ruleFor(css, '.brand-icon')).toContain('var(--color-shadow-drop)')
   // both glow layers must be present — assert each distinctly so the outer-glow

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.106.1",
+  "version": "4.106.2",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.106.1",
+  "version": "4.106.2",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
Phase 4 of #767 — rebased onto `main` after #771 landed (supersedes the auto-closed #773, same commit).

Wires the Recharts JS color constants to the `--chart-*` CSS tokens: every constant is `var(--chart-*, <hex fallback>)`, so charts become runtime-themeable while the default dark render stays identical. `PROVIDER_SERIES_COLORS` stays literal (engine identity). Gauge/sparkline strokes move onto the shared hex `--chart-tone-*` tokens (byte-exact, drops the dead `--color-track`). `test/chart-primitives.test.ts` locks each JS fallback to its CSS default.

**Validated in a real browser:** `var()` resolves in SVG presentation attributes (how Recharts renders `fill`/`stroke`) — confirmed computed colors match; the hex fallback also resolves. web tests 351 / typecheck / lint / build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)