### PR TITLE
chore(scripts): bring scripts/ under typecheck coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "packageManager": "pnpm@10.28.2",
   "scripts": {
     "build": "pnpm --filter @canonry/canonry run build",
-    "typecheck": "pnpm -r --no-bail run typecheck",
+    "typecheck": "pnpm -r --no-bail run typecheck && tsc --noEmit -p scripts/tsconfig.json",
     "test": "vitest run",
     "lint": "pnpm -r run lint",
     "dev:api": "pnpm --filter @ainyc/canonry-api run dev",
@@ -16,7 +16,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^24.5.1",
+    "better-sqlite3": "^12.6.2",
     "eslint": "^9.0.0",
     "eslint-plugin-regexp": "^3.1.0",
     "globals": "^17.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,9 +31,15 @@ importers:
       '@eslint/js':
         specifier: ^9.0.0
         version: 9.39.4
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
       '@types/node':
         specifier: ^24.5.1
         version: 24.12.0
+      better-sqlite3:
+        specifier: ^12.6.2
+        version: 12.6.2
       eslint:
         specifier: ^9.0.0
         version: 9.39.4(jiti@2.6.1)

--- a/scripts/sov-rework-analysis.ts
+++ b/scripts/sov-rework-analysis.ts
@@ -150,17 +150,6 @@ function pct(num: number, denom: number, digits = 1): string {
 function mean(xs: number[]): number {
   return xs.length === 0 ? 0 : xs.reduce((a, b) => a + b, 0) / xs.length
 }
-function median(xs: number[]): number {
-  if (xs.length === 0) return 0
-  const s = [...xs].sort((a, b) => a - b)
-  const mid = Math.floor(s.length / 2)
-  return s.length % 2 === 0 ? (s[mid - 1]! + s[mid]!) / 2 : s[mid]!
-}
-function p90(xs: number[]): number {
-  if (xs.length === 0) return 0
-  const s = [...xs].sort((a, b) => a - b)
-  return s[Math.floor(s.length * 0.9)]!
-}
 
 // ─── Main analysis ───
 function main(): void {

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "incremental": false,
+    "allowImportingTsExtensions": false
+  },
+  "include": ["./*.ts"]
+}


### PR DESCRIPTION
Follow-up to #779: the capture-script TDZ bug escaped `tsc` because `scripts/` sat outside every tsconfig, only the code-quality bot saw it.

- `scripts/tsconfig.json` (extends base, includes `./*.ts`), chained into the root `typecheck` script that CI's validate job already runs, so future script bugs fail PRs, not refresh runs.
- Verified it catches the exact escaped bug: pointed at the pre-#779 code it reports `TS2448: Block-scoped variable 'expectedReplay' used before its declaration`.
- Coverage immediately surfaced pre-existing rot in the legacy SoV analysis script: its `better-sqlite3` import had no root dev dependency (now pinned to the same version as packages/db) and two dead stat helpers (removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)