### PR TITLE
refactor(web): migrate mid-weight pages + lib helpers to design tokens (DS-3)

### DIFF
--- a/apps/web/src/lib/highlight.ts
+++ b/apps/web/src/lib/highlight.ts
@@ -45,7 +45,7 @@ export function highlightTermsInText(text: string, terms: string[] | HighlightTe
   if (allTerms.length === 0) {
     return segments.map((seg, i) =>
       seg.type === 'bold'
-        ? React.createElement('strong', { key: `b-${i}`, className: 'text-zinc-200 font-semibold' }, seg.value)
+        ? React.createElement('strong', { key: `b-${i}`, className: 'text-strong font-semibold' }, seg.value)
         : seg.value,
     ).filter(Boolean) as ReactNode[]
   }
@@ -60,7 +60,7 @@ export function highlightTermsInText(text: string, terms: string[] | HighlightTe
   if (sources.length === 0) {
     return segments.map((seg, i) =>
       seg.type === 'bold'
-        ? React.createElement('strong', { key: `b-${i}`, className: 'text-zinc-200 font-semibold' }, seg.value)
+        ? React.createElement('strong', { key: `b-${i}`, className: 'text-strong font-semibold' }, seg.value)
         : seg.value,
     ).filter(Boolean) as ReactNode[]
   }
@@ -88,11 +88,11 @@ export function highlightTermsInText(text: string, terms: string[] | HighlightTe
         const cls = termClassMap.get(brandKeyFromText(part)) ?? 'answer-highlight'
         return seg.type === 'bold'
           ? React.createElement('mark', { key: `hl-${si}-${pi}`, className: cls },
-              React.createElement('strong', { className: 'text-zinc-200 font-semibold' }, part))
+              React.createElement('strong', { className: 'text-strong font-semibold' }, part))
           : React.createElement('mark', { key: `hl-${si}-${pi}`, className: cls }, part)
       }
       return seg.type === 'bold'
-        ? React.createElement('strong', { key: `b-${si}-${pi}`, className: 'text-zinc-200 font-semibold' }, part)
+        ? React.createElement('strong', { key: `b-${si}-${pi}`, className: 'text-strong font-semibold' }, part)
         : part
     })
   }).filter(Boolean) as ReactNode[]

