### PR TITLE
fix(analytics): stop two confirmed non-additive re-aggregations

### DIFF
--- a/packages/api-routes/src/analytics.ts
+++ b/packages/api-routes/src/analytics.ts
@@ -929,7 +929,30 @@ function computeQueryChanges(
   }))
 }
 
-function computeTrend(buckets: TimeBucket[], rateKey: 'citationRate' | 'mentionRate'): TrendDirection {
+/**
+ * Pooled rate across buckets: total numerator over total denominator.
+ *
+ * NOT the mean of the per-bucket rates. A rate is not additive across the
+ * buckets that produced it, so averaging them unweighted lets a bucket holding
+ * 2 snapshots move the verdict as much as one holding 200 — a single sparse
+ * sweep could flip `improving`/`declining` on its own. Pooling the raw counts
+ * weights each bucket by the evidence it actually carries.
+ *
+ * Reads `cited` / `mentionedCount` rather than re-deriving from the rate, so
+ * the already-rounded per-bucket rate never compounds into the comparison.
+ */
+export function pooledRate(buckets: TimeBucket[], rateKey: 'citationRate' | 'mentionRate'): number {
+  const countKey = rateKey === 'citationRate' ? 'cited' : 'mentionedCount'
+  let numerator = 0
+  let denominator = 0
+  for (const bucket of buckets) {
+    numerator += bucket[countKey]
+    denominator += bucket.total
+  }
+  return denominator > 0 ? numerator / denominator : 0
+}
+
+export function computeTrend(buckets: TimeBucket[], rateKey: 'citationRate' | 'mentionRate'): TrendDirection {
   const nonEmpty = buckets.filter(b => b.total > 0)
   if (nonEmpty.length < 2) return 'stable'
 
@@ -937,8 +960,8 @@ function computeTrend(buckets: TimeBucket[], rateKey: 'citationRate' | 'mentionR
   const firstHalf = nonEmpty.slice(0, mid)
   const secondHalf = nonEmpty.slice(mid)
 
-  const avgFirst = firstHalf.reduce((s, b) => s + b[rateKey], 0) / firstHalf.length
-  const avgSecond = secondHalf.reduce((s, b) => s + b[rateKey], 0) / secondHalf.length
+  const avgFirst = pooledRate(firstHalf, rateKey)
+  const avgSecond = pooledRate(secondHalf, rateKey)
 
   const diff = avgSecond - avgFirst
   // Threshold: 5 percentage points

--- a/packages/api-routes/src/content-data.ts
+++ b/packages/api-routes/src/content-data.ts
@@ -309,11 +309,31 @@ function buildGaTrafficByPage(db: DatabaseClient, projectId: string): Map<string
   return map
 }
 
+/**
+ * Total AI-referral sessions for the project.
+ *
+ * Pinned to the `session` attribution lens. `ga_ai_referrals` holds one row per
+ * `sourceDimension` — `session`, `first_user` and `manual_utm` are three
+ * OVERLAPPING views of the same visits, fetched as three separate GA4 reports,
+ * not three disjoint groups of traffic. Summing across them multiplies the
+ * total by roughly the number of lenses (measured 800 vs 264, a 3.0x inflation,
+ * on a live project).
+ *
+ * Every other consumer already guards this: `report.ts` pins `session` and
+ * `ga.ts` takes the winning lens per tuple via `pickWinningDimension`. Pinning
+ * the same lens here keeps the content engine's denominator consistent with the
+ * report's numerator.
+ */
 function sumAiReferralSessions(db: DatabaseClient, projectId: string): number {
   const rows = db
     .select({ sessions: gaAiReferrals.sessions })
     .from(gaAiReferrals)
-    .where(eq(gaAiReferrals.projectId, projectId))
+    .where(
+      and(
+        eq(gaAiReferrals.projectId, projectId),
+        eq(gaAiReferrals.sourceDimension, 'session'),
+      ),
+    )
     .all()
   return rows.reduce((acc, r) => acc + (r.sessions ?? 0), 0)
 }

--- a/packages/api-routes/test/analytics-trend-weighting.test.ts
+++ b/packages/api-routes/test/analytics-trend-weighting.test.ts
@@ -1,0 +1,99 @@
+import { test, expect, describe } from 'vitest'
+import type { TimeBucket } from '@ainyc/canonry-contracts'
+import { computeTrend, pooledRate } from '../src/analytics.js'
+
+/**
+ * A rate is not additive across the buckets that produced it. Averaging
+ * per-bucket rates unweighted lets a bucket holding 2 snapshots move the
+ * improving/declining verdict as much as one holding 200.
+ */
+function bucket(cited: number, total: number, mentioned = cited): TimeBucket {
+  return {
+    startDate: '2026-07-01T00:00:00.000Z',
+    endDate: '2026-07-02T00:00:00.000Z',
+    dataStartDate: '2026-07-01T00:00:00.000Z',
+    dataEndDate: '2026-07-01T00:00:00.000Z',
+    sweepCount: 1,
+    citationRate: total > 0 ? Math.round((cited / total) * 10000) / 10000 : 0,
+    cited,
+    total,
+    queryCount: total,
+    mentionRate: total > 0 ? Math.round((mentioned / total) * 10000) / 10000 : 0,
+    mentionedCount: mentioned,
+    byProvider: {},
+    modelEvidenceByProvider: {},
+  } as TimeBucket
+}
+
+describe('pooledRate', () => {
+  test('weights each bucket by the evidence it carries', () => {
+    // 1/2 and 99/198 are both 50%, but a plain mean of the RATES would also be
+    // 50% here; the discriminating case is below.
+    expect(pooledRate([bucket(1, 2), bucket(99, 198)], 'citationRate')).toBe(100 / 200)
+  })
+
+  test('a sparse bucket cannot outvote a dense one', () => {
+    // Unweighted mean of rates = (1.0 + 0.1) / 2 = 0.55
+    // Pooled = (2 + 20) / (2 + 200) = 0.1089…
+    const buckets = [bucket(2, 2), bucket(20, 200)]
+    expect(pooledRate(buckets, 'citationRate')).toBeCloseTo(22 / 202, 10)
+    const unweighted = (buckets[0]!.citationRate + buckets[1]!.citationRate) / 2
+    expect(unweighted).toBeCloseTo(0.55, 10)
+  })
+
+  test('reads mentionedCount for the mention rate, not cited', () => {
+    expect(pooledRate([bucket(0, 10, 7)], 'mentionRate')).toBe(0.7)
+    expect(pooledRate([bucket(0, 10, 7)], 'citationRate')).toBe(0)
+  })
+
+  test('returns 0 rather than dividing by zero', () => {
+    expect(pooledRate([], 'citationRate')).toBe(0)
+    expect(pooledRate([bucket(0, 0)], 'citationRate')).toBe(0)
+  })
+
+  test('does not compound the per-bucket rounding', () => {
+    // 1/3 stores as 0.3333; pooling the raw counts keeps full precision.
+    expect(pooledRate([bucket(1, 3), bucket(1, 3)], 'citationRate')).toBe(2 / 6)
+  })
+})
+
+describe('computeTrend', () => {
+  test('a single sparse sweep no longer flips the verdict', () => {
+    // First half: 100/200 = 50%. Second half: a dense 96/200 = 48% (a real
+    // 2pp dip, inside the 5pp threshold) plus one 2-snapshot sweep at 100%.
+    // Unweighted mean of the second half = (0.48 + 1.0)/2 = 0.74 → "improving".
+    // Pooled = (96 + 2)/(200 + 2) = 48.5% → correctly "stable".
+    const buckets = [bucket(50, 100), bucket(50, 100), bucket(96, 200), bucket(2, 2)]
+    expect(computeTrend(buckets, 'citationRate')).toBe('stable')
+  })
+
+  test('still reports a real improvement', () => {
+    const buckets = [bucket(20, 100), bucket(20, 100), bucket(40, 100), bucket(40, 100)]
+    expect(computeTrend(buckets, 'citationRate')).toBe('improving')
+  })
+
+  test('still reports a real decline', () => {
+    const buckets = [bucket(40, 100), bucket(40, 100), bucket(20, 100), bucket(20, 100)]
+    expect(computeTrend(buckets, 'citationRate')).toBe('declining')
+  })
+
+  test('holds the 5-percentage-point threshold', () => {
+    // Clearly under and clearly over. The exact-5pp boundary is deliberately
+    // not asserted: 0.55 - 0.5 is 0.050000000000000044 in IEEE 754, so a
+    // `> 0.05` guard trips on it. That float sensitivity predates this change
+    // and pinning it would lock in an artifact rather than intended behavior.
+    const under = [bucket(50, 100), bucket(54, 100)]
+    expect(computeTrend(under, 'citationRate')).toBe('stable')
+    const over = [bucket(50, 100), bucket(56, 100)]
+    expect(computeTrend(over, 'citationRate')).toBe('improving')
+  })
+
+  test('empty buckets are excluded before the split', () => {
+    expect(computeTrend([bucket(0, 0), bucket(0, 0)], 'citationRate')).toBe('stable')
+  })
+
+  test('fewer than two non-empty buckets is stable, not a verdict', () => {
+    expect(computeTrend([bucket(10, 10)], 'citationRate')).toBe('stable')
+    expect(computeTrend([], 'citationRate')).toBe('stable')
+  })
+})

--- a/packages/api-routes/test/content.test.ts
+++ b/packages/api-routes/test/content.test.ts
@@ -282,6 +282,35 @@ describe('content routes', () => {
       expect(body.contextMetrics.latestRunId).toBeTruthy()
     })
 
+    it('counts one AI-referral visit once, not once per attribution lens', async () => {
+      const { projectId, latestRunId } = seedProject(db)
+      // GA4 returns `session`, `first_user` and `manual_utm` as three separate
+      // reports over the SAME visits — overlapping lenses, not disjoint
+      // traffic. The seeded row above is the `session` lens (schema default);
+      // these two describe the same 142 sessions from the other two angles.
+      // Summing all three reported ~3x on live data (800 vs 264).
+      for (const sourceDimension of ['first_user', 'manual_utm']) {
+        db.insert(gaAiReferrals).values({
+          id: crypto.randomUUID(),
+          projectId,
+          syncRunId: latestRunId,
+          date: '2026-04-01',
+          source: 'chat.openai.com',
+          medium: 'referral',
+          sourceDimension,
+          sessions: 138,
+          users: 126,
+          syncedAt: new Date().toISOString(),
+        }).run()
+      }
+
+      const res = await app.inject({ method: 'GET', url: '/projects/example/content/targets' })
+      expect(res.statusCode).toBe(200)
+      const body = JSON.parse(res.payload)
+      // 142, not 142 + 138 + 138 = 418.
+      expect(body.contextMetrics.totalAiReferralSessions).toBe(142)
+    })
+
     it('classifies Q1 as CREATE (no page) with competitor evidence demand source', async () => {
       seedProject(db)
       const res = await app.inject({ method: 'GET', url: '/projects/example/content/targets' })


### PR DESCRIPTION
## Context

A repo-wide audit of the dimensioned-sum bug class (the one [#831](https://github.com/Canonry/canonry/pull/831) fixed for GA daily users) found it is not three instances but roughly 20 sites. This PR lands the two that need no product decision. The rest are listed at the bottom because they do.

## What changed

**1. `content-data.ts` counted every AI-referral visit once per attribution lens.**

`ga_ai_referrals` holds one row per `sourceDimension`. GA4 returns `session`, `first_user` and `manual_utm` as three separate reports over the *same* visits — overlapping lenses, not disjoint traffic. `sumAiReferralSessions` summed all three.

Measured on live data: **800 vs 264, a 3.03x inflation.**

Every other consumer already guards this (`report.ts:410` pins `session`, `ga.ts` takes the winning lens per tuple via `pickWinningDimension`, whose own comment states the mechanism). So the content engine's denominator was ~3x the report's numerator for the same period. Pinned to the same lens.

**2. `analytics.ts` decided the trend verdict from an unweighted mean of rates.**

`computeTrend` averaged per-bucket `citationRate`/`mentionRate` without weighting by `total`, so a bucket holding 2 snapshots moved `improving`/`declining`/`stable` as much as one holding 200. A single sparse sweep could flip the verdict on its own.

Now pools the raw `cited` / `mentionedCount` over `total`. Pooling counts rather than weighting the stored rate also avoids compounding the rounding already applied at bucket construction.

## Verification

- Both regression tests were confirmed to **fail with their fix reverted**, then pass with it restored.
- The trend tests assert exact pooled math, the sparse-bucket case that motivated the fix, and that real improvements and declines are still reported.
- One boundary is deliberately not pinned: exactly 5pp trips the `> 0.05` guard because `0.55 - 0.5` is `0.050000000000000044` in IEEE 754. That float sensitivity predates this change; asserting it would lock in an artifact.
- `pnpm typecheck` clean, `pnpm lint` 0 errors, full suite **461 files / 5675 tests** passing.

## Deliberately not in this PR

Each of these needs a decision rather than a mechanical fix:

- **`report.ts` AI-referral users** (`totalUsers`/`paidUsers`/`organicUsers`) sums a COUNT DISTINCT across date, channelGroup and landingPage, and its query carries no date filter at all, so it sums the project's entire retained history into a client-facing tile. There is no un-dimensioned AI-referral fetch to read instead: fixing it means a new totals table mirroring `ga_daily_totals`, or dropping the `users` columns.
- **GSC per-query impressions** (`report.ts`, `content-data.ts`, `composites.ts`) cross the `page` dimension, which `schema.ts:241-243` documents as fanning one SERP into N rows. Measured +25.8% on live data. This one has **no fix available** — there is no un-dimensioned per-query fetch and `gsc_daily_totals` has no query column. The options are a permanent marker or accepting the approximation explicitly.
- **`content-data.ts` GSC rows carry no date bound at all**, feeding an absolute `>= 100` threshold, so the signal saturates as history accumulates. There is no window concept anywhere in the content pipeline, so adding one changes which queries reach `high` confidence and therefore what the engine recommends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)