### PR TITLE
refactor(web): migrate project components to design tokens

### DIFF
--- a/apps/web/src/components/project/BacklinksSection.tsx
+++ b/apps/web/src/components/project/BacklinksSection.tsx
@@ -40,7 +40,7 @@ function Hint({
         type="button"
         aria-label={label}
         aria-describedby={open ? id : undefined}
-        className="inline-flex h-4 w-4 items-center justify-center rounded-full text-zinc-500 hover:text-zinc-200 focus:text-zinc-200 focus:outline-none focus-visible:ring-1 focus-visible:ring-zinc-500"
+        className="inline-flex h-4 w-4 items-center justify-center rounded-full text-muted hover:text-strong focus:text-strong focus:outline-none focus-visible:ring-1 focus-visible:ring-mono-500"
         onMouseEnter={() => setOpen(true)}
         onMouseLeave={() => setOpen(false)}
         onFocus={() => setOpen(true)}
@@ -52,7 +52,7 @@ function Hint({
         <span
           id={id}
           role="tooltip"
-          className={`absolute z-50 w-64 rounded border border-zinc-700 bg-zinc-900 px-3 py-2 text-xs font-normal leading-relaxed text-zinc-200 shadow-lg ${
+          className={`absolute z-50 w-64 rounded border border-strong bg-bg-elevated px-3 py-2 text-xs font-normal leading-relaxed text-strong shadow-lg ${
             placement === 'top' ? 'bottom-full mb-2' : 'top-full mt-2'
           } left-1/2 -translate-x-1/2 whitespace-normal`}
         >
@@ -324,45 +324,45 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
         <div>
           <p className="eyebrow eyebrow-soft">Backlinks</p>
           <h2>Referring domains</h2>
-          <p className="text-sm text-zinc-500 mt-1 max-w-2xl">
+          <p className="text-sm text-muted mt-1 max-w-2xl">
             Domains linking to {' '}
-            <span className="text-zinc-300">{projectName}</span>, from whichever source you have set up — the{' '}
-            <span className="text-zinc-300">Common Crawl</span> hyperlink graph (~monthly) and{' '}
-            <span className="text-zinc-300">Bing Webmaster</span> inbound links (live).
+            <span className="text-neutral">{projectName}</span>, from whichever source you have set up — the{' '}
+            <span className="text-neutral">Common Crawl</span> hyperlink graph (~monthly) and{' '}
+            <span className="text-neutral">Bing Webmaster</span> inbound links (live).
           </p>
         </div>
       </div>
 
       {error && (
-        <Card className="surface-card p-4 mb-4 border-rose-800/60">
-          <p className="text-sm text-rose-300">{error}</p>
+        <Card className="surface-card p-4 mb-4 border-negative-800/60">
+          <p className="text-sm text-negative">{error}</p>
         </Card>
       )}
       {activeRun && (
-        <Card className="surface-card p-4 mb-4 border-sky-800/60">
+        <Card className="surface-card p-4 mb-4 border-info-800/60">
           <div className="flex items-start gap-3">
-            <Loader2 className="h-5 w-5 text-sky-400 animate-spin shrink-0 mt-0.5" aria-hidden />
+            <Loader2 className="h-5 w-5 text-info-400 animate-spin shrink-0 mt-0.5" aria-hidden />
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2 flex-wrap">
-                <p className="text-sm font-medium text-zinc-100">
+                <p className="text-sm font-medium text-heading">
                   {syncSource === 'bing-webmaster' ? 'Bing sync running' : 'Extract running'}
                 </p>
                 <ToneBadge tone="neutral">{activeRun.status}</ToneBadge>
-                <span className="text-xs text-zinc-500 tabular-nums">
+                <span className="text-xs text-muted tabular-nums">
                   {formatElapsed(activeRun.startedAt ?? null, activeRun.createdAt)} elapsed · refreshing every 3s
                 </span>
                 <span className="sr-only">now={now}</span>
               </div>
               {syncSource === 'bing-webmaster' ? (
-                <p className="text-xs text-zinc-500 mt-1">
+                <p className="text-xs text-muted mt-1">
                   Pulling inbound links live from Bing Webmaster for{' '}
-                  <span className="text-zinc-300">{projectName}</span>. Time depends on how many pages link to your site.
+                  <span className="text-neutral">{projectName}</span>. Time depends on how many pages link to your site.
                 </p>
               ) : (
-                <p className="text-xs text-zinc-500 mt-1">
+                <p className="text-xs text-muted mt-1">
                   Re-querying the cached Common Crawl release for{' '}
-                  <span className="text-zinc-300">{projectName}</span>. No re-download — the ~16&nbsp;GB dump already lives at{' '}
-                  <code className="text-zinc-400">~/.canonry/cache/commoncrawl/</code>. Typically takes ~5 minutes.
+                  <span className="text-neutral">{projectName}</span>. No re-download — the ~16&nbsp;GB dump already lives at{' '}
+                  <code className="text-secondary">~/.canonry/cache/commoncrawl/</code>. Typically takes ~5 minutes.
                 </p>
               )}
             </div>
@@ -370,23 +370,23 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
         </Card>
       )}
       {justCompletedRun && !activeRun && (
-        <Card className={`surface-card p-4 mb-4 ${justCompletedRun.status === 'failed' ? 'border-rose-800/60' : 'border-emerald-800/60'}`}>
+        <Card className={`surface-card p-4 mb-4 ${justCompletedRun.status === 'failed' ? 'border-negative-800/60' : 'border-positive-800/60'}`}>
           <div className="flex items-start gap-3">
             {justCompletedRun.status === 'failed' ? (
-              <span className="h-5 w-5 shrink-0 mt-0.5 text-rose-400 text-lg leading-none" aria-hidden>!</span>
+              <span className="h-5 w-5 shrink-0 mt-0.5 text-negative-400 text-lg leading-none" aria-hidden>!</span>
             ) : (
-              <CheckCircle2 className="h-5 w-5 text-emerald-400 shrink-0 mt-0.5" aria-hidden />
+              <CheckCircle2 className="h-5 w-5 text-positive-400 shrink-0 mt-0.5" aria-hidden />
             )}
             <div className="flex-1">
-              <p className={`text-sm font-medium ${justCompletedRun.status === 'failed' ? 'text-rose-300' : 'text-emerald-300'}`}>
+              <p className={`text-sm font-medium ${justCompletedRun.status === 'failed' ? 'text-negative' : 'text-positive'}`}>
                 {syncSource === 'bing-webmaster'
                   ? (justCompletedRun.status === 'failed' ? 'Bing sync failed' : 'Bing sync complete')
                   : (justCompletedRun.status === 'failed' ? 'Extract failed' : 'Extract complete')}
               </p>
               {justCompletedRun.error
-                ? <p className="text-xs text-zinc-500 mt-1">{summarizeRunError(justCompletedRun.error)}</p>
+                ? <p className="text-xs text-muted mt-1">{summarizeRunError(justCompletedRun.error)}</p>
                 : justCompletedRun.status !== 'failed'
-                  ? <p className="text-xs text-zinc-500 mt-1">
+                  ? <p className="text-xs text-muted mt-1">
                       {syncSource === 'bing-webmaster'
                         ? 'Inbound links refreshed live from Bing Webmaster.'
                         : 'Backlinks refreshed from the cached release.'}
@@ -405,7 +405,7 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
     if (loading || !sources) {
       return (
         <Card className="surface-card p-6">
-          <p className="text-sm text-zinc-500">Loading backlinks…</p>
+          <p className="text-sm text-muted">Loading backlinks…</p>
         </Card>
       )
     }
@@ -426,7 +426,7 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
       <div className="flex items-center gap-2 mb-4 flex-wrap" role="tablist" aria-label="Backlink source">
         {avail.sources.map((s) => {
           const active = s.source === selectedSource
-          const dot = s.hasData ? 'bg-emerald-500' : s.connected ? 'bg-amber-500' : 'bg-zinc-600'
+          const dot = s.hasData ? 'bg-positive-500' : s.connected ? 'bg-caution-500' : 'bg-mono-600'
           return (
             <button
               key={s.source}
@@ -434,15 +434,15 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
               role="tab"
               aria-selected={active}
               onClick={() => pickSource(s.source)}
-              className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-zinc-500 ${
+              className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-mono-500 ${
                 active
-                  ? 'border-zinc-500 bg-zinc-800 text-zinc-100'
-                  : 'border-zinc-800 bg-zinc-900/40 text-zinc-400 hover:text-zinc-200'
+                  ? 'border-mono-500 bg-mono-800 text-heading'
+                  : 'border-base bg-bg-elevated/40 text-secondary hover:text-strong'
               }`}
             >
               <span className={`h-1.5 w-1.5 rounded-full ${dot}`} aria-hidden />
               {SOURCE_LABELS[s.source]}
-              {s.hasData && <span className="text-zinc-500 tabular-nums">{formatNumber(s.totalLinkingDomains)}</span>}
+              {s.hasData && <span className="text-muted tabular-nums">{formatNumber(s.totalLinkingDomains)}</span>}
             </button>
           )
         })}
