### PR TITLE
fix(analytics): scope run selection to answer-visibility sweeps

### DIFF
--- a/packages/api-routes/src/analytics.ts
+++ b/packages/api-routes/src/analytics.ts
@@ -4,7 +4,7 @@ import { filterTrackedSnapshots, groupRunsByCreatedAt, pickGroupRepresentative, 
 import {
   AI_PROVIDER_INFRA_DOMAINS, brandLabelFromDomain, categorizeSource, categoryLabel, CitationStates,
   classifySurfaceFromCategory, surfaceClassFromCompetitorType, surfaceClassLabel,
-  effectiveDomains, normalizeProjectDomain, parseWindow, windowCutoff, validationError,
+  effectiveDomains, normalizeProjectDomain, parseWindow, RunKinds, windowCutoff, validationError,
 } from '@ainyc/canonry-contracts'
 import type {
   BrandMetricsDto, GapAnalysisDto, SourceBreakdownDto,
@@ -29,7 +29,7 @@ export async function analyticsRoutes(app: FastifyInstance) {
     const projectRuns = app.db
       .select()
       .from(runs)
-      .where(and(eq(runs.projectId, project.id), notProbeRun()))
+      .where(and(eq(runs.projectId, project.id), eq(runs.kind, RunKinds['answer-visibility']), notProbeRun()))
       .orderBy(runs.createdAt)
       .all()
       .filter(r => r.status === 'completed' || r.status === 'partial')
@@ -130,10 +130,13 @@ export async function analyticsRoutes(app: FastifyInstance) {
     // classification reads snapshots across all locations in it. The single
     // `runId` returned in the response is the deterministic representative
     // (id DESC tiebreak) so callers get a stable id. See #480.
+    // Only `answer-visibility` runs carry query snapshots — a newer sync run
+    // (traffic/gsc/ga/gbp/backlinks/site-audit) would otherwise become "latest"
+    // and classify an empty snapshot set.
     const completedRuns = app.db
       .select()
       .from(runs)
-      .where(and(eq(runs.projectId, project.id), notProbeRun()))
+      .where(and(eq(runs.projectId, project.id), eq(runs.kind, RunKinds['answer-visibility']), notProbeRun()))
       .orderBy(desc(runs.createdAt), desc(runs.id))
       .all()
       .filter(r => r.status === 'completed' || r.status === 'partial')
@@ -145,11 +148,11 @@ export async function analyticsRoutes(app: FastifyInstance) {
       return reply.send({ cited: [], gap: [], uncited: [], mentionedQueries: [], mentionGap: [], notMentioned: [], runId: '', window } satisfies GapAnalysisDto)
     }
 
-    // All runs in window (for consistency signal)
+    // All sweep runs in window (for consistency signal)
     const windowRuns = app.db
       .select()
       .from(runs)
-      .where(and(eq(runs.projectId, project.id), notProbeRun()))
+      .where(and(eq(runs.projectId, project.id), eq(runs.kind, RunKinds['answer-visibility']), notProbeRun()))
       .orderBy(runs.createdAt)
       .all()
       .filter(r => r.status === 'completed' || r.status === 'partial')
@@ -354,11 +357,11 @@ export async function analyticsRoutes(app: FastifyInstance) {
       if (mapped) storedSurfaceClasses.set(normalizeProjectDomain(row.domain), mapped)
     }
 
-    // All runs in window
+    // All sweep runs in window
     const windowRuns = app.db
       .select()
       .from(runs)
-      .where(and(eq(runs.projectId, project.id), notProbeRun()))
+      .where(and(eq(runs.projectId, project.id), eq(runs.kind, RunKinds['answer-visibility']), notProbeRun()))
       .orderBy(desc(runs.createdAt), desc(runs.id))
       .all()
       .filter(r => r.status === 'completed' || r.status === 'partial')

--- a/packages/api-routes/test/analytics.test.ts
+++ b/packages/api-routes/test/analytics.test.ts
@@ -1148,3 +1148,95 @@ describe('GET /projects/:name/analytics/sources — ranked + byProvider + classi
     expect(body.limit).toBeNull()
   })
 })
+
+// A project that also ingests traffic (or syncs GSC/GA/GBP) accumulates runs whose
+// kind is not `answer-visibility`. Those runs carry zero query_snapshots, so any
+// analytics read that resolves "the latest run" without filtering on kind lands on
+// one of them and classifies an empty snapshot set. traffic-sync alone runs every
+// 30 minutes, so for those projects the newest run is essentially never a sweep.
+describe('analytics ignores non-sweep run kinds', () => {
+  let app: ReturnType<typeof Fastify>
+  let db: ReturnType<typeof createClient>
+  let tmpDir: string
+  let sweepOlderId: string
+  let sweepLatestId: string
+
+  const DAY_MS = 86_400_000
+  const iso = (daysAgo: number) => new Date(Date.now() - daysAgo * DAY_MS).toISOString()
+
+  beforeAll(async () => {
+    const ctx = buildApp()
+    app = ctx.app
+    db = ctx.db
+    tmpDir = ctx.tmpDir
+    await app.ready()
+
+    const projectId = crypto.randomUUID()
+    db.insert(projects).values({
+      id: projectId, name: 'kind-filter', displayName: 'Kind Filter',
+      canonicalDomain: 'kindfilter.com', ownedDomains: [], country: 'US', language: 'en',
+      tags: [], labels: {}, providers: ['gemini'], locations: [], defaultLocation: null,
+      configSource: 'api', configRevision: 1, createdAt: iso(50), updatedAt: iso(50),
+    }).run()
+
+    // Queries predate every bucket so bucket normalization keeps them.
+    const citedQId = crypto.randomUUID()
+    const uncitedQId = crypto.randomUUID()
+    db.insert(queries).values([
+      { id: citedQId, projectId, query: 'cited query', createdAt: iso(50) },
+      { id: uncitedQId, projectId, query: 'uncited query', createdAt: iso(50) },
+    ]).run()
+
+    // Two real sweeps, 3 days apart → a 3-day span → daily buckets.
+    sweepOlderId = crypto.randomUUID()
+    sweepLatestId = crypto.randomUUID()
+    db.insert(runs).values([
+      { id: sweepOlderId, projectId, kind: 'answer-visibility', status: 'completed', trigger: 'manual', location: null, startedAt: iso(40), finishedAt: iso(40), error: null, createdAt: iso(40) },
+      { id: sweepLatestId, projectId, kind: 'answer-visibility', status: 'completed', trigger: 'manual', location: null, startedAt: iso(37), finishedAt: iso(37), error: null, createdAt: iso(37) },
+    ]).run()
+
+    for (const [runId, at] of [[sweepOlderId, iso(40)], [sweepLatestId, iso(37)]] as const) {
+      db.insert(querySnapshots).values([
+        { id: crypto.randomUUID(), runId, queryId: citedQId, provider: 'gemini', citationState: 'cited', answerMentioned: true, answerText: 'kindfilter.com is great', citedDomains: ['kindfilter.com'], competitorOverlap: [], location: null, rawResponse: '{}', createdAt: at },
+        { id: crypto.randomUUID(), runId, queryId: uncitedQId, provider: 'gemini', citationState: 'not-cited', answerMentioned: false, answerText: 'no mention here', citedDomains: [], competitorOverlap: [], location: null, rawResponse: '{}', createdAt: at },
+      ]).run()
+    }
+
+    // The newest run is a traffic-sync with no snapshots — exactly what a
+    // traffic-connected project looks like in production.
+    db.insert(runs).values({
+      id: crypto.randomUUID(), projectId, kind: 'traffic-sync', status: 'completed',
+      trigger: 'scheduled', location: null, startedAt: iso(0), finishedAt: iso(0),
+      error: null, createdAt: iso(0),
+    }).run()
+  })
+
+  afterAll(async () => {
+    await app.close()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('gaps classifies the latest sweep, not the newer traffic-sync run', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/v1/projects/kind-filter/analytics/gaps' })
+    const body = JSON.parse(res.payload)
+
+    expect(body.runId).toBe(sweepLatestId)
+    expect(body.cited.map((q: { query: string }) => q.query)).toEqual(['cited query'])
+    expect(body.uncited.map((q: { query: string }) => q.query)).toEqual(['uncited query'])
+    expect(body.mentionedQueries.map((q: { query: string }) => q.query)).toEqual(['cited query'])
+    expect(body.notMentioned.map((q: { query: string }) => q.query)).toEqual(['uncited query'])
+  })
+
+  it('sources reports the latest sweep as runId, not the traffic-sync run', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/v1/projects/kind-filter/analytics/sources?window=all' })
+    expect(JSON.parse(res.payload).runId).toBe(sweepLatestId)
+  })
+
+  it('metrics bucket size derives from the sweep span, not a distant non-sweep run', async () => {
+    // Sweeps span 3 days → bucketSizeForSpan(3) = 1 (daily) → one bucket per sweep day.
+    // Counting the traffic-sync run stretches the span to 40 days → 7-day buckets,
+    // which collapses both sweeps into a single bucket.
+    const res = await app.inject({ method: 'GET', url: '/api/v1/projects/kind-filter/analytics/metrics?window=all' })
+    expect(JSON.parse(res.payload).buckets).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
## Problem

The three `/analytics/*` reads select project runs filtering only on `(projectId, notProbeRun())` — never on `runs.kind`. Only `answer-visibility` runs carry `query_snapshots`, so a newer run of any other kind silently displaces the sweep these routes mean to read.

`GET /projects/:name/analytics/gaps` is the worst case. It resolves "the latest completed run group" and classifies that group's snapshots. When the newest run is a `traffic-sync` (zero snapshots), **every gap array returns empty**. Since `traffic-sync` is scheduled every 30 minutes, a traffic-connected project's newest run is essentially never a sweep, so gap analysis is permanently blank — no error, just `[]`.

Reproduced against a copy of a real database: three projects, all returning `0` gap items across every window. With this fix they return `16`, `26`, and `42`.

Also affected, less severely:

| Route | Effect | Values wrong? |
|---|---|---|
| `metrics` | Bucket span derived from the polluted run list, so a distant sync run widened `bucketSizeForSpan` (daily buckets collapsed to weekly) | No — empty buckets are dropped |
| `sources` | Reported a non-sweep run as the response `runId` | No — aggregates key off snapshots |

## Fix

AND-in `eq(runs.kind, RunKinds['answer-visibility'])` on the four run queries. This matches `report.ts:1077`, `visibility-stats.ts:296`, `intelligence.ts:277`, and `content-data.ts:252`, which already filter this way — `analytics.ts` did not even import `RunKinds`.

No contract change. Projects that only ever sweep behave identically.

## Why it survived

Every existing analytics fixture seeds only `answer-visibility` runs, so no test ever exercised the path. The new tests seed what production actually looks like: two sweeps three days apart, plus a newer `traffic-sync` run with no snapshots. All three fail before the change and pass after.

## Verification

- `pnpm typecheck` clean workspace-wide
- `eslint` 0 errors
- `packages/api-routes` suite: 1411 passing
- Patched routes run against a copy of a live DB, confirming real gap data is restored

## Follow-up (not in this PR)

Six call sites now hand-roll the same `eq(runs.kind, RunKinds['answer-visibility'])` predicate. A shared `answerVisibilityRun()` helper in `helpers.ts` — mirroring `notProbeRun()` — would be a natural consolidation, and a `probe-exclusion.test.ts`-style regression test would stop a future aggregate route from forgetting the filter. Kept out of this change to keep the bug fix reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)