### PR TITLE
fix(ga): report deduplicated daily users instead of a landing-page sum

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -22,6 +22,7 @@ erDiagram
 
   projects ||--o| ga_connections : "has (1:1)"
   projects ||--o{ ga_traffic_snapshots : has
+  projects ||--o{ ga_daily_totals : has
   projects ||--o{ ga_traffic_summaries : has
   projects ||--o{ ga_ai_referrals : has
   projects ||--o{ ga_social_referrals : has
@@ -139,6 +140,7 @@ configuration value into an observation. Treat NULL as unknown.
 |-------|---------|
 | **ga_connections** | GA4 property connection (1:1 with project) |
 | **ga_traffic_snapshots** | Per-page daily traffic snapshots. Includes `sessions`, `organic_sessions`, and `direct_sessions` (nullable; populated by GA4 sync) — supports per-channel landing-page breakdowns. |
+| **ga_daily_totals** | GA4 property-level daily totals (no landing-page dimension), so `users` is deduplicated by GA and matches the GA UI. `SUM(users)` over `ga_traffic_snapshots` overcounts multi-page visitors and must not be used for a daily user count. Unique: `(project_id, date)` |
 | **ga_traffic_summaries** | Aggregated traffic summaries |
 | **ga_ai_referrals** | AI engine referral tracking. `traffic_class` splits `paid` AI traffic (paid/cpc/sponsored UTM values or GA4 paid channel groups, including tagged ChatGPT ads) from `organic`/non-paid AI referrals. Unique: `(projectId, date, source, medium, sourceDimension, channelGroup, landingPage)` |
 | **ga_social_referrals** | Social media referral tracking. Unique: `(projectId, date, source, medium, channelGroup)` |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.123.0",
+  "version": "4.124.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -1736,6 +1736,7 @@ export type Ga4SessionHistoryEntry = {
     sessions: number;
     organicSessions: number;
     users: number;
+    usersSource: 'deduplicated' | 'landing-page-sum';
 };
 
 export type Ga4SocialReferralHistoryEntry = {

--- a/packages/api-routes/src/ga-session-history.ts
+++ b/packages/api-routes/src/ga-session-history.ts
@@ -1,0 +1,52 @@
+import type { GA4SessionHistoryEntry } from '@ainyc/canonry-contracts'
+
+/** One day's landing-page-dimensioned aggregation from `ga_traffic_snapshots`. */
+export interface LandingPageDayAggregate {
+  date: string
+  sessions: number
+  organicSessions: number
+  /** `SUM(users)` across landing pages — overcounts, used only as a fallback. */
+  users: number
+}
+
+/** One day's property-level totals from `ga_daily_totals` (no page dimension). */
+export interface DailyTotalRow {
+  date: string
+  users: number
+}
+
+/**
+ * Build the daily session series, taking `users` from the deduplicated
+ * property-level totals whenever that day has been synced.
+ *
+ * Why this exists: `users` is not additive across landing pages. GA counts one
+ * visitor who reads three pages as ONE user, but that visitor contributes to
+ * three `ga_traffic_snapshots` rows, so `SUM(users) GROUP BY date` inflates the
+ * day. `ga_daily_totals` stores the same day fetched with only the `date`
+ * dimension, letting GA do the dedup, so it matches what the GA UI reports.
+ *
+ * `sessions` and `organicSessions` keep coming from the landing-page rows:
+ * GA4 attributes exactly one landing page per session, so summing them is
+ * correct, and organic has no property-level counterpart in this table.
+ *
+ * Days synced before this table existed have no total row. Rather than silently
+ * mixing two methodologies along one x-axis, each entry reports which one
+ * produced its `users` via `usersSource`.
+ */
+export function buildSessionHistory(
+  landingPageDays: readonly LandingPageDayAggregate[],
+  dailyTotals: readonly DailyTotalRow[],
+): GA4SessionHistoryEntry[] {
+  const totalsByDate = new Map(dailyTotals.map((row) => [row.date, row.users]))
+
+  return landingPageDays.map((day) => {
+    const deduplicated = totalsByDate.get(day.date)
+    return {
+      date: day.date,
+      sessions: day.sessions,
+      organicSessions: day.organicSessions,
+      users: deduplicated ?? day.users,
+      usersSource: deduplicated === undefined ? 'landing-page-sum' as const : 'deduplicated' as const,
+    }
+  })
+}

--- a/packages/api-routes/src/ga.ts
+++ b/packages/api-routes/src/ga.ts
@@ -1,15 +1,17 @@
 import crypto from 'node:crypto'
 import { eq, desc, and, sql } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
-import { gaTrafficSnapshots, gaTrafficSummaries, gaTrafficWindowSummaries, gaAiReferrals, gaSocialReferrals, runs } from '@ainyc/canonry-db'
+import { gaTrafficSnapshots, gaTrafficSummaries, gaTrafficWindowSummaries, gaDailyTotals, gaAiReferrals, gaSocialReferrals, runs } from '@ainyc/canonry-db'
 import { AiReferralTrafficClasses, classifyAiReferralTrafficClass, validationError, notFound, RunKinds, RunStatuses, RunTriggers, parseWindow, windowCutoff, normalizeUrlPath } from '@ainyc/canonry-contracts'
 import type { AiReferralTrafficClass, GA4ChannelBreakdownDto } from '@ainyc/canonry-contracts'
 import { resolveProject, writeAuditLog } from './helpers.js'
+import { buildSessionHistory } from './ga-session-history.js'
 import {
   getAccessToken,
   fetchTrafficByLandingPage,
   fetchAggregateSummary,
   fetchWindowSummary,
+  fetchDailyTotals,
   fetchAiReferrals,
   fetchSocialReferrals,
   verifyConnection,
@@ -464,6 +466,9 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
     app.db.delete(gaTrafficSummaries)
       .where(eq(gaTrafficSummaries.projectId, project.id))
       .run()
+    app.db.delete(gaDailyTotals)
+      .where(eq(gaDailyTotals.projectId, project.id))
+      .run()
     app.db.delete(gaAiReferrals)
       .where(eq(gaAiReferrals.projectId, project.id))
       .run()
@@ -573,9 +578,14 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       // Windowed summaries (7d/30d/90d) are fetched alongside so the dashboard can show
       // deduplicated totalUsers per window without summing per-page snapshots (overcounts).
       const WINDOW_KEYS = ['7d', '30d', '90d'] as const
+      // Daily totals carry NO landing-page dimension, so GA deduplicates
+      // `users` per day. Fetched unconditionally alongside the summary for the
+      // same reason the summary is: the daily series is a foundation read, not
+      // a channel breakdown the `only` flag scopes.
       const fetches: Promise<unknown>[] = [
         fetchAggregateSummary(accessToken, propertyId, days),
         ...WINDOW_KEYS.map((w) => fetchWindowSummary(accessToken, propertyId, w)),
+        fetchDailyTotals(accessToken, propertyId, days),
       ]
       if (syncTraffic) fetches.push(fetchTrafficByLandingPage(accessToken, propertyId, days))
       if (syncAi) fetches.push(fetchAiReferrals(accessToken, propertyId, days))
@@ -584,7 +594,8 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       const results = await Promise.all(fetches)
       const summary: Awaited<ReturnType<typeof fetchAggregateSummary>> = results[0] as Awaited<ReturnType<typeof fetchAggregateSummary>>
       const windowSummaries = results.slice(1, 1 + WINDOW_KEYS.length) as Array<Awaited<ReturnType<typeof fetchWindowSummary>>>
-      let idx = 1 + WINDOW_KEYS.length
+      const dailyTotals = results[1 + WINDOW_KEYS.length] as Awaited<ReturnType<typeof fetchDailyTotals>>
+      let idx = 2 + WINDOW_KEYS.length
       if (syncTraffic) { rows = results[idx++] as typeof rows }
       if (syncAi) { aiReferrals = results[idx++] as typeof aiReferrals }
       if (syncSocial) { socialReferrals = results[idx++] as typeof socialReferrals }
@@ -620,6 +631,34 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
               syncRunId: runId,
             }).run()
           }
+        }
+
+        // Deduplicated per-day totals. Written on every sync (not gated on
+        // `syncTraffic`) because they are the honest denominator for the daily
+        // series regardless of which breakdowns were refreshed. Delete-range
+        // then insert keeps the unique (project, date) index clean when a
+        // re-sync covers days that already have a row.
+        tx.delete(gaDailyTotals)
+          .where(
+            and(
+              eq(gaDailyTotals.projectId, project.id),
+              sql`${gaDailyTotals.date} >= ${summary.periodStart}`,
+              sql`${gaDailyTotals.date} <= ${summary.periodEnd}`,
+            ),
+          )
+          .run()
+
+        for (const row of dailyTotals) {
+          tx.insert(gaDailyTotals).values({
+            id: crypto.randomUUID(),
+            projectId: project.id,
+            date: row.date,
+            sessions: row.sessions,
+            users: row.users,
+            syncedAt: now,
+            syncRunId: runId,
+            createdAt: now,
+          }).run()
         }
 
         if (syncAi) {
@@ -1399,12 +1438,25 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       .orderBy(gaTrafficSnapshots.date)
       .all()
 
-    return rows.map((r) => ({
-      date: r.date,
-      sessions: r.sessions ?? 0,
-      organicSessions: r.organicSessions ?? 0,
-      users: r.users ?? 0,
-    }))
+    // Deduplicated per-day users, where synced. See `buildSessionHistory` for
+    // why the landing-page sum cannot be trusted for this metric.
+    const totalConditions = [eq(gaDailyTotals.projectId, project.id)]
+    if (cutoffDate) totalConditions.push(sql`${gaDailyTotals.date} >= ${cutoffDate}`)
+    const totals = app.db
+      .select({ date: gaDailyTotals.date, users: gaDailyTotals.users })
+      .from(gaDailyTotals)
+      .where(and(...totalConditions))
+      .all()
+
+    return buildSessionHistory(
+      rows.map((r) => ({
+        date: r.date,
+        sessions: r.sessions ?? 0,
+        organicSessions: r.organicSessions ?? 0,
+        users: r.users ?? 0,
+      })),
+      totals,
+    )
   })
 
   // GET /projects/:name/ga/coverage

--- a/packages/api-routes/test/db-dto-coverage.test.ts
+++ b/packages/api-routes/test/db-dto-coverage.test.ts
@@ -398,6 +398,10 @@ const COVERAGE: Record<string, CoverageEntry> = {
     dto: ga4ConnectionDtoSchema,
     internal: {},
   },
+  gaDailyTotals: {
+    kind: 'internal-only',
+    reason: 'Property-level daily GA4 totals (no landing-page dim), the deduplicated `users` source for the session-history response. Backing store only — its values reach callers through that response, not as a direct row DTO. Mirrors gscDailyTotals.',
+  },
   gaTrafficSnapshots: {
     kind: 'dto',
     dto: ga4TrafficSnapshotDtoSchema,

--- a/packages/api-routes/test/ga-session-history.test.ts
+++ b/packages/api-routes/test/ga-session-history.test.ts
@@ -1,0 +1,87 @@
+import { test, expect, describe } from 'vitest'
+import { buildSessionHistory } from '../src/ga-session-history.js'
+
+/**
+ * The bug this guards: `users` is not additive across landing pages. A real
+ * project's 2026-07-20 had 55 landing-page rows summing to 192 users while GA
+ * reported 158 — a 22% overcount that made canonry look wrong next to the GA UI.
+ */
+describe('buildSessionHistory', () => {
+  test('prefers the deduplicated daily total over the landing-page sum', () => {
+    const result = buildSessionHistory(
+      [{ date: '2026-07-20', sessions: 197, organicSessions: 120, users: 192 }],
+      [{ date: '2026-07-20', users: 158 }],
+    )
+
+    expect(result).toEqual([{
+      date: '2026-07-20',
+      sessions: 197,
+      organicSessions: 120,
+      users: 158,
+      usersSource: 'deduplicated',
+    }])
+  })
+
+  test('falls back to the landing-page sum when the day has no total row', () => {
+    const result = buildSessionHistory(
+      [{ date: '2026-05-01', sessions: 40, organicSessions: 25, users: 61 }],
+      [],
+    )
+
+    expect(result[0]!.users).toBe(61)
+    expect(result[0]!.usersSource).toBe('landing-page-sum')
+  })
+
+  test('labels each day independently across a partially-backfilled series', () => {
+    const result = buildSessionHistory(
+      [
+        { date: '2026-05-01', sessions: 40, organicSessions: 25, users: 61 },
+        { date: '2026-07-20', sessions: 197, organicSessions: 120, users: 192 },
+      ],
+      [{ date: '2026-07-20', users: 158 }],
+    )
+
+    expect(result.map((r) => r.usersSource)).toEqual(['landing-page-sum', 'deduplicated'])
+    expect(result.map((r) => r.users)).toEqual([61, 158])
+  })
+
+  test('never invents a day the landing-page series does not have', () => {
+    // A total row outside the requested window must not add a point to the
+    // series — the landing-page rows define which days exist.
+    const result = buildSessionHistory(
+      [{ date: '2026-07-20', sessions: 197, organicSessions: 120, users: 192 }],
+      [{ date: '2026-07-20', users: 158 }, { date: '2026-07-19', users: 140 }],
+    )
+
+    expect(result).toHaveLength(1)
+    expect(result[0]!.date).toBe('2026-07-20')
+  })
+
+  test('keeps sessions and organicSessions from the landing-page rows', () => {
+    // Sessions ARE additive (GA4 attributes one landing page per session), so
+    // the dedup fix must not touch them.
+    const result = buildSessionHistory(
+      [{ date: '2026-07-20', sessions: 197, organicSessions: 120, users: 192 }],
+      [{ date: '2026-07-20', users: 158 }],
+    )
+
+    expect(result[0]!.sessions).toBe(197)
+    expect(result[0]!.organicSessions).toBe(120)
+  })
+
+  test('honors a zero deduplicated total instead of falling back', () => {
+    // 0 is a real measurement; `?? fallback` on a nullish check must not treat
+    // it as missing.
+    const result = buildSessionHistory(
+      [{ date: '2026-07-20', sessions: 0, organicSessions: 0, users: 3 }],
+      [{ date: '2026-07-20', users: 0 }],
+    )
+
+    expect(result[0]!.users).toBe(0)
+    expect(result[0]!.usersSource).toBe('deduplicated')
+  })
+
+  test('returns an empty series when the project has no traffic rows', () => {
+    expect(buildSessionHistory([], [{ date: '2026-07-20', users: 158 }])).toEqual([])
+  })
+})

--- a/packages/api-routes/test/ga.test.ts
+++ b/packages/api-routes/test/ga.test.ts
@@ -6,7 +6,7 @@ import crypto from 'node:crypto'
 import Fastify from 'fastify'
 import { eq, inArray } from 'drizzle-orm'
 import { RunKinds, RunStatuses, RunTriggers } from '@ainyc/canonry-contracts'
-import { createClient, migrate, gaAiReferrals, gaSocialReferrals, gaTrafficSnapshots, gaTrafficSummaries, gaTrafficWindowSummaries, runs } from '@ainyc/canonry-db'
+import { createClient, migrate, gaAiReferrals, gaSocialReferrals, gaTrafficSnapshots, gaTrafficSummaries, gaTrafficWindowSummaries, gaDailyTotals, runs } from '@ainyc/canonry-db'
 import { apiRoutes } from '../src/index.js'
 import type { Ga4CredentialStore, Ga4CredentialRecord } from '../src/ga.js'
 
@@ -247,6 +247,12 @@ describe('GA4 routes', () => {
       totalDirectSessions: windowKey === '7d' ? 4 : windowKey === '30d' ? 16 : 40,
       totalUsers: windowKey === '7d' ? 15 : windowKey === '30d' ? 55 : 140,
     }))
+    // Deduplicated per-day users. Deliberately BELOW the landing-page sums
+    // (40 / 25) — that gap is the bug this table exists to close.
+    const fetchDailyTotalsSpy = vi.spyOn(gaModule, 'fetchDailyTotals').mockResolvedValue([
+      { date: '2026-03-19', sessions: 50, users: 33 },
+      { date: '2026-03-20', sessions: 30, users: 21 },
+    ])
     const fetchAiReferralsSpy = vi.spyOn(gaModule, 'fetchAiReferrals').mockResolvedValue([
       { date: '2026-03-20', source: 'chatgpt.com', medium: 'referral', trafficClass: 'organic', channelGroup: 'Referral', landingPage: '/pricing?utm_source=chatgpt.com', sessions: 12, users: 9, sourceDimension: 'session' },
     ])
@@ -304,6 +310,19 @@ describe('GA4 routes', () => {
     expect(byKey['30d']!.totalDirectSessions).toBe(16)
     expect(windowSummaries.every((r) => r.syncRunId === gaRuns[0]!.id)).toBe(true)
 
+    // Deduplicated per-day totals persisted. These are the numbers the daily
+    // series must report — NOT the landing-page sums (40 / 25), which count a
+    // multi-page visitor once per page.
+    const dailyTotals = db.select().from(gaDailyTotals)
+      .where(eq(gaDailyTotals.projectId, projectId))
+      .all()
+      .sort((a, b) => a.date.localeCompare(b.date))
+    expect(dailyTotals.map((r) => [r.date, r.users])).toEqual([
+      ['2026-03-19', 33],
+      ['2026-03-20', 21],
+    ])
+    expect(dailyTotals.every((r) => r.syncRunId === gaRuns[0]!.id)).toBe(true)
+
     const aiReferrals = db.select().from(gaAiReferrals)
       .where(eq(gaAiReferrals.projectId, projectId))
       .all()
@@ -328,6 +347,7 @@ describe('GA4 routes', () => {
     fetchTrafficSpy.mockRestore()
     fetchAggregateSpy.mockRestore()
     fetchWindowSummarySpy.mockRestore()
+    fetchDailyTotalsSpy.mockRestore()
     fetchAiReferralsSpy.mockRestore()
     fetchSocialReferralsSpy.mockRestore()
     credentials.delete('test-project')
@@ -397,6 +417,7 @@ describe('GA4 routes', () => {
       totalDirectSessions: 0,
       totalUsers: 0,
     }))
+    const fetchDailyTotalsSpy = vi.spyOn(gaModule, 'fetchDailyTotals').mockResolvedValue([])
     const fetchAiReferralsSpy = vi.spyOn(gaModule, 'fetchAiReferrals').mockResolvedValue([])
     const fetchSocialReferralsSpy = vi.spyOn(gaModule, 'fetchSocialReferrals').mockResolvedValue([])
 
@@ -414,6 +435,7 @@ describe('GA4 routes', () => {
     fetchTrafficSpy.mockRestore()
     fetchAggregateSpy.mockRestore()
     fetchWindowSummarySpy.mockRestore()
+    fetchDailyTotalsSpy.mockRestore()
     fetchAiReferralsSpy.mockRestore()
     fetchSocialReferralsSpy.mockRestore()
     credentials.delete('test-project')
@@ -475,6 +497,9 @@ describe('GA4 routes', () => {
       totalDirectSessions: 5000,
       totalUsers: 22000,
     }))
+    const fetchDailyTotalsSpy = vi.spyOn(gaModule, 'fetchDailyTotals').mockResolvedValue([
+      { date: today, sessions: 30000, users: 22000 },
+    ])
     const fetchAiReferralsSpy = vi.spyOn(gaModule, 'fetchAiReferrals').mockResolvedValue([])
     const fetchSocialReferralsSpy = vi.spyOn(gaModule, 'fetchSocialReferrals').mockResolvedValue([
       { date: today, source: 'facebook.com', medium: 'referral', sessions: 1273, users: 900, channelGroup: 'Organic Social' },
@@ -539,6 +564,7 @@ describe('GA4 routes', () => {
       fetchTrafficSpy.mockRestore()
       fetchAggregateSpy.mockRestore()
       fetchWindowSummarySpy.mockRestore()
+      fetchDailyTotalsSpy.mockRestore()
       fetchAiReferralsSpy.mockRestore()
       fetchSocialReferralsSpy.mockRestore()
       credentials.delete('only-social-foundation')
@@ -2188,6 +2214,19 @@ describe('GA4 routes', () => {
       syncedAt: now,
     }).run()
 
+    // 2026-03-17 has a deduplicated total (9) intentionally LOWER than the
+    // landing-page sum (8 + 4 = 12) — one visitor read both pages. 03-18 is
+    // left without one so the legacy fallback is exercised in the same series.
+    db.insert(gaDailyTotals).values({
+      id: crypto.randomUUID(),
+      projectId,
+      date: '2026-03-17',
+      sessions: 15,
+      users: 9,
+      syncedAt: now,
+      createdAt: now,
+    }).run()
+
     const res = await app.inject({
       method: 'GET',
       url: '/api/v1/projects/test-project/ga/session-history',
@@ -2199,13 +2238,17 @@ describe('GA4 routes', () => {
       sessions: number
       organicSessions: number
       users: number
+      usersSource: string
     }>
     expect(body).toEqual([
-      { date: '2026-03-17', sessions: 15, organicSessions: 5, users: 12 },
-      { date: '2026-03-18', sessions: 7, organicSessions: 3, users: 6 },
+      { date: '2026-03-17', sessions: 15, organicSessions: 5, users: 9, usersSource: 'deduplicated' },
+      { date: '2026-03-18', sessions: 7, organicSessions: 3, users: 6, usersSource: 'landing-page-sum' },
     ])
 
     credentials.delete('test-project')
+    db.delete(gaDailyTotals)
+      .where(eq(gaDailyTotals.projectId, projectId))
+      .run()
     db.delete(gaTrafficSnapshots)
       .where(eq(gaTrafficSnapshots.projectId, projectId))
       .run()

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.123.0",
+  "version": "4.124.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/commands/ga.ts
+++ b/packages/canonry/src/commands/ga.ts
@@ -328,9 +328,17 @@ export async function gaSessionHistory(project: string, opts?: { window?: string
   console.log(`  ${'DATE'.padEnd(dateWidth)}  ${'SESSIONS'.padEnd(10)}${'ORGANIC'.padEnd(10)}${'USERS'.padEnd(8)}`)
   console.log(`  ${'─'.repeat(dateWidth)}  ${'─'.repeat(10)}${'─'.repeat(10)}${'─'.repeat(8)}`)
   for (const row of result) {
+    // Mark days whose user count is the older per-page sum so a mixed series
+    // never reads as one consistent measurement.
+    const users = row.usersSource === 'deduplicated' ? String(row.users) : `${row.users}*`
     console.log(
-      `  ${row.date.padEnd(dateWidth)}  ${String(row.sessions).padEnd(10)}${String(row.organicSessions).padEnd(10)}${String(row.users).padEnd(8)}`,
+      `  ${row.date.padEnd(dateWidth)}  ${String(row.sessions).padEnd(10)}${String(row.organicSessions).padEnd(10)}${users.padEnd(8)}`,
     )
+  }
+  if (result.some((row) => row.usersSource !== 'deduplicated')) {
+    console.log('\n  * Visitor count is approximate — it adds up each page a visitor landed on,')
+    console.log('    so someone who read several pages is counted more than once. Run')
+    console.log(`    "canonry ga sync ${project}" to replace these with exact counts.`)
   }
 }
 

--- a/packages/contracts/src/formatting.ts
+++ b/packages/contracts/src/formatting.ts
@@ -147,3 +147,18 @@ export function formatWindowCountDelta(
   const sign = d.deltaAbs > 0 ? '+' : ''
   return `${sign}${formatNumber(Math.round(d.deltaAbs))} ${countLabel} ${windowLabel}`
 }
+
+/**
+ * Convert a compact `YYYYMMDD` calendar date to ISO `YYYY-MM-DD`.
+ *
+ * Google's reporting APIs return the `date` dimension in the compact form
+ * while canonry stores and compares ISO dates everywhere. Values that are
+ * already ISO (or any other shape) are returned unchanged, so this is safe to
+ * apply to a mixed series and safe to re-apply.
+ *
+ * Pure string surgery — no Date construction, so no timezone can shift the day.
+ */
+export function compactDateToIso(value: string): string {
+  if (value.length !== 8 || !/^\d{8}$/.test(value)) return value
+  return `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}`
+}

--- a/packages/contracts/src/ga.ts
+++ b/packages/contracts/src/ga.ts
@@ -388,6 +388,17 @@ export const ga4SessionHistoryEntrySchema = z.object({
   date: z.string(),
   sessions: z.number(),
   organicSessions: z.number(),
+  /**
+   * Unique visitors for the day. Deduplicated by GA when `usersSource` is
+   * `deduplicated`; a landing-page sum (which overcounts multi-page visitors)
+   * for days synced before per-day totals were captured.
+   */
   users: z.number(),
+  /**
+   * How `users` was derived. `deduplicated` matches the GA UI's active users;
+   * `landing-page-sum` is the legacy overcount kept so historical days still
+   * render. Never compare the two across a series without saying which is which.
+   */
+  usersSource: z.enum(['deduplicated', 'landing-page-sum']),
 })
 export type GA4SessionHistoryEntry = z.infer<typeof ga4SessionHistoryEntrySchema>

--- a/packages/contracts/test/formatting.test.ts
+++ b/packages/contracts/test/formatting.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import {
   MIN_PCT_BASE,
+  compactDateToIso,
   deltaPercent,
   deltaTone,
   formatAverageDelta,
@@ -258,5 +259,30 @@ describe('parseInclusiveEndMs', () => {
 
   test('returns null for an unparseable value', () => {
     expect(parseInclusiveEndMs('not-a-date')).toBeNull()
+  })
+})
+
+describe('compactDateToIso', () => {
+  test('converts a GA4 compact date to ISO', () => {
+    expect(compactDateToIso('20260720')).toBe('2026-07-20')
+  })
+
+  test('leaves an already-ISO date untouched (idempotent)', () => {
+    expect(compactDateToIso('2026-07-20')).toBe('2026-07-20')
+    expect(compactDateToIso(compactDateToIso('20260720'))).toBe('2026-07-20')
+  })
+
+  test('passes through values that are not 8 digits', () => {
+    expect(compactDateToIso('')).toBe('')
+    expect(compactDateToIso('(other)')).toBe('(other)')
+    expect(compactDateToIso('2026072')).toBe('2026072')
+    expect(compactDateToIso('2026-7-20')).toBe('2026-7-20')
+  })
+
+  test('does not shift the day across timezones', () => {
+    // Pure string surgery — no Date construction, so a UTC-negative offset
+    // cannot roll the date back to the 19th.
+    expect(compactDateToIso('20260101')).toBe('2026-01-01')
+    expect(compactDateToIso('20261231')).toBe('2026-12-31')
   })
 })

--- a/packages/db/AGENTS.md
+++ b/packages/db/AGENTS.md
@@ -18,7 +18,7 @@ Drizzle ORM schema, migrations, and database client. SQLite locally (via better-
 
 - **Core domain**: projects, queries, competitors, runs, querySnapshots, auditLog
 - **Scheduling**: schedules, notifications, webhooks
-- **Integrations**: googleConnections (metadata only — credentials in config.yaml), gscData, gscDailyTotals (property-level daily totals — headline/trend source), urlInspections, gscCoverage, gscTraffic, bingConnections, bingUrlInspections, bingKeywordStats, ga4Connections (metadata only — credentials in config.yaml), ga4TrafficSnapshots, ga4AiReferrals, ga4Summaries, gaSocialReferrals
+- **Integrations**: googleConnections (metadata only — credentials in config.yaml), gscData, gscDailyTotals (property-level daily totals — headline/trend source), urlInspections, gscCoverage, gscTraffic, bingConnections, bingUrlInspections, bingKeywordStats, ga4Connections (metadata only — credentials in config.yaml), ga4TrafficSnapshots, gaDailyTotals (property-level daily totals — deduplicated `users`, unlike the per-page snapshots), ga4AiReferrals, ga4Summaries, gaSocialReferrals
 - **System**: apiKeys, usageCounters
 
 ## Patterns

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -2351,11 +2351,12 @@ export const MIGRATION_VERSIONS: ReadonlyArray<MigrationVersion> = [
         sessions     INTEGER NOT NULL DEFAULT 0,
         users        INTEGER NOT NULL DEFAULT 0,
         synced_at    TEXT NOT NULL,
-        sync_run_id  TEXT,
+        sync_run_id  TEXT REFERENCES runs(id) ON DELETE CASCADE,
         created_at   TEXT NOT NULL
       )`,
       `CREATE UNIQUE INDEX IF NOT EXISTS idx_ga_daily_totals_project_date ON ga_daily_totals(project_id, date)`,
       `CREATE INDEX IF NOT EXISTS idx_ga_daily_totals_project ON ga_daily_totals(project_id)`,
+      `CREATE INDEX IF NOT EXISTS idx_ga_daily_totals_run ON ga_daily_totals(sync_run_id)`,
     ],
   },
 ]

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -2334,6 +2334,30 @@ export const MIGRATION_VERSIONS: ReadonlyArray<MigrationVersion> = [
       backfillQuerySnapshotServedModel(tx)
     },
   },
+  {
+    // `users` is not additive across landing pages — one visitor who lands on
+    // three pages is one user but contributes to three `ga_traffic_snapshots`
+    // rows. Summing that dimensioned table overcounts the day. This table
+    // stores the same day fetched with NO landing-page dimension, so GA does
+    // the dedup and the stored number matches the GA UI. Same shape and
+    // rationale as `gsc_daily_totals`.
+    version: 106,
+    name: 'ga-daily-totals',
+    statements: [
+      `CREATE TABLE IF NOT EXISTS ga_daily_totals (
+        id           TEXT PRIMARY KEY,
+        project_id   TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+        date         TEXT NOT NULL,
+        sessions     INTEGER NOT NULL DEFAULT 0,
+        users        INTEGER NOT NULL DEFAULT 0,
+        synced_at    TEXT NOT NULL,
+        sync_run_id  TEXT,
+        created_at   TEXT NOT NULL
+      )`,
+      `CREATE UNIQUE INDEX IF NOT EXISTS idx_ga_daily_totals_project_date ON ga_daily_totals(project_id, date)`,
+      `CREATE INDEX IF NOT EXISTS idx_ga_daily_totals_project ON ga_daily_totals(project_id)`,
+    ],
+  },
 ]
 
 /**

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -450,6 +450,36 @@ export const gaTrafficSnapshots = sqliteTable('ga_traffic_snapshots', {
   index('idx_ga_traffic_run').on(table.syncRunId),
 ])
 
+/**
+ * Property-level GA4 totals for one day, fetched with NO landing-page
+ * dimension — the daily counterpart to `ga_summaries`' windowed totals.
+ *
+ * Exists because `users` is not additive across a dimension: one visitor who
+ * lands on three pages is ONE user but appears in three `ga_traffic_snapshots`
+ * rows, so `SUM(users) GROUP BY date` overcounts (a real project showed 192 vs
+ * GA's 158 for a single day). GA does the dedup when the report carries only
+ * the date dimension, so these rows match the GA UI.
+ *
+ * `sessions` comes back in the same response and is stored alongside, so the
+ * property-level session count is available without a second fetch. Nothing
+ * reads it yet: sessions ARE additive (GA4 attributes one landing page per
+ * session), so the landing-page sum is already correct for them and carries
+ * the organic split this table does not. Same shape as `gsc_daily_totals`.
+ */
+export const gaDailyTotals = sqliteTable('ga_daily_totals', {
+  id: text('id').primaryKey(),
+  projectId: text('project_id').notNull().references(() => projects.id, { onDelete: 'cascade' }),
+  date: text('date').notNull(),
+  sessions: integer('sessions').notNull().default(0),
+  users: integer('users').notNull().default(0),
+  syncedAt: text('synced_at').notNull(),
+  syncRunId: text('sync_run_id').references(() => runs.id, { onDelete: 'cascade' }),
+  createdAt: text('created_at').notNull(),
+}, (table) => [
+  uniqueIndex('idx_ga_daily_totals_project_date').on(table.projectId, table.date),
+  index('idx_ga_daily_totals_project').on(table.projectId),
+])
+
 export const gaAiReferrals = sqliteTable('ga_ai_referrals', {
   id: text('id').primaryKey(),
   projectId: text('project_id').notNull().references(() => projects.id, { onDelete: 'cascade' }),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -478,6 +478,7 @@ export const gaDailyTotals = sqliteTable('ga_daily_totals', {
 }, (table) => [
   uniqueIndex('idx_ga_daily_totals_project_date').on(table.projectId, table.date),
   index('idx_ga_daily_totals_project').on(table.projectId),
+  index('idx_ga_daily_totals_run').on(table.syncRunId),
 ])
 
 export const gaAiReferrals = sqliteTable('ga_ai_referrals', {

--- a/packages/db/test/ga-daily-totals.test.ts
+++ b/packages/db/test/ga-daily-totals.test.ts
@@ -46,6 +46,51 @@ describe('ga_daily_totals migration', () => {
     }
   })
 
+  test('declares both foreign keys the schema requires', () => {
+    // A CREATE TABLE that omits a REFERENCES clause still accepts every INSERT
+    // and only shows up as orphaned rows much later. SQLite cannot add a FK to
+    // an existing column, so this drift is expensive once shipped — assert the
+    // constraint list directly rather than inferring it from behavior alone.
+    const { db, tmpDir } = tempDb()
+    try {
+      const fks = db.$client
+        .prepare(`PRAGMA foreign_key_list(ga_daily_totals)`)
+        .all() as Array<{ table: string; from: string; to: string; on_delete: string }>
+      const byColumn = Object.fromEntries(fks.map((fk) => [fk.from, fk]))
+
+      expect(byColumn.project_id).toMatchObject({ table: 'projects', to: 'id', on_delete: 'CASCADE' })
+      expect(byColumn.sync_run_id).toMatchObject({ table: 'runs', to: 'id', on_delete: 'CASCADE' })
+    } finally {
+      db.$client.close()
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  test('cascades away with the run that produced it', () => {
+    const { db, tmpDir } = tempDb()
+    try {
+      db.$client
+        .prepare(`INSERT INTO runs (id, project_id, kind, status, trigger, created_at)
+                  VALUES ('run1','p1','ga-sync','completed','manual','2026-07-21T00:00:00Z')`)
+        .run()
+      db.$client
+        .prepare(`INSERT INTO ga_daily_totals (id, project_id, date, sessions, users, synced_at, sync_run_id, created_at)
+                  VALUES ('r1','p1','2026-07-20',100,158,'2026-07-21T00:00:00Z','run1','2026-07-21T00:00:00Z')`)
+        .run()
+
+      // Deleting the sync run must take its totals with it. Without the FK the
+      // row survives, leaving a total whose provenance points at nothing.
+      db.$client.prepare(`DELETE FROM runs WHERE id='run1'`).run()
+      const remaining = db.$client
+        .prepare(`SELECT COUNT(*) AS n FROM ga_daily_totals`)
+        .get() as { n: number }
+      expect(remaining.n).toBe(0)
+    } finally {
+      db.$client.close()
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
   test('cascades away with its project', () => {
     const { db, tmpDir } = tempDb()
     try {

--- a/packages/db/test/ga-daily-totals.test.ts
+++ b/packages/db/test/ga-daily-totals.test.ts
@@ -1,0 +1,63 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { test, expect, describe } from 'vitest'
+import { createClient, migrate } from '../src/index.js'
+
+function tempDb() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-ga-daily-totals-'))
+  const db = createClient(path.join(tmpDir, 'test.db'))
+  migrate(db)
+  db.$client
+    .prepare(`INSERT INTO projects (id, name, display_name, canonical_domain, country, language, created_at, updated_at)
+              VALUES ('p1','proj','Proj','example.com','US','en','2026-07-20T00:00:00Z','2026-07-20T00:00:00Z')`)
+    .run()
+  return { db, tmpDir }
+}
+
+function insert(db: ReturnType<typeof createClient>, id: string, date: string, users: number) {
+  db.$client
+    .prepare(`INSERT INTO ga_daily_totals (id, project_id, date, sessions, users, synced_at, created_at)
+              VALUES (?, 'p1', ?, 100, ?, '2026-07-21T00:00:00Z', '2026-07-21T00:00:00Z')`)
+    .run(id, date, users)
+}
+
+describe('ga_daily_totals migration', () => {
+  test('creates the table with a working unique (project_id, date) index', () => {
+    const { db, tmpDir } = tempDb()
+    try {
+      insert(db, 'r1', '2026-07-20', 158)
+      // A second row for the same project+date must be rejected, so a re-sync
+      // can never leave two competing totals for one day.
+      expect(() => insert(db, 'r2', '2026-07-20', 999)).toThrow(/UNIQUE/i)
+
+      // A different day is fine.
+      insert(db, 'r3', '2026-07-19', 140)
+      const rows = db.$client
+        .prepare(`SELECT date, users FROM ga_daily_totals WHERE project_id='p1' ORDER BY date`)
+        .all()
+      expect(rows).toEqual([
+        { date: '2026-07-19', users: 140 },
+        { date: '2026-07-20', users: 158 },
+      ])
+    } finally {
+      db.$client.close()
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  test('cascades away with its project', () => {
+    const { db, tmpDir } = tempDb()
+    try {
+      insert(db, 'r1', '2026-07-20', 158)
+      db.$client.prepare(`DELETE FROM projects WHERE id='p1'`).run()
+      const remaining = db.$client
+        .prepare(`SELECT COUNT(*) AS n FROM ga_daily_totals`)
+        .get() as { n: number }
+      expect(remaining.n).toBe(0)
+    } finally {
+      db.$client.close()
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/db/test/schema-migration-fk-parity.test.ts
+++ b/packages/db/test/schema-migration-fk-parity.test.ts
@@ -1,0 +1,105 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { test, expect } from 'vitest'
+import { getTableConfig } from 'drizzle-orm/sqlite-core'
+import { createClient, migrate } from '../src/index.js'
+import * as schema from '../src/schema.js'
+
+/**
+ * `schema.ts` is the type-level contract; `migrate.ts` is what actually reaches
+ * disk. Nothing ties them together, so a `CREATE TABLE` that omits a REFERENCES
+ * clause type-checks, lints, and passes every behavioral test — the table just
+ * silently loses referential integrity. The failure surfaces much later as
+ * orphaned rows pointing at deleted parents.
+ *
+ * That drift is unusually expensive to repair: SQLite cannot add a foreign key
+ * to an existing column, so a shipped migration has to be fixed with a full
+ * table rebuild (see `rebuildBacklinkTableWithSource`). Catching it before the
+ * migration ships keeps it a one-line change.
+ *
+ * This migrates a fresh database and compares every foreign key drizzle
+ * declares against what SQLite actually created.
+ */
+
+interface SqliteForeignKey {
+  from: string
+  table: string
+  to: string
+  on_delete: string
+}
+
+function normalizeAction(action: string | undefined): string {
+  // Drizzle spells it 'cascade'; SQLite reports 'CASCADE'. Absent means SQLite's
+  // default, which it reports as 'NO ACTION'.
+  return (action ?? 'no action').toUpperCase()
+}
+
+test('every foreign key declared in schema.ts exists in the migrated database', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-fk-parity-'))
+  const db = createClient(path.join(tmpDir, 'test.db'))
+  try {
+    migrate(db)
+
+    const problems: string[] = []
+    let tablesChecked = 0
+    let foreignKeysChecked = 0
+
+    for (const exported of Object.values(schema)) {
+      let config
+      try {
+        config = getTableConfig(exported as never)
+      } catch {
+        continue // not a table (enum, helper, type)
+      }
+      tablesChecked++
+
+      const tableExists = db.$client
+        .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name = ?`)
+        .get(config.name)
+      if (!tableExists) {
+        problems.push(`${config.name}: declared in schema.ts but no migration creates it`)
+        continue
+      }
+
+      const actual = db.$client
+        .prepare(`PRAGMA foreign_key_list(${config.name})`)
+        .all() as SqliteForeignKey[]
+      const actualByColumn = new Map(actual.map((fk) => [fk.from, fk]))
+
+      for (const foreignKey of config.foreignKeys) {
+        const reference = foreignKey.reference()
+        const column = reference.columns[0]!.name
+        const referencedTable = getTableConfig(reference.foreignTable as never).name
+        foreignKeysChecked++
+
+        const found = actualByColumn.get(column)
+        if (!found) {
+          problems.push(
+            `${config.name}.${column}: schema.ts declares REFERENCES ${referencedTable}, but the migration created the column with no foreign key`,
+          )
+          continue
+        }
+        if (found.table !== referencedTable) {
+          problems.push(
+            `${config.name}.${column}: schema.ts references ${referencedTable}, migration references ${found.table}`,
+          )
+        }
+        const expectedOnDelete = normalizeAction(foreignKey.onDelete)
+        const actualOnDelete = normalizeAction(found.on_delete)
+        if (expectedOnDelete !== actualOnDelete) {
+          problems.push(
+            `${config.name}.${column}: schema.ts says ON DELETE ${expectedOnDelete}, migration says ON DELETE ${actualOnDelete}`,
+          )
+        }
+      }
+    }
+
+    expect(tablesChecked).toBeGreaterThan(50)
+    expect(foreignKeysChecked).toBeGreaterThan(90)
+    expect(problems, `schema.ts / migrate.ts foreign-key drift:\n  ${problems.join('\n  ')}`).toEqual([])
+  } finally {
+    db.$client.close()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  }
+})

--- a/packages/integration-google-analytics/src/ga4-client.ts
+++ b/packages/integration-google-analytics/src/ga4-client.ts
@@ -1,5 +1,5 @@
 import crypto from 'node:crypto'
-import { AI_ENGINE_DOMAINS, classifyAiReferralTrafficClass, withRetry } from '@ainyc/canonry-contracts'
+import { AI_ENGINE_DOMAINS, classifyAiReferralTrafficClass, compactDateToIso, withRetry } from '@ainyc/canonry-contracts'
 import {
   GA4_DATA_API_BASE,
   GA4_SCOPE,
@@ -517,11 +517,8 @@ export async function fetchTrafficByLandingPage(
     row.directSessions = directMap.get(key) ?? 0
   }
 
-  // Convert YYYYMMDD to YYYY-MM-DD
   for (const row of rows) {
-    if (row.date.length === 8 && !row.date.includes('-')) {
-      row.date = `${row.date.slice(0, 4)}-${row.date.slice(4, 6)}-${row.date.slice(6, 8)}`
-    }
+    row.date = compactDateToIso(row.date)
   }
 
   ga4Log('info', 'fetch-traffic.done', { propertyId, rowCount: rows.length })
@@ -632,6 +629,59 @@ export async function fetchAggregateSummary(
 
   ga4Log('info', 'fetch-aggregate.done', { propertyId, ...summary })
   return summary
+}
+
+export interface GA4DailyTotalRow {
+  date: string
+  sessions: number
+  users: number
+}
+
+/**
+ * Fetch per-day totals with `date` as the ONLY dimension.
+ *
+ * This is `fetchAggregateSummary`'s rationale applied at daily granularity:
+ * `totalUsers` is deduplicated by GA within whatever dimensions the report
+ * carries, so adding a landing-page dimension turns one visitor who read three
+ * pages into three counted users. Requesting only `date` makes GA do the dedup
+ * per day, which is what the GA UI's "Active users" reports.
+ *
+ * `sessions` is returned alongside because it IS additive (GA4 attributes one
+ * landing page per session), which makes it a free consistency check against
+ * the landing-page sum.
+ */
+export async function fetchDailyTotals(
+  accessToken: string,
+  propertyId: string,
+  days?: number,
+): Promise<GA4DailyTotalRow[]> {
+  validateAccessToken(accessToken)
+  validatePropertyId(propertyId)
+
+  const syncDays = Math.min(Math.max(1, days ?? GA4_DEFAULT_SYNC_DAYS), GA4_MAX_SYNC_DAYS)
+  const endDate = new Date()
+  const startDate = new Date()
+  startDate.setDate(startDate.getDate() - syncDays)
+
+  ga4Log('info', 'fetch-daily-totals.start', { propertyId, days: syncDays })
+
+  // One row per day in the range, so the window itself bounds the response —
+  // `+ 1` covers both endpoints being inclusive. No paging needed.
+  const res = await runReport(accessToken, propertyId, {
+    dateRanges: [{ startDate: formatDate(startDate), endDate: formatDate(endDate) }],
+    dimensions: [{ name: DIM.date }],
+    metrics: [{ name: MET.sessions }, { name: MET.totalUsers }],
+    limit: syncDays + 1,
+  })
+
+  const rows: GA4DailyTotalRow[] = (res.rows ?? []).map((row) => ({
+    date: compactDateToIso(row.dimensionValues[0]?.value ?? ''),
+    sessions: parseInt(row.metricValues[0]?.value ?? '0', 10) || 0,
+    users: parseInt(row.metricValues[1]?.value ?? '0', 10) || 0,
+  })).filter((row) => row.date.length > 0)
+
+  ga4Log('info', 'fetch-daily-totals.done', { propertyId, days: syncDays, rows: rows.length })
+  return rows
 }
 
 export interface GA4WindowSummary {
@@ -858,11 +908,8 @@ export async function fetchAiReferrals(
   }
   const dedupedRows = [...deduped.values()]
 
-  // Convert YYYYMMDD to YYYY-MM-DD
   for (const row of dedupedRows) {
-    if (row.date.length === 8 && !row.date.includes('-')) {
-      row.date = `${row.date.slice(0, 4)}-${row.date.slice(4, 6)}-${row.date.slice(6, 8)}`
-    }
+    row.date = compactDateToIso(row.date)
   }
 
   ga4Log('info', 'fetch-ai-referrals.done', { propertyId, rowCount: dedupedRows.length })
@@ -950,11 +997,8 @@ export async function fetchSocialReferrals(
     if (pageRows.length < PAGE_SIZE || offset >= totalRows) break
   }
 
-  // Convert YYYYMMDD to YYYY-MM-DD
   for (const row of rows) {
-    if (row.date.length === 8 && !row.date.includes('-')) {
-      row.date = `${row.date.slice(0, 4)}-${row.date.slice(4, 6)}-${row.date.slice(6, 8)}`
-    }
+    row.date = compactDateToIso(row.date)
   }
 
   ga4Log('info', 'fetch-social-referrals.done', { propertyId, rowCount: rows.length })

--- a/packages/integration-google-analytics/src/index.ts
+++ b/packages/integration-google-analytics/src/index.ts
@@ -4,11 +4,12 @@ export {
   fetchTrafficByLandingPage,
   fetchAggregateSummary,
   fetchWindowSummary,
+  fetchDailyTotals,
   fetchAiReferrals,
   fetchSocialReferrals,
   verifyConnection,
   verifyConnectionWithToken,
 } from './ga4-client.js'
-export type { GA4AggregateSummary, GA4WindowSummary } from './ga4-client.js'
+export type { GA4AggregateSummary, GA4WindowSummary, GA4DailyTotalRow } from './ga4-client.js'
 export * from './constants.js'
 export * from './types.js'


### PR DESCRIPTION
## Context

`GET /projects/:name/ga/session-history` derived each day's `users` from `SUM(ga_traffic_snapshots.users) GROUP BY date`. That table is dimensioned by landing page, and `users` is not additive across that dimension — GA counts a visitor who reads three pages as ONE user, but that visitor produces three rows.

On a real project, 2026-07-20 summed to **192** while GA reported **158** — a 22% overcount, and a recurring "why doesn't this match GA?" question.

The codebase already solved this at window granularity: `fetchWindowSummary` requests 7d/30d/90d totals with no landing-page dimension so GA does the dedup. This applies the same treatment per day.

## What changed

- **`ga_daily_totals`** (migration v106, additive-only) stores one row per project-day, fetched with `date` as the only dimension. Mirrors `gsc_daily_totals`, including the unique `(project_id, date)` index.
- **`fetchDailyTotals`** issues that report; the GA sync persists it with delete-range-then-insert inside the existing transaction, and disconnect clears it.
- **session-history** prefers the stored total, falling back to the old sum for days synced before this existed. A new **`usersSource`** field (`deduplicated` | `landing-page-sum`) reports which produced each number, so a partially-backfilled series never reads as one consistent measurement. The CLI marks fallback days with `*` and explains the caveat in plain language.

Sessions and organic sessions still come from the landing-page rows — GA4 attributes one landing page per session, so summing those is correct and they carry the organic split the new table does not.

Also centralizes the `YYYYMMDD` → ISO conversion that was duplicated inline at three call sites into `compactDateToIso` in contracts. The new guard is stricter (requires 8 digits), so a non-numeric 8-character value is passed through rather than mangled.

## Scope note

Two other `SUM(users)` sites group **per landing page**, where per-page users is the correct grain — unchanged. One more (`/ga/traffic`'s fallback when no window-summary row exists) is the same bug class but pre-existing and already has a preferred deduplicated source when present; left for a separate change rather than widening this one.

## Verification

- New calculation tests cover the dedup preference, the fallback, mixed-methodology labeling, a zero total (not treated as missing), and that a total outside the window never invents a day.
- The route test now proves the behavior end-to-end with one deduplicated day and one fallback day in the same response.
- DB test asserts the unique index actually rejects a duplicate day and that rows cascade with the project.
- `pnpm typecheck` clean, `pnpm lint` 0 errors, full suite **459 files / 5660 tests** passing.

No UI change: the activity chart plots only `sessions` and `organicSessions`, never `users`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)