### PR TITLE
chore(release): 4.114.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.114.0",
+  "version": "4.114.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.114.0",
+  "version": "4.114.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
Patch release packaging #804 (drop the redundant locale tag-row from the embed project header) so the deployable image builds from a versioned main commit instead of a branch build.

Version-only change: root + `packages/canonry` package.json `4.114.0` → `4.114.1`. No code or behavior change.