### PR TITLE
feat(web): hide operator controls + brand in the read-only embed render (white-label de-leak)

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -189,6 +189,16 @@ export function getEmbedConfig(): EmbedClientConfig | null {
   return embed?.enabled ? embed : null
 }
 
+/**
+ * True in the read-only embed render. embed presence == read-only for v1 (the
+ * embed key is the read-only project-scoped key), so operator/write controls hide
+ * while every read-only view still renders. NOT a security boundary (the API key
+ * scope is) - purely white-label UI cleanliness.
+ */
+export function isEmbed(): boolean {
+  return getEmbedConfig() !== null
+}
+
 function getApiBase(): string {
   if (typeof window !== 'undefined' && window.__CANONRY_CONFIG__?.basePath) {
     // Strip trailing slash then append /api/v1 so we never get double slashes

--- a/apps/web/src/components/project/ActivitySection.tsx
+++ b/apps/web/src/components/project/ActivitySection.tsx
@@ -34,6 +34,7 @@ import {
   triggerGaSync,
   disconnectGa,
   heyClient,
+  isEmbed,
 } from '../../api.js'
 import {
   getApiV1ProjectsByNameGaAiReferralHistoryOptions,
@@ -113,7 +114,7 @@ function ServerActivityPanel({ projectName }: { projectName: string }) {
           <p className="text-xs text-muted mt-1">
             Server-side log evidence of bulk crawlers, on-demand AI user fetches (ChatGPT-User, Perplexity-User),
             and AI referral sessions — orthogonal to GA4 click-through traffic below.{' '}
-            <Link to="/traffic" className="text-link hover:underline">Manage sources →</Link>
+            {!isEmbed() && <Link to="/traffic" className="text-link hover:underline">Manage sources →</Link>}
           </p>
         </div>
       </div>
@@ -122,10 +123,14 @@ function ServerActivityPanel({ projectName }: { projectName: string }) {
         <Card className="p-5">
           <div className="text-sm text-secondary">
             No server traffic source connected yet.{' '}
-            <Link to="/traffic" className="text-link hover:underline">
-              Connect a traffic source
-            </Link>{' '}
-            to surface bot crawls and AI referrals straight from server logs.
+            {!isEmbed() && (
+              <>
+                <Link to="/traffic" className="text-link hover:underline">
+                  Connect a traffic source
+                </Link>{' '}
+                to surface bot crawls and AI referrals straight from server logs.
+              </>
+            )}
           </div>
         </Card>
       ) : (
@@ -162,13 +167,17 @@ function ServerActivityPanel({ projectName }: { projectName: string }) {
                     {s.lastSyncedAt ? relativeTime(s.lastSyncedAt) : 'never'}
                   </td>
                   <td className="px-4 py-3 text-right">
-                    <Link
-                      to="/traffic/$projectName/$sourceId"
-                      params={{ projectName, sourceId: s.id }}
-                      className="text-link hover:underline text-xs"
-                    >
-                      Detail →
-                    </Link>
+                    {isEmbed() ? (
+                      <span className="text-muted text-xs">Detail</span>
+                    ) : (
+                      <Link
+                        to="/traffic/$projectName/$sourceId"
+                        params={{ projectName, sourceId: s.id }}
+                        className="text-link hover:underline text-xs"
+                      >
+                        Detail →
+                      </Link>
+                    )}
                   </td>
                 </tr>
               ))}
@@ -484,6 +493,15 @@ export function ClickThroughActivity({ projectName }: { projectName: string }) {
 
   // Not connected state
   if (!status?.connected) {
+    if (isEmbed()) {
+      return (
+        <Card className="p-5">
+          <div className="text-sm text-secondary">
+            No Google Analytics 4 property connected yet.
+          </div>
+        </Card>
+      )
+    }
     return (
       <Ga4ConnectForm
         projectName={projectName}
@@ -542,27 +560,29 @@ export function ClickThroughActivity({ projectName }: { projectName: string }) {
             {status.clientEmail && <> &middot; <span className="text-muted">{status.clientEmail}</span></>}
           </span>
         </div>
-        <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={syncing}
-            onClick={asyncHandler(handleSync)}
-          >
-            <RefreshCw className={`w-3.5 h-3.5 mr-1.5 ${syncing ? 'animate-spin' : ''}`} />
-            {syncing ? 'Syncing…' : 'Sync'}
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="text-negative-400 hover:text-negative"
-            disabled={disconnecting}
-            onClick={asyncHandler(handleDisconnect)}
-          >
-            <Unplug className="w-3.5 h-3.5 mr-1.5" />
-            Disconnect
-          </Button>
-        </div>
+        {!isEmbed() && (
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={syncing}
+              onClick={asyncHandler(handleSync)}
+            >
+              <RefreshCw className={`w-3.5 h-3.5 mr-1.5 ${syncing ? 'animate-spin' : ''}`} />
+              {syncing ? 'Syncing…' : 'Sync'}
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-negative-400 hover:text-negative"
+              disabled={disconnecting}
+              onClick={asyncHandler(handleDisconnect)}
+            >
+              <Unplug className="w-3.5 h-3.5 mr-1.5" />
+              Disconnect
+            </Button>
+          </div>
+        )}
       </div>
 
       {/* Summary gauges */}
@@ -617,10 +637,12 @@ export function ClickThroughActivity({ projectName }: { projectName: string }) {
         ) : (
           <div className="surface-card rounded-lg p-6 text-center border border-default">
             <p className="text-sm text-secondary mb-3">No traffic data yet.</p>
-            <Button variant="outline" size="sm" disabled={syncing} onClick={asyncHandler(handleSync)}>
-              <RefreshCw className={`w-3.5 h-3.5 mr-1.5 ${syncing ? 'animate-spin' : ''}`} />
-              Sync from GA4
-            </Button>
+            {!isEmbed() && (
+              <Button variant="outline" size="sm" disabled={syncing} onClick={asyncHandler(handleSync)}>
+                <RefreshCw className={`w-3.5 h-3.5 mr-1.5 ${syncing ? 'animate-spin' : ''}`} />
+                Sync from GA4
+              </Button>
+            )}
           </div>
         )}
       </section>

--- a/apps/web/src/components/project/BacklinksSection.tsx
+++ b/apps/web/src/components/project/BacklinksSection.tsx
@@ -73,6 +73,7 @@ import {
   fetchRunDetail,
   triggerBacklinkExtract,
   triggerBingBacklinkSync,
+  isEmbed,
   ApiError,
 } from '../../api.js'
 import type {
@@ -473,15 +474,19 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
                 Connect a Bing Webmaster account, then sync.
               </li>
             </ul>
-            <div className="mt-4 flex items-center gap-3 flex-wrap">
-              <Button asChild type="button" size="sm">
-                <a href={publicPath('/backlinks')}>Set up Common Crawl</a>
-              </Button>
-            </div>
-            <p className="mt-3 text-xs text-muted">
-              Connect Bing with{' '}
-              <code className="text-secondary">canonry bing connect {projectName} --api-key &lt;key&gt;</code>.
-            </p>
+            {!isEmbed() && (
+              <>
+                <div className="mt-4 flex items-center gap-3 flex-wrap">
+                  <Button asChild type="button" size="sm">
+                    <a href={publicPath('/backlinks')}>Set up Common Crawl</a>
+                  </Button>
+                </div>
+                <p className="mt-3 text-xs text-muted">
+                  Connect Bing with{' '}
+                  <code className="text-secondary">canonry bing connect {projectName} --api-key &lt;key&gt;</code>.
+                </p>
+              </>
+            )}
           </div>
         </div>
       </Card>
@@ -512,12 +517,14 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
                     Bing Webmaster synced for <code className="text-neutral">{projectName}</code>, but every inbound
                     link in the latest window is a crawler/proxy host (hidden by default). Re-sync to check for new links.
                   </p>
-                  <div className="mt-4">
-                    <Button type="button" variant="outline" size="sm" disabled={bingSyncing || activeRun !== null} onClick={asyncHandler(handleBingSync)}>
-                      <Download className="h-4 w-4 mr-1.5" aria-hidden />
-                      {activeRun ? 'Sync running…' : bingSyncing ? 'Queuing…' : 'Re-sync Bing inbound links'}
-                    </Button>
-                  </div>
+                  {!isEmbed() && (
+                    <div className="mt-4">
+                      <Button type="button" variant="outline" size="sm" disabled={bingSyncing || activeRun !== null} onClick={asyncHandler(handleBingSync)}>
+                        <Download className="h-4 w-4 mr-1.5" aria-hidden />
+                        {activeRun ? 'Sync running…' : bingSyncing ? 'Queuing…' : 'Re-sync Bing inbound links'}
+                      </Button>
+                    </div>
+                  )}
                 </>
               ) : connected ? (
                 <>
@@ -526,12 +533,14 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
                     Bing Webmaster is connected for <code className="text-neutral">{projectName}</code> but no inbound
                     links have been synced yet. Run a sync to pull them live from your account.
                   </p>
-                  <div className="mt-4">
-                    <Button type="button" size="sm" disabled={bingSyncing || activeRun !== null} onClick={asyncHandler(handleBingSync)}>
-                      <Play className="h-4 w-4 mr-1.5" aria-hidden />
-                      {activeRun ? 'Sync running…' : bingSyncing ? 'Queuing…' : 'Sync Bing inbound links'}
-                    </Button>
-                  </div>
+                  {!isEmbed() && (
+                    <div className="mt-4">
+                      <Button type="button" size="sm" disabled={bingSyncing || activeRun !== null} onClick={asyncHandler(handleBingSync)}>
+                        <Play className="h-4 w-4 mr-1.5" aria-hidden />
+                        {activeRun ? 'Sync running…' : bingSyncing ? 'Queuing…' : 'Sync Bing inbound links'}
+                      </Button>
+                    </div>
+                  )}
                 </>
               ) : (
                 <>
@@ -552,10 +561,12 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
     }
 
     return renderDataView(
-      <Button type="button" variant="outline" size="sm" disabled={bingSyncing || activeRun !== null} onClick={asyncHandler(handleBingSync)}>
-        <Download className="h-4 w-4 mr-1.5" aria-hidden />
-        {activeRun ? 'Sync running…' : bingSyncing ? 'Queuing…' : 'Re-sync Bing'}
-      </Button>,
+      isEmbed() ? null : (
+        <Button type="button" variant="outline" size="sm" disabled={bingSyncing || activeRun !== null} onClick={asyncHandler(handleBingSync)}>
+          <Download className="h-4 w-4 mr-1.5" aria-hidden />
+          {activeRun ? 'Sync running…' : bingSyncing ? 'Queuing…' : 'Re-sync Bing'}
+        </Button>
+      ),
     )
   }
 
@@ -581,11 +592,13 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
                   <p className="text-sm text-muted mt-1">
                     Run a workspace release sync to populate backlinks for every project in this workspace.
                   </p>
-                  <div className="mt-4">
-                    <Button asChild type="button" size="sm">
-                      <a href={publicPath('/backlinks')}>Set up backlinks</a>
-                    </Button>
-                  </div>
+                  {!isEmbed() && (
+                    <div className="mt-4">
+                      <Button asChild type="button" size="sm">
+                        <a href={publicPath('/backlinks')}>Set up backlinks</a>
+                      </Button>
+                    </div>
+                  )}
                 </>
               )}
               {hasRunningSync && (
@@ -595,11 +608,13 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
                     A workspace release sync is running ({latestSync.status}
                     {latestSync.phaseDetail ? ` — ${latestSync.phaseDetail}` : ''}). Backlinks will appear here once it finishes.
                   </p>
-                  <div className="mt-4">
-                    <Button asChild type="button" variant="outline" size="sm">
-                      <a href={publicPath('/backlinks')}>View sync status</a>
-                    </Button>
-                  </div>
+                  {!isEmbed() && (
+                    <div className="mt-4">
+                      <Button asChild type="button" variant="outline" size="sm">
+                        <a href={publicPath('/backlinks')}>View sync status</a>
+                      </Button>
+                    </div>
+                  )}
                 </>
               )}
               {hasFailedSync && (
@@ -608,11 +623,13 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
                   <p className="text-sm text-muted mt-1">
                     {latestSync.error ?? 'The workspace release sync failed. Retry from the Backlinks admin page.'}
                   </p>
-                  <div className="mt-4">
-                    <Button asChild type="button" size="sm">
-                      <a href={publicPath('/backlinks')}>Go to Backlinks admin</a>
-                    </Button>
-                  </div>
+                  {!isEmbed() && (
+                    <div className="mt-4">
+                      <Button asChild type="button" size="sm">
+                        <a href={publicPath('/backlinks')}>Go to Backlinks admin</a>
+                      </Button>
+                    </div>
+                  )}
                 </>
               )}
               {hasReadySync && !hasRunningSync && !hasEmptySummary && !justFailed && (
@@ -622,21 +639,23 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
                     Release <code className="text-neutral">{latestSync.release}</code> is ready but no backlinks have been extracted for{' '}
                     <code className="text-neutral">{projectName}</code>. Run an extract to populate data using the cached release.
                   </p>
-                  <div className="mt-4 flex items-center gap-3 flex-wrap">
-                    <Button type="button" size="sm" disabled={extracting || activeRun !== null} onClick={asyncHandler(handleExtract)}>
-                      <Play className="h-4 w-4 mr-1.5" aria-hidden />
-                      {activeRun ? 'Extract running…' : extracting ? 'Queuing…' : 'Run extract'}
-                    </Button>
-                    <Hint label="What does Run extract do?">
-                      <span className="block">
-                        Runs a DuckDB query against the <span className="text-strong">cached release files</span> at{' '}
-                        <code className="text-neutral">~/.canonry/cache/commoncrawl/</code> to find referring domains for <span className="text-strong">{projectName}</span>.
-                      </span>
-                      <span className="mt-2 block text-secondary">
-                        No re-download. Typically takes <span className="text-strong">~5 min</span>.
-                      </span>
-                    </Hint>
-                  </div>
+                  {!isEmbed() && (
+                    <div className="mt-4 flex items-center gap-3 flex-wrap">
+                      <Button type="button" size="sm" disabled={extracting || activeRun !== null} onClick={asyncHandler(handleExtract)}>
+                        <Play className="h-4 w-4 mr-1.5" aria-hidden />
+                        {activeRun ? 'Extract running…' : extracting ? 'Queuing…' : 'Run extract'}
+                      </Button>
+                      <Hint label="What does Run extract do?">
+                        <span className="block">
+                          Runs a DuckDB query against the <span className="text-strong">cached release files</span> at{' '}
+                          <code className="text-neutral">~/.canonry/cache/commoncrawl/</code> to find referring domains for <span className="text-strong">{projectName}</span>.
+                        </span>
+                        <span className="mt-2 block text-secondary">
+                          No re-download. Typically takes <span className="text-strong">~5 min</span>.
+                        </span>
+                      </Hint>
+                    </div>
+                  )}
                 </>
               )}
               {justFailed && (
@@ -646,11 +665,13 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
                     See the error above for details. If the cache files for release{' '}
                     <code className="text-neutral">{latestSync?.release}</code> are missing, re-sync the release from the Backlinks admin to restore the ~16 GB dump, then re-run the extract.
                   </p>
-                  <div className="mt-4 flex items-center gap-3 flex-wrap">
-                    <Button asChild type="button" size="sm">
-                      <a href={publicPath('/backlinks')}>Go to Backlinks admin</a>
-                    </Button>
-                  </div>
+                  {!isEmbed() && (
+                    <div className="mt-4 flex items-center gap-3 flex-wrap">
+                      <Button asChild type="button" size="sm">
+                        <a href={publicPath('/backlinks')}>Go to Backlinks admin</a>
+                      </Button>
+                    </div>
+                  )}
                 </>
               )}
               {hasEmptySummary && (
@@ -669,23 +690,25 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
                   <p className="text-sm text-muted mt-3">
                     Try syncing a newer release — each Common Crawl dump is a different snapshot of the web graph.
                   </p>
-                  <div className="mt-4 flex items-center gap-3 flex-wrap">
-                    <Button asChild type="button" size="sm">
-                      <a href={publicPath('/backlinks')}>Go to Backlinks admin</a>
-                    </Button>
-                    <Button type="button" variant="outline" size="sm" disabled={extracting || activeRun !== null} onClick={asyncHandler(handleExtract)}>
-                      <Play className="h-4 w-4 mr-1.5" aria-hidden />
-                      {activeRun ? 'Extract running…' : extracting ? 'Queuing…' : 'Re-run extract'}
-                    </Button>
-                    <Hint label="What does Re-run extract do?">
-                      <span className="block">
-                        Re-queries the cached release for <span className="text-strong">{summary!.targetDomain}</span>. Only useful if the cache files were incomplete last time.
-                      </span>
-                      <span className="mt-2 block text-secondary">
-                        No re-download. ~5 min. If the release genuinely has no links for your domain, this won&rsquo;t help — sync a different release instead.
-                      </span>
-                    </Hint>
-                  </div>
+                  {!isEmbed() && (
+                    <div className="mt-4 flex items-center gap-3 flex-wrap">
+                      <Button asChild type="button" size="sm">
+                        <a href={publicPath('/backlinks')}>Go to Backlinks admin</a>
+                      </Button>
+                      <Button type="button" variant="outline" size="sm" disabled={extracting || activeRun !== null} onClick={asyncHandler(handleExtract)}>
+                        <Play className="h-4 w-4 mr-1.5" aria-hidden />
+                        {activeRun ? 'Extract running…' : extracting ? 'Queuing…' : 'Re-run extract'}
+                      </Button>
+                      <Hint label="What does Re-run extract do?">
+                        <span className="block">
+                          Re-queries the cached release for <span className="text-strong">{summary!.targetDomain}</span>. Only useful if the cache files were incomplete last time.
+                        </span>
+                        <span className="mt-2 block text-secondary">
+                          No re-download. ~5 min. If the release genuinely has no links for your domain, this won&rsquo;t help — sync a different release instead.
+                        </span>
+                      </Hint>
+                    </div>
+                  )}
                 </>
               )}
             </div>
@@ -696,22 +719,28 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
 
     return renderDataView(
       <>
-        <Button type="button" variant="outline" size="sm" disabled={extracting || activeRun !== null} onClick={asyncHandler(handleExtract)}>
-          <Download className="h-4 w-4 mr-1.5" aria-hidden />
-          {activeRun ? 'Extract running…' : extracting ? 'Queuing…' : 'Re-run extract'}
-        </Button>
-        <Hint label="What does Re-run extract do?">
-          <span className="block">
-            Re-queries the <span className="text-strong">cached release files</span> at{' '}
-            <code className="text-neutral">~/.canonry/cache/commoncrawl/</code> for <span className="text-strong">{projectName}</span>. Replaces existing backlink rows for this project under the current release.
-          </span>
-          <span className="mt-2 block text-secondary">
-            <span className="text-strong">No re-download</span> of the ~16 GB dump. Typically <span className="text-strong">~5 min</span>.
-          </span>
-        </Hint>
-        <Button asChild type="button" variant="outline" size="sm">
-          <a href={publicPath('/backlinks')}>Open admin</a>
-        </Button>
+        {!isEmbed() && (
+          <>
+            <Button type="button" variant="outline" size="sm" disabled={extracting || activeRun !== null} onClick={asyncHandler(handleExtract)}>
+              <Download className="h-4 w-4 mr-1.5" aria-hidden />
+              {activeRun ? 'Extract running…' : extracting ? 'Queuing…' : 'Re-run extract'}
+            </Button>
+            <Hint label="What does Re-run extract do?">
+              <span className="block">
+                Re-queries the <span className="text-strong">cached release files</span> at{' '}
+                <code className="text-neutral">~/.canonry/cache/commoncrawl/</code> for <span className="text-strong">{projectName}</span>. Replaces existing backlink rows for this project under the current release.
+              </span>
+              <span className="mt-2 block text-secondary">
+                <span className="text-strong">No re-download</span> of the ~16 GB dump. Typically <span className="text-strong">~5 min</span>.
+              </span>
+            </Hint>
+          </>
+        )}
+        {!isEmbed() && (
+          <Button asChild type="button" variant="outline" size="sm">
+            <a href={publicPath('/backlinks')}>Open admin</a>
+          </Button>
+        )}
       </>,
     )
   }

--- a/apps/web/src/components/project/DiscoverySection.tsx
+++ b/apps/web/src/components/project/DiscoverySection.tsx
@@ -7,6 +7,7 @@ import {
   promoteDiscovery,
   triggerDiscoveryRun,
   heyClient,
+  isEmbed,
   type DiscoveryPromoteResult,
 } from '../../api.js'
 import {
@@ -157,7 +158,9 @@ export function DiscoverySection({ projectName }: { projectName: string }) {
           <p className="eyebrow eyebrow-soft">Discovery</p>
           <h2>Find new queries to track</h2>
           <p className="mt-1 max-w-3xl text-sm leading-6 text-muted">
-            Describe your ideal customer and Canonry generates the questions they would ask an AI engine, checks which ones already cite your site, then lets you add the promising ones to your tracked queries.
+            {isEmbed()
+              ? 'Generated questions your ideal customers would ask an AI engine, with a check of which ones already cite your site.'
+              : 'Describe your ideal customer and Canonry generates the questions they would ask an AI engine, checks which ones already cite your site, then lets you add the promising ones to your tracked queries.'}
           </p>
         </div>
         <Button
@@ -204,15 +207,17 @@ export function DiscoverySection({ projectName }: { projectName: string }) {
                   More questions means broader coverage but a longer run. 100 is a good default.
                 </span>
               </label>
-              <Button
-                type="button"
-                size="sm"
-                disabled={startMutation.isPending}
-                onClick={() => startMutation.mutate()}
-              >
-                <Play size={14} />
-                {startMutation.isPending ? 'Starting…' : 'Find queries'}
-              </Button>
+              {!isEmbed() && (
+                <Button
+                  type="button"
+                  size="sm"
+                  disabled={startMutation.isPending}
+                  onClick={() => startMutation.mutate()}
+                >
+                  <Play size={14} />
+                  {startMutation.isPending ? 'Starting…' : 'Find queries'}
+                </Button>
+              )}
             </div>
           </Card>
 
@@ -318,15 +323,17 @@ export function DiscoverySection({ projectName }: { projectName: string }) {
                   <p className="eyebrow eyebrow-soft">Step 2</p>
                   <h3>Add queries to your project</h3>
                 </div>
-                <Button
-                  type="button"
-                  size="sm"
-                  disabled={promoteMutation.isPending || safeDefaultCount === 0}
-                  onClick={() => promoteMutation.mutate(undefined)}
-                >
-                  <CheckCircle2 size={14} />
-                  {promoteMutation.isPending ? 'Adding…' : 'Add recommended queries'}
-                </Button>
+                {!isEmbed() && (
+                  <Button
+                    type="button"
+                    size="sm"
+                    disabled={promoteMutation.isPending || safeDefaultCount === 0}
+                    onClick={() => promoteMutation.mutate(undefined)}
+                  >
+                    <CheckCircle2 size={14} />
+                    {promoteMutation.isPending ? 'Adding…' : 'Add recommended queries'}
+                  </Button>
+                )}
               </div>
               {previewQuery.isLoading ? (
                 <p className="text-sm text-muted">Loading recommendations…</p>

--- a/apps/web/src/components/project/GbpSection.tsx
+++ b/apps/web/src/components/project/GbpSection.tsx
@@ -52,7 +52,7 @@ import {
   formatChartDateTick,
   formatChartDateLabel,
 } from '../shared/ChartPrimitives.js'
-import { fetchInsights, heyClient } from '../../api.js'
+import { fetchInsights, heyClient, isEmbed } from '../../api.js'
 import { addToast } from '../../lib/toast-store.js'
 import { getRunTrackerState, subscribeRunTracker, trackRun } from '../../lib/run-tracker-store.js'
 
@@ -288,15 +288,17 @@ export function GbpSection({ projectName, projectId }: { projectName: string; pr
           </div>
           <div className="flex items-center gap-2">
             <ToneBadge tone="positive">Connected</ToneBadge>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              disabled={isSyncing}
-              onClick={() => syncMutation.mutate({ client: heyClient, path: { name: projectName }, body: {} })}
-            >
-              {isSyncing ? 'Syncing…' : 'Sync'}
-            </Button>
+            {!isEmbed() && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={isSyncing}
+                onClick={() => syncMutation.mutate({ client: heyClient, path: { name: projectName }, body: {} })}
+              >
+                {isSyncing ? 'Syncing…' : 'Sync'}
+              </Button>
+            )}
           </div>
         </div>
 
@@ -437,7 +439,7 @@ export function GbpSection({ projectName, projectId }: { projectName: string; pr
                       <th className="text-left">Location</th>
                       <th className="text-left">Address</th>
                       <th className="text-left">Status</th>
-                      <th className="text-right">Action</th>
+                      {!isEmbed() && <th className="text-right">Action</th>}
                     </tr>
                   </thead>
                   <tbody>
@@ -450,21 +452,23 @@ export function GbpSection({ projectName, projectId }: { projectName: string; pr
                             {loc.selected ? 'Tracked' : 'Not tracked'}
                           </ToneBadge>
                         </td>
-                        <td className="text-right">
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            disabled={selectionMutation.isPending}
-                            onClick={() => selectionMutation.mutate({
-                              client: heyClient,
-                              path: { name: projectName, locationName: loc.locationName },
-                              body: { selected: !loc.selected },
-                            })}
-                          >
-                            {loc.selected ? 'Untrack' : 'Track'}
-                          </Button>
-                        </td>
+                        {!isEmbed() && (
+                          <td className="text-right">
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              disabled={selectionMutation.isPending}
+                              onClick={() => selectionMutation.mutate({
+                                client: heyClient,
+                                path: { name: projectName, locationName: loc.locationName },
+                                body: { selected: !loc.selected },
+                              })}
+                            >
+                              {loc.selected ? 'Untrack' : 'Track'}
+                            </Button>
+                          </td>
+                        )}
                       </tr>
                     ))}
                   </tbody>
@@ -590,7 +594,7 @@ function GbpLocationEvidenceTable({
       <div className="section-head section-head-inline mb-2">
         <div className="flex items-center gap-2">
           <p className="eyebrow eyebrow-soft">Source evidence</p>
-          <InfoTooltip text="Each column names the Google surface it came from. Missing or empty means that surface did not return a value in the latest Canonry sync, not that every Google product lacks the information." />
+          <InfoTooltip text={isEmbed() ? 'Each column names the Google surface it came from. Missing or empty means that surface did not return a value in the latest sync, not that every Google product lacks the information.' : 'Each column names the Google surface it came from. Missing or empty means that surface did not return a value in the latest Canonry sync, not that every Google product lacks the information.'} />
         </div>
         <span className="text-[11px] text-faint">{locations.length} location{locations.length === 1 ? '' : 's'}</span>
       </div>

--- a/apps/web/src/components/project/GscSection.tsx
+++ b/apps/web/src/components/project/GscSection.tsx
@@ -18,6 +18,7 @@ import {
   fetchSettings,
   googleConnect,
   googleDisconnect,
+  isEmbed,
   saveGoogleProperty,
   inspectGscUrl,
   saveSitemapUrl,
@@ -698,13 +699,15 @@ export function GscSection({
               <code className="text-secondary">{gscConn.domain}</code>
               <span className="text-mono-700">·</span>
               <span>Last updated {formatTimestamp(gscConn.updatedAt)}</span>
-              <button
-                type="button"
-                className="ml-auto text-muted transition-colors hover:text-negative-400"
-                onClick={asyncHandler(handleDisconnect)}
-              >
-                Disconnect
-              </button>
+              {!isEmbed() && (
+                <button
+                  type="button"
+                  className="ml-auto text-muted transition-colors hover:text-negative-400"
+                  onClick={asyncHandler(handleDisconnect)}
+                >
+                  Disconnect
+                </button>
+              )}
             </div>
           ) : (
             <Card className="surface-card">
@@ -723,20 +726,22 @@ export function GscSection({
                     ? 'Generate a Google OAuth link for this project and have the client sign in with a Google account that already has access to the correct Search Console property.'
                     : 'Set Google OAuth client credentials first. Once configured, you can generate a consent link for this project domain.'}
                 </p>
-                <div className="mt-3 flex flex-wrap items-center gap-2">
-                  {googleConfigured ? (
-                    <Button type="button" variant="outline" size="sm" disabled={connecting} onClick={asyncHandler(handleConnect)}>
-                      {connecting ? 'Opening\u2026' : 'Connect Google Search Console'}
-                    </Button>
-                  ) : (
-                    <Button type="button" variant="outline" size="sm" asChild>
-                      <Link to="/settings">Open Settings</Link>
-                    </Button>
-                  )}
-                  {!googleConfigured && (
-                    <p className="text-xs text-muted">The same Google OAuth app credentials are shared across all projects.</p>
-                  )}
-                </div>
+                {!isEmbed() && (
+                  <div className="mt-3 flex flex-wrap items-center gap-2">
+                    {googleConfigured ? (
+                      <Button type="button" variant="outline" size="sm" disabled={connecting} onClick={asyncHandler(handleConnect)}>
+                        {connecting ? 'Opening\u2026' : 'Connect Google Search Console'}
+                      </Button>
+                    ) : (
+                      <Button type="button" variant="outline" size="sm" asChild>
+                        <Link to="/settings">Open Settings</Link>
+                      </Button>
+                    )}
+                    {!googleConfigured && (
+                      <p className="text-xs text-muted">The same Google OAuth app credentials are shared across all projects.</p>
+                    )}
+                  </div>
+                )}
               </div>
             </Card>
           )}
@@ -753,32 +758,34 @@ export function GscSection({
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium text-caution-300">Set your sitemap URL</p>
                   <p className="mt-1 text-xs text-caution-400/70">Canonry uses your sitemap to discover URLs for index coverage inspection. Auto-discover from GSC or enter it manually.</p>
-                  <div className="mt-2 flex flex-col gap-2">
-                    <div className="flex flex-col gap-2 lg:flex-row">
-                      <Button
-                        type="button"
-                        size="sm"
-                        disabled={triggerDiscoverSitemapsMutation.isPending || !gscConn.propertyId}
-                        onClick={asyncHandler(handleDiscoverSitemaps)}
-                      >
-                        {triggerDiscoverSitemapsMutation.isPending ? 'Discovering\u2026' : 'Auto-discover from GSC'}
-                      </Button>
-                      <span className="self-center text-xs text-caution-400/60">or enter manually:</span>
+                  {!isEmbed() && (
+                    <div className="mt-2 flex flex-col gap-2">
+                      <div className="flex flex-col gap-2 lg:flex-row">
+                        <Button
+                          type="button"
+                          size="sm"
+                          disabled={triggerDiscoverSitemapsMutation.isPending || !gscConn.propertyId}
+                          onClick={asyncHandler(handleDiscoverSitemaps)}
+                        >
+                          {triggerDiscoverSitemapsMutation.isPending ? 'Discovering\u2026' : 'Auto-discover from GSC'}
+                        </Button>
+                        <span className="self-center text-xs text-caution-400/60">or enter manually:</span>
+                      </div>
+                      <div className="flex flex-col gap-2 lg:flex-row">
+                        <input
+                          className="flex-1 rounded border border-caution-800/40 bg-transparent px-2 py-1.5 text-sm text-strong placeholder-mono-500 focus:border-caution-600 focus:outline-none"
+                          type="url"
+                          placeholder="https://example.com/sitemap.xml"
+                          value={sitemapUrlInput}
+                          onChange={(e) => setSitemapUrlInput(e.target.value)}
+                          onKeyDown={(e) => e.key === 'Enter' && void handleSaveSitemap()}
+                        />
+                        <Button type="button" size="sm" variant="outline" disabled={savingSitemap || !sitemapUrlInput.trim()} onClick={asyncHandler(handleSaveSitemap)}>
+                          {savingSitemap ? 'Saving\u2026' : 'Save sitemap URL'}
+                        </Button>
+                      </div>
                     </div>
-                    <div className="flex flex-col gap-2 lg:flex-row">
-                      <input
-                        className="flex-1 rounded border border-caution-800/40 bg-transparent px-2 py-1.5 text-sm text-strong placeholder-mono-500 focus:border-caution-600 focus:outline-none"
-                        type="url"
-                        placeholder="https://example.com/sitemap.xml"
-                        value={sitemapUrlInput}
-                        onChange={(e) => setSitemapUrlInput(e.target.value)}
-                        onKeyDown={(e) => e.key === 'Enter' && void handleSaveSitemap()}
-                      />
-                      <Button type="button" size="sm" variant="outline" disabled={savingSitemap || !sitemapUrlInput.trim()} onClick={asyncHandler(handleSaveSitemap)}>
-                        {savingSitemap ? 'Saving\u2026' : 'Save sitemap URL'}
-                      </Button>
-                    </div>
-                  </div>
+                  )}
                 </div>
               </div>
             </div>
@@ -796,7 +803,7 @@ export function GscSection({
                     <h3>Index coverage</h3>
                   </div>
                   <div className="flex items-center gap-2">
-                    {coverage && coverage.notIndexed.length > 0 && (
+                    {!isEmbed() && coverage && coverage.notIndexed.length > 0 && (
                       <Button
                         type="button"
                         variant="outline"
@@ -1026,15 +1033,17 @@ export function GscSection({
                                 <p className="text-sm font-medium text-strong">{group.reason}</p>
                                 <p className="mt-1 text-xs text-muted">{group.count} affected page{group.count !== 1 ? 's' : ''}</p>
                               </div>
-                              <Button
-                                type="button"
-                                variant="outline"
-                                size="sm"
-                                disabled={requestingIndexing}
-                                onClick={() => void handleRequestIndexing(group.urls.map((u) => u.url))}
-                              >
-                                {requestingIndexing ? 'Requesting\u2026' : `Request indexing (${group.count})`}
-                              </Button>
+                              {!isEmbed() && (
+                                <Button
+                                  type="button"
+                                  variant="outline"
+                                  size="sm"
+                                  disabled={requestingIndexing}
+                                  onClick={() => void handleRequestIndexing(group.urls.map((u) => u.url))}
+                                >
+                                  {requestingIndexing ? 'Requesting\u2026' : `Request indexing (${group.count})`}
+                                </Button>
+                              )}
                             </div>
 
                             <table className="data-table w-full text-sm">
@@ -1042,7 +1051,7 @@ export function GscSection({
                                 <tr>
                                   <th className="text-left">URL</th>
                                   <th className="text-left">Last Crawl</th>
-                                  <th className="w-8"></th>
+                                  {!isEmbed() && <th className="w-8"></th>}
                                 </tr>
                               </thead>
                               <tbody>
@@ -1050,17 +1059,19 @@ export function GscSection({
                                   <tr key={row.id}>
                                     <td className="max-w-sm truncate text-strong">{row.url}</td>
                                     <td className="text-secondary">{row.crawlTime ? row.crawlTime.split('T')[0] : '\u2014'}</td>
-                                    <td>
-                                      <button
-                                        type="button"
-                                        className="text-xs text-muted hover:text-strong transition-colors"
-                                        disabled={requestingIndexing}
-                                        onClick={() => void handleRequestIndexing([row.url])}
-                                        title="Request indexing"
-                                      >
-                                        Index
-                                      </button>
-                                    </td>
+                                    {!isEmbed() && (
+                                      <td>
+                                        <button
+                                          type="button"
+                                          className="text-xs text-muted hover:text-strong transition-colors"
+                                          disabled={requestingIndexing}
+                                          onClick={() => void handleRequestIndexing([row.url])}
+                                          title="Request indexing"
+                                        >
+                                          Index
+                                        </button>
+                                      </td>
+                                    )}
                                   </tr>
                                 ))}
                               </tbody>
@@ -1441,19 +1452,21 @@ export function GscSection({
                     <h3>Inspect a URL</h3>
                   </div>
                 </div>
-                <div className="mt-3 flex flex-col gap-2 lg:flex-row">
-                  <input
-                    className="flex-1 rounded border border-strong bg-transparent px-2 py-1.5 text-sm text-strong placeholder-mono-600 focus:border-mono-500 focus:outline-none"
-                    type="url"
-                    placeholder="https://example.com/page"
-                    value={inspectionUrl}
-                    onChange={(e) => setInspectionUrl(e.target.value)}
-                    onKeyDown={(e) => e.key === 'Enter' && void handleInspect()}
-                  />
-                  <Button type="button" size="sm" disabled={inspecting || !gscConn?.propertyId || !inspectionUrl.trim()} onClick={asyncHandler(handleInspect)}>
-                    {inspecting ? 'Inspecting\u2026' : 'Inspect URL'}
-                  </Button>
-                </div>
+                {!isEmbed() && (
+                  <div className="mt-3 flex flex-col gap-2 lg:flex-row">
+                    <input
+                      className="flex-1 rounded border border-strong bg-transparent px-2 py-1.5 text-sm text-strong placeholder-mono-600 focus:border-mono-500 focus:outline-none"
+                      type="url"
+                      placeholder="https://example.com/page"
+                      value={inspectionUrl}
+                      onChange={(e) => setInspectionUrl(e.target.value)}
+                      onKeyDown={(e) => e.key === 'Enter' && void handleInspect()}
+                    />
+                    <Button type="button" size="sm" disabled={inspecting || !gscConn?.propertyId || !inspectionUrl.trim()} onClick={asyncHandler(handleInspect)}>
+                      {inspecting ? 'Inspecting\u2026' : 'Inspect URL'}
+                    </Button>
+                  </div>
+                )}
                 {inspectionResult && (
                   <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
                     <div className="rounded-lg border border-default bg-surface-subtle p-3">
@@ -1622,9 +1635,11 @@ export function GscSection({
                           <Button type="button" size="sm" variant="outline" disabled={propertiesLoading} onClick={() => void loadProperties(gscConn)}>
                             {propertiesLoading ? 'Refreshing\u2026' : 'Refresh properties'}
                           </Button>
-                          <Button type="button" size="sm" disabled={!selectedProperty || savingProperty} onClick={asyncHandler(handleSaveProperty)}>
-                            {savingProperty ? 'Saving\u2026' : 'Save property'}
-                          </Button>
+                          {!isEmbed() && (
+                            <Button type="button" size="sm" disabled={!selectedProperty || savingProperty} onClick={asyncHandler(handleSaveProperty)}>
+                              {savingProperty ? 'Saving\u2026' : 'Save property'}
+                            </Button>
+                          )}
                         </div>
                         <p className="text-xs text-muted">The selected property is used for future syncs and URL inspections for this project.</p>
                       </div>
@@ -1659,14 +1674,16 @@ export function GscSection({
                             Replace existing imported rows for the requested range
                           </label>
                         </div>
-                        <Button
-                          type="button"
-                          size="sm"
-                          disabled={triggerGscSyncMutation.isPending || !gscConn.propertyId}
-                          onClick={asyncHandler(handleSync)}
-                        >
-                          {triggerGscSyncMutation.isPending ? 'Queueing\u2026' : 'Queue sync'}
-                        </Button>
+                        {!isEmbed() && (
+                          <Button
+                            type="button"
+                            size="sm"
+                            disabled={triggerGscSyncMutation.isPending || !gscConn.propertyId}
+                            onClick={asyncHandler(handleSync)}
+                          >
+                            {triggerGscSyncMutation.isPending ? 'Queueing\u2026' : 'Queue sync'}
+                          </Button>
+                        )}
                         {!gscConn.propertyId && (
                           <p className="text-xs text-caution-400">Select a Search Console property before queueing a sync.</p>
                         )}
@@ -1700,15 +1717,17 @@ export function GscSection({
                         >
                           {listingSitemaps ? 'Loading\u2026' : 'Browse sitemaps from GSC'}
                         </Button>
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="outline"
-                          disabled={triggerDiscoverSitemapsMutation.isPending || !gscConn.propertyId}
-                          onClick={asyncHandler(handleDiscoverSitemaps)}
-                        >
-                          {triggerDiscoverSitemapsMutation.isPending ? 'Discovering\u2026' : 'Auto-discover and queue inspection'}
-                        </Button>
+                        {!isEmbed() && (
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="outline"
+                            disabled={triggerDiscoverSitemapsMutation.isPending || !gscConn.propertyId}
+                            onClick={asyncHandler(handleDiscoverSitemaps)}
+                          >
+                            {triggerDiscoverSitemapsMutation.isPending ? 'Discovering\u2026' : 'Auto-discover and queue inspection'}
+                          </Button>
+                        )}
                       </div>
                       <p className="text-xs text-muted">Browse lists available sitemaps without queueing a run. Auto-discover saves the primary sitemap and queues an inspection.</p>
                       {discoveredSitemaps && discoveredSitemaps.length > 0 && (
@@ -1744,32 +1763,35 @@ export function GscSection({
                           })}
                         </div>
                       )}
-                      <div className="flex flex-col gap-2 lg:flex-row">
-                        <input
-                          className="flex-1 rounded border border-strong bg-transparent px-2 py-1.5 text-sm text-strong placeholder-mono-600 focus:border-mono-500 focus:outline-none"
-                          type="url"
-                          placeholder={gscConn.sitemapUrl ? 'Update sitemap URL\u2026' : 'https://example.com/sitemap.xml'}
-                          value={sitemapUrlInput}
-                          onChange={(e) => setSitemapUrlInput(e.target.value)}
-                          onKeyDown={(e) => e.key === 'Enter' && sitemapUrlInput.trim() && void handleSaveSitemap()}
-                        />
-                        <Button type="button" size="sm" disabled={savingSitemap || !sitemapUrlInput.trim()} onClick={asyncHandler(handleSaveSitemap)}>
-                          {savingSitemap ? 'Saving\u2026' : gscConn.sitemapUrl ? 'Update' : 'Save'}
-                        </Button>
-                      </div>
-                      <div className="flex flex-col gap-2 lg:flex-row">
-                        <input
-                          className="flex-1 rounded border border-strong bg-transparent px-2 py-1.5 text-sm text-strong placeholder-mono-600 focus:border-mono-500 focus:outline-none"
-                          type="url"
-                          placeholder="Sitemap URL for inspection (leave empty for saved default)"
-                          id={`gsc-sitemap-inspect-${projectName}`}
-                        />
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="outline"
-                          disabled={triggerInspectSitemapMutation.isPending || !gscConn.propertyId}
-                          onClick={asyncHandler(async () => {
+                      {!isEmbed() && (
+                        <div className="flex flex-col gap-2 lg:flex-row">
+                          <input
+                            className="flex-1 rounded border border-strong bg-transparent px-2 py-1.5 text-sm text-strong placeholder-mono-600 focus:border-mono-500 focus:outline-none"
+                            type="url"
+                            placeholder={gscConn.sitemapUrl ? 'Update sitemap URL\u2026' : 'https://example.com/sitemap.xml'}
+                            value={sitemapUrlInput}
+                            onChange={(e) => setSitemapUrlInput(e.target.value)}
+                            onKeyDown={(e) => e.key === 'Enter' && sitemapUrlInput.trim() && void handleSaveSitemap()}
+                          />
+                          <Button type="button" size="sm" disabled={savingSitemap || !sitemapUrlInput.trim()} onClick={asyncHandler(handleSaveSitemap)}>
+                            {savingSitemap ? 'Saving\u2026' : gscConn.sitemapUrl ? 'Update' : 'Save'}
+                          </Button>
+                        </div>
+                      )}
+                      {!isEmbed() && (
+                        <div className="flex flex-col gap-2 lg:flex-row">
+                          <input
+                            className="flex-1 rounded border border-strong bg-transparent px-2 py-1.5 text-sm text-strong placeholder-mono-600 focus:border-mono-500 focus:outline-none"
+                            type="url"
+                            placeholder="Sitemap URL for inspection (leave empty for saved default)"
+                            id={`gsc-sitemap-inspect-${projectName}`}
+                          />
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="outline"
+                            disabled={triggerInspectSitemapMutation.isPending || !gscConn.propertyId}
+                            onClick={asyncHandler(async () => {
                             const el = document.getElementById(`gsc-sitemap-inspect-${projectName}`) as HTMLInputElement | null
                             const url = el?.value?.trim() || gscConn.sitemapUrl || undefined
                             setError(null)
@@ -1786,8 +1808,9 @@ export function GscSection({
                           })}
                         >
                           {triggerInspectSitemapMutation.isPending ? 'Queueing\u2026' : 'Inspect sitemap'}
-                        </Button>
-                      </div>
+                          </Button>
+                        </div>
+                      )}
                       {!gscConn.propertyId && (
                         <p className="text-xs text-caution-400">Select a Search Console property first.</p>
                       )}

--- a/apps/web/src/components/project/NotificationsSection.tsx
+++ b/apps/web/src/components/project/NotificationsSection.tsx
@@ -5,7 +5,7 @@ import { Card } from '../ui/card.js'
 import { ToneBadge } from '../shared/ToneBadge.js'
 import { addToast } from '../../lib/toast-store.js'
 import { asyncHandler } from '../../lib/async-handler.js'
-import { listNotifications, addNotification, removeNotification, sendTestNotification, type ApiNotification } from '../../api.js'
+import { listNotifications, addNotification, removeNotification, sendTestNotification, isEmbed, type ApiNotification } from '../../api.js'
 
 // --- Notification events ---
 const NOTIFICATION_EVENTS = [
@@ -111,14 +111,14 @@ export function NotificationsSection({ projectName }: { projectName: string }) {
           <p className="eyebrow eyebrow-soft">Automation</p>
           <h2>Notifications</h2>
         </div>
-        {notifs !== 'loading' && (
+        {!isEmbed() && notifs !== 'loading' && (
           <Button type="button" variant="outline" size="sm" onClick={() => { setAdding(!adding); setError(null) }}>
             {adding ? 'Cancel' : '+ Add webhook'}
           </Button>
         )}
       </div>
 
-      {adding && (
+      {!isEmbed() && adding && (
         <div className="mb-3 rounded-lg border border-base bg-bg-elevated/40 p-4 space-y-3">
           <div className="space-y-1.5">
             <label className="text-xs font-medium text-secondary">Webhook URL</label>
@@ -215,12 +215,16 @@ export function NotificationsSection({ projectName }: { projectName: string }) {
                           </ToneBadge>
                         )
                       })()}
-                      <Button variant="ghost" size="sm" type="button" disabled={testStates[n.id]?.state === 'testing'} onClick={() => { void handleTest(n.id) }}>
-                        Test
-                      </Button>
-                      <Button variant="ghost" size="sm" type="button" disabled={removingIds.has(n.id)} onClick={() => { void handleRemove(n.id) }}>
-                        {removingIds.has(n.id) ? 'Removing…' : 'Remove'}
-                      </Button>
+                      {!isEmbed() && (
+                        <Button variant="ghost" size="sm" type="button" disabled={testStates[n.id]?.state === 'testing'} onClick={() => { void handleTest(n.id) }}>
+                          Test
+                        </Button>
+                      )}
+                      {!isEmbed() && (
+                        <Button variant="ghost" size="sm" type="button" disabled={removingIds.has(n.id)} onClick={() => { void handleRemove(n.id) }}>
+                          {removingIds.has(n.id) ? 'Removing…' : 'Remove'}
+                        </Button>
+                      )}
                     </div>
                   </td>
                 </tr>

--- a/apps/web/src/components/project/ProjectSettingsSection.tsx
+++ b/apps/web/src/components/project/ProjectSettingsSection.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import { Button } from '../ui/button.js'
-import { addLocation, removeLocation, setDefaultLocation, type ApiLocation } from '../../api.js'
+import { addLocation, removeLocation, setDefaultLocation, isEmbed, type ApiLocation } from '../../api.js'
 import { addToast } from '../../lib/toast-store.js'
 import { asyncHandler } from '../../lib/async-handler.js'
 
@@ -207,7 +207,7 @@ export function ProjectSettingsSection({
           <p className="eyebrow eyebrow-soft">Configuration</p>
           <h2>Project settings</h2>
         </div>
-        {!editing && (
+        {!isEmbed() && !editing && (
           <Button type="button" variant="outline" size="sm" onClick={() => setEditing(true)}>
             Edit settings
           </Button>
@@ -221,7 +221,7 @@ export function ProjectSettingsSection({
         </div>
       )}
 
-      {editing ? (
+      {!isEmbed() && editing ? (
         <div className="rounded-lg border border-base bg-bg-elevated/40 p-4 space-y-4">
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div>
@@ -388,7 +388,7 @@ export function ProjectSettingsSection({
                             <td className="py-1.5 pr-3 text-muted">{loc.timezone ?? '\u2014'}</td>
                             <td className="py-1.5">
                               <div className="flex items-center gap-1.5">
-                                {loc.label !== project.defaultLocation && (
+                                {!isEmbed() && loc.label !== project.defaultLocation && (
                                   <button
                                     type="button"
                                     disabled={locationWorking}
@@ -399,15 +399,17 @@ export function ProjectSettingsSection({
                                     Set default
                                   </button>
                                 )}
-                                <button
-                                  type="button"
-                                  disabled={locationWorking}
-                                  onClick={() => { void handleRemoveLocation(loc.label) }}
-                                  className="text-[10px] text-muted hover:text-negative-400 transition-colors disabled:opacity-40"
-                                  aria-label={`Remove location ${loc.label}`}
-                                >
-                                  Remove
-                                </button>
+                                {!isEmbed() && (
+                                  <button
+                                    type="button"
+                                    disabled={locationWorking}
+                                    onClick={() => { void handleRemoveLocation(loc.label) }}
+                                    className="text-[10px] text-muted hover:text-negative-400 transition-colors disabled:opacity-40"
+                                    aria-label={`Remove location ${loc.label}`}
+                                  >
+                                    Remove
+                                  </button>
+                                )}
                               </div>
                             </td>
                           </tr>
@@ -417,7 +419,7 @@ export function ProjectSettingsSection({
                   ) : (
                     <p className="text-muted text-xs mb-2">No locations configured</p>
                   )}
-                  {showAddLocation ? (
+                  {isEmbed() ? null : showAddLocation ? (
                     <div className="mt-2 rounded border border-base bg-bg-elevated/50 p-3 space-y-2">
                       <p className="text-[10px] font-medium uppercase tracking-wide text-muted">Add location</p>
                       <div className="grid grid-cols-2 gap-2">

--- a/apps/web/src/components/project/ScheduleSection.tsx
+++ b/apps/web/src/components/project/ScheduleSection.tsx
@@ -6,7 +6,7 @@ import { ToneBadge } from '../shared/ToneBadge.js'
 import { formatHour, buildPreset, parsePreset, scheduleLabel } from '../../lib/format-helpers.js'
 import { addToast } from '../../lib/toast-store.js'
 import { asyncHandler } from '../../lib/async-handler.js'
-import { fetchSchedule, saveSchedule, removeSchedule, type ApiSchedule } from '../../api.js'
+import { fetchSchedule, saveSchedule, removeSchedule, isEmbed, type ApiSchedule } from '../../api.js'
 
 // --- Schedule helpers ---
 const FREQ_OPTIONS = [
@@ -155,7 +155,7 @@ export function ScheduleSection({ projectName }: { projectName: string }) {
           <p className="eyebrow eyebrow-soft">Automation</p>
           <h2>Scheduled runs</h2>
         </div>
-        {schedule !== 'loading' && !editing && (
+        {!isEmbed() && schedule !== 'loading' && !editing && (
           <Button type="button" variant="outline" size="sm" onClick={startEditing}>
             {schedule ? 'Edit schedule' : '+ Set schedule'}
           </Button>
@@ -187,19 +187,23 @@ export function ScheduleSection({ projectName }: { projectName: string }) {
               <ToneBadge tone={schedule.enabled ? 'positive' : 'neutral'}>
                 {schedule.enabled ? 'Active' : 'Paused'}
               </ToneBadge>
-              <Button type="button" variant="outline" size="sm" disabled={saving} onClick={asyncHandler(handleToggleEnabled)}>
-                {schedule.enabled ? 'Pause' : 'Resume'}
-              </Button>
-              <Button type="button" variant="ghost" size="sm" disabled={removing} onClick={asyncHandler(handleRemove)}>
-                {removing ? 'Removing...' : 'Remove'}
-              </Button>
+              {!isEmbed() && (
+                <Button type="button" variant="outline" size="sm" disabled={saving} onClick={asyncHandler(handleToggleEnabled)}>
+                  {schedule.enabled ? 'Pause' : 'Resume'}
+                </Button>
+              )}
+              {!isEmbed() && (
+                <Button type="button" variant="ghost" size="sm" disabled={removing} onClick={asyncHandler(handleRemove)}>
+                  {removing ? 'Removing...' : 'Remove'}
+                </Button>
+              )}
             </div>
           </div>
           {error && <p className="text-negative-400 text-sm mt-2">{error}</p>}
         </Card>
       )}
 
-      {editing && (
+      {!isEmbed() && editing && (
         <div className="rounded-lg border border-base bg-bg-elevated/40 p-4 space-y-3">
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">

--- a/apps/web/src/components/project/TechnicalAeoSection.tsx
+++ b/apps/web/src/components/project/TechnicalAeoSection.tsx
@@ -4,7 +4,7 @@ import { AlertTriangle, ChevronDown, ChevronRight, Play, RefreshCw, ScanSearch }
 import type { MetricTone } from '../../view-models.js'
 import type { SiteAuditFactorSummaryDto, SiteAuditPageDto } from '@ainyc/canonry-contracts'
 
-import { triggerSiteAudit, heyClient } from '../../api.js'
+import { triggerSiteAudit, isEmbed, heyClient } from '../../api.js'
 import {
   getApiV1ProjectsByNameTechnicalAeoOptions,
   getApiV1ProjectsByNameTechnicalAeoPagesOptions,
@@ -117,12 +117,14 @@ export function TechnicalAeoSection({ projectName }: { projectName: string }) {
           A technical AEO audit crawls your sitemap and scores every page for structured data, AI-readable content,
           crawler access, freshness, and more, then rolls it up into one site score.
         </p>
-        <div className="mt-5 flex items-center justify-center gap-3">
-          <Button type="button" onClick={() => runMutation.mutate()} disabled={runMutation.isPending}>
-            <Play className="mr-1.5 h-4 w-4" aria-hidden="true" />
-            {runMutation.isPending ? 'Starting…' : 'Run first audit'}
-          </Button>
-        </div>
+        {!isEmbed() && (
+          <div className="mt-5 flex items-center justify-center gap-3">
+            <Button type="button" onClick={() => runMutation.mutate()} disabled={runMutation.isPending}>
+              <Play className="mr-1.5 h-4 w-4" aria-hidden="true" />
+              {runMutation.isPending ? 'Starting…' : 'Run first audit'}
+            </Button>
+          </div>
+        )}
         <p className="mt-3 text-xs text-faint">
           Or from the CLI: <code className="text-secondary">canonry technical-aeo run {projectName} --wait</code>
         </p>
@@ -192,10 +194,12 @@ export function TechnicalAeoSection({ projectName }: { projectName: string }) {
             <RefreshCw className="mr-1.5 h-4 w-4" aria-hidden="true" />
             Refresh
           </Button>
-          <Button type="button" size="sm" onClick={() => runMutation.mutate()} disabled={runMutation.isPending}>
-            <Play className="mr-1.5 h-4 w-4" aria-hidden="true" />
-            {runMutation.isPending ? 'Starting…' : 'Re-run audit'}
-          </Button>
+          {!isEmbed() && (
+            <Button type="button" size="sm" onClick={() => runMutation.mutate()} disabled={runMutation.isPending}>
+              <Play className="mr-1.5 h-4 w-4" aria-hidden="true" />
+              {runMutation.isPending ? 'Starting…' : 'Re-run audit'}
+            </Button>
+          )}
         </div>
       </section>
 

--- a/apps/web/src/components/project/YamlApplyPanel.tsx
+++ b/apps/web/src/components/project/YamlApplyPanel.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { parseAllDocuments } from 'yaml'
 
 import { Button } from '../ui/button.js'
-import { applyProjectConfig } from '../../api.js'
+import { applyProjectConfig, isEmbed } from '../../api.js'
 import { addToast } from '../../lib/toast-store.js'
 import { asyncHandler } from '../../lib/async-handler.js'
 
@@ -11,6 +11,11 @@ export function YamlApplyPanel({ onApplied }: { onApplied: () => void }) {
   const [applying, setApplying] = useState(false)
   const [results, setResults] = useState<string[]>([])
   const [errors, setErrors] = useState<string[]>([])
+
+  // The whole panel is a write surface (paste config → apply). Nothing read-only
+  // here, so it renders nothing in the read-only embed. Hook order is preserved
+  // (the early return is after all hooks) - Rules of Hooks hold on both paths.
+  if (isEmbed()) return null
 
   const handleApply = async () => {
     if (!yamlText.trim()) return

--- a/apps/web/src/pages/BacklinksPage.tsx
+++ b/apps/web/src/pages/BacklinksPage.tsx
@@ -53,6 +53,7 @@ import {
   fetchLatestReleaseSync,
   fetchReleaseSyncs,
   installBacklinks,
+  isEmbed,
   pruneCachedRelease,
   triggerReleaseSync,
   ApiError,
@@ -330,12 +331,14 @@ export function BacklinksPage() {
                     Will be installed into <code className="text-neutral">{status.pluginDir}</code> (~40 MB).
                   </p>
                 )}
-                <div className="mt-3">
-                  <Button type="button" size="sm" disabled={installing} onClick={asyncHandler(handleInstall)}>
-                    <Download className="h-4 w-4 mr-1.5" aria-hidden />
-                    {installing ? 'Installing…' : 'Install DuckDB'}
-                  </Button>
-                </div>
+                {!isEmbed() && (
+                  <div className="mt-3">
+                    <Button type="button" size="sm" disabled={installing} onClick={asyncHandler(handleInstall)}>
+                      <Download className="h-4 w-4 mr-1.5" aria-hidden />
+                      {installing ? 'Installing…' : 'Install DuckDB'}
+                    </Button>
+                  </div>
+                )}
               </div>
             </div>
           )}
@@ -439,28 +442,30 @@ export function BacklinksPage() {
                   <ExternalLink className="h-3 w-3" aria-hidden />
                 </a>
               </div>
-              <div className="flex items-center gap-2 shrink-0">
-                <Button
-                  type="button"
-                  size="sm"
-                  disabled={syncing || !status?.duckdbInstalled || (!latestAvailable && !releaseInput.trim())}
-                  onClick={asyncHandler(handleSync)}
-                >
-                  <Play className="h-4 w-4 mr-1.5" aria-hidden />
-                  {syncing ? 'Queuing…' : 'Run sync'}
-                </Button>
-                <Hint label="What does Run sync do?">
-                  <span className="block">
-                    Downloads the auto-detected (or chosen) Common Crawl release (~16 GB) to{' '}
-                    <code className="text-neutral">~/.canonry/cache/commoncrawl/</code>, then runs a single DuckDB query that extracts referring domains for every project in this workspace.
-                  </span>
-                  <span className="mt-2 block text-secondary">
-                    First time for a release: <span className="text-strong">~10–20 min download + ~5 min query</span>. Re-running the same release later: <span className="text-strong">skips download, just re-queries</span> (~5 min).
-                  </span>
-                </Hint>
-              </div>
+              {!isEmbed() && (
+                <div className="flex items-center gap-2 shrink-0">
+                  <Button
+                    type="button"
+                    size="sm"
+                    disabled={syncing || !status?.duckdbInstalled || (!latestAvailable && !releaseInput.trim())}
+                    onClick={asyncHandler(handleSync)}
+                  >
+                    <Play className="h-4 w-4 mr-1.5" aria-hidden />
+                    {syncing ? 'Queuing…' : 'Run sync'}
+                  </Button>
+                  <Hint label="What does Run sync do?">
+                    <span className="block">
+                      Downloads the auto-detected (or chosen) Common Crawl release (~16 GB) to{' '}
+                      <code className="text-neutral">~/.canonry/cache/commoncrawl/</code>, then runs a single DuckDB query that extracts referring domains for every project in this workspace.
+                    </span>
+                    <span className="mt-2 block text-secondary">
+                      First time for a release: <span className="text-strong">~10–20 min download + ~5 min query</span>. Re-running the same release later: <span className="text-strong">skips download, just re-queries</span> (~5 min).
+                    </span>
+                  </Hint>
+                </div>
+              )}
             </div>
-            {!showOverride ? (
+            {isEmbed() ? null : !showOverride ? (
               <button
                 type="button"
                 className="text-xs text-muted hover:text-neutral focus:text-neutral focus:outline-none focus-visible:ring-1 focus-visible:ring-mono-500 rounded"
@@ -526,7 +531,7 @@ export function BacklinksPage() {
                 <th className="px-4 py-2 font-medium">Sync status</th>
                 <th className="px-4 py-2 text-right font-medium">Size</th>
                 <th className="px-4 py-2 font-medium">Last used</th>
-                <th className="px-4 py-2 font-medium sr-only">Actions</th>
+                {!isEmbed() && <th className="px-4 py-2 font-medium sr-only">Actions</th>}
               </tr>
             </thead>
             <tbody>
@@ -542,21 +547,23 @@ export function BacklinksPage() {
                   </td>
                   <td className="px-4 py-2 text-right text-secondary tabular-nums">{formatBytes(row.bytes)}</td>
                   <td className="px-4 py-2 text-secondary">{relativeTime(row.lastUsedAt)}</td>
-                  <td className="px-4 py-2 text-right">
-                    <div className="inline-flex items-center gap-1">
-                      <Button type="button" variant="outline" size="sm" onClick={() => { void handlePrune(row.release) }}>
-                        <Trash2 className="h-4 w-4 mr-1.5" aria-hidden />
-                        Prune
-                      </Button>
-                      <Hint label="What does Prune do?" placement="top">
-                        Deletes the ~16 GB cache for this release from disk. Backlink results already in SQLite remain untouched. To re-run extracts against this release, you&rsquo;d have to sync it again (another ~16 GB download).
-                      </Hint>
-                    </div>
-                  </td>
+                  {!isEmbed() && (
+                    <td className="px-4 py-2 text-right">
+                      <div className="inline-flex items-center gap-1">
+                        <Button type="button" variant="outline" size="sm" onClick={() => { void handlePrune(row.release) }}>
+                          <Trash2 className="h-4 w-4 mr-1.5" aria-hidden />
+                          Prune
+                        </Button>
+                        <Hint label="What does Prune do?" placement="top">
+                          Deletes the ~16 GB cache for this release from disk. Backlink results already in SQLite remain untouched. To re-run extracts against this release, you&rsquo;d have to sync it again (another ~16 GB download).
+                        </Hint>
+                      </div>
+                    </td>
+                  )}
                 </tr>
               ))}
               {cached.length === 0 && (
-                <tr><td className="px-4 py-4 text-sm text-muted" colSpan={5}>
+                <tr><td className="px-4 py-4 text-sm text-muted" colSpan={isEmbed() ? 4 : 5}>
                   No cached releases on this machine. If you ran a sync from a different machine (or deleted the cache), the backlink data is still in the database — but you&rsquo;ll need to re-sync a release to run new extracts.
                 </td></tr>
               )}

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -54,6 +54,7 @@ import {
   fetchRunDetail,
   heyClient,
   getEmbedConfig,
+  isEmbed,
   type ApiBingConnection,
   type ApiBingSite,
   type ApiBingInspection,
@@ -311,6 +312,20 @@ function BingSection({
   }
 
   if (!connection?.connected) {
+    if (isEmbed()) {
+      return (
+        <Card className="surface-card">
+          <div className="section-head section-head-inline">
+            <div>
+              <p className="eyebrow eyebrow-soft">Connection</p>
+              <h3>Domain authorization</h3>
+            </div>
+            <ToneBadge tone="caution">Not connected</ToneBadge>
+          </div>
+          <p className="text-sm text-neutral">Bing Webmaster Tools is not connected for this project.</p>
+        </Card>
+      )
+    }
     return (
       <Card className="surface-card">
         <div className="section-head section-head-inline">
@@ -366,7 +381,7 @@ function BingSection({
           </div>
           <div className="flex items-center gap-2">
             <ToneBadge tone="positive">Connected</ToneBadge>
-            <Button size="sm" variant="ghost" onClick={asyncHandler(handleDisconnect)}>Disconnect</Button>
+            {!isEmbed() && <Button size="sm" variant="ghost" onClick={asyncHandler(handleDisconnect)}>Disconnect</Button>}
           </div>
         </div>
         <div className="space-y-3">
@@ -404,7 +419,7 @@ function BingSection({
                     <option key={s.url} value={s.url}>{s.url}{s.verified ? ' (verified)' : ''}</option>
                   ))}
                 </select>
-                <Button size="sm" disabled={!selectedSite} onClick={asyncHandler(handleSetSite)}>Set Site</Button>
+                {!isEmbed() && <Button size="sm" disabled={!selectedSite} onClick={asyncHandler(handleSetSite)}>Set Site</Button>}
               </div>
             ) : (
               <p className="mt-3 text-xs text-muted">
@@ -435,7 +450,7 @@ function BingSection({
           </div>
           <div className="flex items-center gap-2">
             <ToneBadge tone="positive">Connected</ToneBadge>
-            <Button size="sm" variant="ghost" onClick={asyncHandler(handleDisconnect)}>Disconnect</Button>
+            {!isEmbed() && <Button size="sm" variant="ghost" onClick={asyncHandler(handleDisconnect)}>Disconnect</Button>}
           </div>
         </div>
         {error && <p className="mb-3 text-xs text-negative-400">{error}</p>}
@@ -447,7 +462,7 @@ function BingSection({
               <span className="text-xs text-muted">{connection.domain}</span>
             </div>
             <p className="mt-2 text-xs text-muted">
-              Canonry stores Bing connections per canonical domain. This project is currently mapped to <code>{connection.siteUrl}</code>.
+              {isEmbed() ? <>This project is currently mapped to <code>{connection.siteUrl}</code>.</> : <>Canonry stores Bing connections per canonical domain. This project is currently mapped to <code>{connection.siteUrl}</code>.</>}
             </p>
           </div>
           <div className="grid gap-3 lg:grid-cols-2">
@@ -503,9 +518,11 @@ function BingSection({
               <div>
                 <div className="mb-2 flex items-center justify-between gap-3">
                   <h4 className="text-xs font-medium text-secondary">Not Indexed ({coverage.notIndexed.length})</h4>
-                  <Button size="sm" variant="ghost" disabled={requestingIndexing} onClick={asyncHandler(handleSubmitAllUnindexed)}>
-                    {requestingIndexing ? 'Submitting…' : 'Submit all to Bing'}
-                  </Button>
+                  {!isEmbed() && (
+                    <Button size="sm" variant="ghost" disabled={requestingIndexing} onClick={asyncHandler(handleSubmitAllUnindexed)}>
+                      {requestingIndexing ? 'Submitting…' : 'Submit all to Bing'}
+                    </Button>
+                  )}
                 </div>
                 <div className="overflow-x-auto rounded-lg border border-default">
                   <table className="w-full text-xs">
@@ -513,7 +530,7 @@ function BingSection({
                       <tr className="border-b border-base">
                         <th className="text-left py-1.5 px-3 text-muted font-medium">URL</th>
                         <th className="text-left py-1.5 px-3 text-muted font-medium w-16">HTTP</th>
-                        <th className="text-right py-1.5 px-3 text-muted font-medium w-20">Action</th>
+                        {!isEmbed() && <th className="text-right py-1.5 px-3 text-muted font-medium w-20">Action</th>}
                       </tr>
                     </thead>
                     <tbody>
@@ -521,15 +538,17 @@ function BingSection({
                         <tr key={row.id} className="border-b border-base/50">
                           <td className="py-1.5 px-3 text-neutral truncate max-w-[480px]">{row.url}</td>
                           <td className="py-1.5 px-3 text-secondary">{row.httpCode ?? '\u2014'}</td>
-                          <td className="py-1.5 px-3 text-right">
-                            <button
-                              className="text-[10px] text-secondary hover:text-strong underline underline-offset-2"
-                              disabled={requestingIndexing}
-                              onClick={() => { void handleSubmitUrl(row.url) }}
-                            >
-                              Submit
-                            </button>
-                          </td>
+                          {!isEmbed() && (
+                            <td className="py-1.5 px-3 text-right">
+                              <button
+                                className="text-[10px] text-secondary hover:text-strong underline underline-offset-2"
+                                disabled={requestingIndexing}
+                                onClick={() => { void handleSubmitUrl(row.url) }}
+                              >
+                                Submit
+                              </button>
+                            </td>
+                          )}
                         </tr>
                       ))}
                     </tbody>
@@ -542,9 +561,11 @@ function BingSection({
               <div>
                 <div className="mb-2 flex items-center justify-between gap-3">
                   <h4 className="text-xs font-medium text-secondary">Unknown — not yet confirmed ({(coverage.unknown ?? []).length})</h4>
-                  <Button size="sm" variant="ghost" disabled={requestingIndexing} onClick={asyncHandler(handleSubmitAllUnindexed)}>
-                    {requestingIndexing ? 'Submitting…' : 'Submit all to Bing'}
-                  </Button>
+                  {!isEmbed() && (
+                    <Button size="sm" variant="ghost" disabled={requestingIndexing} onClick={asyncHandler(handleSubmitAllUnindexed)}>
+                      {requestingIndexing ? 'Submitting…' : 'Submit all to Bing'}
+                    </Button>
+                  )}
                 </div>
                 <div className="overflow-x-auto rounded-lg border border-default">
                   <table className="w-full text-xs">
@@ -552,7 +573,7 @@ function BingSection({
                       <tr className="border-b border-base">
                         <th className="text-left py-1.5 px-3 text-muted font-medium">URL</th>
                         <th className="text-left py-1.5 px-3 text-muted font-medium w-32">Last Crawled</th>
-                        <th className="text-right py-1.5 px-3 text-muted font-medium w-20">Action</th>
+                        {!isEmbed() && <th className="text-right py-1.5 px-3 text-muted font-medium w-20">Action</th>}
                       </tr>
                     </thead>
                     <tbody>
@@ -560,15 +581,17 @@ function BingSection({
                         <tr key={row.id} className="border-b border-base/50">
                           <td className="py-1.5 px-3 text-neutral truncate max-w-[480px]">{row.url}</td>
                           <td className="py-1.5 px-3 text-secondary">{row.lastCrawledDate ? formatTimestamp(row.lastCrawledDate) : '\u2014'}</td>
-                          <td className="py-1.5 px-3 text-right">
-                            <button
-                              className="text-[10px] text-secondary hover:text-strong underline underline-offset-2"
-                              disabled={requestingIndexing}
-                              onClick={() => { void handleSubmitUrl(row.url) }}
-                            >
-                              Submit
-                            </button>
-                          </td>
+                          {!isEmbed() && (
+                            <td className="py-1.5 px-3 text-right">
+                              <button
+                                className="text-[10px] text-secondary hover:text-strong underline underline-offset-2"
+                                disabled={requestingIndexing}
+                                onClick={() => { void handleSubmitUrl(row.url) }}
+                              >
+                                Submit
+                              </button>
+                            </td>
+                          )}
                         </tr>
                       ))}
                     </tbody>
@@ -609,19 +632,21 @@ function BingSection({
 
         {activeTab === 'inspections' && (
           <div className="mt-4 space-y-3">
-            <div className="flex flex-col gap-2 lg:flex-row">
-              <input
-                type="text"
-                className="flex-1 rounded border border-strong bg-transparent px-2 py-1.5 text-sm text-strong placeholder-mono-600 focus:border-mono-500 focus:outline-none"
-                placeholder="URL to inspect"
-                value={inspectionUrl}
-                onChange={(e) => setInspectionUrl(e.target.value)}
-                onKeyDown={(e) => { if (e.key === 'Enter') { void handleInspect() } }}
-              />
-              <Button size="sm" disabled={!inspectionUrl.trim()} onClick={asyncHandler(handleInspect)}>
-                Inspect
-              </Button>
-            </div>
+            {!isEmbed() && (
+              <div className="flex flex-col gap-2 lg:flex-row">
+                <input
+                  type="text"
+                  className="flex-1 rounded border border-strong bg-transparent px-2 py-1.5 text-sm text-strong placeholder-mono-600 focus:border-mono-500 focus:outline-none"
+                  placeholder="URL to inspect"
+                  value={inspectionUrl}
+                  onChange={(e) => setInspectionUrl(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') { void handleInspect() } }}
+                />
+                <Button size="sm" disabled={!inspectionUrl.trim()} onClick={asyncHandler(handleInspect)}>
+                  Inspect
+                </Button>
+              </div>
+            )}
 
             {inspectionResult && (
               <div className="rounded border border-base bg-bg-elevated/40 p-3 text-xs space-y-1">
@@ -918,9 +943,11 @@ function SearchConsoleSection({
               Scan both engines at a glance, then open the Google or Bing workspace when you need to inspect coverage or take action.
             </p>
           </div>
-          <Button type="button" variant="outline" size="sm" disabled={loading || refreshState !== 'idle'} onClick={() => void handleRefresh()}>
-            {loading ? 'Loading…' : refreshState === 'syncing' ? 'Refreshing Google & Bing…' : refreshState === 'reloading' ? 'Reloading workspaces…' : 'Refresh all'}
-          </Button>
+          {!isEmbed() && (
+            <Button type="button" variant="outline" size="sm" disabled={loading || refreshState !== 'idle'} onClick={() => void handleRefresh()}>
+              {loading ? 'Loading…' : refreshState === 'syncing' ? 'Refreshing Google & Bing…' : refreshState === 'reloading' ? 'Reloading workspaces…' : 'Refresh all'}
+            </Button>
+          )}
         </div>
 
         {error && (
@@ -1195,7 +1222,7 @@ function OverviewBrief({
           ) : (
             <>
               <p className="overview-brief-panel-title">No outstanding action</p>
-              <p className="overview-brief-panel-copy">Keep monitoring. Canonry will surface regressions and new query opportunities here.</p>
+              <p className="overview-brief-panel-copy">{isEmbed() ? 'Keep monitoring. Regressions and new query opportunities will surface here.' : 'Keep monitoring. Canonry will surface regressions and new query opportunities here.'}</p>
             </>
           )}
         </div>
@@ -2109,16 +2136,18 @@ function ProjectPageContent({
               {(model.project.ownedDomains ?? []).map((d) => (
                 <span key={d} className="inline-flex items-center gap-1 rounded-full border border-strong/60 bg-surface-inset-hover px-2 py-0.5 text-xs text-neutral">
                   {d}
-                  <button
-                    type="button"
-                    className="-mr-1 ml-0.5 inline-flex items-center justify-center rounded p-1 leading-none text-muted hover:bg-mono-700/40 hover:text-strong transition-colors"
-                    disabled={ownedDomainSaving}
-                    onClick={() => { void handleRemoveOwnedDomain(d) }}
-                    aria-label={`Remove ${d}`}
-                  >×</button>
+                  {!isEmbed() && (
+                    <button
+                      type="button"
+                      className="-mr-1 ml-0.5 inline-flex items-center justify-center rounded p-1 leading-none text-muted hover:bg-mono-700/40 hover:text-strong transition-colors"
+                      disabled={ownedDomainSaving}
+                      onClick={() => { void handleRemoveOwnedDomain(d) }}
+                      aria-label={`Remove ${d}`}
+                    >×</button>
+                  )}
                 </span>
               ))}
-              {addingOwnedDomain ? (
+              {isEmbed() ? null : addingOwnedDomain ? (
                 <span className="inline-flex items-center gap-1">
                   <input
                     className="rounded border border-strong bg-transparent px-1.5 py-0.5 text-xs text-strong placeholder-mono-600 focus:border-mono-500 focus:outline-none w-40"
@@ -2143,6 +2172,7 @@ function ProjectPageContent({
               )}
             </div>
           )}
+          {(!isEmbed() || (model.project.aliases ?? []).length > 0) && (
           <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
             <span className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wide text-muted mr-1">
               Also known as
@@ -2151,16 +2181,18 @@ function ProjectPageContent({
             {(model.project.aliases ?? []).map((a) => (
               <span key={a} className="inline-flex items-center gap-1 rounded-full border border-strong/60 bg-surface-inset-hover px-2 py-0.5 text-xs text-neutral">
                 {a}
-                <button
-                  type="button"
-                  className="-mr-1 ml-0.5 inline-flex items-center justify-center rounded p-1 leading-none text-muted hover:bg-mono-700/40 hover:text-strong transition-colors"
-                  disabled={aliasSaving}
-                  onClick={() => { void handleRemoveAlias(a) }}
-                  aria-label={`Remove ${a}`}
-                >×</button>
+                {!isEmbed() && (
+                  <button
+                    type="button"
+                    className="-mr-1 ml-0.5 inline-flex items-center justify-center rounded p-1 leading-none text-muted hover:bg-mono-700/40 hover:text-strong transition-colors"
+                    disabled={aliasSaving}
+                    onClick={() => { void handleRemoveAlias(a) }}
+                    aria-label={`Remove ${a}`}
+                  >×</button>
+                )}
               </span>
             ))}
-            {addingAlias ? (
+            {isEmbed() ? null : addingAlias ? (
               <span className="inline-flex items-center gap-1">
                 <input
                   className="rounded border border-strong bg-transparent px-1.5 py-0.5 text-xs text-strong placeholder-mono-600 focus:border-mono-500 focus:outline-none w-40"
@@ -2184,28 +2216,31 @@ function ProjectPageContent({
               >+ alias</button>
             )}
           </div>
+          )}
         </div>
         <div className="page-header-right">
           <p className="text-sm text-muted">{model.dateRangeLabel}</p>
-          <div className="flex items-center gap-2">
-            <Button type="button" variant="outline" size="icon" onClick={asyncHandler(handleExport)} aria-label="Export project as YAML">
-              <Download className="h-4 w-4 text-secondary" />
-            </Button>
-            <Button type="button" variant="outline" size="icon" onClick={() => setShowDeleteConfirm(true)} aria-label="Delete project">
-              <Trash2 className="h-4 w-4 text-secondary" />
-            </Button>
-            <Button
-              type="button"
-              disabled={triggerRunMutation.isPending || hasActiveVisibilitySweep}
-              onClick={asyncHandler(handleTriggerRun)}
-            >
-              {triggerRunMutation.isPending
-                ? 'Starting…'
-                : hasActiveVisibilitySweep
-                  ? 'Sweep running…'
-                  : 'Run now'}
-            </Button>
-          </div>
+          {!isEmbed() && (
+            <div className="flex items-center gap-2">
+              <Button type="button" variant="outline" size="icon" onClick={asyncHandler(handleExport)} aria-label="Export project as YAML">
+                <Download className="h-4 w-4 text-secondary" />
+              </Button>
+              <Button type="button" variant="outline" size="icon" onClick={() => setShowDeleteConfirm(true)} aria-label="Delete project">
+                <Trash2 className="h-4 w-4 text-secondary" />
+              </Button>
+              <Button
+                type="button"
+                disabled={triggerRunMutation.isPending || hasActiveVisibilitySweep}
+                onClick={asyncHandler(handleTriggerRun)}
+              >
+                {triggerRunMutation.isPending
+                  ? 'Starting…'
+                  : hasActiveVisibilitySweep
+                    ? 'Sweep running…'
+                    : 'Run now'}
+              </Button>
+            </div>
+          )}
         </div>
       </div>
 
@@ -2260,9 +2295,11 @@ function ProjectPageContent({
               </div>
               <div className="flex items-center gap-3">
                 <p className="supporting-copy">{model.competitors.length} tracked</p>
-                <Button type="button" variant="outline" size="sm" onClick={() => setAddingCompetitor(!addingCompetitor)}>
-                  {addingCompetitor ? 'Cancel' : '+ Add competitor'}
-                </Button>
+                {!isEmbed() && (
+                  <Button type="button" variant="outline" size="sm" onClick={() => setAddingCompetitor(!addingCompetitor)}>
+                    {addingCompetitor ? 'Cancel' : '+ Add competitor'}
+                  </Button>
+                )}
               </div>
             </div>
 
@@ -2319,7 +2356,7 @@ function ProjectPageContent({
                       setCompetitorFilter(domain)
                       focusOverviewSection('evidence-section', true)
                     }}
-                    onRemoveCompetitor={(domain) => { void handleRemoveCompetitor(domain) }}
+                    onRemoveCompetitor={isEmbed() ? undefined : (domain) => { void handleRemoveCompetitor(domain) }}
                     activeFilter={competitorFilter}
                   />
                 </div>
@@ -2333,12 +2370,14 @@ function ProjectPageContent({
             title="Query evidence"
             meta={`${model.queryCounts.total} ${model.queryCounts.total === 1 ? 'query' : 'queries'}`}
           >
-            <div className="mb-3 flex items-center justify-end">
-              <Button type="button" variant="outline" size="sm" onClick={() => setManagingQueries(!managingQueries)}>
-                {managingQueries ? 'Done' : 'Manage queries'}
-              </Button>
-            </div>
-            {managingQueries && (
+            {!isEmbed() && (
+              <div className="mb-3 flex items-center justify-end">
+                <Button type="button" variant="outline" size="sm" onClick={() => setManagingQueries(!managingQueries)}>
+                  {managingQueries ? 'Done' : 'Manage queries'}
+                </Button>
+              </div>
+            )}
+            {!isEmbed() && managingQueries && (
               <div className="mb-3 rounded-lg border border-base bg-bg-elevated/40 p-3">
                 {trackedQueries.length > 0 ? (
                   <ul className="mb-3 max-h-64 divide-y divide-mono-800/60 overflow-y-auto rounded border border-default">

--- a/apps/web/src/pages/ReportPage.tsx
+++ b/apps/web/src/pages/ReportPage.tsx
@@ -27,7 +27,7 @@ import {
 
 import { ToneBadge } from '../components/shared/ToneBadge.js'
 import { Button } from '../components/ui/button.js'
-import { downloadReportHtml, heyClient, ApiError } from '../api.js'
+import { downloadReportHtml, heyClient, isEmbed, ApiError } from '../api.js'
 import { getApiV1ProjectsByNameReportOptions } from '@ainyc/canonry-api-client/react-query'
 import { asyncHandler } from '../lib/async-handler.js'
 import { useDismissContentTarget } from '../queries/mutations.js'
@@ -579,7 +579,7 @@ function ActionPlanSection({ report, audience, projectName }: { report: ProjectR
                 <p className="mt-3 border-t border-default pt-3 text-xs text-neutral">
                   <span className="font-medium">{isClient ? 'What success looks like:' : 'Win condition:'}</span> {action.successMetric}
                 </p>
-                {action.targetRef && (
+                {action.targetRef && !isEmbed() && (
                   <div className="mt-3 flex justify-end">
                     <button
                       type="button"

--- a/apps/web/src/pages/RunsPage.tsx
+++ b/apps/web/src/pages/RunsPage.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { Button } from '../components/ui/button.js'
 import { Card } from '../components/ui/card.js'
 import { RunRow } from '../components/shared/RunRow.js'
+import { isEmbed } from '../api.js'
 import { toTitleCase } from '../lib/format-helpers.js'
 import { useTriggerAllRuns } from '../queries/mutations.js'
 import { useDashboardOverview as useDashboard } from '../queries/use-dashboard-overview.js'
@@ -55,9 +56,11 @@ export function RunsPage() {
             Status, type, project, duration, and the shortest explanation that makes the outcome trustworthy.
           </p>
         </div>
-        <Button type="button" variant="outline" size="sm" disabled={triggerAllRunsMutation.isPending} onClick={() => void handleTriggerAll()}>
-          {triggerAllRunsMutation.isPending ? 'Queueing…' : 'Run all projects'}
-        </Button>
+        {!isEmbed() && (
+          <Button type="button" variant="outline" size="sm" disabled={triggerAllRunsMutation.isPending} onClick={() => void handleTriggerAll()}>
+            {triggerAllRunsMutation.isPending ? 'Queueing…' : 'Run all projects'}
+          </Button>
+        )}
       </div>
 
       <section>

--- a/apps/web/src/pages/TrafficPage.tsx
+++ b/apps/web/src/pages/TrafficPage.tsx
@@ -5,7 +5,7 @@ import { Plus, RefreshCw } from 'lucide-react'
 
 import { TrafficSourceStatuses, type TrafficSourceDto } from '@ainyc/canonry-contracts'
 
-import { heyClient, type ApiProject, type ApiTrafficSourceDetail } from '../api.js'
+import { heyClient, isEmbed, type ApiProject, type ApiTrafficSourceDetail } from '../api.js'
 import {
   getApiV1ProjectsByNameTrafficSourcesByIdOptions,
   getApiV1ProjectsOptions,
@@ -61,18 +61,20 @@ export function TrafficPage() {
             Bulk crawler hits, AI user fetches (ChatGPT-User, Perplexity-User), and AI referral sessions pulled directly from your server logs. Independent of GA — useful when you need server-side evidence that an AI engine actually hit a page.
           </p>
         </div>
-        <div className="flex flex-wrap items-center justify-end gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={() => setConnectOpen(true)}
-            disabled={!activeProject}
-          >
-            <Plus className="size-3.5" />
-            Connect a source
-          </Button>
-        </div>
+        {!isEmbed() && (
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setConnectOpen(true)}
+              disabled={!activeProject}
+            >
+              <Plus className="size-3.5" />
+              Connect a source
+            </Button>
+          </div>
+        )}
       </div>
 
       <section>
@@ -97,24 +99,30 @@ export function TrafficPage() {
         ) : sources.length === 0 ? (
           <Card className="p-8 text-center">
             <p className="text-sm text-neutral">No traffic sources connected for {activeProject}.</p>
-            <p className="mt-1 text-xs text-muted">Connect a traffic source to start ingesting crawler hits and AI-referral sessions from your server logs.</p>
-            <div className="mt-4 flex flex-wrap items-center justify-center gap-2">
-              <Button type="button" variant="outline" size="sm" onClick={() => setConnectOpen(true)}>
-                <Plus className="size-3.5" />
-                Connect a source
-              </Button>
-            </div>
+            {!isEmbed() && (
+              <>
+                <p className="mt-1 text-xs text-muted">Connect a traffic source to start ingesting crawler hits and AI-referral sessions from your server logs.</p>
+                <div className="mt-4 flex flex-wrap items-center justify-center gap-2">
+                  <Button type="button" variant="outline" size="sm" onClick={() => setConnectOpen(true)}>
+                    <Plus className="size-3.5" />
+                    Connect a source
+                  </Button>
+                </div>
+              </>
+            )}
           </Card>
         ) : (
           <SourcesTable projectName={activeProject} sources={sources} />
         )}
       </section>
 
-      <ConnectSourceDrawer
-        open={connectOpen}
-        onOpenChange={setConnectOpen}
-        projectName={activeProject}
-      />
+      {!isEmbed() && (
+        <ConnectSourceDrawer
+          open={connectOpen}
+          onOpenChange={setConnectOpen}
+          projectName={activeProject}
+        />
+      )}
     </div>
   )
 }

--- a/apps/web/src/pages/TrafficSourceDetailPage.tsx
+++ b/apps/web/src/pages/TrafficSourceDetailPage.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, ChevronLeft, ChevronRight, RefreshCw, X } from 'lucide-react
 
 import { TrafficEventKinds, type TrafficEventEntry } from '@ainyc/canonry-contracts'
 
+import { isEmbed } from '../api.js'
 import { Button } from '../components/ui/button.js'
 import { Card } from '../components/ui/card.js'
 import { InfoTooltip } from '../components/shared/InfoTooltip.js'
@@ -346,16 +347,18 @@ export function TrafficSourceDetailPage() {
         </div>
         <div className="flex items-center gap-2">
           <ToneBadge tone={toneFromTrafficSourceStatus(detail.status)}>{detail.status}</ToneBadge>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            disabled={sync.isPending}
-            onClick={() => void handleSync()}
-          >
-            <RefreshCw className={`size-3.5 ${sync.isPending ? 'animate-spin' : ''}`} />
-            {sync.isPending ? 'Syncing…' : 'Sync now'}
-          </Button>
+          {!isEmbed() && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={sync.isPending}
+              onClick={() => void handleSync()}
+            >
+              <RefreshCw className={`size-3.5 ${sync.isPending ? 'animate-spin' : ''}`} />
+              {sync.isPending ? 'Syncing…' : 'Sync now'}
+            </Button>
+          )}
         </div>
       </div>
 
@@ -416,7 +419,7 @@ export function TrafficSourceDetailPage() {
             ) : null}
           </Card>
         ) : (
-          <Card className="px-4 py-3 text-sm text-muted">No traffic-sync runs recorded yet. Hit "Sync now" above to create one.</Card>
+          <Card className="px-4 py-3 text-sm text-muted">{isEmbed() ? 'No traffic-sync runs recorded yet.' : 'No traffic-sync runs recorded yet. Hit "Sync now" above to create one.'}</Card>
         )}
       </section>
 

--- a/apps/web/test/app-embed.test.tsx
+++ b/apps/web/test/app-embed.test.tsx
@@ -84,3 +84,69 @@ test('embed theme applies allowlisted CSS custom properties to the shell', async
   })
   expect(html).toContain('--canonry-embed-bg:#00aaff')
 })
+
+// White-label de-leak: the read-only embed render hides every write/operator
+// control that would 403 on click against the read-only project-scoped key,
+// while keeping every read-only view. Not a security boundary (the API key
+// scope is) — purely UI cleanliness. See isEmbed() in src/api.ts.
+test('embed hides the page-header write cluster (export / delete / run) that leaks on every tab', async () => {
+  const embed = await renderAt('/projects/project_citypoint', { enabled: true })
+  const operator = await renderAt('/projects/project_citypoint')
+
+  // Operator sees the header action cluster…
+  expect(operator).toContain('Export project as YAML')
+  expect(operator).toContain('Delete project')
+  // …the embed render does not (this cluster renders OUTSIDE the tab switch, so
+  // it would otherwise leak on the default overview embed).
+  expect(embed).not.toContain('Export project as YAML')
+  expect(embed).not.toContain('Delete project')
+
+  // A read-only view still renders in the embed (the project name + a section
+  // heading + a metric label), proving we hid controls, not content.
+  expect(embed).toContain('Citypoint Dental NYC')
+  expect(embed).toContain('Where competitors are winning')
+  expect(embed).toContain('Mention share')
+})
+
+test('embed hides the overview competitor + query managers and the identity editors', async () => {
+  const embed = await renderAt('/projects/project_citypoint', { enabled: true })
+  const operator = await renderAt('/projects/project_citypoint')
+
+  // Operator sees the overview write affordances + the alias editor row…
+  expect(operator).toContain('+ Add competitor')
+  expect(operator).toContain('Manage queries')
+  expect(operator).toContain('Also known as')
+  // …none of which render in the embed.
+  expect(embed).not.toContain('+ Add competitor')
+  expect(embed).not.toContain('Manage queries')
+  expect(embed).not.toContain('Also known as')
+})
+
+// A default embed config (enabled, no `views` allowlist) makes every top-level
+// route reachable inside the iframe — `embedViewIdForPath` maps them but the
+// unset allowlist permits them all. These admin pages (/runs, /traffic,
+// /backlinks) must therefore hide their own operator write controls too, not
+// just the project-tab buttons. Same rule: hide the mutating control, keep the
+// read-only view.
+test('embed hides the operator write controls on the top-level admin pages (default config, no views allowlist)', async () => {
+  // /runs — "Run all projects" triggers a sweep across every project.
+  const runsEmbed = await renderAt('/runs', { enabled: true })
+  const runsOperator = await renderAt('/runs')
+  expect(runsOperator).toContain('Run all projects')
+  expect(runsEmbed).not.toContain('Run all projects')
+  expect(runsEmbed).toContain('Runs') // the read-only page still renders
+
+  // /traffic — "Connect a source" opens the write drawer.
+  const trafficEmbed = await renderAt('/traffic', { enabled: true })
+  const trafficOperator = await renderAt('/traffic')
+  expect(trafficOperator).toContain('Connect a source')
+  expect(trafficEmbed).not.toContain('Connect a source')
+  expect(trafficEmbed).toContain('Server traffic') // the read-only page still renders
+
+  // /backlinks — "Run sync" downloads + queries a Common Crawl release.
+  const backlinksEmbed = await renderAt('/backlinks', { enabled: true })
+  const backlinksOperator = await renderAt('/backlinks')
+  expect(backlinksOperator).toContain('Run sync')
+  expect(backlinksEmbed).not.toContain('Run sync')
+  expect(backlinksEmbed).toContain('Backlinks') // the read-only page still renders
+})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.112.6",
+  "version": "4.112.7",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.112.6",
+  "version": "4.112.7",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
The chromeless embed render (#716) hides the shell, but every WRITE/OPERATOR control still rendered inside the routed dashboard a client sees, and cross-nav links + top-level admin pages were reachable. A client saw operator buttons (Run now, Delete project, Export YAML, Connect, Submit to Google, ...) that 403 on click. This gates them so the embed reads as the agency's own tech.

**This is white-label UI cleanliness, NOT a security fix.** The read-only project-scoped key already 403s every write server-side (the API boundary is intact); this removes the presentational leak.

## What
- New `isEmbed()` helper in `apps/web/src/api.ts` (`getEmbedConfig() !== null`; embed presence == read-only for v1). Every mutating control is wrapped in `{!isEmbed() && ...}`; every read-only VIEW (tables, charts, coverage, evidence, report body, scorecards) still renders.
- Gated ~60 controls across ProjectPage (header cluster Run/Delete/Export - it leaks on every tab - plus competitor/query/domain/alias editors, GSC connect/sync/request-indexing) and the section components (Gsc/Activity/Discovery/Gbp/Backlinks/TechnicalAeo/Schedule/Notifications/ProjectSettings) + `YamlApplyPanel` + ReportPage Dismiss (Download kept - a legit client affordance).
- Gated the cross-nav LINKS into the top-level admin pages, and the top-level pages themselves (`RunsPage` Run-all, `TrafficPage`/`TrafficSourceDetailPage` Connect/Sync, `BacklinksPage` Install/Sync/Prune) so a default embed (no `views` allowlist) cannot reach an ungated operator surface even by direct URL.
- Brand: hid 4 in-page Canonry wordmarks under embed. CLI-copy (`canonry <cmd>` / `canonry.yaml`) inside gated connect/empty states left as a separate copy decision.
- Not gated (deliberate): navigation onClicks (jump-to-section, openRun, filters, pagination); the report Download; AeroBar (already unmounted in embed).

## Verified
typecheck 0 . 367 web tests (incl. new app-embed cases asserting write controls hidden under embed, read-only views present, operator view still shows them) . dashboard-class-baseline UNCHANGED (operator SSR byte-identical) . report-renderer parity green . no-literal-palette ratchet green . lint 0 . build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)