### PR TITLE
chore(release): publish 4.122.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.122.0",
+  "version": "4.122.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.122.0",
+  "version": "4.122.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
Cuts a patch release from the final ads activation-recovery main commit. The prior 4.122.0 version bump landed in an intermediate merge commit, so the publish workflow did not emit the versioned npm or container artifacts.\n\nValidation:\n- pnpm install --frozen-lockfile\n- pnpm --filter @canonry/canonry typecheck\n- repository pre-commit lint (0 errors; existing warnings only)