### PR TITLE
fix(api-routes): scope the timeline run window to sweeps

### DIFF
--- a/packages/api-routes/src/history.ts
+++ b/packages/api-routes/src/history.ts
@@ -6,6 +6,7 @@ import {
   CitationStates,
   mentionStateFromAnswerMentioned,
   notFound,
+  RunKinds,
   validationError,
   visibilityStateFromAnswerMentioned,
 } from '@ainyc/canonry-contracts'
@@ -143,19 +144,39 @@ export async function historyRoutes(app: FastifyInstance) {
       .where(eq(queries.projectId, project.id))
       .all()
 
-    // Get project runs ordered by creation time
+    // Get project runs ordered by creation time.
+    //
+    // Restricted to `answer-visibility` runs — the only kind that writes
+    // `query_snapshots` (the sole snapshot writer is the sweep path in
+    // `job-runner.executeRun`, and `POST /projects/:name/runs` pins that
+    // path's `kind` to the `answer-visibility` literal). Every field this
+    // route returns is derived from snapshots, so including other kinds adds
+    // nothing to the response — but it does consume the `limit` window.
+    // Projects sync traffic every ~30 minutes while sweeps run roughly twice
+    // a month, so an unfiltered `limit=20` selects ~10 hours of integration
+    // syncs and zero sweeps, and every entry comes back with `runs: []`
+    // (issue: "Query evidence" panel stuck on "Awaiting first run").
+    // With the filter, `limit` means "the last N sweeps", which is what every
+    // caller intends. `visibility-stats` filters on the same run kind, but also
+    // narrows to completed/partial runs; this route deliberately does not, so a
+    // failed sweep still appears in the timeline.
+    const runKindFilter = and(
+      eq(runs.projectId, project.id),
+      notProbeRun(),
+      eq(runs.kind, RunKinds['answer-visibility']),
+    )
     const requestedLimit = parseOptionalPositiveInt(request.query.limit, 100)
     const projectRuns = requestedLimit == null
       ? app.db
         .select()
         .from(runs)
-        .where(and(eq(runs.projectId, project.id), notProbeRun()))
+        .where(runKindFilter)
         .orderBy(asc(runs.createdAt))
         .all()
       : app.db
         .select()
         .from(runs)
-        .where(and(eq(runs.projectId, project.id), notProbeRun()))
+        .where(runKindFilter)
         .orderBy(desc(runs.createdAt))
         .limit(requestedLimit)
         .all()

--- a/packages/api-routes/test/timeline-run-kind.test.ts
+++ b/packages/api-routes/test/timeline-run-kind.test.ts
@@ -1,0 +1,174 @@
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import Fastify from 'fastify'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  createClient,
+  migrate,
+  projects,
+  queries as queriesTable,
+  runs,
+  querySnapshots,
+} from '@ainyc/canonry-db'
+import { apiRoutes } from '../src/index.js'
+
+/**
+ * `GET /projects/:name/timeline` derives everything it returns from
+ * `query_snapshots`, and only `answer-visibility` runs write those. Every
+ * other run kind (`traffic-sync`, `gsc-sync`, `ga-sync`, …) contributes no
+ * data but still occupies a slot in the `?limit=N` window.
+ *
+ * A real project syncs traffic every ~30 minutes and sweeps roughly twice a
+ * month, so the newest N runs are almost always pure integration syncs. The
+ * dashboard asks for `?limit=20`, which selected ~10 hours of traffic syncs
+ * and zero sweeps — the timeline came back with `runs: []` for every query
+ * and the "Query evidence" panel rendered "Awaiting first run" against months
+ * of real history.
+ *
+ * This file locks the invariant: the timeline's run window is measured in
+ * SWEEPS, not in runs of any kind. It seeds one completed answer-visibility
+ * run with snapshots, then buries it under 25 newer `traffic-sync` runs —
+ * more than the limit under test, so an unfiltered query cannot reach it.
+ */
+
+interface Ctx {
+  app: ReturnType<typeof Fastify>
+  db: ReturnType<typeof createClient>
+  tmpDir: string
+  sweepRunId: string
+}
+
+const PROJECT = 'timeline-run-kind'
+
+/** Runs created AFTER the sweep, enough to fully displace it at limit=20. */
+const TRAFFIC_SYNC_COUNT = 25
+
+function buildCtx(): Ctx {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-timeline-kind-'))
+  const db = createClient(path.join(tmpDir, 'test.db'))
+  migrate(db)
+  const app = Fastify()
+  app.register(apiRoutes, { db, skipAuth: true })
+
+  const now = Date.now()
+  // The sweep is the OLDEST run on the project.
+  const sweepCreatedAt = new Date(now - (TRAFFIC_SYNC_COUNT + 1) * 60_000).toISOString()
+
+  const projectId = crypto.randomUUID()
+  db.insert(projects).values({
+    id: projectId,
+    name: PROJECT,
+    displayName: 'Timeline Run Kind',
+    canonicalDomain: 'real-brand.example.com',
+    country: 'US',
+    language: 'en',
+    providers: ['openai'],
+    locations: [],
+    createdAt: sweepCreatedAt,
+    updatedAt: sweepCreatedAt,
+  }).run()
+
+  const queryId = crypto.randomUUID()
+  db.insert(queriesTable).values({
+    id: queryId,
+    projectId,
+    query: 'best AEO platform',
+    createdAt: sweepCreatedAt,
+  }).run()
+
+  // The only snapshot-bearing run.
+  const sweepRunId = crypto.randomUUID()
+  db.insert(runs).values({
+    id: sweepRunId,
+    projectId,
+    kind: 'answer-visibility',
+    status: 'completed',
+    trigger: 'manual',
+    createdAt: sweepCreatedAt,
+    finishedAt: sweepCreatedAt,
+  }).run()
+  db.insert(querySnapshots).values({
+    id: crypto.randomUUID(),
+    runId: sweepRunId,
+    queryId,
+    queryText: 'best AEO platform',
+    provider: 'openai',
+    citationState: 'cited',
+    answerMentioned: true,
+    citedDomains: ['real-brand.example.com'],
+    competitorOverlap: [],
+    recommendedCompetitors: [],
+    answerText: 'real-brand.example.com is the canonical AEO platform.',
+    rawResponse: JSON.stringify({ groundingSources: [] }),
+    createdAt: sweepCreatedAt,
+  }).run()
+
+  // Integration syncs, all newer than the sweep. These carry no snapshots.
+  for (let i = 0; i < TRAFFIC_SYNC_COUNT; i++) {
+    const createdAt = new Date(now - (TRAFFIC_SYNC_COUNT - i) * 60_000).toISOString()
+    db.insert(runs).values({
+      id: crypto.randomUUID(),
+      projectId,
+      kind: 'traffic-sync',
+      status: 'completed',
+      trigger: 'scheduled',
+      createdAt,
+      finishedAt: createdAt,
+    }).run()
+  }
+
+  return { app, db, tmpDir, sweepRunId }
+}
+
+let ctx: Ctx
+
+beforeEach(() => { ctx = buildCtx() })
+afterEach(async () => {
+  await ctx.app.close()
+  fs.rmSync(ctx.tmpDir, { recursive: true, force: true })
+})
+
+type TimelineBody = Array<{
+  query: string
+  runs: Array<{ runId: string }>
+  providerRuns?: Record<string, Array<{ runId: string }>>
+}>
+
+async function getTimeline(query: string): Promise<TimelineBody> {
+  const res = await ctx.app.inject({
+    method: 'GET',
+    url: `/api/v1/projects/${PROJECT}/timeline${query}`,
+  })
+  expect(res.statusCode).toBe(200)
+  return res.json() as TimelineBody
+}
+
+describe('timeline run window counts sweeps, not runs of every kind', () => {
+  it('?limit=20 still surfaces the sweep buried under 25 newer traffic-sync runs', async () => {
+    // This is the exact call the project dashboard makes
+    // (DASHBOARD_TIMELINE_RUN_LIMIT = 20). Before the run-kind filter, the
+    // newest 20 runs were all traffic-syncs and this came back as 0.
+    const body = await getTimeline('?limit=20')
+    expect(body).toHaveLength(1)
+    const entry = body[0]!
+    expect(entry.query).toBe('best AEO platform')
+    expect(entry.runs).toHaveLength(1)
+    expect(entry.runs[0]!.runId).toBe(ctx.sweepRunId)
+    expect(entry.providerRuns?.openai).toHaveLength(1)
+  })
+
+  it('a small limit selects the newest sweeps, unaffected by interleaved sync runs', async () => {
+    // limit=1 is the tightest window there is; the single sweep must still win.
+    const body = await getTimeline('?limit=1')
+    expect(body[0]?.runs.map(r => r.runId)).toEqual([ctx.sweepRunId])
+  })
+
+  it('the unlimited response matches the limited one (no other kind ever contributed)', async () => {
+    const unlimited = await getTimeline('')
+    const limited = await getTimeline('?limit=20')
+    expect(unlimited).toEqual(limited)
+    expect(unlimited[0]?.runs.map(r => r.runId)).toEqual([ctx.sweepRunId])
+  })
+})


