### PR TITLE
Fix external API routing errors

### DIFF
--- a/packages/canonry/src/client.ts
+++ b/packages/canonry/src/client.ts
@@ -586,6 +586,27 @@ export class ApiClient {
       )
     }
 
+    // Every operation routed through ApiClient is a JSON API operation. A
+    // successful HTML document means a reverse-proxy or base-path miss fell
+    // through to the dashboard SPA; don't let that masquerade as a connection
+    // failure later when a command tries to read it as a DTO.
+    const contentType = result.response.headers.get('content-type')
+    if (result.response.ok && contentType?.toLowerCase().startsWith('text/html')) {
+      throw new CliError({
+        code: 'UNEXPECTED_RESPONSE_FORMAT',
+        message:
+          `Expected a JSON response from the canonry API at ${result.request.url}, ` +
+          `but received ${contentType} (HTTP ${result.response.status}). ` +
+          'Check the server URL and base path.',
+        exitCode: EXIT_SYSTEM_ERROR,
+        details: {
+          requestUrl: result.request.url,
+          contentType,
+          httpStatus: result.response.status,
+        },
+      })
+    }
+
     if (result.error !== undefined && result.error !== null) {
       const errorObj =
         typeof result.error === 'object' &&

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -37,6 +37,7 @@ import { perplexityAdapter } from "@ainyc/canonry-provider-perplexity";
 import {
   authInvalid,
   authRequired,
+  notFound,
   validationError,
   embedClientConfigForRequest,
   serializeForInlineScript,
@@ -2281,9 +2282,8 @@ export async function createServer(opts: {
         url.startsWith("/api/") ||
         (basePath !== undefined && url.startsWith(`${basePath}api/`));
       if (isApiRoute) {
-        return reply
-          .status(404)
-          .send({ error: "Not found", path: request.url });
+        const error = notFound("API route", url);
+        return reply.status(error.statusCode).send(error.toJSON());
       }
 
       // When a base path is configured, only serve the SPA for paths under it.

--- a/packages/canonry/test/index.test.ts
+++ b/packages/canonry/test/index.test.ts
@@ -17,6 +17,7 @@ const { version: PKG_VERSION } = _require('../package.json') as { version: strin
 describe('canonry', () => {
   afterEach(() => {
     vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
   })
 
   it('loadConfig throws when no config exists', () => {
@@ -1330,6 +1331,53 @@ describe('canonry', () => {
       await app.close()
       fs.rmSync(tmpDir, { recursive: true, force: true })
     }
+  })
+
+  it('ApiClient keeps analytics, visibility stats, and Technical AEO under /api/v1 for an external base URL', async () => {
+    const fakeFetch = vi.fn(async () =>
+      new Response('{}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fakeFetch)
+
+    const client = new ApiClient('https://example.test/canonry', 'cnry_test', { skipProbe: true })
+    await client.getVisibilityStats('acme')
+    await client.getAnalyticsMetrics('acme')
+    await client.getAnalyticsGaps('acme')
+    await client.getAnalyticsSources('acme')
+    await client.getTechnicalAeoScore('acme')
+
+    expect(fakeFetch.mock.calls.map(([request]) => (request as Request).url)).toEqual([
+      'https://example.test/canonry/api/v1/projects/acme/visibility-stats',
+      'https://example.test/canonry/api/v1/projects/acme/analytics/metrics',
+      'https://example.test/canonry/api/v1/projects/acme/analytics/gaps',
+      'https://example.test/canonry/api/v1/projects/acme/analytics/sources',
+      'https://example.test/canonry/api/v1/projects/acme/technical-aeo',
+    ])
+  })
+
+  it('ApiClient reports an HTML SPA fallback as a response-format error', async () => {
+    const fakeFetch = vi.fn(async () =>
+      new Response('<!doctype html><html><body>Canonry</body></html>', {
+        status: 200,
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+      }),
+    )
+    vi.stubGlobal('fetch', fakeFetch)
+
+    const client = new ApiClient('https://example.test/canonry', 'cnry_test', { skipProbe: true })
+
+    await expect(client.getVisibilityStats('acme')).rejects.toMatchObject({
+      code: 'UNEXPECTED_RESPONSE_FORMAT',
+      exitCode: 2,
+      details: {
+        requestUrl: 'https://example.test/canonry/api/v1/projects/acme/visibility-stats',
+        contentType: 'text/html; charset=utf-8',
+        httpStatus: 200,
+      },
+    })
   })
 
   it('openapi endpoint is public and reports the Canonry version', async () => {

--- a/packages/canonry/test/server-embed.test.ts
+++ b/packages/canonry/test/server-embed.test.ts
@@ -262,6 +262,24 @@ describe('server embed mode (#716)', () => {
     }
   })
 
+  it('keeps a base-path API-shaped miss JSON instead of serving the SPA', async () => {
+    const { app, cleanup } = await buildServer(undefined, true, { basePath: '/canonry/' })
+    try {
+      const res = await app.inject({ method: 'GET', url: '/canonry/api/this-route-does-not-exist' })
+
+      expect(res.statusCode).toBe(404)
+      expect(res.headers['content-type']).toContain('application/json')
+      expect(JSON.parse(res.body)).toMatchObject({
+        error: {
+          code: 'NOT_FOUND',
+        },
+      })
+      expect(res.body).not.toContain('id="root"')
+    } finally {
+      await cleanup()
+    }
+  })
+
   it('ON: injects views in the client block when configured', async () => {
     const { app, cleanup } = await buildServer({
       enabled: true,


### PR DESCRIPTION
Fixes misleading external-base-path failures when a Canonry API call reaches dashboard HTML instead of JSON.

The client now returns a structured response-format error, and API-shaped SPA misses return canonical NOT_FOUND JSON.

Regression tests lock /api/v1 request construction for visibility stats, analytics, and Technical AEO.

Validated with the full Canonry test suite, typecheck, and lint (baseline warnings only).