### PR TITLE
chore(discovery): inaugural discover-eval baseline (canonry 4.111.0)

### DIFF
--- a/canonry-discovery-eval-baseline.json
+++ b/canonry-discovery-eval-baseline.json
@@ -1,0 +1,70 @@
+{
+  "capturedAt": "2026-07-02T22:25:37.829Z",
+  "scorecards": [
+    {
+      "shape": "eval-local-single-intent",
+      "seedCountRaw": 30,
+      "canonicalCount": 16,
+      "canonicalCountTruncated": false,
+      "retention": 0.5333333333333333,
+      "brandShare": 0,
+      "groundingShare": 0,
+      "bandPairFraction": 0.4,
+      "probeCount": 2,
+      "warning": null,
+      "durationSeconds": 28
+    },
+    {
+      "shape": "eval-local-multi-intent",
+      "seedCountRaw": 30,
+      "canonicalCount": 23,
+      "canonicalCountTruncated": false,
+      "retention": 0.7666666666666667,
+      "brandShare": 0,
+      "groundingShare": 0,
+      "bandPairFraction": 0.423,
+      "probeCount": 2,
+      "warning": null,
+      "durationSeconds": 24
+    },
+    {
+      "shape": "eval-b2b-saas",
+      "seedCountRaw": 30,
+      "canonicalCount": 25,
+      "canonicalCountTruncated": false,
+      "retention": 0.8333333333333334,
+      "brandShare": 0,
+      "groundingShare": 0,
+      "bandPairFraction": 0.1862,
+      "probeCount": 2,
+      "warning": null,
+      "durationSeconds": 19
+    },
+    {
+      "shape": "eval-national-ecommerce",
+      "seedCountRaw": 30,
+      "canonicalCount": 25,
+      "canonicalCountTruncated": false,
+      "retention": 0.8333333333333334,
+      "brandShare": 0,
+      "groundingShare": 0,
+      "bandPairFraction": 0.3057,
+      "probeCount": 2,
+      "warning": null,
+      "durationSeconds": 25
+    },
+    {
+      "shape": "eval-problem-heavy-consumer",
+      "seedCountRaw": 30,
+      "canonicalCount": 30,
+      "canonicalCountTruncated": false,
+      "retention": 1,
+      "brandShare": 0,
+      "groundingShare": 0,
+      "bandPairFraction": 0.131,
+      "probeCount": 2,
+      "warning": null,
+      "durationSeconds": 27
+    }
+  ]
+}


### PR DESCRIPTION
The committed baseline for `canonry discover eval` (#781), captured against a clean 4.111.0 container:

| shape | canonicals | retention | brand | grounding | band | time |
|---|---|---|---|---|---|---|
| local-single-intent | 16 | 0.53 | 0.00 | 0.00 | 0.40 | 28s |
| local-multi-intent | 23 | 0.77 | 0.00 | 0.00 | 0.42 | 24s |
| b2b-saas | 25 | 0.83 | 0.00 | 0.00 | 0.19 | 19s |
| national-ecommerce | 25 | 0.83 | 0.00 | 0.00 | 0.31 | 25s |
| problem-heavy-consumer | 30 | 1.00 | 0.00 | 0.00 | 0.13 | 27s |

Notable: zero brand leakage and zero grounding contribution across every shape; the homogeneous-local shape reproduced 16 canonicals for the third independent live run; all canonical counts read from the new pre-truncation `canonical_count`. Future quality changes diff against this file and regenerate it deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)