### PR TITLE
fix(db): backfill ga_ai_referrals.traffic_class (migration v96)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.115.0",
+  "version": "4.115.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.115.0",
+  "version": "4.115.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1,4 +1,5 @@
 import { sql } from 'drizzle-orm'
+import { classifyGa4AiReferralTrafficClass } from '@ainyc/canonry-contracts'
 import type { DatabaseClient } from './client.js'
 import { parseJsonColumn } from './json.js'
 
@@ -2008,12 +2009,35 @@ export const MIGRATION_VERSIONS: ReadonlyArray<MigrationVersion> = [
     run: (tx) => {
       if (!tableExists(tx, 'ga_ai_referrals')) return
       // Split AI referral traffic into paid vs organic/non-paid at ingest.
-      // Existing rows default to organic because historical data has no
-      // durable paid signal beyond source/medium/channel labels.
+      // Rows that already exist take the 'organic' default here; v96 backfills
+      // them by re-deriving the class from the columns already on each row.
       if (!columnExists(tx, 'ga_ai_referrals', 'traffic_class')) {
         tx.run(sql.raw(`ALTER TABLE ga_ai_referrals ADD COLUMN traffic_class TEXT NOT NULL DEFAULT 'organic'`))
       }
       tx.run(sql.raw(`CREATE INDEX IF NOT EXISTS idx_ga_ai_ref_traffic_class ON ga_ai_referrals(project_id, date, traffic_class)`))
+    },
+  },
+  {
+    // v95 added `ga_ai_referrals.traffic_class` with `DEFAULT 'organic'` and did
+    // not classify the rows that already existed. Every historical AI referral
+    // was therefore stamped 'organic', including paid ChatGPT-ads traffic
+    // carrying `medium='cpc'` / `channel_group='Paid Other'`. That silently
+    // reports purchased sessions as organic wins.
+    //
+    // The class is a pure function of columns already stored on each row, so
+    // re-derive it here instead of making an operator delete and re-fetch
+    // identical data from GA4.
+    //
+    // Every row is re-classified, not only the "unclassified" ones: v95's
+    // default is indistinguishable from a genuinely-organic classification, so
+    // there is no way to tell the two apart. `classifyGa4AiReferralTrafficClass`
+    // is pure and deterministic, so re-running it over already-correct rows
+    // writes nothing, which is what makes this version safe to replay.
+    version: 96,
+    name: 'ga-ai-referral-traffic-class-backfill',
+    statements: [],
+    run: (tx) => {
+      backfillGaAiReferralTrafficClass(tx)
     },
   },
 ]
