### PR TITLE
Harden embed auth and render token propagation

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -294,9 +294,14 @@ export function RunNotificationObserver() {
 export function RootLayout() {
   // ── Context-based initial data (tests inject via DashboardProvider) ──
   const contextDashboard = useInitialDashboard()
+  // Read-only embed mode (#716). Resolved once (the injected config is fixed for
+  // the page lifetime). In embed mode the root shell is chromeless, so it should
+  // not fetch instance settings just to build nav/settings state it will not
+  // render. The server-side embed tab policy intentionally blocks /settings.
+  const embed = useMemo(() => getEmbedConfig(), [])
 
   // ── Data fetching via TanStack Query ──
-  const { dashboard, isLoading, refetch: refreshData } = useDashboard()
+  const { dashboard, isLoading, refetch: refreshData } = useDashboard(undefined, { includeSettings: !embed })
   const enableLiveStatus = !contextDashboard
   const healthQuery = useHealth(enableLiveStatus, contextDashboard?.health)
   const healthSnapshot = healthQuery.data ?? contextDashboard?.health ?? defaultHealthSnapshot
@@ -444,14 +449,12 @@ export function RootLayout() {
     return 'Not found'
   })()
 
-  // Read-only embed mode (#716). Resolved once (the injected config is fixed for
-  // the page lifetime). When set, render chromeless: only the requested view,
+  // When set, render chromeless: only the requested view,
   // with NO sidebar / topbar / mobile nav / footer / drawers / run observer /
   // toaster / AeroBar. The view allowlist is a presentational gate — a
   // non-allowlisted route renders an unavailable state instead of the page, so
   // surfaces like /settings are never reachable inside the iframe. Placed after
   // every hook above so the Rules of Hooks hold on both render paths.
-  const embed = useMemo(() => getEmbedConfig(), [])
   // When the embed theme names a client font, inject its Google-Fonts stylesheet
   // so `--font-sans` resolves to a loaded family. No-op off-embed / when unset.
   useEffect(() => {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -177,6 +177,49 @@ declare global {
   }
 }
 
+function getEmbedRenderToken(): string | undefined {
+  if (typeof window === 'undefined') return undefined
+  const token = window.__CANONRY_CONFIG__?.embed?.renderToken
+  return typeof token === 'string' && token.length > 0 ? token : undefined
+}
+
+function appendEmbedRenderToken(url: string): string {
+  const token = getEmbedRenderToken()
+  if (!token) return url
+
+  let parsed: URL
+  try {
+    const base = typeof window !== 'undefined' && window.location ? window.location.href : 'http://localhost/'
+    parsed = new URL(url, base)
+  } catch {
+    return url
+  }
+
+  if (!parsed.pathname.includes('/api/v1')) return url
+  parsed.searchParams.set('token', token)
+
+  return /^[a-z][a-z\d+.-]*:/i.test(url)
+    ? parsed.toString()
+    : `${parsed.pathname}${parsed.search}${parsed.hash}`
+}
+
+function requestWithUrl(request: Request, url: string): Request {
+  return new Request(url, {
+    method: request.method,
+    headers: request.headers,
+    body: request.body,
+    cache: request.cache,
+    credentials: request.credentials,
+    integrity: request.integrity,
+    keepalive: request.keepalive,
+    mode: request.mode,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    signal: request.signal,
+  })
+}
+
 /**
  * The read-only embed config (#716) when the server has enabled embed mode.
  * Returns `null` outside the browser or when embed is off, so callers can treat
@@ -332,6 +375,11 @@ heyClient.interceptors.response.use((res, req) => {
   return res
 })
 
+heyClient.interceptors.request.use((req) => {
+  const url = appendEmbedRenderToken(req.url)
+  return url === req.url ? req : requestWithUrl(req, url)
+})
+
 /**
  * Result shape returned by every generated SDK operation. `data` is typed
  * `unknown` here — see `packages/canonry/src/client.ts` for the rationale
@@ -395,7 +443,7 @@ async function invokeWeb<T>(call: () => Promise<SdkResult>): Promise<T> {
 async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
   const key = getApiKey()
   const hasBody = options?.body != null
-  const res = await fetch(`${API_BASE}${path}`, {
+  const res = await fetch(appendEmbedRenderToken(`${API_BASE}${path}`), {
     ...options,
     credentials: options?.credentials ?? 'same-origin',
     headers: {
@@ -1456,10 +1504,13 @@ export async function downloadReportHtml(project: string, audience: ReportAudien
   const key = getApiKey()
   const params = new URLSearchParams({ audience })
   if (period !== undefined) params.set('period', String(period))
-  const res = await fetch(`${API_BASE}/projects/${encodeURIComponent(project)}/report.html?${params.toString()}`, {
-    credentials: 'same-origin',
-    headers: key ? { Authorization: `Bearer ${key}` } : {},
-  })
+  const res = await fetch(
+    appendEmbedRenderToken(`${API_BASE}/projects/${encodeURIComponent(project)}/report.html?${params.toString()}`),
+    {
+      credentials: 'same-origin',
+      headers: key ? { Authorization: `Bearer ${key}` } : {},
+    },
+  )
   if (!res.ok) {
     throw new ApiError(`Failed to download report: ${res.status}`, res.status)
   }

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -183,19 +183,25 @@ function getEmbedRenderToken(): string | undefined {
   return typeof token === 'string' && token.length > 0 ? token : undefined
 }
 
-function appendEmbedRenderToken(url: string): string {
+export function appendEmbedRenderToken(url: string): string {
   const token = getEmbedRenderToken()
   if (!token) return url
 
   let parsed: URL
+  const base = typeof window !== 'undefined' && window.location ? window.location.href : 'http://localhost/'
   try {
-    const base = typeof window !== 'undefined' && window.location ? window.location.href : 'http://localhost/'
     parsed = new URL(url, base)
   } catch {
     return url
   }
 
-  if (!parsed.pathname.includes('/api/v1')) return url
+  const currentOrigin = new URL(base).origin
+  if (parsed.origin !== currentOrigin) return url
+
+  const publicBase = getPublicBase().replace(/\/$/, '')
+  const apiPath = `${publicBase}/api/v1`
+  if (parsed.pathname !== apiPath && !parsed.pathname.startsWith(`${apiPath}/`)) return url
+
   parsed.searchParams.set('token', token)
 
   return /^[a-z][a-z\d+.-]*:/i.test(url)
@@ -204,10 +210,9 @@ function appendEmbedRenderToken(url: string): string {
 }
 
 function requestWithUrl(request: Request, url: string): Request {
-  return new Request(url, {
+  const init: RequestInit & { duplex?: 'half' } = {
     method: request.method,
     headers: request.headers,
-    body: request.body,
     cache: request.cache,
     credentials: request.credentials,
     integrity: request.integrity,
@@ -217,7 +222,12 @@ function requestWithUrl(request: Request, url: string): Request {
     referrer: request.referrer,
     referrerPolicy: request.referrerPolicy,
     signal: request.signal,
-  })
+  }
+  if (request.body) {
+    init.body = request.body
+    init.duplex = 'half'
+  }
+  return new Request(url, init)
 }
 
 /**

--- a/apps/web/src/queries/use-dashboard-overview.ts
+++ b/apps/web/src/queries/use-dashboard-overview.ts
@@ -44,9 +44,14 @@ import { useInitialDashboard } from '../contexts/dashboard-context.js'
  * signal. The duplicated client derivation in `buildAttentionItems` is
  * tracked for removal in a follow-up.
  */
-export function useDashboardOverview(initialDashboard?: DashboardVm | null) {
+interface DashboardOverviewOptions {
+  includeSettings?: boolean
+}
+
+export function useDashboardOverview(initialDashboard?: DashboardVm | null, options: DashboardOverviewOptions = {}) {
   const contextDashboard = useInitialDashboard()
   const effectiveInitial = initialDashboard ?? contextDashboard?.dashboard ?? null
+  const includeSettings = options.includeSettings ?? true
 
   const projectsQuery = useQuery({
     ...getApiV1ProjectsOptions({ client: heyClient }),
@@ -69,7 +74,7 @@ export function useDashboardOverview(initialDashboard?: DashboardVm | null) {
 
   const settingsQuery = useQuery({
     ...getApiV1SettingsOptions({ client: heyClient }),
-    enabled: !effectiveInitial,
+    enabled: !effectiveInitial && includeSettings,
   })
 
   const projects = projectsQuery.data ?? []
@@ -143,12 +148,15 @@ export function useDashboardOverview(initialDashboard?: DashboardVm | null) {
   const isLoading = !effectiveInitial && !dashboard && !isError
 
   const refetch = useCallback(async () => {
-    await Promise.all([
+    const queries: Array<Promise<unknown>> = [
       projectsQuery.refetch(),
       runsQuery.refetch(),
-      settingsQuery.refetch(),
-    ])
-  }, [projectsQuery.refetch, runsQuery.refetch, settingsQuery.refetch])
+    ]
+    if (includeSettings) {
+      queries.push(settingsQuery.refetch())
+    }
+    await Promise.all(queries)
+  }, [includeSettings, projectsQuery.refetch, runsQuery.refetch, settingsQuery.refetch])
 
   return {
     dashboard,

--- a/apps/web/test/api-fetch-headers.test.ts
+++ b/apps/web/test/api-fetch-headers.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, onTestFinished, describe } from 'vitest'
 
-import { connectServerTrafficWordpress, installBacklinks, triggerGscSync } from '../src/api.js'
+import { connectServerTrafficWordpress, fetchProjects, installBacklinks, loginWithPassword, triggerGscSync } from '../src/api.js'
 
 /**
  * After the hey-api migration the SDK calls `fetch(new Request(...))` —
@@ -48,6 +48,14 @@ function jsonResponse(body: unknown, status = 200) {
     status,
     headers: { 'content-type': 'application/json' },
   })
+}
+
+function withEmbedRenderToken(token: string): () => void {
+  const previous = window.__CANONRY_CONFIG__
+  window.__CANONRY_CONFIG__ = { embed: { enabled: true, renderToken: token } }
+  return () => {
+    window.__CANONRY_CONFIG__ = previous
+  }
 }
 
 describe('apiFetch Content-Type header', () => {
@@ -118,5 +126,39 @@ describe('apiFetch Content-Type header', () => {
       applicationPassword: 'xxxx xxxx',
       displayName: 'WP logs',
     })
+  })
+
+  test('appends the embed render token to generated SDK API requests', async () => {
+    let observed: Observed | undefined
+    const restoreFetch = mockFetch((req) => {
+      observed = req
+      return jsonResponse([])
+    })
+    const restoreConfig = withEmbedRenderToken('render-token-123')
+    onTestFinished(() => {
+      restoreFetch()
+      restoreConfig()
+    })
+
+    await fetchProjects()
+
+    expect(observed?.path).toBe('/api/v1/projects?token=render-token-123')
+  })
+
+  test('appends the embed render token to raw apiFetch requests', async () => {
+    let observed: Observed | undefined
+    const restoreFetch = mockFetch((req) => {
+      observed = req
+      return jsonResponse({ authenticated: true })
+    })
+    const restoreConfig = withEmbedRenderToken('render-token-456')
+    onTestFinished(() => {
+      restoreFetch()
+      restoreConfig()
+    })
+
+    await loginWithPassword('pw')
+
+    expect(observed?.path).toBe('/api/v1/session?token=render-token-456')
   })
 })

--- a/apps/web/test/api-fetch-headers.test.ts
+++ b/apps/web/test/api-fetch-headers.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, onTestFinished, describe } from 'vitest'
 
-import { connectServerTrafficWordpress, fetchProjects, installBacklinks, loginWithPassword, triggerGscSync } from '../src/api.js'
+import { appendEmbedRenderToken, connectServerTrafficWordpress, fetchProjects, installBacklinks, loginWithPassword, triggerGscSync } from '../src/api.js'
 
 /**
  * After the hey-api migration the SDK calls `fetch(new Request(...))` —
@@ -143,6 +143,34 @@ describe('apiFetch Content-Type header', () => {
     await fetchProjects()
 
     expect(observed?.path).toBe('/api/v1/projects?token=render-token-123')
+  })
+
+  test('appends the embed render token to generated SDK API requests with bodies', async () => {
+    let observed: Observed | undefined
+    const restoreFetch = mockFetch((req) => {
+      observed = req
+      return jsonResponse({ id: 'run-1', status: 'queued' })
+    })
+    const restoreConfig = withEmbedRenderToken('render-token-body')
+    onTestFinished(() => {
+      restoreFetch()
+      restoreConfig()
+    })
+
+    await triggerGscSync('demo', { days: 7 })
+
+    expect(observed?.path).toBe('/api/v1/projects/demo/google/gsc/sync?token=render-token-body')
+    expect(observed?.method).toBe('POST')
+    expect(observed?.body).toBeTruthy()
+  })
+
+  test('only appends the embed render token to same-origin canonical API paths', () => {
+    const restoreConfig = withEmbedRenderToken('render-token-safe')
+    onTestFinished(restoreConfig)
+
+    expect(appendEmbedRenderToken('/api/v1/projects')).toBe('/api/v1/projects?token=render-token-safe')
+    expect(appendEmbedRenderToken('/nested/api/v1ish/projects')).toBe('/nested/api/v1ish/projects')
+    expect(appendEmbedRenderToken('https://example.test/api/v1/projects')).toBe('https://example.test/api/v1/projects')
   })
 
   test('appends the embed render token to raw apiFetch requests', async () => {

--- a/apps/web/test/app-embed-callgraph.test.tsx
+++ b/apps/web/test/app-embed-callgraph.test.tsx
@@ -1,0 +1,146 @@
+import { afterEach, beforeAll, expect, onTestFinished, test } from 'vitest'
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { RouterProvider } from '@tanstack/react-router'
+
+import { createAppRouter } from '../src/router/router.js'
+import { preloadAllLazyRoutes } from '../src/router/routes.js'
+
+beforeAll(async () => {
+  await preloadAllLazyRoutes()
+})
+
+afterEach(() => {
+  cleanup()
+  delete window.__CANONRY_CONFIG__
+})
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function canonicalPath(input: RequestInfo | URL): string {
+  const raw = input instanceof Request ? input.url : String(input)
+  const parsed = new URL(raw, window.location.origin)
+  parsed.searchParams.delete('token')
+  const search = parsed.searchParams.toString()
+  return `${parsed.pathname}${search ? `?${search}` : ''}`
+}
+
+const project = {
+  id: 'project_citypoint',
+  name: 'citypoint',
+  displayName: 'Citypoint Dental NYC',
+  canonicalDomain: 'citypoint.example',
+  ownedDomains: [],
+  aliases: [],
+  country: 'US',
+  language: 'en',
+  tags: [],
+  labels: {},
+  providers: [],
+  locations: [],
+  defaultLocation: null,
+  autoExtractBacklinks: false,
+  configSource: 'cli',
+  configRevision: 1,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+}
+
+const emptyMetrics = {
+  window: 'all',
+  buckets: [],
+  overall: { citationRate: 0, cited: 0, total: 0, mentionRate: 0, mentionedCount: 0 },
+  byProvider: {},
+  trend: 'stable',
+  mentionTrend: 'stable',
+  queryChanges: [],
+}
+
+const emptyCitationVisibility = {
+  summary: {
+    providersConfigured: 0,
+    providersCiting: 0,
+    providersMentioning: 0,
+    totalQueries: 0,
+    queriesCitedAndMentioned: 0,
+    queriesCitedOnly: 0,
+    queriesMentionedOnly: 0,
+    queriesInvisible: 0,
+    latestRunId: null,
+    latestRunAt: null,
+  },
+  byQuery: [],
+  competitorGaps: [],
+  status: 'no-data',
+  reason: 'no-runs-yet',
+}
+
+test('embed project overview only issues reads covered by the overview server allowlist', async () => {
+  window.__CANONRY_CONFIG__ = {
+    embed: {
+      enabled: true,
+      projectTabs: ['overview'],
+      renderToken: 'render-token-callgraph',
+    },
+  }
+
+  const observed = new Set<string>()
+  const disallowed: string[] = []
+  const restoreFetch = (() => {
+    const realFetch = globalThis.fetch
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const path = canonicalPath(input)
+      observed.add(path)
+
+      if (path === '/health') return jsonResponse({ version: 'test', databaseUrlConfigured: true })
+      if (path === '/api/v1/projects') return jsonResponse([project])
+      if (path === '/api/v1/runs?kind=answer-visibility') return jsonResponse([])
+      if (path === '/api/v1/projects/citypoint') return jsonResponse(project)
+      if (path === '/api/v1/projects/citypoint/runs?kind=answer-visibility') return jsonResponse([])
+      if (path === '/api/v1/projects/citypoint/queries') return jsonResponse([])
+      if (path === '/api/v1/projects/citypoint/competitors') return jsonResponse([])
+      if (path === '/api/v1/projects/citypoint/timeline') return jsonResponse([])
+      if (path === '/api/v1/projects/citypoint/google/gsc/coverage') return jsonResponse(null)
+      if (path === '/api/v1/projects/citypoint/bing/coverage') return jsonResponse(null)
+      if (path === '/api/v1/projects/citypoint/insights') return jsonResponse([])
+      if (path === '/api/v1/projects/citypoint/overview') return jsonResponse(null)
+      if (path === '/api/v1/projects/citypoint/analytics/metrics') return jsonResponse(emptyMetrics)
+      if (path === '/api/v1/projects/citypoint/citations/visibility') return jsonResponse(emptyCitationVisibility)
+
+      if (path.startsWith('/api/v1/')) {
+        disallowed.push(path)
+        return jsonResponse({ error: 'outside embed overview allowlist' }, 403)
+      }
+      return jsonResponse({}, 404)
+    }) as typeof fetch
+    return () => {
+      globalThis.fetch = realFetch
+    }
+  })()
+  onTestFinished(restoreFetch)
+
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const router = createAppRouter(queryClient, { initialEntries: ['/projects/citypoint'] })
+  await router.load()
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+
+  await waitFor(() => {
+    expect(observed.has('/api/v1/projects/citypoint/citations/visibility')).toBe(true)
+    expect(observed.has('/api/v1/projects/citypoint/analytics/metrics')).toBe(true)
+  })
+
+  expect(disallowed).toEqual([])
+  expect(Array.from(observed).some(path => path.startsWith('/api/v1/settings'))).toBe(false)
+})

--- a/apps/web/test/use-dashboard-overview.test.tsx
+++ b/apps/web/test/use-dashboard-overview.test.tsx
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, onTestFinished, test } from 'vitest'
+import { waitFor, renderHook } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createElement, type ReactNode } from 'react'
+
+import { useDashboardOverview } from '../src/queries/use-dashboard-overview.js'
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function mockFetch(handler: (path: string) => Response | Promise<Response>) {
+  const realFetch = globalThis.fetch
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = input instanceof Request ? input.url : String(input)
+    const path = url.replace(/^https?:\/\/[^/]+/, '') || url
+    return handler(path)
+  }) as typeof fetch
+  return () => {
+    globalThis.fetch = realFetch
+  }
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return createElement(QueryClientProvider, { client }, children)
+}
+
+afterEach(() => {
+  delete window.__CANONRY_CONFIG__
+})
+
+describe('useDashboardOverview', () => {
+  test('can skip the global settings read for embed rendering', async () => {
+    const paths: string[] = []
+    const restoreFetch = mockFetch((path) => {
+      paths.push(path)
+      if (path.startsWith('/api/v1/projects')) return jsonResponse([])
+      if (path.startsWith('/api/v1/runs')) return jsonResponse([])
+      if (path.startsWith('/api/v1/settings')) return jsonResponse({ error: 'settings should not be fetched' }, 500)
+      return jsonResponse({})
+    })
+    onTestFinished(restoreFetch)
+
+    renderHook(
+      () => useDashboardOverview(null, { includeSettings: false }),
+      { wrapper },
+    )
+
+    await waitFor(() => {
+      expect(paths.some(path => path.startsWith('/api/v1/projects'))).toBe(true)
+      expect(paths.some(path => path.startsWith('/api/v1/runs'))).toBe(true)
+    })
+    expect(paths.some(path => path.startsWith('/api/v1/settings'))).toBe(false)
+  })
+})

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -41,6 +41,13 @@ Opens at [http://127.0.0.1:4100](http://127.0.0.1:4100). No configuration needed
 > process. Restarting `canonry serve` (or `canonry stop` / a crash) clears them,
 > so you'll be asked to sign in again after a restart. This is expected.
 
+> **Only disable the dashboard password behind upstream auth.** `dashboard:
+> { requirePassword: false }` (or `CANONRY_DASHBOARD_REQUIRE_PASSWORD=0`) skips
+> Canonry's browser password gate while leaving API bearer-key auth intact. Set
+> it false only when an upstream layer enforces auth, such as the Canonry Embed
+> proxy. Never expose an engine with `requirePassword: false` directly to the
+> internet.
+
 ---
 
 ## Behind a Reverse Proxy

--- a/packages/api-routes/src/auth.ts
+++ b/packages/api-routes/src/auth.ts
@@ -169,7 +169,7 @@ function isGlobalAnswerVisibilityRunsList(request: FastifyRequest, url: string):
 function isAnswerVisibilityRunsList(request: FastifyRequest, rest: string): boolean {
   if (rest !== 'runs') return false
   const kind = queryValue(request, 'kind')
-  return !kind || kind === RunKinds['answer-visibility']
+  return kind === RunKinds['answer-visibility']
 }
 
 function isAnswerVisibilityRunDetail(request: FastifyRequest, url: string): boolean {

--- a/packages/api-routes/src/auth.ts
+++ b/packages/api-routes/src/auth.ts
@@ -160,34 +160,45 @@ function projectRouteRest(url: string): string | null {
   return match[1] ?? ''
 }
 
+function isGlobalAnswerVisibilityRunsList(request: FastifyRequest, url: string): boolean {
+  if (!url.endsWith('/runs')) return false
+  const kind = queryValue(request, 'kind')
+  return kind === RunKinds['answer-visibility']
+}
+
 function isAnswerVisibilityRunsList(request: FastifyRequest, rest: string): boolean {
   if (rest !== 'runs') return false
   const kind = queryValue(request, 'kind')
   return !kind || kind === RunKinds['answer-visibility']
 }
 
-function isOverviewRead(request: FastifyRequest, url: string): boolean {
+function isAnswerVisibilityRunDetail(request: FastifyRequest, url: string): boolean {
+  const runMatch = url.match(/\/runs\/([^/?#]+)$/)
+  if (!runMatch) return false
+  const run = request.server.db
+    .select({ kind: runs.kind })
+    .from(runs)
+    .where(eq(runs.id, decodeURIComponent(runMatch[1]!)))
+    .get()
+  // Unknown ids continue downstream to the route's normal 404. Existing
+  // answer-visibility ids are safe for the project dashboard evidence drawer.
+  return !run || run.kind === RunKinds['answer-visibility']
+}
+
+function isProjectShellRead(request: FastifyRequest, url: string): boolean {
   if (url.endsWith('/projects')) return true
-  if (url.endsWith('/runs')) {
-    const kind = queryValue(request, 'kind')
-    return kind === RunKinds['answer-visibility']
-  }
+  if (isGlobalAnswerVisibilityRunsList(request, url)) return true
 
   const rest = projectRouteRest(url)
-  if (rest === null) {
-    const runMatch = url.match(/\/runs\/([^/?#]+)$/)
-    if (!runMatch) return false
-    const run = request.server.db
-      .select({ kind: runs.kind })
-      .from(runs)
-      .where(eq(runs.id, decodeURIComponent(runMatch[1]!)))
-      .get()
-    return !run || run.kind === RunKinds['answer-visibility']
-  }
+  if (rest === null) return isAnswerVisibilityRunDetail(request, url)
 
-  if (isAnswerVisibilityRunsList(request, rest)) return true
+  return rest === '' || isAnswerVisibilityRunsList(request, rest)
+}
+
+function isOverviewRead(url: string): boolean {
+  const rest = projectRouteRest(url)
+  if (rest === null) return false
   return new Set([
-    '',
     'queries',
     'competitors',
     'timeline',
@@ -196,12 +207,18 @@ function isOverviewRead(request: FastifyRequest, url: string): boolean {
     'google/gsc/coverage',
     'bing/coverage',
     'insights',
+    'citations/visibility',
   ]).has(rest)
 }
 
 function isTechnicalAeoRead(url: string): boolean {
   const rest = projectRouteRest(url)
   return rest === 'technical-aeo' || rest === 'technical-aeo/pages' || rest === 'technical-aeo/trend'
+}
+
+function isReportRead(url: string): boolean {
+  const rest = projectRouteRest(url)
+  return rest === 'report' || rest === 'report.html'
 }
 
 function enforceEmbedProjectTabs(request: FastifyRequest, configuredTabs: readonly string[] | undefined): void {
@@ -217,8 +234,10 @@ function enforceEmbedProjectTabs(request: FastifyRequest, configuredTabs: readon
   }
 
   const url = request.url.split('?')[0]!
-  if (tabs.includes('overview') && isOverviewRead(request, url)) return
+  if (isProjectShellRead(request, url)) return
+  if (tabs.includes('overview') && isOverviewRead(url)) return
   if (tabs.includes('technical-aeo') && isTechnicalAeoRead(url)) return
+  if (tabs.includes('report') && isReportRead(url)) return
 
   throw forbidden('This endpoint is not available for the configured embed tabs.')
 }

--- a/packages/api-routes/src/auth.ts
+++ b/packages/api-routes/src/auth.ts
@@ -1,8 +1,16 @@
 import crypto from 'node:crypto'
 import { eq } from 'drizzle-orm'
 import type { FastifyInstance, FastifyRequest } from 'fastify'
-import { apiKeys, projects } from '@ainyc/canonry-db'
-import { authRequired, authInvalid, forbidden, isReadOnlyKey } from '@ainyc/canonry-contracts'
+import { apiKeys, projects, runs } from '@ainyc/canonry-db'
+import {
+  authRequired,
+  authInvalid,
+  forbidden,
+  isReadOnlyKey,
+  normalizeIdTokens,
+  RunKinds,
+  splitList,
+} from '@ainyc/canonry-contracts'
 
 /**
  * HTTP methods that mutate state. A read-only key is rejected on these; the
@@ -102,6 +110,13 @@ function shouldSkipAuth(url: string): boolean {
 export interface AuthPluginOptions {
   sessionCookieName?: string
   resolveSessionApiKeyId?: (sessionId: string) => string | null | Promise<string | null>
+  /**
+   * When set, the server is running in embed mode and this is the effective
+   * project-tab allowlist. It is a server-side data boundary layered on top of
+   * the read-only/project-scoped key: hidden tabs' API reads are rejected even
+   * if a client forges the URL.
+   */
+  embedProjectTabs?: readonly string[]
 }
 
 function parseCookies(header: string | undefined): Record<string, string> {
@@ -124,6 +139,88 @@ function parseCookies(header: string | undefined): Record<string, string> {
       }
       return cookies
     }, {})
+}
+
+function queryValue(request: FastifyRequest, key: string): string | undefined {
+  const raw = (request.query as Record<string, unknown> | undefined)?.[key]
+  if (typeof raw === 'string') return raw
+  if (Array.isArray(raw) && typeof raw[0] === 'string') return raw[0]
+  return undefined
+}
+
+function requestEmbedProjectTabs(request: FastifyRequest, fallback: readonly string[] | undefined): string[] | undefined {
+  const headerTabs = normalizeIdTokens(splitList(request.headers['x-canonry-embed-tabs']))
+  if (headerTabs) return headerTabs
+  return fallback && fallback.length > 0 ? [...fallback] : undefined
+}
+
+function projectRouteRest(url: string): string | null {
+  const match = url.match(/\/projects\/[^/]+(?:\/([^?#]*))?$/)
+  if (!match) return null
+  return match[1] ?? ''
+}
+
+function isAnswerVisibilityRunsList(request: FastifyRequest, rest: string): boolean {
+  if (rest !== 'runs') return false
+  const kind = queryValue(request, 'kind')
+  return !kind || kind === RunKinds['answer-visibility']
+}
+
+function isOverviewRead(request: FastifyRequest, url: string): boolean {
+  if (url.endsWith('/projects')) return true
+  if (url.endsWith('/runs')) {
+    const kind = queryValue(request, 'kind')
+    return kind === RunKinds['answer-visibility']
+  }
+
+  const rest = projectRouteRest(url)
+  if (rest === null) {
+    const runMatch = url.match(/\/runs\/([^/?#]+)$/)
+    if (!runMatch) return false
+    const run = request.server.db
+      .select({ kind: runs.kind })
+      .from(runs)
+      .where(eq(runs.id, decodeURIComponent(runMatch[1]!)))
+      .get()
+    return !run || run.kind === RunKinds['answer-visibility']
+  }
+
+  if (isAnswerVisibilityRunsList(request, rest)) return true
+  return new Set([
+    '',
+    'queries',
+    'competitors',
+    'timeline',
+    'overview',
+    'analytics/metrics',
+    'google/gsc/coverage',
+    'bing/coverage',
+    'insights',
+  ]).has(rest)
+}
+
+function isTechnicalAeoRead(url: string): boolean {
+  const rest = projectRouteRest(url)
+  return rest === 'technical-aeo' || rest === 'technical-aeo/pages' || rest === 'technical-aeo/trend'
+}
+
+function enforceEmbedProjectTabs(request: FastifyRequest, configuredTabs: readonly string[] | undefined): void {
+  const tabs = requestEmbedProjectTabs(request, configuredTabs)
+  if (!tabs || tabs.length === 0) return
+  if (request.method === 'OPTIONS') return
+
+  // In embed mode with a tab allowlist, the public iframe is a read surface.
+  // The read-only key already blocks writes, but this makes the tab policy
+  // independent of key shape and future write routes.
+  if (WRITE_METHODS.has(request.method)) {
+    throw forbidden('This endpoint is not available in embed mode.')
+  }
+
+  const url = request.url.split('?')[0]!
+  if (tabs.includes('overview') && isOverviewRead(request, url)) return
+  if (tabs.includes('technical-aeo') && isTechnicalAeoRead(url)) return
+
+  throw forbidden('This endpoint is not available for the configured embed tabs.')
 }
 
 export async function authPlugin(app: FastifyInstance, opts: AuthPluginOptions = {}) {
@@ -193,6 +290,8 @@ export async function authPlugin(app: FastifyInstance, opts: AuthPluginOptions =
     if (isReadOnlyKey(scopes) && WRITE_METHODS.has(request.method)) {
       throw forbidden('This API key is read-only and cannot perform write operations.')
     }
+
+    enforceEmbedProjectTabs(request, opts.embedProjectTabs)
 
     // Project-scope gate. A key bound to a single project (`project_id` set) may
     // only touch THAT project. The project name is the first `/projects/<name>`

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -79,6 +79,8 @@ export interface ApiRoutesOptions {
   /** Optional cookie-backed browser session support */
   sessionCookieName?: string
   resolveSessionApiKeyId?: (sessionId: string) => string | null | Promise<string | null>
+  /** Effective project-tab allowlist when the host runs the API in embed mode. */
+  embedProjectTabs?: readonly string[]
 
   /** Callback when a run is created (wire up job runner) */
   onRunCreated?: (runId: string, projectId: string, providers?: string[], location?: import('@ainyc/canonry-contracts').LocationContext | null) => void
@@ -313,6 +315,7 @@ export async function apiRoutes(app: FastifyInstance, opts: ApiRoutesOptions) {
       await authPlugin(api, {
         sessionCookieName: opts.sessionCookieName,
         resolveSessionApiKeyId: opts.resolveSessionApiKeyId,
+        embedProjectTabs: opts.embedProjectTabs,
       })
     }
 

--- a/packages/canonry/src/config.ts
+++ b/packages/canonry/src/config.ts
@@ -213,6 +213,15 @@ export interface AgentConfigEntry {
   mode?: 'disabled'
 }
 
+export interface DashboardConfigEntry {
+  /**
+   * Whether the browser dashboard requires Canonry's built-in password/session
+   * gate. Defaults to true. Set false only when an upstream layer enforces auth
+   * and the engine is not directly internet-reachable.
+   */
+  requirePassword?: boolean
+}
+
 /**
  * Google Places API config — supplemental rendered-listing data for GBP
  * lodging locations (#648). The API key authenticates Place Details calls
@@ -255,6 +264,9 @@ export interface CanonryConfig {
   openaiAds?: OpenAiAdsConfigEntry
   // Dashboard password hash (SHA-256 hex) — set during first dashboard visit
   dashboardPasswordHash?: string
+  // Browser dashboard auth gate. `dashboard.requirePassword=false` trusts an
+  // upstream auth layer while keeping API bearer-key auth intact.
+  dashboard?: DashboardConfigEntry
   // Telemetry (opt-out: undefined/true = enabled, false = disabled)
   telemetry?: boolean
   anonymousId?: string

--- a/packages/canonry/src/embed.ts
+++ b/packages/canonry/src/embed.ts
@@ -3,6 +3,13 @@ import { normalizeIdTokens, parseOriginList, splitList } from '@ainyc/canonry-co
 import type { CanonryConfig } from './config.js'
 
 const DEFAULT_EMBED_PROJECT_TABS = ['overview']
+export const SERVER_ENFORCED_EMBED_PROJECT_TABS = ['overview', 'technical-aeo', 'report'] as const
+
+export function unsupportedEmbedProjectTabs(projectTabs: readonly string[] | undefined): string[] {
+  if (!projectTabs) return []
+  const supported = new Set<string>(SERVER_ENFORCED_EMBED_PROJECT_TABS)
+  return projectTabs.filter(tab => !supported.has(tab))
+}
 
 /**
  * Read-only embed mode (issue #716) — resolve the effective embed settings from

--- a/packages/canonry/src/embed.ts
+++ b/packages/canonry/src/embed.ts
@@ -2,6 +2,8 @@ import type { ResolvedEmbedConfig } from '@ainyc/canonry-contracts'
 import { normalizeIdTokens, parseOriginList, splitList } from '@ainyc/canonry-contracts'
 import type { CanonryConfig } from './config.js'
 
+const DEFAULT_EMBED_PROJECT_TABS = ['overview']
+
 /**
  * Read-only embed mode (issue #716) — resolve the effective embed settings from
  * environment variables layered over `~/.canonry/config.yaml`.
@@ -22,9 +24,9 @@ import type { CanonryConfig } from './config.js'
  *    lowercased + de-duped; an empty list collapses to `undefined` (= all
  *    views) so an empty allowlist never silently bricks every embed.
  *  - `projectTabs`: `CANONRY_EMBED_PROJECT_TABS` when set, else
- *    `config.embed.projectTabs`, lowercased + de-duped; empty → `undefined`
- *    (= all tabs). Hides individual project-page tabs (search-console,
- *    activity, backlinks, ...) that `views` cannot reach.
+ *    `config.embed.projectTabs`, lowercased + de-duped. Empty/missing defaults
+ *    to `overview` in embed mode so the client-facing iframe starts locked
+ *    down rather than exposing every project tab.
  *  - `theme`: `config.embed.theme` only (no env form).
  */
 export function resolveEmbedConfig(env: NodeJS.ProcessEnv, config: CanonryConfig): ResolvedEmbedConfig {
@@ -48,7 +50,7 @@ export function resolveEmbedConfig(env: NodeJS.ProcessEnv, config: CanonryConfig
     env.CANONRY_EMBED_PROJECT_TABS !== undefined
       ? splitList(env.CANONRY_EMBED_PROJECT_TABS)
       : splitList(embed?.projectTabs)
-  const projectTabs = normalizeIdTokens(rawProjectTabs)
+  const projectTabs = normalizeIdTokens(rawProjectTabs) ?? (enabled ? DEFAULT_EMBED_PROJECT_TABS : undefined)
 
   return {
     enabled,

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -48,7 +48,7 @@ import {
   type ProviderAdapter,
 } from "@ainyc/canonry-contracts";
 import type { CanonryConfig, ProviderConfigEntry } from "./config.js";
-import { resolveEmbedConfig } from "./embed.js";
+import { resolveEmbedConfig, SERVER_ENFORCED_EMBED_PROJECT_TABS, unsupportedEmbedProjectTabs } from "./embed.js";
 import { resolveAgentEnabled } from "./agent-config.js";
 import { saveConfigPatch, loadConfig, getConfigPath } from "./config.js";
 import { getPlacesConfig } from "./places-config.js";
@@ -1186,6 +1186,16 @@ export async function createServer(opts: {
   const embedCsp = embed.enabled
     ? frameAncestorsHeaderValue(embed.allowedOrigins)
     : undefined;
+  const unsupportedProjectTabs = unsupportedEmbedProjectTabs(embed.projectTabs);
+  if (embed.enabled && unsupportedProjectTabs.length > 0) {
+    app.log.warn(
+      {
+        projectTabs: unsupportedProjectTabs,
+        supportedProjectTabs: [...SERVER_ENFORCED_EMBED_PROJECT_TABS],
+      },
+      "Embed project tabs include unsupported values; API reads for those tabs will be blocked",
+    );
+  }
   const dashboardRequirePassword = resolveDashboardRequirePassword(process.env, opts.config);
   app.log.info(
     { dashboardRequirePassword },

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -162,6 +162,20 @@ interface SessionRecord {
   expiresAt: number;
 }
 
+function parseBooleanEnv(value: string | undefined): boolean | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (normalized === "1" || normalized === "true" || normalized === "yes") return true;
+  if (normalized === "0" || normalized === "false" || normalized === "no") return false;
+  return undefined;
+}
+
+function resolveDashboardRequirePassword(env: NodeJS.ProcessEnv, config: CanonryConfig): boolean {
+  return parseBooleanEnv(env.CANONRY_DASHBOARD_REQUIRE_PASSWORD)
+    ?? config.dashboard?.requirePassword
+    ?? true;
+}
+
 /** All known API adapters — add new providers here */
 const API_ADAPTERS: ProviderAdapter[] = [
   geminiAdapter,
@@ -1172,6 +1186,11 @@ export async function createServer(opts: {
   const embedCsp = embed.enabled
     ? frameAncestorsHeaderValue(embed.allowedOrigins)
     : undefined;
+  const dashboardRequirePassword = resolveDashboardRequirePassword(process.env, opts.config);
+  app.log.info(
+    { dashboardRequirePassword },
+    "Dashboard password gate resolved",
+  );
 
   // Register API routes.
   // When a basePath is set, routes are registered at `${basePath}api/v1` so they
@@ -1303,6 +1322,9 @@ export async function createServer(opts: {
   };
 
   app.get(apiPrefix + "/session", async (request, reply) => {
+    if (!dashboardRequirePassword) {
+      return reply.send({ authenticated: true, setupRequired: false });
+    }
     const sessionId = parseCookies(request.headers.cookie)[SESSION_COOKIE_NAME];
     return reply.send({
       authenticated: Boolean(sessionId && resolveSessionApiKeyId(sessionId)),
@@ -1314,6 +1336,9 @@ export async function createServer(opts: {
   app.post<{
     Body: { password?: string };
   }>(apiPrefix + "/session/setup", async (request, reply) => {
+    if (!dashboardRequirePassword) {
+      return reply.send({ authenticated: true, setupRequired: false });
+    }
     // First-run dashboard password setup mints a session bound to the install's
     // default `*` API key — full read/write on every project. That is safe on a
     // loopback bind (only local processes can reach it) but a pre-auth privilege
@@ -1351,6 +1376,9 @@ export async function createServer(opts: {
   app.post<{
     Body: { password?: string; apiKey?: string };
   }>(apiPrefix + "/session", async (request, reply) => {
+    if (!dashboardRequirePassword) {
+      return reply.send({ authenticated: true, setupRequired: false });
+    }
     const password = request.body?.password?.trim();
     const apiKey = request.body?.apiKey?.trim();
 
@@ -1489,6 +1517,7 @@ export async function createServer(opts: {
     skipAuth: false,
     sessionCookieName: SESSION_COOKIE_NAME,
     resolveSessionApiKeyId,
+    ...(embed.enabled && embed.projectTabs ? { embedProjectTabs: embed.projectTabs } : {}),
     explainContentRecommendation,
     briefContentRecommendation,
     briefPromptVersion: RECOMMENDATION_BRIEF_PROMPT_VERSION,
@@ -2121,6 +2150,7 @@ export async function createServer(opts: {
       html: string,
       projectTabsOverride?: string | string[],
       themeOverride?: string | string[],
+      renderTokenOverride?: string | string[],
     ): string => {
       const clientConfig: Record<string, unknown> = {};
       if (basePath) clientConfig.basePath = basePath;
@@ -2128,10 +2158,12 @@ export async function createServer(opts: {
       // (non-embed) serve emits byte-for-byte the same `{}` / `{basePath}`.
       // `projectTabs` + `theme` may be overridden PER REQUEST by the
       // X-Canonry-Embed-Tabs / X-Canonry-Embed-Theme headers the Embed v2 /e
-      // proxy sets per dashboard (the end client cannot reach this loopback
-      // engine to set them); absent headers keep the boot config.
+      // proxy sets per dashboard. The proxy also sets X-Canonry-Embed-Render-Token
+      // for the initial HTML so the SPA can call back through /e/api/v1 without
+      // seeing the engine key. The end client cannot reach this loopback engine
+      // to set any of these headers; absent headers keep the boot config.
       if (embed.enabled) {
-        const embedClient = embedClientConfigForRequest(embed, projectTabsOverride, themeOverride);
+        const embedClient = embedClientConfigForRequest(embed, projectTabsOverride, themeOverride, renderTokenOverride);
         if (embedClient) clientConfig.embed = embedClient;
       }
 
@@ -2166,6 +2198,7 @@ export async function createServer(opts: {
             html,
             reply.request.headers["x-canonry-embed-tabs"],
             reply.request.headers["x-canonry-embed-theme"],
+            reply.request.headers["x-canonry-embed-render-token"],
           ),
         );
     };

--- a/packages/canonry/test/embed.test.ts
+++ b/packages/canonry/test/embed.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { resolveEmbedConfig } from '../src/embed.js'
+import { resolveEmbedConfig, unsupportedEmbedProjectTabs } from '../src/embed.js'
 import type { CanonryConfig } from '../src/config.js'
 
 function baseConfig(embed?: CanonryConfig['embed']): CanonryConfig {
@@ -92,10 +92,23 @@ describe('resolveEmbedConfig', () => {
     expect(resolveEmbedConfig({ CANONRY_EMBED: '1' }, cfg).projectTabs).toEqual(['overview', 'technical-aeo'])
   })
 
-  it('normalizes an empty / whitespace-only projectTabs list to undefined (= all tabs), never []', () => {
+  it('defaults an empty / whitespace-only projectTabs list to overview in embed mode', () => {
     expect(
       resolveEmbedConfig({ CANONRY_EMBED: '1', CANONRY_EMBED_PROJECT_TABS: '   ' }, baseConfig()).projectTabs,
-    ).toBeUndefined()
-    expect(resolveEmbedConfig({ CANONRY_EMBED: '1' }, baseConfig()).projectTabs).toBeUndefined()
+    ).toEqual(['overview'])
+    expect(resolveEmbedConfig({ CANONRY_EMBED: '1' }, baseConfig()).projectTabs).toEqual(['overview'])
+  })
+
+  it('does not default projectTabs when embed is disabled', () => {
+    expect(resolveEmbedConfig({}, baseConfig()).projectTabs).toBeUndefined()
+  })
+})
+
+describe('unsupportedEmbedProjectTabs', () => {
+  it('returns tab names that have no server-side read classifier', () => {
+    expect(unsupportedEmbedProjectTabs(['overview', 'technical-aeo', 'report', 'backlinks', 'local'])).toEqual([
+      'backlinks',
+      'local',
+    ])
   })
 })

--- a/packages/canonry/test/server-embed.test.ts
+++ b/packages/canonry/test/server-embed.test.ts
@@ -539,6 +539,7 @@ describe('server embed mode (#716)', () => {
       for (const url of [
         '/api/v1/settings',
         `/api/v1/projects/${name}/google/connections`,
+        `/api/v1/projects/${name}/runs`,
         `/api/v1/projects/${name}/technical-aeo`,
         '/api/v1/runs/run_audit',
       ]) {

--- a/packages/canonry/test/server-embed.test.ts
+++ b/packages/canonry/test/server-embed.test.ts
@@ -3,7 +3,8 @@ import os from 'node:os'
 import fs from 'node:fs'
 import path from 'node:path'
 import crypto from 'node:crypto'
-import { createClient, migrate, apiKeys, type DatabaseClient } from '@ainyc/canonry-db'
+import { createClient, migrate, apiKeys, projects, runs, type DatabaseClient } from '@ainyc/canonry-db'
+import { RunKinds } from '@ainyc/canonry-contracts'
 import { createServer } from '../src/server.js'
 import type { CanonryConfig } from '../src/config.js'
 
@@ -15,6 +16,7 @@ const EMBED_ENV = [
   'CANONRY_EMBED_ORIGINS',
   'CANONRY_EMBED_VIEWS',
   'CANONRY_EMBED_PROJECT_TABS',
+  'CANONRY_DASHBOARD_REQUIRE_PASSWORD',
 ] as const
 
 interface Built {
@@ -24,7 +26,11 @@ interface Built {
   cleanup: () => Promise<void>
 }
 
-async function buildServer(embed?: CanonryConfig['embed'], withIndexHtml = true): Promise<Built> {
+async function buildServer(
+  embed?: CanonryConfig['embed'],
+  withIndexHtml = true,
+  configPatch: Partial<CanonryConfig> = {},
+): Promise<Built> {
   const tmpDir = path.join(os.tmpdir(), `canonry-embed-${crypto.randomUUID()}`)
   const assetsDir = path.join(tmpDir, 'assets')
   fs.mkdirSync(assetsDir, { recursive: true })
@@ -42,6 +48,7 @@ async function buildServer(embed?: CanonryConfig['embed'], withIndexHtml = true)
     database: dbPath,
     apiKey,
     ...(embed ? { embed } : {}),
+    ...configPatch,
   }
 
   const app = await createServer({ config, db, logger: false, assetsDir })
@@ -54,6 +61,23 @@ async function buildServer(embed?: CanonryConfig['embed'], withIndexHtml = true)
       fs.rmSync(tmpDir, { recursive: true, force: true })
     },
   }
+}
+
+function seedProject(db: DatabaseClient, id = 'proj_1', name = 'acme') {
+  const now = new Date().toISOString()
+  db.insert(projects)
+    .values({
+      id,
+      name,
+      displayName: 'Acme',
+      canonicalDomain: 'example.com',
+      country: 'US',
+      language: 'en',
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run()
+  return { id, name, now }
 }
 
 describe('server embed mode (#716)', () => {
@@ -99,6 +123,43 @@ describe('server embed mode (#716)', () => {
     }
   })
 
+  it('dashboard.requirePassword defaults to true, preserving the first-run password gate', async () => {
+    const { app, cleanup } = await buildServer()
+    try {
+      const res = await app.inject({ method: 'GET', url: '/api/v1/session' })
+      expect(res.statusCode).toBe(200)
+      expect(JSON.parse(res.body)).toEqual({ authenticated: false, setupRequired: true })
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('dashboard.requirePassword=false skips the browser password gate without requiring embed mode', async () => {
+    const { app, cleanup } = await buildServer(undefined, true, {
+      dashboard: { requirePassword: false },
+    })
+    try {
+      const res = await app.inject({ method: 'GET', url: '/api/v1/session' })
+      expect(res.statusCode).toBe(200)
+      expect(JSON.parse(res.body)).toEqual({ authenticated: true, setupRequired: false })
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('CANONRY_DASHBOARD_REQUIRE_PASSWORD overrides config for container deploys', async () => {
+    process.env.CANONRY_DASHBOARD_REQUIRE_PASSWORD = '0'
+    const { app, cleanup } = await buildServer(undefined, true, {
+      dashboard: { requirePassword: true },
+    })
+    try {
+      const res = await app.inject({ method: 'GET', url: '/api/v1/session' })
+      expect(JSON.parse(res.body)).toEqual({ authenticated: true, setupRequired: false })
+    } finally {
+      await cleanup()
+    }
+  })
+
   it('ON + origins: exact frame-ancestors header on the root AND on a deep-link fallback', async () => {
     const { app, cleanup } = await buildServer({ enabled: true, allowOrigins: ['https://host.example'] })
     try {
@@ -107,7 +168,8 @@ describe('server embed mode (#716)', () => {
       expect(root.headers['content-security-policy']).toBe('frame-ancestors https://host.example')
       expect(root.headers['x-frame-options']).toBeUndefined()
       // The injected client block opts the SPA into chromeless render.
-      expect(root.body).toContain('"embed":{"enabled":true}')
+      expect(root.body).toContain('"embed":{"enabled":true')
+      expect(root.body).toContain('"projectTabs":["overview"]')
       // No 'unsafe-inline' is forced — the inline config script still ships.
       expect(root.body).toContain('window.__CANONRY_CONFIG__')
       expect(root.headers['content-security-policy']).not.toContain('unsafe-inline')
@@ -142,6 +204,16 @@ describe('server embed mode (#716)', () => {
     try {
       const res = await app.inject({ method: 'GET', url: '/' })
       expect(res.headers['content-security-policy']).toBe("frame-ancestors 'none'")
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('ON + no project tabs configured: defaults to overview-only in the client config', async () => {
+    const { app, cleanup } = await buildServer({ enabled: true, allowOrigins: ['https://host.example'] })
+    try {
+      const res = await app.inject({ method: 'GET', url: '/' })
+      expect(res.body).toContain('"projectTabs":["overview"]')
     } finally {
       await cleanup()
     }
@@ -295,6 +367,50 @@ describe('server embed mode (#716)', () => {
     }
   })
 
+  it('ON: a per-request X-Canonry-Embed-Render-Token header injects the render token for /e API calls', async () => {
+    const { app, cleanup } = await buildServer({ enabled: true, allowOrigins: ['https://host.example'] })
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/',
+        headers: { 'x-canonry-embed-render-token': 'render.jwt.token' },
+      })
+      expect(res.body).toContain('"renderToken":"render.jwt.token"')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('OFF: the X-Canonry-Embed-Render-Token header is ignored (no embed block)', async () => {
+    const { app, cleanup } = await buildServer()
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/',
+        headers: { 'x-canonry-embed-render-token': 'render.jwt.token' },
+      })
+      expect(res.body).toContain('<script>window.__CANONRY_CONFIG__={}</script>')
+      expect(res.body).not.toContain('renderToken')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('ON: a </script> payload in X-Canonry-Embed-Render-Token is escaped (XSS)', async () => {
+    const { app, cleanup } = await buildServer({ enabled: true, allowOrigins: ['https://host.example'] })
+    try {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/',
+        headers: { 'x-canonry-embed-render-token': '</script><img src=x onerror=alert(1)>' },
+      })
+      expect(res.body).not.toContain('</script><img')
+      expect(res.body).toContain('\\u003c/script\\u003e\\u003cimg')
+    } finally {
+      await cleanup()
+    }
+  })
+
   it('OFF: the X-Canonry-Embed-Theme header is ignored (no embed block, byte-for-byte default)', async () => {
     const { app, cleanup } = await buildServer()
     try {
@@ -338,6 +454,7 @@ describe('server embed mode (#716)', () => {
   it('embed mode does NOT weaken the read-only write gate (regression)', async () => {
     const { app, apiKey, db, cleanup } = await buildServer({ enabled: true, allowOrigins: ['https://host.example'] })
     try {
+      seedProject(db, 'gate_proj', 'gate-test')
       // Mint a read-only key alongside the server's default full key.
       const readOnlyRaw = `cnry_${crypto.randomBytes(16).toString('hex')}`
       db.insert(apiKeys)
@@ -351,21 +468,10 @@ describe('server embed mode (#716)', () => {
         })
         .run()
       const auth = { authorization: `Bearer ${readOnlyRaw}` }
-      const fullAuth = { authorization: `Bearer ${apiKey}` }
 
       // Reads pass.
       const read = await app.inject({ method: 'GET', url: '/api/v1/projects', headers: auth })
       expect(read.statusCode).toBe(200)
-
-      // Seed a real project with the full key so the write routes below resolve
-      // a target rather than 404-ing before the method-based gate is exercised.
-      const seed = await app.inject({
-        method: 'PUT',
-        url: '/api/v1/projects/gate-test',
-        headers: fullAuth,
-        payload: { displayName: 'Gate Test', canonicalDomain: 'example.com', country: 'US', language: 'en' },
-      })
-      expect(seed.statusCode).toBe(201)
 
       // Writes are still 403 FORBIDDEN with embed enabled — across a route with
       // no requireScope (runs), a create/update (PUT), and a DELETE.
@@ -383,6 +489,84 @@ describe('server embed mode (#716)', () => {
     }
   })
 
+  it('ON + overview tabs: server-side policy allows overview reads and blocks hidden tab data', async () => {
+    const { app, apiKey, db, cleanup } = await buildServer({ enabled: true, allowOrigins: ['https://host.example'] })
+    try {
+      const { id: projectId, name, now } = seedProject(db)
+      db.insert(runs)
+        .values({
+          id: 'run_answer',
+          projectId,
+          kind: RunKinds['answer-visibility'],
+          status: 'completed',
+          trigger: 'manual',
+          createdAt: now,
+        })
+        .run()
+      db.insert(runs)
+        .values({
+          id: 'run_audit',
+          projectId,
+          kind: RunKinds['site-audit'],
+          status: 'completed',
+          trigger: 'manual',
+          createdAt: now,
+        })
+        .run()
+
+      const auth = { authorization: `Bearer ${apiKey}` }
+      const overviewReads = [
+        `/api/v1/projects/${name}`,
+        `/api/v1/projects/${name}/queries`,
+        `/api/v1/projects/${name}/competitors`,
+        `/api/v1/projects/${name}/runs?kind=answer-visibility`,
+        `/api/v1/runs/run_answer`,
+      ]
+      for (const url of overviewReads) {
+        const res = await app.inject({ method: 'GET', url, headers: auth })
+        expect(res.statusCode, `${url} should be reachable for overview embed data`).not.toBe(403)
+      }
+
+      for (const url of [
+        '/api/v1/settings',
+        `/api/v1/projects/${name}/google/connections`,
+        `/api/v1/projects/${name}/technical-aeo`,
+        '/api/v1/runs/run_audit',
+      ]) {
+        const res = await app.inject({ method: 'GET', url, headers: auth })
+        expect(res.statusCode, `${url} should be hidden by overview-only embed tabs`).toBe(403)
+      }
+
+      const write = await app.inject({
+        method: 'POST',
+        url: `/api/v1/projects/${name}/queries`,
+        headers: auth,
+        payload: { queries: ['best roofer'] },
+      })
+      expect(write.statusCode).toBe(403)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('ON + per-request tabs: X-Canonry-Embed-Tabs can allow technical-AEO reads server-side', async () => {
+    const { app, apiKey, db, cleanup } = await buildServer({ enabled: true, allowOrigins: ['https://host.example'] })
+    try {
+      const { name } = seedProject(db)
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/v1/projects/${name}/technical-aeo`,
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          'x-canonry-embed-tabs': 'overview,technical-aeo',
+        },
+      })
+      expect(res.statusCode).not.toBe(403)
+    } finally {
+      await cleanup()
+    }
+  })
+
   it('env (CANONRY_EMBED + CANONRY_EMBED_ORIGINS) is wired through createServer and overrides config', async () => {
     process.env.CANONRY_EMBED = '1'
     process.env.CANONRY_EMBED_ORIGINS = 'https://env.example'
@@ -391,7 +575,7 @@ describe('server embed mode (#716)', () => {
     try {
       const res = await app.inject({ method: 'GET', url: '/' })
       expect(res.headers['content-security-policy']).toBe('frame-ancestors https://env.example')
-      expect(res.body).toContain('"embed":{"enabled":true}')
+      expect(res.body).toContain('"embed":{"enabled":true')
     } finally {
       await cleanup()
     }

--- a/packages/canonry/test/server-embed.test.ts
+++ b/packages/canonry/test/server-embed.test.ts
@@ -452,7 +452,7 @@ describe('server embed mode (#716)', () => {
   })
 
   it('embed mode does NOT weaken the read-only write gate (regression)', async () => {
-    const { app, apiKey, db, cleanup } = await buildServer({ enabled: true, allowOrigins: ['https://host.example'] })
+    const { app, db, cleanup } = await buildServer({ enabled: true, allowOrigins: ['https://host.example'] })
     try {
       seedProject(db, 'gate_proj', 'gate-test')
       // Mint a read-only key alongside the server's default full key.
@@ -516,9 +516,18 @@ describe('server embed mode (#716)', () => {
 
       const auth = { authorization: `Bearer ${apiKey}` }
       const overviewReads = [
+        '/api/v1/projects',
+        '/api/v1/runs?kind=answer-visibility',
         `/api/v1/projects/${name}`,
+        `/api/v1/projects/${name}/overview`,
         `/api/v1/projects/${name}/queries`,
         `/api/v1/projects/${name}/competitors`,
+        `/api/v1/projects/${name}/timeline`,
+        `/api/v1/projects/${name}/analytics/metrics`,
+        `/api/v1/projects/${name}/google/gsc/coverage`,
+        `/api/v1/projects/${name}/bing/coverage`,
+        `/api/v1/projects/${name}/insights`,
+        `/api/v1/projects/${name}/citations/visibility`,
         `/api/v1/projects/${name}/runs?kind=answer-visibility`,
         `/api/v1/runs/run_answer`,
       ]
@@ -544,6 +553,37 @@ describe('server embed mode (#716)', () => {
         payload: { queries: ['best roofer'] },
       })
       expect(write.statusCode).toBe(403)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('ON + per-request tabs: X-Canonry-Embed-Tabs can allow report reads server-side', async () => {
+    const { app, apiKey, db, cleanup } = await buildServer({ enabled: true, allowOrigins: ['https://host.example'] })
+    try {
+      const { name } = seedProject(db)
+      const auth = {
+        authorization: `Bearer ${apiKey}`,
+        'x-canonry-embed-tabs': 'report',
+      }
+
+      for (const url of [
+        '/api/v1/projects',
+        `/api/v1/projects/${name}`,
+        `/api/v1/projects/${name}/runs?kind=answer-visibility`,
+        `/api/v1/projects/${name}/report`,
+        `/api/v1/projects/${name}/report.html?audience=client&period=30`,
+      ]) {
+        const res = await app.inject({ method: 'GET', url, headers: auth })
+        expect(res.statusCode, `${url} should be reachable for report embed data`).not.toBe(403)
+      }
+
+      const hidden = await app.inject({
+        method: 'GET',
+        url: `/api/v1/projects/${name}/technical-aeo`,
+        headers: auth,
+      })
+      expect(hidden.statusCode).toBe(403)
     } finally {
       await cleanup()
     }

--- a/packages/contracts/src/embed.ts
+++ b/packages/contracts/src/embed.ts
@@ -62,6 +62,12 @@ export interface EmbedClientConfig {
   /** Project-tab allowlist; `undefined` means "all tabs". */
   projectTabs?: string[]
   theme?: Record<string, string>
+  /**
+   * Short-lived Canonry Embed render token for the fronting /e proxy. This is
+   * NOT a Canonry API key; the platform re-verifies it and injects the
+   * project-scoped engine key server-side.
+   */
+  renderToken?: string
 }
 
 /** The CSP keyword for same-origin framing, passed through verbatim when configured. */
@@ -213,6 +219,12 @@ function parseThemeOverride(raw: string | string[] | undefined): Record<string, 
   return Object.keys(out).length > 0 ? out : undefined
 }
 
+function parseRenderTokenOverride(raw: string | string[] | undefined): string | undefined {
+  const value = Array.isArray(raw) ? raw[0] : raw
+  if (typeof value !== 'string' || value.length === 0 || value.length > 4096) return undefined
+  return value
+}
+
 /**
  * The client-config block for ONE request: the boot-resolved embed settings, but
  * with `projectTabs` and `theme` replaced by per-request overrides when present.
@@ -226,14 +238,17 @@ export function embedClientConfigForRequest(
   resolved: ResolvedEmbedConfig,
   projectTabsOverride: string | string[] | undefined,
   themeOverride?: string | string[],
+  renderTokenOverride?: string | string[],
 ): EmbedClientConfig | undefined {
   const base = buildEmbedClientConfig(resolved)
   if (!base) return undefined
   const tabs = normalizeIdTokens(splitList(projectTabsOverride))
   const theme = parseThemeOverride(themeOverride)
+  const renderToken = parseRenderTokenOverride(renderTokenOverride)
   let out = base
   if (tabs) out = { ...out, projectTabs: tabs }
   if (theme) out = { ...out, theme }
+  if (renderToken) out = { ...out, renderToken }
   return out
 }
 

--- a/packages/contracts/test/embed.test.ts
+++ b/packages/contracts/test/embed.test.ts
@@ -228,6 +228,25 @@ describe('embedClientConfigForRequest', () => {
       theme: { mode: 'light' },
     })
   })
+
+  it('adds the per-request render token when supplied by the embed proxy', () => {
+    expect(embedClientConfigForRequest(enabled, undefined, undefined, 'render.jwt.token')).toEqual({
+      enabled: true,
+      projectTabs: ['overview', 'technical-aeo', 'report'],
+      renderToken: 'render.jwt.token',
+    })
+  })
+
+  it('ignores an empty / oversized render token header', () => {
+    expect(embedClientConfigForRequest(enabled, undefined, undefined, '')).toEqual({
+      enabled: true,
+      projectTabs: ['overview', 'technical-aeo', 'report'],
+    })
+    expect(embedClientConfigForRequest(enabled, undefined, undefined, 'x'.repeat(5000))).toEqual({
+      enabled: true,
+      projectTabs: ['overview', 'technical-aeo', 'report'],
+    })
+  })
 })
 
 describe('serializeForInlineScript', () => {


### PR DESCRIPTION
## Summary
- Add a configurable dashboard password bypass for trusted upstream auth layers
- Default embed project tabs to `overview` and enforce tab-aware API gating server-side
- Propagate the embed render token through web API calls so the iframe can proxy requests without exposing the engine key
- Update embed and auth tests plus deployment guidance to cover the new behavior

## Testing
- Added and updated unit/integration coverage for embed config, auth gating, and request token propagation
- Not run (not requested)