### PR TITLE
refactor(web): migrate 3 project sections to design tokens (DS-1)

### DIFF
--- a/apps/web/src/components/project/CitationVisibilitySection.tsx
+++ b/apps/web/src/components/project/CitationVisibilitySection.tsx
@@ -29,7 +29,7 @@ export function CitationVisibilitySection({ projectName }: { projectName: string
             <h2>Citation + answer-mention coverage</h2>
           </div>
         </div>
-        <p className="text-sm text-rose-400">{error instanceof Error ? error.message : String(error)}</p>
+        <p className="text-sm text-negative-400">{error instanceof Error ? error.message : String(error)}</p>
       </section>
     )
   }
@@ -44,7 +44,7 @@ export function CitationVisibilitySection({ projectName }: { projectName: string
             <h2>Citation + answer-mention coverage</h2>
           </div>
         </div>
-        <p className="text-sm text-zinc-500">
+        <p className="text-sm text-muted">
           {data.reason === 'no-queries'
             ? 'Add queries to start tracking AI citations.'
             : 'Run a sweep to see which engines cite this project.'}
@@ -64,7 +64,7 @@ export function CitationVisibilitySection({ projectName }: { projectName: string
             Cited by {providersCiting} of {providersConfigured} engines
             <InfoTooltip text="An engine is &lsquo;citing&rsquo; when our domain appears in its grounding source list (the structured citation/search-result attribution it returns alongside the answer). Counts each configured engine that cites the project on at least one tracked query in the latest snapshot per (query × provider)." />
           </h2>
-          <p className="text-base text-zinc-300 flex items-center gap-2">
+          <p className="text-base text-neutral flex items-center gap-2">
             Mentioned in {providersMentioning} of {providersConfigured} engine answers
             <InfoTooltip text="An engine is &lsquo;mentioning&rsquo; when our brand or domain appears inside the prose of the answer text — independent of whether it&rsquo;s in the citation list. Models often name-drop from training without citing a fresh page." />
           </p>
@@ -125,19 +125,19 @@ type Tone = 'positive' | 'positive-dim' | 'caution' | 'negative' | 'neutral'
 
 function SummaryCell({ label, value, helper, tone }: { label: string; value: string; helper: string; tone: Tone }) {
   const valueClass = tone === 'positive'
-    ? 'text-emerald-300'
+    ? 'text-positive'
     : tone === 'positive-dim'
-      ? 'text-emerald-400/70'
+      ? 'text-positive-400/70'
       : tone === 'caution'
-        ? 'text-amber-300'
+        ? 'text-caution'
         : tone === 'negative'
-          ? 'text-rose-300'
-          : 'text-zinc-100'
+          ? 'text-negative'
+          : 'text-heading'
   return (
-    <div className="rounded-md border border-zinc-800/60 bg-zinc-900/30 px-4 py-3">
-      <p className="text-[10px] uppercase tracking-wide text-zinc-500">{label}</p>
+    <div className="rounded-md border border-default bg-surface px-4 py-3">
+      <p className="text-[10px] uppercase tracking-wide text-muted">{label}</p>
       <p className={`mt-1 text-2xl font-semibold tabular-nums ${valueClass}`}>{value}</p>
-      <p className="text-[11px] text-zinc-500">{helper}</p>
+      <p className="text-[11px] text-muted">{helper}</p>
     </div>
   )
 }
@@ -152,7 +152,7 @@ function CoverageTable({ data }: { data: CitationVisibilityResponse }) {
   }, [data.byQuery])
 
   if (data.byQuery.length === 0) {
-    return <p className="text-sm text-zinc-500">No query coverage rows.</p>
+    return <p className="text-sm text-muted">No query coverage rows.</p>
   }
 
   return (
@@ -175,13 +175,13 @@ function CoverageTable({ data }: { data: CitationVisibilityResponse }) {
           <tbody>
             {data.byQuery.map(row => (
               <tr key={row.queryId}>
-                <td className="font-medium text-zinc-100">{row.query}</td>
+                <td className="font-medium text-heading">{row.query}</td>
                 {providerColumns.map(p => {
                   const provider = row.providers.find(x => x.provider === p)
                   return (
                     <td key={p} className="text-center">
                       {provider == null ? (
-                        <Minus className="inline h-3.5 w-3.5 text-zinc-700" aria-label="no data" />
+                        <Minus className="inline h-3.5 w-3.5 text-mono-700" aria-label="no data" />
                       ) : (
                         <DualIndicator provider={provider} />
                       )}
@@ -192,10 +192,10 @@ function CoverageTable({ data }: { data: CitationVisibilityResponse }) {
                   <span
                     className={
                       row.totalProviders > 0 && row.citedCount === row.totalProviders
-                        ? 'text-emerald-300'
+                        ? 'text-positive'
                         : row.citedCount > 0
-                          ? 'text-emerald-400/70'
-                          : 'text-zinc-500'
+                          ? 'text-positive-400/70'
+                          : 'text-muted'
                     }
                   >
                     {row.citedCount}/{row.totalProviders}
@@ -205,10 +205,10 @@ function CoverageTable({ data }: { data: CitationVisibilityResponse }) {
                   <span
                     className={
                       row.totalProviders > 0 && row.mentionedCount === row.totalProviders
-                        ? 'text-sky-300'
+                        ? 'text-info-300'
                         : row.mentionedCount > 0
-                          ? 'text-sky-400/70'
-                          : 'text-zinc-500'
+                          ? 'text-info-400/70'
+                          : 'text-muted'
                     }
                   >
                     {row.mentionedCount}/{row.totalProviders}
@@ -225,7 +225,7 @@ function CoverageTable({ data }: { data: CitationVisibilityResponse }) {
 
 function CoverageLegend() {
   return (
-    <div className="mb-2 flex flex-wrap items-center gap-3 text-[11px] text-zinc-500">
+    <div className="mb-2 flex flex-wrap items-center gap-3 text-[11px] text-muted">
       <span className="flex items-center gap-1.5">
         <IndicatorDot active tone="cited" />
         <span>cited (in sources)</span>
@@ -262,21 +262,21 @@ function describeIndicator(provider: CitationCoverageProvider): string {
 
 function IndicatorDot({ active, tone }: { active: boolean; tone: 'cited' | 'mentioned' }) {
   if (!active) {
-    return <span className="inline-block h-2 w-2 rounded-full border border-zinc-700/80 bg-transparent" aria-hidden="true" />
+    return <span className="inline-block h-2 w-2 rounded-full border border-strong/80 bg-transparent" aria-hidden="true" />
   }
   const className = tone === 'cited'
-    ? 'inline-block h-2 w-2 rounded-full bg-emerald-400 shadow-[0_0_0_1px_rgba(16,185,129,0.25)]'
-    : 'inline-block h-2 w-2 rounded-full bg-sky-400 shadow-[0_0_0_1px_rgba(56,189,248,0.25)]'
+    ? 'inline-block h-2 w-2 rounded-full bg-positive-400 shadow-[0_0_0_1px_rgba(16,185,129,0.25)]'
+    : 'inline-block h-2 w-2 rounded-full bg-info-400 shadow-[0_0_0_1px_rgba(56,189,248,0.25)]'
   return <span className={className} aria-hidden="true" />
 }
 
 function CompetitorGapList({ data }: { data: CitationVisibilityResponse }) {
   return (
     <div className="mt-4">
-      <h3 className="text-sm font-semibold text-zinc-200 mb-2 flex items-center gap-2">
+      <h3 className="text-sm font-semibold text-strong mb-2 flex items-center gap-2">
         Competitor gaps
         <InfoTooltip text="Queries where the project is not cited but a configured competitor is. Each row maps to one (query, engine) pair — the same query may surface for multiple engines." />
-        <span className="text-[10px] font-normal uppercase tracking-wide text-zinc-500">
+        <span className="text-[10px] font-normal uppercase tracking-wide text-muted">
           {data.competitorGaps.length} {data.competitorGaps.length === 1 ? 'gap' : 'gaps'}
         </span>
       </h3>
@@ -292,9 +292,9 @@ function CompetitorGapList({ data }: { data: CitationVisibilityResponse }) {
           <tbody>
             {data.competitorGaps.map(gap => (
               <tr key={`${gap.queryId}::${gap.provider}`}>
-                <td className="font-medium text-zinc-100">{gap.query}</td>
+                <td className="font-medium text-heading">{gap.query}</td>
                 <td><ProviderBadge provider={gap.provider} /></td>
-                <td className="text-zinc-300">{gap.citingCompetitors.join(', ')}</td>
+                <td className="text-neutral">{gap.citingCompetitors.join(', ')}</td>
               </tr>
             ))}
           </tbody>

--- a/apps/web/src/components/project/DiscoverySection.tsx
+++ b/apps/web/src/components/project/DiscoverySection.tsx
@@ -156,7 +156,7 @@ export function DiscoverySection({ projectName }: { projectName: string }) {
         <div>
           <p className="eyebrow eyebrow-soft">Discovery</p>
           <h2>Find new queries to track</h2>
-          <p className="mt-1 max-w-3xl text-sm leading-6 text-zinc-500">
+          <p className="mt-1 max-w-3xl text-sm leading-6 text-muted">
             Describe your ideal customer and Canonry generates the questions they would ask an AI engine, checks which ones already cite your site, then lets you add the promising ones to your tracked queries.
           </p>
         </div>
@@ -184,23 +184,23 @@ export function DiscoverySection({ projectName }: { projectName: string }) {
             </div>
             <div className="space-y-3">
               <label className="block">
-                <span className="text-xs text-zinc-500">Who is your ideal customer?</span>
+                <span className="text-xs text-muted">Who is your ideal customer?</span>
                 <textarea
-                  className="mt-1 min-h-24 w-full rounded border border-zinc-700 bg-transparent px-3 py-2 text-sm text-zinc-200 placeholder-zinc-600 focus:border-zinc-500 focus:outline-none"
+                  className="mt-1 min-h-24 w-full rounded border border-strong bg-transparent px-3 py-2 text-sm text-strong placeholder-mono-600 focus:border-mono-500 focus:outline-none"
                   placeholder="e.g. Small e-commerce stores that want AI-powered customer support. Leave blank to use the customer profile saved on this project."
                   value={icpDescription}
                   onChange={(event) => setIcpDescription(event.target.value)}
                 />
               </label>
               <label className="block">
-                <span className="text-xs text-zinc-500">How many questions to test</span>
+                <span className="text-xs text-muted">How many questions to test</span>
                 <input
-                  className="mt-1 w-full rounded border border-zinc-700 bg-transparent px-3 py-2 text-sm text-zinc-200 placeholder-zinc-600 focus:border-zinc-500 focus:outline-none"
+                  className="mt-1 w-full rounded border border-strong bg-transparent px-3 py-2 text-sm text-strong placeholder-mono-600 focus:border-mono-500 focus:outline-none"
                   inputMode="numeric"
                   value={maxProbes}
                   onChange={(event) => setMaxProbes(event.target.value)}
                 />
-                <span className="mt-1 block text-[11px] text-zinc-600">
+                <span className="mt-1 block text-[11px] text-faint">
                   More questions means broader coverage but a longer run. 100 is a good default.
                 </span>
               </label>
@@ -225,7 +225,7 @@ export function DiscoverySection({ projectName }: { projectName: string }) {
               {sessionsQuery.isFetching && <ToneBadge tone="neutral">Loading</ToneBadge>}
             </div>
             {sessions.length === 0 ? (
-              <p className="text-sm text-zinc-500">No discovery runs yet. Describe your customer above to start your first one.</p>
+              <p className="text-sm text-muted">No discovery runs yet. Describe your customer above to start your first one.</p>
             ) : (
               <div className="space-y-2">
                 {sessions.map(session => (
@@ -234,16 +234,16 @@ export function DiscoverySection({ projectName }: { projectName: string }) {
                     type="button"
                     className={`w-full rounded-md border px-3 py-2 text-left transition-colors ${
                       selectedSessionId === session.id
-                        ? 'border-zinc-600 bg-zinc-900/70'
-                        : 'border-zinc-800/60 bg-zinc-950/40 hover:border-zinc-700 hover:bg-zinc-900/40'
+                        ? 'border-mono-600 bg-bg-elevated/70'
+                        : 'border-default bg-bg/40 hover:border-strong hover:bg-bg-elevated/40'
                     }`}
                     onClick={() => setSelectedSessionId(session.id)}
                   >
                     <div className="flex items-center justify-between gap-3">
-                      <span className="text-sm font-medium text-zinc-100">{shortId(session.id)}</span>
+                      <span className="text-sm font-medium text-heading">{shortId(session.id)}</span>
                       <ToneBadge tone={toneForSession(session.status)}>{session.status}</ToneBadge>
                     </div>
-                    <div className="mt-2 grid grid-cols-3 gap-2 text-[11px] text-zinc-500">
+                    <div className="mt-2 grid grid-cols-3 gap-2 text-[11px] text-muted">
                       <span>Cited {session.citedCount ?? 0}</span>
                       <span>Opportunity {session.aspirationalCount ?? 0}</span>
                       <span>Low value {session.wastedCount ?? 0}</span>
@@ -266,7 +266,7 @@ export function DiscoverySection({ projectName }: { projectName: string }) {
             </div>
 
             {!activeSession ? (
-              <p className="text-sm text-zinc-500">Start a run above, or pick one from Recent runs to see its progress.</p>
+              <p className="text-sm text-muted">Start a run above, or pick one from Recent runs to see its progress.</p>
             ) : (
               <div className="space-y-4">
                 <div className="grid gap-3 sm:grid-cols-4">
@@ -277,31 +277,31 @@ export function DiscoverySection({ projectName }: { projectName: string }) {
                 </div>
 
                 {activeSession.error && (
-                  <div className="rounded-md border border-rose-800/40 bg-rose-950/20 px-3 py-2 text-sm text-rose-300">
+                  <div className="rounded-md border border-negative-800/40 bg-negative-950/20 px-3 py-2 text-sm text-negative">
                     {activeSession.error}
                   </div>
                 )}
 
                 {activeSession.warning && (
-                  <div className="rounded-md border border-amber-800/40 bg-amber-950/20 px-3 py-2 text-sm text-amber-300">
+                  <div className="rounded-md border border-caution-800/40 bg-caution-950/20 px-3 py-2 text-sm text-caution">
                     {activeSession.warning}
                   </div>
                 )}
 
                 {activeSession.icpDescription && (
-                  <div className="rounded-md border border-zinc-800/60 bg-zinc-900/30 px-3 py-2">
-                    <p className="text-[10px] uppercase tracking-wide text-zinc-500">Customer profile</p>
-                    <p className="mt-1 text-sm text-zinc-300">{activeSession.icpDescription}</p>
+                  <div className="rounded-md border border-default bg-surface px-3 py-2">
+                    <p className="text-[10px] uppercase tracking-wide text-muted">Customer profile</p>
+                    <p className="mt-1 text-sm text-neutral">{activeSession.icpDescription}</p>
                   </div>
                 )}
 
                 {activeSession.competitorMap.length > 0 && (
                   <div>
-                    <p className="mb-2 text-xs font-medium text-zinc-400">Sites that keep getting cited</p>
+                    <p className="mb-2 text-xs font-medium text-secondary">Sites that keep getting cited</p>
                     <div className="flex flex-wrap gap-2">
                       {activeSession.competitorMap.slice(0, 8).map(entry => (
-                        <span key={entry.domain} className="rounded-md border border-zinc-800/60 bg-zinc-950 px-2 py-1 text-xs text-zinc-300">
-                          {entry.domain} <span className="text-zinc-500">{entry.hits}</span>
+                        <span key={entry.domain} className="rounded-md border border-default bg-bg px-2 py-1 text-xs text-neutral">
+                          {entry.domain} <span className="text-muted">{entry.hits}</span>
                         </span>
                       ))}
                     </div>
@@ -329,7 +329,7 @@ export function DiscoverySection({ projectName }: { projectName: string }) {
                 </Button>
               </div>
               {previewQuery.isLoading ? (
-                <p className="text-sm text-zinc-500">Loading recommendations…</p>
+                <p className="text-sm text-muted">Loading recommendations…</p>
               ) : preview ? (
                 <div className="space-y-4">
                   <div className="grid gap-3 sm:grid-cols-4">
@@ -338,16 +338,16 @@ export function DiscoverySection({ projectName }: { projectName: string }) {
                     <DiscoveryMetric label="Opportunities" value={preview.queriesByBucket.aspirational.length} tone="caution" />
                     <DiscoveryMetric label="Low value (skipped)" value={preview.queriesByBucket['wasted-surface'].length} tone="negative" />
                   </div>
-                  <p className="text-xs leading-5 text-zinc-500">
+                  <p className="text-xs leading-5 text-muted">
                     Adding queries starts tracking the “already cited” and “opportunity” questions, plus any competitor sites that kept showing up. “Low value” questions are listed below for reference only and are not added.
                   </p>
                   {preview.suggestedCompetitors.length > 0 && (
                     <div>
-                      <p className="mb-2 text-xs font-medium text-zinc-400">Competitor sites that will be added</p>
+                      <p className="mb-2 text-xs font-medium text-secondary">Competitor sites that will be added</p>
                       <div className="flex flex-wrap gap-2">
                         {preview.suggestedCompetitors.map(entry => (
-                          <span key={entry.domain} className="rounded-md border border-zinc-800/60 bg-zinc-950 px-2 py-1 text-xs text-zinc-300">
-                            {entry.domain} <span className="text-zinc-500">{entry.hits}</span>
+                          <span key={entry.domain} className="rounded-md border border-default bg-bg px-2 py-1 text-xs text-neutral">
+                            {entry.domain} <span className="text-muted">{entry.hits}</span>
                           </span>
                         ))}
                       </div>
@@ -355,7 +355,7 @@ export function DiscoverySection({ projectName }: { projectName: string }) {
                   )}
                 </div>
               ) : (
-                <p className="text-sm text-zinc-500">No recommendations available for this run.</p>
+                <p className="text-sm text-muted">No recommendations available for this run.</p>
               )}
             </Card>
           )}
@@ -369,7 +369,7 @@ export function DiscoverySection({ projectName }: { projectName: string }) {
               {detailQuery.isFetching && <ToneBadge tone="neutral">Loading</ToneBadge>}
             </div>
             {probeRows.length === 0 ? (
-              <p className="text-sm text-zinc-500">Results show up here once the run starts testing questions.</p>
+              <p className="text-sm text-muted">Results show up here once the run starts testing questions.</p>
             ) : (
               <div className="evidence-table-wrap">
                 <table className="evidence-table">
@@ -383,11 +383,11 @@ export function DiscoverySection({ projectName }: { projectName: string }) {
                   <tbody>
                     {probeRows.map(probe => (
                       <tr key={probe.id}>
-                        <td className="font-medium text-zinc-100">{probe.query}</td>
+                        <td className="font-medium text-heading">{probe.query}</td>
                         <td>
                           <ToneBadge tone={toneForBucket(probe.bucket)}>{bucketLabel(probe.bucket)}</ToneBadge>
                         </td>
-                        <td className="text-zinc-400">
+                        <td className="text-secondary">
                           {probe.citedDomains.length > 0 ? probe.citedDomains.slice(0, 3).join(', ') : '-'}
                         </td>
                       </tr>
@@ -413,10 +413,10 @@ function DiscoveryMetric({
   tone?: 'positive' | 'caution' | 'negative' | 'neutral'
 }) {
   const valueClass =
-    tone === 'positive' ? 'text-emerald-300' : tone === 'caution' ? 'text-amber-300' : tone === 'negative' ? 'text-rose-300' : 'text-zinc-100'
+    tone === 'positive' ? 'text-positive' : tone === 'caution' ? 'text-caution' : tone === 'negative' ? 'text-negative' : 'text-heading'
   return (
-    <div className="rounded-md border border-zinc-800/60 bg-zinc-900/30 px-4 py-3">
-      <p className="text-[10px] uppercase tracking-wide text-zinc-500">{label}</p>
+    <div className="rounded-md border border-default bg-surface px-4 py-3">
+      <p className="text-[10px] uppercase tracking-wide text-muted">{label}</p>
       <p className={`mt-1 text-2xl font-semibold tabular-nums ${valueClass}`}>{value}</p>
     </div>
   )

--- a/apps/web/src/components/project/TechnicalAeoSection.tsx
+++ b/apps/web/src/components/project/TechnicalAeoSection.tsx
@@ -45,7 +45,7 @@ function scoreTone(score: number): MetricTone {
 }
 
 function scoreTextClass(score: number): string {
-  return score >= 70 ? 'text-emerald-400' : score >= 40 ? 'text-amber-400' : 'text-rose-400'
+  return score >= 70 ? 'text-positive-400' : score >= 40 ? 'text-caution-400' : 'text-negative-400'
 }
 
 function factorTone(status: SiteAuditFactorSummaryDto['status']): MetricTone {
@@ -111,8 +111,8 @@ export function TechnicalAeoSection({ projectName }: { projectName: string }) {
   if (!score || !score.hasData) {
     return (
       <Card className="surface-card mt-6 p-8 text-center">
-        <ScanSearch className="mx-auto mb-3 h-8 w-8 text-zinc-500" aria-hidden="true" />
-        <h2 className="text-base font-semibold text-zinc-100">No technical audit yet</h2>
+        <ScanSearch className="mx-auto mb-3 h-8 w-8 text-muted" aria-hidden="true" />
+        <h2 className="text-base font-semibold text-heading">No technical audit yet</h2>
         <p className="supporting-copy mx-auto mt-2 max-w-md">
           A technical AEO audit crawls your sitemap and scores every page for structured data, AI-readable content,
           crawler access, freshness, and more, then rolls it up into one site score.
@@ -123,8 +123,8 @@ export function TechnicalAeoSection({ projectName }: { projectName: string }) {
             {runMutation.isPending ? 'Starting…' : 'Run first audit'}
           </Button>
         </div>
-        <p className="mt-3 text-xs text-zinc-600">
-          Or from the CLI: <code className="text-zinc-400">canonry technical-aeo run {projectName} --wait</code>
+        <p className="mt-3 text-xs text-faint">
+          Or from the CLI: <code className="text-secondary">canonry technical-aeo run {projectName} --wait</code>
         </p>
       </Card>
     )
@@ -157,34 +157,34 @@ export function TechnicalAeoSection({ projectName }: { projectName: string }) {
   return (
     <div className="mt-6">
       {/* Hero — aggregate score + sitemap provenance + action */}
-      <section className="surface-card flex flex-wrap items-start justify-between gap-6 rounded-lg border border-zinc-800/60 bg-zinc-900/30 p-6">
+      <section className="surface-card flex flex-wrap items-start justify-between gap-6 rounded-lg border border-default bg-surface p-6">
         <div className="min-w-0">
           <p className="eyebrow eyebrow-soft">Technical AEO</p>
           <div className="mt-1 flex items-baseline gap-3">
             <span className={`text-4xl font-semibold tabular-nums ${scoreTextClass(score.aggregateScore)}`}>
               {score.aggregateScore}
             </span>
-            <span className="text-lg text-zinc-500">/ 100</span>
+            <span className="text-lg text-muted">/ 100</span>
             <ToneBadge tone={scoreTone(score.aggregateScore)}>{statusLabel(score.aggregateScore)}</ToneBadge>
             {deltaLabel ? <ToneBadge tone={deltaTone}>{deltaLabel}</ToneBadge> : null}
           </div>
           <p className="supporting-copy mt-2 tabular-nums">
             {score.pagesDiscovered} URL{score.pagesDiscovered === 1 ? '' : 's'} in sitemap · {score.pagesAudited} audited · {score.pagesSkipped} skipped · {score.pagesErrored} errored
           </p>
-          <p className="mt-1 flex flex-wrap items-center gap-x-1.5 text-xs text-zinc-500">
-            <span className="text-zinc-600">Sitemap:</span>
+          <p className="mt-1 flex flex-wrap items-center gap-x-1.5 text-xs text-muted">
+            <span className="text-faint">Sitemap:</span>
             <a
               href={score.sitemapUrl ?? '#'}
               target="_blank"
               rel="noreferrer"
-              className="max-w-[22rem] truncate text-zinc-400 underline decoration-zinc-700 underline-offset-2 hover:text-zinc-200"
+              className="max-w-[22rem] truncate text-secondary underline decoration-mono-700 underline-offset-2 hover:text-strong"
             >
               {score.sitemapUrl}
             </a>
             <InfoTooltip text="Every audit re-reads this sitemap, so pages you add or remove are picked up on the next run. Discovered/audited counts and the score reflect the sitemap at the time of the latest run. Override it with `canonry technical-aeo run <project> --sitemap-url <url>`." />
           </p>
           {score.auditedAt ? (
-            <p className="mt-0.5 text-xs text-zinc-600">Audited {new Date(score.auditedAt).toLocaleString()}</p>
+            <p className="mt-0.5 text-xs text-faint">Audited {new Date(score.auditedAt).toLocaleString()}</p>
           ) : null}
         </div>
         <div className="flex items-center gap-2">
@@ -275,54 +275,54 @@ export function TechnicalAeoSection({ projectName }: { projectName: string }) {
                 const belowPassTotal = f.pagesPartial + f.pagesFailing
                 return (
                   <Fragment key={f.id}>
-                    <tr className={expanded ? 'bg-zinc-900/30' : undefined}>
+                    <tr className={expanded ? 'bg-surface' : undefined}>
                       <td>
                         <button
                           type="button"
-                          className="flex items-center gap-1.5 text-left font-medium text-zinc-200 hover:text-zinc-50"
+                          className="flex items-center gap-1.5 text-left font-medium text-strong hover:text-primary"
                           aria-expanded={expanded}
                           onClick={() => setExpandedFactor(expanded ? null : f.id)}
                         >
                           {expanded
-                            ? <ChevronDown className="h-3.5 w-3.5 shrink-0 text-zinc-500" aria-hidden="true" />
-                            : <ChevronRight className="h-3.5 w-3.5 shrink-0 text-zinc-500" aria-hidden="true" />}
+                            ? <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted" aria-hidden="true" />
+                            : <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted" aria-hidden="true" />}
                           {f.name}
                         </button>
                       </td>
-                      <td className="text-right tabular-nums text-zinc-500">{f.weight}%</td>
-                      <td className="text-right tabular-nums text-zinc-200">{f.avgScore}</td>
+                      <td className="text-right tabular-nums text-muted">{f.weight}%</td>
+                      <td className="text-right tabular-nums text-strong">{f.avgScore}</td>
                       <td><ToneBadge tone={factorTone(f.status)}>{statusLabel(f.avgScore)}</ToneBadge></td>
-                      <td className="tabular-nums text-zinc-400">
-                        <span className="text-emerald-400">{f.pagesPassing}</span>
+                      <td className="tabular-nums text-secondary">
+                        <span className="text-positive-400">{f.pagesPassing}</span>
                         {' / '}
-                        <span className="text-amber-400">{f.pagesPartial}</span>
+                        <span className="text-caution-400">{f.pagesPartial}</span>
                         {' / '}
-                        <span className="text-rose-400">{f.pagesFailing}</span>
+                        <span className="text-negative-400">{f.pagesFailing}</span>
                       </td>
                     </tr>
                     {expanded ? (
-                      <tr className="bg-zinc-900/30">
+                      <tr className="bg-surface">
                         <td colSpan={5} className="px-4 pb-4 pt-0">
-                          <div className="space-y-4 border-l border-zinc-800 pl-4">
+                          <div className="space-y-4 border-l border-base pl-4">
                             {issue && issue.topRecommendations.length > 0 ? (
                               <div>
-                                <p className="eyebrow eyebrow-soft mb-1.5 text-zinc-500">How to fix</p>
+                                <p className="eyebrow eyebrow-soft mb-1.5 text-muted">How to fix</p>
                                 <ul className="space-y-1">
                                   {issue.topRecommendations.map((rec, i) => (
-                                    <li key={i} className="flex gap-2 text-sm text-zinc-300">
-                                      <span className="select-none text-zinc-600">→</span>
+                                    <li key={i} className="flex gap-2 text-sm text-neutral">
+                                      <span className="select-none text-faint">→</span>
                                       <span>{rec}</span>
                                     </li>
                                   ))}
                                 </ul>
                               </div>
                             ) : belowPassTotal === 0 ? (
-                              <p className="text-sm text-zinc-500">Every audited page passes this factor.</p>
+                              <p className="text-sm text-muted">Every audited page passes this factor.</p>
                             ) : null}
 
                             {belowPassTotal > 0 ? (
                               <div>
-                                <p className="eyebrow eyebrow-soft mb-1.5 text-zinc-500">
+                                <p className="eyebrow eyebrow-soft mb-1.5 text-muted">
                                   Pages below pass ({belowPassTotal})
                                 </p>
                                 <ul className="space-y-1">
@@ -333,7 +333,7 @@ export function TechnicalAeoSection({ projectName }: { projectName: string }) {
                                         href={row.url}
                                         target="_blank"
                                         rel="noreferrer"
-                                        className="truncate text-zinc-300 hover:text-zinc-100"
+                                        className="truncate text-neutral hover:text-heading"
                                         title={row.url}
                                       >
                                         {row.url}
@@ -342,12 +342,12 @@ export function TechnicalAeoSection({ projectName }: { projectName: string }) {
                                   ))}
                                 </ul>
                                 {belowPass.length > FACTOR_DRILLDOWN_PAGE_CAP ? (
-                                  <p className="mt-1 text-xs text-zinc-600">
+                                  <p className="mt-1 text-xs text-faint">
                                     + {belowPass.length - FACTOR_DRILLDOWN_PAGE_CAP} more below pass
                                   </p>
                                 ) : null}
                                 {pagesCapped ? (
-                                  <p className="mt-1 text-xs text-zinc-600">Showing the worst {allPages.length} audited pages.</p>
+                                  <p className="mt-1 text-xs text-faint">Showing the worst {allPages.length} audited pages.</p>
                                 ) : null}
                               </div>
                             ) : null}
@@ -373,22 +373,22 @@ export function TechnicalAeoSection({ projectName }: { projectName: string }) {
               <InfoTooltip text="Factors scoring below pass across the most pages, ranked by site-wide impact. Fixing one of these typically lifts many pages at once." />
             </h2>
           </div>
-          <div className="mt-3 divide-y divide-zinc-800/60 overflow-hidden rounded-lg border border-zinc-800/60">
+          <div className="mt-3 divide-y divide-mono-800/60 overflow-hidden rounded-lg border border-default">
             {score.crossCuttingIssues.map((issue) => {
               return (
                 <div key={issue.factorId} className="p-4">
                   <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-                    <span className="text-sm font-medium text-zinc-100">{issue.factorName}</span>
+                    <span className="text-sm font-medium text-heading">{issue.factorName}</span>
                     <ToneBadge tone={scoreTone(issue.avgScore)}>{statusLabel(issue.avgScore)}</ToneBadge>
-                    <span className="text-xs tabular-nums text-zinc-500">
+                    <span className="text-xs tabular-nums text-muted">
                       avg {issue.avgScore} · affects {issue.affectedPages} of {issue.totalPages} pages ({issue.affectedPct}%)
                     </span>
                   </div>
                   {issue.topRecommendations.length > 0 ? (
                     <ul className="mt-2 space-y-1">
                       {issue.topRecommendations.map((rec, i) => (
-                        <li key={i} className="flex gap-2 text-sm text-zinc-400">
-                          <span className="select-none text-zinc-600">→</span>
+                        <li key={i} className="flex gap-2 text-sm text-secondary">
+                          <span className="select-none text-faint">→</span>
                           <span>{rec}</span>
                         </li>
                       ))}
@@ -409,12 +409,12 @@ export function TechnicalAeoSection({ projectName }: { projectName: string }) {
             <h2>Per-page breakdown</h2>
           </div>
           {hasErrors ? (
-            <div className="inline-flex items-center gap-1 rounded-full border border-zinc-800/60 p-0.5" role="group" aria-label="Filter pages">
+            <div className="inline-flex items-center gap-1 rounded-full border border-default p-0.5" role="group" aria-label="Filter pages">
               <button
                 type="button"
                 onClick={() => setErrorsOnly(false)}
                 aria-pressed={!showErrorsOnly}
-                className={`rounded-full px-3 py-1 text-xs font-medium tabular-nums transition-colors ${!showErrorsOnly ? 'bg-zinc-800 text-zinc-100' : 'text-zinc-500 hover:text-zinc-300'}`}
+                className={`rounded-full px-3 py-1 text-xs font-medium tabular-nums transition-colors ${!showErrorsOnly ? 'bg-mono-800 text-heading' : 'text-muted hover:text-neutral'}`}
               >
                 All {score.pagesAudited}
               </button>
@@ -422,7 +422,7 @@ export function TechnicalAeoSection({ projectName }: { projectName: string }) {
                 type="button"
                 onClick={() => setErrorsOnly(true)}
                 aria-pressed={showErrorsOnly}
-                className={`rounded-full px-3 py-1 text-xs font-medium tabular-nums transition-colors ${showErrorsOnly ? 'bg-rose-500/15 text-rose-300' : 'text-zinc-500 hover:text-zinc-300'}`}
+                className={`rounded-full px-3 py-1 text-xs font-medium tabular-nums transition-colors ${showErrorsOnly ? 'bg-negative-500/15 text-negative' : 'text-muted hover:text-neutral'}`}
               >
                 Errors {score.pagesErrored}
               </button>
@@ -447,12 +447,12 @@ export function TechnicalAeoSection({ projectName }: { projectName: string }) {
                     <tr key={p.url}>
                       <td className="text-right tabular-nums">
                         {p.status === 'error'
-                          ? <span className="inline-flex items-center gap-1 text-rose-400"><AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />err</span>
+                          ? <span className="inline-flex items-center gap-1 text-negative-400"><AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />err</span>
                           : <span className={scoreTextClass(p.overallScore)}>{p.overallScore}</span>}
                       </td>
                       <td>{p.status === 'error' ? <ToneBadge tone="negative">Error</ToneBadge> : <ToneBadge tone={scoreTone(p.overallScore)}>{statusLabel(p.overallScore)}</ToneBadge>}</td>
                       <td className="w-full max-w-0">
-                        <a href={p.url} target="_blank" rel="noreferrer" className="block truncate text-zinc-300 hover:text-zinc-100" title={p.status === 'error' ? p.error ?? p.url : p.url}>
+                        <a href={p.url} target="_blank" rel="noreferrer" className="block truncate text-neutral hover:text-heading" title={p.status === 'error' ? p.error ?? p.url : p.url}>
                           {p.url}
                         </a>
                       </td>
@@ -462,7 +462,7 @@ export function TechnicalAeoSection({ projectName }: { projectName: string }) {
               </table>
             </div>
             {pagesCapped ? (
-              <p className="mt-2 text-xs text-zinc-600">Showing the worst {allPages.length} of {score.pagesAudited} audited pages.</p>
+              <p className="mt-2 text-xs text-faint">Showing the worst {allPages.length} of {score.pagesAudited} audited pages.</p>
             ) : null}
           </>
         )}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -49,9 +49,6 @@ const RAW_PALETTE_ALLOWLIST = [
   'apps/web/src/pages/ProjectsPage.tsx',
   'apps/web/src/pages/OverviewPage.tsx',
   'apps/web/src/pages/RunsPage.tsx',
-  'apps/web/src/components/project/TechnicalAeoSection.tsx',
-  'apps/web/src/components/project/DiscoverySection.tsx',
-  'apps/web/src/components/project/CitationVisibilitySection.tsx',
   'apps/web/src/lib/highlight.ts',
   'apps/web/src/lib/tone-helpers.ts',
 ]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.112.0",
+  "version": "4.112.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.112.0",
+  "version": "4.112.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
Phase 3 design-token slice (issue #767), the 3 project-section files #783 did not cover: TechnicalAeoSection, DiscoverySection, CitationVisibilitySection (141 raw-palette sites).

- **Class-only, no redesign.** The literal->token mapping was extracted verbatim from the merged, reviewed #783 so token choices stay consistent across the migration.
- Removes the 3 files from the `RAW_PALETTE_ALLOWLIST` ratchet (they can no longer regress).

Verified: 0 residual raw-palette classes; every produced scale shade exists in `@theme` (explicit inert-token check); typecheck + web lint (the ratchet, with the files de-allowlisted) green; 356 token + dashboard-class-baseline tests pass with no snapshot drift; build clean. `scan:colors` 900 -> 759.

🤖 Generated with [Claude Code](https://claude.com/claude-code)