### PR DESCRIPTION
## What

The project page's Query evidence panel shows every tracked query as "Awaiting first run" / "No data" / "0/1", even for projects with months of sweep history. This scopes the timeline route's run window to `answer-visibility` runs, the only kind that carries query snapshots.

## Why

The dashboard asks the timeline endpoint for the latest 20 runs of **any** kind. Projects run a traffic-sync every ~30 minutes, so the newest 20 runs span roughly 10 hours and contain zero sweeps. Every timeline entry then returns `runs: []`, and the dashboard falls through to a synthetic "never run yet" row per query.

Measured across the four projects on one instance, none had a sweep inside its newest 20 runs. The newest sweep sat at rank 280, 863, 1112, and 2931 respectively. Since sweeps are typically manual and infrequent, the panel is blank essentially always. Raising the limit does not help: the `limit` query param is silently clamped to 100, and even the uncapped path would need to reach past a thousand runs.

Regression from #819 (`eebea2da`), which introduced the client-side limit of 20. Before it the client sent no limit and received full history.

## How

`packages/api-routes/src/history.ts` adds `eq(runs.kind, RunKinds['answer-visibility'])` to both branches of the run select, hoisted into one shared predicate so they cannot drift. `limit` now means "the last N sweeps", which is what every caller intended.

