### PR TITLE
refactor(web): migrate App.tsx + 5 light pages to design tokens (DS-2)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -769,25 +769,25 @@ export function RootLayout() {
         >
           <div className="flex flex-wrap items-center gap-x-5 gap-y-1 text-sm">
             <StatusBadge status={selectedRun.status} />
-            <span className="text-zinc-400">{selectedRun.startedAt}</span>
-            <span className="text-zinc-500">{selectedRun.duration}</span>
-            <span className="text-zinc-600">{selectedRun.triggerLabel}</span>
+            <span className="text-secondary">{selectedRun.startedAt}</span>
+            <span className="text-muted">{selectedRun.duration}</span>
+            <span className="text-faint">{selectedRun.triggerLabel}</span>
           </div>
           {selectedRun.status === 'failed' && selectedRun.statusDetail && (
-            <p className="text-sm text-rose-300/80 mt-2">{selectedRun.statusDetail}</p>
+            <p className="text-sm text-negative/80 mt-2">{selectedRun.statusDetail}</p>
           )}
 
           {/* Run activity log */}
           <div className="mt-4">
-            <p className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 mb-2">Activity Log</p>
+            <p className="text-[10px] font-semibold uppercase tracking-wider text-muted mb-2">Activity Log</p>
             {runDetailLoading ? (
-              <p className="text-sm text-zinc-500">Loading run details...</p>
+              <p className="text-sm text-muted">Loading run details...</p>
             ) : runDetail?.snapshots && runDetail.snapshots.length > 0 ? (
               <div className="space-y-2">
                 {runDetail.snapshots.map((snap) => (
-                  <div key={snap.id} className="rounded-lg border border-zinc-800/60 bg-zinc-900/30 p-3">
+                  <div key={snap.id} className="rounded-lg border border-default bg-surface p-3">
                     <div className="flex items-center justify-between gap-2 mb-1">
-                      <p className="text-sm font-medium text-zinc-200 truncate">{snap.query ?? 'Unknown query'}</p>
+                      <p className="text-sm font-medium text-strong truncate">{snap.query ?? 'Unknown query'}</p>
                       <div className="flex items-center gap-1.5">
                         <ProviderBadge provider={snap.provider} />
                         <Badge variant={snap.citationState === CitationStates.cited ? 'success' : 'neutral'}>
@@ -796,21 +796,21 @@ export function RootLayout() {
                       </div>
                     </div>
                     {snap.model && (
-                      <p className="text-[11px] text-zinc-500 font-mono">{snap.model}</p>
+                      <p className="text-[11px] text-muted font-mono">{snap.model}</p>
                     )}
                     {snap.citedDomains.length > 0 && (
-                      <p className="text-xs text-zinc-500 mt-1">
-                        <span className="text-zinc-400">Sources:</span> {snap.citedDomains.join(', ')}
+                      <p className="text-xs text-muted mt-1">
+                        <span className="text-secondary">Sources:</span> {snap.citedDomains.join(', ')}
                       </p>
                     )}
                     {snap.competitorOverlap.length > 0 && (
-                      <p className="text-xs text-rose-400/80 mt-0.5">
+                      <p className="text-xs text-negative-400/80 mt-0.5">
                         Competitor cited: {snap.competitorOverlap.join(', ')}
                       </p>
                     )}
                     {snap.groundingSources && snap.groundingSources.length > 0 && (
                       <details className="mt-2">
-                        <summary className="text-xs text-zinc-500 cursor-pointer hover:text-zinc-400">
+                        <summary className="text-xs text-muted cursor-pointer hover:text-secondary">
                           {snap.groundingSources.length} grounding source{snap.groundingSources.length !== 1 ? 's' : ''}
                         </summary>
                         <ul className="mt-1 space-y-0.5">
@@ -820,9 +820,9 @@ export function RootLayout() {
                             const href = safeExternalUrl(src.uri)
                             const label = src.title || src.uri
                             return (
-                              <li key={i} className="text-xs text-zinc-500 truncate">
+                              <li key={i} className="text-xs text-muted truncate">
                                 {href ? (
-                                  <a href={href} target="_blank" rel="noopener noreferrer" className="hover:text-zinc-300">{label}</a>
+                                  <a href={href} target="_blank" rel="noopener noreferrer" className="hover:text-neutral">{label}</a>
                                 ) : (
                                   <span>{label}</span>
                                 )}
@@ -834,36 +834,36 @@ export function RootLayout() {
                     )}
                     {snap.answerText && (
                       <details className="mt-1">
-                        <summary className="text-xs text-zinc-500 cursor-pointer hover:text-zinc-400">Answer preview</summary>
-                        <p className="mt-1 text-xs text-zinc-400 leading-relaxed whitespace-pre-wrap">{snap.answerText}</p>
+                        <summary className="text-xs text-muted cursor-pointer hover:text-secondary">Answer preview</summary>
+                        <p className="mt-1 text-xs text-secondary leading-relaxed whitespace-pre-wrap">{snap.answerText}</p>
                       </details>
                     )}
                   </div>
                 ))}
                 {runDetail.status === 'running' && (
-                  <div className="flex items-center gap-2 p-3 text-sm text-zinc-500">
-                    <span className="inline-block h-2 w-2 rounded-full bg-amber-500 animate-pulse" />
+                  <div className="flex items-center gap-2 p-3 text-sm text-muted">
+                    <span className="inline-block h-2 w-2 rounded-full bg-caution-500 animate-pulse" />
                     Running remaining queries...
                   </div>
                 )}
               </div>
             ) : runDetail && runDetail.status === 'running' ? (
-              <div className="flex items-center gap-2 p-3 text-sm text-zinc-500">
-                <span className="inline-block h-2 w-2 rounded-full bg-amber-500 animate-pulse" />
+              <div className="flex items-center gap-2 p-3 text-sm text-muted">
+                <span className="inline-block h-2 w-2 rounded-full bg-caution-500 animate-pulse" />
                 Waiting for first query result...
               </div>
             ) : runDetail && runDetail.status === 'queued' ? (
-              <div className="flex items-center gap-2 p-3 text-sm text-zinc-500">
-                <span className="inline-block h-2 w-2 rounded-full bg-zinc-500 animate-pulse" />
+              <div className="flex items-center gap-2 p-3 text-sm text-muted">
+                <span className="inline-block h-2 w-2 rounded-full bg-mono-500 animate-pulse" />
                 Run queued, waiting for execution slot...
               </div>
             ) : runDetail && runDetail.error ? (
-              <div className="rounded-lg border border-rose-800/40 bg-rose-950/20 p-3">
-                <p className="text-sm font-medium text-rose-300 mb-2">Run failed</p>
-                <pre className="text-xs text-rose-300/80 whitespace-pre-wrap break-words max-h-48 overflow-y-auto font-mono leading-5">{formatErrorLog(runDetail.error)}</pre>
+              <div className="rounded-lg border border-negative-800/40 bg-negative-950/20 p-3">
+                <p className="text-sm font-medium text-negative mb-2">Run failed</p>
+                <pre className="text-xs text-negative/80 whitespace-pre-wrap break-words max-h-48 overflow-y-auto font-mono leading-5">{formatErrorLog(runDetail.error)}</pre>
               </div>
             ) : (
-              <p className="text-sm text-zinc-500">No snapshot data available.</p>
+              <p className="text-sm text-muted">No snapshot data available.</p>
             )}
           </div>
         </Drawer>

--- a/apps/web/src/pages/OverviewPage.tsx
+++ b/apps/web/src/pages/OverviewPage.tsx
@@ -38,9 +38,9 @@ function OverviewProjectCard({
       <div className="project-row-stat">
         <div className="metric-inline-block">
           <p className="metric-inline-label">Mentioned</p>
-          <p className={`metric-inline-value ${project.mentionTone === 'caution' ? 'text-amber-400' : ''}`}>{project.mentionScore}</p>
+          <p className={`metric-inline-value ${project.mentionTone === 'caution' ? 'text-caution-400' : ''}`}>{project.mentionScore}</p>
           <p className="metric-inline-delta">{project.mentionDelta}</p>
-          {project.providerCoverage && <p className="text-[10px] font-medium text-amber-400/80">{project.providerCoverage}</p>}
+          {project.providerCoverage && <p className="text-[10px] font-medium text-caution-400/80">{project.providerCoverage}</p>}
         </div>
       </div>
       <div className="project-row-stat">
@@ -50,7 +50,7 @@ function OverviewProjectCard({
         </div>
       </div>
       <span className="project-row-link">
-        <ChevronRight className="h-4 w-4 text-zinc-500" />
+        <ChevronRight className="h-4 w-4 text-muted" />
       </span>
     </Link>
   )
@@ -70,7 +70,7 @@ export function OverviewPage() {
         </div>
         <div className="space-y-3">
           {[1, 2, 3].map((i) => (
-            <div key={i} className="rounded-xl border border-zinc-800/60 bg-zinc-900/30 p-4 flex items-center gap-4">
+            <div key={i} className="rounded-xl border border-default bg-surface p-4 flex items-center gap-4">
               <div className="flex-1 space-y-2">
                 <div className="skeleton-text w-36" />
                 <div className="skeleton-text-sm w-48" />
@@ -102,7 +102,7 @@ export function OverviewPage() {
           <p className="page-subtitle">Visibility and execution state across all projects</p>
         </div>
         <div className="page-header-right">
-          <p className="text-[11px] text-zinc-600">{model.lastUpdatedAt}</p>
+          <p className="text-[11px] text-faint">{model.lastUpdatedAt}</p>
         </div>
       </div>
 

--- a/apps/web/src/pages/ProjectsPage.tsx
+++ b/apps/web/src/pages/ProjectsPage.tsx
@@ -23,14 +23,14 @@ export function ProjectsPage() {
           <div className="skeleton-text h-6 w-28" />
           <div className="skeleton-text-sm w-40" />
         </div>
-        <div className="rounded-xl border border-zinc-800/60 bg-zinc-900/30 overflow-hidden">
-          <div className="p-3 border-b border-zinc-800/60 flex gap-8">
+        <div className="rounded-xl border border-default bg-surface overflow-hidden">
+          <div className="p-3 border-b border-default flex gap-8">
             {['Name', 'Domain', 'Mentions', 'Last run', 'Country'].map((h) => (
               <div key={h} className="skeleton-text-sm w-16" />
             ))}
           </div>
           {[1, 2, 3].map((i) => (
-            <div key={i} className="p-3 border-b border-zinc-800/40 flex gap-8 items-center">
+            <div key={i} className="p-3 border-b border-subtle flex gap-8 items-center">
               <div className="flex-1 space-y-1">
                 <div className="skeleton-text w-28" />
                 <div className="skeleton-text-sm w-16" />
@@ -113,7 +113,7 @@ export function ProjectsPage() {
           <div className="section-head">
             <div>
               <p className="eyebrow eyebrow-soft">New project</p>
-              <h2 className="text-sm font-medium text-zinc-200">Create a new monitoring project</h2>
+              <h2 className="text-sm font-medium text-strong">Create a new monitoring project</h2>
             </div>
           </div>
           <div className="compact-stack mt-4">
@@ -182,7 +182,7 @@ export function ProjectsPage() {
               </div>
             </div>
           </div>
-          {error ? <p className="text-rose-400 text-sm mt-3">{error}</p> : null}
+          {error ? <p className="text-negative-400 text-sm mt-3">{error}</p> : null}
           <div className="flex items-center gap-3 mt-4">
             <Button type="button" disabled={!slug || !domain || saving} onClick={asyncHandler(handleCreate)}>
               {saving ? 'Creating...' : 'Create project'}
@@ -215,25 +215,25 @@ export function ProjectsPage() {
                       <Link
                         to="/projects/$projectName"
                         params={{ projectName: p.project.name }}
-                        className="text-zinc-100 font-medium hover:underline"
+                        className="text-heading font-medium hover:underline"
                         onClick={(e) => e.stopPropagation()}
                       >
                         {p.project.displayName || p.project.name}
                       </Link>
-                      <p className="text-[11px] text-zinc-500">{p.project.name}</p>
+                      <p className="text-[11px] text-muted">{p.project.name}</p>
                     </td>
-                    <td className="text-zinc-400">{p.project.canonicalDomain}</td>
+                    <td className="text-secondary">{p.project.canonicalDomain}</td>
                     <td>
                       <ToneBadge tone={p.mentionSummary.tone}>{p.mentionSummary.value}</ToneBadge>
                     </td>
-                    <td className="text-zinc-500 text-sm">
+                    <td className="text-muted text-sm">
                       {latestRun ? (
                         <StatusBadge status={latestRun.status} />
                       ) : (
-                        <span className="text-zinc-600">No runs</span>
+                        <span className="text-faint">No runs</span>
                       )}
                     </td>
-                    <td className="text-right text-zinc-500">{p.project.country}</td>
+                    <td className="text-right text-muted">{p.project.country}</td>
                   </tr>
                 )
               })}

--- a/apps/web/src/pages/RunsPage.tsx
+++ b/apps/web/src/pages/RunsPage.tsx
@@ -21,7 +21,7 @@ export function RunsPage() {
         </div>
         <div className="space-y-2">
           {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="rounded-xl border border-zinc-800/60 bg-zinc-900/30 p-3 flex items-center gap-3">
+            <div key={i} className="rounded-xl border border-default bg-surface p-3 flex items-center gap-3">
               <div className="flex-1 space-y-1.5">
                 <div className="skeleton-text w-40" />
                 <div className="skeleton-text-sm w-56" />

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -66,7 +66,7 @@ export function SettingsPage() {
                 <dd className="font-mono text-xs">
                   {provider.model ?? provider.defaultModel ?? 'unknown'}
                   {!provider.model && provider.defaultModel && (
-                    <span className="ml-1 font-sans text-zinc-500">(default)</span>
+                    <span className="ml-1 font-sans text-muted">(default)</span>
                   )}
                 </dd>
               </div>
@@ -83,7 +83,7 @@ export function SettingsPage() {
                 </>
               )}
             </dl>
-            <p className="mt-2 text-sm text-zinc-500">{provider.detail}</p>
+            <p className="mt-2 text-sm text-muted">{provider.detail}</p>
             <div className="mt-2">
               <Button
                 type="button"
@@ -127,7 +127,7 @@ export function SettingsPage() {
               <dd className="font-mono text-xs">~/.canonry/config.yaml</dd>
             </div>
           </dl>
-          <p className="mt-2 text-sm text-zinc-500">{settings.google.detail}</p>
+          <p className="mt-2 text-sm text-muted">{settings.google.detail}</p>
           <div className="mt-2">
             <Button
               type="button"
@@ -167,7 +167,7 @@ export function SettingsPage() {
               <dd className="font-mono text-xs">~/.canonry/config.yaml</dd>
             </div>
           </dl>
-          <p className="mt-2 text-sm text-zinc-500">{settings.bing.detail}</p>
+          <p className="mt-2 text-sm text-muted">{settings.bing.detail}</p>
           <div className="mt-2">
             <Button
               type="button"
@@ -179,15 +179,15 @@ export function SettingsPage() {
             </Button>
           </div>
           {configuringBing && (
-            <div className="mt-3 rounded-lg border border-zinc-800 bg-zinc-900/40 p-3 space-y-2">
+            <div className="mt-3 rounded-lg border border-base bg-bg-elevated/40 p-3 space-y-2">
               <div>
                 <div className="flex items-center justify-between">
-                  <label className="text-xs text-zinc-500" htmlFor="bing-api-key">API Key</label>
+                  <label className="text-xs text-muted" htmlFor="bing-api-key">API Key</label>
                   <a
                     href="https://www.bing.com/webmasters/"
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-[10px] text-zinc-500 hover:text-zinc-300 underline underline-offset-2"
+                    className="text-[10px] text-muted hover:text-neutral underline underline-offset-2"
                   >
                     Bing Webmaster Tools
                   </a>
@@ -195,17 +195,17 @@ export function SettingsPage() {
                 <input
                   id="bing-api-key"
                   type="password"
-                  className="mt-0.5 w-full rounded border border-zinc-700 bg-transparent px-2 py-1.5 text-sm text-zinc-200 placeholder-zinc-600 focus:border-zinc-500 focus:outline-none"
+                  className="mt-0.5 w-full rounded border border-strong bg-transparent px-2 py-1.5 text-sm text-strong placeholder-mono-600 focus:border-mono-500 focus:outline-none"
                   placeholder="Bing Webmaster Tools API key"
                   value={bingApiKey}
                   onChange={(e) => setBingApiKey(e.target.value)}
                 />
               </div>
-              <p className="text-[11px] text-zinc-500">
+              <p className="text-[11px] text-muted">
                 This key is stored in <code>~/.canonry/config.yaml</code>. Project-level Bing connections are created separately per canonical domain.
               </p>
-              {bingError && <p className="text-xs text-rose-400">{bingError}</p>}
-              {bingSuccess && <p className="text-xs text-emerald-400">Bing API key updated.</p>}
+              {bingError && <p className="text-xs text-negative-400">{bingError}</p>}
+              {bingSuccess && <p className="text-xs text-positive-400">Bing API key updated.</p>}
               <Button type="button" size="sm" disabled={!bingApiKey.trim() || bingSaving} onClick={asyncHandler(async () => {
                 if (!bingApiKey.trim()) return
                 setBingSaving(true)

--- a/apps/web/src/pages/TrafficPage.tsx
+++ b/apps/web/src/pages/TrafficPage.tsx
@@ -91,13 +91,13 @@ export function TrafficPage() {
         </div>
 
         {!activeProject ? (
-          <Card className="p-6 text-center text-sm text-zinc-500">No projects yet.</Card>
+          <Card className="p-6 text-center text-sm text-muted">No projects yet.</Card>
         ) : sourcesQuery.isLoading ? (
-          <Card className="p-6 text-center text-sm text-zinc-500">Loading sources…</Card>
+          <Card className="p-6 text-center text-sm text-muted">Loading sources…</Card>
         ) : sources.length === 0 ? (
           <Card className="p-8 text-center">
-            <p className="text-sm text-zinc-300">No traffic sources connected for {activeProject}.</p>
-            <p className="mt-1 text-xs text-zinc-500">Connect a traffic source to start ingesting crawler hits and AI-referral sessions from your server logs.</p>
+            <p className="text-sm text-neutral">No traffic sources connected for {activeProject}.</p>
+            <p className="mt-1 text-xs text-muted">Connect a traffic source to start ingesting crawler hits and AI-referral sessions from your server logs.</p>
             <div className="mt-4 flex flex-wrap items-center justify-center gap-2">
               <Button type="button" variant="outline" size="sm" onClick={() => setConnectOpen(true)}>
                 <Plus className="size-3.5" />
@@ -139,9 +139,9 @@ function SourcesTable({ projectName, sources }: { projectName: string; sources: 
   }))
 
   return (
-    <div className="rounded-xl border border-zinc-800/60 bg-zinc-900/30 overflow-hidden">
+    <div className="rounded-xl border border-default bg-surface overflow-hidden">
       <table className="w-full text-sm">
-        <thead className="bg-zinc-900/50 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+        <thead className="bg-bg-elevated/50 text-[10px] font-semibold uppercase tracking-wider text-muted">
           <tr>
             <th className="px-4 py-2 text-left">Source</th>
             <th className="px-4 py-2 text-left">Status</th>
@@ -153,44 +153,44 @@ function SourcesTable({ projectName, sources }: { projectName: string; sources: 
             <th className="px-4 py-2 text-right" />
           </tr>
         </thead>
-        <tbody className="divide-y divide-zinc-800/60">
+        <tbody className="divide-y divide-mono-800/60">
           {rows.map(({ source, detail, isLoading }) => (
-            <tr key={source.id} className="hover:bg-zinc-900/40 transition-colors">
+            <tr key={source.id} className="hover:bg-bg-elevated/40 transition-colors">
               <td className="px-4 py-3">
-                <div className="font-medium text-zinc-100">{source.displayName}</div>
-                <div className="text-[11px] text-zinc-500 font-mono">{source.sourceType} · {source.id.slice(0, 8)}</div>
+                <div className="font-medium text-heading">{source.displayName}</div>
+                <div className="text-[11px] text-muted font-mono">{source.sourceType} · {source.id.slice(0, 8)}</div>
               </td>
               <td className="px-4 py-3">
                 <ToneBadge tone={toneFromTrafficSourceStatus(source.status)}>
                   {source.status}
                 </ToneBadge>
                 {source.lastError ? (
-                  <p className="mt-1 max-w-[18rem] truncate text-[11px] text-rose-400/80" title={source.lastError}>
+                  <p className="mt-1 max-w-[18rem] truncate text-[11px] text-negative-400/80" title={source.lastError}>
                     {source.lastError}
                   </p>
                 ) : null}
               </td>
-              <td className="px-4 py-3 text-zinc-300">{relativeTime(source.lastSyncedAt)}</td>
+              <td className="px-4 py-3 text-neutral">{relativeTime(source.lastSyncedAt)}</td>
               <td
-                className="px-4 py-3 text-right tabular-nums text-zinc-100"
+                className="px-4 py-3 text-right tabular-nums text-heading"
                 title={detail ? `${detail.totals24h.crawlerHits.toLocaleString('en-US')} total crawler hits` : undefined}
               >
                 {isLoading ? '—' : formatCompact(detail?.totals24h.crawlerContentHits ?? 0)}
               </td>
-              <td className="px-4 py-3 text-right tabular-nums text-zinc-500">
+              <td className="px-4 py-3 text-right tabular-nums text-muted">
                 {isLoading ? '—' : formatCompact(detail?.totals24h.crawlerInfraHits ?? 0)}
               </td>
-              <td className="px-4 py-3 text-right tabular-nums text-zinc-100">
+              <td className="px-4 py-3 text-right tabular-nums text-heading">
                 {isLoading ? '—' : formatCompact(detail?.totals24h.aiUserFetchHits ?? 0)}
               </td>
-              <td className="px-4 py-3 text-right tabular-nums text-zinc-100">
+              <td className="px-4 py-3 text-right tabular-nums text-heading">
                 {isLoading ? '—' : formatCompact(detail?.totals24h.aiReferralHits ?? 0)}
               </td>
               <td className="px-4 py-3 text-right">
                 <Link
                   to="/traffic/$projectName/$sourceId"
                   params={{ projectName, sourceId: source.id }}
-                  className="inline-flex items-center gap-1 text-xs text-zinc-300 hover:text-zinc-100"
+                  className="inline-flex items-center gap-1 text-xs text-neutral hover:text-heading"
                 >
                   <RefreshCw className="size-3" />
                   View
@@ -200,9 +200,9 @@ function SourcesTable({ projectName, sources }: { projectName: string; sources: 
           ))}
         </tbody>
       </table>
-      <p className="border-t border-zinc-800/60 px-4 py-2 text-[11px] text-zinc-600">
+      <p className="border-t border-default px-4 py-2 text-[11px] text-faint">
         Showing {sources.filter((s) => s.status !== TrafficSourceStatuses.archived).length} active source{sources.length === 1 ? '' : 's'} for {projectName}.
-        Same shape as <code className="text-zinc-400">canonry traffic status {projectName} --format json</code>.
+        Same shape as <code className="text-secondary">canonry traffic status {projectName} --format json</code>.
       </p>
     </div>
   )

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,17 +38,11 @@ const ALT_CHART_LIB_PATTERNS = [
 // Remove a file the moment its slice lands. When this list is empty, delete the
 // `ignores: [...RAW_PALETTE_ALLOWLIST, ...]` line in the block below.
 const RAW_PALETTE_ALLOWLIST = [
-  'apps/web/src/App.tsx',
   'apps/web/src/pages/ProjectPage.tsx',
   'apps/web/src/pages/ReportPage.tsx',
   'apps/web/src/pages/BacklinksPage.tsx',
   'apps/web/src/pages/TrafficSourceDetailPage.tsx',
   'apps/web/src/pages/SetupPage.tsx',
-  'apps/web/src/pages/TrafficPage.tsx',
-  'apps/web/src/pages/SettingsPage.tsx',
-  'apps/web/src/pages/ProjectsPage.tsx',
-  'apps/web/src/pages/OverviewPage.tsx',
-  'apps/web/src/pages/RunsPage.tsx',
   'apps/web/src/lib/highlight.ts',
   'apps/web/src/lib/tone-helpers.ts',
 ]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.112.1",
+  "version": "4.112.2",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.112.1",
+  "version": "4.112.2",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
Phase 3 design-token slice (issue #767): App.tsx (31) + ProjectsPage/OverviewPage/RunsPage/SettingsPage/TrafficPage (~59), ~90 raw-palette sites.

- Class-only, same #783-derived mapping as DS-1 (#786).
- App.tsx's chromeless embed-shell branch + `window.location.pathname` routing are untouched (27/27 balanced, only color-class lines changed).
- Removes the 6 files from the `RAW_PALETTE_ALLOWLIST` ratchet.

Verified: 0 residual raw-palette; no inert tokens (explicit @theme check); typecheck + web lint (ratchet, de-allowlisted) green; 356 token + class-baseline + app tests pass, no snapshot drift; build clean. `scan:colors` 759 -> 669.

🤖 Generated with [Claude Code](https://claude.com/claude-code)