### PR TITLE
chore(release): bump canonry to 4.125.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.124.0",
+  "version": "4.125.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.124.0",
+  "version": "4.125.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Context

PR #833 landed the guarded OpenAI Ads launch-version refresh after 4.124.0 had already been published by an unrelated merge. This version bump gives that fix a new immutable release tag for canonry-platform tenant upgrades.

## What ships

- Bumps the root and `@canonry/canonry` package versions from 4.124.0 to 4.125.0.
- Triggers npm and Docker publication for the already-green Engine change.

## Validation

- [x] JSON version consistency check
- [x] `git diff --check`
- [x] Pre-commit lint, 0 errors
- [x] PR #833 full CI passed before merge