### PR TITLE
Add refresh feedback to project UI

### DIFF
--- a/apps/web/src/components/project/DiscoverySection.tsx
+++ b/apps/web/src/components/project/DiscoverySection.tsx
@@ -151,6 +151,29 @@ export function DiscoverySection({ projectName }: { projectName: string }) {
   const safeDefaultCount = (preview?.queriesByBucket.cited.length ?? 0) + (preview?.queriesByBucket.aspirational.length ?? 0)
   const probeRows = useMemo(() => (detail?.probes ?? []).slice(0, 30), [detail?.probes])
 
+  async function handleRefreshSessions() {
+    try {
+      const result = await sessionsQuery.refetch()
+      if (result.error) throw result.error
+      const count = result.data?.length ?? 0
+      addToast({
+        title: 'Discovery sessions refreshed',
+        detail: `${count} recent session${count === 1 ? '' : 's'} loaded.`,
+        tone: 'positive',
+        dedupeKey: `discovery:refresh:${projectName}`,
+        dedupeMode: 'replace',
+      })
+    } catch (error) {
+      addToast({
+        title: 'Discovery refresh failed',
+        detail: error instanceof Error ? error.message : 'Could not reload discovery sessions.',
+        tone: 'negative',
+        dedupeKey: `discovery:refresh:${projectName}`,
+        dedupeMode: 'replace',
+      })
+    }
+  }
+
   return (
     <section className="page-section-divider">
       <div className="section-head section-head-inline">
@@ -168,9 +191,9 @@ export function DiscoverySection({ projectName }: { projectName: string }) {
           variant="outline"
           size="sm"
           disabled={sessionsQuery.isFetching}
-          onClick={() => void sessionsQuery.refetch()}
+          onClick={() => void handleRefreshSessions()}
         >
-          <RefreshCw size={14} />
+          <RefreshCw className={`size-3.5 ${sessionsQuery.isFetching ? 'animate-spin' : ''}`} aria-hidden="true" />
           Refresh
         </Button>
       </div>

--- a/apps/web/src/components/project/GscSection.tsx
+++ b/apps/web/src/components/project/GscSection.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import { useQueryClient } from '@tanstack/react-query'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { ChevronLeft, ChevronRight, RefreshCw } from 'lucide-react'
 import type { GscPerformanceDailyDto, MetricsWindow } from '@ainyc/canonry-contracts'
 
 import { Button } from '../ui/button.js'
@@ -210,7 +210,10 @@ export function GscSection({
   const triggerDiscoverSitemapsMutation = useTriggerDiscoverSitemaps()
   const triggerInspectSitemapMutation = useTriggerInspectSitemap()
 
-  async function loadProperties(currentConn: ApiGoogleConnection | undefined) {
+  async function loadProperties(
+    currentConn: ApiGoogleConnection | undefined,
+    options: { force?: boolean; notify?: boolean } = {},
+  ) {
     if (!currentConn) {
       setProperties([])
       setSelectedProperty('')
@@ -221,14 +224,33 @@ export function GscSection({
     try {
       const { sites } = await queryClient.fetchQuery({
         ...getApiV1ProjectsByNameGooglePropertiesOptions({ client: heyClient, path: { name: projectName } }),
-        staleTime: GSC_STALE_MS,
+        staleTime: options.force ? 0 : GSC_STALE_MS,
       })
       setProperties(sites)
       setSelectedProperty(currentConn.propertyId ?? sites[0]?.siteUrl ?? '')
       setActionNeeded(null)
+      if (options.notify) {
+        addToast({
+          title: 'GSC properties refreshed',
+          detail: `${sites.length} propert${sites.length === 1 ? 'y' : 'ies'} available for this connection.`,
+          tone: sites.length > 0 ? 'positive' : 'caution',
+          dedupeKey: `gsc:properties:${projectName}`,
+          dedupeMode: 'replace',
+        })
+      }
     } catch (err) {
       setProperties([])
       reportGscError(err, 'Failed to load Search Console properties')
+      if (options.notify) {
+        const info = extractApiErrorInfo(err)
+        addToast({
+          title: 'GSC property refresh failed',
+          detail: info.message || 'Failed to load Search Console properties',
+          tone: 'negative',
+          dedupeKey: `gsc:properties:${projectName}`,
+          dedupeMode: 'replace',
+        })
+      }
     } finally {
       setPropertiesLoading(false)
     }
@@ -304,7 +326,7 @@ export function GscSection({
     }
   }
 
-  async function loadInspectionHistory() {
+  async function loadInspectionHistory(options: { force?: boolean; notify?: boolean } = {}) {
     setLoadingInspections(true)
     try {
       const filterUrl = inspectionFilterUrl.trim() || undefined
@@ -317,43 +339,83 @@ export function GscSection({
             path: { name: projectName },
             query: inspectionsQuery as never,
           }),
-          staleTime: GSC_STALE_MS,
+          staleTime: options.force ? 0 : GSC_STALE_MS,
         }),
         queryClient.fetchQuery({
           ...getApiV1ProjectsByNameGoogleGscDeindexedOptions({ client: heyClient, path: { name: projectName } }),
-          staleTime: GSC_STALE_MS,
+          staleTime: options.force ? 0 : GSC_STALE_MS,
         }),
       ])
       setInspections(history)
       setDeindexed(deindexedRows)
+      if (options.notify) {
+        addToast({
+          title: 'Inspection history refreshed',
+          detail: `${history.length} recent inspection${history.length === 1 ? '' : 's'} loaded${deindexedRows.length > 0 ? `, ${deindexedRows.length} deindexed URL${deindexedRows.length === 1 ? '' : 's'} flagged` : ''}.`,
+          tone: 'positive',
+          dedupeKey: `gsc:inspection-history:${projectName}`,
+          dedupeMode: 'replace',
+        })
+      }
     } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load GSC inspection history'
       setInspections([])
       setDeindexed([])
-      setError(err instanceof Error ? err.message : 'Failed to load GSC inspection history')
+      setError(message)
+      if (options.notify) {
+        addToast({
+          title: 'Inspection history refresh failed',
+          detail: message,
+          tone: 'negative',
+          dedupeKey: `gsc:inspection-history:${projectName}`,
+          dedupeMode: 'replace',
+        })
+      }
     } finally {
       setLoadingInspections(false)
     }
   }
 
-  async function loadCoverage() {
+  async function loadCoverage(options: { force?: boolean; notify?: boolean } = {}) {
     setLoadingCoverage(true)
     try {
       const [data, history] = await Promise.all([
         queryClient.fetchQuery({
           ...getApiV1ProjectsByNameGoogleGscCoverageOptions({ client: heyClient, path: { name: projectName } }),
-          staleTime: GSC_STALE_MS,
+          staleTime: options.force ? 0 : GSC_STALE_MS,
         }),
         queryClient.fetchQuery({
           ...getApiV1ProjectsByNameGoogleGscCoverageHistoryOptions({ client: heyClient, path: { name: projectName } }),
-          staleTime: GSC_STALE_MS,
+          staleTime: options.force ? 0 : GSC_STALE_MS,
         }).catch(() => []),
       ])
       setCoverage(data)
       setCoverageHistory(history)
+      if (options.notify) {
+        addToast({
+          title: 'GSC coverage refreshed',
+          detail: data.summary.total > 0
+            ? `${data.summary.indexed}/${data.summary.total} URLs indexed. Use Inspect sitemap to re-read new sitemap URLs.`
+            : 'No coverage rows yet. Inspect the sitemap to populate this view.',
+          tone: data.summary.total > 0 ? 'positive' : 'caution',
+          dedupeKey: `gsc:coverage:${projectName}`,
+          dedupeMode: 'replace',
+        })
+      }
     } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load coverage data'
       setCoverage(null)
       setCoverageHistory([])
-      setError(err instanceof Error ? err.message : 'Failed to load coverage data')
+      setError(message)
+      if (options.notify) {
+        addToast({
+          title: 'GSC coverage refresh failed',
+          detail: message,
+          tone: 'negative',
+          dedupeKey: `gsc:coverage:${projectName}`,
+          dedupeMode: 'replace',
+        })
+      }
     } finally {
       setLoadingCoverage(false)
     }
@@ -375,7 +437,15 @@ export function GscSection({
         dedupeMode: 'replace',
       })
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to request indexing')
+      const message = err instanceof Error ? err.message : 'Failed to request indexing'
+      setError(message)
+      addToast({
+        title: 'Indexing request failed',
+        detail: message,
+        tone: 'negative',
+        dedupeKey: `gsc:indexing:${projectName}`,
+        dedupeMode: 'replace',
+      })
     } finally {
       setRequestingIndexing(false)
     }
@@ -397,7 +467,15 @@ export function GscSection({
         dedupeMode: 'replace',
       })
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to request indexing')
+      const message = err instanceof Error ? err.message : 'Failed to request indexing'
+      setError(message)
+      addToast({
+        title: 'Indexing request failed',
+        detail: message,
+        tone: 'negative',
+        dedupeKey: `gsc:indexing-all:${projectName}`,
+        dedupeMode: 'replace',
+      })
     } finally {
       setRequestingIndexing(false)
     }
@@ -456,9 +534,32 @@ export function GscSection({
       setDiscoveredSitemaps(result.sitemaps)
       if (result.sitemaps.length === 0) {
         setNotice('No sitemaps found in this GSC property. Submit a sitemap in Google Search Console first.')
+        addToast({
+          title: 'No GSC sitemaps found',
+          detail: 'Submit a sitemap in Google Search Console, then browse again.',
+          tone: 'caution',
+          dedupeKey: `gsc:sitemaps:${projectName}`,
+          dedupeMode: 'replace',
+        })
+      } else {
+        addToast({
+          title: 'GSC sitemaps loaded',
+          detail: `${result.sitemaps.length} sitemap${result.sitemaps.length === 1 ? '' : 's'} returned from Search Console.`,
+          tone: 'positive',
+          dedupeKey: `gsc:sitemaps:${projectName}`,
+          dedupeMode: 'replace',
+        })
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to list sitemaps')
+      const message = err instanceof Error ? err.message : 'Failed to list sitemaps'
+      setError(message)
+      addToast({
+        title: 'Could not load GSC sitemaps',
+        detail: message,
+        tone: 'negative',
+        dedupeKey: `gsc:sitemaps:${projectName}`,
+        dedupeMode: 'replace',
+      })
     } finally {
       setListingSitemaps(false)
     }
@@ -814,7 +915,8 @@ export function GscSection({
                         {requestingIndexing ? 'Requesting\u2026' : `Request indexing (${coverage.notIndexed.length})`}
                       </Button>
                     )}
-                    <Button type="button" variant="outline" size="sm" disabled={loadingCoverage} onClick={() => void loadCoverage()}>
+                    <Button type="button" variant="outline" size="sm" disabled={loadingCoverage} onClick={() => void loadCoverage({ force: true, notify: true })}>
+                      <RefreshCw className={`h-3.5 w-3.5 ${loadingCoverage ? 'animate-spin' : ''}`} aria-hidden="true" />
                       {loadingCoverage ? 'Loading\u2026' : 'Refresh coverage'}
                     </Button>
                   </div>
@@ -1180,6 +1282,7 @@ export function GscSection({
                       ))}
                     </div>
                     <Button type="button" variant="outline" size="sm" disabled={loadingPerformance} onClick={() => { setPerformanceOffset(0); void loadPerformanceRows(0); void loadPerformanceDaily() }}>
+                      <RefreshCw className={`h-3.5 w-3.5 ${loadingPerformance ? 'animate-spin' : ''}`} aria-hidden="true" />
                       {loadingPerformance ? 'Loading\u2026' : 'Apply filters'}
                     </Button>
                   </div>
@@ -1496,7 +1599,8 @@ export function GscSection({
                     <p className="eyebrow eyebrow-soft">History</p>
                     <h3>Inspection log</h3>
                   </div>
-                  <Button type="button" variant="outline" size="sm" disabled={loadingInspections} onClick={() => void loadInspectionHistory()}>
+                  <Button type="button" variant="outline" size="sm" disabled={loadingInspections} onClick={() => void loadInspectionHistory({ force: true, notify: true })}>
+                    <RefreshCw className={`h-3.5 w-3.5 ${loadingInspections ? 'animate-spin' : ''}`} aria-hidden="true" />
                     {loadingInspections ? 'Loading\u2026' : 'Refresh history'}
                   </Button>
                 </div>
@@ -1508,7 +1612,7 @@ export function GscSection({
                     value={inspectionFilterUrl}
                     onChange={(e) => setInspectionFilterUrl(e.target.value)}
                   />
-                  <Button type="button" size="sm" variant="outline" disabled={loadingInspections} onClick={() => void loadInspectionHistory()}>
+                  <Button type="button" size="sm" variant="outline" disabled={loadingInspections} onClick={() => void loadInspectionHistory({ force: true, notify: true })}>
                     Apply filter
                   </Button>
                 </div>
@@ -1632,7 +1736,8 @@ export function GscSection({
                           )}
                         </select>
                         <div className="flex flex-wrap items-center gap-2">
-                          <Button type="button" size="sm" variant="outline" disabled={propertiesLoading} onClick={() => void loadProperties(gscConn)}>
+                          <Button type="button" size="sm" variant="outline" disabled={propertiesLoading} onClick={() => void loadProperties(gscConn, { force: true, notify: true })}>
+                            <RefreshCw className={`h-3.5 w-3.5 ${propertiesLoading ? 'animate-spin' : ''}`} aria-hidden="true" />
                             {propertiesLoading ? 'Refreshing\u2026' : 'Refresh properties'}
                           </Button>
                           {!isEmbed() && (

--- a/apps/web/src/components/project/TechnicalAeoSection.tsx
+++ b/apps/web/src/components/project/TechnicalAeoSection.tsx
@@ -9,9 +9,6 @@ import {
   getApiV1ProjectsByNameTechnicalAeoOptions,
   getApiV1ProjectsByNameTechnicalAeoPagesOptions,
   getApiV1ProjectsByNameTechnicalAeoTrendOptions,
-  getApiV1ProjectsByNameTechnicalAeoQueryKey,
-  getApiV1ProjectsByNameTechnicalAeoPagesQueryKey,
-  getApiV1ProjectsByNameTechnicalAeoTrendQueryKey,
   getApiV1RunsQueryKey,
 } from '@ainyc/canonry-api-client/react-query'
 import {
@@ -61,6 +58,7 @@ export function TechnicalAeoSection({ projectName }: { projectName: string }) {
   const queryClient = useQueryClient()
   const [errorsOnly, setErrorsOnly] = useState(false)
   const [expandedFactor, setExpandedFactor] = useState<string | null>(null)
+  const [refreshing, setRefreshing] = useState(false)
 
   const scoreQuery = useQuery(getApiV1ProjectsByNameTechnicalAeoOptions({ client: heyClient, path: { name: projectName } }))
   const trendQuery = useQuery(getApiV1ProjectsByNameTechnicalAeoTrendOptions({
@@ -95,10 +93,35 @@ export function TechnicalAeoSection({ projectName }: { projectName: string }) {
     },
   })
 
-  const refreshAll = () => {
-    void queryClient.invalidateQueries({ queryKey: getApiV1ProjectsByNameTechnicalAeoQueryKey({ client: heyClient, path: { name: projectName } }) })
-    void queryClient.invalidateQueries({ queryKey: getApiV1ProjectsByNameTechnicalAeoTrendQueryKey({ client: heyClient, path: { name: projectName }, query: { limit: 30 } }) })
-    void queryClient.invalidateQueries({ queryKey: getApiV1ProjectsByNameTechnicalAeoPagesQueryKey({ client: heyClient, path: { name: projectName }, query: { limit: PAGES_FETCH_LIMIT, sort: 'score-asc' } }) })
+  const refreshAll = async () => {
+    setRefreshing(true)
+    try {
+      const [scoreResult] = await Promise.all([
+        scoreQuery.refetch(),
+        trendQuery.refetch(),
+        pagesQuery.refetch(),
+      ])
+      if (scoreResult.error) throw scoreResult.error
+      addToast({
+        title: 'Technical AEO refreshed',
+        detail: scoreResult.data?.hasData
+          ? `Latest score is ${scoreResult.data.aggregateScore}/100 from ${scoreResult.data.pagesAudited} audited page${scoreResult.data.pagesAudited === 1 ? '' : 's'}.`
+          : 'No audit data yet. Run an audit to crawl the sitemap.',
+        tone: scoreResult.data?.hasData ? 'positive' : 'caution',
+        dedupeKey: `technical-aeo:refresh:${projectName}`,
+        dedupeMode: 'replace',
+      })
+    } catch (error) {
+      addToast({
+        title: 'Technical AEO refresh failed',
+        detail: error instanceof Error ? error.message : 'Could not reload technical audit data.',
+        tone: 'negative',
+        dedupeKey: `technical-aeo:refresh:${projectName}`,
+        dedupeMode: 'replace',
+      })
+    } finally {
+      setRefreshing(false)
+    }
   }
 
   const score = scoreQuery.data
@@ -190,9 +213,9 @@ export function TechnicalAeoSection({ projectName }: { projectName: string }) {
           ) : null}
         </div>
         <div className="flex items-center gap-2">
-          <Button type="button" variant="outline" size="sm" onClick={refreshAll}>
-            <RefreshCw className="mr-1.5 h-4 w-4" aria-hidden="true" />
-            Refresh
+          <Button type="button" variant="outline" size="sm" onClick={() => void refreshAll()} disabled={refreshing}>
+            <RefreshCw className={`h-3.5 w-3.5 ${refreshing ? 'animate-spin' : ''}`} aria-hidden="true" />
+            {refreshing ? 'Refreshing\u2026' : 'Refresh'}
           </Button>
           {!isEmbed() && (
             <Button type="button" size="sm" onClick={() => runMutation.mutate()} disabled={runMutation.isPending}>

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { ChevronDown, ChevronRight, Download, Trash2 } from 'lucide-react'
+import { ChevronDown, ChevronRight, Download, RefreshCw, Trash2 } from 'lucide-react'
 import { useParams, useNavigate } from '@tanstack/react-router'
 import { Link } from '@tanstack/react-router'
 import { useQueryClient } from '@tanstack/react-query'
@@ -806,6 +806,13 @@ function SearchConsoleSection({
 
     setRefreshState('syncing')
     setError(null)
+    addToast({
+      title: 'Refreshing search coverage',
+      detail: 'Queueing Google and Bing checks, then reloading the workspaces.',
+      tone: 'neutral',
+      dedupeKey: `search-console-refresh:${projectName}`,
+      dedupeMode: 'replace',
+    })
 
     const failures: string[] = []
 
@@ -877,11 +884,35 @@ function SearchConsoleSection({
       setWorkspaceRefreshNonce((current) => current + 1)
 
       if (failures.length > 0) {
-        setError(`Partial refresh: ${failures.join('; ')}`)
+        const message = `Partial refresh: ${failures.join('; ')}`
+        setError(message)
+        addToast({
+          title: 'Search coverage partially refreshed',
+          detail: message,
+          tone: 'caution',
+          dedupeKey: `search-console-refresh:${projectName}`,
+          dedupeMode: 'replace',
+        })
+      } else {
+        addToast({
+          title: 'Search coverage refreshed',
+          detail: 'Google and Bing workspaces are reloaded with the latest stored coverage.',
+          tone: 'positive',
+          dedupeKey: `search-console-refresh:${projectName}`,
+          dedupeMode: 'replace',
+        })
       }
     } catch (err) {
       if (!signal.aborted) {
-        setError(err instanceof Error ? err.message : 'Refresh failed')
+        const message = err instanceof Error ? err.message : 'Refresh failed'
+        setError(message)
+        addToast({
+          title: 'Search coverage refresh failed',
+          detail: message,
+          tone: 'negative',
+          dedupeKey: `search-console-refresh:${projectName}`,
+          dedupeMode: 'replace',
+        })
       }
     } finally {
       if (!signal.aborted) {
@@ -945,6 +976,7 @@ function SearchConsoleSection({
           </div>
           {!isEmbed() && (
             <Button type="button" variant="outline" size="sm" disabled={loading || refreshState !== 'idle'} onClick={() => void handleRefresh()}>
+              <RefreshCw className={`h-3.5 w-3.5 ${refreshState !== 'idle' ? 'animate-spin' : ''}`} aria-hidden="true" />
               {loading ? 'Loading…' : refreshState === 'syncing' ? 'Refreshing Google & Bing…' : refreshState === 'reloading' ? 'Reloading workspaces…' : 'Refresh all'}
             </Button>
           )}


### PR DESCRIPTION
## Summary
- Add toast feedback and busy icons to project Search coverage refresh, Discovery refresh, and Technical AEO refresh actions.
- Force manual GSC coverage, inspection history, and property reloads to bypass stale cached reads and report success or failure.
- Add visible GSC feedback for sitemap browsing, indexing requests, and filter/application actions so button clicks do not feel silent.

## Validation
- `git diff --check`
- Commit hook: `pnpm -r run lint` (passes with existing warnings)
- Earlier workspace validation: `pnpm --filter @ainyc/canonry-web run typecheck`, `pnpm --filter @ainyc/canonry-web run lint`, `pnpm --filter @ainyc/canonry-web run build`
