### PR TITLE
fix(web): clarify empty Bing backlink sync state

### DIFF
--- a/apps/web/src/components/project/BacklinksSection.tsx
+++ b/apps/web/src/components/project/BacklinksSection.tsx
@@ -511,21 +511,44 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
             </div>
             <div className="flex-1">
               {connected && everSynced ? (
-                <>
-                  <h3 className="text-base font-semibold text-heading">No non-crawler referring domains</h3>
-                  <p className="text-sm text-muted mt-1">
-                    Bing Webmaster synced for <code className="text-neutral">{projectName}</code>, but every inbound
-                    link in the latest window is a crawler/proxy host (hidden by default). Re-sync to check for new links.
-                  </p>
-                  {!isEmbed() && (
-                    <div className="mt-4">
-                      <Button type="button" variant="outline" size="sm" disabled={bingSyncing || activeRun !== null} onClick={asyncHandler(handleBingSync)}>
-                        <Download className="h-4 w-4 mr-1.5" aria-hidden />
-                        {activeRun ? 'Sync running…' : bingSyncing ? 'Queuing…' : 'Re-sync Bing inbound links'}
-                      </Button>
-                    </div>
-                  )}
-                </>
+                hiddenCount > 0 ? (
+                  <>
+                    <h3 className="text-base font-semibold text-heading">No non-crawler referring domains</h3>
+                    <p className="text-sm text-muted mt-1">
+                      Bing Webmaster synced for <code className="text-neutral">{projectName}</code>, but{' '}
+                      {formatNumber(hiddenCount)} crawler/proxy referring domain{hiddenCount === 1 ? '' : 's'} in
+                      the latest window {hiddenCount === 1 ? 'is' : 'are'} hidden by default. Re-sync to check for new links.
+                    </p>
+                    {!isEmbed() && (
+                      <div className="mt-4">
+                        <Button type="button" variant="outline" size="sm" disabled={bingSyncing || activeRun !== null} onClick={asyncHandler(handleBingSync)}>
+                          <Download className="h-4 w-4 mr-1.5" aria-hidden />
+                          {activeRun ? 'Sync running…' : bingSyncing ? 'Queuing…' : 'Re-sync Bing inbound links'}
+                        </Button>
+                      </div>
+                    )}
+                  </>
+                ) : (
+                  <>
+                    <h3 className="text-base font-semibold text-heading">No Bing inbound links returned</h3>
+                    <p className="text-sm text-muted mt-1">
+                      Bing Webmaster synced for <code className="text-neutral">{projectName}</code>, but the Bing
+                      backlink API returned <span className="text-neutral">0 inbound-link rows</span> in the latest
+                      window. There were no referring domains to filter.
+                    </p>
+                    <p className="text-xs text-muted mt-2">
+                      Re-sync later or compare against the Bing Webmaster Tools backlink export for this verified site.
+                    </p>
+                    {!isEmbed() && (
+                      <div className="mt-4">
+                        <Button type="button" variant="outline" size="sm" disabled={bingSyncing || activeRun !== null} onClick={asyncHandler(handleBingSync)}>
+                          <Download className="h-4 w-4 mr-1.5" aria-hidden />
+                          {activeRun ? 'Sync running…' : bingSyncing ? 'Queuing…' : 'Re-sync Bing inbound links'}
+                        </Button>
+                      </div>
+                    )}
+                  </>
+                )
               ) : connected ? (
                 <>
                   <h3 className="text-base font-semibold text-heading">No Bing inbound links yet</h3>

--- a/apps/web/test/backlinks-section.test.tsx
+++ b/apps/web/test/backlinks-section.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react'
+import { afterEach, expect, onTestFinished, test } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+
+import { BacklinksSection } from '../src/components/project/BacklinksSection.js'
+import { jsonResponse, mockFetch, pathOf } from './mock-fetch.js'
+
+afterEach(cleanup)
+
+type BingEmptyCase = 'zero-raw' | 'all-filtered'
+
+function installBacklinksApiMock(kind: BingEmptyCase) {
+  const restoreFetch = mockFetch((url) => {
+    const parsed = new URL(url)
+    const path = pathOf(url).split('?')[0]!
+    const source = parsed.searchParams.get('source') ?? 'commoncrawl'
+
+    if (path === '/api/v1/projects/azcoatings/backlinks/sources') {
+      return jsonResponse({
+        projectId: 'project-1',
+        targetDomain: 'azcoatingsllc.com',
+        anyConnected: true,
+        anyData: true,
+        sources: [
+          {
+            source: 'commoncrawl',
+            connected: false,
+            hasData: false,
+            latestRelease: null,
+            totalLinkingDomains: 0,
+            lastSyncedAt: null,
+          },
+          {
+            source: 'bing-webmaster',
+            connected: true,
+            hasData: true,
+            latestRelease: 'bing-2026-07-09',
+            totalLinkingDomains: 0,
+            lastSyncedAt: '2026-07-09T16:00:00.000Z',
+          },
+        ],
+      })
+    }
+
+    if (path === '/api/v1/backlinks/syncs/latest') return jsonResponse(null)
+    if (path === '/api/v1/projects/azcoatings/backlinks/history') return jsonResponse([])
+    if (path === '/api/v1/projects/azcoatings/runs') return jsonResponse([])
+
+    if (path === '/api/v1/projects/azcoatings/backlinks/summary') {
+      if (source !== 'bing-webmaster') return jsonResponse(null)
+      return jsonResponse({
+        projectId: 'project-1',
+        release: 'bing-2026-07-09',
+        targetDomain: 'azcoatingsllc.com',
+        totalLinkingDomains: 0,
+        totalHosts: 0,
+        top10HostsShare: '0',
+        queriedAt: '2026-07-09T16:00:00.000Z',
+        source: 'bing-webmaster',
+        ...(kind === 'all-filtered'
+          ? { excludedLinkingDomains: 4, excludedHosts: 12 }
+          : {}),
+      })
+    }
+
+    if (path === '/api/v1/projects/azcoatings/backlinks/domains') {
+      return jsonResponse({
+        source,
+        summary: null,
+        total: 0,
+        rows: [],
+      })
+    }
+
+    throw new Error(`Unexpected fetch: ${url}`)
+  })
+  onTestFinished(restoreFetch)
+}
+
+test('Bing empty state says the API returned zero raw inbound links when nothing was filtered', async () => {
+  installBacklinksApiMock('zero-raw')
+
+  render(<BacklinksSection projectName="azcoatings" />)
+
+  expect(await screen.findByText('No Bing inbound links returned')).toBeTruthy()
+  expect(screen.getByText(/0 inbound-link rows/)).toBeTruthy()
+  expect(screen.getByText(/There were no referring domains to filter/)).toBeTruthy()
+  expect(screen.queryByText(/every inbound link/i)).toBeNull()
+})
+
+test('Bing empty state reports hidden crawler/proxy domains when filtered rows exist', async () => {
+  installBacklinksApiMock('all-filtered')
+
+  render(<BacklinksSection projectName="azcoatings" />)
+
+  expect(await screen.findByText('No non-crawler referring domains')).toBeTruthy()
+  await waitFor(() => {
+    expect(screen.getByText(/4 crawler\/proxy referring domains/)).toBeTruthy()
+  })
+  expect(screen.queryByText(/0 inbound-link rows/)).toBeNull()
+})


### PR DESCRIPTION
## Summary
Clarifies the Bing backlinks empty state so a synced zero-count window no longer claims every inbound link was filtered as crawler/proxy traffic.
The dashboard now distinguishes true zero raw Bing rows from all-filtered crawler/proxy rows, and shows the hidden crawler/proxy count when applicable.
Added web regression coverage for both empty synced states.

## Checks
- pnpm --filter @ainyc/canonry-web test -- backlinks-section.test.tsx
- pnpm --filter @ainyc/canonry-web run typecheck
- pnpm --filter @ainyc/canonry-web run lint
- pnpm --filter @canonry/canonry test -- bing-backlinks-sync.test.ts backlinks-commands.test.ts
- pnpm --filter @ainyc/canonry-api-routes test -- backlinks.test.ts doctor-backlinks.test.ts
- pnpm --filter @ainyc/canonry-integration-bing test -- bing-client.test.ts
