### PR TITLE
fix(ads): refresh reviewed launch versions safely

### DIFF
--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -8184,6 +8184,10 @@ export type PostApiV1ProjectsByNameAdsActivationGrantsData = {
         };
         executorApiKeyId: string;
         expiresAt: string;
+        /**
+         * Exact rejects any provider version drift. refresh_semantically_unchanged rebinds versions only when the live paused tree still matches its durable create receipts field-for-field.
+         */
+        versionPolicy?: 'exact' | 'refresh_semantically_unchanged';
     };
     path: {
         /**

--- a/packages/api-routes/src/ads-activation-routes.ts
+++ b/packages/api-routes/src/ads-activation-routes.ts
@@ -4,6 +4,7 @@ import { and, asc, eq, gt, isNotNull, isNull, lte, or, sql } from 'drizzle-orm'
 import {
   ADS_ACTIVATE_SCOPE,
   ADS_APPROVE_SCOPE,
+  AdsActivationVersionPolicies,
   AdsActivationGrantStates,
   AdsActivationEntityTypes,
   AdsOperationKinds,
@@ -47,7 +48,9 @@ import {
   hashAdsActivationManifest,
   hashAdsActivationOperationRequest,
   preflightAdsActivationApproval,
+  refreshSemanticallyUnchangedAdsActivationManifest,
   serializeAdsActivationManifest,
+  type AdsActivationEntitySnapshot,
   type AdsActivationClaimInput,
   type AdsActivationClaimResult,
   type AdsActivationResult,
@@ -70,6 +73,11 @@ const ACTIVATION_STEP_INSERT_BATCH_SIZE = 40
 export interface AdsActivationRuntime {
   adAccountId: string
   provider: AdsActivationProvider
+  semanticallyMatchesMaterialization?: (
+    entityType: import('@ainyc/canonry-contracts').AdsActivationEntityType,
+    entityId: string,
+    entity: AdsActivationEntitySnapshot,
+  ) => boolean
 }
 
 export interface AdsActivationRoutesOptions {
@@ -1150,10 +1158,18 @@ export function registerAdsActivationRoutes(
       const runtime = await opts.resolveRuntime(project)
       let preflight: Awaited<ReturnType<typeof preflightAdsActivationApproval>>
       try {
-        preflight = await preflightAdsActivationApproval(runtime.provider, {
-          adAccountId: runtime.adAccountId,
-          manifest: body.manifest,
-        })
+        preflight = body.versionPolicy === AdsActivationVersionPolicies.refreshSemanticallyUnchanged
+          ? await refreshSemanticallyUnchangedAdsActivationManifest(runtime.provider, {
+              adAccountId: runtime.adAccountId,
+              manifest: body.manifest,
+              semanticallyMatchesMaterialization:
+                runtime.semanticallyMatchesMaterialization
+                ?? (() => false),
+            })
+          : await preflightAdsActivationApproval(runtime.provider, {
+              adAccountId: runtime.adAccountId,
+              manifest: body.manifest,
+            })
       } catch (error) {
         if (error instanceof AdsActivationError) throw mapApprovalPreflightError(error)
         throw error

--- a/packages/api-routes/src/ads-activation.ts
+++ b/packages/api-routes/src/ads-activation.ts
@@ -12,8 +12,10 @@ import {
   AdsOperationStepStates,
   AdsReviewStatuses,
   type AdsActivationEntityType,
+  type AdsAdGroupBillingEventType,
   type AdsActivationGrantDto,
   type AdsActivationManifest,
+  type AdsCampaignBiddingType,
   type AdsOperationStepDto,
 } from '@ainyc/canonry-contracts'
 import type { adsOperations } from '@ainyc/canonry-db'
@@ -81,6 +83,14 @@ export interface AdsActivationApprovalPreflightRequest {
 export interface AdsActivationApprovalPreflightResult {
   manifest: AdsActivationManifest
   manifestHash: string
+}
+
+export interface AdsActivationVersionRefreshRequest extends AdsActivationApprovalPreflightRequest {
+  semanticallyMatchesMaterialization: (
+    entityType: AdsActivationEntityType,
+    entityId: string,
+    entity: AdsActivationEntitySnapshot,
+  ) => boolean
 }
 
 export type AdsActivationGrantRecord = AdsActivationGrantDto
@@ -218,6 +228,18 @@ export interface AdsActivationEntitySnapshot {
   campaignId?: string | null
   adGroupId?: string | null
   reviewStatus?: string | null
+  biddingType?: AdsCampaignBiddingType | null
+  conversionEventSettingIds?: string[] | null
+  billingEventType?: AdsAdGroupBillingEventType | null
+  name?: string | null
+  description?: string | null
+  startTime?: number | null
+  endTime?: number | null
+  lifetimeSpendLimitMicros?: number | null
+  locationIds?: string[] | null
+  contextHints?: string[] | null
+  maxBidMicros?: number | null
+  creative?: { title: string; body: string; targetUrl: string; fileId: string } | null
 }
 
 export interface AdsActivationProvider {
@@ -803,6 +825,93 @@ export async function preflightAdsActivationApproval(
     await readAndValidatePaused(provider, target)
   }
   return { manifest, manifestHash: hashAdsActivationManifest(manifest) }
+}
+
+/**
+ * Rebind only provider concurrency versions after an asynchronous review
+ * transition. Entity IDs, exact descendants, paused state, ad approval, and
+ * every materialized semantic field must still match the durable create
+ * receipts. A second exact preflight closes the read-to-grant race.
+ */
+export async function refreshSemanticallyUnchangedAdsActivationManifest(
+  provider: AdsActivationProvider,
+  request: AdsActivationVersionRefreshRequest,
+): Promise<AdsActivationApprovalPreflightResult> {
+  const manifest = canonicalManifest(request.manifest)
+  await validateAccount(provider, request.adAccountId)
+  await validateExactDescendants(provider, manifest, {
+    entityType: AdsActivationEntityTypes.campaign,
+    entityId: manifest.campaign.id,
+    parentId: null,
+    expectedUpdatedAt: manifest.campaign.expectedUpdatedAt,
+  })
+
+  const versions = new Map<string, number>()
+  for (const target of activationTargets(manifest)) {
+    let entity: AdsActivationEntitySnapshot
+    try {
+      entity = await readTarget(provider, target)
+    } catch {
+      throw targetError(
+        AdsActivationErrorCodes.providerReadFailed,
+        'An ads entity could not be verified for version refresh',
+        502,
+        target,
+      )
+    }
+    validateIdentity(target, entity)
+    validateAdApproval(target, entity)
+    if (entity.status !== PROVIDER_PAUSED) {
+      throw targetError(AdsActivationErrorCodes.entityNotPaused, 'Every approved ads entity must still be paused', 409, target)
+    }
+    if (!Number.isInteger(entity.updatedAt) || entity.updatedAt === null || entity.updatedAt < 0) {
+      throw targetError(
+        AdsActivationErrorCodes.providerReadFailed,
+        'An ads entity did not report a usable provider version',
+        502,
+        target,
+      )
+    }
+    if (!request.semanticallyMatchesMaterialization(target.entityType, target.entityId, entity)) {
+      throw targetError(
+        AdsActivationErrorCodes.entityMismatch,
+        'An ads entity no longer matches its materialized approved fields',
+        409,
+        target,
+      )
+    }
+    versions.set(`${target.entityType}:${target.entityId}`, entity.updatedAt)
+  }
+
+  const version = (entityType: AdsActivationEntityType, entityId: string): number => {
+    const current = versions.get(`${entityType}:${entityId}`)
+    if (current === undefined) {
+      throw new AdsActivationError(
+        AdsActivationErrorCodes.persistenceFailed,
+        'A refreshed ads entity version is missing',
+        500,
+      )
+    }
+    return current
+  }
+  const refreshed: AdsActivationManifest = {
+    campaign: {
+      id: manifest.campaign.id,
+      expectedUpdatedAt: version(AdsActivationEntityTypes.campaign, manifest.campaign.id),
+      adGroups: manifest.campaign.adGroups.map((group) => ({
+        id: group.id,
+        expectedUpdatedAt: version(AdsActivationEntityTypes.ad_group, group.id),
+        ads: group.ads.map((ad) => ({
+          id: ad.id,
+          expectedUpdatedAt: version(AdsActivationEntityTypes.ad, ad.id),
+        })),
+      })),
+    },
+  }
+  return preflightAdsActivationApproval(provider, {
+    adAccountId: request.adAccountId,
+    manifest: refreshed,
+  })
 }
 
 function stepTarget(manifest: AdsActivationManifest, step: AdsActivationStepRecord): ActivationTarget {

--- a/packages/api-routes/src/ads.ts
+++ b/packages/api-routes/src/ads.ts
@@ -3,6 +3,7 @@ import type { FastifyInstance, FastifyRequest } from 'fastify'
 import { eq, and, asc, gt, gte, lt, lte, ne, inArray, or, isNull, isNotNull, sql } from 'drizzle-orm'
 import {
   ADS_WRITE_SCOPE,
+  AdsActivationEntityTypes,
   AdsAdGroupBillingEventTypes,
   AdsCampaignBiddingTypes,
   AdsEntityTypes,
@@ -65,6 +66,7 @@ import type {
   AdsGeoSearchResponse,
   AdsConversionPixelListResponse,
   AdsConversionEventSettingListResponse,
+  AdsActivationEntityType,
 } from '@ainyc/canonry-contracts'
 import { adsConnections, adsCampaigns, adsAdGroups, adsAds, adsInsightsDaily, adsOperations, projects, runs } from '@ainyc/canonry-db'
 import { requireScope } from './auth.js'
@@ -568,6 +570,66 @@ function entityMatchesReconcileFields(
   return fingerprint === null
     ? candidateFingerprint === requestHash(desired)
     : candidateFingerprint === fingerprint
+}
+
+function semanticallyMatchesMaterializedEntity(
+  app: FastifyInstance,
+  input: {
+    projectId: string
+    adAccountId: string
+    entityType: AdsActivationEntityType
+    entityId: string
+    entity: AdsOperatorEntityResult
+  },
+): boolean {
+  const createKind = (() => {
+    switch (input.entityType) {
+      case AdsActivationEntityTypes.campaign:
+        return AdsOperationKinds.campaign_create
+      case AdsActivationEntityTypes.ad_group:
+        return AdsOperationKinds.ad_group_create
+      case AdsActivationEntityTypes.ad:
+        return AdsOperationKinds.ad_create
+    }
+  })()
+  const updateKind = (() => {
+    switch (input.entityType) {
+      case AdsActivationEntityTypes.campaign:
+        return AdsOperationKinds.campaign_update
+      case AdsActivationEntityTypes.ad_group:
+        return AdsOperationKinds.ad_group_update
+      case AdsActivationEntityTypes.ad:
+        return AdsOperationKinds.ad_update
+    }
+  })()
+  const rows = app.db.select().from(adsOperations).where(and(
+    eq(adsOperations.projectId, input.projectId),
+    eq(adsOperations.entityType, input.entityType),
+    eq(adsOperations.entityId, input.entityId),
+    inArray(adsOperations.kind, [createKind, updateKind]),
+  )).orderBy(asc(adsOperations.createdAt), asc(adsOperations.id)).all()
+
+  // Unknown or in-flight updates mean the provider state cannot be attributed
+  // to an approved durable receipt. A successful update also requires a new
+  // Platform plan review rather than silently refreshing the original create.
+  if (rows.some((row) =>
+    row.state === AdsOperationStates.pending
+    || row.state === AdsOperationStates.reconciling
+    || row.state === AdsOperationStates.unknown
+    || (row.kind === updateKind && row.state === AdsOperationStates.succeeded))) {
+    return false
+  }
+  const creates = rows.filter((row) => row.kind === createKind && row.state === AdsOperationStates.succeeded)
+  if (creates.length !== 1) return false
+  const create = creates[0]!
+  if (
+    create.adAccountId !== input.adAccountId
+    || create.reconcileStrategy !== AdsReconcileStrategies.create_fingerprint
+    || !create.reconcileFields
+  ) {
+    return false
+  }
+  return entityMatchesReconcileFields(input.entity, create.reconcileFields, null)
 }
 
 function reconcileFieldsWithoutParent(fields: AdsReconcileFields): AdsReconcileFields {
@@ -1638,6 +1700,16 @@ export async function adsRoutes(app: FastifyInstance, opts: AdsRoutesOptions): P
       }
       return {
         adAccountId,
+        semanticallyMatchesMaterialization: (entityType, entityId, entity) => {
+          if (entity.status === null || entity.updatedAt === null) return false
+          return semanticallyMatchesMaterializedEntity(app, {
+            projectId: project.id,
+            adAccountId,
+            entityType,
+            entityId,
+            entity: { ...entity, status: entity.status, updatedAt: entity.updatedAt },
+          })
+        },
         provider: {
           getAccount: refreshAccount,
           getCampaign: (id) => operator.getCampaign(apiKey, id),

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -2483,6 +2483,13 @@ const routeCatalog: OpenApiOperation[] = [
               manifest: adsActivationManifestSchema,
               executorApiKeyId: adsEntityIdSchema,
               expiresAt: { type: 'string', format: 'date-time' },
+              versionPolicy: {
+                type: 'string',
+                enum: ['exact', 'refresh_semantically_unchanged'],
+                default: 'exact',
+                description:
+                  'Exact rejects any provider version drift. refresh_semantically_unchanged rebinds versions only when the live paused tree still matches its durable create receipts field-for-field.',
+              },
             },
           },
         },

--- a/packages/api-routes/test/ads-activation-routes.test.ts
+++ b/packages/api-routes/test/ads-activation-routes.test.ts
@@ -9,9 +9,11 @@ import {
   ADS_APPROVE_SCOPE,
   AdsActivationEntityTypes,
   AdsActivationGrantStates,
+  AdsEntityStatuses,
   AdsOperationKinds,
   AdsOperationStates,
   AdsOperationStepStates,
+  AdsReconcileStrategies,
   AppError,
   adsOperationDtoSchema,
   type AdsActivationManifest,
@@ -309,6 +311,7 @@ function buildHarness(options: ActivationHarnessOptions = {}) {
   async function createGrant(
     executorApiKeyId = 'key_executor',
     manifest: AdsActivationManifest = MANIFEST,
+    versionPolicy?: 'exact' | 'refresh_semantically_unchanged',
   ) {
     return app.inject({
       method: 'POST',
@@ -318,6 +321,7 @@ function buildHarness(options: ActivationHarnessOptions = {}) {
         manifest,
         executorApiKeyId,
         expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+        ...(versionPolicy ? { versionPolicy } : {}),
       },
     })
   }
@@ -1050,6 +1054,139 @@ describe('ads approval-bound activation routes', () => {
     expect(response.statusCode).toBe(400)
     expect(response.body).toContain('ADS_ACTIVATION_ENTITY_STALE')
     expect(ctx.db.select().from(adsActivationGrants).all()).toHaveLength(0)
+  })
+
+  it('refreshes review-only versions only when the provider tree matches its create receipts', async () => {
+    ctx.entities.set('cmpn_approved', {
+      id: 'cmpn_approved',
+      name: 'Approved campaign',
+      description: null,
+      status: AdsEntityStatuses.paused,
+      updatedAt: 10,
+      startTime: null,
+      endTime: null,
+      lifetimeSpendLimitMicros: 10_000_000,
+      locationIds: ['1000232'],
+      biddingType: 'clicks',
+      conversionEventSettingIds: ['event_1'],
+    })
+    ctx.entities.set('adgrp_approved', {
+      id: 'adgrp_approved',
+      campaignId: 'cmpn_approved',
+      name: 'Approved group',
+      description: null,
+      status: AdsEntityStatuses.paused,
+      updatedAt: 20,
+      contextHints: ['buyer question'],
+      maxBidMicros: 1_000_000,
+      billingEventType: 'click',
+    })
+    ctx.entities.set('ad_approved', {
+      id: 'ad_approved',
+      adGroupId: 'adgrp_approved',
+      name: 'Approved ad',
+      creative: {
+        title: 'See your AI search gaps',
+        body: 'Get a free audit.',
+        targetUrl: 'https://canonry.ai/audit',
+        fileId: 'file_1',
+      },
+      reviewStatus: 'approved',
+      status: AdsEntityStatuses.paused,
+      updatedAt: 31,
+    })
+    const now = new Date().toISOString()
+    ctx.db.insert(adsOperations).values([
+      {
+        id: 'create_campaign',
+        projectId: 'project_activation',
+        adAccountId: 'adacct_approved',
+        operationKey: 'create:campaign',
+        requestHash: 'hash_campaign',
+        kind: AdsOperationKinds.campaign_create,
+        state: AdsOperationStates.succeeded,
+        entityType: AdsActivationEntityTypes.campaign,
+        entityId: 'cmpn_approved',
+        upstreamUpdatedAt: 10,
+        reconcileStrategy: AdsReconcileStrategies.create_fingerprint,
+        reconcileFields: {
+          name: 'Approved campaign',
+          description: null,
+          status: AdsEntityStatuses.paused,
+          startTime: null,
+          endTime: null,
+          lifetimeSpendLimitMicros: 10_000_000,
+          locationIds: ['1000232'],
+          biddingType: 'clicks',
+          conversionEventSettingIds: ['event_1'],
+        },
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: 'create_group',
+        projectId: 'project_activation',
+        adAccountId: 'adacct_approved',
+        operationKey: 'create:group',
+        requestHash: 'hash_group',
+        kind: AdsOperationKinds.ad_group_create,
+        state: AdsOperationStates.succeeded,
+        entityType: AdsActivationEntityTypes.ad_group,
+        entityId: 'adgrp_approved',
+        upstreamUpdatedAt: 20,
+        reconcileStrategy: AdsReconcileStrategies.create_fingerprint,
+        reconcileFields: {
+          campaignId: 'cmpn_approved',
+          name: 'Approved group',
+          description: null,
+          status: AdsEntityStatuses.paused,
+          contextHints: ['buyer question'],
+          maxBidMicros: 1_000_000,
+          billingEventType: 'click',
+        },
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: 'create_ad',
+        projectId: 'project_activation',
+        adAccountId: 'adacct_approved',
+        operationKey: 'create:ad',
+        requestHash: 'hash_ad',
+        kind: AdsOperationKinds.ad_create,
+        state: AdsOperationStates.succeeded,
+        entityType: AdsActivationEntityTypes.ad,
+        entityId: 'ad_approved',
+        upstreamUpdatedAt: 30,
+        reconcileStrategy: AdsReconcileStrategies.create_fingerprint,
+        reconcileFields: {
+          adGroupId: 'adgrp_approved',
+          name: 'Approved ad',
+          status: AdsEntityStatuses.paused,
+        },
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]).run()
+
+    const response = await ctx.createGrant(
+      'key_executor',
+      MANIFEST,
+      'refresh_semantically_unchanged',
+    )
+    expect(response.statusCode, response.body).toBe(200)
+    const grant = JSON.parse(response.body).grant
+    expect(grant.manifest.campaign.adGroups[0].ads[0].expectedUpdatedAt).toBe(31)
+    expect(grant.manifestHash).toBe(hashAdsActivationManifest(grant.manifest))
+
+    ctx.entities.get('ad_approved')!.name = 'Changed outside the approved plan'
+    const rejected = await ctx.createGrant(
+      'key_executor',
+      MANIFEST,
+      'refresh_semantically_unchanged',
+    )
+    expect(rejected.statusCode).toBe(400)
+    expect(rejected.body).toContain('ADS_ACTIVATION_ENTITY_MISMATCH')
   })
 
   it('refuses to consume a grant after the project reconnects to another ad account', async () => {

--- a/packages/api-routes/test/ads-activation.test.ts
+++ b/packages/api-routes/test/ads-activation.test.ts
@@ -19,6 +19,7 @@ import {
   hashAdsActivationManifest,
   hashAdsActivationOperationRequest,
   preflightAdsActivationApproval,
+  refreshSemanticallyUnchangedAdsActivationManifest,
   serializeAdsActivationManifest,
   type AdsActivationClaimInput,
   type AdsActivationClaimResult,
@@ -501,6 +502,42 @@ describe('approval-bound ads activation core', () => {
       manifest: MANIFEST,
     })).rejects.toMatchObject({ code: AdsActivationErrorCodes.entityMismatch })
     expect(mutationCalls(omittedActiveDescendant)).toEqual([])
+  })
+
+  it('refreshes review-only provider versions and rejects semantic drift', async () => {
+    const provider = new FakeProvider()
+    provider.setEntity(AdsActivationEntityTypes.ad, {
+      id: 'ad_1',
+      adGroupId: 'adgrp_1',
+      reviewStatus: 'approved',
+      status: 'paused',
+      updatedAt: 301,
+    })
+
+    const matched: string[] = []
+    const refreshed = await refreshSemanticallyUnchangedAdsActivationManifest(provider, {
+      adAccountId: 'adacct_1',
+      manifest: MANIFEST,
+      semanticallyMatchesMaterialization: (entityType, entityId) => {
+        matched.push(entityKey(entityType, entityId))
+        return true
+      },
+    })
+
+    expect(refreshed.manifest.campaign.adGroups[0]!.ads[0]!.expectedUpdatedAt).toBe(301)
+    expect(refreshed.manifestHash).toBe(hashAdsActivationManifest(refreshed.manifest))
+    expect(matched).toEqual(['ad:ad_1', 'ad_group:adgrp_1', 'campaign:cmpn_1'])
+    expect(mutationCalls(provider)).toEqual([])
+
+    await expect(refreshSemanticallyUnchangedAdsActivationManifest(provider, {
+      adAccountId: 'adacct_1',
+      manifest: MANIFEST,
+      semanticallyMatchesMaterialization: (_entityType, entityId) => entityId !== 'ad_1',
+    })).rejects.toMatchObject({
+      code: AdsActivationErrorCodes.entityMismatch,
+      entity: { entityType: 'ad', entityId: 'ad_1' },
+    })
+    expect(mutationCalls(provider)).toEqual([])
   })
 
   it('activates ads, then ad groups, then the campaign with durable checkpoints', async () => {

--- a/packages/canonry/src/ads-sync.ts
+++ b/packages/canonry/src/ads-sync.ts
@@ -15,6 +15,7 @@ import type {
   OpenAiAdsAd,
   OpenAiAdsAdGroup,
   OpenAiAdsCampaign,
+  OpenAiAdsInsightHourRange,
   OpenAiAdsInsightRow,
 } from '@ainyc/canonry-integration-openai-ads'
 import type { CanonryConfig } from './config.js'
@@ -25,6 +26,39 @@ const log = createLogger('AdsSync')
 
 const CAMPAIGN_INSIGHT_FIELDS = ['campaign.impressions', 'campaign.clicks', 'campaign.spend', 'campaign.conversions', 'metadata.readable_time']
 const AD_GROUP_INSIGHT_FIELDS = ['ad_group.impressions', 'ad_group.clicks', 'ad_group.spend', 'ad_group.conversions', 'metadata.readable_time']
+const INSIGHTS_LOOKBACK_MS = 90 * 24 * 60 * 60 * 1_000
+
+function accountHour(date: Date, timezone: string): string {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    hourCycle: 'h23',
+  }).formatToParts(date)
+  const value = (type: Intl.DateTimeFormatPartTypes): string => {
+    const part = parts.find((candidate) => candidate.type === type)?.value
+    if (!part) throw new Error(`OpenAI Ads account timezone did not produce a ${type}`)
+    return part
+  }
+  return `${value('year')}-${value('month')}-${value('day')}T${value('hour')}`
+}
+
+export function trailingAdsInsightHourRange(
+  now: Date,
+  timezone: string,
+): OpenAiAdsInsightHourRange {
+  // The live API rejects conversion fields without time_ranges[] and rejects
+  // incomplete future local days. A timezone-aware hour range includes the
+  // current completed boundary and works across daylight-saving transitions.
+  return {
+    type: 'hour_range',
+    since: accountHour(new Date(now.getTime() - INSIGHTS_LOOKBACK_MS), timezone),
+    until: accountHour(now, timezone),
+    timezone,
+  }
+}
 
 interface AdsSyncOptions {
   config: CanonryConfig
@@ -101,6 +135,7 @@ export async function executeAdsSync(
     // so one bad campaign degrades the run to partial instead of failed.
     const account = await getAdAccount(apiKey)
     const campaigns = await listCampaigns(apiKey)
+    const insightTimeRanges = [trailingAdsInsightHourRange(new Date(), account.timezone)]
 
     const errors = new Map<string, string>()
     const adGroupsByCampaign = new Map<string, OpenAiAdsAdGroup[]>()
@@ -112,12 +147,18 @@ export async function executeAdsSync(
       try {
         const [adGroups, campaignInsights] = await Promise.all([
           listAdGroups(apiKey, campaign.id),
-          getCampaignInsights(apiKey, campaign.id, { fields: CAMPAIGN_INSIGHT_FIELDS }),
+          getCampaignInsights(apiKey, campaign.id, {
+            fields: CAMPAIGN_INSIGHT_FIELDS,
+            timeRanges: insightTimeRanges,
+          }),
         ])
         const groupResults = await Promise.all(adGroups.map(async (group) => ({
           group,
           ads: await listAds(apiKey, group.id),
-          insights: await getAdGroupInsights(apiKey, group.id, { fields: AD_GROUP_INSIGHT_FIELDS }),
+          insights: await getAdGroupInsights(apiKey, group.id, {
+            fields: AD_GROUP_INSIGHT_FIELDS,
+            timeRanges: insightTimeRanges,
+          }),
         })))
 
         syncedCampaigns.push(campaign)

--- a/packages/canonry/test/ads-commands.test.ts
+++ b/packages/canonry/test/ads-commands.test.ts
@@ -475,7 +475,10 @@ describe('ads lifecycle commands', () => {
 
     await adsActivationGrantCreate('canonry-audit', { input: inputPath, format: 'json' })
 
-    expect(mockCreateAdsActivationGrant).toHaveBeenCalledWith('canonry-audit', request)
+    expect(mockCreateAdsActivationGrant).toHaveBeenCalledWith('canonry-audit', {
+      ...request,
+      versionPolicy: 'exact',
+    })
     expect(JSON.parse(log.mock.calls[0]![0] as string)).toEqual(APPROVED_GRANT)
   })
 

--- a/packages/canonry/test/ads-sync.test.ts
+++ b/packages/canonry/test/ads-sync.test.ts
@@ -14,7 +14,7 @@ import {
   adsAds,
   adsInsightsDaily,
 } from '@ainyc/canonry-db'
-import { executeAdsSync } from '../src/ads-sync.js'
+import { executeAdsSync, trailingAdsInsightHourRange } from '../src/ads-sync.js'
 import type { CanonryConfig } from '../src/config.js'
 
 const NOW = '2026-06-10T00:00:00.000Z'
@@ -115,6 +115,18 @@ afterEach(() => {
 })
 
 describe('executeAdsSync', () => {
+  it('builds the verified trailing hour-range contract in the advertiser timezone', () => {
+    expect(trailingAdsInsightHourRange(
+      new Date('2026-07-21T17:37:00.000Z'),
+      'America/New_York',
+    )).toEqual({
+      type: 'hour_range',
+      since: '2026-04-22T13',
+      until: '2026-07-21T13',
+      timezone: 'America/New_York',
+    })
+  })
+
   it('snapshots entities, normalizes insights spend to micros, and completes the run', async () => {
     const db = createTempDb()
     seed(db)

--- a/packages/contracts/src/ads.ts
+++ b/packages/contracts/src/ads.ts
@@ -840,10 +840,22 @@ export const adsOperationStepDtoSchema = z.discriminatedUnion('state', [
 export type AdsOperationStepDto = z.infer<typeof adsOperationStepDtoSchema>
 
 /** Human approval request. The authenticated key becomes the approver. */
+export const AdsActivationVersionPolicies = {
+  exact: 'exact',
+  refreshSemanticallyUnchanged: 'refresh_semantically_unchanged',
+} as const
+
+export const adsActivationVersionPolicySchema = z.enum([
+  AdsActivationVersionPolicies.exact,
+  AdsActivationVersionPolicies.refreshSemanticallyUnchanged,
+])
+export type AdsActivationVersionPolicy = z.infer<typeof adsActivationVersionPolicySchema>
+
 export const adsActivationGrantCreateRequestSchema = z.object({
   manifest: adsActivationManifestSchema,
   executorApiKeyId: adsEntityIdSchema,
   expiresAt: adsActivationIsoTimestampSchema,
+  versionPolicy: adsActivationVersionPolicySchema.default(AdsActivationVersionPolicies.exact),
 }).strict()
 export type AdsActivationGrantCreateRequest = z.infer<typeof adsActivationGrantCreateRequestSchema>
 

--- a/packages/contracts/test/ads.test.ts
+++ b/packages/contracts/test/ads.test.ts
@@ -832,7 +832,13 @@ describe('approval-bound campaign-tree activation contracts', () => {
       manifest: ACTIVATION_MANIFEST,
       executorApiKeyId: 'key_executor',
       expiresAt: '2026-07-18T00:00:00.000Z',
-    })).toMatchObject({ executorApiKeyId: 'key_executor' })
+    })).toMatchObject({ executorApiKeyId: 'key_executor', versionPolicy: 'exact' })
+    expect(adsActivationGrantCreateRequestSchema.parse({
+      manifest: ACTIVATION_MANIFEST,
+      executorApiKeyId: 'key_executor',
+      expiresAt: '2026-07-18T00:00:00.000Z',
+      versionPolicy: 'refresh_semantically_unchanged',
+    }).versionPolicy).toBe('refresh_semantically_unchanged')
     expect(adsActivationGrantCreateRequestSchema.safeParse({
       manifest: ACTIVATION_MANIFEST,
       executorApiKeyId: 'key_executor',

--- a/packages/integration-openai-ads/src/ads-client.ts
+++ b/packages/integration-openai-ads/src/ads-client.ts
@@ -397,7 +397,11 @@ async function fetchAllPages<T>(apiKey: string, path: string, queryPairs: readon
 }
 
 function insightsPairs(opts?: OpenAiAdsInsightsOptions): string[] {
-  return (opts?.fields ?? []).map((field) => `fields[]=${encodeURIComponent(field)}`)
+  return [
+    ...(opts?.fields ?? []).map((field) => `fields[]=${encodeURIComponent(field)}`),
+    ...(opts?.timeRanges ?? []).map((range) =>
+      `time_ranges[]=${encodeURIComponent(JSON.stringify(range))}`),
+  ]
 }
 
 export async function getAdAccount(apiKey: string): Promise<OpenAiAdsAccount> {

--- a/packages/integration-openai-ads/src/index.ts
+++ b/packages/integration-openai-ads/src/index.ts
@@ -60,6 +60,7 @@ export type {
   OpenAiAdsGeoLocation,
   OpenAiAdsGeoSearchResponse,
   OpenAiAdsInsightRow,
+  OpenAiAdsInsightHourRange,
   OpenAiAdsInsightsOptions,
   OpenAiAdsListResponse,
   OpenAiAdsLocationTarget,

--- a/packages/integration-openai-ads/src/types.ts
+++ b/packages/integration-openai-ads/src/types.ts
@@ -312,6 +312,19 @@ export interface OpenAiAdsInsightsOptions {
   // 'metadata.readable_time'. Invalid names get a 400 whose message
   // enumerates the valid catalog.
   fields?: string[]
+  /** Live Advertiser API contract: conversion metrics require at least one
+   *  JSON-encoded time_ranges[] object. Hour ranges are account-timezone
+   *  aware and avoid treating a still-open local day as a future range. */
+  timeRanges?: OpenAiAdsInsightHourRange[]
+}
+
+export interface OpenAiAdsInsightHourRange {
+  type: 'hour_range'
+  /** Inclusive local account hour in YYYY-MM-DDTHH format. */
+  since: string
+  /** Exclusive local account hour in YYYY-MM-DDTHH format. */
+  until: string
+  timezone: string
 }
 
 interface OpenAiAdsErrorEnvelope {

--- a/packages/integration-openai-ads/test/ads-client.test.ts
+++ b/packages/integration-openai-ads/test/ads-client.test.ts
@@ -642,6 +642,24 @@ describe('insights', () => {
     expect(rows[0]!.readable_time).toBe('2026-06-10')
   })
 
+  it('serializes verified account-timezone hour ranges for conversion metrics', async () => {
+    const calls = mockFetchOnce(makeListResponse([FIXTURE_INSIGHT_ROW_FULL]))
+
+    await getCampaignInsights('test-key', 'cmpn_abc', {
+      fields: ['campaign.conversions', 'metadata.readable_time'],
+      timeRanges: [{
+        type: 'hour_range',
+        since: '2026-04-21T13',
+        until: '2026-07-21T13',
+        timezone: 'America/New_York',
+      }],
+    })
+
+    expect(calls[0]!.url).toBe(
+      `${OPENAI_ADS_API_BASE}/campaigns/cmpn_abc/insights?fields[]=campaign.conversions&fields[]=metadata.readable_time&time_ranges[]=%7B%22type%22%3A%22hour_range%22%2C%22since%22%3A%222026-04-21T13%22%2C%22until%22%3A%222026-07-21T13%22%2C%22timezone%22%3A%22America%2FNew_York%22%7D`,
+    )
+  })
+
   it('supports ad-group-level insights', async () => {
     const calls = mockFetchOnce(
       makeListResponse([{ ...FIXTURE_INSIGHT_ROW_FULL, id: 'start=1:end=2:entity_id=adgrp_abc' }]),


### PR DESCRIPTION
## Summary

Fixes the live beta launch failure where OpenAI asynchronous ad review advanced an ad updated_at after paused materialization, causing the exact activation preflight to reject the otherwise unchanged campaign.

- Adds an explicit activation grant version policy. The existing default remains exact.
- Adds refresh_semantically_unchanged for the approval path. It re-enumerates the exact campaign tree, requires every entity to remain paused, requires every ad to be approved, compares current semantic fields with the durable successful create receipts, rejects any successful or unresolved update, refreshes only updated_at values, then runs a second exact preflight to close the race.
- Adds the now-required timezone-aware time_ranges parameter to campaign and ad-group insight requests when conversion fields are requested.
- Regenerates the API client contract and documents the new request field.

## Live failure reproduced

The paused campaign was created successfully, but grant creation failed closed with ADS_ACTIVATION_ENTITY_STALE after OpenAI review changed the ad version. A subsequent sync returned 400 because conversions now require time_ranges. No activation grant was created and no spend occurred.

The time range shape was verified against the live OpenAI Ads API using an hour_range with since, until, and the advertiser account timezone.

## Safety properties

- exact remains the default and existing callers retain the prior behavior.
- Entity IDs, descendants, and parent relationships must match exactly.
- Campaign, ad-group, and ad semantic fields must match their durable create receipts.
- All entities must still be paused and all ads must be approved.
- Any actual update, unknown receipt, content change, or version race fails closed.

## Validation

- pnpm run typecheck
- pnpm run lint: zero errors
- pnpm run test: 457 files, 5,650 tests passed
- Focused activation route tests: 99 passed
- Live read-only Ads API contract probe for time_ranges

## Rollout

Ship this Engine change first, publish the next image, upgrade the beta tenant, then ship the dependent canonry-platform PR. The campaign remains paused until a new human launch approval creates and consumes a grant.