### PR TITLE
feat(analytics): disclose provider-side model changes in a reporting period

### DIFF
--- a/apps/web/src/components/project/VisibilityTrendSection.tsx
+++ b/apps/web/src/components/project/VisibilityTrendSection.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useId, useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
+import { buildModelChangeNotice } from '@ainyc/canonry-contracts'
 import type { BrandMetricsDto, MetricsWindow } from '@ainyc/canonry-contracts'
-import { formatModelChangeDisclosure } from '@ainyc/canonry-contracts'
 import {
   CartesianGrid,
   CHART_AXIS_STROKE,
@@ -558,10 +558,11 @@ export function VisibilityTrendSection({
   )
   const servedAttribution = useMemo(() => (data ? readServedModelAttribution(data) : {}), [data])
   const serviceMismatch = useMemo(() => (data ? readModelServiceMismatch(data) : {}), [data])
-  // Null on an older API and on any window that spans no change — both render
-  // nothing at all, never a partial sentence.
-  const modelChangeDisclosure = useMemo(
-    () => (data ? formatModelChangeDisclosure(readModelPointerChanges(data)) : null),
+  // Null on an older API and on a project whose engines are all on fixed model
+  // ids. An engine that CAN be moved but has no update on record is a separate,
+  // quieter state — see `buildModelChangeNotice`.
+  const modelChangeNotice = useMemo(
+    () => (data ? buildModelChangeNotice(readModelPointerChanges(data)) : null),
     [data],
   )
 
@@ -606,6 +607,17 @@ export function VisibilityTrendSection({
 
   const header = (
     <>
+      {/* Above the section head, which is where the headline number and its
+          delta live. Whoever is about to send that number to a client has to
+          meet the caveat BEFORE they read it, so it cannot sit under the head
+          (they have already read the number) or in the model-evidence aside
+          below the chart (they have already sent it). Tinted, not alarming —
+          nothing is broken, the reading just needs care. */}
+      {modelChangeNotice?.kind === 'change' && (
+        <p className="mb-3 rounded-lg border border-caution-800/60 bg-caution-950/20 px-3 py-2 text-[11px] leading-snug text-secondary">
+          {modelChangeNotice.text}
+        </p>
+      )}
       <div className="visibility-trend-head">
         <div className="space-y-1">
           <p className="eyebrow eyebrow-soft">Trend</p>
@@ -639,13 +651,15 @@ export function VisibilityTrendSection({
         )}
         <Segmented options={WINDOW_OPTIONS} value={window} onChange={setWindow} ariaLabel="Time window" className="sm:ml-auto" />
       </div>
-      {/* Sits above the chart rather than in the model-evidence aside below it:
-          whoever is about to send this number to a client has to meet the
-          caveat before they read the number, not after. Tinted, not alarming —
-          nothing is broken, the reading just needs care. */}
-      {modelChangeDisclosure && (
-        <p className="mt-3 rounded-lg border border-caution-800/60 bg-caution-950/20 px-3 py-2 text-[11px] leading-snug text-secondary">
-          {modelChangeDisclosure}
+      {/* The common case, and the reason it is a bare muted line under the
+          controls rather than a tinted box above the head: it caveats nothing,
+          it only refuses to let an un-updated record read as proof that nothing
+          happened. Untinted, one line, with the explanation in the tooltip so
+          the surface stays a data surface. */}
+      {modelChangeNotice?.kind === 'no-known-change' && (
+        <p className="mt-3 text-[11px] leading-snug text-muted">
+          {modelChangeNotice.text}
+          <InfoTooltip text={modelChangeNotice.detail} />
         </p>
       )}
     </>

--- a/apps/web/src/components/project/VisibilityTrendSection.tsx
+++ b/apps/web/src/components/project/VisibilityTrendSection.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useId, useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import type { BrandMetricsDto, MetricsWindow } from '@ainyc/canonry-contracts'
+import { formatModelChangeDisclosure } from '@ainyc/canonry-contracts'
 import {
   CartesianGrid,
   CHART_AXIS_STROKE,
@@ -41,6 +42,7 @@ import {
   partitionModelAttributionEvents,
   readBucketModelEvidence,
   readModelAttribution,
+  readModelPointerChanges,
   readModelServiceMismatch,
   readServedModelAttribution,
   truncatedProviderCounts,
@@ -556,6 +558,12 @@ export function VisibilityTrendSection({
   )
   const servedAttribution = useMemo(() => (data ? readServedModelAttribution(data) : {}), [data])
   const serviceMismatch = useMemo(() => (data ? readModelServiceMismatch(data) : {}), [data])
+  // Null on an older API and on any window that spans no change — both render
+  // nothing at all, never a partial sentence.
+  const modelChangeDisclosure = useMemo(
+    () => (data ? formatModelChangeDisclosure(readModelPointerChanges(data)) : null),
+    [data],
+  )
 
   // Headline readout: the selected metric's latest bucket value plus its change
   // across the visible window. Quantifies "where it sits now, which way it
@@ -631,6 +639,15 @@ export function VisibilityTrendSection({
         )}
         <Segmented options={WINDOW_OPTIONS} value={window} onChange={setWindow} ariaLabel="Time window" className="sm:ml-auto" />
       </div>
+      {/* Sits above the chart rather than in the model-evidence aside below it:
+          whoever is about to send this number to a client has to meet the
+          caveat before they read the number, not after. Tinted, not alarming —
+          nothing is broken, the reading just needs care. */}
+      {modelChangeDisclosure && (
+        <p className="mt-3 rounded-lg border border-caution-800/60 bg-caution-950/20 px-3 py-2 text-[11px] leading-snug text-secondary">
+          {modelChangeDisclosure}
+        </p>
+      )}
     </>
   )
 

--- a/apps/web/src/lib/visibility-trend-helpers.ts
+++ b/apps/web/src/lib/visibility-trend-helpers.ts
@@ -3,6 +3,7 @@ import type {
   ModelAttribution,
   ModelAttributionEvent,
   ModelEvidenceState,
+  ModelPointerChangeDisclosure,
   ModelServiceMismatch,
   QueryChangeEvent,
   ServedModelAttribution,
@@ -60,6 +61,7 @@ type MetricsWithOptionalModelAttribution = BrandMetricsDto & {
   modelAttribution?: ModelAttribution
   servedModelAttribution?: ServedModelAttribution
   modelServiceMismatch?: Record<string, ModelServiceMismatch>
+  modelPointerChanges?: Record<string, ModelPointerChangeDisclosure>
 }
 
 export interface GroupedModelAttributionEvent {
@@ -213,6 +215,16 @@ export function readServedModelAttribution(dto: BrandMetricsDto): ServedModelAtt
 
 export function readModelServiceMismatch(dto: BrandMetricsDto): Record<string, ModelServiceMismatch> {
   return (dto as MetricsWithOptionalModelAttribution).modelServiceMismatch ?? {}
+}
+
+/**
+ * Providers whose numbers span a known change to a moving model id. Absent on
+ * an older API, empty for a project on fixed model ids. Rendering is
+ * `formatModelChangeDisclosure` from contracts — the wording is shared with the
+ * CLI so neither surface can soften the caveat the other gives.
+ */
+export function readModelPointerChanges(dto: BrandMetricsDto): Record<string, ModelPointerChangeDisclosure> {
+  return (dto as MetricsWithOptionalModelAttribution).modelPointerChanges ?? {}
 }
 
 /** The raw ids an engine reported, joined for display. Empty → the normalized label stands alone. */

--- a/apps/web/src/lib/visibility-trend-helpers.ts
+++ b/apps/web/src/lib/visibility-trend-helpers.ts
@@ -218,10 +218,11 @@ export function readModelServiceMismatch(dto: BrandMetricsDto): Record<string, M
 }
 
 /**
- * Providers whose numbers span a known change to a moving model id. Absent on
- * an older API, empty for a project on fixed model ids. Rendering is
- * `formatModelChangeDisclosure` from contracts — the wording is shared with the
- * CLI so neither surface can soften the caveat the other gives.
+ * Providers whose numbers were produced by a model id the provider is free to
+ * move onto a different underlying model. Absent on an older API, empty for a
+ * project on fixed model ids. The sentence a reader sees is built from these
+ * facts by `buildModelChangeNotice` in contracts, which the CLI calls too, so
+ * neither surface can word this caveat more softly than the other.
  */
 export function readModelPointerChanges(dto: BrandMetricsDto): Record<string, ModelPointerChangeDisclosure> {
   return (dto as MetricsWithOptionalModelAttribution).modelPointerChanges ?? {}

--- a/apps/web/test/visibility-trend-helpers.test.ts
+++ b/apps/web/test/visibility-trend-helpers.test.ts
@@ -483,26 +483,19 @@ describe('truncatedProviderCounts', () => {
   })
 })
 
-/**
- * The rendering itself (wording, ordering, the closing line, the plain-language
- * guard) is shared with the CLI and tested at its home in
- * `packages/contracts/test/model-pointers.test.ts`. What is web-specific, and
- * all that is asserted here, is reading the field off a DTO that may not carry
- * it: this dashboard build can be pointed at an older server.
- */
 describe('readModelPointerChanges', () => {
   const metrics = (extra?: Record<string, unknown>) =>
     ({ ...dto([]), ...extra }) as unknown as BrandMetricsDto
 
+  // Partial on purpose: this reader must pass through whatever the server sent,
+  // including a response from a build that predates some of these fields.
   const openaiChange = {
     modelIds: ['chat-latest'],
     changeCount: 1,
     unverifiedChangeCount: 0,
     firstChangeDate: '2026-06-24',
     lastChangeDate: '2026-06-24',
-    summary: 'The model behind "chat-latest" changed on 2026-06-24, inside this reporting period. '
-      + 'Part of any movement in this number comes from that change and not from how often AI names you.',
-  } satisfies ModelPointerChangeDisclosure
+  } as unknown as ModelPointerChangeDisclosure
 
   it('reads nothing from an older API and nothing from a project on fixed model ids', () => {
     expect(readModelPointerChanges(metrics())).toEqual({})

--- a/apps/web/test/visibility-trend-helpers.test.ts
+++ b/apps/web/test/visibility-trend-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import type { BrandMetricsDto, ModelAttribution, ModelEvidenceState } from '@ainyc/canonry-contracts'
+import type { BrandMetricsDto, ModelAttribution, ModelEvidenceState, ModelPointerChangeDisclosure } from '@ainyc/canonry-contracts'
 import {
   buildMentionShareTrendRows,
   buildSelectedTrendRows,
@@ -9,6 +9,7 @@ import {
   truncatedProviderCounts,
   formatModelEvidence,
   groupModelAttributionEvents,
+  readModelPointerChanges,
   latestPlottedProviderModelEvidence,
   readBucketModelEvidence,
   readModelAttribution,
@@ -479,5 +480,37 @@ describe('truncatedProviderCounts', () => {
     })).toEqual([{ provider: 'gemini', shown: 2, total: 40 }])
 
     expect(truncatedProviderCounts({})).toEqual([])
+  })
+})
+
+/**
+ * The rendering itself (wording, ordering, the closing line, the plain-language
+ * guard) is shared with the CLI and tested at its home in
+ * `packages/contracts/test/model-pointers.test.ts`. What is web-specific, and
+ * all that is asserted here, is reading the field off a DTO that may not carry
+ * it: this dashboard build can be pointed at an older server.
+ */
+describe('readModelPointerChanges', () => {
+  const metrics = (extra?: Record<string, unknown>) =>
+    ({ ...dto([]), ...extra }) as unknown as BrandMetricsDto
+
+  const openaiChange = {
+    modelIds: ['chat-latest'],
+    changeCount: 1,
+    unverifiedChangeCount: 0,
+    firstChangeDate: '2026-06-24',
+    lastChangeDate: '2026-06-24',
+    summary: 'The model behind "chat-latest" changed on 2026-06-24, inside this reporting period. '
+      + 'Part of any movement in this number comes from that change and not from how often AI names you.',
+  } satisfies ModelPointerChangeDisclosure
+
+  it('reads nothing from an older API and nothing from a project on fixed model ids', () => {
+    expect(readModelPointerChanges(metrics())).toEqual({})
+    expect(readModelPointerChanges(metrics({ modelPointerChanges: {} }))).toEqual({})
+  })
+
+  it('passes the server disclosures through untouched', () => {
+    expect(readModelPointerChanges(metrics({ modelPointerChanges: { openai: openaiChange } })))
+      .toEqual({ openai: openaiChange })
   })
 })

--- a/apps/web/test/visibility-trend-section.test.tsx
+++ b/apps/web/test/visibility-trend-section.test.tsx
@@ -378,8 +378,12 @@ test('says nothing about served models when the API omits them', async () => {
   expect(screen.queryByText('What the engines answered with')).toBeNull()
 })
 
-const MODEL_CHANGE_NEXT_ACTION = 'Compare this period with earlier ones carefully.'
+const CLOSING_LINE = 'rather than from a real change in how AI answers about you, so compare periods carefully.'
 
+/** One confirmed update. The `summary` is a LEGACY field an older server used
+ *  to send, kept here deliberately: it is the hostile wording this lane
+ *  replaced, so a surface that ever renders the server's sentence again instead
+ *  of building its own fails these tests loudly. */
 const OPENAI_CHANGE = {
   modelIds: ['chat-latest'],
   changeCount: 1,
@@ -390,15 +394,14 @@ const OPENAI_CHANGE = {
     + 'Part of any movement in this number comes from that change and not from how often AI names you.',
 }
 
-const GEMINI_CHANGE = {
-  modelIds: ['gemini-flash-latest'],
-  changeCount: 2,
+const PERPLEXITY_CHANGE = {
+  modelIds: ['sonar-latest'],
+  changeCount: 1,
   unverifiedChangeCount: 0,
-  firstChangeDate: '2026-06-02',
-  lastChangeDate: '2026-06-30',
-  summary: 'The model behind "gemini-flash-latest" changed more than once in this reporting period, '
-    + 'between 2026-06-02 and 2026-06-30. '
-    + 'Part of any movement in this number comes from those changes and not from how often AI names you.',
+  firstChangeDate: '2026-06-10',
+  lastChangeDate: '2026-06-10',
+  summary: 'The model behind "sonar-latest" changed on 2026-06-10, inside this reporting period. '
+    + 'Part of any movement in this number comes from that change and not from how often AI names you.',
 }
 
 function mockMetrics(extra?: Record<string, unknown>) {
@@ -411,33 +414,64 @@ function mockMetrics(extra?: Record<string, unknown>) {
   })
 }
 
-test('discloses a single provider-side model change above the chart', async () => {
+test('meets the reader with the model-update caveat before the headline number', async () => {
   onTestFinished(mockMetrics({ modelPointerChanges: { openai: OPENAI_CHANGE } }))
 
   renderSection()
 
-  const note = await screen.findByText(`${OPENAI_CHANGE.summary} ${MODEL_CHANGE_NEXT_ACTION}`)
-  // Above the chart, not buried in the model-evidence aside below it: whoever
-  // is about to send this number to a client meets the caveat first.
+  const note = await screen.findByText(/The model behind ChatGPT/)
+  expect(note.textContent).toBe(
+    'The model behind ChatGPT was updated on 2026-06-24, inside this period. '
+    + `Some of the movement in these numbers may come from this update ${CLOSING_LINE}`,
+  )
+  // The point of the placement: the number the operator is about to send to a
+  // client must not be readable before the caveat. Above the chart is not
+  // enough — the headline value and its delta sit in the section head, above
+  // the chart too.
+  const headline = document.querySelector('.visibility-trend-current-value')!
+  expect(note.compareDocumentPosition(headline) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   const chart = document.querySelector('.visibility-trend-chart')!
   expect(note.compareDocumentPosition(chart) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
 })
 
-test('discloses changes on several engines in one note with one closing line', async () => {
+test('states one fact per affected engine and closes with a single consequence', async () => {
   onTestFinished(mockMetrics({
-    modelPointerChanges: { openai: OPENAI_CHANGE, gemini: GEMINI_CHANGE },
+    modelPointerChanges: { openai: OPENAI_CHANGE, perplexity: PERPLEXITY_CHANGE },
   }))
 
   renderSection()
 
-  const note = await screen.findByText(/The model behind/)
+  const note = await screen.findByText(/The model behind ChatGPT/)
   expect(note.textContent).toBe(
-    `${GEMINI_CHANGE.summary} ${OPENAI_CHANGE.summary} ${MODEL_CHANGE_NEXT_ACTION}`,
+    'The model behind ChatGPT was updated on 2026-06-24, inside this period. '
+    + 'The model behind Perplexity was updated on 2026-06-10, inside this period. '
+    + `Some of the movement in these numbers may come from these updates ${CLOSING_LINE}`,
   )
-  expect(note.textContent!.split(MODEL_CHANGE_NEXT_ACTION)).toHaveLength(2)
+  // Two engines are two facts and ONE warning. Repeating the consequence per
+  // engine read as two separate alarms about the same three numbers.
+  const sentences = note.textContent!.split('. ').map(s => s.trim())
+  expect(new Set(sentences).size).toBe(sentences.length)
 })
 
-test('renders no disclosure at all when the API omits the field or reports no change', async () => {
+test('reports an engine that can be updated with nothing on record, quietly', async () => {
+  onTestFinished(mockMetrics({
+    modelPointerChanges: { openai: { modelIds: ['chat-latest'], changeCount: 0, unverifiedChangeCount: 0 } },
+  }))
+
+  renderSection()
+
+  const line = await screen.findByText('No model updates are on record for ChatGPT in this period.')
+  // Quiet: no caution box, and the explanation is in a tooltip rather than set
+  // as prose on the surface. This renders on every load for anyone on a moving
+  // model id, so weight matters as much as the words.
+  expect(line.className).not.toContain('caution')
+  expect(within(line).getByRole('button')).toBeTruthy()
+  // And it does NOT jump the headline — nothing is being caveated.
+  const headline = document.querySelector('.visibility-trend-current-value')!
+  expect(line.compareDocumentPosition(headline) & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy()
+})
+
+test('renders nothing at all when the API omits the field or reports no exposure', async () => {
   const restore = mockMetrics()
   onTestFinished(restore)
 
@@ -447,7 +481,7 @@ test('renders no disclosure at all when the API omits the field or reports no ch
   // merely because the DTO had not arrived yet.
   await screen.findByRole('list', { name: 'Engines' })
   expect(screen.queryByText(/The model behind/)).toBeNull()
-  expect(screen.queryByText(/Compare this period with earlier ones carefully/)).toBeNull()
+  expect(screen.queryByText(/No model updates are on record/)).toBeNull()
 
   cleanup()
   restore()
@@ -456,4 +490,52 @@ test('renders no disclosure at all when the API omits the field or reports no ch
   renderSection()
   await screen.findByRole('list', { name: 'Engines' })
   expect(screen.queryByText(/The model behind/)).toBeNull()
+  expect(screen.queryByText(/No model updates are on record/)).toBeNull()
+})
+
+test('tells the reader how recently the update record was checked', async () => {
+  // The quiet line on its own is indistinguishable from a record nobody has
+  // updated in six months. The date is what separates "we looked and found
+  // nothing" from "nobody has looked", so it has to reach the reader — not
+  // merely ride on the DTO, which is where an earlier cut left it.
+  onTestFinished(mockMetrics({
+    modelPointerChanges: {
+      openai: {
+        modelIds: ['chat-latest'],
+        changeCount: 0,
+        unverifiedChangeCount: 0,
+        knownGoodAsOf: '2026-07-20',
+        checkedThroughPeriodEnd: true,
+      },
+    },
+  }))
+
+  renderSection()
+
+  const line = await screen.findByText('No model updates are on record for ChatGPT in this period.')
+  const tip = within(line).getByRole('button')
+  expect(tip.getAttribute('aria-label')).toContain('We last checked for model updates on 2026-07-20.')
+})
+
+test('says when the period runs past the last time the record was checked', async () => {
+  onTestFinished(mockMetrics({
+    modelPointerChanges: {
+      openai: {
+        modelIds: ['chat-latest'],
+        changeCount: 0,
+        unverifiedChangeCount: 0,
+        knownGoodAsOf: '2026-07-20',
+        checkedThroughPeriodEnd: false,
+      },
+    },
+  }))
+
+  renderSection()
+
+  const line = await screen.findByText('No model updates are on record for ChatGPT in this period.')
+  const tip = within(line).getByRole('button')
+  expect(tip.getAttribute('aria-label')).toContain(
+    'We last checked for model updates on 2026-07-20, and this period runs past that date,'
+    + ' so there may be later updates we do not know about.',
+  )
 })

--- a/apps/web/test/visibility-trend-section.test.tsx
+++ b/apps/web/test/visibility-trend-section.test.tsx
@@ -377,3 +377,83 @@ test('says nothing about served models when the API omits them', async () => {
   await screen.findByText('Model evidence changes')
   expect(screen.queryByText('What the engines answered with')).toBeNull()
 })
+
+const MODEL_CHANGE_NEXT_ACTION = 'Compare this period with earlier ones carefully.'
+
+const OPENAI_CHANGE = {
+  modelIds: ['chat-latest'],
+  changeCount: 1,
+  unverifiedChangeCount: 0,
+  firstChangeDate: '2026-06-24',
+  lastChangeDate: '2026-06-24',
+  summary: 'The model behind "chat-latest" changed on 2026-06-24, inside this reporting period. '
+    + 'Part of any movement in this number comes from that change and not from how often AI names you.',
+}
+
+const GEMINI_CHANGE = {
+  modelIds: ['gemini-flash-latest'],
+  changeCount: 2,
+  unverifiedChangeCount: 0,
+  firstChangeDate: '2026-06-02',
+  lastChangeDate: '2026-06-30',
+  summary: 'The model behind "gemini-flash-latest" changed more than once in this reporting period, '
+    + 'between 2026-06-02 and 2026-06-30. '
+    + 'Part of any movement in this number comes from those changes and not from how often AI names you.',
+}
+
+function mockMetrics(extra?: Record<string, unknown>) {
+  return mockFetch((url) => {
+    const path = url.split('?')[0]!
+    if (path.endsWith('/projects/test-project/analytics/metrics')) {
+      return jsonResponse({ ...metricsDto(TWO_BUCKETS), ...extra })
+    }
+    throw new Error(`Unexpected fetch: ${url}`)
+  })
+}
+
+test('discloses a single provider-side model change above the chart', async () => {
+  onTestFinished(mockMetrics({ modelPointerChanges: { openai: OPENAI_CHANGE } }))
+
+  renderSection()
+
+  const note = await screen.findByText(`${OPENAI_CHANGE.summary} ${MODEL_CHANGE_NEXT_ACTION}`)
+  // Above the chart, not buried in the model-evidence aside below it: whoever
+  // is about to send this number to a client meets the caveat first.
+  const chart = document.querySelector('.visibility-trend-chart')!
+  expect(note.compareDocumentPosition(chart) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+})
+
+test('discloses changes on several engines in one note with one closing line', async () => {
+  onTestFinished(mockMetrics({
+    modelPointerChanges: { openai: OPENAI_CHANGE, gemini: GEMINI_CHANGE },
+  }))
+
+  renderSection()
+
+  const note = await screen.findByText(/The model behind/)
+  expect(note.textContent).toBe(
+    `${GEMINI_CHANGE.summary} ${OPENAI_CHANGE.summary} ${MODEL_CHANGE_NEXT_ACTION}`,
+  )
+  expect(note.textContent!.split(MODEL_CHANGE_NEXT_ACTION)).toHaveLength(2)
+})
+
+test('renders no disclosure at all when the API omits the field or reports no change', async () => {
+  const restore = mockMetrics()
+  onTestFinished(restore)
+
+  renderSection()
+
+  // Wait for the loaded chart before asserting an absence, so this cannot pass
+  // merely because the DTO had not arrived yet.
+  await screen.findByRole('list', { name: 'Engines' })
+  expect(screen.queryByText(/The model behind/)).toBeNull()
+  expect(screen.queryByText(/Compare this period with earlier ones carefully/)).toBeNull()
+
+  cleanup()
+  restore()
+
+  onTestFinished(mockMetrics({ modelPointerChanges: {} }))
+  renderSection()
+  await screen.findByRole('list', { name: 'Engines' })
+  expect(screen.queryByText(/The model behind/)).toBeNull()
+})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.122.1",
+  "version": "4.123.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -1263,12 +1263,20 @@ export type BrandMetricsDto = {
     };
     modelPointerChanges: {
         [key: string]: {
+            status: 'no-known-change' | 'known-change';
             modelIds: Array<string>;
+            changes: Array<{
+                modelId: string;
+                date: string;
+                confirmed: boolean;
+                sourceUrl: string;
+            }>;
             changeCount: number;
             unverifiedChangeCount: number;
-            firstChangeDate: string;
-            lastChangeDate: string;
-            summary: string;
+            firstChangeDate?: string;
+            lastChangeDate?: string;
+            knownGoodAsOf: string;
+            checkedThroughPeriodEnd: boolean;
         };
     };
 };

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -1261,6 +1261,16 @@ export type BrandMetricsDto = {
             };
         };
     };
+    modelPointerChanges: {
+        [key: string]: {
+            modelIds: Array<string>;
+            changeCount: number;
+            unverifiedChangeCount: number;
+            firstChangeDate: string;
+            lastChangeDate: string;
+            summary: string;
+        };
+    };
 };
 
 export type CcAvailableRelease = {

--- a/packages/api-routes/src/analytics.ts
+++ b/packages/api-routes/src/analytics.ts
@@ -4,14 +4,15 @@ import { filterTrackedSnapshots, groupRunsByCreatedAt, pickGroupRepresentative, 
 import {
   AI_PROVIDER_INFRA_DOMAINS, brandLabelFromDomain, categorizeSource, categoryLabel, CitationStates,
   classifySurfaceFromCategory, surfaceClassFromCompetitorType, surfaceClassLabel,
-  effectiveDomains, normalizeProjectDomain, parseWindow, RunKinds, RunStatuses, windowCutoff, validationError,
+  effectiveDomains, findModelPointerChanges, normalizeProjectDomain, parseWindow, RunKinds, RunStatuses,
+  windowCutoff, validationError,
 } from '@ainyc/canonry-contracts'
 import type {
   BrandMetricsDto, GapAnalysisDto, SourceBreakdownDto,
   TimeBucket, TrendDirection, GapQuery, GapCategory,
   SourceCategory, SourceCategoryCount, ProviderMetric, QueryChangeEvent,
   RankedSourceList, SourceRankEntry, SurfaceClass, SurfaceClassCount, ModelEvidenceState,
-  ModelServiceMismatch,
+  ModelPointerChangeDisclosure, ModelServiceMismatch,
 } from '@ainyc/canonry-contracts'
 import { buildMentionShare } from '@ainyc/canonry-intelligence'
 import { notProbeRun, resolveProject, resolveSnapshotAnswerMentioned } from './helpers.js'
@@ -57,6 +58,7 @@ export async function analyticsRoutes(app: FastifyInstance) {
         modelAttribution: {},
         servedModelAttribution: {},
         modelServiceMismatch: {},
+        modelPointerChanges: {},
       } satisfies BrandMetricsDto)
     }
 
@@ -303,6 +305,37 @@ export async function analyticsRoutes(app: FastifyInstance) {
       }
     }
 
+    // Some model ids are not models: the provider re-points them at whatever it
+    // is currently serving, and the response echoes the same id back on both
+    // sides of the swap. No amount of served-model capture can see that, so the
+    // only honest move is to check the sweeps that produced these numbers
+    // against a dated record of known changes and disclose the overlap.
+    //
+    // The period is per-provider and comes from the DATA, not the requested
+    // window: it is the span of sweeps that actually contributed, so a provider
+    // added halfway through the window is not caveated for a change that
+    // predates its first sweep.
+    const modelPointerChanges: Record<string, ModelPointerChangeDisclosure> = {}
+    const pointerScopeByProvider = new Map<string, { modelIds: Set<string>; start: string; end: string }>()
+    for (const snapshot of allSnapshots) {
+      const scope = pointerScopeByProvider.get(snapshot.provider)
+        ?? { modelIds: new Set<string>(), start: snapshot.runCreatedAt, end: snapshot.runCreatedAt }
+      if (snapshot.runCreatedAt < scope.start) scope.start = snapshot.runCreatedAt
+      if (snapshot.runCreatedAt > scope.end) scope.end = snapshot.runCreatedAt
+      // Configured AND served: a project can configure a pinned id while the
+      // provider serves a moving one, and either side being a pointer exposes
+      // the number.
+      const configured = snapshot.model?.trim()
+      if (configured) scope.modelIds.add(configured)
+      const served = snapshot.servedModel?.trim()
+      if (served) scope.modelIds.add(served)
+      pointerScopeByProvider.set(snapshot.provider, scope)
+    }
+    for (const [provider, scope] of pointerScopeByProvider) {
+      const disclosure = findModelPointerChanges({ modelIds: scope.modelIds, start: scope.start, end: scope.end })
+      if (disclosure) modelPointerChanges[provider] = disclosure
+    }
+
     // Trends
     const trend = computeTrend(buckets, 'citationRate')
     const mentionTrend = computeTrend(buckets, 'mentionRate')
@@ -310,7 +343,7 @@ export async function analyticsRoutes(app: FastifyInstance) {
     // Query change annotations
     const queryChanges = computeQueryChanges(projectQueries, cutoff)
 
-    return reply.send({ window, buckets, overall, byProvider, trend, mentionTrend, queryChanges, modelAttribution, servedModelAttribution, modelServiceMismatch } satisfies BrandMetricsDto)
+    return reply.send({ window, buckets, overall, byProvider, trend, mentionTrend, queryChanges, modelAttribution, servedModelAttribution, modelServiceMismatch, modelPointerChanges } satisfies BrandMetricsDto)
   })
 
   // GET /projects/:name/analytics/gaps — brand gap analysis

--- a/packages/api-routes/src/analytics.ts
+++ b/packages/api-routes/src/analytics.ts
@@ -4,7 +4,7 @@ import { filterTrackedSnapshots, groupRunsByCreatedAt, pickGroupRepresentative, 
 import {
   AI_PROVIDER_INFRA_DOMAINS, brandLabelFromDomain, categorizeSource, categoryLabel, CitationStates,
   classifySurfaceFromCategory, surfaceClassFromCompetitorType, surfaceClassLabel,
-  effectiveDomains, findModelPointerChanges, normalizeProjectDomain, parseWindow, RunKinds, RunStatuses,
+  effectiveDomains, evaluateModelPointerExposure, normalizeProjectDomain, parseWindow, RunKinds, RunStatuses,
   windowCutoff, validationError,
 } from '@ainyc/canonry-contracts'
 import type {
@@ -12,7 +12,7 @@ import type {
   TimeBucket, TrendDirection, GapQuery, GapCategory,
   SourceCategory, SourceCategoryCount, ProviderMetric, QueryChangeEvent,
   RankedSourceList, SourceRankEntry, SurfaceClass, SurfaceClassCount, ModelEvidenceState,
-  ModelPointerChangeDisclosure, ModelServiceMismatch,
+  ModelExposureWindow, ModelPointerChangeDisclosure, ModelServiceMismatch,
 } from '@ainyc/canonry-contracts'
 import { buildMentionShare } from '@ainyc/canonry-intelligence'
 import { notProbeRun, resolveProject, resolveSnapshotAnswerMentioned } from './helpers.js'
@@ -312,28 +312,51 @@ export async function analyticsRoutes(app: FastifyInstance) {
     // against a dated record of known changes and disclose the overlap.
     //
     // The period is per-provider and comes from the DATA, not the requested
-    // window: it is the span of sweeps that actually contributed, so a provider
-    // added halfway through the window is not caveated for a change that
-    // predates its first sweep.
+    // window: it is the span of sweeps that actually contributed, which is the
+    // same period `byProvider` is computed over, so the caveat and the number it
+    // sits under always describe the same stretch of time.
+    //
+    // Within that period each model id gets its OWN first/last-seen span, taken
+    // from the sweeps that observed it. Crossing "every id seen in the period"
+    // with "the period" would caveat a project for a change to an id it had
+    // already stopped running, and stay silent for the mirror case — a project
+    // is only affected by a change that happened while it was on that id.
     const modelPointerChanges: Record<string, ModelPointerChangeDisclosure> = {}
-    const pointerScopeByProvider = new Map<string, { modelIds: Set<string>; start: string; end: string }>()
+    interface PointerScope { exposures: Map<string, ModelExposureWindow>; start: string; end: string }
+    const pointerScopeByProvider = new Map<string, PointerScope>()
     for (const snapshot of allSnapshots) {
       const scope = pointerScopeByProvider.get(snapshot.provider)
-        ?? { modelIds: new Set<string>(), start: snapshot.runCreatedAt, end: snapshot.runCreatedAt }
+        ?? { exposures: new Map<string, ModelExposureWindow>(), start: snapshot.runCreatedAt, end: snapshot.runCreatedAt }
       if (snapshot.runCreatedAt < scope.start) scope.start = snapshot.runCreatedAt
       if (snapshot.runCreatedAt > scope.end) scope.end = snapshot.runCreatedAt
-      // Configured AND served: a project can configure a pinned id while the
-      // provider serves a moving one, and either side being a pointer exposes
-      // the number.
-      const configured = snapshot.model?.trim()
-      if (configured) scope.modelIds.add(configured)
-      const served = snapshot.servedModel?.trim()
-      if (served) scope.modelIds.add(served)
+      // Configured AND served: a project can configure a fixed id while the
+      // provider serves a moving one, and either side being a moving id exposes
+      // the number. Each is timestamped by the sweep that observed it.
+      for (const modelId of [snapshot.model?.trim(), snapshot.servedModel?.trim()]) {
+        if (!modelId) continue
+        const key = modelId.toLowerCase()
+        const seen = scope.exposures.get(key)
+        if (!seen) {
+          scope.exposures.set(key, { modelId, firstSeen: snapshot.runCreatedAt, lastSeen: snapshot.runCreatedAt })
+          continue
+        }
+        if (snapshot.runCreatedAt < seen.firstSeen) seen.firstSeen = snapshot.runCreatedAt
+        if (snapshot.runCreatedAt > seen.lastSeen) seen.lastSeen = snapshot.runCreatedAt
+      }
       pointerScopeByProvider.set(snapshot.provider, scope)
     }
     for (const [provider, scope] of pointerScopeByProvider) {
-      const disclosure = findModelPointerChanges({ modelIds: scope.modelIds, start: scope.start, end: scope.end })
-      if (disclosure) modelPointerChanges[provider] = disclosure
+      const exposure = evaluateModelPointerExposure({
+        exposures: scope.exposures.values(),
+        periodStart: scope.start,
+        periodEnd: scope.end,
+      })
+      // A provider on fixed model ids is omitted. The other two states are both
+      // carried: "we know of no change" is a different answer from "you are not
+      // exposed", and collapsing them is what would let a stale list read as
+      // safety on a surface.
+      if (exposure.status === 'not-exposed') continue
+      modelPointerChanges[provider] = exposure
     }
 
     // Trends

--- a/packages/api-routes/test/analytics.test.ts
+++ b/packages/api-routes/test/analytics.test.ts
@@ -5,6 +5,7 @@ import os from 'node:os'
 import crypto from 'node:crypto'
 import Fastify from 'fastify'
 import { createClient, migrate, projects, queries, runs, querySnapshots, competitors, domainClassifications } from '@ainyc/canonry-db'
+import { MODEL_POINTER_REGISTRY_CHECKED_THROUGH } from '@ainyc/canonry-contracts'
 import { apiRoutes } from '../src/index.js'
 
 function buildApp() {
@@ -1873,8 +1874,11 @@ describe('analytics metrics — model changes we cannot see in the response', ()
     const res = await app.inject({ method: 'GET', url: `/api/v1/projects/${name}/analytics/metrics?window=all` })
     expect(res.statusCode).toBe(200)
     return JSON.parse(res.payload).modelPointerChanges as Record<string, {
+      status: 'known-change' | 'no-known-change'
       modelIds: string[]; changeCount: number; unverifiedChangeCount: number
-      firstChangeDate: string; lastChangeDate: string; summary: string
+      changes: Array<{ modelId: string; date: string; confirmed: boolean; sourceUrl: string }>
+      firstChangeDate?: string; lastChangeDate?: string
+      knownGoodAsOf: string; checkedThroughPeriodEnd: boolean
     }>
   }
 
@@ -1901,7 +1905,10 @@ describe('analytics metrics — model changes we cannot see in the response', ()
     expect(changes.openai!.changeCount).toBe(1)
     expect(changes.openai!.modelIds).toEqual(['chat-latest'])
     expect(changes.openai!.firstChangeDate).toBe('2026-06-24')
-    expect(changes.openai!.summary).toContain('changed on 2026-06-24')
+    expect(changes.openai!.lastChangeDate).toBe('2026-06-24')
+    // The wire carries no prose. The sentence a reader sees is built from these
+    // fields by `buildModelChangeNotice`, and is pinned in the contracts suite.
+    expect(changes.openai!).not.toHaveProperty('summary')
   })
 
   it('the served id is identical on both sides, which is why the date has to come from elsewhere', async () => {
@@ -1915,23 +1922,85 @@ describe('analytics metrics — model changes we cannot see in the response', ()
     expect(body.modelServiceMismatch).toEqual({})
   })
 
-  it('says "more than once" when the sweeps span several changes', async () => {
+  it('asserts only the change the record confirms and hedges the doubtful one', async () => {
+    // Both 2026-05-28 and 2026-06-24 fall in this span, but only 2026-06-24 is
+    // unambiguous in the source. Reporting "changed more than once between
+    // 2026-05-28 and 2026-06-24" would state a provider change to a client on
+    // the strength of copy-pasted changelog wording.
     seed('pointer-spans-many', [
       { at: '2026-05-10T09:00:00.000Z', provider: 'openai', model: 'chat-latest', servedModel: 'chat-latest' },
       { at: '2026-07-02T09:00:00.000Z', provider: 'openai', model: 'chat-latest', servedModel: 'chat-latest' },
     ])
     const changes = await pointerChangesFor('pointer-spans-many')
     expect(changes.openai!.changeCount).toBe(2)
-    expect(changes.openai!.summary).toContain('more than once')
-    expect(changes.openai!.summary).toContain('between 2026-05-28 and 2026-06-24')
+    expect(changes.openai!.unverifiedChangeCount).toBe(1)
+    expect(changes.openai!.changes.map(c => [c.date, c.confirmed])).toEqual([
+      ['2026-05-28', false],
+      ['2026-06-24', true],
+    ])
+    expect(changes.openai!.firstChangeDate).toBe('2026-05-28')
+    expect(changes.openai!.lastChangeDate).toBe('2026-06-24')
   })
 
-  it('says nothing when the sweeps span no known change', async () => {
+  it('reports a quiet period as "no known change", not as silence', async () => {
+    // The fail-safe. This project IS on a moving id — the list simply has no
+    // dated change in its period. That is a different answer from "you are not
+    // exposed", and a list that has fallen behind produces exactly this state,
+    // so it has to reach the surface with the date it was last checked.
     seed('pointer-spans-none', [
       { at: '2026-06-01T09:00:00.000Z', provider: 'openai', model: 'chat-latest', servedModel: 'chat-latest' },
       { at: '2026-06-20T09:00:00.000Z', provider: 'openai', model: 'chat-latest', servedModel: 'chat-latest' },
     ])
-    expect(await pointerChangesFor('pointer-spans-none')).toEqual({})
+    const changes = await pointerChangesFor('pointer-spans-none')
+    expect(Object.keys(changes)).toEqual(['openai'])
+    expect(changes.openai!.status).toBe('no-known-change')
+    expect(changes.openai!.changeCount).toBe(0)
+    expect(changes.openai!.changes).toEqual([])
+    // The freshness marker has to be ON THE WIRE for a surface to be able to
+    // say it; that it reaches a reader is pinned in the contracts suite.
+    expect(changes.openai!.knownGoodAsOf).toBe(MODEL_POINTER_REGISTRY_CHECKED_THROUGH)
+    expect(changes.openai!.checkedThroughPeriodEnd).toBe(true)
+  })
+
+  it('does not caveat a project for a change it had already switched away from', async () => {
+    // Ran chat-latest through 2026-06-10, then moved to a pinned model. The
+    // 2026-06-24 change happened while it was on the pinned model, so it
+    // cannot be in these numbers. Crossing "ids seen in the period" with "the
+    // period" warned here — the regression this test pins.
+    seed('pointer-switched-away', [
+      { at: BEFORE_CHANGE, provider: 'openai', model: 'chat-latest', servedModel: 'chat-latest' },
+      { at: AFTER_CHANGE, provider: 'openai', model: 'gpt-5.6-terra', servedModel: 'gpt-5.6-terra-2026-06-01' },
+    ])
+    const changes = await pointerChangesFor('pointer-switched-away')
+    expect(changes.openai!.status).toBe('no-known-change')
+    expect(changes.openai!.changeCount).toBe(0)
+    expect(changes.openai!.changes).toEqual([])
+  })
+
+  it('does not caveat a project for a change that predates its switch TO the id', async () => {
+    // The mirror case: pinned until 2026-06-10, moved onto chat-latest on
+    // 2026-07-02. The 2026-06-24 change is before its first sweep on that id.
+    seed('pointer-switched-to', [
+      { at: BEFORE_CHANGE, provider: 'openai', model: 'gpt-5.6-terra', servedModel: 'gpt-5.6-terra-2026-06-01' },
+      { at: AFTER_CHANGE, provider: 'openai', model: 'chat-latest', servedModel: 'chat-latest' },
+    ])
+    const changes = await pointerChangesFor('pointer-switched-to')
+    expect(changes.openai!.status).toBe('no-known-change')
+    expect(changes.openai!.changeCount).toBe(0)
+    expect(changes.openai!.changes).toEqual([])
+  })
+
+  it('caveats the project that WAS on the id across the change, over the same sweeps', async () => {
+    // Same two sweep dates as the two tests above; the only difference is that
+    // this project stayed on the moving id. If the disclosure fires here and
+    // not there, it is keyed on exposure and not on the window.
+    seed('pointer-stayed-on', [
+      { at: BEFORE_CHANGE, provider: 'openai', model: 'chat-latest', servedModel: 'chat-latest' },
+      { at: AFTER_CHANGE, provider: 'openai', model: 'chat-latest', servedModel: 'chat-latest' },
+    ])
+    const changes = await pointerChangesFor('pointer-stayed-on')
+    expect(changes.openai!.status).toBe('known-change')
+    expect(changes.openai!.changes.map(c => c.date)).toEqual(['2026-06-24'])
   })
 
   it('says nothing for a project on a pinned model id across the same dates', async () => {
@@ -1958,14 +2027,18 @@ describe('analytics metrics — model changes we cannot see in the response', ()
 
   it('scopes the period to each provider own sweeps', async () => {
     // gemini only ran after the change, so its numbers cannot straddle it and
-    // it must not inherit openai's caveat.
+    // it must not inherit openai's caveat — but it IS on a moving id, so it
+    // gets the quiet state rather than nothing.
     seed('pointer-per-provider', [
       { at: BEFORE_CHANGE, provider: 'openai', model: 'chat-latest', servedModel: 'chat-latest' },
       { at: AFTER_CHANGE, provider: 'openai', model: 'chat-latest', servedModel: 'chat-latest' },
       { at: AFTER_CHANGE, provider: 'gemini', model: 'chat-latest', servedModel: 'chat-latest' },
     ])
     const changes = await pointerChangesFor('pointer-per-provider')
-    expect(Object.keys(changes)).toEqual(['openai'])
+    expect(changes.openai!.status).toBe('known-change')
+    expect(changes.gemini!.status).toBe('no-known-change')
+    expect(changes.gemini!.changeCount).toBe(0)
+    expect(changes.gemini!.changes).toEqual([])
   })
 
   it('discloses when the provider SERVED a moving id the project did not configure', async () => {

--- a/packages/api-routes/test/analytics.test.ts
+++ b/packages/api-routes/test/analytics.test.ts
@@ -1816,3 +1816,176 @@ describe('analytics metrics — bucket dates vs real observation dates', () => {
     }
   })
 })
+
+// A model id like `chat-latest` is not a model — the provider re-points it at
+// whatever it is currently serving and the response echoes the same id back on
+// both sides of the swap. These use ABSOLUTE dates against `window=all` because
+// the whole check is a comparison with real published change dates; a
+// clock-relative seed would silently stop covering them.
+describe('analytics metrics — model changes we cannot see in the response', () => {
+  let app: ReturnType<typeof Fastify>
+  let db: ReturnType<typeof createClient>
+  let tmpDir: string
+
+  // 2026-06-24 is a known re-point of `chat-latest` in the seeded registry.
+  const BEFORE_CHANGE = '2026-06-10T09:00:00.000Z'
+  const AFTER_CHANGE = '2026-07-02T09:00:00.000Z'
+
+  const seed = (
+    name: string,
+    sweeps: ReadonlyArray<{ at: string; provider: string; model: string | null; servedModel: string | null }>,
+  ) => {
+    const projectId = crypto.randomUUID()
+    const oldest = sweeps.map(s => s.at).sort()[0]!
+    db.insert(projects).values({
+      id: projectId, name, displayName: name, canonicalDomain: `${name}.example`,
+      ownedDomains: '[]', country: 'US', language: 'en', tags: '[]', labels: '{}',
+      providers: JSON.stringify([...new Set(sweeps.map(s => s.provider))]),
+      locations: '[]', defaultLocation: null, configSource: 'api', configRevision: 1,
+      createdAt: oldest, updatedAt: oldest,
+    }).run()
+    const queryId = crypto.randomUUID()
+    db.insert(queries).values({ id: queryId, projectId, query: `${name} query`, createdAt: oldest }).run()
+
+    // One run per distinct sweep time; providers observed in the same sweep
+    // share it, exactly as a real multi-provider sweep does.
+    const runIdByTime = new Map<string, string>()
+    for (const sweep of sweeps) {
+      let runId = runIdByTime.get(sweep.at)
+      if (!runId) {
+        runId = crypto.randomUUID()
+        runIdByTime.set(sweep.at, runId)
+        db.insert(runs).values({
+          id: runId, projectId, kind: 'answer-visibility', status: 'completed', trigger: 'manual',
+          location: null, startedAt: sweep.at, finishedAt: sweep.at, error: null, createdAt: sweep.at,
+        }).run()
+      }
+      db.insert(querySnapshots).values({
+        id: crypto.randomUUID(), runId, queryId, provider: sweep.provider,
+        model: sweep.model, servedModel: sweep.servedModel,
+        citationState: 'not-cited', answerText: '', citedDomains: [], competitorOverlap: [],
+        location: null, rawResponse: '{}', createdAt: sweep.at,
+      }).run()
+    }
+  }
+
+  const pointerChangesFor = async (name: string) => {
+    const res = await app.inject({ method: 'GET', url: `/api/v1/projects/${name}/analytics/metrics?window=all` })
+    expect(res.statusCode).toBe(200)
+    return JSON.parse(res.payload).modelPointerChanges as Record<string, {
+      modelIds: string[]; changeCount: number; unverifiedChangeCount: number
+      firstChangeDate: string; lastChangeDate: string; summary: string
+    }>
+  }
+
+  beforeAll(async () => {
+    const ctx = buildApp()
+    app = ctx.app
+    db = ctx.db
+    tmpDir = ctx.tmpDir
+    await app.ready()
+  })
+
+  afterAll(async () => {
+    await app.close()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('discloses a change that landed between two sweeps', async () => {
+    seed('pointer-spans-one', [
+      { at: BEFORE_CHANGE, provider: 'openai', model: 'chat-latest', servedModel: 'chat-latest' },
+      { at: AFTER_CHANGE, provider: 'openai', model: 'chat-latest', servedModel: 'chat-latest' },
+    ])
+    const changes = await pointerChangesFor('pointer-spans-one')
+    expect(Object.keys(changes)).toEqual(['openai'])
+    expect(changes.openai!.changeCount).toBe(1)
+    expect(changes.openai!.modelIds).toEqual(['chat-latest'])
+    expect(changes.openai!.firstChangeDate).toBe('2026-06-24')
+    expect(changes.openai!.summary).toContain('changed on 2026-06-24')
+  })
+
+  it('the served id is identical on both sides, which is why the date has to come from elsewhere', async () => {
+    // Guards the premise: #818 capture cannot detect this. If served capture
+    // ever DID differ across a re-point, this test tells the next maintainer
+    // the disclosure lane may be redundant.
+    const res = await app.inject({ method: 'GET', url: '/api/v1/projects/pointer-spans-one/analytics/metrics?window=all' })
+    const body = JSON.parse(res.payload)
+    expect(body.servedModelAttribution.openai.events).toEqual([])
+    expect(body.servedModelAttribution.openai.latestObservation.state).toEqual({ status: 'known', model: 'chat-latest' })
+    expect(body.modelServiceMismatch).toEqual({})
+  })
+
+  it('says "more than once" when the sweeps span several changes', async () => {
+    seed('pointer-spans-many', [
+      { at: '2026-05-10T09:00:00.000Z', provider: 'openai', model: 'chat-latest', servedModel: 'chat-latest' },
+      { at: '2026-07-02T09:00:00.000Z', provider: 'openai', model: 'chat-latest', servedModel: 'chat-latest' },
+    ])
+    const changes = await pointerChangesFor('pointer-spans-many')
+    expect(changes.openai!.changeCount).toBe(2)
+    expect(changes.openai!.summary).toContain('more than once')
+    expect(changes.openai!.summary).toContain('between 2026-05-28 and 2026-06-24')
+  })
+
+  it('says nothing when the sweeps span no known change', async () => {
+    seed('pointer-spans-none', [
+      { at: '2026-06-01T09:00:00.000Z', provider: 'openai', model: 'chat-latest', servedModel: 'chat-latest' },
+      { at: '2026-06-20T09:00:00.000Z', provider: 'openai', model: 'chat-latest', servedModel: 'chat-latest' },
+    ])
+    expect(await pointerChangesFor('pointer-spans-none')).toEqual({})
+  })
+
+  it('says nothing for a project on a pinned model id across the same dates', async () => {
+    seed('pointer-pinned', [
+      { at: BEFORE_CHANGE, provider: 'openai', model: 'gpt-5.6-terra', servedModel: 'gpt-5.6-terra-2026-06-01' },
+      { at: AFTER_CHANGE, provider: 'openai', model: 'gpt-5.6-terra', servedModel: 'gpt-5.6-terra-2026-06-01' },
+    ])
+    expect(await pointerChangesFor('pointer-pinned')).toEqual({})
+  })
+
+  it('counts a change dated exactly on the first and last sweep day', async () => {
+    seed('pointer-boundary-start', [
+      { at: '2026-06-24T23:30:00.000Z', provider: 'openai', model: 'chat-latest', servedModel: 'chat-latest' },
+      { at: '2026-07-05T09:00:00.000Z', provider: 'openai', model: 'chat-latest', servedModel: 'chat-latest' },
+    ])
+    expect((await pointerChangesFor('pointer-boundary-start')).openai!.changeCount).toBe(1)
+
+    seed('pointer-boundary-end', [
+      { at: '2026-06-15T09:00:00.000Z', provider: 'openai', model: 'chat-latest', servedModel: 'chat-latest' },
+      { at: '2026-06-24T00:10:00.000Z', provider: 'openai', model: 'chat-latest', servedModel: 'chat-latest' },
+    ])
+    expect((await pointerChangesFor('pointer-boundary-end')).openai!.changeCount).toBe(1)
+  })
+
+  it('scopes the period to each provider own sweeps', async () => {
+    // gemini only ran after the change, so its numbers cannot straddle it and
+    // it must not inherit openai's caveat.
+    seed('pointer-per-provider', [
+      { at: BEFORE_CHANGE, provider: 'openai', model: 'chat-latest', servedModel: 'chat-latest' },
+      { at: AFTER_CHANGE, provider: 'openai', model: 'chat-latest', servedModel: 'chat-latest' },
+      { at: AFTER_CHANGE, provider: 'gemini', model: 'chat-latest', servedModel: 'chat-latest' },
+    ])
+    const changes = await pointerChangesFor('pointer-per-provider')
+    expect(Object.keys(changes)).toEqual(['openai'])
+  })
+
+  it('discloses when the provider SERVED a moving id the project did not configure', async () => {
+    seed('pointer-served-only', [
+      { at: BEFORE_CHANGE, provider: 'openai', model: 'gpt-5.6-terra', servedModel: 'chat-latest' },
+      { at: AFTER_CHANGE, provider: 'openai', model: 'gpt-5.6-terra', servedModel: 'chat-latest' },
+    ])
+    const changes = await pointerChangesFor('pointer-served-only')
+    expect(changes.openai!.modelIds).toEqual(['chat-latest'])
+  })
+
+  it('is absent, not null, for a project with no runs at all', async () => {
+    const projectId = crypto.randomUUID()
+    db.insert(projects).values({
+      id: projectId, name: 'pointer-empty', displayName: 'pointer-empty',
+      canonicalDomain: 'pointer-empty.example', ownedDomains: '[]', country: 'US', language: 'en',
+      tags: '[]', labels: '{}', providers: '["openai"]', locations: '[]', defaultLocation: null,
+      configSource: 'api', configRevision: 1,
+      createdAt: '2026-06-01T00:00:00.000Z', updatedAt: '2026-06-01T00:00:00.000Z',
+    }).run()
+    expect(await pointerChangesFor('pointer-empty')).toEqual({})
+  })
+})

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.122.1",
+  "version": "4.123.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/commands/analytics.ts
+++ b/packages/canonry/src/commands/analytics.ts
@@ -1,4 +1,4 @@
-import { formatModelChangeDisclosure, type ModelPointerChangeDisclosure } from '@ainyc/canonry-contracts'
+import { buildModelChangeNotice, type ModelPointerChangeDisclosure } from '@ainyc/canonry-contracts'
 import { createApiClient, type BrandMetricsDto, type GapAnalysisDto, type SourceBreakdownDto } from '../client.js'
 import { CliError, isMachineFormat } from '../cli-error.js'
 
@@ -84,6 +84,17 @@ function printMetrics(data: BrandMetricsDto): void {
 
   const pct = (n: number) => `${(n * 100).toFixed(1)}%`
 
+  // BEFORE the first number, not after the last one. This is the note that
+  // changes how everything below it should be read, and an operator who has
+  // already scrolled past the rates has already formed the reading it is trying
+  // to correct.
+  const modelChangeNotice = buildModelChangeNotice(readModelPointerChanges(data))
+  if (modelChangeNotice?.kind === 'change') {
+    console.log(`\n  Model Updates Behind These Numbers:`)
+    console.log(`    ${modelChangeNotice.text}`)
+    console.log('')
+  }
+
   console.log(`  Overall: ${pct(data.overall.citationRate)} (${data.overall.cited}/${data.overall.total})`)
   console.log(`  Trend:   ${data.trend}`)
 
@@ -118,12 +129,16 @@ function printMetrics(data: BrandMetricsDto): void {
     }
   }
 
-  // Printed BEFORE the model sections: it is the one note that changes how the
-  // numbers above should be read, so it must not sit at the bottom of the dump.
-  const modelChangeDisclosure = formatModelChangeDisclosure(readModelPointerChanges(data))
-  if (modelChangeDisclosure) {
-    console.log(`\n  Model Changes Behind These Numbers:`)
-    console.log(`    ${modelChangeDisclosure}`)
+  // The no-known-update state is context, not a caveat, so it rides down here
+  // with the rest of the model evidence instead of interrupting the numbers.
+  // The detail line is printed rather than dropped: it carries how recently the
+  // record was checked, and without it "nothing on record" reads as proof that
+  // nothing happened. The dashboard puts the same sentence in a tooltip; a
+  // terminal has nowhere to hide it, so it goes on the next line.
+  if (modelChangeNotice?.kind === 'no-known-change') {
+    console.log(`\n  Model Updates Behind These Numbers:`)
+    console.log(`    ${modelChangeNotice.text}`)
+    console.log(`    ${modelChangeNotice.detail}`)
   }
 
   const attributionEntries = Object.entries(readModelAttribution(data))
@@ -186,11 +201,9 @@ function readModelServiceMismatch(data: BrandMetricsDto): BrandMetricsDto['model
 }
 
 /**
- * Providers whose numbers span a known change to a moving model id — one the
- * provider re-points at a different underlying model without the API response
- * changing at all. Absent on an older server, empty for a project on fixed
- * model ids. Rendering is `formatModelChangeDisclosure` from contracts, shared
- * with the dashboard so neither surface can soften the caveat the other gives.
+ * Providers whose numbers were produced by a model id the provider is free to
+ * re-point at a different underlying model without the API response changing at
+ * all. Absent on an older server, empty for a project on fixed model ids.
  */
 function readModelPointerChanges(data: BrandMetricsDto): Record<string, ModelPointerChangeDisclosure> {
   const legacyCompatible = data as unknown as { modelPointerChanges?: Record<string, ModelPointerChangeDisclosure> }

--- a/packages/canonry/src/commands/analytics.ts
+++ b/packages/canonry/src/commands/analytics.ts
@@ -1,3 +1,4 @@
+import { formatModelChangeDisclosure, type ModelPointerChangeDisclosure } from '@ainyc/canonry-contracts'
 import { createApiClient, type BrandMetricsDto, type GapAnalysisDto, type SourceBreakdownDto } from '../client.js'
 import { CliError, isMachineFormat } from '../cli-error.js'
 
@@ -117,6 +118,14 @@ function printMetrics(data: BrandMetricsDto): void {
     }
   }
 
+  // Printed BEFORE the model sections: it is the one note that changes how the
+  // numbers above should be read, so it must not sit at the bottom of the dump.
+  const modelChangeDisclosure = formatModelChangeDisclosure(readModelPointerChanges(data))
+  if (modelChangeDisclosure) {
+    console.log(`\n  Model Changes Behind These Numbers:`)
+    console.log(`    ${modelChangeDisclosure}`)
+  }
+
   const attributionEntries = Object.entries(readModelAttribution(data))
     .sort(([a], [b]) => a.localeCompare(b))
   if (attributionEntries.length > 0) {
@@ -174,6 +183,18 @@ function readServedModelAttribution(data: BrandMetricsDto): BrandMetricsDto['ser
 function readModelServiceMismatch(data: BrandMetricsDto): BrandMetricsDto['modelServiceMismatch'] {
   const legacyCompatible = data as unknown as { modelServiceMismatch?: BrandMetricsDto['modelServiceMismatch'] }
   return legacyCompatible.modelServiceMismatch ?? {}
+}
+
+/**
+ * Providers whose numbers span a known change to a moving model id — one the
+ * provider re-points at a different underlying model without the API response
+ * changing at all. Absent on an older server, empty for a project on fixed
+ * model ids. Rendering is `formatModelChangeDisclosure` from contracts, shared
+ * with the dashboard so neither surface can soften the caveat the other gives.
+ */
+function readModelPointerChanges(data: BrandMetricsDto): Record<string, ModelPointerChangeDisclosure> {
+  const legacyCompatible = data as unknown as { modelPointerChanges?: Record<string, ModelPointerChangeDisclosure> }
+  return legacyCompatible.modelPointerChanges ?? {}
 }
 
 /** A newer CLI can be pointed at an older server during a rolling upgrade. */

--- a/packages/canonry/test/analytics.test.ts
+++ b/packages/canonry/test/analytics.test.ts
@@ -6,7 +6,7 @@ import crypto from 'node:crypto'
 import { createClient, migrate, apiKeys } from '@ainyc/canonry-db'
 import { createServer } from '../src/server.js'
 import { ApiClient } from '../src/client.js'
-import type { BrandMetricsDto } from '@ainyc/canonry-contracts'
+import type { BrandMetricsDto, ModelPointerChangeDisclosure } from '@ainyc/canonry-contracts'
 
 function captureOutput(fn: () => Promise<void>): Promise<{ stdout: string; stderr: string }> {
   const logs: string[] = []
@@ -19,6 +19,57 @@ function captureOutput(fn: () => Promise<void>): Promise<{ stdout: string; stder
     console.log = origLog
     console.error = origError
   }).then(() => ({ stdout: logs.join('\n'), stderr: errors.join('\n') }))
+}
+
+/**
+ * Deliberately a literal, not the imported constant: this pins the sentence a
+ * user actually reads, so editing the shared copy in contracts fails here
+ * instead of silently changing what the CLI prints.
+ */
+const MODEL_CHANGE_NEXT_ACTION = 'Compare this period with earlier ones carefully.'
+
+const OPENAI_CHANGE: ModelPointerChangeDisclosure = {
+  modelIds: ['chat-latest'],
+  changeCount: 1,
+  unverifiedChangeCount: 0,
+  firstChangeDate: '2026-06-24',
+  lastChangeDate: '2026-06-24',
+  summary: 'The model behind "chat-latest" changed on 2026-06-24, inside this reporting period. '
+    + 'Part of any movement in this number comes from that change and not from how often AI names you.',
+}
+
+const GEMINI_CHANGE: ModelPointerChangeDisclosure = {
+  modelIds: ['gemini-flash-latest'],
+  changeCount: 2,
+  unverifiedChangeCount: 0,
+  firstChangeDate: '2026-06-02',
+  lastChangeDate: '2026-06-30',
+  summary: 'The model behind "gemini-flash-latest" changed more than once in this reporting period, '
+    + 'between 2026-06-02 and 2026-06-30. '
+    + 'Part of any movement in this number comes from those changes and not from how often AI names you.',
+}
+
+/** Cast because the fixture omits the newer optional fields the CLI degrades over. */
+function metricsWith(modelPointerChanges?: Record<string, ModelPointerChangeDisclosure>): BrandMetricsDto {
+  return {
+    window: '30d',
+    buckets: [],
+    overall: { citationRate: 0, cited: 0, total: 0, mentionRate: 0, mentionedCount: 0 },
+    byProvider: {},
+    trend: 'stable',
+    mentionTrend: 'stable',
+    queryChanges: [],
+    modelAttribution: {
+      openai: {
+        latestObservation: {
+          observedAt: '2026-07-15T12:00:00.000Z',
+          state: { status: 'known', model: 'chat-latest' },
+        },
+        events: [],
+      },
+    },
+    ...(modelPointerChanges ? { modelPointerChanges } : {}),
+  } as unknown as BrandMetricsDto
 }
 
 describe('analytics command', () => {
@@ -231,6 +282,78 @@ describe('analytics command', () => {
       // The served lane, in plain language.
       expect(stdout).toContain('What the Engines Answered With:')
       expect(stdout).toContain('openai: gpt-5.6-sol at 2026-07-15T12:00:00.000Z — not the known gpt-5.6 you selected')
+    } finally {
+      metricsSpy.mockRestore()
+    }
+  })
+
+  it('discloses a single provider-side model change in plain language', async () => {
+    const metricsSpy = vi.spyOn(ApiClient.prototype, 'getAnalyticsMetrics')
+      .mockResolvedValue(metricsWith({ openai: OPENAI_CHANGE }))
+    try {
+      const { showAnalytics } = await import('../src/commands/analytics.js')
+      const { stdout } = await captureOutput(() => showAnalytics('test-proj', { feature: 'metrics' }))
+      expect(stdout).toContain('Model Changes Behind These Numbers:')
+      expect(stdout).toContain(`${OPENAI_CHANGE.summary} ${MODEL_CHANGE_NEXT_ACTION}`)
+      // Ahead of the model sections — it is the note that changes how the
+      // numbers above it should be read.
+      expect(stdout.indexOf('Model Changes Behind These Numbers:')).toBeLessThan(stdout.indexOf('Model Evidence:'))
+    } finally {
+      metricsSpy.mockRestore()
+    }
+  })
+
+  it('discloses several changes across engines with one shared caveat', async () => {
+    const metricsSpy = vi.spyOn(ApiClient.prototype, 'getAnalyticsMetrics')
+      .mockResolvedValue(metricsWith({ openai: OPENAI_CHANGE, gemini: GEMINI_CHANGE }))
+    try {
+      const { showAnalytics } = await import('../src/commands/analytics.js')
+      const { stdout } = await captureOutput(() => showAnalytics('test-proj', { feature: 'metrics' }))
+      expect(stdout).toContain(`${GEMINI_CHANGE.summary} ${OPENAI_CHANGE.summary} ${MODEL_CHANGE_NEXT_ACTION}`)
+      // One closing line however many engines are affected.
+      expect(stdout.split(MODEL_CHANGE_NEXT_ACTION)).toHaveLength(2)
+    } finally {
+      metricsSpy.mockRestore()
+    }
+  })
+
+  it('prints no disclosure when the server omits the field or reports no change', async () => {
+    const metricsSpy = vi.spyOn(ApiClient.prototype, 'getAnalyticsMetrics').mockResolvedValue(metricsWith())
+    try {
+      const { showAnalytics } = await import('../src/commands/analytics.js')
+      const older = await captureOutput(() => showAnalytics('test-proj', { feature: 'metrics' }))
+      expect(older.stdout).toContain('Model Evidence:')
+      expect(older.stdout).not.toContain('Model Changes Behind These Numbers:')
+      expect(older.stdout).not.toContain('The model behind')
+
+      metricsSpy.mockResolvedValue(metricsWith({}))
+      const unchanged = await captureOutput(() => showAnalytics('test-proj', { feature: 'metrics' }))
+      expect(unchanged.stdout).not.toContain('Model Changes Behind These Numbers:')
+      expect(unchanged.stdout).not.toContain('The model behind')
+    } finally {
+      metricsSpy.mockRestore()
+    }
+  })
+
+  /**
+   * The copy is the deliverable, and it must read identically here and on the
+   * dashboard. Pinned so a later edit cannot quietly reintroduce the internal
+   * words an agency owner does not speak.
+   */
+  it('keeps the disclosure free of internal vocabulary', async () => {
+    const metricsSpy = vi.spyOn(ApiClient.prototype, 'getAnalyticsMetrics')
+      .mockResolvedValue(metricsWith({ openai: OPENAI_CHANGE }))
+    try {
+      const { showAnalytics } = await import('../src/commands/analytics.js')
+      const { stdout } = await captureOutput(() => showAnalytics('test-proj', { feature: 'metrics' }))
+      const note = stdout.split('\n').find(line => line.includes('The model behind'))!
+      expect(note.trim()).toBe(`${OPENAI_CHANGE.summary} ${MODEL_CHANGE_NEXT_ACTION}`)
+      // What happened, what it means for the number, and what to do about it.
+      expect(note).toContain('changed on 2026-06-24, inside this reporting period')
+      expect(note).toContain('not from how often AI names you')
+      for (const banned of ['pointer', 'alias', 'snapshot', 'drift', 'attribution', 'divergence']) {
+        expect(note.toLowerCase()).not.toContain(banned)
+      }
     } finally {
       metricsSpy.mockRestore()
     }

--- a/packages/canonry/test/analytics.test.ts
+++ b/packages/canonry/test/analytics.test.ts
@@ -6,7 +6,7 @@ import crypto from 'node:crypto'
 import { createClient, migrate, apiKeys } from '@ainyc/canonry-db'
 import { createServer } from '../src/server.js'
 import { ApiClient } from '../src/client.js'
-import type { BrandMetricsDto, ModelPointerChangeDisclosure } from '@ainyc/canonry-contracts'
+import type { BrandMetricsDto } from '@ainyc/canonry-contracts'
 
 function captureOutput(fn: () => Promise<void>): Promise<{ stdout: string; stderr: string }> {
   const logs: string[] = []
@@ -22,13 +22,20 @@ function captureOutput(fn: () => Promise<void>): Promise<{ stdout: string; stder
 }
 
 /**
- * Deliberately a literal, not the imported constant: this pins the sentence a
- * user actually reads, so editing the shared copy in contracts fails here
- * instead of silently changing what the CLI prints.
+ * Deliberately literals, not imported constants: these pin the sentences a user
+ * actually reads. The same literals are pinned in
+ * `apps/web/test/visibility-trend-helpers.test.ts` — the CLI carries a mirrored
+ * copy of the dashboard's copy builder, and identical literals in both suites
+ * are what stops one surface softening the caveat the other gives.
  */
-const MODEL_CHANGE_NEXT_ACTION = 'Compare this period with earlier ones carefully.'
+const CLOSING_LINE = 'rather than from a real change in how AI answers about you, so compare periods carefully.'
 
-const OPENAI_CHANGE: ModelPointerChangeDisclosure = {
+/** `summary` is a LEGACY field an older server used to send, kept here
+ *  deliberately: it is the hostile wording this lane replaced, so a surface
+ *  that ever renders the server's sentence again instead of building its own
+ *  fails these tests loudly. Cast because these fixtures model what a server of
+ *  any vintage may put on the wire, not the current full shape. */
+const OPENAI_CHANGE = {
   modelIds: ['chat-latest'],
   changeCount: 1,
   unverifiedChangeCount: 0,
@@ -38,19 +45,26 @@ const OPENAI_CHANGE: ModelPointerChangeDisclosure = {
     + 'Part of any movement in this number comes from that change and not from how often AI names you.',
 }
 
-const GEMINI_CHANGE: ModelPointerChangeDisclosure = {
-  modelIds: ['gemini-flash-latest'],
-  changeCount: 2,
+const PERPLEXITY_CHANGE = {
+  modelIds: ['sonar-latest'],
+  changeCount: 1,
   unverifiedChangeCount: 0,
-  firstChangeDate: '2026-06-02',
-  lastChangeDate: '2026-06-30',
-  summary: 'The model behind "gemini-flash-latest" changed more than once in this reporting period, '
-    + 'between 2026-06-02 and 2026-06-30. '
-    + 'Part of any movement in this number comes from those changes and not from how often AI names you.',
+  firstChangeDate: '2026-06-10',
+  lastChangeDate: '2026-06-10',
+  summary: 'The model behind "sonar-latest" changed on 2026-06-10, inside this reporting period. '
+    + 'Part of any movement in this number comes from that change and not from how often AI names you.',
+}
+
+const OPENAI_UNCONFIRMED = {
+  modelIds: ['chat-latest'],
+  changeCount: 1,
+  unverifiedChangeCount: 1,
+  firstChangeDate: '2026-05-28',
+  lastChangeDate: '2026-05-28',
 }
 
 /** Cast because the fixture omits the newer optional fields the CLI degrades over. */
-function metricsWith(modelPointerChanges?: Record<string, ModelPointerChangeDisclosure>): BrandMetricsDto {
+function metricsWith(modelPointerChanges?: Record<string, unknown>): BrandMetricsDto {
   return {
     window: '30d',
     buckets: [],
@@ -287,48 +301,135 @@ describe('analytics command', () => {
     }
   })
 
-  it('discloses a single provider-side model change in plain language', async () => {
+  it('names the engine the reader knows and prints the caveat above the numbers', async () => {
     const metricsSpy = vi.spyOn(ApiClient.prototype, 'getAnalyticsMetrics')
       .mockResolvedValue(metricsWith({ openai: OPENAI_CHANGE }))
     try {
       const { showAnalytics } = await import('../src/commands/analytics.js')
       const { stdout } = await captureOutput(() => showAnalytics('test-proj', { feature: 'metrics' }))
-      expect(stdout).toContain('Model Changes Behind These Numbers:')
-      expect(stdout).toContain(`${OPENAI_CHANGE.summary} ${MODEL_CHANGE_NEXT_ACTION}`)
-      // Ahead of the model sections — it is the note that changes how the
-      // numbers above it should be read.
-      expect(stdout.indexOf('Model Changes Behind These Numbers:')).toBeLessThan(stdout.indexOf('Model Evidence:'))
+      const note = stdout.split('\n').find(line => line.includes('The model behind'))!
+      expect(note.trim()).toBe(
+        'The model behind ChatGPT was updated on 2026-06-24, inside this period. '
+        + `Some of the movement in these numbers may come from this update ${CLOSING_LINE}`,
+      )
+      // "chat-latest" is an internal model id. An agency owner reads engines.
+      expect(note).not.toContain('chat-latest')
+      // Above the FIRST number, not merely above the model sections at the
+      // bottom: an operator who has already read the rates has already formed
+      // the reading this note exists to correct.
+      expect(stdout.indexOf('Model Updates Behind These Numbers:')).toBeLessThan(stdout.indexOf('Overall:'))
     } finally {
       metricsSpy.mockRestore()
     }
   })
 
-  it('discloses several changes across engines with one shared caveat', async () => {
+  it('states one fact per engine and closes with a single consequence', async () => {
     const metricsSpy = vi.spyOn(ApiClient.prototype, 'getAnalyticsMetrics')
-      .mockResolvedValue(metricsWith({ openai: OPENAI_CHANGE, gemini: GEMINI_CHANGE }))
+      .mockResolvedValue(metricsWith({ openai: OPENAI_CHANGE, perplexity: PERPLEXITY_CHANGE }))
     try {
       const { showAnalytics } = await import('../src/commands/analytics.js')
       const { stdout } = await captureOutput(() => showAnalytics('test-proj', { feature: 'metrics' }))
-      expect(stdout).toContain(`${GEMINI_CHANGE.summary} ${OPENAI_CHANGE.summary} ${MODEL_CHANGE_NEXT_ACTION}`)
-      // One closing line however many engines are affected.
-      expect(stdout.split(MODEL_CHANGE_NEXT_ACTION)).toHaveLength(2)
+      const note = stdout.split('\n').find(line => line.includes('The model behind'))!
+      expect(note.trim()).toBe(
+        'The model behind ChatGPT was updated on 2026-06-24, inside this period. '
+        + 'The model behind Perplexity was updated on 2026-06-10, inside this period. '
+        + `Some of the movement in these numbers may come from these updates ${CLOSING_LINE}`,
+      )
+      // Two engines are two facts and ONE warning; repeating the consequence
+      // per engine read as two separate alarms about the same numbers.
+      const sentences = note.trim().split('. ').map(s => s.trim())
+      expect(new Set(sentences).size).toBe(sentences.length)
     } finally {
       metricsSpy.mockRestore()
     }
   })
 
-  it('prints no disclosure when the server omits the field or reports no change', async () => {
+  it('never states an unconfirmed update as fact, and never hides it either', async () => {
+    const metricsSpy = vi.spyOn(ApiClient.prototype, 'getAnalyticsMetrics')
+      .mockResolvedValue(metricsWith({ openai: OPENAI_UNCONFIRMED }))
+    try {
+      const { showAnalytics } = await import('../src/commands/analytics.js')
+      const { stdout } = await captureOutput(() => showAnalytics('test-proj', { feature: 'metrics' }))
+      const note = stdout.split('\n').find(line => line.includes('The model behind'))!
+      expect(note.trim()).toBe(
+        'The model behind ChatGPT may have been updated on 2026-05-28, inside this period, though that is not confirmed. '
+        + `If so, some of the movement in these numbers may come from this update ${CLOSING_LINE}`,
+      )
+      expect(note).not.toContain('was updated')
+    } finally {
+      metricsSpy.mockRestore()
+    }
+  })
+
+  it('says so quietly, and low in the output, when an engine can be updated but nothing is on record', async () => {
+    const metricsSpy = vi.spyOn(ApiClient.prototype, 'getAnalyticsMetrics')
+      .mockResolvedValue(metricsWith({ openai: { ...OPENAI_CHANGE, changeCount: 0, unverifiedChangeCount: 0 } }))
+    try {
+      const { showAnalytics } = await import('../src/commands/analytics.js')
+      const { stdout } = await captureOutput(() => showAnalytics('test-proj', { feature: 'metrics' }))
+      // Silence here is indistinguishable from a record nobody has updated in
+      // six months, so the common case still says something — just not above
+      // the numbers, where it would be noise on every single run.
+      expect(stdout).toContain('No model updates are on record for ChatGPT in this period.')
+      expect(stdout.indexOf('No model updates are on record')).toBeGreaterThan(stdout.indexOf('Overall:'))
+    } finally {
+      metricsSpy.mockRestore()
+    }
+  })
+
+  it('prints how recently the update record was checked, since a terminal has no tooltip', async () => {
+    // The dashboard hides this sentence in a tooltip. The CLI has nowhere to
+    // hide it, and dropping it is what makes "nothing on record" read as proof
+    // that nothing happened rather than as the age of our knowledge.
+    const metricsSpy = vi.spyOn(ApiClient.prototype, 'getAnalyticsMetrics')
+      .mockResolvedValue(metricsWith({
+        openai: {
+          modelIds: ['chat-latest'],
+          changeCount: 0,
+          unverifiedChangeCount: 0,
+          knownGoodAsOf: '2026-07-20',
+          checkedThroughPeriodEnd: true,
+        },
+      }))
+    try {
+      const { showAnalytics } = await import('../src/commands/analytics.js')
+      const { stdout } = await captureOutput(() => showAnalytics('test-proj', { feature: 'metrics' }))
+      expect(stdout).toContain('We last checked for model updates on 2026-07-20.')
+    } finally {
+      metricsSpy.mockRestore()
+    }
+  })
+
+  it('says out loud when the period runs past the last check', async () => {
+    const metricsSpy = vi.spyOn(ApiClient.prototype, 'getAnalyticsMetrics')
+      .mockResolvedValue(metricsWith({
+        openai: { ...OPENAI_CHANGE, knownGoodAsOf: '2026-07-20', checkedThroughPeriodEnd: false },
+      }))
+    try {
+      const { showAnalytics } = await import('../src/commands/analytics.js')
+      const { stdout } = await captureOutput(() => showAnalytics('test-proj', { feature: 'metrics' }))
+      // Finding one update must never imply we found all of them.
+      expect(stdout).toContain(
+        'We last checked for model updates on 2026-07-20, and this period runs past that date,'
+        + ' so there may be later updates we do not know about.',
+      )
+    } finally {
+      metricsSpy.mockRestore()
+    }
+  })
+
+  it('prints nothing when the server omits the field or reports no exposure', async () => {
     const metricsSpy = vi.spyOn(ApiClient.prototype, 'getAnalyticsMetrics').mockResolvedValue(metricsWith())
     try {
       const { showAnalytics } = await import('../src/commands/analytics.js')
       const older = await captureOutput(() => showAnalytics('test-proj', { feature: 'metrics' }))
       expect(older.stdout).toContain('Model Evidence:')
-      expect(older.stdout).not.toContain('Model Changes Behind These Numbers:')
+      expect(older.stdout).not.toContain('Model Updates Behind These Numbers:')
       expect(older.stdout).not.toContain('The model behind')
 
       metricsSpy.mockResolvedValue(metricsWith({}))
       const unchanged = await captureOutput(() => showAnalytics('test-proj', { feature: 'metrics' }))
-      expect(unchanged.stdout).not.toContain('Model Changes Behind These Numbers:')
+      expect(unchanged.stdout).not.toContain('Model Updates Behind These Numbers:')
       expect(unchanged.stdout).not.toContain('The model behind')
     } finally {
       metricsSpy.mockRestore()
@@ -336,24 +437,20 @@ describe('analytics command', () => {
   })
 
   /**
-   * The copy is the deliverable, and it must read identically here and on the
-   * dashboard. Pinned so a later edit cannot quietly reintroduce the internal
-   * words an agency owner does not speak.
+   * The copy is the deliverable. Pinned so a later edit cannot quietly
+   * reintroduce the internal words an agency owner does not speak.
    */
-  it('keeps the disclosure free of internal vocabulary', async () => {
+  it('keeps the note free of internal vocabulary and em-dashes', async () => {
     const metricsSpy = vi.spyOn(ApiClient.prototype, 'getAnalyticsMetrics')
       .mockResolvedValue(metricsWith({ openai: OPENAI_CHANGE }))
     try {
       const { showAnalytics } = await import('../src/commands/analytics.js')
       const { stdout } = await captureOutput(() => showAnalytics('test-proj', { feature: 'metrics' }))
       const note = stdout.split('\n').find(line => line.includes('The model behind'))!
-      expect(note.trim()).toBe(`${OPENAI_CHANGE.summary} ${MODEL_CHANGE_NEXT_ACTION}`)
-      // What happened, what it means for the number, and what to do about it.
-      expect(note).toContain('changed on 2026-06-24, inside this reporting period')
-      expect(note).toContain('not from how often AI names you')
       for (const banned of ['pointer', 'alias', 'snapshot', 'drift', 'attribution', 'divergence']) {
         expect(note.toLowerCase()).not.toContain(banned)
       }
+      expect(note).not.toContain('—')
     } finally {
       metricsSpy.mockRestore()
     }

--- a/packages/contracts/AGENTS.md
+++ b/packages/contracts/AGENTS.md
@@ -15,7 +15,7 @@ Shared DTOs, enums, Zod schemas, error codes, config validation, and **generic u
 | `src/snapshot.ts` | Snapshot DTOs and diff types |
 | `src/config-schema.ts` | Config file Zod validation |
 | `src/models.ts` | Shared model types |
-| `src/model-pointers.ts` | Hand-maintained record of dates on which a provider changed the model behind a moving id (`chat-latest` and friends), plus `findModelPointerChanges` (does a reporting period span one?) and `formatModelChangeDisclosure` (the plain-language caveat both the dashboard and the CLI render). Add a new dated entry to `MODEL_POINTER_EVENTS` whenever the provider's changelog announces one. |
+| `src/model-pointers.ts` | Hand-maintained record of dates on which a provider changed the model behind a moving id (`chat-latest` and friends), plus `evaluateModelPointerExposure` (did a change land while the project was running that id?) and `buildModelChangeNotice` (the plain-language caveat both the dashboard and the CLI render — the ONLY wording of it; the DTO carries facts, never prose). Add a new dated entry to `MODEL_POINTER_EVENTS` whenever the provider's changelog announces one, AND move `MODEL_POINTER_REGISTRY_CHECKED_THROUGH` to the day you re-read the sources — every disclosure states that date, so a stale one reads as knowledge we do not have. |
 | `src/analytics.ts` | Analytics response DTOs |
 | `src/formatting.ts` | Generic formatters: `formatRatio`, `formatNumber`, `formatDate`, `formatIsoDate`, `formatDateRange` |
 | `src/url-normalize.ts` | Domain / URL normalization helpers |

--- a/packages/contracts/AGENTS.md
+++ b/packages/contracts/AGENTS.md
@@ -15,6 +15,7 @@ Shared DTOs, enums, Zod schemas, error codes, config validation, and **generic u
 | `src/snapshot.ts` | Snapshot DTOs and diff types |
 | `src/config-schema.ts` | Config file Zod validation |
 | `src/models.ts` | Shared model types |
+| `src/model-pointers.ts` | Hand-maintained record of dates on which a provider changed the model behind a moving id (`chat-latest` and friends), plus `findModelPointerChanges` (does a reporting period span one?) and `formatModelChangeDisclosure` (the plain-language caveat both the dashboard and the CLI render). Add a new dated entry to `MODEL_POINTER_EVENTS` whenever the provider's changelog announces one. |
 | `src/analytics.ts` | Analytics response DTOs |
 | `src/formatting.ts` | Generic formatters: `formatRatio`, `formatNumber`, `formatDate`, `formatIsoDate`, `formatDateRange` |
 | `src/url-normalize.ts` | Domain / URL normalization helpers |

--- a/packages/contracts/src/analytics.ts
+++ b/packages/contracts/src/analytics.ts
@@ -274,14 +274,21 @@ export const brandMetricsDtoSchema = z.object({
   /** Providers currently serving a different top-level model than the one configured. */
   modelServiceMismatch: z.record(z.string(), modelServiceMismatchSchema).default({}),
   /**
-   * Providers where a model id the project RAN is one the provider re-points at
-   * a different underlying model, and a known re-point landed inside the span
-   * of sweeps these numbers come from. Sibling of `modelServiceMismatch`: same
-   * `.default({})` back-compat, and the same "this is evidence about the
-   * measurement, not project configuration" role. A mismatch is something we
-   * OBSERVED; this is something we could never observe from the response, which
-   * is exactly why it has to be disclosed from a dated record instead.
-   * Empty for every project on pinned model ids.
+   * Providers where a model id the project RAN is one the provider can swap for
+   * a different underlying model without saying so. Sibling of
+   * `modelServiceMismatch`: same `.default({})` back-compat, and the same "this
+   * is evidence about the measurement, not project configuration" role. A
+   * mismatch is something we OBSERVED; this is something we could never observe
+   * from the response, which is exactly why it has to be disclosed from a dated
+   * record instead.
+   *
+   * A provider is present in BOTH exposed states — `known-change` (a dated
+   * change landed while the project was running the id) and `no-known-change`
+   * (it is on such an id and our hand-maintained list has nothing for its
+   * period). The second one carries `knownGoodAsOf` so a surface can say how
+   * fresh that knowledge is: a list that has fallen behind produces exactly
+   * that state, and letting it read as silence is the failure this field
+   * exists to prevent. Empty only for a project entirely on fixed model ids.
    */
   modelPointerChanges: z.record(z.string(), modelPointerChangeDisclosureSchema).default({}),
 })

--- a/packages/contracts/src/analytics.ts
+++ b/packages/contracts/src/analytics.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { modelPointerChangeDisclosureSchema } from './model-pointers.js'
 import { sourceCategorySchema } from './source-categories.js'
 import { surfaceClassSchema } from './surface-class.js'
 
@@ -272,6 +273,17 @@ export const brandMetricsDtoSchema = z.object({
   servedModelAttribution: servedModelAttributionSchema.default({}),
   /** Providers currently serving a different top-level model than the one configured. */
   modelServiceMismatch: z.record(z.string(), modelServiceMismatchSchema).default({}),
+  /**
+   * Providers where a model id the project RAN is one the provider re-points at
+   * a different underlying model, and a known re-point landed inside the span
+   * of sweeps these numbers come from. Sibling of `modelServiceMismatch`: same
+   * `.default({})` back-compat, and the same "this is evidence about the
+   * measurement, not project configuration" role. A mismatch is something we
+   * OBSERVED; this is something we could never observe from the response, which
+   * is exactly why it has to be disclosed from a dated record instead.
+   * Empty for every project on pinned model ids.
+   */
+  modelPointerChanges: z.record(z.string(), modelPointerChangeDisclosureSchema).default({}),
 })
 export type BrandMetricsDto = z.infer<typeof brandMetricsDtoSchema>
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,6 +1,7 @@
 export * from './api-keys.js'
 export * from './config-schema.js'
 export * from './models.js'
+export * from './model-pointers.js'
 export * from './errors.js'
 export * from './google.js'
 export * from './gbp.js'

--- a/packages/contracts/src/model-pointers.ts
+++ b/packages/contracts/src/model-pointers.ts
@@ -1,0 +1,267 @@
+import { z } from 'zod'
+
+import { formatIsoDate } from './formatting.js'
+
+/**
+ * KNOWN MODEL-POINTER EVENTS — a hand-maintained record of the dates on which a
+ * provider changed the model sitting behind a moving model id.
+ *
+ * WHY THIS FILE EXISTS
+ * --------------------
+ * Some provider model ids are not models. `chat-latest` names "whatever model
+ * ChatGPT is currently using", and the provider re-points it whenever the
+ * consumer product changes. A sweep cannot see the swap: the API echoes the
+ * same id back on both sides of it, so a client's mention share can move
+ * because the model changed, and that is indistinguishable from the client's
+ * own position moving. Everything here exists so a number whose reporting
+ * period spans a known change can carry an honest caveat.
+ *
+ * WHERE THE DATES COME FROM
+ * -------------------------
+ * The provider's own public changelog and deprecation pages (`sourceUrl` on
+ * every entry). Those pages announce only THAT the model behind an id changed —
+ * they never say what it changed TO, and the API response carries no identifier
+ * for the new model either. So the date is all we get, and the date is all we
+ * claim. Nothing here should ever be extended into a guess about which model is
+ * now behind an id.
+ *
+ * HOW TO ADD A NEW ONE
+ * --------------------
+ * Append one line to `MODEL_POINTER_EVENTS` below. Copy the shape of the line
+ * above it: model id, `YYYY-MM-DD` date, kind, whether the source states the
+ * change plainly (`confirmed`), the source URL, and a `note` quoting the source
+ * verbatim so the next maintainer can re-check the reading without re-doing the
+ * research. Order does not matter — the lookup sorts. Keep entries even after
+ * an id is retired: historical reporting periods still span them.
+ *
+ * THIS LIST ROTS IF NOBODY UPDATES IT. That is the standing risk of the whole
+ * approach: a missing entry means a silent model change reported to a client as
+ * their own performance. Re-read the changelog whenever a pointer id shows up in
+ * a project's configuration, and whenever a number moves without an explanation.
+ */
+
+/**
+ * What a source says happened to a model id on a date.
+ *
+ * - `introduced` — the id started existing. Provenance only.
+ * - `repointed` — the SAME id started resolving to a different model. This is
+ *   the invisible one, and the only kind that produces a disclosure.
+ * - `retired`  — the id stopped being served. Loud by construction (calls fail
+ *   or the operator re-configures), and the configured/served model evidence
+ *   already shows it, so it does not produce a disclosure either.
+ */
+export const modelPointerEventKindSchema = z.enum(['introduced', 'repointed', 'retired'])
+export type ModelPointerEventKind = z.infer<typeof modelPointerEventKindSchema>
+export const ModelPointerEventKinds = modelPointerEventKindSchema.enum
+
+export const modelPointerEventSchema = z.object({
+  /** The moving model id as the provider spells it, e.g. `chat-latest`. */
+  modelId: z.string().trim().min(1),
+  /** Calendar day the source attributes the event to, `YYYY-MM-DD`. */
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'date must be YYYY-MM-DD'),
+  kind: modelPointerEventKindSchema,
+  /**
+   * False when the source is ambiguous about whether the model actually
+   * changed. An unverified change still discloses — under-warning is the
+   * expensive direction — but the copy hedges instead of asserting.
+   */
+  confirmed: z.boolean(),
+  /** Public page a maintainer can re-read to check this entry. */
+  sourceUrl: z.string().url(),
+  /** Verbatim quote or reading note, so the entry can be audited without re-research. */
+  note: z.string().min(1),
+})
+export type ModelPointerEvent = z.infer<typeof modelPointerEventSchema>
+
+/**
+ * The seed record. Every entry below was checked against the linked official
+ * page. Append new ones at the bottom.
+ */
+export const MODEL_POINTER_EVENTS: readonly ModelPointerEvent[] = [
+  { modelId: 'chatgpt-4o-latest', date: '2024-08-15', kind: 'introduced', confirmed: true, sourceUrl: 'https://developers.openai.com/api/docs/changelog', note: 'Verbatim: "Released dynamic model for chatgpt-4o-latest—this model will point to the latest GPT-4o model used by ChatGPT." First moving id in the lineage.' },
+  { modelId: 'chatgpt-4o-latest', date: '2026-02-17', kind: 'retired', confirmed: true, sourceUrl: 'https://developers.openai.com/api/docs/deprecations.md', note: 'Shutdown 2026-02-17, replacement gpt-5.1-chat-latest. Announced under the heading "2025-11-18: chatgpt-4o-latest snapshot".' },
+  { modelId: 'gpt-5.1-chat-latest', date: '2025-11-13', kind: 'introduced', confirmed: true, sourceUrl: 'https://developers.openai.com/api/docs/changelog', note: 'Introduced inside the GPT-5.1 launch entry, not as a standalone entry.' },
+  { modelId: 'gpt-5.2-chat-latest', date: '2025-12-11', kind: 'introduced', confirmed: true, sourceUrl: 'https://developers.openai.com/api/docs/changelog', note: 'Introduced inside the GPT-5.2 launch entry.' },
+  { modelId: 'gpt-5.2-chat-latest', date: '2026-02-10', kind: 'repointed', confirmed: true, sourceUrl: 'https://developers.openai.com/api/docs/changelog', note: 'Verbatim: "Updated the gpt-5.2-chat-latest slug to point to the latest model currently used in ChatGPT." Target model NOT named.' },
+  { modelId: 'gpt-5.3-chat-latest', date: '2026-03-03', kind: 'introduced', confirmed: true, sourceUrl: 'https://developers.openai.com/api/docs/changelog', note: 'Verbatim: "Released gpt-5.3-chat-latest to the Chat Completions and Responses API. This model points to the GPT-5.3 Instant snapshot currently used in ChatGPT."' },
+  { modelId: 'gpt-5.3-chat-latest', date: '2026-03-16', kind: 'repointed', confirmed: true, sourceUrl: 'https://developers.openai.com/api/docs/changelog', note: 'Verbatim: "Updated the gpt-5.3-chat-latest slug to point to the latest model currently used in ChatGPT." Target model NOT named.' },
+  { modelId: 'chat-latest', date: '2026-05-05', kind: 'introduced', confirmed: true, sourceUrl: 'https://developers.openai.com/api/docs/changelog', note: 'Verbatim: "Released chat-latest snapshot which points to the latest Instant model currently used in ChatGPT... The underlying model snapshot will be regularly updated."' },
+  { modelId: 'chat-latest', date: '2026-05-28', kind: 'repointed', confirmed: false, sourceUrl: 'https://developers.openai.com/api/docs/changelog', note: 'UNCONFIRMED. The entry reads "Released chat-latest snapshot..." — the verb is "Released", the same boilerplate as the 2026-05-05 entry, not "Updated" as used on 2026-06-24. Only "the latest improvements" vs "our latest improvements" differs. Either a real change logged with copy-pasted text, or a duplicated entry; the record does not disambiguate.' },
+  { modelId: 'chat-latest', date: '2026-06-24', kind: 'repointed', confirmed: true, sourceUrl: 'https://developers.openai.com/api/docs/changelog', note: 'The changelog entry uses the verb "Updated" (unlike the "Released" boilerplate of 2026-05-05 and 2026-05-28), which is the wording reserved for a real change. Target model NOT named. Re-read the source before relying on the exact wording — this entry was recorded from the 2026-05-28 comparison, not quoted directly.' },
+]
+
+/**
+ * Only a re-point produces a disclosure. An `introduced` date is the day the id
+ * started existing, so no reporting period can straddle a change in what it
+ * resolves to; a `retired` id fails loudly and already shows up as a configured
+ * model change. The silent one — same id, different model, identical API
+ * response — is `repointed`, and that is the whole reason this check exists.
+ */
+const DISCLOSING_KINDS: ReadonlySet<ModelPointerEventKind> = new Set([ModelPointerEventKinds.repointed])
+
+/**
+ * Every model id the registry knows to be a moving pointer. Derived from the
+ * events so a registry entry is the single edit that also marks an id exposed.
+ */
+export const KNOWN_MOVING_POINTER_MODEL_IDS: ReadonlySet<string> = new Set(
+  MODEL_POINTER_EVENTS.map(event => event.modelId.toLowerCase()),
+)
+
+/**
+ * True when a model id names "whatever the provider is currently using" rather
+ * than a fixed model — which is what decides whether a project is exposed to
+ * this problem at all. A project on a pinned id never gets a disclosure.
+ *
+ * Two ways an id qualifies, and the second one matters most: a `-latest` suffix
+ * is the universal vendor convention for a moving id (`chat-latest`,
+ * `chatgpt-4o-latest`, `gpt-5.3-chat-latest`, and the Anthropic `-latest`
+ * aliases), so a pointer shipped tomorrow is treated as exposed BEFORE anyone
+ * gets around to adding it to the registry. The registry then supplies the
+ * dates. Failing this open would mean silently treating a moving id as pinned.
+ */
+export function isMovingPointerModelId(modelId: string): boolean {
+  const id = modelId.trim().toLowerCase()
+  if (id.length === 0) return false
+  return KNOWN_MOVING_POINTER_MODEL_IDS.has(id) || id.endsWith('-latest')
+}
+
+/**
+ * A plain-language caveat for a number whose reporting period spans one or more
+ * known changes to a model the project actually ran.
+ */
+export const modelPointerChangeDisclosureSchema = z.object({
+  /** The moving model ids the project ran that changed inside the period, sorted. */
+  modelIds: z.array(z.string().trim().min(1)).min(1),
+  /** How many known changes landed inside the period, across those ids. */
+  changeCount: z.number().int().positive(),
+  /**
+   * How many of `changeCount` come from a source that does not plainly state a
+   * change happened. Equal to `changeCount` means the whole caveat is hedged.
+   */
+  unverifiedChangeCount: z.number().int().nonnegative(),
+  /** Earliest change date inside the period, `YYYY-MM-DD`. */
+  firstChangeDate: z.string(),
+  /** Latest change date inside the period. Equal to `firstChangeDate` when there is one change. */
+  lastChangeDate: z.string(),
+  /** Ready-to-render sentence. Says what happened and what it means for the number. */
+  summary: z.string().min(1),
+})
+export type ModelPointerChangeDisclosure = z.infer<typeof modelPointerChangeDisclosureSchema>
+
+export interface ModelPointerChangeQuery {
+  /**
+   * Every model id the project actually RAN over the period — configured and
+   * served alike. Pinned ids are ignored, so passing the full set is correct
+   * and a project on a pinned id gets nothing back.
+   */
+  modelIds: Iterable<string>
+  /** Start of the reporting period. `YYYY-MM-DD` or a full ISO timestamp. Inclusive. */
+  start: string
+  /** End of the reporting period. Same formats. Inclusive. */
+  end: string
+}
+
+function quoted(modelIds: readonly string[]): string {
+  const quotedIds = modelIds.map(id => `"${id}"`)
+  if (quotedIds.length === 1) return quotedIds[0]!
+  if (quotedIds.length === 2) return `${quotedIds[0]} and ${quotedIds[1]}`
+  return `${quotedIds.slice(0, -1).join(', ')}, and ${quotedIds[quotedIds.length - 1]}`
+}
+
+/**
+ * Determine whether any moving model id the project actually ran was changed
+ * inside the reporting period.
+ *
+ * Boundaries are INCLUSIVE on both ends and compared as calendar days: a change
+ * dated exactly on the first or last day of the period counts, because a sweep
+ * on that day may have run on either side of it. Returns `undefined` when the
+ * project ran no moving id, or ran one with no known change in range — those
+ * are the same answer to a reader ("nothing to caveat") and neither should
+ * produce a warning.
+ */
+export function findModelPointerChanges(query: ModelPointerChangeQuery): ModelPointerChangeDisclosure | undefined {
+  const exposedIds = new Set<string>()
+  for (const modelId of query.modelIds) {
+    const id = modelId.trim()
+    if (id.length > 0 && isMovingPointerModelId(id)) exposedIds.add(id.toLowerCase())
+  }
+  if (exposedIds.size === 0) return undefined
+
+  // Compared as UTC calendar days, so a full sweep instant and a bare day stamp
+  // are the same kind of value by the time they reach the range check.
+  const startDay = formatIsoDate(query.start)
+  const endDay = formatIsoDate(query.end)
+  if (startDay > endDay) return undefined
+
+  const matches = MODEL_POINTER_EVENTS
+    .filter(event => DISCLOSING_KINDS.has(event.kind))
+    .filter(event => exposedIds.has(event.modelId.trim().toLowerCase()))
+    .filter(event => event.date >= startDay && event.date <= endDay)
+    .sort((a, b) => a.date.localeCompare(b.date) || a.modelId.localeCompare(b.modelId))
+
+  if (matches.length === 0) return undefined
+
+  const modelIds = [...new Set(matches.map(event => event.modelId))].sort()
+  const changeCount = matches.length
+  const unverifiedChangeCount = matches.filter(event => !event.confirmed).length
+  const firstChangeDate = matches[0]!.date
+  const lastChangeDate = matches[matches.length - 1]!.date
+  const allUnverified = unverifiedChangeCount === changeCount
+
+  const subject = `The model behind ${quoted(modelIds)}`
+  const verb = allUnverified ? 'may have changed' : 'changed'
+  // Several changes are reported as "more than once" with the outer dates —
+  // a reader needs to know the number is unreliable, not a change log.
+  const what = changeCount > 1
+    ? `${subject} ${verb} more than once in this reporting period, between ${firstChangeDate} and ${lastChangeDate}.`
+    : `${subject} ${verb} on ${firstChangeDate}, inside this reporting period.`
+
+  const those = changeCount > 1 ? 'those changes' : 'that change'
+  const hedge = allUnverified ? (changeCount > 1 ? 'If they did, part' : 'If it did, part') : 'Part'
+  const soFar = `${hedge} of any movement in this number comes from ${those} and not from how often AI names you.`
+
+  return {
+    modelIds,
+    changeCount,
+    unverifiedChangeCount,
+    firstChangeDate,
+    lastChangeDate,
+    summary: `${what} ${soFar}`,
+  }
+}
+
+/**
+ * What the reader is supposed to DO about it, and the reason the caveat is on
+ * screen at all: somebody is about to put this number in front of a client.
+ * Appended once, however many engines are affected — repeating it would read as
+ * two separate warnings about the same number.
+ */
+export const MODEL_CHANGE_NEXT_ACTION = 'Compare this period with earlier ones carefully.'
+
+/**
+ * The whole caveat as one short paragraph, given the per-provider disclosures a
+ * metrics response carried.
+ *
+ * Lives here rather than in each surface because the dashboard, the CLI, and
+ * anything else reading this DTO must not word the same warning three different
+ * ways — a softer sentence on one surface is the failure this whole lane exists
+ * to prevent. The per-provider sentences are rendered verbatim and ordered by
+ * provider so the paragraph is stable between reads.
+ *
+ * Returns `null` when there is nothing to say: an older server omits the field,
+ * a project on fixed model ids has an empty record, and an entry with no usable
+ * sentence is dropped rather than rendered half-stated.
+ */
+export function formatModelChangeDisclosure(
+  // Deliberately `Partial`: the caller is reading a decoded HTTP response, not a
+  // value this process built, so `summary` is a claim about the wire and an
+  // entry that fails it is dropped rather than rendered half-stated.
+  disclosures: Record<string, Partial<ModelPointerChangeDisclosure>> | undefined,
+): string | null {
+  const summaries = Object.entries(disclosures ?? {})
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([, entry]) => entry.summary?.trim())
+    .filter((summary): summary is string => summary !== undefined && summary.length > 0)
+  if (summaries.length === 0) return null
+  return `${summaries.join(' ')} ${MODEL_CHANGE_NEXT_ACTION}`
+}

--- a/packages/contracts/src/model-pointers.ts
+++ b/packages/contracts/src/model-pointers.ts
@@ -34,10 +34,19 @@ import { formatIsoDate } from './formatting.js'
  * research. Order does not matter — the lookup sorts. Keep entries even after
  * an id is retired: historical reporting periods still span them.
  *
+ * Then move `MODEL_POINTER_REGISTRY_CHECKED_THROUGH` to the day you read the
+ * sources. Adding an event without moving that date leaves every disclosure
+ * claiming knowledge older than it has; moving it without re-reading every
+ * source is worse, because that date is what the product tells operators.
+ *
  * THIS LIST ROTS IF NOBODY UPDATES IT. That is the standing risk of the whole
  * approach: a missing entry means a silent model change reported to a client as
- * their own performance. Re-read the changelog whenever a pointer id shows up in
- * a project's configuration, and whenever a number moves without an explanation.
+ * their own performance. There is no feed to automate this against: deprecations
+ * are published as a parseable page, but a re-point exists only as a sentence in
+ * a rendered HTML changelog. So: re-read the changelog whenever a moving id shows
+ * up in a project's configuration, and whenever a number moves without an
+ * explanation. Nothing here fails closed on its own — the only protection
+ * against a stale list is that every disclosure states when it was last checked.
  */
 
 /**
@@ -87,7 +96,7 @@ export const MODEL_POINTER_EVENTS: readonly ModelPointerEvent[] = [
   { modelId: 'gpt-5.3-chat-latest', date: '2026-03-16', kind: 'repointed', confirmed: true, sourceUrl: 'https://developers.openai.com/api/docs/changelog', note: 'Verbatim: "Updated the gpt-5.3-chat-latest slug to point to the latest model currently used in ChatGPT." Target model NOT named.' },
   { modelId: 'chat-latest', date: '2026-05-05', kind: 'introduced', confirmed: true, sourceUrl: 'https://developers.openai.com/api/docs/changelog', note: 'Verbatim: "Released chat-latest snapshot which points to the latest Instant model currently used in ChatGPT... The underlying model snapshot will be regularly updated."' },
   { modelId: 'chat-latest', date: '2026-05-28', kind: 'repointed', confirmed: false, sourceUrl: 'https://developers.openai.com/api/docs/changelog', note: 'UNCONFIRMED. The entry reads "Released chat-latest snapshot..." — the verb is "Released", the same boilerplate as the 2026-05-05 entry, not "Updated" as used on 2026-06-24. Only "the latest improvements" vs "our latest improvements" differs. Either a real change logged with copy-pasted text, or a duplicated entry; the record does not disambiguate.' },
-  { modelId: 'chat-latest', date: '2026-06-24', kind: 'repointed', confirmed: true, sourceUrl: 'https://developers.openai.com/api/docs/changelog', note: 'The changelog entry uses the verb "Updated" (unlike the "Released" boilerplate of 2026-05-05 and 2026-05-28), which is the wording reserved for a real change. Target model NOT named. Re-read the source before relying on the exact wording — this entry was recorded from the 2026-05-28 comparison, not quoted directly.' },
+  { modelId: 'chat-latest', date: '2026-06-24', kind: 'repointed', confirmed: true, sourceUrl: 'https://developers.openai.com/api/docs/changelog', note: 'Verbatim (re-read at source 2026-07-20): "Updated the chat-latest snapshot, which points to the latest Instant model currently used in ChatGPT." The verb is "Updated", unlike the "Released" boilerplate of 2026-05-05 and 2026-05-28, which is the wording the changelog reserves for a real change. Target model NOT named. The only unambiguous chat-latest change on record.' },
 ]
 
 /**
@@ -126,142 +135,469 @@ export function isMovingPointerModelId(modelId: string): boolean {
 }
 
 /**
- * A plain-language caveat for a number whose reporting period spans one or more
- * known changes to a model the project actually ran.
+ * The day a maintainer last read the provider changelogs end to end and
+ * confirmed the list below is complete through that date.
+ *
+ * This is the honesty marker for the whole feature. There is no machine-readable
+ * feed for these events — the deprecation page is parseable, but a re-point is
+ * announced only as a sentence in a rendered HTML changelog — so the list is
+ * maintained by hand and WILL fall behind. Knowing nothing happened is only
+ * worth something alongside the date we last looked, so every disclosure carries
+ * this date and a reporting period reaching past it is reported as unchecked
+ * rather than as clear.
+ *
+ * Move this forward ONLY after re-reading every `sourceUrl` below.
+ */
+export const MODEL_POINTER_REGISTRY_CHECKED_THROUGH = '2026-07-20'
+
+/**
+ * How exposed a set of numbers is to a silent model change.
+ *
+ * - `not-exposed` — every model id the project ran is a fixed one. Nothing to
+ *   say, and nothing should render.
+ * - `no-known-change` — the project ran a moving id and we know of no change to
+ *   it while it was running. NOT the same as safe: it is the answer a stale
+ *   list also gives, which is why this state carries `knownGoodAsOf` and has to
+ *   be sayable on a surface instead of collapsing into silence.
+ * - `known-change` — a change we have a date for landed while the project was
+ *   running the id. The number is contaminated and the caveat is mandatory.
+ *
+ * Collapsing the middle state into the first is the failure this feature
+ * exists to prevent: a list that has rotted would read as "nothing happened".
+ */
+export const modelPointerExposureStatusSchema = z.enum(['not-exposed', 'no-known-change', 'known-change'])
+export type ModelPointerExposureStatus = z.infer<typeof modelPointerExposureStatusSchema>
+export const ModelPointerExposureStatuses = modelPointerExposureStatusSchema.enum
+
+/**
+ * One known change that landed inside the period, carried through to the
+ * surfaces so they can word a confirmed and an unconfirmed event differently
+ * without re-deriving anything from the registry.
+ */
+export const modelPointerChangeSchema = z.object({
+  modelId: z.string().trim().min(1),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  /** False when the source does not plainly state that the model changed. */
+  confirmed: z.boolean(),
+  sourceUrl: z.string().url(),
+})
+export type ModelPointerChange = z.infer<typeof modelPointerChangeSchema>
+
+/**
+ * The FACTS about a number produced on a moving model id — either that a known
+ * change landed inside the period, or that the id can change under us and all
+ * we can honestly report is how recently we checked.
+ *
+ * Deliberately carries no prose. The sentence a person reads is built from these
+ * fields by `buildModelChangeNotice` below, on whichever surface is rendering,
+ * so there is exactly one wording of this caveat in the product. An earlier cut
+ * shipped a server-rendered `summary` alongside surfaces that each built their
+ * own sentence; three wordings of one warning is the failure this lane exists to
+ * prevent, so the wire carries data and the copy has a single home.
  */
 export const modelPointerChangeDisclosureSchema = z.object({
-  /** The moving model ids the project ran that changed inside the period, sorted. */
+  /** Which of the two exposed states this is. Never `not-exposed`: those are omitted entirely. */
+  status: z.enum(['no-known-change', 'known-change']),
+  /** Every moving model id the project actually ran in this period, sorted. */
   modelIds: z.array(z.string().trim().min(1)).min(1),
-  /** How many known changes landed inside the period, across those ids. */
-  changeCount: z.number().int().positive(),
+  /**
+   * The known changes that landed while the project was running the id, oldest
+   * first. Empty exactly when `status` is `no-known-change`.
+   */
+  changes: z.array(modelPointerChangeSchema),
+  /** `changes.length`, kept as its own field so a surface can branch without walking the list. */
+  changeCount: z.number().int().nonnegative(),
   /**
    * How many of `changeCount` come from a source that does not plainly state a
-   * change happened. Equal to `changeCount` means the whole caveat is hedged.
+   * change happened. Those are never asserted as fact in the copy, and never
+   * dropped either — one direction overstates risk, the other hides it.
    */
   unverifiedChangeCount: z.number().int().nonnegative(),
-  /** Earliest change date inside the period, `YYYY-MM-DD`. */
-  firstChangeDate: z.string(),
+  /** Earliest change date inside the period, `YYYY-MM-DD`. Absent when there is none. */
+  firstChangeDate: z.string().optional(),
   /** Latest change date inside the period. Equal to `firstChangeDate` when there is one change. */
-  lastChangeDate: z.string(),
-  /** Ready-to-render sentence. Says what happened and what it means for the number. */
-  summary: z.string().min(1),
+  lastChangeDate: z.string().optional(),
+  /** The day the change list was last checked against the provider's own pages. */
+  knownGoodAsOf: z.string(),
+  /**
+   * False when the reporting period runs past `knownGoodAsOf` — the stretch
+   * after that date has not been checked at all, so the absence of a change
+   * there is ignorance, not evidence.
+   */
+  checkedThroughPeriodEnd: z.boolean(),
 })
 export type ModelPointerChangeDisclosure = z.infer<typeof modelPointerChangeDisclosureSchema>
 
-export interface ModelPointerChangeQuery {
-  /**
-   * Every model id the project actually RAN over the period — configured and
-   * served alike. Pinned ids are ignored, so passing the full set is correct
-   * and a project on a pinned id gets nothing back.
-   */
-  modelIds: Iterable<string>
-  /** Start of the reporting period. `YYYY-MM-DD` or a full ISO timestamp. Inclusive. */
-  start: string
-  /** End of the reporting period. Same formats. Inclusive. */
-  end: string
+/** A project that ran no moving model id at all. Nothing renders. */
+export interface ModelPointerNotExposed {
+  status: typeof ModelPointerExposureStatuses['not-exposed']
 }
 
-function quoted(modelIds: readonly string[]): string {
-  const quotedIds = modelIds.map(id => `"${id}"`)
-  if (quotedIds.length === 1) return quotedIds[0]!
-  if (quotedIds.length === 2) return `${quotedIds[0]} and ${quotedIds[1]}`
-  return `${quotedIds.slice(0, -1).join(', ')}, and ${quotedIds[quotedIds.length - 1]}`
+export type ModelPointerExposure = ModelPointerNotExposed | ModelPointerChangeDisclosure
+
+/**
+ * The span over which the project was actually running ONE model id, taken from
+ * the sweeps themselves.
+ *
+ * This is the whole correctness of the feature. Crossing "ids seen anywhere in
+ * the period" with "the period" warns a project that switched off a moving id in
+ * March about a change in June, and stays silent for the mirror case. A change
+ * only matters if the project was running that id when it happened.
+ */
+export interface ModelExposureWindow {
+  modelId: string
+  /** First sweep instant this id was observed on. `YYYY-MM-DD` or a full ISO timestamp. */
+  firstSeen: string
+  /** Last sweep instant this id was observed on. Same formats. */
+  lastSeen: string
+}
+
+export interface ModelPointerExposureQuery {
+  /**
+   * One entry per model id the project ran — configured and served alike, since
+   * either side being a moving id exposes the number. Fixed ids are ignored, so
+   * passing everything is correct.
+   */
+  exposures: Iterable<ModelExposureWindow>
+  /**
+   * The reporting period these numbers cover. MUST be the same period the
+   * metrics themselves were computed over — a caveat describing a different
+   * window than the number it sits under is worse than no caveat.
+   */
+  periodStart: string
+  /** End of that same period. Inclusive. */
+  periodEnd: string
 }
 
 /**
- * Determine whether any moving model id the project actually ran was changed
- * inside the reporting period.
+ * Determine how exposed a set of numbers is to a silent model change.
  *
- * Boundaries are INCLUSIVE on both ends and compared as calendar days: a change
- * dated exactly on the first or last day of the period counts, because a sweep
- * on that day may have run on either side of it. Returns `undefined` when the
- * project ran no moving id, or ran one with no known change in range — those
- * are the same answer to a reader ("nothing to caveat") and neither should
- * produce a warning.
+ * A change counts only when its date falls inside the period AND inside the span
+ * over which the project was running that particular id. Both bounds are
+ * INCLUSIVE and compared as UTC calendar days: a change dated on the first or
+ * last day the id was seen counts, because a sweep on that day may have run on
+ * either side of the swap.
+ *
+ * Never returns `undefined`. A project running a moving id with nothing known
+ * against it gets the middle state, not silence — see
+ * `modelPointerExposureStatusSchema`.
  */
-export function findModelPointerChanges(query: ModelPointerChangeQuery): ModelPointerChangeDisclosure | undefined {
-  const exposedIds = new Set<string>()
-  for (const modelId of query.modelIds) {
-    const id = modelId.trim()
-    if (id.length > 0 && isMovingPointerModelId(id)) exposedIds.add(id.toLowerCase())
+export function evaluateModelPointerExposure(query: ModelPointerExposureQuery): ModelPointerExposure {
+  const periodStart = formatIsoDate(query.periodStart)
+  const periodEnd = formatIsoDate(query.periodEnd)
+  if (periodStart > periodEnd) return { status: ModelPointerExposureStatuses['not-exposed'] }
+
+  // Merge by lowercase id but keep the first spelling seen: the copy quotes the
+  // id back at the operator, and it should look like what they configured.
+  const exposed = new Map<string, { modelId: string; start: string; end: string }>()
+  for (const exposure of query.exposures) {
+    const modelId = exposure.modelId.trim()
+    if (modelId.length === 0 || !isMovingPointerModelId(modelId)) continue
+    const firstSeen = formatIsoDate(exposure.firstSeen)
+    const lastSeen = formatIsoDate(exposure.lastSeen)
+    if (firstSeen > lastSeen) continue
+    const key = modelId.toLowerCase()
+    const existing = exposed.get(key)
+    if (!existing) {
+      exposed.set(key, { modelId, start: firstSeen, end: lastSeen })
+      continue
+    }
+    if (firstSeen < existing.start) existing.start = firstSeen
+    if (lastSeen > existing.end) existing.end = lastSeen
   }
-  if (exposedIds.size === 0) return undefined
+  if (exposed.size === 0) return { status: ModelPointerExposureStatuses['not-exposed'] }
 
-  // Compared as UTC calendar days, so a full sweep instant and a bare day stamp
-  // are the same kind of value by the time they reach the range check.
-  const startDay = formatIsoDate(query.start)
-  const endDay = formatIsoDate(query.end)
-  if (startDay > endDay) return undefined
+  const repoints = MODEL_POINTER_EVENTS.filter(event => DISCLOSING_KINDS.has(event.kind))
+  const matches: ModelPointerChange[] = []
+  for (const event of repoints) {
+    const window = exposed.get(event.modelId.trim().toLowerCase())
+    if (!window) continue
+    // Clamped to the reporting period as well as to the exposure window, so a
+    // caller passing a wider window than the period cannot widen the caveat.
+    const from = window.start > periodStart ? window.start : periodStart
+    const to = window.end < periodEnd ? window.end : periodEnd
+    if (from > to) continue
+    if (event.date < from || event.date > to) continue
+    matches.push({ modelId: event.modelId, date: event.date, confirmed: event.confirmed, sourceUrl: event.sourceUrl })
+  }
+  matches.sort((a, b) => a.date.localeCompare(b.date) || a.modelId.localeCompare(b.modelId))
 
-  const matches = MODEL_POINTER_EVENTS
-    .filter(event => DISCLOSING_KINDS.has(event.kind))
-    .filter(event => exposedIds.has(event.modelId.trim().toLowerCase()))
-    .filter(event => event.date >= startDay && event.date <= endDay)
-    .sort((a, b) => a.date.localeCompare(b.date) || a.modelId.localeCompare(b.modelId))
+  const knownGoodAsOf = MODEL_POINTER_REGISTRY_CHECKED_THROUGH
+  const checkedThroughPeriodEnd = periodEnd <= knownGoodAsOf
+  const ranIds = [...exposed.values()].map(w => w.modelId).sort()
 
-  if (matches.length === 0) return undefined
-
-  const modelIds = [...new Set(matches.map(event => event.modelId))].sort()
-  const changeCount = matches.length
-  const unverifiedChangeCount = matches.filter(event => !event.confirmed).length
-  const firstChangeDate = matches[0]!.date
-  const lastChangeDate = matches[matches.length - 1]!.date
-  const allUnverified = unverifiedChangeCount === changeCount
-
-  const subject = `The model behind ${quoted(modelIds)}`
-  const verb = allUnverified ? 'may have changed' : 'changed'
-  // Several changes are reported as "more than once" with the outer dates —
-  // a reader needs to know the number is unreliable, not a change log.
-  const what = changeCount > 1
-    ? `${subject} ${verb} more than once in this reporting period, between ${firstChangeDate} and ${lastChangeDate}.`
-    : `${subject} ${verb} on ${firstChangeDate}, inside this reporting period.`
-
-  const those = changeCount > 1 ? 'those changes' : 'that change'
-  const hedge = allUnverified ? (changeCount > 1 ? 'If they did, part' : 'If it did, part') : 'Part'
-  const soFar = `${hedge} of any movement in this number comes from ${those} and not from how often AI names you.`
+  if (matches.length === 0) {
+    // The fail-safe state, and the reason it is a state at all rather than an
+    // absence: a list nobody has updated in six months produces exactly this,
+    // and it must not be renderable as "you are fine". `knownGoodAsOf` travels
+    // with it so whatever surface renders it has to say when we last looked.
+    return {
+      status: ModelPointerExposureStatuses['no-known-change'],
+      modelIds: ranIds,
+      changes: [],
+      changeCount: 0,
+      unverifiedChangeCount: 0,
+      knownGoodAsOf,
+      checkedThroughPeriodEnd,
+    }
+  }
 
   return {
-    modelIds,
-    changeCount,
-    unverifiedChangeCount,
-    firstChangeDate,
-    lastChangeDate,
-    summary: `${what} ${soFar}`,
+    status: ModelPointerExposureStatuses['known-change'],
+    modelIds: ranIds,
+    changes: matches,
+    changeCount: matches.length,
+    // Unconfirmed events are counted separately rather than folded in — the
+    // 2026-05-28 entry is the reason: its changelog wording does not
+    // distinguish a real change from a duplicated announcement, and a client on
+    // that window would otherwise be told a provider changed their model when
+    // the record does not actually say so.
+    unverifiedChangeCount: matches.filter(m => !m.confirmed).length,
+    firstChangeDate: matches[0]!.date,
+    lastChangeDate: matches[matches.length - 1]!.date,
+    knownGoodAsOf,
+    checkedThroughPeriodEnd,
   }
 }
 
 /**
- * What the reader is supposed to DO about it, and the reason the caveat is on
- * screen at all: somebody is about to put this number in front of a client.
- * Appended once, however many engines are affected — repeating it would read as
- * two separate warnings about the same number.
+ * Answer engines in the reader's vocabulary. The disclosure record is keyed by
+ * our internal provider name, but the person about to send this number to a
+ * client thinks in ChatGPT / Claude / Gemini / Perplexity. A caveat naming a
+ * model id is one they cannot map onto anything they are looking at, so the
+ * engine name is what every sentence below leads with — never the model id.
  */
-export const MODEL_CHANGE_NEXT_ACTION = 'Compare this period with earlier ones carefully.'
+const ANSWER_ENGINE_NAMES: Record<string, string> = {
+  openai: 'ChatGPT',
+  chatgpt: 'ChatGPT',
+  anthropic: 'Claude',
+  claude: 'Claude',
+  google: 'Gemini',
+  gemini: 'Gemini',
+  perplexity: 'Perplexity',
+}
+
+function answerEngineName(provider: string): string {
+  const key = provider.trim().toLowerCase()
+  return ANSWER_ENGINE_NAMES[key] ?? provider.charAt(0).toUpperCase() + provider.slice(1)
+}
 
 /**
- * The whole caveat as one short paragraph, given the per-provider disclosures a
- * metrics response carried.
+ * What a surface should say about provider-side model updates, if anything.
+ *
+ * - `change` — a known update landed inside the period. This is the caveat, and
+ *   it belongs where the reader meets it BEFORE the numbers.
+ * - `no-known-change` — the project ran a model id that can be moved onto a
+ *   different model, and nothing is on record inside the period. Rendered
+ *   quietly, because this is the common case on every load, but rendered: this
+ *   is also what a record nobody has updated produces, so `detail` always says
+ *   when the record was last checked.
+ *
+ * `detail` is the supporting explanation. A surface with somewhere to put it
+ * (a tooltip) should; a surface without one (the CLI) prints it as a second
+ * line. It is never dropped — it carries the freshness of the record.
+ */
+export type ModelChangeNotice =
+  | { kind: 'change'; text: string }
+  | { kind: 'no-known-change'; text: string; detail: string }
+
+/**
+ * One engine's exposure, normalized out of whatever the server sent. Every
+ * field is derived defensively: this is a decoded HTTP response from a server
+ * that may be older or newer than the code reading it.
+ */
+interface EngineModelChange {
+  engine: string
+  confirmedDates: string[]
+  unconfirmedDates: string[]
+  confirmedCount: number
+  unconfirmedCount: number
+  knownGoodAsOf: string | null
+  checkedThroughPeriodEnd: boolean
+}
+
+/**
+ * The wire shape, widened. Everything is optional because none of it is
+ * guaranteed by the server on the other end of the connection.
+ */
+type WireModelPointerChange = Partial<ModelPointerChangeDisclosure> & {
+  changes?: readonly { date?: string | null; confirmed?: boolean | null }[] | null
+  unconfirmedChangeCount?: number | null
+}
+
+function countOf(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? Math.floor(value) : 0
+}
+
+/** Day stamps only. A full ISO instant would print a time nobody can act on. */
+function dayOf(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length >= 10 ? value.trim().slice(0, 10) : null
+}
+
+function sortedUnique(days: (string | null)[]): string[] {
+  return [...new Set(days.filter((d): d is string => d !== null))].sort()
+}
+
+function normalizeEngineChange(provider: string, entry: WireModelPointerChange): EngineModelChange {
+  const engine = answerEngineName(provider)
+  const perChange = Array.isArray(entry.changes) ? entry.changes : []
+  const changeCount = countOf(entry.changeCount) || perChange.length
+  // `unverifiedChangeCount` is the field the current server sends;
+  // `unconfirmedChangeCount` is accepted so a rename cannot silently turn every
+  // hedged update into an asserted one, and the per-update array is the last
+  // fallback so a server that only ships the breakdown still hedges correctly.
+  const unconfirmedCount = Math.min(
+    changeCount,
+    countOf(entry.unverifiedChangeCount)
+      || countOf(entry.unconfirmedChangeCount)
+      || perChange.filter(c => c.confirmed === false).length,
+  )
+  // No fallback to this build's own constant. Claiming a freshness the server
+  // did not state would be the exact lie the field exists to prevent, so an
+  // older server that omits it simply gets no freshness sentence.
+  const knownGoodAsOf = dayOf(entry.knownGoodAsOf)
+  const checkedThroughPeriodEnd = entry.checkedThroughPeriodEnd !== false
+  const common = {
+    engine,
+    confirmedCount: changeCount - unconfirmedCount,
+    unconfirmedCount,
+    knownGoodAsOf,
+    checkedThroughPeriodEnd,
+  }
+
+  if (perChange.length > 0) {
+    return {
+      ...common,
+      confirmedDates: sortedUnique(perChange.filter(c => c.confirmed !== false).map(c => dayOf(c.date))),
+      unconfirmedDates: sortedUnique(perChange.filter(c => c.confirmed === false).map(c => dayOf(c.date))),
+    }
+  }
+
+  // No per-update breakdown. The outer dates can only be attributed when every
+  // update in the period has the same confidence; a mixed period gets no dates
+  // rather than a date attached to the wrong claim.
+  const span = sortedUnique([dayOf(entry.firstChangeDate), dayOf(entry.lastChangeDate)])
+  if (changeCount === 0) return { ...common, confirmedDates: [], unconfirmedDates: [] }
+  if (unconfirmedCount === 0) return { ...common, confirmedDates: span, unconfirmedDates: [] }
+  if (common.confirmedCount === 0) return { ...common, confirmedDates: [], unconfirmedDates: span }
+  return { ...common, confirmedDates: [], unconfirmedDates: [] }
+}
+
+function joinNames(names: readonly string[]): string {
+  if (names.length === 1) return names[0]!
+  if (names.length === 2) return `${names[0]} and ${names[1]}`
+  return `${names.slice(0, -1).join(', ')}, and ${names[names.length - 1]}`
+}
+
+/** "on 2026-06-24" for a single dated update, a range for several. */
+function whenPhrase(dates: readonly string[], count: number): string | null {
+  if (dates.length === 0) return null
+  if (dates.length === 1 && count <= 1) return `on ${dates[0]}`
+  return `more than once between ${dates[0]} and ${dates[dates.length - 1]}`
+}
+
+/**
+ * The per-engine clause. It says WHAT happened and to WHICH engine, and nothing
+ * else — the consequence and the instruction are one shared sentence at the end,
+ * so two affected engines produce two facts and not two warnings.
+ */
+function engineClause(change: EngineModelChange): string {
+  const confirmedWhen = whenPhrase(change.confirmedDates, change.confirmedCount)
+  const unconfirmedWhen = whenPhrase(change.unconfirmedDates, change.unconfirmedCount)
+  const subject = `The model behind ${change.engine}`
+
+  if (change.confirmedCount > 0 && change.unconfirmedCount === 0) {
+    return confirmedWhen
+      ? `${subject} was updated ${confirmedWhen}, inside this period.`
+      : `${subject} was updated inside this period.`
+  }
+  if (change.confirmedCount === 0) {
+    // Never stated as fact. The record hints at an update and does not settle it.
+    return unconfirmedWhen
+      ? `${subject} may have been updated ${unconfirmedWhen}, inside this period, though that is not confirmed.`
+      : `${subject} may have been updated inside this period, though that is not confirmed.`
+  }
+  if (confirmedWhen && unconfirmedWhen) {
+    return `${subject} was updated ${confirmedWhen}, inside this period, and may also have been updated ${unconfirmedWhen}.`
+  }
+  const more = change.unconfirmedCount > 1 ? 'more times' : 'once more'
+  return `${subject} was updated inside this period, and may have been updated ${more}, though that is not confirmed.`
+}
+
+/**
+ * The date we last read the provider changelogs, as a sentence, when the period
+ * runs past it. Silence about the unchecked tail would let ignorance read as
+ * evidence, which is the whole point of carrying the date on the wire.
+ *
+ * Returns null when the period is fully covered (nothing to warn about) or when
+ * the server never told us the date (nothing we can honestly say).
+ */
+function uncheckedTailSentence(entries: readonly EngineModelChange[]): string | null {
+  const unchecked = entries.filter(e => !e.checkedThroughPeriodEnd && e.knownGoodAsOf !== null)
+  if (unchecked.length === 0) return null
+  // The oldest check is the honest one to quote: it bounds what we know across
+  // every engine on the surface.
+  const oldest = unchecked.map(e => e.knownGoodAsOf!).sort()[0]!
+  return `We last checked for model updates on ${oldest}, and this period runs past that date,`
+    + ' so there may be later updates we do not know about.'
+}
+
+/**
+ * Build the whole notice from the per-provider record a metrics response
+ * carried.
  *
  * Lives here rather than in each surface because the dashboard, the CLI, and
- * anything else reading this DTO must not word the same warning three different
- * ways — a softer sentence on one surface is the failure this whole lane exists
- * to prevent. The per-provider sentences are rendered verbatim and ordered by
- * provider so the paragraph is stable between reads.
+ * anything else reading this DTO must not word the same warning differently — a
+ * softer sentence on one surface is the failure this whole lane exists to
+ * prevent. Each engine contributes one fact and the notice closes with one
+ * consequence, once, however many engines are affected.
  *
- * Returns `null` when there is nothing to say: an older server omits the field,
- * a project on fixed model ids has an empty record, and an entry with no usable
- * sentence is dropped rather than rendered half-stated.
+ * Returns `null` when there is nothing to say at all: an older server omits the
+ * field entirely, and a project on fixed model ids has an empty record.
  */
-export function formatModelChangeDisclosure(
-  // Deliberately `Partial`: the caller is reading a decoded HTTP response, not a
-  // value this process built, so `summary` is a claim about the wire and an
-  // entry that fails it is dropped rather than rendered half-stated.
-  disclosures: Record<string, Partial<ModelPointerChangeDisclosure>> | undefined,
-): string | null {
-  const summaries = Object.entries(disclosures ?? {})
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([, entry]) => entry.summary?.trim())
-    .filter((summary): summary is string => summary !== undefined && summary.length > 0)
-  if (summaries.length === 0) return null
-  return `${summaries.join(' ')} ${MODEL_CHANGE_NEXT_ACTION}`
+export function buildModelChangeNotice(
+  disclosures: Record<string, WireModelPointerChange | null | undefined> | undefined,
+): ModelChangeNotice | null {
+  const entries = Object.entries(disclosures ?? {})
+    .map(([provider, entry]) => normalizeEngineChange(provider, entry ?? {}))
+    .sort((a, b) => a.engine.localeCompare(b.engine))
+  if (entries.length === 0) return null
+
+  const changed = entries.filter(e => e.confirmedCount + e.unconfirmedCount > 0)
+  if (changed.length === 0) {
+    // Exposed, nothing on record. One quiet line, with the reason it matters and
+    // the age of the record in the detail rather than on the surface — this
+    // renders on every load for anyone on a moving model id and must not become
+    // noise. But it is never silence: silence is what a rotted record looks
+    // like, and it would read as proof that nothing happened.
+    const engines = [...new Set(entries.map(e => e.engine))]
+    const plural = engines.length > 1
+    // The unchecked-tail sentence already names the date and is the stronger
+    // statement, so it replaces the plain "we last checked" rather than joining
+    // it — saying both would name the same date twice in two sentences.
+    const tail = uncheckedTailSentence(entries)
+    const checked = [...new Set(entries.map(e => e.knownGoodAsOf).filter((d): d is string => d !== null))].sort()
+    const freshness = tail ?? (checked.length > 0 ? `We last checked for model updates on ${checked[0]}.` : null)
+    return {
+      kind: 'no-known-change',
+      text: `No model updates are on record for ${joinNames(engines)} in this period.`,
+      detail: `${plural ? 'These engines' : 'This engine'} can be moved onto a different underlying model`
+        + ' without the data ever showing a different model name, so we check each period against a record of'
+        + ` known updates. Nothing is listed inside this one.${freshness ? ` ${freshness}` : ''}`,
+    }
+  }
+
+  const totalChanges = changed.reduce((n, e) => n + e.confirmedCount + e.unconfirmedCount, 0)
+  const anyConfirmed = changed.some(e => e.confirmedCount > 0)
+  const noun = totalChanges === 1 ? 'this update' : 'these updates'
+  // One consequence, one instruction, however many engines are affected. The
+  // subject is "these numbers" because a surface plots several of them.
+  const consequence = anyConfirmed
+    ? `Some of the movement in these numbers may come from ${noun} rather than from a real change in how AI answers about you, so compare periods carefully.`
+    : `If so, some of the movement in these numbers may come from ${noun} rather than from a real change in how AI answers about you, so compare periods carefully.`
+  // The known updates are the headline, but an unchecked tail still has to be
+  // said out loud: "we found one" must not imply "we found all of them".
+  const tail = uncheckedTailSentence(entries)
+
+  return { kind: 'change', text: `${changed.map(engineClause).join(' ')} ${consequence}${tail ? ` ${tail}` : ''}` }
 }

--- a/packages/contracts/test/model-pointers.test.ts
+++ b/packages/contracts/test/model-pointers.test.ts
@@ -2,14 +2,15 @@ import { describe, it, expect } from 'vitest'
 
 import {
   KNOWN_MOVING_POINTER_MODEL_IDS,
-  MODEL_CHANGE_NEXT_ACTION,
   MODEL_POINTER_EVENTS,
-  findModelPointerChanges,
-  formatModelChangeDisclosure,
+  MODEL_POINTER_REGISTRY_CHECKED_THROUGH,
+  buildModelChangeNotice,
+  evaluateModelPointerExposure,
   isMovingPointerModelId,
   modelPointerChangeDisclosureSchema,
   modelPointerEventSchema,
   type ModelPointerChangeDisclosure,
+  type ModelPointerExposure,
 } from '../src/model-pointers.js'
 
 // Real dates from the seeded registry. Named here so a test failure points at
@@ -18,6 +19,33 @@ const CHAT_LATEST_UNCONFIRMED_REPOINT = '2026-05-28'
 const CHAT_LATEST_REPOINT = '2026-06-24'
 const CHAT_LATEST_INTRODUCED = '2026-05-05'
 const GPT_53_REPOINT = '2026-03-16'
+
+/** The common case: every id run for the whole period. */
+function overWholePeriod(modelIds: string[], periodStart: string, periodEnd: string): ModelPointerExposure {
+  return evaluateModelPointerExposure({
+    exposures: modelIds.map(modelId => ({ modelId, firstSeen: periodStart, lastSeen: periodEnd })),
+    periodStart,
+    periodEnd,
+  })
+}
+
+/** Narrows to the disclosed shape, failing loudly rather than returning undefined. */
+function disclosed(exposure: ModelPointerExposure): ModelPointerChangeDisclosure {
+  expect(exposure.status).not.toBe('not-exposed')
+  return exposure as ModelPointerChangeDisclosure
+}
+
+/**
+ * The sentence a reader would actually be shown for this exposure, as one
+ * engine's worth of it. The disclosure itself carries only facts; the copy is
+ * built by `buildModelChangeNotice`, so a test about wording has to go through
+ * it rather than reading a field off the DTO.
+ */
+function noticeText(exposure: ModelPointerExposure): string {
+  const notice = buildModelChangeNotice({ openai: disclosed(exposure) })
+  expect(notice).not.toBeNull()
+  return notice!.kind === 'no-known-change' ? `${notice!.text} ${notice!.detail}` : notice!.text
+}
 
 describe('the registry itself', () => {
   it('every seeded entry is a valid event', () => {
@@ -43,6 +71,27 @@ describe('the registry itself', () => {
   it('holds no duplicate (model, date, kind) rows', () => {
     const keys = MODEL_POINTER_EVENTS.map(e => `${e.modelId}|${e.date}|${e.kind}`)
     expect(new Set(keys).size).toBe(keys.length)
+  })
+
+  it('claims to be checked through a date no earlier than its newest entry', () => {
+    // A marker BEFORE the newest entry means someone edited one of the two and
+    // not the other, and every disclosure would then be dated by a check that
+    // demonstrably did not cover the list it is describing.
+    expect(MODEL_POINTER_REGISTRY_CHECKED_THROUGH).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    for (const event of MODEL_POINTER_EVENTS) {
+      expect(event.date <= MODEL_POINTER_REGISTRY_CHECKED_THROUGH).toBe(true)
+    }
+  })
+
+  it('records the only unambiguous chat-latest change as confirmed and the doubtful one as not', () => {
+    // The 2026-05-28 changelog entry reuses the "Released" boilerplate of the
+    // 2026-05-05 introduction instead of the "Updated" wording of 2026-06-24.
+    // It may be a real change or a duplicated entry; the record does not say.
+    const byDate = new Map(MODEL_POINTER_EVENTS
+      .filter(e => e.modelId === 'chat-latest' && e.kind === 'repointed')
+      .map(e => [e.date, e.confirmed]))
+    expect(byDate.get(CHAT_LATEST_REPOINT)).toBe(true)
+    expect(byDate.get(CHAT_LATEST_UNCONFIRMED_REPOINT)).toBe(false)
   })
 })
 
@@ -74,26 +123,32 @@ describe('isMovingPointerModelId', () => {
   })
 })
 
-describe('findModelPointerChanges — a period spanning one change', () => {
-  const disclosure = findModelPointerChanges({
-    modelIds: ['chat-latest'],
-    start: '2026-06-01',
-    end: '2026-06-30',
-  })
+describe('a period spanning one change', () => {
+  const disclosure = disclosed(overWholePeriod(['chat-latest'], '2026-06-01', '2026-06-30'))
 
   it('discloses the change', () => {
-    expect(disclosure).toBeDefined()
-    expect(disclosure!.changeCount).toBe(1)
-    expect(disclosure!.unverifiedChangeCount).toBe(0)
-    expect(disclosure!.modelIds).toEqual(['chat-latest'])
-    expect(disclosure!.firstChangeDate).toBe(CHAT_LATEST_REPOINT)
-    expect(disclosure!.lastChangeDate).toBe(CHAT_LATEST_REPOINT)
+    expect(disclosure.status).toBe('known-change')
+    expect(disclosure.changeCount).toBe(1)
+    expect(disclosure.unverifiedChangeCount).toBe(0)
+    expect(disclosure.modelIds).toEqual(['chat-latest'])
+    expect(disclosure.firstChangeDate).toBe(CHAT_LATEST_REPOINT)
+    expect(disclosure.lastChangeDate).toBe(CHAT_LATEST_REPOINT)
+  })
+
+  it('carries the event itself so a surface can word it and cite the source', () => {
+    expect(disclosure.changes).toEqual([{
+      modelId: 'chat-latest',
+      date: CHAT_LATEST_REPOINT,
+      confirmed: true,
+      sourceUrl: expect.stringContaining('https://'),
+    }])
   })
 
   it('names the date and says what it means for the number', () => {
-    expect(disclosure!.summary).toBe(
-      'The model behind "chat-latest" changed on 2026-06-24, inside this reporting period.'
-      + ' Part of any movement in this number comes from that change and not from how often AI names you.',
+    expect(noticeText(disclosure)).toBe(
+      'The model behind ChatGPT was updated on 2026-06-24, inside this period.'
+      + ' Some of the movement in these numbers may come from this update'
+      + ' rather than from a real change in how AI answers about you, so compare periods carefully.',
     )
   })
 
@@ -102,269 +157,512 @@ describe('findModelPointerChanges — a period spanning one change', () => {
   })
 })
 
-describe('findModelPointerChanges — a period spanning several changes', () => {
-  const disclosure = findModelPointerChanges({
-    modelIds: ['chat-latest'],
-    start: '2026-05-01',
-    end: '2026-07-01',
-  })
+describe('a period spanning several changes', () => {
+  const disclosure = disclosed(overWholePeriod(['chat-latest'], '2026-05-01', '2026-07-01'))
 
   it('counts both changes in range', () => {
-    expect(disclosure!.changeCount).toBe(2)
-    expect(disclosure!.firstChangeDate).toBe(CHAT_LATEST_UNCONFIRMED_REPOINT)
-    expect(disclosure!.lastChangeDate).toBe(CHAT_LATEST_REPOINT)
+    expect(disclosure.changeCount).toBe(2)
+    expect(disclosure.firstChangeDate).toBe(CHAT_LATEST_UNCONFIRMED_REPOINT)
+    expect(disclosure.lastChangeDate).toBe(CHAT_LATEST_REPOINT)
   })
 
   it('does not count the day the id was introduced as a change', () => {
     // 2026-05-05 is inside this period. The id starting to exist is not the
     // model behind it changing, and no reporting period can straddle it.
     expect(CHAT_LATEST_INTRODUCED >= '2026-05-01' && CHAT_LATEST_INTRODUCED <= '2026-07-01').toBe(true)
-    expect(disclosure!.changeCount).toBe(2)
+    expect(disclosure.changeCount).toBe(2)
+    expect(noticeText(disclosure)).not.toContain(CHAT_LATEST_INTRODUCED)
+  })
+})
+
+describe('a period spanning no known change', () => {
+  // Built per test, not once for the describe: this is the state a regression
+  // collapses into `not-exposed`, and a shared const would abort the whole file
+  // instead of failing the tests that name the behaviour.
+  const quietPeriod = () => disclosed(overWholePeriod(['chat-latest'], '2026-06-01', '2026-06-20'))
+
+  it('still says something: no known change is not the same as no exposure', () => {
+    // The fail-safe. A stale list answers "we know of nothing" exactly like a
+    // fresh one does, so this state has to be visible and dated rather than
+    // collapsing into the silence a project on fixed ids gets.
+    const disclosure = quietPeriod()
+    expect(disclosure.status).toBe('no-known-change')
+    expect(disclosure.changes).toEqual([])
+    expect(disclosure.changeCount).toBe(0)
+    expect(disclosure.modelIds).toEqual(['chat-latest'])
   })
 
-  it('says "more than once" with the outer dates instead of listing every date', () => {
-    expect(disclosure!.summary).toBe(
-      'The model behind "chat-latest" changed more than once in this reporting period,'
-      + ' between 2026-05-28 and 2026-06-24.'
-      + ' Part of any movement in this number comes from those changes and not from how often AI names you.',
+  it('says how fresh the knowledge is instead of implying safety', () => {
+    const disclosure = quietPeriod()
+    expect(disclosure.knownGoodAsOf).toBe(MODEL_POINTER_REGISTRY_CHECKED_THROUGH)
+    expect(disclosure.checkedThroughPeriodEnd).toBe(true)
+    // The date has to reach a reader, not just the DTO. A record nobody has
+    // updated produces this exact state, so the sentence says when we looked.
+    expect(noticeText(disclosure)).toContain(
+      `We last checked for model updates on ${MODEL_POINTER_REGISTRY_CHECKED_THROUGH}.`,
     )
-    expect(disclosure!.summary).not.toContain('2026-05-05')
+    expect(() => modelPointerChangeDisclosureSchema.parse(disclosure)).not.toThrow()
+  })
+
+  it('says the same for a period entirely before the id existed', () => {
+    expect(disclosed(overWholePeriod(['chat-latest'], '2026-01-01', '2026-01-31')).status).toBe('no-known-change')
+  })
+
+  it('says the same for a moving id the registry has no dates for at all', () => {
+    // Exposed by the suffix rule, nothing known about it. Reporting this as
+    // silence would be the exact failure: an unrecorded moving id would read
+    // as a pinned model.
+    const unknownId = disclosed(overWholePeriod(['gpt-6-chat-latest'], '2026-01-01', '2026-06-30'))
+    expect(unknownId.status).toBe('no-known-change')
+    expect(unknownId.modelIds).toEqual(['gpt-6-chat-latest'])
+  })
+
+  it('returns nothing at all when the period is inverted', () => {
+    expect(evaluateModelPointerExposure({
+      exposures: [{ modelId: 'chat-latest', firstSeen: '2026-05-01', lastSeen: '2026-07-01' }],
+      periodStart: '2026-07-01',
+      periodEnd: '2026-05-01',
+    }).status).toBe('not-exposed')
   })
 })
 
-describe('findModelPointerChanges — a period spanning no changes', () => {
-  it('returns nothing for a quiet period on an exposed id', () => {
-    // A project genuinely running chat-latest, but between the known changes.
-    expect(findModelPointerChanges({
-      modelIds: ['chat-latest'],
-      start: '2026-06-01',
-      end: '2026-06-20',
-    })).toBeUndefined()
+describe('a period reaching past the day the list was last checked', () => {
+  const periodEnd = '2026-12-31'
+  const disclosure = disclosed(overWholePeriod(['chat-latest'], '2026-06-01', periodEnd))
+
+  it('flags that the tail of the period was never checked', () => {
+    expect(periodEnd > MODEL_POINTER_REGISTRY_CHECKED_THROUGH).toBe(true)
+    expect(disclosure.checkedThroughPeriodEnd).toBe(false)
   })
 
-  it('returns nothing for a period entirely before the id existed', () => {
-    expect(findModelPointerChanges({
-      modelIds: ['chat-latest'],
-      start: '2026-01-01',
-      end: '2026-01-31',
-    })).toBeUndefined()
+  it('says so in the copy, so ignorance never reads as clearance', () => {
+    expect(noticeText(disclosure)).toContain(
+      `We last checked for model updates on ${MODEL_POINTER_REGISTRY_CHECKED_THROUGH},`
+      + ' and this period runs past that date, so there may be later updates we do not know about.',
+    )
   })
 
-  it('returns nothing when the period is inverted', () => {
-    expect(findModelPointerChanges({
-      modelIds: ['chat-latest'],
-      start: '2026-07-01',
-      end: '2026-05-01',
-    })).toBeUndefined()
+  it('says so in the middle state too', () => {
+    const quietTail = disclosed(overWholePeriod(['gpt-6-chat-latest'], '2026-06-01', periodEnd))
+    expect(quietTail.status).toBe('no-known-change')
+    expect(quietTail.checkedThroughPeriodEnd).toBe(false)
+    expect(noticeText(quietTail)).toContain(
+      'and this period runs past that date, so there may be later updates we do not know about.',
+    )
   })
 })
 
-describe('findModelPointerChanges — boundaries are inclusive', () => {
-  it('counts a change dated exactly on the period START', () => {
-    const disclosure = findModelPointerChanges({
-      modelIds: ['chat-latest'],
-      start: CHAT_LATEST_REPOINT,
-      end: '2026-07-15',
+describe('the change has to have happened while the project was running the id', () => {
+  // The regression this suite exists for: the id set and the period were once
+  // computed independently over the whole span and then crossed, so a project
+  // that changed models mid-window was caveated for a change to a model it was
+  // not running on the day it moved.
+
+  it('says nothing about a change AFTER the project switched away from the id', () => {
+    // Ran chat-latest until 2026-06-01, then moved to a pinned model for the
+    // rest of the period. The 2026-06-24 change cannot have touched it.
+    const exposure = evaluateModelPointerExposure({
+      exposures: [
+        { modelId: 'chat-latest', firstSeen: '2026-05-01', lastSeen: '2026-06-01' },
+        { modelId: 'gpt-5.6-terra', firstSeen: '2026-06-02', lastSeen: '2026-07-15' },
+      ],
+      periodStart: '2026-05-01',
+      periodEnd: '2026-07-15',
     })
-    expect(disclosure?.changeCount).toBe(1)
-    expect(disclosure?.firstChangeDate).toBe(CHAT_LATEST_REPOINT)
+    const disclosure = disclosed(exposure)
+    expect(disclosure.changes.map(c => c.date)).toEqual([CHAT_LATEST_UNCONFIRMED_REPOINT])
+    expect(noticeText(disclosure)).not.toContain(CHAT_LATEST_REPOINT)
   })
 
-  it('counts a change dated exactly on the period END', () => {
-    const disclosure = findModelPointerChanges({
-      modelIds: ['chat-latest'],
-      start: '2026-06-10',
-      end: CHAT_LATEST_REPOINT,
+  it('says nothing about a change BEFORE the project switched to the id', () => {
+    // The mirror case. Moved onto chat-latest on 2026-07-01, well after both
+    // known changes, so its numbers cannot straddle either of them.
+    const exposure = evaluateModelPointerExposure({
+      exposures: [
+        { modelId: 'gpt-5.6-terra', firstSeen: '2026-05-01', lastSeen: '2026-06-30' },
+        { modelId: 'chat-latest', firstSeen: '2026-07-01', lastSeen: '2026-07-15' },
+      ],
+      periodStart: '2026-05-01',
+      periodEnd: '2026-07-15',
     })
-    expect(disclosure?.changeCount).toBe(1)
-    expect(disclosure?.lastChangeDate).toBe(CHAT_LATEST_REPOINT)
+    expect(exposure.status).toBe('no-known-change')
   })
 
-  it('excludes a change one day outside either end', () => {
-    expect(findModelPointerChanges({
-      modelIds: ['chat-latest'],
-      start: '2026-06-25',
-      end: '2026-07-15',
-    })).toBeUndefined()
-    expect(findModelPointerChanges({
-      modelIds: ['chat-latest'],
-      start: '2026-06-10',
-      end: '2026-06-23',
-    })).toBeUndefined()
+  it('counts a change dated exactly on the day the id was FIRST seen', () => {
+    // The sweep that day may have run on either side of the swap.
+    const exposure = evaluateModelPointerExposure({
+      exposures: [{ modelId: 'chat-latest', firstSeen: CHAT_LATEST_REPOINT, lastSeen: '2026-07-15' }],
+      periodStart: '2026-05-01',
+      periodEnd: '2026-07-15',
+    })
+    expect(disclosed(exposure).changes.map(c => c.date)).toEqual([CHAT_LATEST_REPOINT])
+  })
+
+  it('counts a change dated exactly on the day the id was LAST seen', () => {
+    const exposure = evaluateModelPointerExposure({
+      exposures: [{ modelId: 'chat-latest', firstSeen: '2026-06-10', lastSeen: CHAT_LATEST_REPOINT }],
+      periodStart: '2026-06-01',
+      periodEnd: '2026-07-15',
+    })
+    expect(disclosed(exposure).changes.map(c => c.date)).toEqual([CHAT_LATEST_REPOINT])
+  })
+
+  it('excludes a change one day outside either end of the exposure', () => {
+    const after = evaluateModelPointerExposure({
+      exposures: [{ modelId: 'chat-latest', firstSeen: '2026-06-25', lastSeen: '2026-07-15' }],
+      periodStart: '2026-06-01',
+      periodEnd: '2026-07-15',
+    })
+    expect(after.status).toBe('no-known-change')
+    const before = evaluateModelPointerExposure({
+      exposures: [{ modelId: 'chat-latest', firstSeen: '2026-06-01', lastSeen: '2026-06-23' }],
+      periodStart: '2026-06-01',
+      periodEnd: '2026-07-15',
+    })
+    expect(before.status).toBe('no-known-change')
+  })
+
+  it('scores each id against its own exposure, not against the pooled span', () => {
+    // gpt-5.3-chat-latest ran in early March, chat-latest from June. Pooling
+    // their spans would hand each of them the other one's changes.
+    const exposure = evaluateModelPointerExposure({
+      exposures: [
+        { modelId: 'gpt-5.3-chat-latest', firstSeen: '2026-03-01', lastSeen: '2026-03-10' },
+        { modelId: 'chat-latest', firstSeen: '2026-06-01', lastSeen: '2026-06-30' },
+      ],
+      periodStart: '2026-03-01',
+      periodEnd: '2026-06-30',
+    })
+    const disclosure = disclosed(exposure)
+    // 2026-03-16 fell after gpt-5.3-chat-latest was dropped; 2026-06-24 fell
+    // while chat-latest was running.
+    expect(disclosure.changes.map(c => `${c.modelId}@${c.date}`)).toEqual([`chat-latest@${CHAT_LATEST_REPOINT}`])
+    expect(noticeText(disclosure)).not.toContain(GPT_53_REPOINT)
+    // Both ids are still reported as run — the project IS on moving ids.
+    expect(disclosure.modelIds).toEqual(['chat-latest', 'gpt-5.3-chat-latest'])
   })
 
   it('compares calendar days, so a same-day sweep timestamp still counts', () => {
-    // The period bounds are real sweep instants. A sweep at 08:00 on the change
-    // date may have run on either side of the swap, so the day counts.
-    const disclosure = findModelPointerChanges({
-      modelIds: ['chat-latest'],
-      start: `${CHAT_LATEST_REPOINT}T08:00:00.000Z`,
-      end: `${CHAT_LATEST_REPOINT}T23:59:59.000Z`,
+    const exposure = evaluateModelPointerExposure({
+      exposures: [{
+        modelId: 'chat-latest',
+        firstSeen: `${CHAT_LATEST_REPOINT}T08:00:00.000Z`,
+        lastSeen: `${CHAT_LATEST_REPOINT}T23:59:59.000Z`,
+      }],
+      periodStart: `${CHAT_LATEST_REPOINT}T08:00:00.000Z`,
+      periodEnd: `${CHAT_LATEST_REPOINT}T23:59:59.000Z`,
     })
-    expect(disclosure?.changeCount).toBe(1)
+    expect(disclosed(exposure).changeCount).toBe(1)
+  })
+
+  it('never reaches outside the reporting period even if an exposure does', () => {
+    // The period is the contract with the number on screen. A caller passing a
+    // wider exposure must not widen the caveat past what the metrics cover.
+    const exposure = evaluateModelPointerExposure({
+      exposures: [{ modelId: 'chat-latest', firstSeen: '2026-05-01', lastSeen: '2026-07-15' }],
+      periodStart: '2026-06-01',
+      periodEnd: '2026-06-20',
+    })
+    expect(exposure.status).toBe('no-known-change')
   })
 })
 
-describe('findModelPointerChanges — projects that are not exposed', () => {
+describe('projects that are not exposed', () => {
   it('says nothing for a project on pinned model ids, even across a change date', () => {
     // The whole point: a project on a pinned id is unaffected by a re-point and
     // must never be handed a caveat about someone else's model.
-    expect(findModelPointerChanges({
-      modelIds: ['gpt-5.6-terra', 'gemini-3.5-flash', 'claude-sonnet-5'],
-      start: '2026-01-01',
-      end: '2026-12-31',
-    })).toBeUndefined()
+    expect(overWholePeriod(['gpt-5.6-terra', 'gemini-3.5-flash', 'claude-sonnet-5'], '2026-01-01', '2026-12-31'))
+      .toEqual({ status: 'not-exposed' })
   })
 
   it('says nothing for a project with no model ids at all', () => {
-    expect(findModelPointerChanges({ modelIds: [], start: '2026-01-01', end: '2026-12-31' })).toBeUndefined()
-    expect(findModelPointerChanges({ modelIds: ['', '  '], start: '2026-01-01', end: '2026-12-31' })).toBeUndefined()
-  })
-
-  it('says nothing for a pointer the registry has no change for yet', () => {
-    // Exposed by the suffix rule, but nothing is known to have happened to it —
-    // "we have no dates" must read as no caveat, not as a change.
-    expect(findModelPointerChanges({
-      modelIds: ['gpt-6-chat-latest'],
-      start: '2026-01-01',
-      end: '2026-12-31',
-    })).toBeUndefined()
+    expect(overWholePeriod([], '2026-01-01', '2026-12-31').status).toBe('not-exposed')
+    expect(overWholePeriod(['', '  '], '2026-01-01', '2026-12-31').status).toBe('not-exposed')
   })
 
   it('ignores the pinned ids and reports only the exposed one', () => {
-    const disclosure = findModelPointerChanges({
-      modelIds: ['gemini-3.5-flash', 'chat-latest', 'gpt-5.6-terra'],
-      start: '2026-06-01',
-      end: '2026-06-30',
-    })
-    expect(disclosure?.modelIds).toEqual(['chat-latest'])
+    const disclosure = disclosed(overWholePeriod(
+      ['gemini-3.5-flash', 'chat-latest', 'gpt-5.6-terra'], '2026-06-01', '2026-06-30',
+    ))
+    expect(disclosure.modelIds).toEqual(['chat-latest'])
   })
 })
 
-describe('findModelPointerChanges — unverified changes hedge instead of asserting', () => {
-  it('says "may have changed" when every change in range is unverified', () => {
-    const disclosure = findModelPointerChanges({
-      modelIds: ['chat-latest'],
-      start: '2026-05-20',
-      end: '2026-06-01',
-    })
-    expect(disclosure!.changeCount).toBe(1)
-    expect(disclosure!.unverifiedChangeCount).toBe(1)
-    expect(disclosure!.summary).toBe(
-      'The model behind "chat-latest" may have changed on 2026-05-28, inside this reporting period.'
-      + ' If it did, part of any movement in this number comes from that change'
-      + ' and not from how often AI names you.',
+describe('an unconfirmed change is never asserted and never dropped', () => {
+  it('hedges when every change in range is unconfirmed', () => {
+    const disclosure = disclosed(overWholePeriod(['chat-latest'], '2026-05-20', '2026-06-01'))
+    expect(disclosure.changeCount).toBe(1)
+    expect(disclosure.unverifiedChangeCount).toBe(1)
+    expect(noticeText(disclosure)).toBe(
+      'The model behind ChatGPT may have been updated on 2026-05-28, inside this period,'
+      + ' though that is not confirmed.'
+      + ' If so, some of the movement in these numbers may come from this update'
+      + ' rather than from a real change in how AI answers about you, so compare periods carefully.',
     )
   })
 
-  it('asserts plainly when at least one change in range is confirmed', () => {
-    const disclosure = findModelPointerChanges({
-      modelIds: ['chat-latest'],
-      start: '2026-05-20',
-      end: '2026-07-01',
-    })
-    expect(disclosure!.unverifiedChangeCount).toBe(1)
-    expect(disclosure!.changeCount).toBe(2)
-    expect(disclosure!.summary).toContain('changed more than once')
-    expect(disclosure!.summary).not.toContain('may have')
+  it('states the confirmed change and hedges the unconfirmed one separately', () => {
+    // The defect this replaces: pooling them said "changed more than once,
+    // between 2026-05-28 and 2026-06-24", which asserts a date the record does
+    // not support — on exactly the window a client on chat-latest reads today.
+    const disclosure = disclosed(overWholePeriod(['chat-latest'], '2026-05-01', '2026-07-01'))
+    expect(disclosure.changeCount).toBe(2)
+    expect(disclosure.unverifiedChangeCount).toBe(1)
+    expect(noticeText(disclosure)).toBe(
+      'The model behind ChatGPT was updated on 2026-06-24, inside this period,'
+      + ' and may also have been updated on 2026-05-28.'
+      + ' Some of the movement in these numbers may come from these updates'
+      + ' rather than from a real change in how AI answers about you, so compare periods carefully.',
+    )
+    expect(noticeText(disclosure)).not.toContain('more than once')
+  })
+
+  it('keeps the unconfirmed event in the list with its own flag', () => {
+    const disclosure = disclosed(overWholePeriod(['chat-latest'], '2026-05-01', '2026-07-01'))
+    expect(disclosure.changes.map(c => [c.date, c.confirmed])).toEqual([
+      [CHAT_LATEST_UNCONFIRMED_REPOINT, false],
+      [CHAT_LATEST_REPOINT, true],
+    ])
+  })
+
+  it('says "more than once" only about changes the record actually supports', () => {
+    const disclosure = disclosed(overWholePeriod(['chat-latest', 'gpt-5.3-chat-latest'], '2026-01-01', '2026-07-01'))
+    expect(noticeText(disclosure)).toContain(
+      `was updated more than once between ${GPT_53_REPOINT} and ${CHAT_LATEST_REPOINT}`,
+    )
+    expect(noticeText(disclosure)).toContain(`may also have been updated on ${CHAT_LATEST_UNCONFIRMED_REPOINT}`)
   })
 })
 
-describe('findModelPointerChanges — several exposed ids at once', () => {
-  it('pools the ids and reports the outer dates', () => {
-    const disclosure = findModelPointerChanges({
-      modelIds: ['gpt-5.3-chat-latest', 'chat-latest'],
-      start: '2026-01-01',
-      end: '2026-12-31',
-    })
-    expect(disclosure!.modelIds).toEqual(['chat-latest', 'gpt-5.3-chat-latest'])
+describe('several exposed ids at once', () => {
+  it('pools the ids that changed and reports the outer dates', () => {
+    const disclosure = disclosed(overWholePeriod(['gpt-5.3-chat-latest', 'chat-latest'], '2026-01-01', '2026-07-01'))
+    expect(disclosure.modelIds).toEqual(['chat-latest', 'gpt-5.3-chat-latest'])
     // gpt-5.3-chat-latest once, chat-latest twice.
-    expect(disclosure!.changeCount).toBe(3)
-    expect(disclosure!.firstChangeDate).toBe(GPT_53_REPOINT)
-    expect(disclosure!.lastChangeDate).toBe(CHAT_LATEST_REPOINT)
-    expect(disclosure!.summary).toContain('The model behind "chat-latest" and "gpt-5.3-chat-latest"')
+    expect(disclosure.changeCount).toBe(3)
+    expect(disclosure.firstChangeDate).toBe(GPT_53_REPOINT)
+    expect(disclosure.lastChangeDate).toBe(CHAT_LATEST_REPOINT)
+    // The ids are pooled as FACTS on the DTO; the sentence a reader sees names
+    // the engine, never the model ids, so both must hold at once.
+    expect(noticeText(disclosure)).toContain('The model behind ChatGPT')
+    expect(noticeText(disclosure)).not.toContain('chat-latest')
   })
 })
 
 /**
  * The rendering the dashboard and the CLI both call. It lives here so the two
  * surfaces cannot word the same warning differently, and it is tested here
- * rather than in either of them for the same reason.
+ * rather than in either of them for the same reason: an earlier cut of this
+ * feature had a renderer in contracts that nothing called and a near-identical
+ * copy pasted into each surface, which is three wordings of one warning and one
+ * edit away from a client being told something softer on the dashboard than in
+ * the terminal.
+ *
+ * Every sentence a reader can be shown is pinned as a literal. The same
+ * sentences are asserted end-to-end through the DOM in
+ * `apps/web/test/visibility-trend-section.test.tsx` and through stdout in
+ * `packages/canonry/test/analytics.test.ts`.
  */
-describe('formatModelChangeDisclosure', () => {
-  const openai: ModelPointerChangeDisclosure = {
+describe('buildModelChangeNotice', () => {
+  const CLOSE = 'rather than from a real change in how AI answers about you, so compare periods carefully.'
+  const confirmed = (date: string) => ({
     modelIds: ['chat-latest'],
     changeCount: 1,
     unverifiedChangeCount: 0,
-    firstChangeDate: '2026-06-24',
-    lastChangeDate: '2026-06-24',
-    summary: 'The model behind "chat-latest" changed on 2026-06-24, inside this reporting period.'
-      + ' Part of any movement in this number comes from that change and not from how often AI names you.',
-  }
-
-  const gemini: ModelPointerChangeDisclosure = {
-    modelIds: ['gemini-flash-latest'],
-    changeCount: 2,
-    unverifiedChangeCount: 0,
-    firstChangeDate: '2026-06-02',
-    lastChangeDate: '2026-06-30',
-    summary: 'The model behind "gemini-flash-latest" changed more than once in this reporting period,'
-      + ' between 2026-06-02 and 2026-06-30.'
-      + ' Part of any movement in this number comes from those changes and not from how often AI names you.',
-  }
-
-  it('says nothing when there is nothing to say', () => {
-    // An older server omits the field; a project on fixed model ids sends {}.
-    expect(formatModelChangeDisclosure(undefined)).toBeNull()
-    expect(formatModelChangeDisclosure({})).toBeNull()
+    firstChangeDate: date,
+    lastChangeDate: date,
   })
 
-  it('renders the disclosure verbatim and closes with the next action', () => {
-    expect(formatModelChangeDisclosure({ openai })).toBe(
-      'The model behind "chat-latest" changed on 2026-06-24, inside this reporting period.'
-      + ' Part of any movement in this number comes from that change and not from how often AI names you.'
-      + ' Compare this period with earlier ones carefully.',
+  it('says nothing when the server omits the field or the project runs fixed model ids', () => {
+    expect(buildModelChangeNotice(undefined)).toBeNull()
+    expect(buildModelChangeNotice({})).toBeNull()
+  })
+
+  it('names the engine the reader knows, not the model id, and scopes the caveat to every plotted number', () => {
+    const notice = buildModelChangeNotice({ openai: confirmed('2026-06-24') })
+    expect(notice).toEqual({
+      kind: 'change',
+      text: 'The model behind ChatGPT was updated on 2026-06-24, inside this period. '
+        + `Some of the movement in these numbers may come from this update ${CLOSE}`,
+    })
+    // The internal id is what the notice must NOT lead with: an agency owner
+    // cannot map "chat-latest" onto a line of a chart.
+    expect(notice!.text).not.toContain('chat-latest')
+    expect(notice!.text).not.toContain('this number ')
+  })
+
+  /**
+   * Two affected engines are two FACTS and one warning. A per-engine sentence
+   * that bundles the consequence prints "part of any movement in this number
+   * comes from that change" a second time on the same surface.
+   */
+  it('states one fact per engine and closes with exactly one consequence', () => {
+    const notice = buildModelChangeNotice({
+      openai: confirmed('2026-06-24'),
+      perplexity: confirmed('2026-06-10'),
+    })!
+    expect(notice.text).toBe(
+      'The model behind ChatGPT was updated on 2026-06-24, inside this period. '
+      + 'The model behind Perplexity was updated on 2026-06-10, inside this period. '
+      + `Some of the movement in these numbers may come from these updates ${CLOSE}`,
+    )
+    const sentences = notice.text.split('. ').map(s => s.trim())
+    expect(new Set(sentences).size).toBe(sentences.length)
+  })
+
+  it('reports several updates on one engine as a range, not a change log', () => {
+    expect(buildModelChangeNotice({
+      gemini: { changeCount: 2, unverifiedChangeCount: 0, firstChangeDate: '2026-06-02', lastChangeDate: '2026-06-30' },
+    })!.text).toBe(
+      'The model behind Gemini was updated more than once between 2026-06-02 and 2026-06-30, inside this period. '
+      + `Some of the movement in these numbers may come from these updates ${CLOSE}`,
     )
   })
 
-  it('states every affected engine in a stable order, and closes only once', () => {
-    const note = formatModelChangeDisclosure({ openai, gemini })!
-    expect(note).toBe(`${gemini.summary} ${openai.summary} ${MODEL_CHANGE_NEXT_ACTION}`)
-    // One closing line however many engines are affected — repeating it would
-    // read as two separate warnings about the same number.
-    expect(note.split(MODEL_CHANGE_NEXT_ACTION)).toHaveLength(2)
+  it('never asserts an unconfirmed update as fact, and never hides it either', () => {
+    const notice = buildModelChangeNotice({
+      openai: { changeCount: 1, unverifiedChangeCount: 1, firstChangeDate: '2026-05-28', lastChangeDate: '2026-05-28' },
+    })!
+    expect(notice.text).toBe(
+      'The model behind ChatGPT may have been updated on 2026-05-28, inside this period, though that is not confirmed. '
+      + `If so, some of the movement in these numbers may come from this update ${CLOSE}`,
+    )
+    expect(notice.text).not.toContain('was updated')
   })
 
-  it('drops an entry with no usable sentence instead of rendering a half-stated caveat', () => {
-    expect(formatModelChangeDisclosure({ gemini: { ...gemini, summary: '   ' }, openai }))
-      .toBe(`${openai.summary} ${MODEL_CHANGE_NEXT_ACTION}`)
-    expect(formatModelChangeDisclosure({ gemini: { ...gemini, summary: '  ' } })).toBeNull()
+  it('separates a confirmed update from an unconfirmed one when the server dates them', () => {
+    expect(buildModelChangeNotice({
+      openai: {
+        changeCount: 2,
+        unverifiedChangeCount: 1,
+        firstChangeDate: '2026-05-28',
+        lastChangeDate: '2026-06-24',
+        changes: [{ date: '2026-05-28', confirmed: false }, { date: '2026-06-24', confirmed: true }],
+      },
+    })!.text).toBe(
+      'The model behind ChatGPT was updated on 2026-06-24, inside this period, and may also have been updated on 2026-05-28. '
+      + `Some of the movement in these numbers may come from these updates ${CLOSE}`,
+    )
+  })
+
+  it('drops the dates rather than attach one to the wrong claim when confidence is mixed and undated', () => {
+    expect(buildModelChangeNotice({
+      openai: { changeCount: 2, unverifiedChangeCount: 1, firstChangeDate: '2026-05-28', lastChangeDate: '2026-06-24' },
+    })!.text).toBe(
+      'The model behind ChatGPT was updated inside this period, and may have been updated once more, though that is not confirmed. '
+      + `Some of the movement in these numbers may come from these updates ${CLOSE}`,
+    )
+  })
+
+  /**
+   * The middle state. An engine that CAN be moved onto a different model with
+   * nothing on record must not render as silence — silence is exactly what a
+   * record nobody has updated in six months also produces.
+   */
+  it('says so out loud when an engine can be updated but nothing is on record', () => {
+    const notice = buildModelChangeNotice({ openai: { changeCount: 0, unverifiedChangeCount: 0 } })!
+    expect(notice.kind).toBe('no-known-change')
+    expect(notice.text).toBe('No model updates are on record for ChatGPT in this period.')
+    expect(buildModelChangeNotice({
+      openai: { changeCount: 0 }, gemini: { changeCount: 0 },
+    })!.text).toBe('No model updates are on record for ChatGPT and Gemini in this period.')
+  })
+
+  it('drops the quiet line when any engine actually changed, so the caveat stands alone', () => {
+    const notice = buildModelChangeNotice({ openai: confirmed('2026-06-24'), gemini: { changeCount: 0 } })!
+    expect(notice.kind).toBe('change')
+    expect(notice.text).not.toContain('No model updates are on record')
+    expect(notice.text).not.toContain('Gemini')
+  })
+
+  /**
+   * The freshness of the record is the whole reason the quiet state is a state
+   * rather than an absence, and it only does any work if it reaches a reader.
+   * These are the tests that would have caught the server computing
+   * `knownGoodAsOf` while every surface rendered a sentence without it.
+   */
+  describe('how recently the record was checked', () => {
+    it('states the date whenever the server sends it', () => {
+      const notice = buildModelChangeNotice({
+        openai: { changeCount: 0, knownGoodAsOf: '2026-07-20', checkedThroughPeriodEnd: true },
+      })!
+      expect(notice.kind).toBe('no-known-change')
+      expect(notice).toHaveProperty('detail')
+      expect((notice as { detail: string }).detail)
+        .toContain('We last checked for model updates on 2026-07-20.')
+    })
+
+    it('says the tail of the period was never checked, so ignorance cannot read as clearance', () => {
+      const notice = buildModelChangeNotice({
+        openai: { changeCount: 0, knownGoodAsOf: '2026-07-20', checkedThroughPeriodEnd: false },
+      })!
+      const detail = (notice as { detail: string }).detail
+      expect(detail).toContain(
+        'We last checked for model updates on 2026-07-20, and this period runs past that date,'
+        + ' so there may be later updates we do not know about.',
+      )
+      // Not both sentences: naming the same date twice reads as two findings.
+      expect(detail).not.toContain('on 2026-07-20. ')
+    })
+
+    it('warns about the unchecked tail on a KNOWN change too', () => {
+      // "We found one" must never imply "we found all of them".
+      const notice = buildModelChangeNotice({
+        openai: { ...confirmed('2026-06-24'), knownGoodAsOf: '2026-07-20', checkedThroughPeriodEnd: false },
+      })!
+      expect(notice.text).toContain(
+        'We last checked for model updates on 2026-07-20, and this period runs past that date,'
+        + ' so there may be later updates we do not know about.',
+      )
+    })
+
+    it('quotes the OLDEST check when engines disagree, so the weakest knowledge bounds the claim', () => {
+      const notice = buildModelChangeNotice({
+        openai: { changeCount: 0, knownGoodAsOf: '2026-07-20', checkedThroughPeriodEnd: false },
+        gemini: { changeCount: 0, knownGoodAsOf: '2026-03-01', checkedThroughPeriodEnd: false },
+      })!
+      expect((notice as { detail: string }).detail).toContain('on 2026-03-01,')
+      expect((notice as { detail: string }).detail).not.toContain('2026-07-20')
+    })
+
+    it('claims no freshness at all when an older server omits the date', () => {
+      // Falling back to this build's own constant would assert a check the
+      // server never performed, which is the lie the field exists to prevent.
+      const notice = buildModelChangeNotice({ openai: { changeCount: 0 } })!
+      expect((notice as { detail: string }).detail).not.toContain('last checked')
+      expect((notice as { detail: string }).detail).not.toContain(MODEL_POINTER_REGISTRY_CHECKED_THROUGH)
+    })
   })
 })
 
 describe('operator-facing copy stays plain', () => {
   const BANNED = ['pointer', 'alias', 'snapshot', 'drift', 'attribution', 'divergence', 'slug', 'repoint']
 
-  it('never uses internal vocabulary in the closing action', () => {
-    for (const word of BANNED) expect(MODEL_CHANGE_NEXT_ACTION.toLowerCase()).not.toContain(word)
-  })
-
-  it('never uses internal vocabulary in a summary', () => {
+  it('never uses internal vocabulary in any sentence, in any state', () => {
     const periods: Array<[string, string]> = [
       ['2026-06-01', '2026-06-30'],
       ['2026-05-01', '2026-07-01'],
       ['2026-05-20', '2026-06-01'],
       ['2026-01-01', '2026-12-31'],
+      // The quiet states, which the fail-safe renders too.
+      ['2026-06-01', '2026-06-20'],
+      ['2026-01-01', '2026-01-31'],
     ]
     for (const [start, end] of periods) {
-      const disclosure = findModelPointerChanges({
-        modelIds: ['chat-latest', 'gpt-5.3-chat-latest'],
-        start,
-        end,
-      })
-      expect(disclosure).toBeDefined()
-      const summary = disclosure!.summary.toLowerCase()
-      for (const word of BANNED) expect(summary).not.toContain(word)
+      const exposure = overWholePeriod(['chat-latest', 'gpt-5.3-chat-latest'], start, end)
+      const text = noticeText(exposure).toLowerCase()
+      for (const word of BANNED) expect(text).not.toContain(word)
+      // Em-dashes are banned in human-facing copy repo-wide.
+      expect(text).not.toContain('\u2014')
+    }
+  })
+
+  it('never leaks a raw model id into a sentence, in any state', () => {
+    // The registry is keyed by model id and the DTO carries them; the reader is
+    // shown an engine. `-latest` appearing in the copy means an id escaped.
+    for (const [start, end] of [['2026-06-01', '2026-06-30'], ['2026-01-01', '2026-01-31']] as const) {
+      expect(noticeText(overWholePeriod(['chat-latest', 'gpt-5.3-chat-latest'], start, end)))
+        .not.toContain('-latest')
     }
   })
 })

--- a/packages/contracts/test/model-pointers.test.ts
+++ b/packages/contracts/test/model-pointers.test.ts
@@ -1,0 +1,370 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  KNOWN_MOVING_POINTER_MODEL_IDS,
+  MODEL_CHANGE_NEXT_ACTION,
+  MODEL_POINTER_EVENTS,
+  findModelPointerChanges,
+  formatModelChangeDisclosure,
+  isMovingPointerModelId,
+  modelPointerChangeDisclosureSchema,
+  modelPointerEventSchema,
+  type ModelPointerChangeDisclosure,
+} from '../src/model-pointers.js'
+
+// Real dates from the seeded registry. Named here so a test failure points at
+// the registry entry it depends on rather than at a bare literal.
+const CHAT_LATEST_UNCONFIRMED_REPOINT = '2026-05-28'
+const CHAT_LATEST_REPOINT = '2026-06-24'
+const CHAT_LATEST_INTRODUCED = '2026-05-05'
+const GPT_53_REPOINT = '2026-03-16'
+
+describe('the registry itself', () => {
+  it('every seeded entry is a valid event', () => {
+    for (const event of MODEL_POINTER_EVENTS) {
+      expect(() => modelPointerEventSchema.parse(event)).not.toThrow()
+    }
+  })
+
+  it('every seeded entry carries a source a maintainer can re-check', () => {
+    for (const event of MODEL_POINTER_EVENTS) {
+      expect(event.sourceUrl.startsWith('https://')).toBe(true)
+      expect(event.note.trim().length).toBeGreaterThan(0)
+    }
+  })
+
+  it('marks every id it has an event for as a moving pointer', () => {
+    for (const event of MODEL_POINTER_EVENTS) {
+      expect(isMovingPointerModelId(event.modelId)).toBe(true)
+      expect(KNOWN_MOVING_POINTER_MODEL_IDS.has(event.modelId.toLowerCase())).toBe(true)
+    }
+  })
+
+  it('holds no duplicate (model, date, kind) rows', () => {
+    const keys = MODEL_POINTER_EVENTS.map(e => `${e.modelId}|${e.date}|${e.kind}`)
+    expect(new Set(keys).size).toBe(keys.length)
+  })
+})
+
+describe('isMovingPointerModelId', () => {
+  it('treats a pinned model id as not exposed', () => {
+    expect(isMovingPointerModelId('gpt-5.6-terra')).toBe(false)
+    expect(isMovingPointerModelId('gpt-5.4-2026-03-05')).toBe(false)
+    expect(isMovingPointerModelId('gemini-3.5-flash')).toBe(false)
+    expect(isMovingPointerModelId('claude-sonnet-5')).toBe(false)
+  })
+
+  it('treats a registered pointer as exposed regardless of casing or padding', () => {
+    expect(isMovingPointerModelId('  Chat-Latest ')).toBe(true)
+    expect(isMovingPointerModelId('CHATGPT-4O-LATEST')).toBe(true)
+  })
+
+  it('treats an UNREGISTERED -latest id as exposed', () => {
+    // The registry rots; the suffix rule is what keeps a pointer shipped
+    // tomorrow from being silently treated as a pinned model until someone
+    // remembers to add it. Failing this open is the expensive direction.
+    expect(KNOWN_MOVING_POINTER_MODEL_IDS.has('gpt-6-chat-latest')).toBe(false)
+    expect(isMovingPointerModelId('gpt-6-chat-latest')).toBe(true)
+    expect(isMovingPointerModelId('claude-opus-5-latest')).toBe(true)
+  })
+
+  it('ignores an empty or whitespace-only id', () => {
+    expect(isMovingPointerModelId('')).toBe(false)
+    expect(isMovingPointerModelId('   ')).toBe(false)
+  })
+})
+
+describe('findModelPointerChanges — a period spanning one change', () => {
+  const disclosure = findModelPointerChanges({
+    modelIds: ['chat-latest'],
+    start: '2026-06-01',
+    end: '2026-06-30',
+  })
+
+  it('discloses the change', () => {
+    expect(disclosure).toBeDefined()
+    expect(disclosure!.changeCount).toBe(1)
+    expect(disclosure!.unverifiedChangeCount).toBe(0)
+    expect(disclosure!.modelIds).toEqual(['chat-latest'])
+    expect(disclosure!.firstChangeDate).toBe(CHAT_LATEST_REPOINT)
+    expect(disclosure!.lastChangeDate).toBe(CHAT_LATEST_REPOINT)
+  })
+
+  it('names the date and says what it means for the number', () => {
+    expect(disclosure!.summary).toBe(
+      'The model behind "chat-latest" changed on 2026-06-24, inside this reporting period.'
+      + ' Part of any movement in this number comes from that change and not from how often AI names you.',
+    )
+  })
+
+  it('is a valid disclosure', () => {
+    expect(() => modelPointerChangeDisclosureSchema.parse(disclosure)).not.toThrow()
+  })
+})
+
+describe('findModelPointerChanges — a period spanning several changes', () => {
+  const disclosure = findModelPointerChanges({
+    modelIds: ['chat-latest'],
+    start: '2026-05-01',
+    end: '2026-07-01',
+  })
+
+  it('counts both changes in range', () => {
+    expect(disclosure!.changeCount).toBe(2)
+    expect(disclosure!.firstChangeDate).toBe(CHAT_LATEST_UNCONFIRMED_REPOINT)
+    expect(disclosure!.lastChangeDate).toBe(CHAT_LATEST_REPOINT)
+  })
+
+  it('does not count the day the id was introduced as a change', () => {
+    // 2026-05-05 is inside this period. The id starting to exist is not the
+    // model behind it changing, and no reporting period can straddle it.
+    expect(CHAT_LATEST_INTRODUCED >= '2026-05-01' && CHAT_LATEST_INTRODUCED <= '2026-07-01').toBe(true)
+    expect(disclosure!.changeCount).toBe(2)
+  })
+
+  it('says "more than once" with the outer dates instead of listing every date', () => {
+    expect(disclosure!.summary).toBe(
+      'The model behind "chat-latest" changed more than once in this reporting period,'
+      + ' between 2026-05-28 and 2026-06-24.'
+      + ' Part of any movement in this number comes from those changes and not from how often AI names you.',
+    )
+    expect(disclosure!.summary).not.toContain('2026-05-05')
+  })
+})
+
+describe('findModelPointerChanges — a period spanning no changes', () => {
+  it('returns nothing for a quiet period on an exposed id', () => {
+    // A project genuinely running chat-latest, but between the known changes.
+    expect(findModelPointerChanges({
+      modelIds: ['chat-latest'],
+      start: '2026-06-01',
+      end: '2026-06-20',
+    })).toBeUndefined()
+  })
+
+  it('returns nothing for a period entirely before the id existed', () => {
+    expect(findModelPointerChanges({
+      modelIds: ['chat-latest'],
+      start: '2026-01-01',
+      end: '2026-01-31',
+    })).toBeUndefined()
+  })
+
+  it('returns nothing when the period is inverted', () => {
+    expect(findModelPointerChanges({
+      modelIds: ['chat-latest'],
+      start: '2026-07-01',
+      end: '2026-05-01',
+    })).toBeUndefined()
+  })
+})
+
+describe('findModelPointerChanges — boundaries are inclusive', () => {
+  it('counts a change dated exactly on the period START', () => {
+    const disclosure = findModelPointerChanges({
+      modelIds: ['chat-latest'],
+      start: CHAT_LATEST_REPOINT,
+      end: '2026-07-15',
+    })
+    expect(disclosure?.changeCount).toBe(1)
+    expect(disclosure?.firstChangeDate).toBe(CHAT_LATEST_REPOINT)
+  })
+
+  it('counts a change dated exactly on the period END', () => {
+    const disclosure = findModelPointerChanges({
+      modelIds: ['chat-latest'],
+      start: '2026-06-10',
+      end: CHAT_LATEST_REPOINT,
+    })
+    expect(disclosure?.changeCount).toBe(1)
+    expect(disclosure?.lastChangeDate).toBe(CHAT_LATEST_REPOINT)
+  })
+
+  it('excludes a change one day outside either end', () => {
+    expect(findModelPointerChanges({
+      modelIds: ['chat-latest'],
+      start: '2026-06-25',
+      end: '2026-07-15',
+    })).toBeUndefined()
+    expect(findModelPointerChanges({
+      modelIds: ['chat-latest'],
+      start: '2026-06-10',
+      end: '2026-06-23',
+    })).toBeUndefined()
+  })
+
+  it('compares calendar days, so a same-day sweep timestamp still counts', () => {
+    // The period bounds are real sweep instants. A sweep at 08:00 on the change
+    // date may have run on either side of the swap, so the day counts.
+    const disclosure = findModelPointerChanges({
+      modelIds: ['chat-latest'],
+      start: `${CHAT_LATEST_REPOINT}T08:00:00.000Z`,
+      end: `${CHAT_LATEST_REPOINT}T23:59:59.000Z`,
+    })
+    expect(disclosure?.changeCount).toBe(1)
+  })
+})
+
+describe('findModelPointerChanges — projects that are not exposed', () => {
+  it('says nothing for a project on pinned model ids, even across a change date', () => {
+    // The whole point: a project on a pinned id is unaffected by a re-point and
+    // must never be handed a caveat about someone else's model.
+    expect(findModelPointerChanges({
+      modelIds: ['gpt-5.6-terra', 'gemini-3.5-flash', 'claude-sonnet-5'],
+      start: '2026-01-01',
+      end: '2026-12-31',
+    })).toBeUndefined()
+  })
+
+  it('says nothing for a project with no model ids at all', () => {
+    expect(findModelPointerChanges({ modelIds: [], start: '2026-01-01', end: '2026-12-31' })).toBeUndefined()
+    expect(findModelPointerChanges({ modelIds: ['', '  '], start: '2026-01-01', end: '2026-12-31' })).toBeUndefined()
+  })
+
+  it('says nothing for a pointer the registry has no change for yet', () => {
+    // Exposed by the suffix rule, but nothing is known to have happened to it —
+    // "we have no dates" must read as no caveat, not as a change.
+    expect(findModelPointerChanges({
+      modelIds: ['gpt-6-chat-latest'],
+      start: '2026-01-01',
+      end: '2026-12-31',
+    })).toBeUndefined()
+  })
+
+  it('ignores the pinned ids and reports only the exposed one', () => {
+    const disclosure = findModelPointerChanges({
+      modelIds: ['gemini-3.5-flash', 'chat-latest', 'gpt-5.6-terra'],
+      start: '2026-06-01',
+      end: '2026-06-30',
+    })
+    expect(disclosure?.modelIds).toEqual(['chat-latest'])
+  })
+})
+
+describe('findModelPointerChanges — unverified changes hedge instead of asserting', () => {
+  it('says "may have changed" when every change in range is unverified', () => {
+    const disclosure = findModelPointerChanges({
+      modelIds: ['chat-latest'],
+      start: '2026-05-20',
+      end: '2026-06-01',
+    })
+    expect(disclosure!.changeCount).toBe(1)
+    expect(disclosure!.unverifiedChangeCount).toBe(1)
+    expect(disclosure!.summary).toBe(
+      'The model behind "chat-latest" may have changed on 2026-05-28, inside this reporting period.'
+      + ' If it did, part of any movement in this number comes from that change'
+      + ' and not from how often AI names you.',
+    )
+  })
+
+  it('asserts plainly when at least one change in range is confirmed', () => {
+    const disclosure = findModelPointerChanges({
+      modelIds: ['chat-latest'],
+      start: '2026-05-20',
+      end: '2026-07-01',
+    })
+    expect(disclosure!.unverifiedChangeCount).toBe(1)
+    expect(disclosure!.changeCount).toBe(2)
+    expect(disclosure!.summary).toContain('changed more than once')
+    expect(disclosure!.summary).not.toContain('may have')
+  })
+})
+
+describe('findModelPointerChanges — several exposed ids at once', () => {
+  it('pools the ids and reports the outer dates', () => {
+    const disclosure = findModelPointerChanges({
+      modelIds: ['gpt-5.3-chat-latest', 'chat-latest'],
+      start: '2026-01-01',
+      end: '2026-12-31',
+    })
+    expect(disclosure!.modelIds).toEqual(['chat-latest', 'gpt-5.3-chat-latest'])
+    // gpt-5.3-chat-latest once, chat-latest twice.
+    expect(disclosure!.changeCount).toBe(3)
+    expect(disclosure!.firstChangeDate).toBe(GPT_53_REPOINT)
+    expect(disclosure!.lastChangeDate).toBe(CHAT_LATEST_REPOINT)
+    expect(disclosure!.summary).toContain('The model behind "chat-latest" and "gpt-5.3-chat-latest"')
+  })
+})
+
+/**
+ * The rendering the dashboard and the CLI both call. It lives here so the two
+ * surfaces cannot word the same warning differently, and it is tested here
+ * rather than in either of them for the same reason.
+ */
+describe('formatModelChangeDisclosure', () => {
+  const openai: ModelPointerChangeDisclosure = {
+    modelIds: ['chat-latest'],
+    changeCount: 1,
+    unverifiedChangeCount: 0,
+    firstChangeDate: '2026-06-24',
+    lastChangeDate: '2026-06-24',
+    summary: 'The model behind "chat-latest" changed on 2026-06-24, inside this reporting period.'
+      + ' Part of any movement in this number comes from that change and not from how often AI names you.',
+  }
+
+  const gemini: ModelPointerChangeDisclosure = {
+    modelIds: ['gemini-flash-latest'],
+    changeCount: 2,
+    unverifiedChangeCount: 0,
+    firstChangeDate: '2026-06-02',
+    lastChangeDate: '2026-06-30',
+    summary: 'The model behind "gemini-flash-latest" changed more than once in this reporting period,'
+      + ' between 2026-06-02 and 2026-06-30.'
+      + ' Part of any movement in this number comes from those changes and not from how often AI names you.',
+  }
+
+  it('says nothing when there is nothing to say', () => {
+    // An older server omits the field; a project on fixed model ids sends {}.
+    expect(formatModelChangeDisclosure(undefined)).toBeNull()
+    expect(formatModelChangeDisclosure({})).toBeNull()
+  })
+
+  it('renders the disclosure verbatim and closes with the next action', () => {
+    expect(formatModelChangeDisclosure({ openai })).toBe(
+      'The model behind "chat-latest" changed on 2026-06-24, inside this reporting period.'
+      + ' Part of any movement in this number comes from that change and not from how often AI names you.'
+      + ' Compare this period with earlier ones carefully.',
+    )
+  })
+
+  it('states every affected engine in a stable order, and closes only once', () => {
+    const note = formatModelChangeDisclosure({ openai, gemini })!
+    expect(note).toBe(`${gemini.summary} ${openai.summary} ${MODEL_CHANGE_NEXT_ACTION}`)
+    // One closing line however many engines are affected — repeating it would
+    // read as two separate warnings about the same number.
+    expect(note.split(MODEL_CHANGE_NEXT_ACTION)).toHaveLength(2)
+  })
+
+  it('drops an entry with no usable sentence instead of rendering a half-stated caveat', () => {
+    expect(formatModelChangeDisclosure({ gemini: { ...gemini, summary: '   ' }, openai }))
+      .toBe(`${openai.summary} ${MODEL_CHANGE_NEXT_ACTION}`)
+    expect(formatModelChangeDisclosure({ gemini: { ...gemini, summary: '  ' } })).toBeNull()
+  })
+})
+
+describe('operator-facing copy stays plain', () => {
+  const BANNED = ['pointer', 'alias', 'snapshot', 'drift', 'attribution', 'divergence', 'slug', 'repoint']
+
+  it('never uses internal vocabulary in the closing action', () => {
+    for (const word of BANNED) expect(MODEL_CHANGE_NEXT_ACTION.toLowerCase()).not.toContain(word)
+  })
+
+  it('never uses internal vocabulary in a summary', () => {
+    const periods: Array<[string, string]> = [
+      ['2026-06-01', '2026-06-30'],
+      ['2026-05-01', '2026-07-01'],
+      ['2026-05-20', '2026-06-01'],
+      ['2026-01-01', '2026-12-31'],
+    ]
+    for (const [start, end] of periods) {
+      const disclosure = findModelPointerChanges({
+        modelIds: ['chat-latest', 'gpt-5.3-chat-latest'],
+        start,
+        end,
+      })
+      expect(disclosure).toBeDefined()
+      const summary = disclosure!.summary.toLowerCase()
+      for (const word of BANNED) expect(summary).not.toContain(word)
+    }
+  })
+})


### PR DESCRIPTION
## What

Adds a hand-maintained record of dates on which a provider changed the model sitting behind a moving model id (`chat-latest` and its lineage), and discloses it on the analytics surfaces when a reporting period spans one.

- `packages/contracts/src/model-pointers.ts` — the record (10 dated entries, each with the source URL and a verbatim quote from that source), plus `MODEL_POINTER_REGISTRY_CHECKED_THROUGH`, the day the sources were last read end to end.
- `evaluateModelPointerExposure` — matches a change against the span over which the project was actually running that model id, not merely against the reporting window. A change only counts if it landed while the project was on that id.
- Three states, deliberately distinct: not exposed (every id is a fixed one, nothing renders), exposed with nothing on record, and exposed with a known change inside the period. The middle state is carried rather than collapsed into the first, so a record that has fallen behind understates certainty instead of reading as "nothing happened". It carries the last-checked date for exactly that reason.
- Entries whose source does not plainly state that the model changed are worded as unconfirmed and never asserted as fact, but also never dropped.
- `buildModelChangeNotice` builds the sentence once, in contracts. The web trend section and `canonry analytics` both call it, so there is a single wording of the caveat in the product.

## Why

Some model ids are not models. `chat-latest` names whatever model ChatGPT is currently serving, and the provider re-points it when the consumer product changes. A sweep cannot see the swap: the API echoes the same id back on both sides of it. So a tracked number can move because the model changed, and that is indistinguishable from the tracked position itself moving. Without this, that movement gets reported as performance.

## On maintaining the date list by hand

The list is maintained by hand because there is no feed to automate it against. The deprecations page is machine-readable, but re-points are published only as prose in a rendered HTML changelog with no `.md`, `.json`, or `.rss` equivalent. That is a standing risk — a missing entry means a silent model change reported as performance — which is why every disclosure states the date the record was last checked, and why a period running past that date is reported as unchecked rather than as clear.

## Replaces #828

#828 was stacked on `ax/model-attribution-api`, the branch behind #818. #818 was squash-merged, which deleted that branch and caused GitHub to auto-close #828. Its work is rebuilt here as the same two commits cherry-picked onto current `main`.

- The only conflicts were the version strings in `package.json` and `packages/canonry/package.json`; both resolved to main's value, then bumped to 4.123.0 relative to main.
- #818's work comes from `main` and is not re-applied here. The delta is #828's own: 14 files, +2102/-4.
- The generated SDK was regenerated from the spec and produced no diff against the cherry-picked output, confirming the two changes to the analytics metrics DTO compose rather than collide.

Full gate green: typecheck, lint (0 errors), 5646 tests across 457 files, web build, `gen:check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