@@ -2168,6 +2192,51 @@ function tableIsEmpty(db: MigrationDb, table: string): boolean {
   // Table name is a hard-coded constant in this module — safe to interpolate.
   const rows = db.all(sql.raw(`SELECT COUNT(*) as c FROM ${table}`)) as Array<{ c: number }>
   return (rows[0]?.c ?? 0) === 0
+}
+
+interface GaAiReferralClassRow {
+  id: string
+  source: string | null
+  medium: string | null
+  channel_group: string | null
+  landing_page: string | null
+  traffic_class: string | null
+}
+
+/**
+ * Re-derive `ga_ai_referrals.traffic_class` for every row from the same columns
+ * the ingest classifier reads (`source`, `medium`, `channel_group`,
+ * `landing_page`).
+ *
+ * Calls the shared `classifyGa4AiReferralTrafficClass` rather than restating the
+ * heuristic in SQL, so the backfill can never drift from what ingest writes (a
+ * SQL rewrite would also have to drop the landing-page UTM check, which needs
+ * URL parsing).
+ *
+ * Only rows whose stored class actually differs are written, so a replay is a
+ * no-op. Returns the number of rows updated.
+ */
+export function backfillGaAiReferralTrafficClass(tx: MigrationDb): number {
+  if (!tableExists(tx, 'ga_ai_referrals')) return 0
+  if (!columnExists(tx, 'ga_ai_referrals', 'traffic_class')) return 0
+
+  const rows = tx.all(sql.raw(
+    `SELECT id, source, medium, channel_group, landing_page, traffic_class FROM ga_ai_referrals`,
+  )) as GaAiReferralClassRow[]
+
+  let updated = 0
+  for (const row of rows) {
+    const next = classifyGa4AiReferralTrafficClass({
+      source: row.source,
+      medium: row.medium,
+      channelGroup: row.channel_group,
+      landingPage: row.landing_page,
+    })
+    if (next === row.traffic_class) continue
+    tx.run(sql`UPDATE ga_ai_referrals SET traffic_class = ${next} WHERE id = ${row.id}`)
+    updated += 1
+  }
+  return updated
 }
 
 function hasLegacyQuerySchema(db: MigrationDb): boolean {

--- a/packages/db/test/ga-ai-referral-traffic-class-backfill.test.ts
+++ b/packages/db/test/ga-ai-referral-traffic-class-backfill.test.ts
@@ -1,0 +1,130 @@
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { eq } from 'drizzle-orm'
+import { test, expect, onTestFinished } from 'vitest'
+import {
+  backfillGaAiReferralTrafficClass,
+  createClient,
+  gaAiReferrals,
+  migrate,
+  projects,
+} from '../src/index.js'
+
+/**
+ * v95 added `ga_ai_referrals.traffic_class` with `DEFAULT 'organic'` and never
+ * classified the rows that already existed, so paid ChatGPT-ads traffic was
+ * silently reported as organic. v96 re-derives the class from the columns
+ * already on each row. These tests assert the exact reclassification, not just
+ * that "something changed".
+ */
+
+type Db = ReturnType<typeof createClient>
+
+function createTempDb(): Db {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-ai-traffic-class-'))
+  const db = createClient(path.join(tmpDir, 'test.db'))
+  migrate(db)
+  onTestFinished(() => fs.rmSync(tmpDir, { recursive: true, force: true }))
+  return db
+}
+
+function seedProject(db: Db): string {
+  const id = crypto.randomUUID()
+  db.insert(projects).values({
+    id,
+    name: 'ai-traffic-class',
+    displayName: 'AI Traffic Class',
+    canonicalDomain: 'example.com',
+    country: 'US',
+    language: 'en',
+    providers: [],
+    locations: [],
+    createdAt: '2026-06-01T00:00:00.000Z',
+    updatedAt: '2026-06-01T00:00:00.000Z',
+  }).run()
+  return id
+}
+
+/** Insert a referral exactly as v95's `DEFAULT 'organic'` would have left it. */
+function seedDefaultedReferral(db: Db, projectId: string, over: {
+  source: string
+  medium: string
+  channelGroup: string
+  landingPage: string
+}): string {
+  const id = crypto.randomUUID()
+  db.insert(gaAiReferrals).values({
+    id,
+    projectId,
+    date: '2026-06-15',
+    trafficClass: 'organic',
+    sourceDimension: 'session',
+    sessions: 10,
+    users: 9,
+    syncedAt: '2026-07-01T00:00:00.000Z',
+    ...over,
+  }).run()
+  return id
+}
+
+function classOf(db: Db, id: string): string | undefined {
+  return db
+    .select({ trafficClass: gaAiReferrals.trafficClass })
+    .from(gaAiReferrals)
+    .where(eq(gaAiReferrals.id, id))
+    .all()[0]?.trafficClass
+}
+
+function seedThreeRows(db: Db) {
+  const projectId = seedProject(db)
+  // The production case: paid ChatGPT ads, which GA4 tags cpc / Paid Other.
+  const paidByChannel = seedDefaultedReferral(db, projectId, {
+    source: 'chatgpt', medium: 'cpc', channelGroup: 'Paid Other', landingPage: '/pricing',
+  })
+  // A genuinely organic AI referral. Must stay organic.
+  const organic = seedDefaultedReferral(db, projectId, {
+    source: 'chatgpt.com', medium: 'referral', channelGroup: 'Referral', landingPage: '/guide',
+  })
+  // Paid only via a UTM param on the landing page. A SQL-only backfill would
+  // miss this, which is why the migration calls the shared TS classifier.
+  const paidByLandingPage = seedDefaultedReferral(db, projectId, {
+    source: 'chatgpt.com', medium: 'referral', channelGroup: 'Referral', landingPage: '/x?utm_medium=cpc',
+  })
+  return { paidByChannel, organic, paidByLandingPage }
+}
+
+test('backfill reclassifies rows the v95 default stamped organic, and leaves real organic rows alone', () => {
+  const db = createTempDb()
+  const { paidByChannel, organic, paidByLandingPage } = seedThreeRows(db)
+
+  // Precondition: this is the bug. Paid ads sitting in the table as "organic".
+  expect(classOf(db, paidByChannel)).toBe('organic')
+
+  const updated = backfillGaAiReferralTrafficClass(db)
+
+  // Exactly the two paid rows flip; the organic row is not rewritten.
+  expect(updated).toBe(2)
+  expect(classOf(db, paidByChannel)).toBe('paid')
+  expect(classOf(db, paidByLandingPage)).toBe('paid')
+  expect(classOf(db, organic)).toBe('organic')
+})
+
+test('backfill is idempotent: a replay writes nothing and changes nothing', () => {
+  const db = createTempDb()
+  const { paidByChannel, organic, paidByLandingPage } = seedThreeRows(db)
+
+  expect(backfillGaAiReferralTrafficClass(db)).toBe(2)
+  // The classifier is pure, so re-deriving already-correct rows is a no-op.
+  expect(backfillGaAiReferralTrafficClass(db)).toBe(0)
+
+  expect(classOf(db, paidByChannel)).toBe('paid')
+  expect(classOf(db, paidByLandingPage)).toBe('paid')
+  expect(classOf(db, organic)).toBe('organic')
+})
+
+test('backfill is a no-op on a freshly migrated (empty) database', () => {
+  const db = createTempDb()
+  expect(backfillGaAiReferralTrafficClass(db)).toBe(0)
+})

--- a/packages/db/test/migration-downgrade-safety.test.ts
+++ b/packages/db/test/migration-downgrade-safety.test.ts
@@ -47,6 +47,12 @@ const RUN_HOOK_ALLOWLIST: ReadonlySet<number> = new Set([
   // v95 only adds a defaulted column + index, but uses run() to skip partial
   // legacy schemas where ga_ai_referrals has not been bootstrapped yet.
   95,
+  // v96 only rewrites `ga_ai_referrals.traffic_class` VALUES; it makes no schema
+  // change. Downgrade-safe: the column is unknown to any binary older than v95,
+  // so an older engine neither reads nor writes it. It needs run() because the
+  // class comes from the shared TS classifier, which SQL cannot express (the
+  // landing-page check requires URL parsing).
+  96,
 ])
 
 test(`migrations after v${DOWNGRADE_BASELINE} define no run() hook unless explicitly allowlisted`, () => {


### PR DESCRIPTION
## What
Adds migration **v96**, which re-derives `ga_ai_referrals.traffic_class` for every existing row by calling the shared `classifyGa4AiReferralTrafficClass`.

## Why
v95 added the column as `TEXT NOT NULL DEFAULT 'organic'` and never classified the rows that already existed. Every historical AI referral was therefore stamped `organic`, **including paid traffic carrying `medium='cpc'` / `channel_group='Paid Other'`**. Purchased sessions were reported as organic wins.

The failure is silent and directional:
- The default is `organic`, not `unknown`, so a misclassified row looks like a confident organic number rather than missing data.
- `NOT NULL DEFAULT 'organic'` makes a never-classified row byte-identical to a genuinely-organic one, so there are no NULLs to find the affected rows by.
- The only prior remedy was to delete the window and re-fetch identical data from GA4 (`ga sync`), which only fixes the window it re-fetches and depends on an operator remembering to do it.

v95's comment claimed historical rows had "no durable paid signal beyond source/medium/channel labels." Those labels are exactly and only what the classifier reads, so the class was always fully derivable from data already on disk. That comment is corrected here.

## How
- Calls the shared classifier rather than restating the heuristic in SQL. A SQL rewrite could drift from what ingest writes and could not perform the landing-page UTM check (it needs URL parsing).
- Re-classifies **every** row, not just the "unclassified" ones, because the v95 default is indistinguishable from a real classification. The classifier is pure and deterministic, so re-running it over already-correct rows writes nothing.
- Only rows whose stored class differs are written, so a replay is a no-op.
- Allowlisted in `migration-downgrade-safety.test.ts` with a justification: it rewrites values only (no schema change), and the column is unknown to any binary older than v95, so an older engine neither reads nor writes it.

## Tests
Calculation tests assert the exact reclassification, not just that something changed:
- a `cpc` / `Paid Other` row stamped `organic` flips to `paid`
- a row paid **only** via a landing-page UTM param flips to `paid` (the case a SQL-only backfill would miss)
- a genuinely organic row is left alone
- replay returns 0 updates and changes nothing (idempotent)
- no-op on a freshly migrated empty database

Typecheck, lint, and the full `packages/db` suite (108 tests) pass locally.

## Follow-up worth considering
`NOT NULL DEFAULT 'organic'` conflates "not classified" with "organic." A nullable column or an explicit `unknown` class would make unclassified rows visible so a report can say "N sessions unclassified" instead of silently counting them as organic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)