### PR TITLE
Polish embed dashboard overview and trend hints

### DIFF
--- a/apps/web/src/components/project/VisibilityTrendSection.tsx
+++ b/apps/web/src/components/project/VisibilityTrendSection.tsx
@@ -32,6 +32,7 @@ import {
   latestSeriesValue,
   MENTION_SHARE_KEY,
   MENTIONED_KEY,
+  normalizeProviderKey,
   type MetricChoice,
   type TrendSeriesMode,
 } from '../../lib/visibility-trend-helpers.js'
@@ -51,6 +52,7 @@ const METRIC_OPTIONS: Array<{ value: MetricChoice; label: string }> = [
   { value: 'mentioned', label: 'Mentioned' },
   { value: 'cited', label: 'Cited' },
 ]
+const MAX_VISIBLE_PROVIDER_MODELS = 2
 
 /** Dark ring drawn around the active (hovered) dot so it reads against the line. */
 const ACTIVE_DOT_RING = 'var(--chart-tooltip-bg)'
@@ -65,7 +67,8 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
 }
 
 function providerDisplayName(name: string): string {
-  return PROVIDER_DISPLAY_NAMES[name] ?? name.charAt(0).toUpperCase() + name.slice(1)
+  const key = normalizeProviderKey(name)
+  return PROVIDER_DISPLAY_NAMES[key] ?? name.charAt(0).toUpperCase() + name.slice(1)
 }
 
 function round1(n: number): number {
@@ -86,7 +89,7 @@ function seriesColor(key: string, index: number): string {
   if (key === CITED_KEY) return CHART_TONE.positive // emerald
   if (key === MENTIONED_KEY) return CHART_SERIES_COLORS[1]! // blue
   if (key === MENTION_SHARE_KEY) return CHART_TONE.positive
-  return providerSeriesColor(key, index)
+  return providerSeriesColor(normalizeProviderKey(key), index)
 }
 
 function firstSeriesValue(rows: Array<Record<string, string | number | null>>, key: string): number | null {
@@ -169,9 +172,12 @@ export function VisibilityTrendSection({
   const error = metricsQuery.error
 
   const trend = useMemo(() => (data ? buildTrendRows(data, metric, mode) : null), [data, metric, mode])
+  // Capture the window cutoff once per data/window change; this keeps
+  // supplementary model hints stable while the user is looking at the chart.
+  const modelHintNow = useMemo(() => new Date(), [visibilityEvidence, window])
   const providerModelHints = useMemo(
-    () => buildProviderModelHints(visibilityEvidence, window),
-    [visibilityEvidence, window],
+    () => buildProviderModelHints(visibilityEvidence, window, modelHintNow),
+    [visibilityEvidence, window, modelHintNow],
   )
 
   // Headline readout: the selected metric's latest bucket value plus its change
@@ -260,6 +266,9 @@ export function VisibilityTrendSection({
             <ul className="trend-legend" aria-label="Engines">
               {series.map((key, i) => {
                 const value = latestSeriesValue(rows, key)
+                const modelHints = providerModelHints[normalizeProviderKey(key)] ?? []
+                const visibleModels = modelHints.slice(0, MAX_VISIBLE_PROVIDER_MODELS)
+                const hiddenModelCount = modelHints.length - visibleModels.length
                 return (
                   <li key={key} className="trend-legend-item">
                     <span
@@ -269,9 +278,10 @@ export function VisibilityTrendSection({
                     />
                     <span className="trend-legend-label">
                       <span className="trend-legend-name">{seriesLabel(key)}</span>
-                      {(providerModelHints[key] ?? []).map(model => (
+                      {visibleModels.map(model => (
                         <span key={model} className="trend-legend-model"><span aria-hidden="true">· </span>{model}</span>
                       ))}
+                      {hiddenModelCount > 0 && <span className="trend-legend-model-more">+{hiddenModelCount}</span>}
                     </span>
                     {value !== null && <span className="trend-legend-value">{value}%</span>}
                   </li>

--- a/apps/web/src/components/project/VisibilityTrendSection.tsx
+++ b/apps/web/src/components/project/VisibilityTrendSection.tsx
@@ -25,6 +25,7 @@ import { fetchAnalyticsMetrics } from '../../api.js'
 import { STATIC_VISIBILITY_STALE_MS } from '../../queries/query-client.js'
 import {
   buildMentionShareTrendRows,
+  buildProviderModelHints,
   buildTrendRows,
   CITED_KEY,
   formatQueryChangeCaption,
@@ -34,6 +35,7 @@ import {
   type MetricChoice,
   type TrendSeriesMode,
 } from '../../lib/visibility-trend-helpers.js'
+import type { CitationInsightVm } from '../../view-models.js'
 
 const WINDOW_OPTIONS: Array<{ value: MetricsWindow; label: string }> = [
   { value: '7d', label: '7d' },
@@ -144,9 +146,11 @@ function Segmented<T extends string>({
 export function VisibilityTrendSection({
   projectName,
   competitorDomains = [],
+  visibilityEvidence = [],
 }: {
   projectName: string
   competitorDomains?: readonly string[]
+  visibilityEvidence?: readonly CitationInsightVm[]
 }) {
   const [window, setWindow] = useState<MetricsWindow>('all')
   const [metric, setMetric] = useState<MetricChoice>('mentioned')
@@ -165,6 +169,10 @@ export function VisibilityTrendSection({
   const error = metricsQuery.error
 
   const trend = useMemo(() => (data ? buildTrendRows(data, metric, mode) : null), [data, metric, mode])
+  const providerModelHints = useMemo(
+    () => buildProviderModelHints(visibilityEvidence, window),
+    [visibilityEvidence, window],
+  )
 
   // Headline readout: the selected metric's latest bucket value plus its change
   // across the visible window. Quantifies "where it sits now, which way it
@@ -259,7 +267,12 @@ export function VisibilityTrendSection({
                       style={{ backgroundColor: seriesColor(key, i) }}
                       aria-hidden="true"
                     />
-                    <span className="trend-legend-name">{seriesLabel(key)}</span>
+                    <span className="trend-legend-label">
+                      <span className="trend-legend-name">{seriesLabel(key)}</span>
+                      {(providerModelHints[key] ?? []).map(model => (
+                        <span key={model} className="trend-legend-model"><span aria-hidden="true">· </span>{model}</span>
+                      ))}
+                    </span>
                     {value !== null && <span className="trend-legend-value">{value}%</span>}
                   </li>
                 )

--- a/apps/web/src/lib/visibility-trend-helpers.ts
+++ b/apps/web/src/lib/visibility-trend-helpers.ts
@@ -35,6 +35,10 @@ export interface TrendData {
 
 export type ProviderModelHints = Record<string, string[]>
 
+export function normalizeProviderKey(provider: string): string {
+  return provider.trim().toLowerCase()
+}
+
 /** Presentation-only: 0-1 rate → 0-100 axis value, one decimal. */
 function toPercent(rate: number): number {
   return Math.round(rate * 1000) / 10
@@ -108,7 +112,8 @@ export function buildProviderModelHints(
   const byProvider = new Map<string, Map<string, number>>()
 
   for (const row of evidence) {
-    if (!row.provider) continue
+    const providerKey = normalizeProviderKey(row.provider)
+    if (!providerKey) continue
     let sawWindowedHistoryModel = false
 
     for (const point of row.runHistory) {
@@ -116,14 +121,17 @@ export function buildProviderModelHints(
       const createdAt = Date.parse(point.createdAt)
       if (cutoffMs !== null && (!Number.isFinite(createdAt) || createdAt < cutoffMs)) continue
       sawWindowedHistoryModel = true
-      touchModel(byProvider, row.provider, point.model, Number.isFinite(createdAt) ? createdAt : 0)
+      touchModel(byProvider, providerKey, point.model, Number.isFinite(createdAt) ? createdAt : 0)
     }
 
+    // Narrow windows intentionally require an in-window run with model data.
+    // Falling back to all-time `modelsSeen` would make a 7d/30d legend imply
+    // model coverage that is older than the plotted window.
     if (!sawWindowedHistoryModel && window === 'all') {
       for (const model of row.modelsSeen ?? []) {
-        touchModel(byProvider, row.provider, model, 0)
+        touchModel(byProvider, providerKey, model, 0)
       }
-      touchModel(byProvider, row.provider, row.model, Number.MAX_SAFE_INTEGER)
+      touchModel(byProvider, providerKey, row.model, Number.MAX_SAFE_INTEGER)
     }
   }
 

--- a/apps/web/src/lib/visibility-trend-helpers.ts
+++ b/apps/web/src/lib/visibility-trend-helpers.ts
@@ -1,5 +1,5 @@
-import type { BrandMetricsDto, QueryChangeEvent, TrendDirection } from '@ainyc/canonry-contracts'
-import type { MetricTone } from '../view-models.js'
+import type { BrandMetricsDto, MetricsWindow, QueryChangeEvent, TrendDirection } from '@ainyc/canonry-contracts'
+import type { CitationInsightVm, MetricTone } from '../view-models.js'
 
 /**
  * Pure reshaping of `BrandMetricsDto` into Recharts-ready rows for the
@@ -32,6 +32,8 @@ export interface TrendData {
   /** A single bucket can't draw a line — the chart shows a dot + "not enough history" hint. */
   singleBucket: boolean
 }
+
+export type ProviderModelHints = Record<string, string[]>
 
 /** Presentation-only: 0-1 rate → 0-100 axis value, one decimal. */
 function toPercent(rate: number): number {
@@ -73,6 +75,66 @@ export function buildTrendRows(
     return row
   })
   return { rows, series, hasData, singleBucket }
+}
+
+function cutoffMsForWindow(window: MetricsWindow, now: Date): number | null {
+  if (window === 'all') return null
+  const days = window === '7d' ? 7 : window === '30d' ? 30 : 90
+  return now.getTime() - days * 24 * 60 * 60 * 1000
+}
+
+function touchModel(
+  byProvider: Map<string, Map<string, number>>,
+  provider: string,
+  model: string | null | undefined,
+  timestamp: number,
+) {
+  const normalized = model?.trim()
+  if (!normalized) return
+  let models = byProvider.get(provider)
+  if (!models) {
+    models = new Map<string, number>()
+    byProvider.set(provider, models)
+  }
+  models.set(normalized, Math.max(models.get(normalized) ?? Number.NEGATIVE_INFINITY, timestamp))
+}
+
+export function buildProviderModelHints(
+  evidence: readonly CitationInsightVm[],
+  window: MetricsWindow,
+  now = new Date(),
+): ProviderModelHints {
+  const cutoffMs = cutoffMsForWindow(window, now)
+  const byProvider = new Map<string, Map<string, number>>()
+
+  for (const row of evidence) {
+    if (!row.provider) continue
+    let sawWindowedHistoryModel = false
+
+    for (const point of row.runHistory) {
+      if (!point.model) continue
+      const createdAt = Date.parse(point.createdAt)
+      if (cutoffMs !== null && (!Number.isFinite(createdAt) || createdAt < cutoffMs)) continue
+      sawWindowedHistoryModel = true
+      touchModel(byProvider, row.provider, point.model, Number.isFinite(createdAt) ? createdAt : 0)
+    }
+
+    if (!sawWindowedHistoryModel && window === 'all') {
+      for (const model of row.modelsSeen ?? []) {
+        touchModel(byProvider, row.provider, model, 0)
+      }
+      touchModel(byProvider, row.provider, row.model, Number.MAX_SAFE_INTEGER)
+    }
+  }
+
+  return Object.fromEntries(
+    [...byProvider.entries()].map(([provider, models]) => [
+      provider,
+      [...models.entries()]
+        .sort(([modelA, seenA], [modelB, seenB]) => seenB - seenA || modelA.localeCompare(modelB))
+        .map(([model]) => model),
+    ]),
+  )
 }
 
 export function buildMentionShareTrendRows(dto: BrandMetricsDto): TrendData {

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -1268,16 +1268,18 @@ function OverviewDisclosure({
   eyebrow,
   title,
   meta,
+  defaultOpen = false,
   children,
 }: {
   id?: string
   eyebrow: string
   title: string
   meta?: string
+  defaultOpen?: boolean
   children: React.ReactNode
 }) {
   return (
-    <details id={id} className="overview-disclosure page-section-divider scroll-mt-24">
+    <details id={id} className="overview-disclosure page-section-divider scroll-mt-24" open={defaultOpen || undefined}>
       <summary className="overview-disclosure-summary">
         <span>
           <span className="eyebrow eyebrow-soft">{eyebrow}</span>
@@ -2144,7 +2146,7 @@ function ProjectPageContent({
           <h1 className="page-title">{model.project.displayName || model.project.name}</h1>
           <p className="page-subtitle">
             {model.project.canonicalDomain}
-            {(model.project.ownedDomains ?? []).length === 0 && !addingOwnedDomain && (
+            {!isEmbed() && (model.project.ownedDomains ?? []).length === 0 && !addingOwnedDomain && (
               <button
                 type="button"
                 className="ml-2 rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-secondary hover:text-strong hover:bg-surface-inset transition-colors"
@@ -2305,7 +2307,11 @@ function ProjectPageContent({
       {tab === 'overview' ? (
         <>
           <section className="page-section-divider">
-            <VisibilityTrendSection projectName={model.project.name} competitorDomains={competitorDomains} />
+            <VisibilityTrendSection
+              projectName={model.project.name}
+              competitorDomains={competitorDomains}
+              visibilityEvidence={model.visibilityEvidence}
+            />
           </section>
 
           <section className="page-section-divider">
@@ -2401,6 +2407,7 @@ function ProjectPageContent({
             eyebrow="Tracked coverage"
             title="Query evidence"
             meta={`${model.queryCounts.total} ${model.queryCounts.total === 1 ? 'query' : 'queries'}`}
+            defaultOpen={isEmbed()}
           >
             {!isEmbed() && (
               <div className="mb-3 flex items-center justify-end">
@@ -2510,7 +2517,7 @@ function ProjectPageContent({
             />
           </OverviewDisclosure>
 
-          <OverviewDisclosure eyebrow="Analysis" title="Citation and engine diagnostics" meta="Deep dive">
+          <OverviewDisclosure eyebrow="Analysis" title="Citation and engine diagnostics" meta="Deep dive" defaultOpen={isEmbed()}>
             <CitationVisibilitySection projectName={model.project.name} />
 
             {model.providerScores.length > 1 && (
@@ -2550,13 +2557,15 @@ function ProjectPageContent({
             )}
           </OverviewDisclosure>
 
-          <OverviewDisclosure eyebrow="Run history" title="Recent execution history" meta={`${model.recentRuns.length} recent`}>
-            <div className="run-list">
-              {model.recentRuns.map((run) => (
-                <RunRow key={run.id} run={run} />
-              ))}
-            </div>
-          </OverviewDisclosure>
+          {!isEmbed() && (
+            <OverviewDisclosure eyebrow="Run history" title="Recent execution history" meta={`${model.recentRuns.length} recent`}>
+              <div className="run-list">
+                {model.recentRuns.map((run) => (
+                  <RunRow key={run.id} run={run} />
+                ))}
+              </div>
+            </OverviewDisclosure>
+          )}
 
           <section id="action-queue" className="page-section-divider scroll-mt-24 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mono-500/60" tabIndex={-1}>
             <div className="section-head section-head-inline">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -311,6 +311,10 @@
   --chart-axis: #d4d4d8;
 }
 
+[data-theme='light'] .visibility-trend-title {
+  color: var(--color-text-heading);
+}
+
 /* Provider-identity pills on the light canvas: keep the engine hue but flip the
    canvas polarity (light tint + darker ink) so the uppercase label stays legible
    on white. The dark-canvas defaults (literal utilities in ProviderBadge, a
@@ -1032,15 +1036,23 @@
   }
 
   .trend-legend-item {
-    @apply inline-flex items-center gap-1.5;
+    @apply inline-flex min-w-0 items-center gap-1.5;
   }
 
   .trend-legend-swatch {
     @apply h-[3px] w-3.5 shrink-0 rounded-full;
   }
 
+  .trend-legend-label {
+    @apply inline-flex min-w-0 items-baseline gap-1;
+  }
+
   .trend-legend-name {
-    @apply text-[11px] font-medium text-neutral;
+    @apply shrink-0 text-[11px] font-medium text-neutral;
+  }
+
+  .trend-legend-model {
+    @apply inline-block max-w-44 truncate font-mono text-[11px] text-muted;
   }
 
   .trend-legend-value {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1055,6 +1055,10 @@
     @apply inline-block max-w-44 truncate font-mono text-[11px] text-muted;
   }
 
+  .trend-legend-model-more {
+    @apply shrink-0 rounded bg-bg-elevated/60 px-1 py-px font-mono text-[10px] text-muted;
+  }
+
   .trend-legend-value {
     @apply text-[11px] font-semibold tabular-nums text-primary;
   }

--- a/apps/web/test/app-embed.test.tsx
+++ b/apps/web/test/app-embed.test.tsx
@@ -40,6 +40,15 @@ async function renderAt(pathname: string, embed?: EmbedBlock): Promise<string> {
   )
 }
 
+function parseHtml(html: string): Document {
+  return new DOMParser().parseFromString(html, 'text/html')
+}
+
+function detailsForTitle(doc: Document, title: string): HTMLDetailsElement | null {
+  return [...doc.querySelectorAll<HTMLDetailsElement>('details.overview-disclosure')]
+    .find((details) => details.querySelector('.overview-disclosure-title')?.textContent === title) ?? null
+}
+
 test('without embed config the full application chrome renders', async () => {
   const html = await renderAt('/')
   expect(html).toContain('class="sidebar"')
@@ -113,13 +122,34 @@ test('embed hides the overview competitor + query managers and the identity edit
   const operator = await renderAt('/projects/project_citypoint')
 
   // Operator sees the overview write affordances + the alias editor row…
+  expect(operator).toContain('+ add domain')
   expect(operator).toContain('+ Add competitor')
   expect(operator).toContain('Manage queries')
   expect(operator).toContain('Also known as')
   // …none of which render in the embed.
+  expect(embed).not.toContain('+ add domain')
   expect(embed).not.toContain('+ Add competitor')
   expect(embed).not.toContain('Manage queries')
   expect(embed).not.toContain('Also known as')
+
+  const embedDoc = parseHtml(embed)
+  const header = embedDoc.querySelector('.page-header')
+  expect(header?.querySelector('.tag-row')?.textContent).toContain('US')
+  expect(header?.querySelector('.tag-row')?.textContent).toContain('EN')
+  expect(header?.querySelector('.tag-row button, .tag-row input, .tag-row select')).toBeNull()
+})
+
+test('embed defaults client-value overview disclosures open and omits run history', async () => {
+  const embedDoc = parseHtml(await renderAt('/projects/project_citypoint', { enabled: true, views: ['project'] }))
+  const operatorDoc = parseHtml(await renderAt('/projects/project_citypoint'))
+
+  expect(detailsForTitle(operatorDoc, 'Query evidence')?.hasAttribute('open')).toBe(false)
+  expect(detailsForTitle(operatorDoc, 'Citation and engine diagnostics')?.hasAttribute('open')).toBe(false)
+  expect(detailsForTitle(operatorDoc, 'Recent execution history')).not.toBeNull()
+
+  expect(detailsForTitle(embedDoc, 'Query evidence')?.hasAttribute('open')).toBe(true)
+  expect(detailsForTitle(embedDoc, 'Citation and engine diagnostics')?.hasAttribute('open')).toBe(true)
+  expect(detailsForTitle(embedDoc, 'Recent execution history')).toBeNull()
 })
 
 // A default embed config (enabled, no `views` allowlist) makes every top-level

--- a/apps/web/test/design-tokens.test.ts
+++ b/apps/web/test/design-tokens.test.ts
@@ -256,3 +256,10 @@ test('the light theme deepens the tone-scale foreground steps (no bright tone te
     expect(light, `light theme must re-point "${decl}"`).toContain(decl)
   }
 })
+
+test('the light theme gives visibility chart titles a semantic text color', async () => {
+  const css = await compileAppStyles([])
+  const rule = ruleFor(css, "[data-theme='light'] .visibility-trend-title")
+
+  expect(rule).toContain('color: var(--color-text-heading)')
+})

--- a/apps/web/test/visibility-trend-helpers.test.ts
+++ b/apps/web/test/visibility-trend-helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import type { BrandMetricsDto } from '@ainyc/canonry-contracts'
 import {
+  buildProviderModelHints,
   buildMentionShareTrendRows,
   buildTrendRows,
   trendToTone,
@@ -10,6 +11,7 @@ import {
   MENTION_SHARE_KEY,
   MENTIONED_KEY,
 } from '../src/lib/visibility-trend-helpers.js'
+import type { CitationInsightVm } from '../src/view-models.js'
 
 function provider(citationRate: number, mentionRate: number) {
   return { citationRate, cited: 0, total: 4, mentionRate, mentionedCount: 0 }
@@ -39,6 +41,32 @@ function dto(buckets: BrandMetricsDto['buckets']): BrandMetricsDto {
     trend: 'stable',
     mentionTrend: 'stable',
     queryChanges: [],
+  }
+}
+
+function evidence(providerName: string, models: string[]): CitationInsightVm {
+  return {
+    id: `${providerName}-evidence`,
+    query: `${providerName} query`,
+    provider: providerName,
+    model: models.at(-1) ?? null,
+    location: null,
+    citationState: 'cited',
+    visibilityState: 'visible',
+    changeLabel: 'Stable',
+    answerSnippet: '',
+    citedDomains: [],
+    evidenceUrls: [],
+    competitorDomains: [],
+    relatedTechnicalSignals: [],
+    groundingSources: [],
+    summary: '',
+    runHistory: models.map((model, index) => ({
+      runId: `${providerName}-${index}`,
+      citationState: 'cited',
+      createdAt: `2026-04-${String(index + 1).padStart(2, '0')}T00:00:00.000Z`,
+      model,
+    })),
   }
 }
 
@@ -126,6 +154,20 @@ describe('buildTrendRows — data flags', () => {
     const res = buildTrendRows(dto([bucket('2026-04-01', { gemini: provider(0.5, 0.5) })]), 'cited', 'overall')
     expect(res.hasData).toBe(true)
     expect(res.singleBucket).toBe(true)
+  })
+})
+
+describe('buildProviderModelHints', () => {
+  it('returns model versions by provider, latest model first', () => {
+    const hints = buildProviderModelHints([
+      evidence('gemini', ['gemini-2.0-flash', 'gemini-2.5-flash']),
+      evidence('openai', ['gpt-5.4']),
+    ], 'all')
+
+    expect(hints).toEqual({
+      gemini: ['gemini-2.5-flash', 'gemini-2.0-flash'],
+      openai: ['gpt-5.4'],
+    })
   })
 })
 

--- a/apps/web/test/visibility-trend-helpers.test.ts
+++ b/apps/web/test/visibility-trend-helpers.test.ts
@@ -10,6 +10,7 @@ import {
   CITED_KEY,
   MENTION_SHARE_KEY,
   MENTIONED_KEY,
+  normalizeProviderKey,
 } from '../src/lib/visibility-trend-helpers.js'
 import type { CitationInsightVm } from '../src/view-models.js'
 
@@ -158,6 +159,17 @@ describe('buildTrendRows — data flags', () => {
 })
 
 describe('buildProviderModelHints', () => {
+  it('normalizes provider keys so metrics series can join evidence hints safely', () => {
+    expect(normalizeProviderKey(' Gemini ')).toBe('gemini')
+    const hints = buildProviderModelHints([
+      evidence(' Gemini ', ['gemini-2.5-flash']),
+    ], 'all')
+
+    expect(hints).toEqual({
+      gemini: ['gemini-2.5-flash'],
+    })
+  })
+
   it('returns model versions by provider, latest model first', () => {
     const hints = buildProviderModelHints([
       evidence('gemini', ['gemini-2.0-flash', 'gemini-2.5-flash']),

--- a/apps/web/test/visibility-trend-section.test.tsx
+++ b/apps/web/test/visibility-trend-section.test.tsx
@@ -177,7 +177,7 @@ test('labels per-engine legend entries with model versions and model changes', a
   onTestFinished(restore)
 
   renderSectionWithEvidence([
-    evidence('gemini', ['gemini-2.0-flash', 'gemini-2.5-flash']),
+    evidence('gemini', ['gemini-1.5-flash', 'gemini-2.0-flash', 'gemini-2.5-flash']),
     evidence('openai', ['gpt-5.4']),
   ])
 
@@ -185,6 +185,8 @@ test('labels per-engine legend entries with model versions and model changes', a
   expect(within(legend).getByText('Gemini')).toBeTruthy()
   expect(within(legend).getByText('gemini-2.5-flash')).toBeTruthy()
   expect(within(legend).getByText('gemini-2.0-flash')).toBeTruthy()
+  expect(within(legend).queryByText('gemini-1.5-flash')).toBeNull()
+  expect(within(legend).getByText('+1')).toBeTruthy()
   expect(within(legend).getByText('OpenAI')).toBeTruthy()
   expect(within(legend).getByText('gpt-5.4')).toBeTruthy()
 })

--- a/apps/web/test/visibility-trend-section.test.tsx
+++ b/apps/web/test/visibility-trend-section.test.tsx
@@ -28,6 +28,7 @@ vi.mock('recharts', () => {
 })
 
 import { MentionShareTrendSection, VisibilityTrendSection } from '../src/components/project/VisibilityTrendSection.js'
+import type { CitationInsightVm } from '../src/view-models.js'
 import { mockFetch, jsonResponse } from './mock-fetch.js'
 
 function provider(citationRate: number, mentionRate: number) {
@@ -68,6 +69,41 @@ function renderSection() {
       <VisibilityTrendSection projectName="test-project" />
     </QueryClientProvider>,
   )
+}
+
+function renderSectionWithEvidence(visibilityEvidence: readonly CitationInsightVm[]) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <VisibilityTrendSection projectName="test-project" visibilityEvidence={visibilityEvidence} />
+    </QueryClientProvider>,
+  )
+}
+
+function evidence(providerName: string, models: string[]): CitationInsightVm {
+  return {
+    id: `${providerName}-evidence`,
+    query: `${providerName} query`,
+    provider: providerName,
+    model: models.at(-1) ?? null,
+    location: null,
+    citationState: 'cited',
+    visibilityState: 'visible',
+    changeLabel: 'Stable',
+    answerSnippet: '',
+    citedDomains: [],
+    evidenceUrls: [],
+    competitorDomains: [],
+    relatedTechnicalSignals: [],
+    groundingSources: [],
+    summary: '',
+    runHistory: models.map((model, index) => ({
+      runId: `${providerName}-${index}`,
+      citationState: 'cited',
+      createdAt: `2026-04-${String(index + 1).padStart(2, '0')}T00:00:00.000Z`,
+      model,
+    })),
+  }
 }
 
 function renderMentionShareSection(competitorDomains: readonly string[] = ['competitor.com']) {
@@ -128,6 +164,29 @@ test('defaults to the by-engine view with a per-engine legend, and toggles to al
   expect(byEngine.getAttribute('aria-pressed')).toBe('false')
   expect(screen.queryByRole('list', { name: 'Engines' })).toBeNull()
   expect(screen.queryByText('avg')).toBeNull()
+})
+
+test('labels per-engine legend entries with model versions and model changes', async () => {
+  const restore = mockFetch((url) => {
+    const path = url.split('?')[0]!
+    if (path.endsWith('/projects/test-project/analytics/metrics')) {
+      return jsonResponse(metricsDto(TWO_BUCKETS))
+    }
+    throw new Error(`Unexpected fetch: ${url}`)
+  })
+  onTestFinished(restore)
+
+  renderSectionWithEvidence([
+    evidence('gemini', ['gemini-2.0-flash', 'gemini-2.5-flash']),
+    evidence('openai', ['gpt-5.4']),
+  ])
+
+  const legend = await screen.findByRole('list', { name: 'Engines' })
+  expect(within(legend).getByText('Gemini')).toBeTruthy()
+  expect(within(legend).getByText('gemini-2.5-flash')).toBeTruthy()
+  expect(within(legend).getByText('gemini-2.0-flash')).toBeTruthy()
+  expect(within(legend).getByText('OpenAI')).toBeTruthy()
+  expect(within(legend).getByText('gpt-5.4')).toBeTruthy()
 })
 
 test('shows an empty state when there are no buckets yet', async () => {


### PR DESCRIPTION
## Summary
- Add model-version hints to visibility trend legends and surface them from the project overview
- Default embed overview disclosures open, while hiding run history and write affordances that do not fit the embed view
- Tighten light-theme styling for visibility chart titles and legend labels

## Testing
- Added unit tests for provider model hint sorting and windowed behavior
- Added UI tests for embed disclosure defaults and hidden controls
- Added design-token coverage for the light-theme chart title color

Closes #798
Closes #801
Closes #802