@@ -454,22 +454,22 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
     return (
       <Card className="surface-card p-6">
         <div className="flex items-start gap-4">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-zinc-900 text-zinc-400">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-bg-elevated text-secondary">
             <Link2 className="h-5 w-5" aria-hidden />
           </div>
           <div className="flex-1">
-            <h3 className="text-base font-semibold text-zinc-100">No backlink source set up yet</h3>
-            <p className="text-sm text-zinc-500 mt-1 max-w-2xl">
+            <h3 className="text-base font-semibold text-heading">No backlink source set up yet</h3>
+            <p className="text-sm text-muted mt-1 max-w-2xl">
               Connect at least one source to see which domains link to{' '}
-              <code className="text-zinc-300">{projectName}</code>:
+              <code className="text-neutral">{projectName}</code>:
             </p>
-            <ul className="mt-3 space-y-2 text-sm text-zinc-400">
+            <ul className="mt-3 space-y-2 text-sm text-secondary">
               <li>
-                <span className="text-zinc-200">Common Crawl</span> — free public hyperlink graph, refreshes ~monthly.
+                <span className="text-strong">Common Crawl</span> — free public hyperlink graph, refreshes ~monthly.
                 Enable backlinks and run a workspace release sync.
               </li>
               <li>
-                <span className="text-zinc-200">Bing Webmaster</span> — live inbound links from your verified site.
+                <span className="text-strong">Bing Webmaster</span> — live inbound links from your verified site.
                 Connect a Bing Webmaster account, then sync.
               </li>
             </ul>
@@ -478,9 +478,9 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
                 <a href={publicPath('/backlinks')}>Set up Common Crawl</a>
               </Button>
             </div>
-            <p className="mt-3 text-xs text-zinc-500">
+            <p className="mt-3 text-xs text-muted">
               Connect Bing with{' '}
-              <code className="text-zinc-400">canonry bing connect {projectName} --api-key &lt;key&gt;</code>.
+              <code className="text-secondary">canonry bing connect {projectName} --api-key &lt;key&gt;</code>.
             </p>
           </div>
         </div>
@@ -501,15 +501,15 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
       return (
         <Card className="surface-card p-6">
           <div className="flex items-start gap-4">
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-zinc-900 text-zinc-400">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-bg-elevated text-secondary">
               <Link2 className="h-5 w-5" aria-hidden />
             </div>
             <div className="flex-1">
               {connected && everSynced ? (
                 <>
-                  <h3 className="text-base font-semibold text-zinc-100">No non-crawler referring domains</h3>
-                  <p className="text-sm text-zinc-500 mt-1">
-                    Bing Webmaster synced for <code className="text-zinc-300">{projectName}</code>, but every inbound
+                  <h3 className="text-base font-semibold text-heading">No non-crawler referring domains</h3>
+                  <p className="text-sm text-muted mt-1">
+                    Bing Webmaster synced for <code className="text-neutral">{projectName}</code>, but every inbound
                     link in the latest window is a crawler/proxy host (hidden by default). Re-sync to check for new links.
                   </p>
                   <div className="mt-4">
@@ -521,9 +521,9 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
                 </>
               ) : connected ? (
                 <>
-                  <h3 className="text-base font-semibold text-zinc-100">No Bing inbound links yet</h3>
-                  <p className="text-sm text-zinc-500 mt-1">
-                    Bing Webmaster is connected for <code className="text-zinc-300">{projectName}</code> but no inbound
+                  <h3 className="text-base font-semibold text-heading">No Bing inbound links yet</h3>
+                  <p className="text-sm text-muted mt-1">
+                    Bing Webmaster is connected for <code className="text-neutral">{projectName}</code> but no inbound
                     links have been synced yet. Run a sync to pull them live from your account.
                   </p>
                   <div className="mt-4">
@@ -535,12 +535,12 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
                 </>
               ) : (
                 <>
-                  <h3 className="text-base font-semibold text-zinc-100">Bing Webmaster not connected</h3>
-                  <p className="text-sm text-zinc-500 mt-1">
-                    Connect a Bing Webmaster account for <code className="text-zinc-300">{projectName}</code> to pull
+                  <h3 className="text-base font-semibold text-heading">Bing Webmaster not connected</h3>
+                  <p className="text-sm text-muted mt-1">
+                    Connect a Bing Webmaster account for <code className="text-neutral">{projectName}</code> to pull
                     live inbound links, then sync.
                   </p>
-                  <pre className="mt-3 rounded bg-zinc-900 border border-zinc-800 px-3 py-2 text-xs text-zinc-300 overflow-x-auto">
+                  <pre className="mt-3 rounded bg-bg-elevated border border-base px-3 py-2 text-xs text-neutral overflow-x-auto">
                     canonry bing connect {projectName} --api-key &lt;key&gt;
                   </pre>
                 </>
@@ -571,14 +571,14 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
       return (
         <Card className="surface-card p-6">
           <div className="flex items-start gap-4">
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-zinc-900 text-zinc-400">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-bg-elevated text-secondary">
               <Link2 className="h-5 w-5" aria-hidden />
             </div>
             <div className="flex-1">
               {!latestSync && (
                 <>
-                  <h3 className="text-base font-semibold text-zinc-100">No release sync yet</h3>
-                  <p className="text-sm text-zinc-500 mt-1">
+                  <h3 className="text-base font-semibold text-heading">No release sync yet</h3>
+                  <p className="text-sm text-muted mt-1">
                     Run a workspace release sync to populate backlinks for every project in this workspace.
                   </p>
                   <div className="mt-4">
@@ -590,8 +590,8 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
               )}
               {hasRunningSync && (
                 <>
-                  <h3 className="text-base font-semibold text-zinc-100">Sync in progress</h3>
-                  <p className="text-sm text-zinc-500 mt-1">
+                  <h3 className="text-base font-semibold text-heading">Sync in progress</h3>
+                  <p className="text-sm text-muted mt-1">
                     A workspace release sync is running ({latestSync.status}
                     {latestSync.phaseDetail ? ` — ${latestSync.phaseDetail}` : ''}). Backlinks will appear here once it finishes.
                   </p>
@@ -604,8 +604,8 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
               )}
               {hasFailedSync && (
                 <>
-                  <h3 className="text-base font-semibold text-zinc-100">Last sync failed</h3>
-                  <p className="text-sm text-zinc-500 mt-1">
+                  <h3 className="text-base font-semibold text-heading">Last sync failed</h3>
+                  <p className="text-sm text-muted mt-1">
                     {latestSync.error ?? 'The workspace release sync failed. Retry from the Backlinks admin page.'}
                   </p>
                   <div className="mt-4">
@@ -617,10 +617,10 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
               )}
               {hasReadySync && !hasRunningSync && !hasEmptySummary && !justFailed && (
                 <>
-                  <h3 className="text-base font-semibold text-zinc-100">No backlinks yet for this project</h3>
-                  <p className="text-sm text-zinc-500 mt-1">
-                    Release <code className="text-zinc-300">{latestSync.release}</code> is ready but no backlinks have been extracted for{' '}
-                    <code className="text-zinc-300">{projectName}</code>. Run an extract to populate data using the cached release.
+                  <h3 className="text-base font-semibold text-heading">No backlinks yet for this project</h3>
+                  <p className="text-sm text-muted mt-1">
+                    Release <code className="text-neutral">{latestSync.release}</code> is ready but no backlinks have been extracted for{' '}
+                    <code className="text-neutral">{projectName}</code>. Run an extract to populate data using the cached release.
                   </p>
                   <div className="mt-4 flex items-center gap-3 flex-wrap">
                     <Button type="button" size="sm" disabled={extracting || activeRun !== null} onClick={asyncHandler(handleExtract)}>
@@ -629,11 +629,11 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
                     </Button>
                     <Hint label="What does Run extract do?">
                       <span className="block">
-                        Runs a DuckDB query against the <span className="text-zinc-200">cached release files</span> at{' '}
-                        <code className="text-zinc-300">~/.canonry/cache/commoncrawl/</code> to find referring domains for <span className="text-zinc-200">{projectName}</span>.
+                        Runs a DuckDB query against the <span className="text-strong">cached release files</span> at{' '}
+                        <code className="text-neutral">~/.canonry/cache/commoncrawl/</code> to find referring domains for <span className="text-strong">{projectName}</span>.
                       </span>
-                      <span className="mt-2 block text-zinc-400">
-                        No re-download. Typically takes <span className="text-zinc-200">~5 min</span>.
+                      <span className="mt-2 block text-secondary">
+                        No re-download. Typically takes <span className="text-strong">~5 min</span>.
                       </span>
                     </Hint>
                   </div>
@@ -641,10 +641,10 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
               )}
               {justFailed && (
                 <>
-                  <h3 className="text-base font-semibold text-zinc-100">Last extract failed</h3>
-                  <p className="text-sm text-zinc-500 mt-1">
+                  <h3 className="text-base font-semibold text-heading">Last extract failed</h3>
+                  <p className="text-sm text-muted mt-1">
                     See the error above for details. If the cache files for release{' '}
-                    <code className="text-zinc-300">{latestSync?.release}</code> are missing, re-sync the release from the Backlinks admin to restore the ~16 GB dump, then re-run the extract.
+                    <code className="text-neutral">{latestSync?.release}</code> are missing, re-sync the release from the Backlinks admin to restore the ~16 GB dump, then re-run the extract.
                   </p>
                   <div className="mt-4 flex items-center gap-3 flex-wrap">
                     <Button asChild type="button" size="sm">
@@ -655,18 +655,18 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
               )}
               {hasEmptySummary && (
                 <>
-                  <h3 className="text-base font-semibold text-zinc-100">No referring domains found</h3>
-                  <p className="text-sm text-zinc-500 mt-1">
-                    The last extract against release <code className="text-zinc-300">{summary!.release}</code> found{' '}
-                    <span className="text-zinc-300">0 referring domains</span> for{' '}
-                    <code className="text-zinc-300">{summary!.targetDomain}</code>. This can happen when:
+                  <h3 className="text-base font-semibold text-heading">No referring domains found</h3>
+                  <p className="text-sm text-muted mt-1">
+                    The last extract against release <code className="text-neutral">{summary!.release}</code> found{' '}
+                    <span className="text-neutral">0 referring domains</span> for{' '}
+                    <code className="text-neutral">{summary!.targetDomain}</code>. This can happen when:
                   </p>
-                  <ul className="mt-2 space-y-1 text-xs text-zinc-500 list-disc list-inside">
+                  <ul className="mt-2 space-y-1 text-xs text-muted list-disc list-inside">
                     <li>the domain is newer than the release&rsquo;s crawl window</li>
                     <li>the Common Crawl snapshot didn&rsquo;t capture pages that link to it</li>
                     <li>the extract ran against a cache that was missing or incomplete</li>
                   </ul>
-                  <p className="text-sm text-zinc-500 mt-3">
+                  <p className="text-sm text-muted mt-3">
                     Try syncing a newer release — each Common Crawl dump is a different snapshot of the web graph.
                   </p>
                   <div className="mt-4 flex items-center gap-3 flex-wrap">
@@ -679,9 +679,9 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
                     </Button>
                     <Hint label="What does Re-run extract do?">
                       <span className="block">
-                        Re-queries the cached release for <span className="text-zinc-200">{summary!.targetDomain}</span>. Only useful if the cache files were incomplete last time.
+                        Re-queries the cached release for <span className="text-strong">{summary!.targetDomain}</span>. Only useful if the cache files were incomplete last time.
                       </span>
-                      <span className="mt-2 block text-zinc-400">
+                      <span className="mt-2 block text-secondary">
                         No re-download. ~5 min. If the release genuinely has no links for your domain, this won&rsquo;t help — sync a different release instead.
                       </span>
                     </Hint>
@@ -702,11 +702,11 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
         </Button>
         <Hint label="What does Re-run extract do?">
           <span className="block">
-            Re-queries the <span className="text-zinc-200">cached release files</span> at{' '}
-            <code className="text-zinc-300">~/.canonry/cache/commoncrawl/</code> for <span className="text-zinc-200">{projectName}</span>. Replaces existing backlink rows for this project under the current release.
+            Re-queries the <span className="text-strong">cached release files</span> at{' '}
+            <code className="text-neutral">~/.canonry/cache/commoncrawl/</code> for <span className="text-strong">{projectName}</span>. Replaces existing backlink rows for this project under the current release.
           </span>
-          <span className="mt-2 block text-zinc-400">
-            <span className="text-zinc-200">No re-download</span> of the ~16 GB dump. Typically <span className="text-zinc-200">~5 min</span>.
+          <span className="mt-2 block text-secondary">
+            <span className="text-strong">No re-download</span> of the ~16 GB dump. Typically <span className="text-strong">~5 min</span>.
           </span>
         </Hint>
         <Button asChild type="button" variant="outline" size="sm">
@@ -731,34 +731,34 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
           <div className="metric-card">
             <p className="metric-card-eyebrow">Referring domains</p>
             <p className="metric-card-big-value">
-              <span className="text-zinc-50">{formatNumber(summary.totalLinkingDomains)}</span>
+              <span className="text-primary">{formatNumber(summary.totalLinkingDomains)}</span>
             </p>
             <p className="metric-card-sub">unique domains linking to {summary.targetDomain}</p>
           </div>
           <div className="metric-card">
             <p className="metric-card-eyebrow">Total {countNoun}</p>
             <p className="metric-card-big-value">
-              <span className="text-zinc-50">{formatNumber(summary.totalHosts)}</span>
+              <span className="text-primary">{formatNumber(summary.totalHosts)}</span>
             </p>
             <p className="metric-card-sub">aggregate {countNoun} across referring domains</p>
           </div>
           <div className="metric-card">
             <p className="metric-card-eyebrow">Top-10 concentration</p>
             <p className="metric-card-big-value">
-              <span className="text-zinc-50">{formatPct(summary.top10HostsShare)}</span>
+              <span className="text-primary">{formatPct(summary.top10HostsShare)}</span>
             </p>
             <p className="metric-card-sub">share of {countNoun} from the 10 largest linking domains</p>
           </div>
         </div>
 
-        <p className="text-xs text-zinc-600 mt-2">
-          <span className="text-zinc-400">{SOURCE_LABELS[selectedSource]}</span> · {windowNoun}{' '}
-          <code className="text-zinc-400">{summary.release}</code> · queried {relativeTime(summary.queriedAt)}
+        <p className="text-xs text-faint mt-2">
+          <span className="text-secondary">{SOURCE_LABELS[selectedSource]}</span> · {windowNoun}{' '}
+          <code className="text-secondary">{summary.release}</code> · queried {relativeTime(summary.queriedAt)}
           {hiddenCount > 0 && (
-            <> · <span className="text-zinc-500">{hiddenCount} crawler/proxy domain{hiddenCount === 1 ? '' : 's'} hidden</span></>
+            <> · <span className="text-muted">{hiddenCount} crawler/proxy domain{hiddenCount === 1 ? '' : 's'} hidden</span></>
           )}
         </p>
-        <p className="text-[11px] text-zinc-600 mt-0.5">{SOURCE_FRESHNESS[selectedSource]}</p>
+        <p className="text-[11px] text-faint mt-0.5">{SOURCE_FRESHNESS[selectedSource]}</p>
 
         {chartData.length >= 2 && (
           <Card className="surface-card p-4 mt-4">
@@ -798,7 +798,7 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
           <div className="flex items-center justify-between mb-2">
             <p className="eyebrow eyebrow-soft">Top referring domains</p>
             {canPage && (
-              <p className="text-xs text-zinc-600">
+              <p className="text-xs text-faint">
                 Page {page} of {totalPages} · {formatNumber(visibleTotal)} total
               </p>
             )}
@@ -806,20 +806,20 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
           <Card className="surface-card overflow-hidden">
             <table className="w-full text-sm">
               <thead>
-                <tr className="border-b border-zinc-800 text-left text-xs uppercase tracking-wide text-zinc-600">
+                <tr className="border-b border-base text-left text-xs uppercase tracking-wide text-faint">
                   <th className="px-4 py-2 font-medium">Domain</th>
                   <th className="px-4 py-2 text-right font-medium">{countLabel}</th>
                 </tr>
               </thead>
               <tbody>
                 {pageRows.map((row: BacklinkDomainDto) => (
-                  <tr key={row.linkingDomain} className="border-b border-zinc-900 last:border-0">
-                    <td className="px-4 py-2 text-zinc-200">{row.linkingDomain}</td>
-                    <td className="px-4 py-2 text-right text-zinc-400 tabular-nums">{formatNumber(row.numHosts)}</td>
+                  <tr key={row.linkingDomain} className="border-b border-mono-900 last:border-0">
+                    <td className="px-4 py-2 text-strong">{row.linkingDomain}</td>
+                    <td className="px-4 py-2 text-right text-secondary tabular-nums">{formatNumber(row.numHosts)}</td>
                   </tr>
                 ))}
                 {pageRows.length === 0 && (
-                  <tr><td className="px-4 py-4 text-sm text-zinc-500" colSpan={2}>
+                  <tr><td className="px-4 py-4 text-sm text-muted" colSpan={2}>
                     {hiddenCount > 0 && visibleTotal === 0
                       ? `Every referring domain in this ${windowNoun} was a crawler/proxy host (${hiddenCount} hidden).`
                       : `No referring domains in this ${windowNoun}.`}

--- a/apps/web/src/components/project/EvidenceTable.tsx
+++ b/apps/web/src/components/project/EvidenceTable.tsx
@@ -140,12 +140,12 @@ export function summarizeSignalsForItems(items: CitationInsightVm[]): EvidenceSi
 
 function SignalBadge({ signal }: { signal: EvidenceSignalSummary }) {
   const toneClass = signal.tone === 'positive'
-    ? 'border-emerald-500/25 bg-emerald-500/10 text-emerald-300'
+    ? 'border-positive-500/25 bg-positive-500/10 text-positive'
     : signal.tone === 'negative'
-      ? 'border-rose-500/25 bg-rose-500/10 text-rose-300'
+      ? 'border-negative-500/25 bg-negative-500/10 text-negative'
       : signal.tone === 'pending'
-        ? 'border-amber-500/20 bg-amber-500/10 text-amber-300'
-        : 'border-zinc-700/60 bg-zinc-900/70 text-zinc-400'
+        ? 'border-caution-500/20 bg-caution-500/10 text-caution'
+        : 'border-mono-700/60 bg-bg-elevated/70 text-secondary'
   return (
     <span className={`inline-flex items-center rounded-md border px-1.5 py-0.5 text-[10px] font-medium leading-none ${toneClass}`}>
       {signal.label}
@@ -214,9 +214,9 @@ export function EvidenceTable({
   return (
     <div>
       <div className="mb-3 flex flex-wrap items-center gap-2">
-        <span className="text-[10px] uppercase tracking-wide text-zinc-500">View by</span>
+        <span className="text-[10px] uppercase tracking-wide text-muted">View by</span>
         <div
-          className="inline-flex gap-0.5 p-0.5 rounded-md bg-zinc-900/60 border border-zinc-800/40"
+          className="inline-flex gap-0.5 p-0.5 rounded-md bg-bg-elevated/60 border border-subtle"
           role="tablist"
           aria-label="Citation tracking view"
         >
@@ -226,8 +226,8 @@ export function EvidenceTable({
             aria-selected={mode === 'mentions'}
             className={`px-2.5 py-1 text-xs font-medium rounded transition-colors ${
               mode === 'mentions'
-                ? 'bg-zinc-800 text-zinc-100'
-                : 'text-zinc-400 hover:text-zinc-200'
+                ? 'bg-mono-800 text-heading'
+                : 'text-secondary hover:text-strong'
             }`}
             onClick={() => setMode('mentions')}
           >
@@ -239,15 +239,15 @@ export function EvidenceTable({
             aria-selected={mode === 'citations'}
             className={`px-2.5 py-1 text-xs font-medium rounded transition-colors ${
               mode === 'citations'
-                ? 'bg-zinc-800 text-zinc-100'
-                : 'text-zinc-400 hover:text-zinc-200'
+                ? 'bg-mono-800 text-heading'
+                : 'text-secondary hover:text-strong'
             }`}
             onClick={() => setMode('citations')}
           >
             Citations
           </button>
         </div>
-        <span className="text-[11px] text-zinc-500">
+        <span className="text-[11px] text-muted">
           {mode === 'mentions'
             ? 'Brand or domain in answer text'
             : 'Brand or domain in source links'}
@@ -255,7 +255,7 @@ export function EvidenceTable({
         <div className="ml-auto flex items-center gap-3">
           <button
             type="button"
-            className="text-[11px] text-zinc-400 hover:text-zinc-200"
+            className="text-[11px] text-secondary hover:text-strong"
             onClick={() => {
               setExpandedRows(prev =>
                 prev.size === groups.length
@@ -267,9 +267,9 @@ export function EvidenceTable({
             {expandedRows.size === groups.length && groups.length > 0 ? 'Collapse all' : 'Expand all'}
           </button>
           <div className="flex items-center gap-2">
-            <span className="text-[10px] uppercase tracking-wide text-zinc-500">Density</span>
+            <span className="text-[10px] uppercase tracking-wide text-muted">Density</span>
             <div
-              className="inline-flex gap-0.5 p-0.5 rounded-md bg-zinc-900/60 border border-zinc-800/40"
+              className="inline-flex gap-0.5 p-0.5 rounded-md bg-bg-elevated/60 border border-subtle"
               role="tablist"
               aria-label="Evidence row density"
             >
@@ -279,8 +279,8 @@ export function EvidenceTable({
                 aria-selected={density === 'compact'}
                 className={`px-2.5 py-1 text-xs font-medium rounded transition-colors ${
                   density === 'compact'
-                    ? 'bg-zinc-800 text-zinc-100'
-                    : 'text-zinc-400 hover:text-zinc-200'
+                    ? 'bg-mono-800 text-heading'
+                    : 'text-secondary hover:text-strong'
                 }`}
                 onClick={() => setDensity('compact')}
               >
@@ -292,8 +292,8 @@ export function EvidenceTable({
                 aria-selected={density === 'detailed'}
                 className={`px-2.5 py-1 text-xs font-medium rounded transition-colors ${
                   density === 'detailed'
-                    ? 'bg-zinc-800 text-zinc-100'
-                    : 'text-zinc-400 hover:text-zinc-200'
+                    ? 'bg-mono-800 text-heading'
+                    : 'text-secondary hover:text-strong'
                 }`}
                 onClick={() => setDensity('detailed')}
               >
@@ -332,7 +332,7 @@ export function EvidenceTable({
               return (
                 <Fragment key={groupKey}>
                   <tr
-                    className="evidence-phrase-row cursor-pointer hover:bg-zinc-800/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400"
+                    className="evidence-phrase-row cursor-pointer hover:bg-mono-800/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mono-400"
                     onClick={() => toggleRow(groupKey)}
                     onKeyDown={(e) => {
                       if (e.key === 'Enter' || e.key === ' ') {
@@ -347,14 +347,14 @@ export function EvidenceTable({
                     <td>
                       <ChevronRight
                         size={14}
-                        className={`transition-transform duration-150 text-zinc-500 ${isExpanded ? 'rotate-90' : ''}`}
+                        className={`transition-transform duration-150 text-muted ${isExpanded ? 'rotate-90' : ''}`}
                       />
                     </td>
                     <td className="evidence-query-cell">
                       <div>
-                        <span className="font-medium text-zinc-100">{phrase}</span>
+                        <span className="font-medium text-heading">{phrase}</span>
                         {compareLocations && (
-                          <span className="ml-2 text-[10px] uppercase tracking-wide text-zinc-500">
+                          <span className="ml-2 text-[10px] uppercase tracking-wide text-muted">
                             {location ?? 'No location'}
                           </span>
                         )}
@@ -369,7 +369,7 @@ export function EvidenceTable({
                       <div className="flex items-center gap-2">
                         <CitationBadge state={aggState} label={statusLabelForMode(aggState, mode)} />
                         <span
-                          className="text-[11px] text-zinc-500"
+                          className="text-[11px] text-muted"
                           title={`${presentCount} of ${items.length} engines ${countNoun}`}
                         >
                           {presentCount}/{items.length}
@@ -387,7 +387,7 @@ export function EvidenceTable({
                   </tr>
                   {isExpanded && items.map((item, index) => (
                     <Fragment key={item.id}>
-                      <tr className="bg-zinc-900/30">
+                      <tr className="bg-surface">
                         <td />
                         <td className="evidence-query-cell pl-5">
                           <ProviderBadge provider={item.provider} />
@@ -417,7 +417,7 @@ export function EvidenceTable({
                         </td>
                       </tr>
                       {density === 'detailed' && (
-                        <tr className="bg-zinc-900/20">
+                        <tr className="bg-surface-subtle">
                           <td />
                           <td colSpan={5} className="px-5 pb-4">
                             <AnswerInlinePanel
@@ -474,7 +474,7 @@ function AnswerInlinePanel({
   const hasAnswer = item.answerSnippet.trim().length > 0
   if (!hasAnswer) {
     return (
-      <p className="text-[11px] text-zinc-500 italic">
+      <p className="text-[11px] text-muted italic">
         No answer text captured for this run.
       </p>
     )
@@ -485,41 +485,41 @@ function AnswerInlinePanel({
 
   return (
     <div className="space-y-2">
-      <p className="text-[10px] uppercase tracking-wide text-zinc-500">Answer text</p>
-      <p className="text-sm leading-relaxed text-zinc-300">
+      <p className="text-[10px] uppercase tracking-wide text-muted">Answer text</p>
+      <p className="text-sm leading-relaxed text-neutral">
         {highlightTermsInText(body, groups)}
       </p>
       {(item.citedDomains.length > 0 || item.competitorDomains.length > 0) && (
         <div className="flex flex-wrap items-center gap-1.5">
           {item.citedDomains.length > 0 && (
             <>
-              <span className="text-[10px] uppercase tracking-wide text-zinc-500">Cited:</span>
+              <span className="text-[10px] uppercase tracking-wide text-muted">Cited:</span>
               {item.citedDomains.slice(0, 6).map(d => (
                 <span
                   key={`c-${d}`}
-                  className="rounded-full border border-zinc-700/60 bg-zinc-900/60 px-2 py-0.5 text-[11px] text-zinc-300"
+                  className="rounded-full border border-mono-700/60 bg-bg-elevated/60 px-2 py-0.5 text-[11px] text-neutral"
                 >
                   {d}
                 </span>
               ))}
               {item.citedDomains.length > 6 && (
-                <span className="text-[10px] text-zinc-500">+{item.citedDomains.length - 6} more</span>
+                <span className="text-[10px] text-muted">+{item.citedDomains.length - 6} more</span>
               )}
             </>
           )}
           {item.competitorDomains.length > 0 && (
             <>
-              <span className="ml-2 text-[10px] uppercase tracking-wide text-rose-500/80">Competitors:</span>
+              <span className="ml-2 text-[10px] uppercase tracking-wide text-negative-500/80">Competitors:</span>
               {item.competitorDomains.slice(0, 4).map(d => (
                 <span
                   key={`co-${d}`}
-                  className="rounded-full border border-rose-900/40 bg-rose-950/30 px-2 py-0.5 text-[11px] text-rose-300"
+                  className="rounded-full border border-negative-900/40 bg-negative-950/30 px-2 py-0.5 text-[11px] text-negative"
                 >
                   {d}
                 </span>
               ))}
               {item.competitorDomains.length > 4 && (
-                <span className="text-[10px] text-zinc-500">+{item.competitorDomains.length - 4} more</span>
+                <span className="text-[10px] text-muted">+{item.competitorDomains.length - 4} more</span>
               )}
             </>
           )}
@@ -528,7 +528,7 @@ function AnswerInlinePanel({
       {truncated && (
         <button
           type="button"
-          className="text-[11px] font-medium text-emerald-400 hover:text-emerald-300"
+          className="text-[11px] font-medium text-positive-400 hover:text-positive"
           onClick={(e) => { e.stopPropagation(); onViewFull() }}
         >
           View full answer →

--- a/apps/web/src/components/project/GbpSection.tsx
+++ b/apps/web/src/components/project/GbpSection.tsx
@@ -205,12 +205,12 @@ export function GbpSection({ projectName, projectId }: { projectName: string; pr
       {
         title: 'Select locations',
         command: `canonry gbp locations discover ${projectName}`,
-        note: <>Then adopt the ones to sync: <code className="rounded bg-zinc-900/80 px-1 py-0.5 font-mono text-[11px] text-zinc-400">canonry gbp locations select {projectName} &lt;location&gt;</code></>,
+        note: <>Then adopt the ones to sync: <code className="rounded bg-bg-elevated/80 px-1 py-0.5 font-mono text-[11px] text-secondary">canonry gbp locations select {projectName} &lt;location&gt;</code></>,
       },
       {
         title: 'Sync, and keep it fresh',
         command: `canonry gbp sync ${projectName}`,
-        note: <>Schedule it: <code className="rounded bg-zinc-900/80 px-1 py-0.5 font-mono text-[11px] text-zinc-400">canonry schedule set {projectName} --kind gbp-sync --preset daily</code></>,
+        note: <>Schedule it: <code className="rounded bg-bg-elevated/80 px-1 py-0.5 font-mono text-[11px] text-secondary">canonry schedule set {projectName} --kind gbp-sync --preset daily</code></>,
       },
     ]
     return (
@@ -218,22 +218,22 @@ export function GbpSection({ projectName, projectId }: { projectName: string; pr
         <Card className="surface-card">
           <p className="eyebrow eyebrow-soft">Local presence</p>
           <h2>Connect Google Business Profile</h2>
-          <p className="mt-2 max-w-2xl text-sm leading-6 text-zinc-500">
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-muted">
             Track local performance, search terms, place-action CTAs, and how your public Maps listing compares to
             the profile you control. Four steps from the CLI:
           </p>
           <ol className="mt-5 space-y-4">
             {steps.map((step, index) => (
               <li key={step.title} className="grid grid-cols-[1.5rem_1fr] gap-x-3">
-                <span className="mt-0.5 inline-flex h-6 w-6 items-center justify-center rounded-full bg-zinc-800 text-xs font-medium tabular-nums text-zinc-300" aria-hidden="true">
+                <span className="mt-0.5 inline-flex h-6 w-6 items-center justify-center rounded-full bg-mono-800 text-xs font-medium tabular-nums text-neutral" aria-hidden="true">
                   {index + 1}
                 </span>
                 <div className="min-w-0">
-                  <p className="text-sm font-medium text-zinc-200">{step.title}</p>
-                  <code className="mt-1.5 inline-block w-fit max-w-full overflow-x-auto rounded bg-zinc-900/80 px-2 py-1 font-mono text-xs text-zinc-300">
+                  <p className="text-sm font-medium text-strong">{step.title}</p>
+                  <code className="mt-1.5 inline-block w-fit max-w-full overflow-x-auto rounded bg-bg-elevated/80 px-2 py-1 font-mono text-xs text-neutral">
                     {step.command}
                   </code>
-                  <p className="mt-1 text-xs leading-5 text-zinc-500">{step.note}</p>
+                  <p className="mt-1 text-xs leading-5 text-muted">{step.note}</p>
                 </div>
               </li>
             ))}
@@ -300,8 +300,8 @@ export function GbpSection({ projectName, projectId }: { projectName: string; pr
           </div>
         </div>
 
-        <p className="mb-4 text-xs text-zinc-500">
-          {account ? <>Account <span className="font-mono text-zinc-400">{account}</span> · </> : null}
+        <p className="mb-4 text-xs text-muted">
+          {account ? <>Account <span className="font-mono text-secondary">{account}</span> · </> : null}
           {locationsQuery.data ? `${locationsQuery.data.totalSelected} of ${locationsQuery.data.totalDiscovered} locations tracked` : 'Loading locations…'}
         </p>
 
@@ -321,8 +321,8 @@ export function GbpSection({ projectName, projectId }: { projectName: string; pr
         )}
 
         {trackedLocations.length === 0 ? (
-          <p className="text-sm text-zinc-500">
-            No locations are tracked yet. Open <span className="font-medium text-zinc-300">Manage locations</span> below to track the one(s) for this business.
+          <p className="text-sm text-muted">
+            No locations are tracked yet. Open <span className="font-medium text-neutral">Manage locations</span> below to track the one(s) for this business.
           </p>
         ) : (
           <>
@@ -330,8 +330,8 @@ export function GbpSection({ projectName, projectId }: { projectName: string; pr
               <div className="mb-6 grid gap-2">
                 <p className="eyebrow eyebrow-soft">Needs attention</p>
                 {attentionInsights.map((ins) => (
-                  <div key={ins.id} className={['insight-card', insightCardToneClass(ins.severity), 'rounded-r-lg border border-zinc-800/60 bg-zinc-900/30 p-3 pl-4'].filter(Boolean).join(' ')}>
-                    <p className="flex items-center gap-2 text-sm font-medium text-zinc-200">
+                  <div key={ins.id} className={['insight-card', insightCardToneClass(ins.severity), 'rounded-r-lg border border-default bg-surface p-3 pl-4'].filter(Boolean).join(' ')}>
+                    <p className="flex items-center gap-2 text-sm font-medium text-strong">
                       {ins.title}
                       {ins.recommendation?.reason && <InfoTooltip text={ins.recommendation.reason} />}
                     </p>
@@ -373,13 +373,13 @@ export function GbpSection({ projectName, projectId }: { projectName: string; pr
               <div className="section-head section-head-inline mb-2">
                 <p className="eyebrow eyebrow-soft">Search terms</p>
                 {keywordsQuery.data && keywordsQuery.data.total > 0 && (
-                  <span className="text-[11px] text-zinc-600">
+                  <span className="text-[11px] text-faint">
                     {keywordsQuery.data.thresholdedPct}% privacy-thresholded
                   </span>
                 )}
               </div>
               {visibleKeywords.length === 0 ? (
-                <p className="text-sm text-zinc-500">No keyword impressions stored yet.</p>
+                <p className="text-sm text-muted">No keyword impressions stored yet.</p>
               ) : (
                 <table className="data-table w-full text-sm">
                   <thead>
@@ -393,18 +393,18 @@ export function GbpSection({ projectName, projectId }: { projectName: string; pr
                   <tbody>
                     {visibleKeywords.slice(0, 25).map((kw) => (
                       <tr key={`${kw.locationName}:${kw.keyword}`}>
-                        <td className="text-zinc-300">{kw.keyword}</td>
+                        <td className="text-neutral">{kw.keyword}</td>
                         {showKeywordLocation && (
-                          <td className="text-zinc-500">
+                          <td className="text-muted">
                             {locations.find((l) => l.locationName === kw.locationName)?.displayName ?? kw.locationName}
                           </td>
                         )}
-                        <td className="text-right font-mono text-zinc-200">
+                        <td className="text-right font-mono text-strong">
                           {kw.valueCount !== null
                             ? kw.valueCount.toLocaleString()
-                            : <span className="text-zinc-500" title="Privacy floor — Google withheld the exact count">{'<'}{kw.valueThreshold}</span>}
+                            : <span className="text-muted" title="Privacy floor — Google withheld the exact count">{'<'}{kw.valueThreshold}</span>}
                         </td>
-                        <td className="text-right font-mono text-[11px] text-zinc-600">{kw.periodStart}–{kw.periodEnd}</td>
+                        <td className="text-right font-mono text-[11px] text-faint">{kw.periodStart}–{kw.periodEnd}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -417,10 +417,10 @@ export function GbpSection({ projectName, projectId }: { projectName: string; pr
         {/* Manage locations — demoted. Discovery surfaces every location the
             connected Google account can see (often unrelated businesses); track
             only the one(s) for this project here. */}
-        <div className="mt-6 border-t border-zinc-800/60 pt-4">
+        <div className="mt-6 border-t border-default pt-4">
           <button
             type="button"
-            className="flex items-center gap-1.5 text-xs font-medium text-zinc-400 hover:text-zinc-200"
+            className="flex items-center gap-1.5 text-xs font-medium text-secondary hover:text-strong"
             onClick={() => setShowManage((v) => !v)}
             aria-expanded={showManage}
           >
@@ -429,7 +429,7 @@ export function GbpSection({ projectName, projectId }: { projectName: string; pr
           {showManage && (
             <div className="mt-3">
               {locations.length === 0 ? (
-                <p className="text-sm text-zinc-500">No locations discovered. Run <span className="font-mono">canonry gbp locations discover</span>.</p>
+                <p className="text-sm text-muted">No locations discovered. Run <span className="font-mono">canonry gbp locations discover</span>.</p>
               ) : (
                 <table className="data-table w-full text-sm">
                   <thead>
@@ -443,8 +443,8 @@ export function GbpSection({ projectName, projectId }: { projectName: string; pr
                   <tbody>
                     {locations.map((loc) => (
                       <tr key={loc.id}>
-                        <td className="text-zinc-200">{loc.displayName}</td>
-                        <td className="text-zinc-500">{loc.storefrontAddress ?? '—'}</td>
+                        <td className="text-strong">{loc.displayName}</td>
+                        <td className="text-muted">{loc.storefrontAddress ?? '—'}</td>
                         <td>
                           <ToneBadge tone={loc.selected ? 'positive' : 'neutral'}>
                             {loc.selected ? 'Tracked' : 'Not tracked'}
@@ -487,8 +487,8 @@ function ScopeChip({ label, active, onClick }: { label: string; active: boolean;
       onClick={onClick}
       className={`rounded-full border px-3 py-1 text-xs transition-colors ${
         active
-          ? 'border-zinc-500 bg-zinc-800 text-zinc-100'
-          : 'border-zinc-700/60 text-zinc-400 hover:border-zinc-600 hover:text-zinc-200'
+          ? 'border-mono-500 bg-mono-800 text-heading'
+          : 'border-mono-700/60 text-secondary hover:border-mono-600 hover:text-strong'
       }`}
     >
       {label}
@@ -543,7 +543,7 @@ function GbpProfileCompleteness({ summary }: { summary: ProfileCompletenessSumma
   ] satisfies Array<{ label: string; value: string; detail?: string; tone: 'positive' | 'caution' | 'negative' | 'neutral' }>
 
   return (
-    <div className="mb-6 border-y border-zinc-800/60 py-3">
+    <div className="mb-6 border-y border-default py-3">
       <div className="mb-3 flex items-center gap-2">
         <p className="eyebrow eyebrow-soft">Owner profile · Business Information</p>
         <InfoTooltip text="Counts selected locations where Google Business Information returned the owner-authored field. A missing value means it was not returned by this API response, not that every Google surface is empty." />
@@ -551,9 +551,9 @@ function GbpProfileCompleteness({ summary }: { summary: ProfileCompletenessSumma
       <div className="grid gap-x-5 gap-y-3 sm:grid-cols-2 lg:grid-cols-3">
         {rows.map((row) => (
           <div key={row.label} className="grid grid-cols-[minmax(0,1fr)_auto] items-baseline gap-3">
-            <span className="text-xs text-zinc-500">{row.label}</span>
+            <span className="text-xs text-muted">{row.label}</span>
             <span className={`font-mono text-sm tabular-nums ${toneTextClass(row.tone)}`}>{row.value}</span>
-            {row.detail && <span className="col-span-2 text-[11px] text-zinc-600">{row.detail}</span>}
+            {row.detail && <span className="col-span-2 text-[11px] text-faint">{row.detail}</span>}
           </div>
         ))}
       </div>
@@ -592,7 +592,7 @@ function GbpLocationEvidenceTable({
           <p className="eyebrow eyebrow-soft">Source evidence</p>
           <InfoTooltip text="Each column names the Google surface it came from. Missing or empty means that surface did not return a value in the latest Canonry sync, not that every Google product lacks the information." />
         </div>
-        <span className="text-[11px] text-zinc-600">{locations.length} location{locations.length === 1 ? '' : 's'}</span>
+        <span className="text-[11px] text-faint">{locations.length} location{locations.length === 1 ? '' : 's'}</span>
       </div>
       <div className="data-table-wrapper">
         <table className="data-table">
@@ -617,8 +617,8 @@ function GbpLocationEvidenceTable({
                   <tr>
                     <td>
                       <div className="min-w-0">
-                        <p className="font-medium text-zinc-200">{loc.displayName}</p>
-                        <p className="mt-1 text-xs text-zinc-600">{loc.primaryCategoryDisplayName ?? 'Primary category not returned'}</p>
+                        <p className="font-medium text-strong">{loc.displayName}</p>
+                        <p className="mt-1 text-xs text-faint">{loc.primaryCategoryDisplayName ?? 'Primary category not returned'}</p>
                         <div className="mt-2 flex flex-wrap gap-1.5">
                           <ToneBadge tone={loc.selected ? 'positive' : 'neutral'}>
                             {loc.selected ? 'Tracked' : 'Not tracked'}
@@ -642,7 +642,7 @@ function GbpLocationEvidenceTable({
                     </td>
                   </tr>
                   {expanded && (
-                    <tr className="bg-zinc-950/35 hover:bg-zinc-950/35">
+                    <tr className="bg-mono-950/35 hover:bg-mono-950/35">
                       <td colSpan={6} className="px-4 py-4">
                         <LocationEvidenceDetail
                           location={loc}
@@ -772,7 +772,7 @@ function SourceCell({
   return (
     <div>
       <ToneBadge tone={tone}>{label}</ToneBadge>
-      <p className="mt-1.5 text-xs leading-5 text-zinc-600">{detail}</p>
+      <p className="mt-1.5 text-xs leading-5 text-faint">{detail}</p>
     </div>
   )
 }
@@ -811,7 +811,7 @@ function LocationEvidenceDetail({
             <EvidenceRow label="Populated groups" value={lodgingGroups.length > 0 ? lodgingGroups.join(', ') : 'None returned'} />
           </>
         ) : (
-          <p className="leading-5 text-zinc-500">No Lodging API snapshot was stored for this location.</p>
+          <p className="leading-5 text-muted">No Lodging API snapshot was stored for this location.</p>
         )}
       </EvidenceDetailGroup>
 
@@ -823,25 +823,25 @@ function LocationEvidenceDetail({
             <EvidenceRow label="Public signals" value={place.amenities.length > 0 ? place.amenities.join(', ') : 'No supported signals detected'} />
           </>
         ) : (
-          <p className="leading-5 text-zinc-500">No Places Details snapshot was stored for this location.</p>
+          <p className="leading-5 text-muted">No Places Details snapshot was stored for this location.</p>
         )}
         {location.mapsUri && (
-          <a href={location.mapsUri} target="_blank" rel="noopener noreferrer" className="inline-block text-zinc-500 hover:text-zinc-300">
+          <a href={location.mapsUri} target="_blank" rel="noopener noreferrer" className="inline-block text-muted hover:text-neutral">
             View on Google Maps →
           </a>
         )}
-        <div className="mt-3 border-t border-zinc-800/60 pt-3">
+        <div className="mt-3 border-t border-default pt-3">
           {placeActions.length === 0 ? (
-            <p className="leading-5 text-zinc-500">No placeActionLinks returned.</p>
+            <p className="leading-5 text-muted">No placeActionLinks returned.</p>
           ) : (
             <div className="grid gap-2">
               {placeActions.map((action) => (
                 <div key={action.placeActionLinkName} className="grid gap-0.5">
-                  <span className="font-medium text-zinc-300">
+                  <span className="font-medium text-neutral">
                     {formatToken(action.placeActionType)}
                     {action.isPreferred ? ' · preferred' : ''}
                   </span>
-                  <span className="text-zinc-600">
+                  <span className="text-faint">
                     {formatToken(action.providerType)}{action.uri ? ` · ${displayDomain(action.uri)}` : ''}
                   </span>
                 </div>
@@ -857,7 +857,7 @@ function LocationEvidenceDetail({
 function EvidenceDetailGroup({ title, children }: { title: string; children: ReactNode }) {
   return (
     <div>
-      <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-zinc-500">{title}</p>
+      <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-muted">{title}</p>
       <div className="grid gap-2">{children}</div>
     </div>
   )
@@ -866,8 +866,8 @@ function EvidenceDetailGroup({ title, children }: { title: string; children: Rea
 function EvidenceRow({ label, value }: { label: string; value: string }) {
   return (
     <div className="grid grid-cols-[7.25rem_minmax(0,1fr)] gap-3">
-      <span className="text-zinc-600">{label}</span>
-      <span className="min-w-0 break-words text-zinc-400">{value}</span>
+      <span className="text-faint">{label}</span>
+      <span className="min-w-0 break-words text-secondary">{value}</span>
     </div>
   )
 }
@@ -880,10 +880,10 @@ export function completionTone(count: number, total: number, emptyTone: 'caution
 
 function toneTextClass(tone: GbpSourceTone) {
   switch (tone) {
-    case 'positive': return 'text-emerald-300'
-    case 'caution': return 'text-amber-300'
-    case 'negative': return 'text-rose-300'
-    case 'neutral': return 'text-zinc-300'
+    case 'positive': return 'text-positive'
+    case 'caution': return 'text-caution'
+    case 'negative': return 'text-negative'
+    case 'neutral': return 'text-neutral'
   }
 }
 
@@ -994,18 +994,18 @@ function GbpPerformance({
       <div>
         <div className="mb-2 flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
           <p className="eyebrow eyebrow-soft">Profile actions · daily</p>
-          {freshnessLabel && <span className="text-[11px] text-zinc-500">{freshnessLabel}</span>}
+          {freshnessLabel && <span className="text-[11px] text-muted">{freshnessLabel}</span>}
         </div>
         {!hasSeries || profileActionMetrics.length === 0 ? (
-          <p className="text-sm text-zinc-500">No profile action activity yet — run a sync.</p>
+          <p className="text-sm text-muted">No profile action activity yet — run a sync.</p>
         ) : (
           <>
             <GbpTrendChart data={chartData} metrics={profileActionMetrics} kind="line" firstPending={firstPending} lastDate={lastDate} />
             <div className="mt-2 flex flex-wrap gap-x-5 gap-y-1">
               {profileActionStats.map((m) => (
-                <span key={m} className="text-sm text-zinc-400">
+                <span key={m} className="text-sm text-secondary">
                   {formatGbpMetricLabel(m)}{' '}
-                  <span className="font-mono text-zinc-100">{(totals[m] ?? 0).toLocaleString()}</span>
+                  <span className="font-mono text-heading">{(totals[m] ?? 0).toLocaleString()}</span>
                 </span>
               ))}
             </div>
@@ -1021,7 +1021,7 @@ function GbpPerformance({
       )}
 
       {notActive.length > 0 && (
-        <p className="text-xs text-zinc-600">
+        <p className="text-xs text-faint">
           Not active: {notActive.map((m) => formatGbpMetricLabel(m)).join(', ')}
         </p>
       )}

--- a/apps/web/src/components/project/ScheduleSection.tsx
+++ b/apps/web/src/components/project/ScheduleSection.tsx
@@ -174,13 +174,13 @@ export function ScheduleSection({ projectName }: { projectName: string }) {
         <Card className="surface-card compact-card">
           <div className="flex items-start justify-between gap-4">
             <div className="space-y-1">
-              <p className="text-sm font-medium text-zinc-200">{scheduleLabel(schedule.preset ?? null, schedule.cronExpr, schedule.timezone)}</p>
-              <p className="text-xs text-zinc-500">Cron: <span className="font-mono">{schedule.cronExpr}</span></p>
+              <p className="text-sm font-medium text-strong">{scheduleLabel(schedule.preset ?? null, schedule.cronExpr, schedule.timezone)}</p>
+              <p className="text-xs text-muted">Cron: <span className="font-mono">{schedule.cronExpr}</span></p>
               {schedule.nextRunAt && (
-                <p className="text-xs text-zinc-500">Next run: {new Date(schedule.nextRunAt).toLocaleString()}</p>
+                <p className="text-xs text-muted">Next run: {new Date(schedule.nextRunAt).toLocaleString()}</p>
               )}
               {schedule.lastRunAt && (
-                <p className="text-xs text-zinc-500">Last run: {new Date(schedule.lastRunAt).toLocaleString()}</p>
+                <p className="text-xs text-muted">Last run: {new Date(schedule.lastRunAt).toLocaleString()}</p>
               )}
             </div>
             <div className="flex items-center gap-2 shrink-0">
@@ -195,17 +195,17 @@ export function ScheduleSection({ projectName }: { projectName: string }) {
               </Button>
             </div>
           </div>
-          {error && <p className="text-rose-400 text-sm mt-2">{error}</p>}
+          {error && <p className="text-negative-400 text-sm mt-2">{error}</p>}
         </Card>
       )}
 
       {editing && (
-        <div className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-4 space-y-3">
+        <div className="rounded-lg border border-base bg-bg-elevated/40 p-4 space-y-3">
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">
-              <label className="text-xs font-medium text-zinc-400">Frequency</label>
+              <label className="text-xs font-medium text-secondary">Frequency</label>
               <select
-                className="w-full rounded border border-zinc-700 bg-zinc-900 px-2 py-1.5 text-sm text-zinc-200 focus:border-zinc-500 focus:outline-none"
+                className="w-full rounded border border-strong bg-bg-elevated px-2 py-1.5 text-sm text-strong focus:border-mono-500 focus:outline-none"
                 value={freq}
                 onChange={(e) => setFreq(e.target.value)}
               >
@@ -215,9 +215,9 @@ export function ScheduleSection({ projectName }: { projectName: string }) {
               </select>
             </div>
             <div className="space-y-1.5">
-              <label className="text-xs font-medium text-zinc-400">Time</label>
+              <label className="text-xs font-medium text-secondary">Time</label>
               <select
-                className="w-full rounded border border-zinc-700 bg-zinc-900 px-2 py-1.5 text-sm text-zinc-200 focus:border-zinc-500 focus:outline-none disabled:opacity-40"
+                className="w-full rounded border border-strong bg-bg-elevated px-2 py-1.5 text-sm text-strong focus:border-mono-500 focus:outline-none disabled:opacity-40"
                 value={hour}
                 disabled={freq === 'twice-daily' || freq === 'custom'}
                 onChange={(e) => setHour(parseInt(e.target.value))}
@@ -230,9 +230,9 @@ export function ScheduleSection({ projectName }: { projectName: string }) {
           </div>
           {freq === 'custom' && (
             <div className="space-y-1.5">
-              <label className="text-xs font-medium text-zinc-400">Cron expression</label>
+              <label className="text-xs font-medium text-secondary">Cron expression</label>
               <input
-                className="w-full rounded border border-zinc-700 bg-transparent px-2 py-1.5 text-sm text-zinc-200 placeholder-zinc-600 font-mono focus:border-zinc-500 focus:outline-none"
+                className="w-full rounded border border-strong bg-transparent px-2 py-1.5 text-sm text-strong placeholder:text-faint font-mono focus:border-mono-500 focus:outline-none"
                 type="text"
                 placeholder="0 9 * * 1-5"
                 value={customCron}
@@ -241,9 +241,9 @@ export function ScheduleSection({ projectName }: { projectName: string }) {
             </div>
           )}
           <div className="space-y-1.5">
-            <label className="text-xs font-medium text-zinc-400">Timezone</label>
+            <label className="text-xs font-medium text-secondary">Timezone</label>
             <select
-              className="w-full rounded border border-zinc-700 bg-zinc-900 px-2 py-1.5 text-sm text-zinc-200 focus:border-zinc-500 focus:outline-none"
+              className="w-full rounded border border-strong bg-bg-elevated px-2 py-1.5 text-sm text-strong focus:border-mono-500 focus:outline-none"
               value={tzOther ? 'Other' : timezone}
               onChange={(e) => {
                 if (e.target.value === 'Other') { setTzOther(true); setTimezone('Other') }
@@ -257,7 +257,7 @@ export function ScheduleSection({ projectName }: { projectName: string }) {
             </select>
             {tzOther && (
               <input
-                className="w-full rounded border border-zinc-700 bg-transparent px-2 py-1.5 text-sm text-zinc-200 placeholder-zinc-600 focus:border-zinc-500 focus:outline-none"
+                className="w-full rounded border border-strong bg-transparent px-2 py-1.5 text-sm text-strong placeholder:text-faint focus:border-mono-500 focus:outline-none"
                 type="text"
                 placeholder="e.g. America/New_York"
                 value={tzOtherValue}
@@ -265,7 +265,7 @@ export function ScheduleSection({ projectName }: { projectName: string }) {
               />
             )}
           </div>
-          {error && <p className="text-rose-400 text-sm">{error}</p>}
+          {error && <p className="text-negative-400 text-sm">{error}</p>}
           <div className="flex gap-2 justify-end">
             <Button type="button" variant="outline" size="sm" onClick={() => { setEditing(false); setError(null) }}>Cancel</Button>
             <Button

--- a/apps/web/src/components/project/ScheduleSection.tsx
+++ b/apps/web/src/components/project/ScheduleSection.tsx
@@ -232,7 +232,7 @@ export function ScheduleSection({ projectName }: { projectName: string }) {
             <div className="space-y-1.5">
               <label className="text-xs font-medium text-secondary">Cron expression</label>
               <input
-                className="w-full rounded border border-strong bg-transparent px-2 py-1.5 text-sm text-strong placeholder:text-faint font-mono focus:border-mono-500 focus:outline-none"
+                className="w-full rounded border border-strong bg-transparent px-2 py-1.5 text-sm text-strong placeholder-mono-600 font-mono focus:border-mono-500 focus:outline-none"
                 type="text"
                 placeholder="0 9 * * 1-5"
                 value={customCron}
@@ -257,7 +257,7 @@ export function ScheduleSection({ projectName }: { projectName: string }) {
             </select>
             {tzOther && (
               <input
-                className="w-full rounded border border-strong bg-transparent px-2 py-1.5 text-sm text-strong placeholder:text-faint focus:border-mono-500 focus:outline-none"
+                className="w-full rounded border border-strong bg-transparent px-2 py-1.5 text-sm text-strong placeholder-mono-600 focus:border-mono-500 focus:outline-none"
                 type="text"
                 placeholder="e.g. America/New_York"
                 value={tzOtherValue}


### PR DESCRIPTION
## Summary

Migrates four remaining project-surface components from raw Tailwind palette classes to the shared design-token vocabulary:

- `BacklinksSection`
- `GbpSection`
- `EvidenceTable`
- `ScheduleSection`

This is intended as a fidelity-preserving Phase 3 slice: no API calls, state logic, data flow, or copy changed.

## Validation

- `pnpm --filter @ainyc/canonry-web test -- design-tokens.test.ts app.test.tsx`
- `pnpm --filter @ainyc/canonry-web typecheck`
- `pnpm --filter @ainyc/canonry-web build`
- commit-hook `pnpm -r run lint` passed with existing warning-only lint output
- `git diff --check origin/main...HEAD`

## Notes

The changed files are clean under the raw-color scanner. The only scanner hits in `GbpSection` are `#658` issue references in comments, not CSS classes.