### PR TITLE
chore(release): 4.114.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.113.0",
+  "version": "4.114.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.113.0",
+  "version": "4.114.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
Bumps the release version to `4.114.0`.

#797 (embed browser-readiness: `dashboard.requirePassword` config, overview-only server-side tab enforcement, render-token propagation) merged at `4.113.0` — the same version already built and deployed as `canonry:4.113.0`. This bump gives that code a distinct release tag so the published package and built image are unambiguous.

Version-only change (root + `packages/canonry`); the publish workflow keys off `packages/canonry/package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)