### PR TITLE
Stabilize ads activation heartbeat test

### DIFF
--- a/packages/api-routes/src/ads-activation.ts
+++ b/packages/api-routes/src/ads-activation.ts
@@ -1050,7 +1050,6 @@ async function withLeaseHeartbeat<T>(
         schedule()
       })
     }, heartbeatIntervalMs)
-    timer.unref()
   }
 
   schedule()

--- a/packages/api-routes/test/ads-activation-routes.test.ts
+++ b/packages/api-routes/test/ads-activation-routes.test.ts
@@ -837,7 +837,7 @@ describe('ads approval-bound activation routes', () => {
     await ctx.app.close()
     fs.rmSync(ctx.tmpDir, { recursive: true, force: true })
     ctx = buildHarness({
-      activationLeaseMs: 90,
+      activationLeaseMs: 1_000,
       blockAdActivation: true,
     })
     await ctx.app.ready()
@@ -856,7 +856,7 @@ describe('ads approval-bound activation routes', () => {
 
     const firstPromise = ctx.app.inject(request)
     await ctx.activationStarted
-    await new Promise((resolve) => setTimeout(resolve, 140))
+    await new Promise((resolve) => setTimeout(resolve, 1_250))
 
     const concurrent = await ctx.app.inject(request)
     expect(concurrent.statusCode).toBe(200)


### PR DESCRIPTION
Stabilizes approval-bound ads activation heartbeat handling by keeping the lease heartbeat timer referenced while activation work is in flight.

Widens the test-only heartbeat lease from 90ms to 1s so the CI regression still proves renewal past expiry without depending on sub-100ms timer precision.

Root cause was a race where a busy Actions runner could delay the heartbeat long enough for a concurrent replay to recover and complete the operation.

Validation: api-routes activation tests passed under Node 22, api-routes typecheck passed, api-routes lint passed with existing warnings, full commit-hook lint passed with existing warnings, and git diff --check passed.