### PR TITLE
Fix local Google OAuth callback setup

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -232,6 +232,29 @@ function getPublicBase(): string {
   return ''
 }
 
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase().replace(/^\[|\]$/g, '')
+  if (normalized === 'localhost' || normalized === '::1') return true
+  return /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(normalized)
+}
+
+export function resolveLocalGooglePublicUrl(location: Pick<Location, 'protocol' | 'hostname' | 'port'>, basePath?: string): string | undefined {
+  if (location.protocol !== 'http:' && location.protocol !== 'https:') return undefined
+  if (!isLoopbackHostname(location.hostname)) return undefined
+  const port = location.port ? `:${location.port}` : ''
+  const path = basePath ? basePath.replace(/\/$/, '') : ''
+  return `${location.protocol}//localhost${port}${path}`
+}
+
+export function buildGoogleRedirectUri(publicUrl: string): string {
+  return `${publicUrl.replace(/\/$/, '')}/api/v1/google/callback`
+}
+
+function getGoogleConnectPublicUrl(): string | undefined {
+  if (typeof window === 'undefined') return undefined
+  return resolveLocalGooglePublicUrl(window.location, getPublicBase())
+}
+
 function publicPath(path: string): string {
   return `${getPublicBase()}${path}`
 }
@@ -969,12 +992,13 @@ export function fetchGoogleConnections(project: string): Promise<ApiGoogleConnec
   )
 }
 