Lossless: only `answer-visibility` runs can carry `query_snapshots`. The POST body schema constrains the kind with `z.literal`, the scheduler and API are the only two `executeRun` call sites, and nothing mutates `runs.kind` after creation. Other run kinds contributed empty arrays to the response while consuming the limit window. Every field the route emits derives from snapshots, so filtering them out changes no output, only which rows compete for the window.

The route deliberately does not narrow to completed/partial runs, so a failed sweep still shows up.

## Tests

New `packages/api-routes/test/timeline-run-kind.test.ts`, styled after `probe-exclusion.test.ts`: one completed sweep with a cited snapshot as the oldest run, then 25 traffic-syncs created after it. Asserts `?limit=20` (the exact dashboard call) returns one entry whose runs length is 1, that `?limit=1` still finds it, and that the unlimited response deep-equals the limited one, which pins losslessness rather than merely convenience. Against unfixed code all three fail with `runs: []`. No existing test covers a mixed-kind run history.

Full gate green: typecheck, lint, 5,394 tests, web build, `gen:check` (response shape unchanged).

## Follow-up, not fixed here

`apps/web/src/build-dashboard.ts:191` discards a fully-populated `latestRunDetails` when the timeline is empty, which is why the freshest sweep vanished entirely rather than rendering as a single point. Worth doing as defense in depth so a future timeline regression degrades visibly instead of silently, but it is a real change in the hottest render path and does not belong in this fix.

Note the same route backs the MCP `canonry_timeline_get` tool, so anything that concluded "no visibility data" from it since 2026-07-14 was reading an artifact.
