### PR TITLE
Combine overview trend charts

### DIFF
--- a/apps/web/src/components/project/VisibilityTrendSection.tsx
+++ b/apps/web/src/components/project/VisibilityTrendSection.tsx
@@ -1,6 +1,6 @@
-import { useMemo, useState } from 'react'
+import { Fragment, useId, useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import type { MetricsWindow } from '@ainyc/canonry-contracts'
+import type { BrandMetricsDto, MetricsWindow } from '@ainyc/canonry-contracts'
 import {
   CartesianGrid,
   CHART_AXIS_STROKE,
@@ -9,7 +9,6 @@ import {
   CHART_NEUTRAL,
   CHART_SERIES_COLORS,
   CHART_TONE,
-  CHART_TOOLTIP_STYLE,
   ComposedChart,
   formatChartDateLabel,
   formatChartDateTick,
@@ -24,9 +23,8 @@ import { InfoTooltip } from '../shared/InfoTooltip.js'
 import { fetchAnalyticsMetrics } from '../../api.js'
 import { STATIC_VISIBILITY_STALE_MS } from '../../queries/query-client.js'
 import {
-  buildMentionShareTrendRows,
   buildProviderModelHints,
-  buildTrendRows,
+  buildSelectedTrendRows,
   CITED_KEY,
   formatQueryChangeCaption,
   latestSeriesValue,
@@ -48,11 +46,25 @@ const MODE_OPTIONS: Array<{ value: TrendSeriesMode; label: string }> = [
   { value: 'byProvider', label: 'By engine' },
   { value: 'overall', label: 'All engines' },
 ]
-const METRIC_OPTIONS: Array<{ value: MetricChoice; label: string }> = [
-  { value: 'mentioned', label: 'Mentioned' },
-  { value: 'cited', label: 'Cited' },
+const METRIC_OPTIONS: Array<{ value: MetricChoice; label: string; description: string }> = [
+  {
+    value: 'mentioned',
+    label: 'Mentioned',
+    description: 'Your brand or domain appears in the answer text.',
+  },
+  {
+    value: 'cited',
+    label: 'Cited',
+    description: 'Your domain appears in source or grounding links.',
+  },
+  {
+    value: 'mentionShare',
+    label: 'Mention share',
+    description: 'Of all answer-text brand mentions for you and tracked competitors, the share that were you.',
+  },
 ]
 const MAX_VISIBLE_PROVIDER_MODELS = 2
+const MENTION_SHARE_COLOR = CHART_SERIES_COLORS[2]!
 
 /** Dark ring drawn around the active (hovered) dot so it reads against the line. */
 const ACTIVE_DOT_RING = 'var(--chart-tooltip-bg)'
@@ -76,19 +88,20 @@ function round1(n: number): number {
 }
 
 function isOverallSeries(key: string): boolean {
-  return key === CITED_KEY || key === MENTIONED_KEY
+  return key === CITED_KEY || key === MENTIONED_KEY || key === MENTION_SHARE_KEY
 }
 
 function seriesLabel(key: string): string {
   if (key === CITED_KEY) return 'Cited'
   if (key === MENTIONED_KEY) return 'Mentioned'
+  if (key === MENTION_SHARE_KEY) return 'Mention share'
   return providerDisplayName(key)
 }
 
 function seriesColor(key: string, index: number): string {
   if (key === CITED_KEY) return CHART_TONE.positive // emerald
   if (key === MENTIONED_KEY) return CHART_SERIES_COLORS[1]! // blue
-  if (key === MENTION_SHARE_KEY) return CHART_TONE.positive
+  if (key === MENTION_SHARE_KEY) return MENTION_SHARE_COLOR
   return providerSeriesColor(normalizeProviderKey(key), index)
 }
 
@@ -108,6 +121,184 @@ function competitorFrameKey(competitorDomains: readonly string[]): string {
     .join('\n')
 }
 
+type MetricsBucket = BrandMetricsDto['buckets'][number]
+type ProviderMetricBucket = MetricsBucket['byProvider'][string]
+
+interface TooltipPayloadItem {
+  name?: string | number
+  dataKey?: string | number
+  value?: string | number | null
+  color?: string
+}
+
+function metricLabel(metric: MetricChoice): string {
+  if (metric === 'cited') return 'Cited'
+  if (metric === 'mentionShare') return 'Mention share'
+  return 'Mentioned'
+}
+
+function metricField(metric: Exclude<MetricChoice, 'mentionShare'>): 'citationRate' | 'mentionRate' {
+  return metric === 'cited' ? 'citationRate' : 'mentionRate'
+}
+
+function metricCount(bucket: MetricsBucket, metric: Exclude<MetricChoice, 'mentionShare'>): number {
+  return metric === 'cited' ? bucket.cited : bucket.mentionedCount
+}
+
+function providerMetricCount(
+  bucket: MetricsBucket,
+  provider: string,
+  metric: Exclude<MetricChoice, 'mentionShare'>,
+): { count: number; total: number; rate: number } | null {
+  const row = (bucket.byProvider as Record<string, ProviderMetricBucket | undefined>)[provider]
+  if (!row) return null
+  return {
+    count: metric === 'cited' ? row.cited : row.mentionedCount,
+    total: row.total,
+    rate: metric === 'cited' ? row.citationRate : row.mentionRate,
+  }
+}
+
+function findBucket(buckets: readonly MetricsBucket[], label: string | number | undefined): MetricsBucket | null {
+  if (label === undefined) return null
+  const key = String(label)
+  return buckets.find(b => b.startDate === key) ?? null
+}
+
+function formatPercent(value: number | null): string {
+  return value === null ? 'no data' : `${value}%`
+}
+
+function formatRatePercent(rate: number | null | undefined): string {
+  return rate == null ? 'undefined' : `${round1(rate * 100)}%`
+}
+
+function TrendTooltip({
+  active,
+  label,
+  payload,
+  metric,
+  mode,
+  buckets,
+}: {
+  active?: boolean
+  label?: string | number
+  payload?: TooltipPayloadItem[]
+  metric: MetricChoice
+  mode: TrendSeriesMode
+  buckets: readonly MetricsBucket[]
+}) {
+  if (!active) return null
+  const bucket = findBucket(buckets, label)
+  if (!bucket) return null
+
+  if (metric === 'mentionShare') {
+    const projectMentions = bucket.mentionShare.projectMentionSnapshots
+    const competitorMentions = bucket.mentionShare.competitorMentionSnapshots
+    const denominator = projectMentions + competitorMentions
+    const rate = bucket.mentionShare.rate == null ? null : round1(bucket.mentionShare.rate * 100)
+    return (
+      <div className="trend-tooltip">
+        <p className="trend-tooltip-label">{formatChartDateLabel(bucket.startDate)}</p>
+        <div className="trend-tooltip-row">
+          <span className="trend-tooltip-swatch trend-tooltip-swatch-ring" style={{ borderColor: MENTION_SHARE_COLOR }} aria-hidden="true" />
+          <span className="trend-tooltip-name">Mention share</span>
+          <span className="trend-tooltip-value">{formatPercent(rate)}</span>
+        </div>
+        {denominator > 0 ? (
+          <p className="trend-tooltip-detail">You {projectMentions} / {denominator} brand mentions. Competitors {competitorMentions}.</p>
+        ) : (
+          <p className="trend-tooltip-detail">No project or competitor brand mentions in this bucket.</p>
+        )}
+      </div>
+    )
+  }
+
+  const items = mode === 'byProvider'
+    ? (payload ?? []).filter(item => item.dataKey !== undefined)
+    : [{ dataKey: metric === 'cited' ? CITED_KEY : MENTIONED_KEY, value: round1(bucket[metricField(metric)] * 100) }]
+  return (
+    <div className="trend-tooltip">
+      <p className="trend-tooltip-label">{formatChartDateLabel(bucket.startDate)}</p>
+      {items.map((item, index) => {
+        const key = String(item.dataKey ?? item.name ?? '')
+        const providerCounts = mode === 'byProvider' ? providerMetricCount(bucket, key, metric) : null
+        const count = providerCounts?.count ?? metricCount(bucket, metric)
+        const total = providerCounts?.total ?? bucket.total
+        const value = typeof item.value === 'number'
+          ? item.value
+          : providerCounts
+            ? round1(providerCounts.rate * 100)
+            : round1(bucket[metricField(metric)] * 100)
+        const color = item.color ?? seriesColor(key, index)
+        return (
+          <div key={`${key}-${index}`} className="trend-tooltip-block">
+            <div className="trend-tooltip-row">
+              <span className="trend-tooltip-swatch" style={{ backgroundColor: color }} aria-hidden="true" />
+              <span className="trend-tooltip-name">{seriesLabel(key)}</span>
+              <span className="trend-tooltip-value">{formatPercent(value)}</span>
+            </div>
+            <p className="trend-tooltip-detail">
+              {count} / {total} snapshots, {metric === 'cited' ? 'source links' : 'answer text'}
+            </p>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function TrendDataSummary({
+  buckets,
+  metric,
+  mode,
+  series,
+}: {
+  buckets: readonly MetricsBucket[]
+  metric: MetricChoice
+  mode: TrendSeriesMode
+  series: readonly string[]
+}) {
+  return (
+    <table className="sr-only">
+      <caption>{metricLabel(metric)} trend data</caption>
+      <thead>
+        <tr>
+          <th scope="col">Bucket</th>
+          <th scope="col">Values</th>
+        </tr>
+      </thead>
+      <tbody>
+        {buckets.map(bucket => {
+          let valueText: string
+          if (metric === 'mentionShare') {
+            const projectMentions = bucket.mentionShare.projectMentionSnapshots
+            const competitorMentions = bucket.mentionShare.competitorMentionSnapshots
+            const denominator = projectMentions + competitorMentions
+            valueText = denominator > 0
+              ? `${formatRatePercent(bucket.mentionShare.rate)} mention share, ${projectMentions} of ${denominator} brand mentions were you`
+              : 'mention share undefined, no project or competitor brand mentions'
+          } else if (mode === 'byProvider') {
+            valueText = series.map(provider => {
+              const counts = providerMetricCount(bucket, provider, metric)
+              if (!counts) return `${providerDisplayName(provider)} no data`
+              return `${providerDisplayName(provider)} ${formatRatePercent(counts.rate)} ${metricLabel(metric).toLowerCase()}, ${counts.count} of ${counts.total} snapshots`
+            }).join('; ')
+          } else {
+            valueText = `${formatRatePercent(bucket[metricField(metric)])} ${metricLabel(metric).toLowerCase()}, ${metricCount(bucket, metric)} of ${bucket.total} snapshots`
+          }
+          return (
+            <tr key={bucket.startDate}>
+              <th scope="row">{formatChartDateLabel(bucket.startDate)}</th>
+              <td>{valueText}</td>
+            </tr>
+          )
+        })}
+      </tbody>
+    </table>
+  )
+}
+
 /**
  * Single-select segmented control. A group of toggle buttons (`role="group"` +
  * `aria-pressed`), not a tab pattern: these switch the chart's series in place,
@@ -120,26 +311,36 @@ function Segmented<T extends string>({
   ariaLabel,
   className,
 }: {
-  options: Array<{ value: T; label: string }>
+  options: Array<{ value: T; label: string; description?: string }>
   value: T
   onChange: (next: T) => void
   ariaLabel: string
   className?: string
 }) {
+  const descriptionBaseId = useId()
+
   return (
     <div role="group" aria-label={ariaLabel} className={`segmented ${className ?? ''}`}>
       {options.map(opt => {
         const selected = value === opt.value
+        const descriptionId = opt.description ? `${descriptionBaseId}-${opt.value}-description` : undefined
         return (
-          <button
-            key={opt.value}
-            type="button"
-            aria-pressed={selected}
-            className={`segmented-option ${selected ? 'segmented-option-active' : ''}`}
-            onClick={() => onChange(opt.value)}
-          >
-            {opt.label}
-          </button>
+          <Fragment key={opt.value}>
+            <button
+              type="button"
+              aria-pressed={selected}
+              aria-describedby={descriptionId}
+              className={`segmented-option ${selected ? 'segmented-option-active' : ''}`}
+              onClick={() => onChange(opt.value)}
+            >
+              {opt.label}
+            </button>
+            {opt.description && (
+              <span id={descriptionId} className="sr-only">
+                {opt.description}
+              </span>
+            )}
+          </Fragment>
         )
       })}
     </div>
@@ -171,7 +372,11 @@ export function VisibilityTrendSection({
   const data = metricsQuery.data ?? null
   const error = metricsQuery.error
 
-  const trend = useMemo(() => (data ? buildTrendRows(data, metric, mode) : null), [data, metric, mode])
+  const effectiveMode: TrendSeriesMode = metric === 'mentionShare' ? 'overall' : mode
+  const trend = useMemo(
+    () => (data ? buildSelectedTrendRows(data, metric, effectiveMode) : null),
+    [data, metric, effectiveMode],
+  )
   // Capture the window cutoff once per data/window change; this keeps
   // supplementary model hints stable while the user is looking at the chart.
   const modelHintNow = useMemo(() => new Date(), [visibilityEvidence, window])
@@ -183,18 +388,33 @@ export function VisibilityTrendSection({
   // Headline readout: the selected metric's latest bucket value plus its change
   // across the visible window. Quantifies "where it sits now, which way it
   // moved" without reusing the removed trend badges.
-  const byProviderMode = mode === 'byProvider'
-  const metricField = metric === 'cited' ? 'citationRate' : 'mentionRate'
-  const metricLabel = metric === 'cited' ? 'Cited' : 'Mentioned'
-  const metricColor = metric === 'cited' ? CHART_TONE.positive : CHART_SERIES_COLORS[1]!
+  const byProviderMode = metric !== 'mentionShare' && effectiveMode === 'byProvider'
+  const currentMetricLabel = metricLabel(metric)
+  const metricColor = metric === 'cited'
+    ? CHART_TONE.positive
+    : metric === 'mentionShare'
+      ? MENTION_SHARE_COLOR
+      : CHART_SERIES_COLORS[1]!
   // In by-engine mode the headline is the blended rate across every engine,
   // which no single line on the chart matches — neutralize the swatch (so it
   // doesn't read as one engine's color) and tag it "avg".
   const headlineDotColor = byProviderMode ? CHART_NEUTRAL.textDim : metricColor
   const buckets = data?.buckets ?? []
-  const latestPct = buckets.length > 0 ? round1(buckets[buckets.length - 1]![metricField] * 100) : null
-  const firstPct = buckets.length > 0 ? round1(buckets[0]![metricField] * 100) : null
-  const deltaPts = latestPct !== null && firstPct !== null && buckets.length > 1 ? round1(latestPct - firstPct) : null
+  const latestPct = metric === 'mentionShare'
+    ? (trend ? latestSeriesValue(trend.rows, MENTION_SHARE_KEY) : null)
+    : buckets.length > 0
+      ? round1(buckets[buckets.length - 1]![metricField(metric)] * 100)
+      : null
+  const firstPct = metric === 'mentionShare'
+    ? (trend ? firstSeriesValue(trend.rows, MENTION_SHARE_KEY) : null)
+    : buckets.length > 0
+      ? round1(buckets[0]![metricField(metric)] * 100)
+      : null
+  const plottedPointCount = metric === 'mentionShare'
+    ? trend?.rows.filter(row => typeof row[MENTION_SHARE_KEY] === 'number').length ?? 0
+    : buckets.length
+  const deltaPts = latestPct !== null && firstPct !== null && plottedPointCount > 1 ? round1(latestPct - firstPct) : null
+  const competitorCount = competitorDomains.length
 
   const header = (
     <>
@@ -202,14 +422,14 @@ export function VisibilityTrendSection({
         <div className="space-y-1">
           <p className="eyebrow eyebrow-soft">Trend</p>
           <h2 className="visibility-trend-title">
-            Citations &amp; mentions over time
-            <InfoTooltip text="How often AI engines cited your domain as a source (Cited) and named your brand in the answer text (Mentioned), across all tracked queries, over time. Each point is a sweep bucket; rates are the share of (query × provider) snapshots in that bucket." />
+            Answer-engine trend
+            <InfoTooltip text="Three separate signals over sweep buckets: answer text mentions, source citations, and your answer-text mention share against tracked competitors. Mentioned and Cited use query-provider snapshot rates; Mention share uses project plus competitor brand mentions." />
           </h2>
         </div>
         {latestPct !== null && (
           <div className="visibility-trend-current">
             <span className="visibility-trend-current-dot" style={{ backgroundColor: headlineDotColor }} aria-hidden="true" />
-            <span className="visibility-trend-current-label">{metricLabel}</span>
+            <span className="visibility-trend-current-label">{currentMetricLabel}</span>
             {byProviderMode && <span className="visibility-trend-current-qualifier">avg</span>}
             <span className="visibility-trend-current-value">{latestPct}%</span>
             {deltaPts !== null && (
@@ -225,8 +445,10 @@ export function VisibilityTrendSection({
         )}
       </div>
       <div className="visibility-trend-controls">
-        <Segmented options={METRIC_OPTIONS} value={metric} onChange={setMetric} ariaLabel="Metric" />
-        <Segmented options={MODE_OPTIONS} value={mode} onChange={setMode} ariaLabel="Series" />
+        <Segmented options={METRIC_OPTIONS} value={metric} onChange={setMetric} ariaLabel="Metric" className="visibility-trend-metric-control" />
+        {metric !== 'mentionShare' && (
+          <Segmented options={MODE_OPTIONS} value={mode} onChange={setMode} ariaLabel="Series" />
+        )}
         <Segmented options={WINDOW_OPTIONS} value={window} onChange={setWindow} ariaLabel="Time window" className="sm:ml-auto" />
       </div>
     </>
@@ -237,6 +459,8 @@ export function VisibilityTrendSection({
     body = <p className="text-sm text-negative-400">{error instanceof Error ? error.message : String(error)}</p>
   } else if (metricsQuery.isLoading && !data) {
     body = <div className="visibility-trend-chart animate-pulse rounded-lg bg-bg-elevated/40" aria-hidden="true" />
+  } else if (metric === 'mentionShare' && competitorCount === 0) {
+    body = <p className="text-sm text-secondary">Add tracked competitors to measure mention share over time.</p>
   } else if (!data || !trend) {
     body = null
   } else {
@@ -244,25 +468,30 @@ export function VisibilityTrendSection({
     const caption = formatQueryChangeCaption(data.queryChanges)
     if (!hasData) {
       body = (
-        <p className="text-sm text-secondary">Run a sweep to start tracking citations and mentions over time.</p>
+        <p className="text-sm text-secondary">
+          {metric === 'mentionShare'
+            ? 'No answer-text brand mentions for you or tracked competitors in this window yet.'
+            : 'Run a sweep to start tracking citations and mentions over time.'}
+        </p>
       )
-    } else if (mode === 'byProvider' && series.length === 0) {
+    } else if (byProviderMode && series.length === 0) {
       body = (
         <p className="text-sm text-secondary">
           No per-engine breakdown for this data yet. Switch to <span className="text-strong">All engines</span> to see the trend.
         </p>
       )
     } else {
-      const srSummary = `${metricLabel} rate across ${rows.length} ${rows.length === 1 ? 'sweep' : 'sweeps'}. Latest ${latestPct}%${
+      const srSummary = `${currentMetricLabel} rate across ${rows.length} ${rows.length === 1 ? 'sweep' : 'sweeps'}. Latest ${latestPct}%${
         deltaPts !== null ? `, ${deltaPts >= 0 ? 'up' : 'down'} ${Math.abs(deltaPts).toFixed(1)} points over the period` : ''
       }.`
       body = (
         <>
           <p className="sr-only">{srSummary}</p>
+          <TrendDataSummary buckets={buckets} metric={metric} mode={effectiveMode} series={series} />
           {/* Per-engine key with each line's most recent value, so the engines
               and where they sit now are readable at a glance — replaces the
               cramped bottom legend and gives the by-engine view its payoff. */}
-          {mode === 'byProvider' && series.length > 0 && (
+          {byProviderMode && series.length > 0 && (
             <ul className="trend-legend" aria-label="Engines">
               {series.map((key, i) => {
                 const value = latestSeriesValue(rows, key)
@@ -289,7 +518,11 @@ export function VisibilityTrendSection({
               })}
             </ul>
           )}
-          <div className="visibility-trend-chart">
+          <div
+            className="visibility-trend-chart"
+            role="img"
+            aria-label={`${currentMetricLabel} trend chart over ${rows.length} ${rows.length === 1 ? 'bucket' : 'buckets'}`}
+          >
             <ResponsiveContainer width="100%" height="100%">
               <ComposedChart data={rows} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
                 <CartesianGrid stroke={CHART_GRID_STROKE} vertical={false} />
@@ -311,10 +544,8 @@ export function VisibilityTrendSection({
                   width={40}
                 />
                 <RechartsTooltip
-                  {...CHART_TOOLTIP_STYLE}
                   cursor={{ stroke: CHART_AXIS_STROKE, strokeWidth: 1 }}
-                  labelFormatter={formatChartDateLabel}
-                  formatter={(value, name) => [value == null ? 'no data' : `${value}%`, seriesLabel(String(name))]}
+                  content={<TrendTooltip metric={metric} mode={effectiveMode} buckets={buckets} />}
                 />
                 {series.map((key, i) => (
                   <Line
@@ -323,11 +554,14 @@ export function VisibilityTrendSection({
                     dataKey={key}
                     name={key}
                     stroke={seriesColor(key, i)}
+                    strokeDasharray={key === MENTION_SHARE_KEY ? '5 4' : undefined}
                     strokeWidth={isOverallSeries(key) ? 2.5 : 2}
                     // A solid marker on every run/bucket point so the readings are visible.
-                    dot={{ r: 2.5, fill: seriesColor(key, i), strokeWidth: 0 }}
+                    dot={key === MENTION_SHARE_KEY
+                      ? { r: 2.75, fill: 'var(--chart-tooltip-bg)', stroke: seriesColor(key, i), strokeWidth: 1.5 }
+                      : { r: 2.5, fill: seriesColor(key, i), strokeWidth: 0 }}
                     activeDot={{ r: 4, strokeWidth: 2, stroke: ACTIVE_DOT_RING }}
-                    connectNulls
+                    connectNulls={key !== MENTION_SHARE_KEY}
                     isAnimationActive={false}
                   />
                 ))}
@@ -335,7 +569,11 @@ export function VisibilityTrendSection({
             </ResponsiveContainer>
           </div>
           {singleBucket && (
-            <p className="visibility-trend-note">Only one sweep so far. The trend line fills in after the next run.</p>
+            <p className="visibility-trend-note">
+              {metric === 'mentionShare'
+                ? 'Only one competitive mention-share point so far. The trend line fills in after another sweep with brand mentions.'
+                : 'Only one sweep so far. The trend line fills in after the next run.'}
+            </p>
           )}
           {caption && <p className="visibility-trend-note">{caption}</p>}
         </>
@@ -345,143 +583,6 @@ export function VisibilityTrendSection({
 
   return (
     <section className="visibility-trend">
-      {header}
-      {body}
-    </section>
-  )
-}
-
-export function MentionShareTrendSection({
-  projectName,
-  competitorDomains,
-}: {
-  projectName: string
-  competitorDomains: readonly string[]
-}) {
-  const [window, setWindow] = useState<MetricsWindow>('all')
-  const metricsFrameKey = useMemo(() => competitorFrameKey(competitorDomains), [competitorDomains])
-  const competitorCount = competitorDomains.length
-
-  const metricsQuery = useQuery({
-    queryKey: ['analytics-metrics', projectName, window, metricsFrameKey],
-    queryFn: () => fetchAnalyticsMetrics(projectName, window),
-    staleTime: STATIC_VISIBILITY_STALE_MS,
-  })
-  const data = metricsQuery.data ?? null
-  const error = metricsQuery.error
-  const trend = useMemo(() => (data ? buildMentionShareTrendRows(data) : null), [data])
-  const latestPct = trend ? latestSeriesValue(trend.rows, MENTION_SHARE_KEY) : null
-  const firstPct = trend ? firstSeriesValue(trend.rows, MENTION_SHARE_KEY) : null
-  const deltaPts = latestPct !== null && firstPct !== null && latestPct !== firstPct
-    ? round1(latestPct - firstPct)
-    : latestPct !== null && firstPct !== null
-      ? 0
-      : null
-
-  const header = (
-    <>
-      <div className="visibility-trend-head">
-        <div className="space-y-1">
-          <p className="eyebrow eyebrow-soft">Competitive trend</p>
-          <h2 className="visibility-trend-title">
-            Mention share over time
-            <InfoTooltip text="Of all answer-text brand mentions in each sweep bucket (you plus tracked competitors), the share that were you. Buckets with no brand mentions are not plotted." />
-          </h2>
-        </div>
-        {latestPct !== null && (
-          <div className="visibility-trend-current">
-            <span className="visibility-trend-current-dot" style={{ backgroundColor: CHART_TONE.positive }} aria-hidden="true" />
-            <span className="visibility-trend-current-label">Mention share</span>
-            <span className="visibility-trend-current-value">{latestPct}%</span>
-            {deltaPts !== null && (
-              <span
-                className={`visibility-trend-current-delta ${
-                  deltaPts > 0 ? 'text-positive-400' : deltaPts < 0 ? 'text-negative-400' : 'text-muted'
-                }`}
-              >
-                {deltaPts > 0 ? '+' : ''}{deltaPts.toFixed(1)} pts
-              </span>
-            )}
-          </div>
-        )}
-      </div>
-      <div className="visibility-trend-controls">
-        <Segmented options={WINDOW_OPTIONS} value={window} onChange={setWindow} ariaLabel="Time window" className="sm:ml-auto" />
-      </div>
-    </>
-  )
-
-  let body: React.ReactNode
-  if (error) {
-    body = <p className="text-sm text-negative-400">{error instanceof Error ? error.message : String(error)}</p>
-  } else if (metricsQuery.isLoading && !data) {
-    body = <div className="visibility-trend-chart animate-pulse rounded-lg bg-bg-elevated/40" aria-hidden="true" />
-  } else if (competitorCount === 0) {
-    body = <p className="text-sm text-secondary">Add tracked competitors to measure mention share over time.</p>
-  } else if (!data || !trend) {
-    body = null
-  } else if (!trend.hasData) {
-    body = <p className="text-sm text-secondary">No answer-text brand mentions for you or tracked competitors in this window yet.</p>
-  } else {
-    const caption = formatQueryChangeCaption(data.queryChanges)
-    const { rows, singleBucket } = trend
-    const srSummary = `Mention share across ${rows.length} ${rows.length === 1 ? 'sweep bucket' : 'sweep buckets'}. Latest ${latestPct}%${
-      deltaPts !== null ? `, ${deltaPts >= 0 ? 'up' : 'down'} ${Math.abs(deltaPts).toFixed(1)} points over the period` : ''
-    }.`
-    body = (
-      <>
-        <p className="sr-only">{srSummary}</p>
-        <div className="visibility-trend-chart">
-          <ResponsiveContainer width="100%" height="100%">
-            <ComposedChart data={rows} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
-              <CartesianGrid stroke={CHART_GRID_STROKE} vertical={false} />
-              <XAxis
-                dataKey="date"
-                tick={CHART_AXIS_TICK}
-                tickLine={false}
-                axisLine={{ stroke: CHART_AXIS_STROKE }}
-                tickFormatter={formatChartDateTick}
-                minTickGap={24}
-              />
-              <YAxis
-                domain={[0, 100]}
-                ticks={[0, 25, 50, 75, 100]}
-                tickFormatter={(v: number) => `${v}%`}
-                tick={CHART_AXIS_TICK}
-                tickLine={false}
-                axisLine={false}
-                width={40}
-              />
-              <RechartsTooltip
-                {...CHART_TOOLTIP_STYLE}
-                cursor={{ stroke: CHART_AXIS_STROKE, strokeWidth: 1 }}
-                labelFormatter={formatChartDateLabel}
-                formatter={(value) => [value == null ? 'no data' : `${value}%`, 'Mention share']}
-              />
-              <Line
-                type="monotone"
-                dataKey={MENTION_SHARE_KEY}
-                name={MENTION_SHARE_KEY}
-                stroke={CHART_TONE.positive}
-                strokeWidth={2.5}
-                dot={{ r: 2.5, fill: CHART_TONE.positive, strokeWidth: 0 }}
-                activeDot={{ r: 4, strokeWidth: 2, stroke: ACTIVE_DOT_RING }}
-                connectNulls
-                isAnimationActive={false}
-              />
-            </ComposedChart>
-          </ResponsiveContainer>
-        </div>
-        {singleBucket && (
-          <p className="visibility-trend-note">Only one competitive mention-share point so far. The trend line fills in after another sweep with brand mentions.</p>
-        )}
-        {caption && <p className="visibility-trend-note">{caption}</p>}
-      </>
-    )
-  }
-
-  return (
-    <section className="visibility-trend mention-share-trend">
       {header}
       {body}
     </section>

--- a/apps/web/src/lib/visibility-trend-helpers.ts
+++ b/apps/web/src/lib/visibility-trend-helpers.ts
@@ -17,7 +17,8 @@ export const MENTION_SHARE_KEY = '__mentionShare__'
 export type TrendSeriesMode = 'overall' | 'byProvider'
 
 /** Which metric line to plot. */
-export type MetricChoice = 'cited' | 'mentioned'
+export type PresenceMetricChoice = 'cited' | 'mentioned'
+export type MetricChoice = PresenceMetricChoice | 'mentionShare'
 
 export interface TrendRow {
   date: string
@@ -34,6 +35,10 @@ export interface TrendData {
 }
 
 export type ProviderModelHints = Record<string, string[]>
+type BucketProviderMetric = BrandMetricsDto['buckets'][number]['byProvider'][string]
+type BucketWithOptionalProviders = Omit<BrandMetricsDto['buckets'][number], 'byProvider'> & {
+  byProvider?: Record<string, BucketProviderMetric | undefined>
+}
 
 export function normalizeProviderKey(provider: string): string {
   return provider.trim().toLowerCase()
@@ -44,9 +49,13 @@ function toPercent(rate: number): number {
   return Math.round(rate * 1000) / 10
 }
 
+function bucketProviders(bucket: BrandMetricsDto['buckets'][number]): Record<string, BucketProviderMetric | undefined> {
+  return (bucket as BucketWithOptionalProviders).byProvider ?? {}
+}
+
 export function buildTrendRows(
   dto: BrandMetricsDto,
-  metric: MetricChoice,
+  metric: PresenceMetricChoice,
   mode: TrendSeriesMode,
 ): TrendData {
   const hasData = dto.buckets.length > 0
@@ -67,11 +76,12 @@ export function buildTrendRows(
   // `?? {}` guards buckets from an older backend (≤4.67.0) that predates the
   // per-bucket breakdown and omits `byProvider` entirely — degrade to no
   // provider lines instead of throwing on `Object.keys(undefined)`.
-  const series = [...new Set(dto.buckets.flatMap(b => Object.keys(b.byProvider ?? {})))].sort()
+  const series = [...new Set(dto.buckets.flatMap(b => Object.keys(bucketProviders(b))))].sort()
   const rows: TrendRow[] = dto.buckets.map(b => {
     const row: TrendRow = { date: b.startDate }
+    const providers = bucketProviders(b)
     for (const provider of series) {
-      const metricRow = b.byProvider?.[provider]
+      const metricRow = providers[provider]
       // null (not 0) when a provider has no data in this bucket — Recharts
       // `connectNulls` bridges the gap rather than dropping the line to zero.
       row[provider] = metricRow ? toPercent(metricRow[field]) : null
@@ -162,6 +172,15 @@ export function buildMentionShareTrendRows(dto: BrandMetricsDto): TrendData {
     hasData: plottedValues.length > 0,
     singleBucket: plottedValues.length === 1,
   }
+}
+
+export function buildSelectedTrendRows(
+  dto: BrandMetricsDto,
+  metric: MetricChoice,
+  mode: TrendSeriesMode,
+): TrendData {
+  if (metric === 'mentionShare') return buildMentionShareTrendRows(dto)
+  return buildTrendRows(dto, metric, mode)
 }
 
 /**

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -21,7 +21,7 @@ import { GscSection } from '../components/project/GscSection.js'
 import { GbpSection } from '../components/project/GbpSection.js'
 import { BacklinksSection } from '../components/project/BacklinksSection.js'
 import { CitationVisibilitySection } from '../components/project/CitationVisibilitySection.js'
-import { MentionShareTrendSection, VisibilityTrendSection } from '../components/project/VisibilityTrendSection.js'
+import { VisibilityTrendSection } from '../components/project/VisibilityTrendSection.js'
 import { DiscoverySection } from '../components/project/DiscoverySection.js'
 import { TechnicalAeoSection } from '../components/project/TechnicalAeoSection.js'
 import { ReportPage } from './ReportPage.js'
@@ -2312,10 +2312,6 @@ function ProjectPageContent({
               competitorDomains={competitorDomains}
               visibilityEvidence={model.visibilityEvidence}
             />
-          </section>
-
-          <section className="page-section-divider">
-            <MentionShareTrendSection projectName={model.project.name} competitorDomains={competitorDomains} />
           </section>
 
           <OverviewBrief

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1021,6 +1021,14 @@
     @apply mb-3 flex flex-wrap items-center gap-2;
   }
 
+  .visibility-trend-metric-control {
+    @apply w-full sm:w-auto;
+  }
+
+  .visibility-trend-metric-control .segmented-option {
+    @apply flex-1 sm:flex-none;
+  }
+
   .visibility-trend-chart {
     @apply h-64 w-full sm:h-72;
   }
@@ -1061,6 +1069,42 @@
 
   .trend-legend-value {
     @apply text-[11px] font-semibold tabular-nums text-primary;
+  }
+
+  .trend-tooltip {
+    @apply min-w-48 rounded-lg border border-default bg-bg-elevated px-3 py-2 text-xs text-secondary shadow-lg;
+  }
+
+  .trend-tooltip-label {
+    @apply mb-1.5 font-medium text-primary;
+  }
+
+  .trend-tooltip-block {
+    @apply mt-2 first:mt-0;
+  }
+
+  .trend-tooltip-row {
+    @apply flex items-center gap-2;
+  }
+
+  .trend-tooltip-swatch {
+    @apply h-2 w-2 shrink-0 rounded-full;
+  }
+
+  .trend-tooltip-swatch-ring {
+    @apply border bg-transparent;
+  }
+
+  .trend-tooltip-name {
+    @apply text-neutral;
+  }
+
+  .trend-tooltip-value {
+    @apply ml-auto font-semibold tabular-nums text-primary;
+  }
+
+  .trend-tooltip-detail {
+    @apply mt-1 text-[11px] leading-snug text-muted;
   }
 
   /* Segmented control: an inset track with a raised selected chip. Used for the

--- a/apps/web/test/visibility-trend-helpers.test.ts
+++ b/apps/web/test/visibility-trend-helpers.test.ts
@@ -3,6 +3,7 @@ import type { BrandMetricsDto } from '@ainyc/canonry-contracts'
 import {
   buildProviderModelHints,
   buildMentionShareTrendRows,
+  buildSelectedTrendRows,
   buildTrendRows,
   trendToTone,
   formatQueryChangeCaption,
@@ -206,6 +207,25 @@ describe('buildMentionShareTrendRows', () => {
     expect(res.rows[0]![MENTION_SHARE_KEY]).toBeNull()
     expect(res.rows[1]![MENTION_SHARE_KEY]).toBe(50)
     expect(res.singleBucket).toBe(true)
+  })
+})
+
+describe('buildSelectedTrendRows', () => {
+  it('delegates mentioned and cited metrics to the presence trend builder', () => {
+    const d = dto([
+      bucket('2026-04-01', { gemini: provider(0.25, 0.1) }, { citationRate: 0.25, mentionRate: 0.1 }),
+    ])
+
+    expect(buildSelectedTrendRows(d, 'mentioned', 'overall')).toEqual(buildTrendRows(d, 'mentioned', 'overall'))
+    expect(buildSelectedTrendRows(d, 'cited', 'byProvider')).toEqual(buildTrendRows(d, 'cited', 'byProvider'))
+  })
+
+  it('uses mention-share rows regardless of requested series mode', () => {
+    const d = dto([
+      { ...bucket('2026-04-01', { gemini: provider(0.25, 0.1) }), mentionShare: { rate: 0.25, projectMentionSnapshots: 1, competitorMentionSnapshots: 3 } },
+    ])
+
+    expect(buildSelectedTrendRows(d, 'mentionShare', 'byProvider')).toEqual(buildMentionShareTrendRows(d))
   })
 })
 

--- a/apps/web/test/visibility-trend-section.test.tsx
+++ b/apps/web/test/visibility-trend-section.test.tsx
@@ -27,7 +27,7 @@ vi.mock('recharts', () => {
   }
 })
 
-import { MentionShareTrendSection, VisibilityTrendSection } from '../src/components/project/VisibilityTrendSection.js'
+import { VisibilityTrendSection } from '../src/components/project/VisibilityTrendSection.js'
 import type { CitationInsightVm } from '../src/view-models.js'
 import { mockFetch, jsonResponse } from './mock-fetch.js'
 
@@ -62,11 +62,11 @@ const TWO_BUCKETS = [
   },
 ]
 
-function renderSection() {
+function renderSection(competitorDomains: readonly string[] = []) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
     <QueryClientProvider client={queryClient}>
-      <VisibilityTrendSection projectName="test-project" />
+      <VisibilityTrendSection projectName="test-project" competitorDomains={competitorDomains} />
     </QueryClientProvider>,
   )
 }
@@ -106,15 +106,6 @@ function evidence(providerName: string, models: string[]): CitationInsightVm {
   }
 }
 
-function renderMentionShareSection(competitorDomains: readonly string[] = ['competitor.com']) {
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <MentionShareTrendSection projectName="test-project" competitorDomains={competitorDomains} />
-    </QueryClientProvider>,
-  )
-}
-
 test('defaults to the by-engine view with a per-engine legend, and toggles to all-engines', async () => {
   const restore = mockFetch((url) => {
     const path = url.split('?')[0]!
@@ -127,7 +118,7 @@ test('defaults to the by-engine view with a per-engine legend, and toggles to al
 
   renderSection()
 
-  expect(screen.getByText('Citations & mentions over time')).toBeTruthy()
+  expect(screen.getByText('Answer-engine trend')).toBeTruthy()
 
   // The legend only renders once the DTO has loaded (and only in by-engine
   // mode) — wait on it rather than the chart skeleton, which shares the
@@ -138,7 +129,13 @@ test('defaults to the by-engine view with a per-engine legend, and toggles to al
   // Mentioned (no "Both"); Mentioned is the default.
   expect(screen.queryByRole('button', { name: 'Both' })).toBeNull()
   expect(screen.getByRole('button', { name: 'Cited' })).toBeTruthy()
-  expect(screen.getByRole('button', { name: 'Mentioned' }).getAttribute('aria-pressed')).toBe('true')
+  expect(screen.getByRole('button', { name: 'Mention share' })).toBeTruthy()
+  const mentioned = screen.getByRole('button', { name: 'Mentioned' })
+  expect(mentioned.getAttribute('aria-pressed')).toBe('true')
+  expect(mentioned.getAttribute('title')).toBeNull()
+  const mentionedDescriptionId = mentioned.getAttribute('aria-describedby')
+  expect(mentionedDescriptionId).toBeTruthy()
+  expect(document.getElementById(mentionedDescriptionId!)?.textContent).toBe('Your brand or domain appears in the answer text.')
 
   // By engine is the default breakdown; All engines is the other mode.
   const byEngine = screen.getByRole('button', { name: 'By engine' })
@@ -208,7 +205,7 @@ test('shows an empty state when there are no buckets yet', async () => {
   })
 })
 
-test('renders mention-share trend from bucket metrics', async () => {
+test('renders mention-share as a metric view and hides the engine split', async () => {
   const restore = mockFetch((url) => {
     const path = url.split('?')[0]!
     if (path.endsWith('/projects/test-project/analytics/metrics')) {
@@ -218,14 +215,21 @@ test('renders mention-share trend from bucket metrics', async () => {
   })
   onTestFinished(restore)
 
-  renderMentionShareSection()
+  renderSection(['competitor.com'])
 
-  expect(await screen.findByText('Mention share over time')).toBeTruthy()
-  expect(await screen.findByText('75%')).toBeTruthy()
-  expect(screen.getByRole('button', { name: 'All' })).toBeTruthy()
+  await screen.findByRole('list', { name: 'Engines' })
+  const mentionShare = screen.getByRole('button', { name: 'Mention share' })
+  act(() => { fireEvent.click(mentionShare) })
+
+  expect(mentionShare.getAttribute('aria-pressed')).toBe('true')
+  expect(screen.queryByRole('group', { name: 'Series' })).toBeNull()
+  expect(screen.queryByRole('list', { name: 'Engines' })).toBeNull()
+  expect(screen.getByText('75%')).toBeTruthy()
+  expect(screen.getByRole('img', { name: /Mention share trend chart/i })).toBeTruthy()
+  expect(screen.getByText(/75% mention share, 3 of 4 brand mentions were you/)).toBeTruthy()
 })
 
-test('prompts for competitors before rendering mention-share history', async () => {
+test('prompts for competitors before rendering the mention-share metric view', async () => {
   const restore = mockFetch((url) => {
     const path = url.split('?')[0]!
     if (path.endsWith('/projects/test-project/analytics/metrics')) {
@@ -235,7 +239,10 @@ test('prompts for competitors before rendering mention-share history', async () 
   })
   onTestFinished(restore)
 
-  renderMentionShareSection([])
+  renderSection([])
+
+  await screen.findByRole('list', { name: 'Engines' })
+  act(() => { fireEvent.click(screen.getByRole('button', { name: 'Mention share' })) })
 
   await waitFor(() => {
     expect(screen.getByText(/Add tracked competitors/)).toBeTruthy()
@@ -257,7 +264,7 @@ test('refetches mention-share metrics when the competitor frame changes', async 
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   const view = render(
     <QueryClientProvider client={queryClient}>
-      <MentionShareTrendSection projectName="test-project" competitorDomains={['competitor.com']} />
+      <VisibilityTrendSection projectName="test-project" competitorDomains={['competitor.com']} />
     </QueryClientProvider>,
   )
 
@@ -267,7 +274,7 @@ test('refetches mention-share metrics when the competitor frame changes', async 
 
   view.rerender(
     <QueryClientProvider client={queryClient}>
-      <MentionShareTrendSection projectName="test-project" competitorDomains={['competitor.com', 'new-rival.com']} />
+      <VisibilityTrendSection projectName="test-project" competitorDomains={['competitor.com', 'new-rival.com']} />
     </QueryClientProvider>,
   )
 


### PR DESCRIPTION
Combines the separate citations/mentions and mention-share overview charts into one Answer-engine trend chart with metric controls for Mentioned, Cited, and Mention share.
The unified chart adds custom tooltips with denominators, accessible data summaries, and hides the engine split when mention share is selected.
It removes the separate mention-share section from the project overview while keeping competitor-frame refetch behavior and adding focused helper/component test coverage.
Validated with web Vitest, focused ESLint, web typecheck/build/color scan, git diff --check, and the repo lint hook during commit.