--- a/apps/web/src/lib/tone-helpers.ts
+++ b/apps/web/src/lib/tone-helpers.ts
@@ -57,8 +57,8 @@ export function competitorTone(label: string): MetricTone {
 
 /** Maps a metric tone to its Tailwind text-color utility. */
 export const METRIC_TONE_TEXT_CLASS: Record<MetricTone, string> = {
-  positive: 'text-emerald-400',
-  caution: 'text-amber-400',
-  negative: 'text-rose-400',
-  neutral: 'text-zinc-400',
+  positive: 'text-positive-400',
+  caution: 'text-caution-400',
+  negative: 'text-negative-400',
+  neutral: 'text-secondary',
 }

--- a/apps/web/src/pages/BacklinksPage.tsx
+++ b/apps/web/src/pages/BacklinksPage.tsx
@@ -24,7 +24,7 @@ function Hint({
         type="button"
         aria-label={label}
         aria-describedby={open ? id : undefined}
-        className="inline-flex h-4 w-4 items-center justify-center rounded-full text-zinc-500 hover:text-zinc-200 focus:text-zinc-200 focus:outline-none focus-visible:ring-1 focus-visible:ring-zinc-500"
+        className="inline-flex h-4 w-4 items-center justify-center rounded-full text-muted hover:text-strong focus:text-strong focus:outline-none focus-visible:ring-1 focus-visible:ring-mono-500"
         onMouseEnter={() => setOpen(true)}
         onMouseLeave={() => setOpen(false)}
         onFocus={() => setOpen(true)}
@@ -36,7 +36,7 @@ function Hint({
         <span
           id={id}
           role="tooltip"
-          className={`absolute z-50 w-64 rounded border border-zinc-700 bg-zinc-900 px-3 py-2 text-xs font-normal leading-relaxed text-zinc-200 shadow-lg ${
+          className={`absolute z-50 w-64 rounded border border-strong bg-bg-elevated px-3 py-2 text-xs font-normal leading-relaxed text-strong shadow-lg ${
             placement === 'top' ? 'bottom-full mb-2' : 'top-full mt-2'
           } left-1/2 -translate-x-1/2 whitespace-normal`}
         >
@@ -207,18 +207,18 @@ export function BacklinksPage() {
         </div>
       </div>
 
-      <Card className="surface-card p-4 mb-6 border-amber-800/60">
+      <Card className="surface-card p-4 mb-6 border-caution-800/60">
         <div className="flex items-start gap-3">
-          <AlertTriangle className="h-5 w-5 text-amber-400 shrink-0 mt-0.5" aria-hidden />
-          <div className="text-sm text-zinc-300 leading-relaxed">
-            <p className="font-medium text-amber-200">Heads up — a release sync is a large download.</p>
-            <ul className="mt-1.5 space-y-1 text-zinc-400">
+          <AlertTriangle className="h-5 w-5 text-caution-400 shrink-0 mt-0.5" aria-hidden />
+          <div className="text-sm text-neutral leading-relaxed">
+            <p className="font-medium text-caution-200">Heads up — a release sync is a large download.</p>
+            <ul className="mt-1.5 space-y-1 text-secondary">
               <li>
-                <span className="text-zinc-200">~16 GB</span> of gzipped vertex + edge files per release, stored at{' '}
-                <code className="text-zinc-300">~/.canonry/cache/commoncrawl/</code>.
+                <span className="text-strong">~16 GB</span> of gzipped vertex + edge files per release, stored at{' '}
+                <code className="text-neutral">~/.canonry/cache/commoncrawl/</code>.
               </li>
               <li>
-                <span className="text-zinc-200">10–20 min on a fast connection</span> for the download, then ~5 min for the DuckDB query.
+                <span className="text-strong">10–20 min on a fast connection</span> for the download, then ~5 min for the DuckDB query.
               </li>
               <li>
                 One sync covers every project in this workspace. Releases are immutable, so the download only happens once per release.
@@ -236,29 +236,29 @@ export function BacklinksPage() {
           </div>
         </div>
         <Card className="surface-card p-5">
-          <p className="text-sm text-zinc-400 leading-relaxed max-w-3xl mb-4">
+          <p className="text-sm text-secondary leading-relaxed max-w-3xl mb-4">
             Common Crawl publishes a quarterly snapshot of the public web&rsquo;s hyperlink graph. Canonry downloads one{' '}
-            <span className="text-zinc-200">release</span> at a time and extracts backlinks for every project in this
+            <span className="text-strong">release</span> at a time and extracts backlinks for every project in this
             workspace in a single pass.
           </p>
-          <ol className="space-y-3 text-sm text-zinc-400 max-w-3xl">
+          <ol className="space-y-3 text-sm text-secondary max-w-3xl">
             <li className="flex gap-3">
-              <span className="shrink-0 inline-flex h-6 w-6 items-center justify-center rounded-full border border-zinc-700 bg-zinc-900 text-xs font-semibold text-zinc-300 tabular-nums">1</span>
+              <span className="shrink-0 inline-flex h-6 w-6 items-center justify-center rounded-full border border-strong bg-bg-elevated text-xs font-semibold text-neutral tabular-nums">1</span>
               <span>
-                <span className="text-zinc-200 font-medium">Download (one-time, ~16 GB)</span> — vertex + edge files cached to{' '}
-                <code className="text-zinc-300">~/.canonry/cache/commoncrawl/</code>. Runs once per release; subsequent operations reuse the cache.
+                <span className="text-strong font-medium">Download (one-time, ~16 GB)</span> — vertex + edge files cached to{' '}
+                <code className="text-neutral">~/.canonry/cache/commoncrawl/</code>. Runs once per release; subsequent operations reuse the cache.
               </span>
             </li>
             <li className="flex gap-3">
-              <span className="shrink-0 inline-flex h-6 w-6 items-center justify-center rounded-full border border-zinc-700 bg-zinc-900 text-xs font-semibold text-zinc-300 tabular-nums">2</span>
+              <span className="shrink-0 inline-flex h-6 w-6 items-center justify-center rounded-full border border-strong bg-bg-elevated text-xs font-semibold text-neutral tabular-nums">2</span>
               <span>
-                <span className="text-zinc-200 font-medium">Query (~5 min)</span> — one DuckDB pass scans the cached files and extracts referring domains for every project&rsquo;s canonical domain. DuckDB is only used to <span className="text-zinc-200">read</span> these dumps; it doesn&rsquo;t store any canonry state.
+                <span className="text-strong font-medium">Query (~5 min)</span> — one DuckDB pass scans the cached files and extracts referring domains for every project&rsquo;s canonical domain. DuckDB is only used to <span className="text-strong">read</span> these dumps; it doesn&rsquo;t store any canonry state.
               </span>
             </li>
             <li className="flex gap-3">
-              <span className="shrink-0 inline-flex h-6 w-6 items-center justify-center rounded-full border border-zinc-700 bg-zinc-900 text-xs font-semibold text-zinc-300 tabular-nums">3</span>
+              <span className="shrink-0 inline-flex h-6 w-6 items-center justify-center rounded-full border border-strong bg-bg-elevated text-xs font-semibold text-neutral tabular-nums">3</span>
               <span>
-                <span className="text-zinc-200 font-medium">Persist</span> — results land in the same SQLite database the rest of canonry uses. After the first sync, per-project reads (and re-run extracts against the cached release) are instant.
+                <span className="text-strong font-medium">Persist</span> — results land in the same SQLite database the rest of canonry uses. After the first sync, per-project reads (and re-run extracts against the cached release) are instant.
               </span>
             </li>
           </ol>
@@ -266,13 +266,13 @@ export function BacklinksPage() {
       </section>
 
       {error && (
-        <Card className="surface-card p-4 mb-4 border-rose-800/60">
-          <p className="text-sm text-rose-300">{error}</p>
+        <Card className="surface-card p-4 mb-4 border-negative-800/60">
+          <p className="text-sm text-negative">{error}</p>
         </Card>
       )}
       {notice && (
-        <Card className="surface-card p-4 mb-4 border-emerald-800/60">
-          <p className="text-sm text-emerald-300">{notice}</p>
+        <Card className="surface-card p-4 mb-4 border-positive-800/60">
+          <p className="text-sm text-positive">{notice}</p>
         </Card>
       )}
 
@@ -286,11 +286,11 @@ export function BacklinksPage() {
                 <span className="block">
                   DuckDB is a query engine canonry uses to scan the ~16 GB Common Crawl dumps and pull out your referring domains.
                 </span>
-                <span className="mt-2 block text-zinc-400">
-                  It does <span className="text-zinc-200">not</span> store any canonry data — your backlink results live in SQLite alongside the rest of your projects. DuckDB is purely a tool for processing the raw CSV files.
+                <span className="mt-2 block text-secondary">
+                  It does <span className="text-strong">not</span> store any canonry data — your backlink results live in SQLite alongside the rest of your projects. DuckDB is purely a tool for processing the raw CSV files.
                 </span>
-                <span className="mt-2 block text-zinc-500">
-                  Installed on demand (not bundled) into <code className="text-zinc-300">~/.canonry/plugins/</code> so users who never run backlinks don&rsquo;t pay the ~40 MB install cost.
+                <span className="mt-2 block text-muted">
+                  Installed on demand (not bundled) into <code className="text-neutral">~/.canonry/plugins/</code> so users who never run backlinks don&rsquo;t pay the ~40 MB install cost.
                 </span>
               </Hint>
             </h2>
@@ -303,31 +303,31 @@ export function BacklinksPage() {
         </div>
         <Card className="surface-card p-5">
           {loading ? (
-            <p className="text-sm text-zinc-500">Checking…</p>
+            <p className="text-sm text-muted">Checking…</p>
           ) : status?.duckdbInstalled ? (
             <div className="flex items-start gap-3">
-              <CheckCircle2 className="h-5 w-5 text-emerald-400 shrink-0 mt-0.5" aria-hidden />
+              <CheckCircle2 className="h-5 w-5 text-positive-400 shrink-0 mt-0.5" aria-hidden />
               <div>
-                <p className="text-sm text-zinc-200">
+                <p className="text-sm text-strong">
                   Version {status.duckdbVersion ?? 'unknown'} installed at{' '}
-                  <code className="text-zinc-300">{status.pluginDir}</code>
+                  <code className="text-neutral">{status.pluginDir}</code>
                 </p>
-                <p className="text-xs text-zinc-500 mt-1">Required spec: {status.duckdbSpec}</p>
+                <p className="text-xs text-muted mt-1">Required spec: {status.duckdbSpec}</p>
               </div>
             </div>
           ) : (
             <div className="flex items-start gap-3">
-              <AlertCircle className="h-5 w-5 text-amber-400 shrink-0 mt-0.5" aria-hidden />
+              <AlertCircle className="h-5 w-5 text-caution-400 shrink-0 mt-0.5" aria-hidden />
               <div className="flex-1">
-                <p className="text-sm text-zinc-200">
+                <p className="text-sm text-strong">
                   DuckDB is not installed. It&rsquo;s the query engine canonry uses to scan Common Crawl dumps — required before you can run a release sync or per-project extract.
                 </p>
-                <p className="text-xs text-zinc-500 mt-1">
+                <p className="text-xs text-muted mt-1">
                   Installing doesn&rsquo;t touch your project data. DuckDB only reads the downloaded CSV files; backlink results are written to the same SQLite database canonry already uses.
                 </p>
                 {status && (
-                  <p className="text-xs text-zinc-500 mt-1">
-                    Will be installed into <code className="text-zinc-300">{status.pluginDir}</code> (~40 MB).
+                  <p className="text-xs text-muted mt-1">
+                    Will be installed into <code className="text-neutral">{status.pluginDir}</code> (~40 MB).
                   </p>
                 )}
                 <div className="mt-3">
@@ -356,76 +356,76 @@ export function BacklinksPage() {
           {latest && <ToneBadge tone={syncStatusTone(latest.status)}>{latest.status}</ToneBadge>}
         </div>
         <Card className="surface-card p-5">
-          <p className="text-xs text-zinc-500 max-w-3xl mb-4">
-            A release is one Common Crawl dump (e.g. <code className="text-zinc-400">cc-main-2026-jan-feb-mar</code>). Syncing it downloads the graph and populates backlinks for every project in this workspace.
+          <p className="text-xs text-muted max-w-3xl mb-4">
+            A release is one Common Crawl dump (e.g. <code className="text-secondary">cc-main-2026-jan-feb-mar</code>). Syncing it downloads the graph and populates backlinks for every project in this workspace.
           </p>
           {latest ? (
             <div className="space-y-2 text-sm">
-              <p className="text-zinc-200">
-                Release <code className="text-zinc-300">{latest.release}</code>
+              <p className="text-strong">
+                Release <code className="text-neutral">{latest.release}</code>
               </p>
               {latest.phaseDetail && (
-                <p className="text-zinc-500">{latest.phaseDetail}</p>
+                <p className="text-muted">{latest.phaseDetail}</p>
               )}
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-xs text-zinc-500 pt-2">
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-xs text-muted pt-2">
                 <div>
-                  <p className="text-zinc-600 uppercase tracking-wide">Projects</p>
-                  <p className="text-zinc-300 mt-0.5">{latest.projectsProcessed ?? '—'}</p>
+                  <p className="text-faint uppercase tracking-wide">Projects</p>
+                  <p className="text-neutral mt-0.5">{latest.projectsProcessed ?? '—'}</p>
                 </div>
                 <div>
-                  <p className="text-zinc-600 uppercase tracking-wide flex items-center gap-1">
+                  <p className="text-faint uppercase tracking-wide flex items-center gap-1">
                     Rows
                     <Hint label="What are rows?">
                       Total number of (project, referring domain) pairs persisted in SQLite from this sync, across every project in the workspace.
                     </Hint>
                   </p>
-                  <p className="text-zinc-300 mt-0.5">{latest.domainsDiscovered ?? '—'}</p>
+                  <p className="text-neutral mt-0.5">{latest.domainsDiscovered ?? '—'}</p>
                 </div>
                 <div>
-                  <p className="text-zinc-600 uppercase tracking-wide">Started</p>
-                  <p className="text-zinc-300 mt-0.5">{relativeTime(latest.downloadStartedAt ?? latest.createdAt)}</p>
+                  <p className="text-faint uppercase tracking-wide">Started</p>
+                  <p className="text-neutral mt-0.5">{relativeTime(latest.downloadStartedAt ?? latest.createdAt)}</p>
                 </div>
                 <div>
-                  <p className="text-zinc-600 uppercase tracking-wide">Finished</p>
-                  <p className="text-zinc-300 mt-0.5">{relativeTime(latest.queryFinishedAt)}</p>
+                  <p className="text-faint uppercase tracking-wide">Finished</p>
+                  <p className="text-neutral mt-0.5">{relativeTime(latest.queryFinishedAt)}</p>
                 </div>
               </div>
               {latest.error && (
-                <p className="text-sm text-rose-400 pt-2">{latest.error}</p>
+                <p className="text-sm text-negative-400 pt-2">{latest.error}</p>
               )}
             </div>
           ) : (
-            <p className="text-sm text-zinc-500">No release sync has run in this workspace yet.</p>
+            <p className="text-sm text-muted">No release sync has run in this workspace yet.</p>
           )}
           {latestReadyButCacheMissing && (
-            <div className="mt-4 rounded border border-amber-800/60 bg-amber-950/20 p-3">
+            <div className="mt-4 rounded border border-caution-800/60 bg-caution-950/20 p-3">
               <div className="flex items-start gap-2">
-                <AlertTriangle className="h-4 w-4 text-amber-400 shrink-0 mt-0.5" aria-hidden />
-                <div className="text-xs text-zinc-300 leading-relaxed">
-                  <p className="font-medium text-amber-200">Cached files for this release are missing.</p>
-                  <p className="mt-1 text-zinc-400">
+                <AlertTriangle className="h-4 w-4 text-caution-400 shrink-0 mt-0.5" aria-hidden />
+                <div className="text-xs text-neutral leading-relaxed">
+                  <p className="font-medium text-caution-200">Cached files for this release are missing.</p>
+                  <p className="mt-1 text-secondary">
                     The sync record in the database says this release finished successfully, but the ~16 GB dump at{' '}
-                    <code className="text-zinc-300">~/.canonry/cache/commoncrawl/{latest?.release}/</code> isn&rsquo;t on disk. Your backlink data is still intact (it lives in SQLite), but per-project re-run extracts will fail until you either re-sync this release or start a new one.
+                    <code className="text-neutral">~/.canonry/cache/commoncrawl/{latest?.release}/</code> isn&rsquo;t on disk. Your backlink data is still intact (it lives in SQLite), but per-project re-run extracts will fail until you either re-sync this release or start a new one.
                   </p>
                 </div>
               </div>
             </div>
           )}
-          <div className="mt-4 rounded border border-zinc-800 bg-zinc-900/40 p-3">
+          <div className="mt-4 rounded border border-base bg-bg-elevated/40 p-3">
             <div className="flex items-start justify-between gap-3 mb-3">
               <div>
-                <p className="text-[10px] uppercase tracking-wide text-zinc-500">
+                <p className="text-[10px] uppercase tracking-wide text-muted">
                   Auto-detected release
                 </p>
                 {latestAvailable ? (
-                  <p className="text-sm text-zinc-200 mt-0.5">
-                    <code className="text-zinc-100">{latestAvailable.release}</code>
-                    <span className="ml-2 text-xs text-zinc-500">
+                  <p className="text-sm text-strong mt-0.5">
+                    <code className="text-heading">{latestAvailable.release}</code>
+                    <span className="ml-2 text-xs text-muted">
                       — vertex {formatBytes(latestAvailable.vertexBytes)}, edges {formatBytes(latestAvailable.edgesBytes)}
                     </span>
                   </p>
                 ) : (
-                  <p className="text-sm text-zinc-500 mt-0.5">
+                  <p className="text-sm text-muted mt-0.5">
                     {loading ? 'Probing Common Crawl…' : 'Could not auto-detect — pass an explicit release below.'}
                   </p>
                 )}
@@ -433,7 +433,7 @@ export function BacklinksPage() {
                   href={COMMON_CRAWL_RELEASES_URL}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="mt-1 inline-flex items-center gap-1 text-xs text-zinc-400 hover:text-zinc-200 focus:text-zinc-200 focus:outline-none focus-visible:ring-1 focus-visible:ring-zinc-500 rounded"
+                  className="mt-1 inline-flex items-center gap-1 text-xs text-secondary hover:text-strong focus:text-strong focus:outline-none focus-visible:ring-1 focus-visible:ring-mono-500 rounded"
                 >
                   Browse all Common Crawl web-graph releases
                   <ExternalLink className="h-3 w-3" aria-hidden />
@@ -452,10 +452,10 @@ export function BacklinksPage() {
                 <Hint label="What does Run sync do?">
                   <span className="block">
                     Downloads the auto-detected (or chosen) Common Crawl release (~16 GB) to{' '}
-                    <code className="text-zinc-300">~/.canonry/cache/commoncrawl/</code>, then runs a single DuckDB query that extracts referring domains for every project in this workspace.
+                    <code className="text-neutral">~/.canonry/cache/commoncrawl/</code>, then runs a single DuckDB query that extracts referring domains for every project in this workspace.
                   </span>
-                  <span className="mt-2 block text-zinc-400">
-                    First time for a release: <span className="text-zinc-200">~10–20 min download + ~5 min query</span>. Re-running the same release later: <span className="text-zinc-200">skips download, just re-queries</span> (~5 min).
+                  <span className="mt-2 block text-secondary">
+                    First time for a release: <span className="text-strong">~10–20 min download + ~5 min query</span>. Re-running the same release later: <span className="text-strong">skips download, just re-queries</span> (~5 min).
                   </span>
                 </Hint>
               </div>
@@ -463,7 +463,7 @@ export function BacklinksPage() {
             {!showOverride ? (
               <button
                 type="button"
-                className="text-xs text-zinc-500 hover:text-zinc-300 focus:text-zinc-300 focus:outline-none focus-visible:ring-1 focus-visible:ring-zinc-500 rounded"
+                className="text-xs text-muted hover:text-neutral focus:text-neutral focus:outline-none focus-visible:ring-1 focus-visible:ring-mono-500 rounded"
                 onClick={() => setShowOverride(true)}
                 disabled={syncing}
               >
@@ -473,7 +473,7 @@ export function BacklinksPage() {
               <div className="flex flex-wrap items-center gap-2">
                 <input
                   type="text"
-                  className="flex-1 min-w-[240px] rounded border border-zinc-700 bg-transparent px-2.5 py-1.5 text-sm text-zinc-200 placeholder-zinc-600 focus:border-zinc-500 focus:outline-none"
+                  className="flex-1 min-w-[240px] rounded border border-strong bg-transparent px-2.5 py-1.5 text-sm text-strong placeholder-mono-600 focus:border-mono-500 focus:outline-none"
                   placeholder="cc-main-2026-jan-feb-mar"
                   value={releaseInput}
                   onChange={(e) => setReleaseInput(e.target.value)}
@@ -482,7 +482,7 @@ export function BacklinksPage() {
                 />
                 <button
                   type="button"
-                  className="text-xs text-zinc-500 hover:text-zinc-300 focus:text-zinc-300 focus:outline-none focus-visible:ring-1 focus-visible:ring-zinc-500 rounded"
+                  className="text-xs text-muted hover:text-neutral focus:text-neutral focus:outline-none focus-visible:ring-1 focus-visible:ring-mono-500 rounded"
                   onClick={() => { setReleaseInput(''); setShowOverride(false) }}
                   disabled={syncing}
                 >
@@ -492,7 +492,7 @@ export function BacklinksPage() {
             )}
           </div>
           {!status?.duckdbInstalled && (
-            <p className="text-xs text-zinc-600 mt-2">Install DuckDB first to enable sync.</p>
+            <p className="text-xs text-faint mt-2">Install DuckDB first to enable sync.</p>
           )}
         </Card>
       </section>
@@ -506,22 +506,22 @@ export function BacklinksPage() {
               <Hint label="What is this?">
                 <span className="block">
                   Raw Common Crawl dumps stored at{' '}
-                  <code className="text-zinc-300">~/.canonry/cache/commoncrawl/&lt;release&gt;/</code>. Each release takes ~16 GB.
+                  <code className="text-neutral">~/.canonry/cache/commoncrawl/&lt;release&gt;/</code>. Each release takes ~16 GB.
                 </span>
-                <span className="mt-2 block text-zinc-400">
-                  These files are needed to re-run per-project extracts against a release without re-downloading. Pruning here <span className="text-zinc-200">does not delete your backlink data</span> — that lives in SQLite.
+                <span className="mt-2 block text-secondary">
+                  These files are needed to re-run per-project extracts against a release without re-downloading. Pruning here <span className="text-strong">does not delete your backlink data</span> — that lives in SQLite.
                 </span>
               </Hint>
             </h2>
           </div>
         </div>
-        <p className="text-xs text-zinc-500 mb-3 max-w-3xl">
+        <p className="text-xs text-muted mb-3 max-w-3xl">
           Each cached release is a ~16 GB pair of gzipped files. They&rsquo;re needed to re-query the graph (e.g. for a newly-added project) without re-downloading. Safe to prune — backlink results persist in SQLite.
         </p>
         <Card className="surface-card overflow-hidden">
           <table className="w-full text-sm">
             <thead>
-              <tr className="border-b border-zinc-800 text-left text-xs uppercase tracking-wide text-zinc-600">
+              <tr className="border-b border-base text-left text-xs uppercase tracking-wide text-faint">
                 <th className="px-4 py-2 font-medium">Release</th>
                 <th className="px-4 py-2 font-medium">Sync status</th>
                 <th className="px-4 py-2 text-right font-medium">Size</th>
@@ -531,17 +531,17 @@ export function BacklinksPage() {
             </thead>
             <tbody>
               {cached.map((row) => (
-                <tr key={row.release} className="border-b border-zinc-900 last:border-0">
-                  <td className="px-4 py-2 text-zinc-200"><code>{row.release}</code></td>
+                <tr key={row.release} className="border-b border-mono-900 last:border-0">
+                  <td className="px-4 py-2 text-strong"><code>{row.release}</code></td>
                   <td className="px-4 py-2">
                     {row.syncStatus ? (
                       <ToneBadge tone={syncStatusTone(row.syncStatus)}>{row.syncStatus}</ToneBadge>
                     ) : (
-                      <span className="text-zinc-600">—</span>
+                      <span className="text-faint">—</span>
                     )}
                   </td>
-                  <td className="px-4 py-2 text-right text-zinc-400 tabular-nums">{formatBytes(row.bytes)}</td>
-                  <td className="px-4 py-2 text-zinc-400">{relativeTime(row.lastUsedAt)}</td>
+                  <td className="px-4 py-2 text-right text-secondary tabular-nums">{formatBytes(row.bytes)}</td>
+                  <td className="px-4 py-2 text-secondary">{relativeTime(row.lastUsedAt)}</td>
                   <td className="px-4 py-2 text-right">
                     <div className="inline-flex items-center gap-1">
                       <Button type="button" variant="outline" size="sm" onClick={() => { void handlePrune(row.release) }}>
@@ -556,7 +556,7 @@ export function BacklinksPage() {
                 </tr>
               ))}
               {cached.length === 0 && (
-                <tr><td className="px-4 py-4 text-sm text-zinc-500" colSpan={5}>
+                <tr><td className="px-4 py-4 text-sm text-muted" colSpan={5}>
                   No cached releases on this machine. If you ran a sync from a different machine (or deleted the cache), the backlink data is still in the database — but you&rsquo;ll need to re-sync a release to run new extracts.
                 </td></tr>
               )}
@@ -576,7 +576,7 @@ export function BacklinksPage() {
           <Card className="surface-card overflow-hidden">
             <table className="w-full text-sm">
               <thead>
-                <tr className="border-b border-zinc-800 text-left text-xs uppercase tracking-wide text-zinc-600">
+                <tr className="border-b border-base text-left text-xs uppercase tracking-wide text-faint">
                   <th className="px-4 py-2 font-medium">Release</th>
                   <th className="px-4 py-2 font-medium">Status</th>
                   <th className="px-4 py-2 text-right font-medium">Projects</th>
@@ -586,12 +586,12 @@ export function BacklinksPage() {
               </thead>
               <tbody>
                 {history.map((row) => (
-                  <tr key={row.id} className="border-b border-zinc-900 last:border-0">
-                    <td className="px-4 py-2 text-zinc-200"><code>{row.release}</code></td>
+                  <tr key={row.id} className="border-b border-mono-900 last:border-0">
+                    <td className="px-4 py-2 text-strong"><code>{row.release}</code></td>
                     <td className="px-4 py-2"><ToneBadge tone={syncStatusTone(row.status)}>{row.status}</ToneBadge></td>
-                    <td className="px-4 py-2 text-right text-zinc-400 tabular-nums">{row.projectsProcessed ?? '—'}</td>
-                    <td className="px-4 py-2 text-right text-zinc-400 tabular-nums">{row.domainsDiscovered ?? '—'}</td>
-                    <td className="px-4 py-2 text-zinc-400">{relativeTime(row.queryFinishedAt ?? row.updatedAt)}</td>
+                    <td className="px-4 py-2 text-right text-secondary tabular-nums">{row.projectsProcessed ?? '—'}</td>
+                    <td className="px-4 py-2 text-right text-secondary tabular-nums">{row.domainsDiscovered ?? '—'}</td>
+                    <td className="px-4 py-2 text-secondary">{relativeTime(row.queryFinishedAt ?? row.updatedAt)}</td>
                   </tr>
                 ))}
               </tbody>

--- a/apps/web/src/pages/SetupPage.tsx
+++ b/apps/web/src/pages/SetupPage.tsx
@@ -312,14 +312,14 @@ export function SetupPage() {
                     <p className="run-row-title">{check.label}</p>
                     <p className="supporting-copy">{check.detail}</p>
                     {check.id === 'provider' && check.state !== 'ready' && (
-                      <div className="mt-3 rounded-md border border-zinc-800/60 bg-zinc-900/40 p-3 space-y-2">
-                        <p className="text-xs text-zinc-400">
+                      <div className="mt-3 rounded-md border border-default bg-bg-elevated/40 p-3 space-y-2">
+                        <p className="text-xs text-secondary">
                           Paste a Gemini key to enable visibility checks (free at{' '}
                           <a
                             href="https://aistudio.google.com/apikey"
                             target="_blank"
                             rel="noreferrer"
-                            className="text-emerald-400 hover:text-emerald-300 underline underline-offset-2"
+                            className="text-positive-400 hover:text-positive underline underline-offset-2"
                           >
                             aistudio.google.com
                           </a>
@@ -331,7 +331,7 @@ export function SetupPage() {
                             value={geminiKey}
                             onChange={(e) => setGeminiKey(e.target.value)}
                             placeholder="AI... (paste here)"
-                            className="flex-1 rounded-md border border-zinc-800 bg-zinc-950 px-2.5 py-1.5 text-sm text-zinc-100 placeholder:text-zinc-600 focus:border-zinc-600 focus:outline-none font-mono"
+                            className="flex-1 rounded-md border border-base bg-bg px-2.5 py-1.5 text-sm text-heading placeholder:text-faint focus:border-mono-600 focus:outline-none font-mono"
                             disabled={geminiSaving}
                           />
                           <Button
@@ -343,10 +343,10 @@ export function SetupPage() {
                             {geminiSaving ? 'Saving...' : 'Save'}
                           </Button>
                         </div>
-                        {geminiError && <p className="text-xs text-rose-400">{geminiError}</p>}
-                        <p className="text-[11px] text-zinc-600">
+                        {geminiError && <p className="text-xs text-negative-400">{geminiError}</p>}
+                        <p className="text-[11px] text-faint">
                           Other providers (OpenAI, Claude, Perplexity) configurable later via{' '}
-                          <Link to="/settings" className="text-zinc-500 hover:text-zinc-300 underline underline-offset-2">
+                          <Link to="/settings" className="text-muted hover:text-neutral underline underline-offset-2">
                             /settings
                           </Link>
                           .
@@ -390,7 +390,7 @@ export function SetupPage() {
             </div>
             {createdProjectName ? (
               <div className="compact-stack">
-                <p className="text-zinc-300">Project <span className="text-zinc-100 font-medium">{createdProjectName}</span> created successfully.</p>
+                <p className="text-neutral">Project <span className="text-heading font-medium">{createdProjectName}</span> created successfully.</p>
                 <div className="setup-nav">
                   <Button type="button" variant="outline" onClick={goBack}>Back</Button>
                   <Button type="button" onClick={() => setStep(2)}>Continue</Button>
@@ -421,24 +421,24 @@ export function SetupPage() {
                     <input id="language" className="setup-input" type="text" placeholder="en" maxLength={5} value={language} onChange={(e) => setLanguage(e.target.value.toLowerCase())} />
                   </div>
                 </div>
-                <label className="flex items-start gap-3 rounded-md border border-zinc-800/60 bg-zinc-900/30 p-3 cursor-pointer hover:border-zinc-700">
+                <label className="flex items-start gap-3 rounded-md border border-default bg-surface p-3 cursor-pointer hover:border-strong">
                   <input
                     type="checkbox"
-                    className="mt-0.5 h-4 w-4 rounded border-zinc-700 bg-zinc-950"
+                    className="mt-0.5 h-4 w-4 rounded border-strong bg-bg"
                     checked={autoExtractBacklinks}
                     onChange={(e) => setAutoExtractBacklinks(e.target.checked)}
                   />
                   <span className="flex-1">
-                    <span className="block text-sm text-zinc-100">Auto-extract backlinks</span>
-                    <span className="block text-xs text-zinc-500 mt-0.5">
+                    <span className="block text-sm text-heading">Auto-extract backlinks</span>
+                    <span className="block text-xs text-muted mt-0.5">
                       When a new Common Crawl release syncs, automatically extract backlinks for this project.{' '}
-                      <Link to="/backlinks" className="text-emerald-400 hover:text-emerald-300 underline underline-offset-2">
+                      <Link to="/backlinks" className="text-positive-400 hover:text-positive underline underline-offset-2">
                         Manage backlinks
                       </Link>
                     </span>
                   </span>
                 </label>
-                {projectError ? <p className="text-rose-400 text-sm">{projectError}</p> : null}
+                {projectError ? <p className="text-negative-400 text-sm">{projectError}</p> : null}
                 <div className="setup-nav">
                   <Button type="button" variant="outline" onClick={goBack}>Back</Button>
                   <Button type="button" disabled={!slug || !domain || projectSaving} onClick={asyncHandler(handleCreateProject)}>
@@ -479,10 +479,10 @@ export function SetupPage() {
               <div className="compact-stack">
                 {readyProviders.length > 0 ? (
                   <div className="compact-stack">
-                    <div className="flex items-center gap-2 text-zinc-500 text-xs uppercase tracking-wide">
-                      <span className="flex-1 border-t border-zinc-800" />
+                    <div className="flex items-center gap-2 text-muted text-xs uppercase tracking-wide">
+                      <span className="flex-1 border-t border-base" />
                       auto-generate
-                      <span className="flex-1 border-t border-zinc-800" />
+                      <span className="flex-1 border-t border-base" />
                     </div>
                     <div className="flex items-end gap-2">
                       <div className="setup-field flex-1">
@@ -520,13 +520,13 @@ export function SetupPage() {
                         {generatingQueries ? 'Analyzing site...' : 'Generate'}
                       </Button>
                     </div>
-                    {generateError ? <p className="text-rose-400 text-sm">{generateError}</p> : null}
+                    {generateError ? <p className="text-negative-400 text-sm">{generateError}</p> : null}
                   </div>
                 ) : null}
-                <div className="flex items-center gap-2 text-zinc-500 text-xs uppercase tracking-wide">
-                  <span className="flex-1 border-t border-zinc-800" />
+                <div className="flex items-center gap-2 text-muted text-xs uppercase tracking-wide">
+                  <span className="flex-1 border-t border-base" />
                   or type manually
-                  <span className="flex-1 border-t border-zinc-800" />
+                  <span className="flex-1 border-t border-base" />
                 </div>
                 <div className="setup-field">
                   <label className="setup-label" htmlFor="queries">Queries (one per line)</label>
@@ -539,7 +539,7 @@ export function SetupPage() {
                     onChange={(e) => setQueriesText(e.target.value)}
                   />
                 </div>
-                {queriesError ? <p className="text-rose-400 text-sm">{queriesError}</p> : null}
+                {queriesError ? <p className="text-negative-400 text-sm">{queriesError}</p> : null}
                 <div className="setup-nav">
                   <Button type="button" variant="outline" onClick={goBack}>Back</Button>
                   <Button type="button" disabled={parsedQueries.length === 0 || queriesSaving} onClick={asyncHandler(handleSaveQueries)}>
@@ -585,7 +585,7 @@ export function SetupPage() {
                     onChange={(e) => setCompetitorsText(e.target.value)}
                   />
                 </div>
-                {competitorsError ? <p className="text-rose-400 text-sm">{competitorsError}</p> : null}
+                {competitorsError ? <p className="text-negative-400 text-sm">{competitorsError}</p> : null}
                 <div className="setup-nav">
                   <Button type="button" variant="outline" onClick={goBack}>Back</Button>
                   <div className="flex gap-2">
@@ -630,7 +630,7 @@ export function SetupPage() {
             {!runTriggered ? (
               <div className="compact-stack">
                 <p className="supporting-copy">
-                  Everything is configured. Launch an answer-visibility sweep to start tracking citations for <span className="text-zinc-100 font-medium">{createdProjectName}</span>.
+                  Everything is configured. Launch an answer-visibility sweep to start tracking citations for <span className="text-heading font-medium">{createdProjectName}</span>.
                 </p>
                 <div className="setup-nav">
                   <Button type="button" variant="outline" onClick={goBack}>Back</Button>
@@ -641,11 +641,11 @@ export function SetupPage() {
               </div>
             ) : !terminal ? (
               <div className="compact-stack">
-                <p className="text-zinc-300">
+                <p className="text-neutral">
                   Sweep running — typically 30-60s. Polling every 2s…
                 </p>
-                <div className="rounded-md border border-zinc-800/60 bg-zinc-900/30 p-3 text-xs text-zinc-500">
-                  <p>Status: <span className="text-zinc-300">{run?.status ?? 'queued'}</span></p>
+                <div className="rounded-md border border-default bg-surface p-3 text-xs text-muted">
+                  <p>Status: <span className="text-neutral">{run?.status ?? 'queued'}</span></p>
                 </div>
                 <div className="setup-nav">
                   <span />
@@ -656,7 +656,7 @@ export function SetupPage() {
               </div>
             ) : run?.status === 'failed' ? (
               <div className="compact-stack">
-                <p className="text-rose-400">Sweep failed. Inspect the run on the project page for the provider error and retry from there.</p>
+                <p className="text-negative-400">Sweep failed. Inspect the run on the project page for the provider error and retry from there.</p>
                 <div className="setup-nav">
                   <span />
                   <Button type="button" onClick={() => { void navigate({ to: createdProjectName ? `/projects/${encodeURIComponent(createdProjectName)}` : '/' }) }}>
@@ -666,28 +666,28 @@ export function SetupPage() {
               </div>
             ) : (
               <div className="compact-stack">
-                <p className="text-zinc-300">
+                <p className="text-neutral">
                   Sweep complete. Your first answer-visibility snapshot for{' '}
-                  <span className="text-zinc-100 font-medium">{createdProjectName}</span>:
+                  <span className="text-heading font-medium">{createdProjectName}</span>:
                 </p>
                 <div className="grid grid-cols-3 gap-2 mt-1">
-                  <div className="rounded-md border border-zinc-800/60 bg-zinc-900/30 p-3">
-                    <p className="text-[10px] uppercase tracking-wide text-zinc-500">Mentioned</p>
-                    <p className="text-2xl font-bold tabular-nums text-zinc-50 mt-1">{mentioned}<span className="text-zinc-600 text-lg"> / {totalQueries}</span></p>
-                    <p className="text-[11px] text-zinc-500 mt-0.5">queries with brand in answer</p>
+                  <div className="rounded-md border border-default bg-surface p-3">
+                    <p className="text-[10px] uppercase tracking-wide text-muted">Mentioned</p>
+                    <p className="text-2xl font-bold tabular-nums text-primary mt-1">{mentioned}<span className="text-faint text-lg"> / {totalQueries}</span></p>
+                    <p className="text-[11px] text-muted mt-0.5">queries with brand in answer</p>
                   </div>
-                  <div className="rounded-md border border-zinc-800/60 bg-zinc-900/30 p-3">
-                    <p className="text-[10px] uppercase tracking-wide text-zinc-500">Cited</p>
-                    <p className="text-2xl font-bold tabular-nums text-zinc-50 mt-1">{cited}<span className="text-zinc-600 text-lg"> / {totalQueries}</span></p>
-                    <p className="text-[11px] text-zinc-500 mt-0.5">queries with domain in sources</p>
+                  <div className="rounded-md border border-default bg-surface p-3">
+                    <p className="text-[10px] uppercase tracking-wide text-muted">Cited</p>
+                    <p className="text-2xl font-bold tabular-nums text-primary mt-1">{cited}<span className="text-faint text-lg"> / {totalQueries}</span></p>
+                    <p className="text-[11px] text-muted mt-0.5">queries with domain in sources</p>
                   </div>
-                  <div className="rounded-md border border-zinc-800/60 bg-zinc-900/30 p-3">
-                    <p className="text-[10px] uppercase tracking-wide text-zinc-500">Snapshots</p>
-                    <p className="text-2xl font-bold tabular-nums text-zinc-50 mt-1">{snapshots.length}</p>
-                    <p className="text-[11px] text-zinc-500 mt-0.5">total (query × provider)</p>
+                  <div className="rounded-md border border-default bg-surface p-3">
+                    <p className="text-[10px] uppercase tracking-wide text-muted">Snapshots</p>
+                    <p className="text-2xl font-bold tabular-nums text-primary mt-1">{snapshots.length}</p>
+                    <p className="text-[11px] text-muted mt-0.5">total (query × provider)</p>
                   </div>
                 </div>
-                <p className="text-[11px] text-zinc-500 mt-1">
+                <p className="text-[11px] text-muted mt-1">
                   Full evidence, per-provider breakdown, and suggested next queries on the project dashboard.
                 </p>
                 <div className="setup-nav">

--- a/apps/web/src/pages/TrafficSourceDetailPage.tsx
+++ b/apps/web/src/pages/TrafficSourceDetailPage.tsx
@@ -311,7 +311,7 @@ export function TrafficSourceDetailPage() {
   if (!projectName || !sourceId) {
     return (
       <div className="page-container">
-        <p className="text-sm text-zinc-500">Missing project name or source id in URL.</p>
+        <p className="text-sm text-muted">Missing project name or source id in URL.</p>
       </div>
     )
   }
@@ -319,7 +319,7 @@ export function TrafficSourceDetailPage() {
   if (sourceQuery.isLoading) {
     return (
       <div className="page-container">
-        <p className="text-sm text-zinc-500">Loading source…</p>
+        <p className="text-sm text-muted">Loading source…</p>
       </div>
     )
   }
@@ -327,8 +327,8 @@ export function TrafficSourceDetailPage() {
   if (sourceQuery.isError || !detail) {
     return (
       <div className="page-container">
-        <p className="text-sm text-rose-300">Could not load this source.</p>
-        <BackLink canGoBack={canGoBack} className="mt-2 text-xs text-zinc-400 hover:text-zinc-200" />
+        <p className="text-sm text-negative">Could not load this source.</p>
+        <BackLink canGoBack={canGoBack} className="mt-2 text-xs text-secondary hover:text-strong" />
       </div>
     )
   }
@@ -337,11 +337,11 @@ export function TrafficSourceDetailPage() {
     <div className="page-container space-y-8">
       <div className="page-header">
         <div className="page-header-left">
-          <BackLink canGoBack={canGoBack} className="text-xs text-zinc-500 hover:text-zinc-200" />
+          <BackLink canGoBack={canGoBack} className="text-xs text-muted hover:text-strong" />
           <h1 className="page-title mt-2">{detail.displayName}</h1>
           <p className="page-subtitle">
-            {detail.sourceType} · project <span className="text-zinc-300">{projectName}</span> ·
-            <span className="ml-1 font-mono text-zinc-400">{detail.id}</span>
+            {detail.sourceType} · project <span className="text-neutral">{projectName}</span> ·
+            <span className="ml-1 font-mono text-secondary">{detail.id}</span>
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -360,10 +360,10 @@ export function TrafficSourceDetailPage() {
       </div>
 
       {syncError ? (
-        <div className="rounded-md border border-rose-800/50 bg-rose-950/30 px-3 py-2 text-xs text-rose-200">{syncError}</div>
+        <div className="rounded-md border border-negative-800/50 bg-negative-950/30 px-3 py-2 text-xs text-negative-200">{syncError}</div>
       ) : null}
       {syncResult ? (
-        <div className="rounded-md border border-emerald-800/50 bg-emerald-950/30 px-3 py-2 text-xs text-emerald-200">{syncResult}</div>
+        <div className="rounded-md border border-positive-800/50 bg-positive-950/30 px-3 py-2 text-xs text-positive-200">{syncResult}</div>
       ) : null}
 
       <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -398,37 +398,37 @@ export function TrafficSourceDetailPage() {
       </section>
 
       <section>
-        <p className="mb-4 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">Latest sync run</p>
+        <p className="mb-4 text-[10px] font-semibold uppercase tracking-wider text-muted">Latest sync run</p>
         {detail.latestRun ? (
           <Card className="p-4 text-sm">
             <div className="flex flex-wrap items-center gap-x-6 gap-y-1.5">
-              <span className="text-zinc-100">Status: <span className="font-medium">{detail.latestRun.status}</span></span>
-              <span className="text-zinc-500">Started: {formatRelative(detail.latestRun.startedAt)}</span>
+              <span className="text-heading">Status: <span className="font-medium">{detail.latestRun.status}</span></span>
+              <span className="text-muted">Started: {formatRelative(detail.latestRun.startedAt)}</span>
               {detail.latestRun.finishedAt ? (
-                <span className="text-zinc-500">Finished: {formatRelative(detail.latestRun.finishedAt)}</span>
+                <span className="text-muted">Finished: {formatRelative(detail.latestRun.finishedAt)}</span>
               ) : null}
-              <span className="font-mono text-[11px] text-zinc-600">{detail.latestRun.runId}</span>
+              <span className="font-mono text-[11px] text-faint">{detail.latestRun.runId}</span>
             </div>
             {detail.latestRun.error ? (
-              <p className="mt-2 rounded border border-rose-900/40 bg-rose-950/30 px-3 py-2 text-xs text-rose-300">
+              <p className="mt-2 rounded border border-negative-900/40 bg-negative-950/30 px-3 py-2 text-xs text-negative">
                 {detail.latestRun.error}
               </p>
             ) : null}
           </Card>
         ) : (
-          <Card className="px-4 py-3 text-sm text-zinc-500">No traffic-sync runs recorded yet. Hit "Sync now" above to create one.</Card>
+          <Card className="px-4 py-3 text-sm text-muted">No traffic-sync runs recorded yet. Hit "Sync now" above to create one.</Card>
         )}
       </section>
 
       <section>
         <div className="mb-4 flex flex-wrap items-end justify-between gap-x-4 gap-y-3">
           <div>
-            <p className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500">Events</p>
-            <h2 className="mt-1 text-base font-semibold text-zinc-50">
+            <p className="text-[10px] font-semibold uppercase tracking-wider text-muted">Events</p>
+            <h2 className="mt-1 text-base font-semibold text-primary">
               {activeWindow.granularity === 'day' ? 'Daily rollups' : 'Hourly rollups'}
             </h2>
             {totals ? (
-              <p className="mt-1.5 text-xs text-zinc-500">
+              <p className="mt-1.5 text-xs text-muted">
                 {totals.crawlerContentHits.toLocaleString('en-US')} content crawls ·{' '}
                 {totals.crawlerInfraHits.toLocaleString('en-US')} infra (sitemap/robots/assets) ·{' '}
                 {totals.aiUserFetchHits.toLocaleString('en-US')} AI user fetches ·{' '}
@@ -479,13 +479,13 @@ export function TrafficSourceDetailPage() {
             />
           </div>
           {eventsQuery.isError ? (
-            <p className="py-12 text-center text-xs text-rose-400">
+            <p className="py-12 text-center text-xs text-negative-400">
               Failed to load events: {eventsQuery.error instanceof Error ? eventsQuery.error.message : 'Unknown error'}
             </p>
           ) : eventsQuery.isLoading ? (
-            <p className="py-12 text-center text-xs text-zinc-500">Loading events…</p>
+            <p className="py-12 text-center text-xs text-muted">Loading events…</p>
           ) : chartData.length === 0 ? (
-            <p className="py-12 text-center text-xs text-zinc-500">No events in this window.</p>
+            <p className="py-12 text-center text-xs text-muted">No events in this window.</p>
           ) : (
             <div className="h-72">
               <ResponsiveContainer>
@@ -545,19 +545,19 @@ export function TrafficSourceDetailPage() {
       <section>
         <div className="mb-4 flex flex-wrap items-end justify-between gap-x-4 gap-y-2">
           <div>
-            <p className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500">Event rows</p>
-            <p className="mt-1 text-xs text-zinc-500">
-              Showing <span className="tabular-nums text-zinc-300">{filteredEvents.length.toLocaleString('en-US')}</span> of{' '}
-              <span className="tabular-nums text-zinc-500">{visibleEvents.length.toLocaleString('en-US')}</span> events · {LOCAL_TZ}
+            <p className="text-[10px] font-semibold uppercase tracking-wider text-muted">Event rows</p>
+            <p className="mt-1 text-xs text-muted">
+              Showing <span className="tabular-nums text-neutral">{filteredEvents.length.toLocaleString('en-US')}</span> of{' '}
+              <span className="tabular-nums text-muted">{visibleEvents.length.toLocaleString('en-US')}</span> events · {LOCAL_TZ}
             </p>
           </div>
           <div className="flex flex-wrap items-center gap-2">
-            <span className="inline-flex items-center text-zinc-400">
+            <span className="inline-flex items-center text-secondary">
               <select
                 aria-label="Filter by identity"
                 value={identityFilter}
                 onChange={(e) => setIdentityFilter(e.target.value)}
-                className="rounded-md border border-zinc-800 bg-zinc-950 px-2.5 py-1.5 text-xs text-zinc-200 focus:outline-none focus-visible:ring-1 focus-visible:ring-zinc-600"
+                className="rounded-md border border-base bg-bg px-2.5 py-1.5 text-xs text-strong focus:outline-none focus-visible:ring-1 focus-visible:ring-mono-600"
               >
                 <option value="">All identities</option>
                 {identityOptions.map((opt) => (
@@ -568,12 +568,12 @@ export function TrafficSourceDetailPage() {
               </select>
               <InfoTooltip text="The specific bot or AI product making the request (e.g., GPTBot, ChatGPT-User, Perplexity). One operator usually runs several identities." />
             </span>
-            <span className="inline-flex items-center text-zinc-400">
+            <span className="inline-flex items-center text-secondary">
               <select
                 aria-label="Filter by operator"
                 value={operatorFilter}
                 onChange={(e) => setOperatorFilter(e.target.value)}
-                className="rounded-md border border-zinc-800 bg-zinc-950 px-2.5 py-1.5 text-xs text-zinc-200 focus:outline-none focus-visible:ring-1 focus-visible:ring-zinc-600"
+                className="rounded-md border border-base bg-bg px-2.5 py-1.5 text-xs text-strong focus:outline-none focus-visible:ring-1 focus-visible:ring-mono-600"
               >
                 <option value="">All operators</option>
                 {operatorOptions.map((opt) => (
@@ -588,7 +588,7 @@ export function TrafficSourceDetailPage() {
               aria-label="Filter by HTTP status class"
               value={statusClassFilter}
               onChange={(e) => setStatusClassFilter(e.target.value as StatusClassFilter)}
-              className="rounded-md border border-zinc-800 bg-zinc-950 px-2.5 py-1.5 text-xs text-zinc-200 focus:outline-none focus-visible:ring-1 focus-visible:ring-zinc-600"
+              className="rounded-md border border-base bg-bg px-2.5 py-1.5 text-xs text-strong focus:outline-none focus-visible:ring-1 focus-visible:ring-mono-600"
             >
               {STATUS_CLASS_OPTIONS.map((opt) => (
                 <option key={opt.value} value={opt.value}>
@@ -600,7 +600,7 @@ export function TrafficSourceDetailPage() {
               aria-label="Filter by verification claim"
               value={verificationFilter}
               onChange={(e) => setVerificationFilter(e.target.value as VerificationFilter)}
-              className="rounded-md border border-zinc-800 bg-zinc-950 px-2.5 py-1.5 text-xs text-zinc-200 focus:outline-none focus-visible:ring-1 focus-visible:ring-zinc-600"
+              className="rounded-md border border-base bg-bg px-2.5 py-1.5 text-xs text-strong focus:outline-none focus-visible:ring-1 focus-visible:ring-mono-600"
             >
               {VERIFICATION_OPTIONS.map((opt) => (
                 <option key={opt.value} value={opt.value}>
@@ -614,7 +614,7 @@ export function TrafficSourceDetailPage() {
               placeholder="path contains…"
               value={pathFilter}
               onChange={(e) => setPathFilter(e.target.value)}
-              className="w-44 rounded-md border border-zinc-800 bg-zinc-950 px-2.5 py-1.5 text-xs text-zinc-200 placeholder:text-zinc-600 focus:outline-none focus-visible:ring-1 focus-visible:ring-zinc-600"
+              className="w-44 rounded-md border border-base bg-bg px-2.5 py-1.5 text-xs text-strong placeholder:text-faint focus:outline-none focus-visible:ring-1 focus-visible:ring-mono-600"
             />
           </div>
         </div>
@@ -648,7 +648,7 @@ export function TrafficSourceDetailPage() {
             <button
               type="button"
               onClick={clearAllFilters}
-              className="text-xs text-zinc-500 underline-offset-4 hover:text-zinc-200 hover:underline"
+              className="text-xs text-muted underline-offset-4 hover:text-strong hover:underline"
             >
               Clear all
             </button>
@@ -658,11 +658,11 @@ export function TrafficSourceDetailPage() {
         <EventsTable events={pagedEvents} />
 
         {showPagination ? (
-          <div className="mt-3 flex flex-wrap items-center justify-between gap-x-4 gap-y-2 text-xs text-zinc-400">
+          <div className="mt-3 flex flex-wrap items-center justify-between gap-x-4 gap-y-2 text-xs text-secondary">
             <p className="tabular-nums">
-              Showing <span className="text-zinc-300">{pageRangeStart.toLocaleString('en-US')}</span>–
-              <span className="text-zinc-300">{pageRangeEnd.toLocaleString('en-US')}</span> of{' '}
-              <span className="text-zinc-300">{filteredEvents.length.toLocaleString('en-US')}</span> events
+              Showing <span className="text-neutral">{pageRangeStart.toLocaleString('en-US')}</span>–
+              <span className="text-neutral">{pageRangeEnd.toLocaleString('en-US')}</span> of{' '}
+              <span className="text-neutral">{filteredEvents.length.toLocaleString('en-US')}</span> events
             </p>
             <div className="flex items-center gap-2">
               <button
@@ -670,21 +670,21 @@ export function TrafficSourceDetailPage() {
                 onClick={() => setEventsPage((p) => Math.max(1, p - 1))}
                 disabled={currentEventsPage <= 1}
                 aria-label="Previous page"
-                className="inline-flex items-center gap-1 rounded-md border border-zinc-800 bg-zinc-950 px-2.5 py-1.5 text-zinc-200 transition hover:border-zinc-700 hover:text-zinc-50 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-zinc-800 disabled:hover:text-zinc-200"
+                className="inline-flex items-center gap-1 rounded-md border border-base bg-bg px-2.5 py-1.5 text-strong transition hover:border-strong hover:text-primary disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-base disabled:hover:text-strong"
               >
                 <ChevronLeft className="size-3.5" />
                 Prev
               </button>
               <span className="tabular-nums">
-                Page <span className="text-zinc-200">{currentEventsPage}</span> of{' '}
-                <span className="text-zinc-200">{totalEventsPages}</span>
+                Page <span className="text-strong">{currentEventsPage}</span> of{' '}
+                <span className="text-strong">{totalEventsPages}</span>
               </span>
               <button
                 type="button"
                 onClick={() => setEventsPage((p) => Math.min(totalEventsPages, p + 1))}
                 disabled={currentEventsPage >= totalEventsPages}
                 aria-label="Next page"
-                className="inline-flex items-center gap-1 rounded-md border border-zinc-800 bg-zinc-950 px-2.5 py-1.5 text-zinc-200 transition hover:border-zinc-700 hover:text-zinc-50 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-zinc-800 disabled:hover:text-zinc-200"
+                className="inline-flex items-center gap-1 rounded-md border border-base bg-bg px-2.5 py-1.5 text-strong transition hover:border-strong hover:text-primary disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-base disabled:hover:text-strong"
               >
                 Next
                 <ChevronRight className="size-3.5" />
@@ -781,13 +781,13 @@ function labelForVerification(value: VerificationFilter): string {
 
 function ActiveFilterPill({ label, onClear }: { label: string; onClear: () => void }) {
   return (
-    <span className="inline-flex items-center gap-1.5 rounded-full border border-zinc-700 bg-zinc-800/60 px-2.5 py-1 text-[11px] text-zinc-200">
+    <span className="inline-flex items-center gap-1.5 rounded-full border border-strong bg-surface-inset px-2.5 py-1 text-[11px] text-strong">
       {label}
       <button
         type="button"
         onClick={onClear}
         aria-label={`Clear ${label}`}
-        className="rounded-full p-0.5 text-zinc-400 hover:bg-zinc-700/60 hover:text-zinc-100"
+        className="rounded-full p-0.5 text-secondary hover:bg-mono-700/60 hover:text-heading"
       >
         <X className="size-3" />
       </button>
@@ -815,8 +815,8 @@ function SeriesToggle({
       aria-pressed={active}
       className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium transition ${
         active
-          ? 'border-zinc-700 bg-zinc-800/60 text-zinc-100'
-          : 'border-zinc-800 bg-transparent text-zinc-500 hover:text-zinc-300'
+          ? 'border-strong bg-surface-inset text-heading'
+          : 'border-base bg-transparent text-muted hover:text-neutral'
       }`}
     >
       <span
@@ -825,7 +825,7 @@ function SeriesToggle({
         style={{ backgroundColor: color }}
       />
       <span>{label}</span>
-      <span className={`tabular-nums ${active ? 'text-zinc-400' : 'text-zinc-600'}`}>
+      <span className={`tabular-nums ${active ? 'text-secondary' : 'text-faint'}`}>
         {count.toLocaleString('en-US')}
       </span>
     </button>
@@ -862,12 +862,12 @@ function renderEvidence(event: TrafficEventEntry): string {
 
 function EventsTable({ events }: { events: readonly TrafficEventEntry[] }) {
   if (events.length === 0) {
-    return <Card className="p-6 text-center text-sm text-zinc-500">No event rows match the current filters.</Card>
+    return <Card className="p-6 text-center text-sm text-muted">No event rows match the current filters.</Card>
   }
   return (
-    <div className="rounded-xl border border-zinc-800/60 bg-zinc-900/30 overflow-hidden">
+    <div className="rounded-xl border border-default bg-surface overflow-hidden">
       <table className="w-full text-sm">
-        <thead className="bg-zinc-900/50 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+        <thead className="bg-bg-elevated/50 text-[10px] font-semibold uppercase tracking-wider text-muted">
           <tr>
             <th className="px-4 py-2 text-left">Hour</th>
             <th className="px-4 py-2 text-left">Kind</th>
@@ -882,18 +882,18 @@ function EventsTable({ events }: { events: readonly TrafficEventEntry[] }) {
             </th>
           </tr>
         </thead>
-        <tbody className="divide-y divide-zinc-800/60">
+        <tbody className="divide-y divide-mono-800/60">
           {events.map((event, i) => (
-            <tr key={`${event.kind}:${event.tsHour}:${i}`} className="hover:bg-zinc-900/40 transition-colors">
-              <td className="px-4 py-2 font-mono text-xs text-zinc-300">{formatHourLabel(event.tsHour)}</td>
-              <td className="px-4 py-2 text-zinc-300">{renderKindLabel(event.kind)}</td>
-              <td className="px-4 py-2 text-zinc-100">
+            <tr key={`${event.kind}:${event.tsHour}:${i}`} className="hover:bg-bg-elevated/40 transition-colors">
+              <td className="px-4 py-2 font-mono text-xs text-neutral">{formatHourLabel(event.tsHour)}</td>
+              <td className="px-4 py-2 text-neutral">{renderKindLabel(event.kind)}</td>
+              <td className="px-4 py-2 text-heading">
                 {renderIdentity(event)}
-                <span className="ml-2 text-[11px] text-zinc-500">{event.operator}</span>
+                <span className="ml-2 text-[11px] text-muted">{event.operator}</span>
               </td>
-              <td className="px-4 py-2 text-zinc-300">{renderEvidence(event)}</td>
-              <td className="px-4 py-2 truncate font-mono text-xs text-zinc-300">{pathOf(event)}</td>
-              <td className="px-4 py-2 text-right tabular-nums text-zinc-100">{event.hits}</td>
+              <td className="px-4 py-2 text-neutral">{renderEvidence(event)}</td>
+              <td className="px-4 py-2 truncate font-mono text-xs text-neutral">{pathOf(event)}</td>
+              <td className="px-4 py-2 text-right tabular-nums text-heading">{event.hits}</td>
             </tr>
           ))}
         </tbody>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,11 +40,6 @@ const ALT_CHART_LIB_PATTERNS = [
 const RAW_PALETTE_ALLOWLIST = [
   'apps/web/src/pages/ProjectPage.tsx',
   'apps/web/src/pages/ReportPage.tsx',
-  'apps/web/src/pages/BacklinksPage.tsx',
-  'apps/web/src/pages/TrafficSourceDetailPage.tsx',
-  'apps/web/src/pages/SetupPage.tsx',
-  'apps/web/src/lib/highlight.ts',
-  'apps/web/src/lib/tone-helpers.ts',
 ]
 
 // PERMANENT exclusions: ProviderBadge encodes engine identity (not tone) and

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.112.2",
+  "version": "4.112.3",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.112.2",
+  "version": "4.112.3",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
Phase 3 design-token slice (issue #767): SetupPage (62), TrafficSourceDetailPage (107), BacklinksPage (120), plus `lib/highlight.ts` + `lib/tone-helpers.ts` (8) = 297 raw-palette sites.

- Class-only, same #783-derived mapping as DS-1/DS-2.
- Removes the 5 files from the `RAW_PALETTE_ALLOWLIST` ratchet.

Verified: 0 residual raw-palette; no inert tokens; typecheck + web lint (ratchet, de-allowlisted) green; 356 token + class-baseline tests pass, no snapshot drift; build clean. `scan:colors` 669 -> 372.

After this, only ReportPage (149) + ProjectPage (223) remain (DS-4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)