### PR TITLE
chore(release): bump canonry to 4.126.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.125.0",
+  "version": "4.126.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.125.0",
+  "version": "4.126.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
Release bump covering the two non-additive-aggregation fixes merged since 4.125.0.

- **#832** — AI-referral sessions were counted once per GA4 attribution lens (measured **3.03x** on live data: 800 vs 264), and the improving/declining trend verdict came from an unweighted mean of per-bucket rates, letting a 2-snapshot bucket outvote a 200-snapshot one.
- **#834** — per-query GSC impressions now come from an un-dimensioned `['date','query']` fetch instead of summing the page-dimensioned table (measured **+68%** overall, **+495%** on brand+category terms). Merges at day grain so a partial backfill cannot truncate a report window, and exposes a `mixed` source state.

## Why neither feature PR carried its own bump

Two concurrent branches each bumping is exactly what made #832 unmergeable against #835. Keeping the bump in one release commit per batch means feature branches never conflict on `package.json`, and it guarantees the publish workflow actually produces an artifact — merging a PR whose manifests already match `main` silently skips npm publish and omits the version-tagged Docker image, so a version-pinned deployment would keep running the older image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)