### PR TITLE
chore(release): 4.115.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.114.1",
+  "version": "4.115.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.114.1",
+  "version": "4.115.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
Patch/minor release packaging #805 (combine overview trend charts) and #807 (non-destructive competitor management endpoint) so the deployable image builds from a versioned main commit.

Version-only change: root + `packages/canonry` package.json `4.114.1` → `4.115.0`. No code or behavior change.