-export function googleConnect(project: string, type: 'gsc' | 'ga4'): Promise<{ authUrl: string }> {
-  return invokeWeb<{ authUrl: string }>(() =>
+export function googleConnect(project: string, type: 'gsc' | 'ga4'): Promise<{ authUrl: string; redirectUri?: string }> {
+  const publicUrl = getGoogleConnectPublicUrl()
+  return invokeWeb<{ authUrl: string; redirectUri?: string }>(() =>
     postApiV1ProjectsByNameGoogleConnect({
       client: heyClient,
       path: { name: project },
-      body: { type } as never,
+      body: { type, ...(publicUrl ? { publicUrl } : {}) } as never,
     }),
   )
 }

--- a/apps/web/src/components/settings/GoogleOAuthConfigForm.tsx
+++ b/apps/web/src/components/settings/GoogleOAuthConfigForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 
 import { Button } from '../ui/button.js'
-import { updateGoogleAuthConfig } from '../../api.js'
+import { buildGoogleRedirectUri, resolveLocalGooglePublicUrl, updateGoogleAuthConfig } from '../../api.js'
 import { addToast } from '../../lib/toast-store.js'
 import { asyncHandler } from '../../lib/async-handler.js'
 
@@ -13,6 +13,10 @@ export function GoogleOAuthConfigForm({ onSaved }: { onSaved: () => void }) {
   const [success, setSuccess] = useState(false)
 
   const canSave = clientId.trim().length > 0 && clientSecret.trim().length > 0
+  const localPublicUrl = typeof window === 'undefined'
+    ? undefined
+    : resolveLocalGooglePublicUrl(window.location, window.__CANONRY_CONFIG__?.basePath)
+  const redirectUri = localPublicUrl ? buildGoogleRedirectUri(localPublicUrl) : undefined
 
   async function handleSave() {
     if (!canSave) return
@@ -79,6 +83,12 @@ export function GoogleOAuthConfigForm({ onSaved }: { onSaved: () => void }) {
       <p className="text-[11px] text-muted">
         These credentials are stored in <code>~/.canonry/config.yaml</code>. Project-level Search Console connections are created separately per canonical domain.
       </p>
+      {redirectUri && (
+        <div className="rounded border border-default bg-surface px-3 py-2">
+          <p className="text-[11px] text-muted">Authorized redirect URI</p>
+          <code className="mt-1 block break-all text-xs text-strong">{redirectUri}</code>
+        </div>
+      )}
       {error && <p className="text-xs text-negative-400">{error}</p>}
       {success && <p className="text-xs text-positive-400">Google OAuth credentials updated.</p>}
       <Button type="button" size="sm" disabled={!canSave || saving} onClick={asyncHandler(handleSave)}>

--- a/apps/web/test/google-connect-public-url.test.ts
+++ b/apps/web/test/google-connect-public-url.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, onTestFinished, test } from 'vitest'
+
+import { googleConnect, resolveLocalGooglePublicUrl } from '../src/api.js'
+
+interface Observed {
+  method: string | undefined
+  body: BodyInit | null | undefined
+}
+
+function mockFetch(handler: (req: Observed) => Response | Promise<Response>) {
+  const realFetch = globalThis.fetch
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    let method: string | undefined
+    let body: BodyInit | null | undefined
+    if (input instanceof Request) {
+      method = input.method
+      body = init?.body ?? (await input.clone().text().then((text) => (text.length ? text : null)).catch(() => null))
+    } else {
+      method = init?.method
+      body = init?.body
+    }
+    return handler({ method, body })
+  }) as typeof fetch
+  return () => {
+    globalThis.fetch = realFetch
+  }
+}
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('Google OAuth public URL', () => {
+  test('normalizes loopback browser hosts to localhost', () => {
+    expect(resolveLocalGooglePublicUrl({ protocol: 'http:', hostname: '127.0.0.1', port: '4100' }, '/canonry/'))
+      .toBe('http://localhost:4100/canonry')
+    expect(resolveLocalGooglePublicUrl({ protocol: 'http:', hostname: '[::1]', port: '4100' }))
+      .toBe('http://localhost:4100')
+    expect(resolveLocalGooglePublicUrl({ protocol: 'https:', hostname: 'example.com', port: '' }))
+      .toBeUndefined()
+  })
+
+  test('googleConnect sends a local publicUrl for dashboard-initiated OAuth', async () => {
+    const win = window as typeof window & { __CANONRY_CONFIG__?: { basePath?: string } }
+    const previousConfig = win.__CANONRY_CONFIG__
+    win.__CANONRY_CONFIG__ = { basePath: '/canonry/' }
+    onTestFinished(() => {
+      win.__CANONRY_CONFIG__ = previousConfig
+    })
+
+    let observed: Observed | undefined
+    const restore = mockFetch((req) => {
+      observed = req
+      return jsonResponse({
+        authUrl: 'https://accounts.google.com/o/oauth2/v2/auth?client_id=test',
+        redirectUri: 'http://localhost:4100/canonry/api/v1/google/callback',
+      })
+    })
+    onTestFinished(restore)
+
+    const expectedPublicUrl = resolveLocalGooglePublicUrl(window.location, '/canonry/')
+    expect(expectedPublicUrl).toBeTruthy()
+
+    await googleConnect('elkemi', 'gsc')
+
+    expect(observed?.method).toBe('POST')
+    expect(JSON.parse(String(observed?.body))).toEqual({
+      type: 'gsc',
+      publicUrl: expectedPublicUrl,
+    })
+  })
+})

--- a/apps/web/test/google-oauth-config-form.test.tsx
+++ b/apps/web/test/google-oauth-config-form.test.tsx
@@ -1,0 +1,24 @@
+import { afterEach, expect, onTestFinished, test } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { buildGoogleRedirectUri, resolveLocalGooglePublicUrl } from '../src/api.js'
+import { GoogleOAuthConfigForm } from '../src/components/settings/GoogleOAuthConfigForm.js'
+
+afterEach(() => {
+  cleanup()
+})
+
+test('Google OAuth settings shows the local redirect URI to register', () => {
+  const previousConfig = window.__CANONRY_CONFIG__
+  window.__CANONRY_CONFIG__ = { basePath: '/canonry/' }
+  onTestFinished(() => {
+    window.__CANONRY_CONFIG__ = previousConfig
+  })
+
+  render(<GoogleOAuthConfigForm onSaved={() => {}} />)
+
+  const publicUrl = resolveLocalGooglePublicUrl(window.location, '/canonry/')
+  if (!publicUrl) throw new Error('expected jsdom to run on a loopback URL')
+  expect(screen.getByText('Authorized redirect URI')).toBeTruthy()
+  expect(screen.getByText(buildGoogleRedirectUri(publicUrl))).toBeTruthy()
+})

--- a/docs/google-search-console-setup.md
+++ b/docs/google-search-console-setup.md
@@ -52,7 +52,7 @@ https://console.developers.google.com/apis/api/indexing.googleapis.com/overview?
 
 Canonry has two callback paths depending on your setup:
 
-**Option A — Shared callback (recommended).** If you configure a `publicUrl` in your canonry server config or pass `--public-url` when connecting, canonry uses a single shared callback for all projects:
+**Option A — Shared callback (recommended).** Local `canonry serve` installs automatically use the local shared callback from `apiUrl` / the serve port. If you configure a `publicUrl` in your canonry server config or pass `--public-url` when connecting, canonry uses that same shared-callback shape for all projects:
 
 ```
 http://localhost:4100/api/v1/google/callback
@@ -60,7 +60,7 @@ http://localhost:4100/api/v1/google/callback
 
 Register this one URI and you're done. For a custom host, replace `localhost:4100` with your server address.
 
-**Option B — Per-project callbacks (auto-detect fallback).** If no `publicUrl` is configured, canonry generates a per-project redirect URI based on the request headers:
+**Option B — Per-project callbacks (auto-detect fallback).** If canonry cannot resolve a shared callback from `publicUrl` or a local loopback `apiUrl`, it generates a per-project redirect URI based on the request headers:
 
 ```
 http://localhost:4100/api/v1/projects/<project-name>/google/callback

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -401,6 +401,33 @@ export function isLoopbackBindHost(host: string | undefined): boolean {
   return false;
 }
 
+export function resolveGooglePublicUrl(
+  config: Pick<CanonryConfig, "apiUrl" | "publicUrl" | "port">,
+  basePath?: string,
+): string | undefined {
+  const configured = config.publicUrl?.trim();
+  if (configured) return configured;
+
+  try {
+    const url = new URL(config.apiUrl);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return undefined;
+    if (!isLoopbackBindHost(url.hostname)) return undefined;
+
+    const port = config.port && config.port > 0 ? String(config.port) : url.port;
+    if (port === "0") return undefined;
+
+    const pathFromApiUrl =
+      url.pathname && url.pathname !== "/" ? url.pathname.replace(/\/$/, "") : "";
+    const pathFromBasePath = basePath ? basePath.replace(/\/$/, "") : "";
+    const pathSuffix = pathFromApiUrl || pathFromBasePath;
+    const portSuffix = port ? `:${port}` : "";
+
+    return `${url.protocol}//localhost${portSuffix}${pathSuffix}`;
+  } catch {
+    return undefined;
+  }
+}
+
 export async function createServer(opts: {
   config: CanonryConfig;
   db: DatabaseClient;
@@ -1153,6 +1180,7 @@ export async function createServer(opts: {
   // If the proxy does strip the prefix, set CANONRY_BASE_PATH to empty/unset and
   // let the proxy handle path rewriting instead.
   const apiPrefix = basePath ? `${basePath}api/v1` : "/api/v1";
+  const googlePublicUrl = resolveGooglePublicUrl(opts.config, basePath);
   // Ensure the configured API key exists in the DB — handles upgrades from
   // older versions that stored the key in config.yaml but never inserted it
   // into the api_keys table (or used a different DB file).
@@ -1514,7 +1542,7 @@ export async function createServer(opts: {
       buildAgentProvidersResponse(opts.config).providers,
     googleConnectionStore,
     googleStateSecret,
-    publicUrl: opts.config.publicUrl,
+    publicUrl: googlePublicUrl,
     onGscSyncRequested: (
       runId: string,
       projectId: string,

--- a/packages/canonry/test/google-public-url.test.ts
+++ b/packages/canonry/test/google-public-url.test.ts
@@ -1,0 +1,110 @@
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { apiKeys, createClient, migrate, projects } from '@ainyc/canonry-db'
+
+import { createServer, resolveGooglePublicUrl } from '../src/server.js'
+
+describe('resolveGooglePublicUrl', () => {
+  let tmpDir: string | undefined
+
+  afterEach(() => {
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true })
+    tmpDir = undefined
+  })
+
+  it('keeps an explicit publicUrl unchanged', () => {
+    expect(resolveGooglePublicUrl({
+      apiUrl: 'http://localhost:4100',
+      publicUrl: 'https://canonry.example.com/app',
+    })).toBe('https://canonry.example.com/app')
+  })
+
+  it('infers a localhost publicUrl from loopback apiUrl and serve port', () => {
+    expect(resolveGooglePublicUrl({
+      apiUrl: 'http://127.0.0.1:4100',
+      port: 5555,
+    })).toBe('http://localhost:5555')
+  })
+
+  it('includes a configured basePath when the apiUrl has no path', () => {
+    expect(resolveGooglePublicUrl({
+      apiUrl: 'http://localhost:4100',
+    }, '/canonry/')).toBe('http://localhost:4100/canonry')
+  })
+
+  it('includes the apiUrl path when present', () => {
+    expect(resolveGooglePublicUrl({
+      apiUrl: 'http://localhost:4100/canonry',
+    }, '/ignored/')).toBe('http://localhost:4100/canonry')
+  })
+
+  it('does not infer a publicUrl for remote or unusable local URLs', () => {
+    expect(resolveGooglePublicUrl({ apiUrl: 'https://api.example.com' })).toBeUndefined()
+    expect(resolveGooglePublicUrl({ apiUrl: 'http://localhost:0' })).toBeUndefined()
+  })
+
+  it('hands the inferred localhost publicUrl to the Google connect route', async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-google-public-url-'))
+    const dbPath = path.join(tmpDir, 'test.db')
+    const db = createClient(dbPath)
+    migrate(db)
+
+    const apiKey = `cnry_${crypto.randomBytes(16).toString('hex')}`
+    db.insert(apiKeys).values({
+      id: 'key_1',
+      name: 'test',
+      keyHash: crypto.createHash('sha256').update(apiKey).digest('hex'),
+      keyPrefix: apiKey.slice(0, 12),
+      scopes: ['*'],
+      createdAt: new Date().toISOString(),
+    }).run()
+
+    const now = new Date().toISOString()
+    db.insert(projects).values({
+      id: 'p1',
+      name: 'testproj',
+      displayName: 'Test Project',
+      canonicalDomain: 'example.com',
+      country: 'US',
+      language: 'en',
+      createdAt: now,
+      updatedAt: now,
+    }).run()
+
+    const app = await createServer({
+      config: {
+        apiUrl: 'http://127.0.0.1:4100',
+        port: 5555,
+        database: dbPath,
+        apiKey,
+        providers: {},
+        google: {
+          clientId: 'test-client-id',
+          clientSecret: 'test-client-secret',
+          connections: [],
+        },
+      },
+      db,
+      logger: false,
+    })
+
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/v1/projects/testproj/google/connect',
+        headers: { authorization: `Bearer ${apiKey}` },
+        payload: { type: 'gsc' },
+      })
+
+      expect(res.statusCode).toBe(200)
+      const body = res.json() as { authUrl: string; redirectUri: string }
+      expect(body.redirectUri).toBe('http://localhost:5555/api/v1/google/callback')
+      expect(body.authUrl).toContain(encodeURIComponent('http://localhost:5555/api/v1/google/callback'))
+    } finally {
+      await app.close()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Infer a stable localhost Google OAuth public URL for local serve/API flows instead of falling back to per-project auto-detected callbacks.
- Pass that local public URL from the dashboard connect request and show the exact authorized redirect URI in Settings.
- Update the Search Console setup docs and add frontend/server coverage for the local callback behavior.

## Validation
- pnpm --filter @canonry/canonry exec vitest run test/google-public-url.test.ts --config ../../vitest.package.config.ts
- pnpm --filter @ainyc/canonry-web exec vitest run test/google-connect-public-url.test.ts test/google-oauth-config-form.test.tsx --config vitest.config.ts
- pnpm --filter @canonry/canonry run typecheck
- pnpm --filter @ainyc/canonry-web run typecheck
- git diff --check
- commit hook: pnpm -r run lint (warnings only)