### PR TITLE
fix(report): scope AI referrals to the report window, drop the users count

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.126.0",
+  "version": "4.127.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -2886,15 +2886,11 @@ export type ProjectReportDto = {
     } | null;
     aiReferrals: {
         totalSessions: number;
-        totalUsers: number;
         paidSessions: number;
-        paidUsers: number;
         organicSessions: number;
-        organicUsers: number;
         bySource: Array<{
             source: string;
             sessions: number;
-            users: number;
             paidSessions: number;
             organicSessions: number;
             sharePct: number;
@@ -2906,7 +2902,6 @@ export type ProjectReportDto = {
         topLandingPages: Array<{
             page: string;
             sessions: number;
-            users: number;
         }>;
     } | null;
     serverActivity: {

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -2888,9 +2888,13 @@ export type ProjectReportDto = {
         totalSessions: number;
         paidSessions: number;
         organicSessions: number;
+        totalUsers?: number;
+        paidUsers?: number;
+        organicUsers?: number;
         bySource: Array<{
             source: string;
             sessions: number;
+            users?: number;
             paidSessions: number;
             organicSessions: number;
             sharePct: number;
@@ -2902,6 +2906,7 @@ export type ProjectReportDto = {
         topLandingPages: Array<{
             page: string;
             sessions: number;
+            users?: number;
         }>;
     } | null;
     serverActivity: {

--- a/packages/api-routes/src/report-renderer.ts
+++ b/packages/api-routes/src/report-renderer.ts
@@ -1826,7 +1826,6 @@ function renderAiReferrals(report: ProjectReportDto): string {
     <tr>
       <td class="page-cell">${formatLandingPageHtml(p.page)}</td>
       <td class="numeric">${formatNumber(p.sessions)}</td>
-      <td class="numeric">${formatNumber(p.users)}</td>
     </tr>`).join('')
 
   const trendChart = renderLineChart(
@@ -1839,13 +1838,12 @@ function renderAiReferrals(report: ProjectReportDto): string {
     { id: 'ai-referrals', eyebrow: 'Section 9', title: 'AI Referral Traffic', intro: 'Traffic arriving from AI answer engines.' },
     `<div class="metric-grid">
       <div class="metric"><div class="label">Total sessions</div><div class="value">${formatNumber(ai.totalSessions)}</div></div>
-      <div class="metric"><div class="label">Total users</div><div class="value">${formatNumber(ai.totalUsers)}</div></div>
     </div>
     ${trendChart}
     ${sourceBars}
     <div class="chart-card"><h3>Top AI landing pages</h3>
       <table class="report-table">
-        <thead><tr><th>Page</th><th class="numeric">Sessions</th><th class="numeric">Users</th></tr></thead>
+        <thead><tr><th>Page</th><th class="numeric">Sessions</th></tr></thead>
         <tbody>${pageRows}</tbody>
       </table>
     </div>`,

--- a/packages/api-routes/src/report.ts
+++ b/packages/api-routes/src/report.ts
@@ -554,11 +554,39 @@ function buildSocialReferrals(db: DatabaseClient, projectId: string): SocialRefe
   }
 }
 
-function buildAiReferrals(db: DatabaseClient, projectId: string): ProjectReportDto['aiReferrals'] {
+/**
+ * AI-referral traffic for the report window.
+ *
+ * The window is REQUIRED. This read previously had no date bound at all, so a
+ * report labelled "last 30 days" summed the project's entire retained history
+ * into its tiles (measured 3,106 all-time against 52 for the actual window on
+ * a live project).
+ *
+ * Reports SESSIONS only. See `aiReferralSectionSchema` for why the users count
+ * was removed rather than fixed.
+ */
+function buildAiReferrals(
+  db: DatabaseClient,
+  projectId: string,
+  windowDays: number,
+): ProjectReportDto['aiReferrals'] {
+  const latest = db
+    .select({ date: gaAiReferrals.date })
+    .from(gaAiReferrals)
+    .where(eq(gaAiReferrals.projectId, projectId))
+    .orderBy(desc(gaAiReferrals.date))
+    .limit(1)
+    .get()
+  if (!latest) return null
+  const windowStart = windowStartDate(latest.date, windowDays)
   const rows = db
     .select()
     .from(gaAiReferrals)
-    .where(eq(gaAiReferrals.projectId, projectId))
+    .where(and(
+      eq(gaAiReferrals.projectId, projectId),
+      sql`${gaAiReferrals.date} >= ${windowStart}`,
+      sql`${gaAiReferrals.date} <= ${latest.date}`,
+    ))
     .all()
   if (rows.length === 0) return null
 
@@ -598,47 +626,37 @@ function buildAiReferrals(db: DatabaseClient, projectId: string): ProjectReportD
   )
 
   let total = 0
-  let totalUsers = 0
   let paidSessions = 0
-  let paidUsers = 0
   let organicSessions = 0
-  let organicUsers = 0
   const sourceAgg = new Map<string, {
     sessions: number
-    users: number
     paidSessions: number
     organicSessions: number
   }>()
   const trendAgg = new Map<string, number>()
-  const pageAgg = new Map<string, { sessions: number; users: number }>()
+  const pageAgg = new Map<string, { sessions: number }>()
 
   for (const r of dedupedRows) {
     total += r.sessions
-    totalUsers += r.users
     const paid = isPaidAiTrafficClass(r.trafficClass)
     if (paid) {
       paidSessions += r.sessions
-      paidUsers += r.users
     } else {
       organicSessions += r.sessions
-      organicUsers += r.users
     }
     const s = sourceAgg.get(r.source) ?? {
       sessions: 0,
-      users: 0,
       paidSessions: 0,
       organicSessions: 0,
     }
     s.sessions += r.sessions
-    s.users += r.users
     if (paid) s.paidSessions += r.sessions
     else s.organicSessions += r.sessions
     sourceAgg.set(r.source, s)
     trendAgg.set(r.date, (trendAgg.get(r.date) ?? 0) + r.sessions)
     const page = r.landingPageNormalized ?? r.landingPage
-    const p = pageAgg.get(page) ?? { sessions: 0, users: 0 }
+    const p = pageAgg.get(page) ?? { sessions: 0 }
     p.sessions += r.sessions
-    p.users += r.users
     pageAgg.set(page, p)
   }
 
@@ -646,7 +664,6 @@ function buildAiReferrals(db: DatabaseClient, projectId: string): ProjectReportD
     .map(([source, data]) => ({
       source,
       sessions: data.sessions,
-      users: data.users,
       paidSessions: data.paidSessions,
       organicSessions: data.organicSessions,
       sharePct: total > 0 ? Math.round((data.sessions / total) * 100) : 0,
@@ -658,17 +675,14 @@ function buildAiReferrals(db: DatabaseClient, projectId: string): ProjectReportD
     .sort((a, b) => a.date.localeCompare(b.date))
 
   const topLandingPages = [...pageAgg.entries()]
-    .map(([page, data]) => ({ page, sessions: data.sessions, users: data.users }))
+    .map(([page, data]) => ({ page, sessions: data.sessions }))
     .sort((a, b) => b.sessions - a.sessions)
     .slice(0, TOP_AI_REFERRAL_PAGES_LIMIT)
 
   return {
     totalSessions: total,
-    totalUsers,
     paidSessions,
-    paidUsers,
     organicSessions,
-    organicUsers,
     bySource,
     trend,
     topLandingPages,
@@ -2122,7 +2136,7 @@ function buildProjectReport(db: DatabaseClient, projectName: string, periodDays:
   )
   const gaSection = buildGaSection(db, project.id, periodDays)
   const socialSection = buildSocialReferrals(db, project.id)
-  const aiReferralsSection = buildAiReferrals(db, project.id)
+  const aiReferralsSection = buildAiReferrals(db, project.id, periodDays)
   const serverActivitySection = buildServerActivity(db, project.id, periodDays)
   const indexingHealthSection = buildIndexingHealth(db, project.id)
   const citationsTrend = buildCitationsTrend(db, project.id, queryLookup, latestRunLocation)

--- a/packages/api-routes/src/report.ts
+++ b/packages/api-routes/src/report.ts
@@ -555,12 +555,54 @@ function buildSocialReferrals(db: DatabaseClient, projectId: string): SocialRefe
 }
 
 /**
+ * Resolve the window AI referrals are reported over.
+ *
+ * Anchored to the GA SYNC's period, never to the referral table's own
+ * `MAX(date)`. Anchoring to the latest referral row floats the window to
+ * wherever traffic last happened, so a project whose AI referrals stopped
+ * months ago would render those stale rows as "last 30 days" and the empty
+ * state would be unreachable. A GA sync only deletes rows inside its current
+ * summary range, so historical referrals legitimately outlive the window.
+ *
+ * Prefers the window summary for this exact period (the same row the GA
+ * section reports from, so the two agree), then the latest aggregate summary,
+ * then today.
+ */
+function resolveAiReferralWindow(
+  db: DatabaseClient,
+  projectId: string,
+  windowDays: number,
+): { start: string; end: string } {
+  const windowKey = GA_WINDOW_SUMMARY_KEYS[windowDays]
+  const windowSummary = windowKey
+    ? db
+        .select({ periodStart: gaTrafficWindowSummaries.periodStart, periodEnd: gaTrafficWindowSummaries.periodEnd })
+        .from(gaTrafficWindowSummaries)
+        .where(and(
+          eq(gaTrafficWindowSummaries.projectId, projectId),
+          eq(gaTrafficWindowSummaries.windowKey, windowKey),
+        ))
+        .get()
+    : undefined
+  if (windowSummary) return { start: windowSummary.periodStart, end: windowSummary.periodEnd }
+
+  const latestSummary = db
+    .select({ periodEnd: gaTrafficSummaries.periodEnd })
+    .from(gaTrafficSummaries)
+    .where(eq(gaTrafficSummaries.projectId, projectId))
+    .orderBy(desc(gaTrafficSummaries.syncedAt))
+    .get()
+  const end = latestSummary?.periodEnd ?? new Date().toISOString().slice(0, 10)
+  return { start: windowStartDate(end, windowDays), end }
+}
+
+/**
  * AI-referral traffic for the report window.
  *
- * The window is REQUIRED. This read previously had no date bound at all, so a
- * report labelled "last 30 days" summed the project's entire retained history
- * into its tiles (measured 3,106 all-time against 52 for the actual window on
- * a live project).
+ * The window is REQUIRED and comes from the GA sync period. This read
+ * previously had no date bound at all, so a report labelled "last 30 days"
+ * summed the project's entire retained history into its tiles (measured 3,106
+ * all-time against 52 for the actual window on a live project).
  *
  * Reports SESSIONS only. See `aiReferralSectionSchema` for why the users count
  * was removed rather than fixed.
@@ -570,22 +612,14 @@ function buildAiReferrals(
   projectId: string,
   windowDays: number,
 ): ProjectReportDto['aiReferrals'] {
-  const latest = db
-    .select({ date: gaAiReferrals.date })
-    .from(gaAiReferrals)
-    .where(eq(gaAiReferrals.projectId, projectId))
-    .orderBy(desc(gaAiReferrals.date))
-    .limit(1)
-    .get()
-  if (!latest) return null
-  const windowStart = windowStartDate(latest.date, windowDays)
+  const window = resolveAiReferralWindow(db, projectId, windowDays)
   const rows = db
     .select()
     .from(gaAiReferrals)
     .where(and(
       eq(gaAiReferrals.projectId, projectId),
-      sql`${gaAiReferrals.date} >= ${windowStart}`,
-      sql`${gaAiReferrals.date} <= ${latest.date}`,
+      sql`${gaAiReferrals.date} >= ${window.start}`,
+      sql`${gaAiReferrals.date} <= ${window.end}`,
     ))
     .all()
   if (rows.length === 0) return null

--- a/packages/api-routes/test/report-renderer.test.ts
+++ b/packages/api-routes/test/report-renderer.test.ts
@@ -241,23 +241,22 @@ function richReport(): ProjectReportDto {
         { source: 'linkedin.com', medium: 'referral', sessions: 700 },
       ],
     },
+    // Sessions only. The users fields are deprecated and never emitted; the
+    // fixture omits them so it matches what the report actually produces.
     aiReferrals: {
       totalSessions: 200,
-      totalUsers: 150,
       paidSessions: 150,
-      paidUsers: 110,
       organicSessions: 50,
-      organicUsers: 40,
       bySource: [
-        { source: 'chatgpt.com', sessions: 150, users: 110, paidSessions: 150, organicSessions: 0, sharePct: 75 },
-        { source: 'gemini.google.com', sessions: 50, users: 40, paidSessions: 0, organicSessions: 50, sharePct: 25 },
+        { source: 'chatgpt.com', sessions: 150, paidSessions: 150, organicSessions: 0, sharePct: 75 },
+        { source: 'gemini.google.com', sessions: 50, paidSessions: 0, organicSessions: 50, sharePct: 25 },
       ],
       trend: [
         { date: '2026-04-15', sessions: 100 },
         { date: '2026-04-16', sessions: 100 },
       ],
       topLandingPages: [
-        { page: '/', sessions: 120, users: 90 },
+        { page: '/', sessions: 120 },
       ],
     },
     serverActivity: {
@@ -1337,6 +1336,26 @@ describe('renderReportHtml', () => {
     expect(block).toContain('<svg')
     expect(block.toLowerCase()).not.toContain('building baseline')
   })
+  test('the AI referral section reports sessions only, with no users tile or column', () => {
+    const html = renderReportHtml(richReport())
+    // Scope to the AI section: the GA section legitimately keeps a users tile
+    // (its figure comes from GA's deduplicated window summary), so a
+    // whole-document search would be satisfied by the wrong section.
+    const start = html.indexOf('id="ai-referrals"')
+    expect(start).toBeGreaterThan(-1)
+    const nextSection = html.indexOf('<section', start + 1)
+    const aiHtml = nextSection === -1 ? html.slice(start) : html.slice(start, nextSection)
+
+    expect(aiHtml).toContain('Total sessions')
+    expect(aiHtml).not.toContain('Total users')
+    expect(aiHtml).not.toContain('>Users<')
+
+    // The GA section still has its users tile.
+    const gaStart = html.indexOf('id="ga"')
+    expect(gaStart).toBeGreaterThan(-1)
+    expect(html.slice(gaStart)).toContain('Total users')
+  })
+
 })
 
 describe('formatLandingPageHtml', () => {

--- a/packages/api-routes/test/report.test.ts
+++ b/packages/api-routes/test/report.test.ts
@@ -878,13 +878,19 @@ describe('GET /api/v1/projects/:name/report', () => {
     // The deduped total must be MAX(20, 30) = 30, not 20 + 30; the winning
     // lens supplies the paid/organic split.
     const projectId = insertProject(ctx.db, 'ai-overlap-report')
+    // Inside the report window: this test exercises lens dedup, not windowing.
+    const recentDate = (() => {
+      const d = new Date()
+      d.setUTCDate(d.getUTCDate() - 2)
+      return d.toISOString().slice(0, 10)
+    })()
     const now = new Date().toISOString()
 
     ctx.db.insert(gaAiReferrals).values([
       {
         id: crypto.randomUUID(),
         projectId,
-        date: '2026-04-30',
+        date: recentDate,
         source: 'chatgpt.com',
         medium: 'referral',
         trafficClass: 'paid',
@@ -899,7 +905,7 @@ describe('GET /api/v1/projects/:name/report', () => {
       {
         id: crypto.randomUUID(),
         projectId,
-        date: '2026-04-30',
+        date: recentDate,
         source: 'chatgpt.com',
         medium: 'referral',
         trafficClass: 'organic',
@@ -1032,7 +1038,11 @@ describe('GET /api/v1/projects/:name/report', () => {
 
   test('AI referrals dedupe overlapping attribution dimensions per (date, source, medium)', async () => {
     const projectId = insertProject(ctx.db, 'ai-dedupe')
-    const baseDate = '2026-04-30'
+    const baseDate = (() => {
+      const d = new Date()
+      d.setUTCDate(d.getUTCDate() - 2)
+      return d.toISOString().slice(0, 10)
+    })()
     ctx.db.insert(gaAiReferrals).values([
       {
         id: crypto.randomUUID(),
@@ -1086,28 +1096,14 @@ describe('GET /api/v1/projects/:name/report', () => {
     // for the window on a live project).
     ctx.db.insert(gaAiReferrals).values([
       {
-        id: crypto.randomUUID(),
-        projectId,
-        date: iso(2),
-        source: 'chatgpt.com',
-        medium: 'referral',
-        sourceDimension: 'session',
-        landingPage: '/',
-        sessions: 5,
-        users: 5,
-        syncedAt: new Date().toISOString(),
+        id: crypto.randomUUID(), projectId, date: iso(2),
+        source: 'chatgpt.com', medium: 'referral', sourceDimension: 'session',
+        landingPage: '/', sessions: 5, users: 5, syncedAt: new Date().toISOString(),
       },
       {
-        id: crypto.randomUUID(),
-        projectId,
-        date: iso(300),
-        source: 'chatgpt.com',
-        medium: 'referral',
-        sourceDimension: 'session',
-        landingPage: '/',
-        sessions: 500,
-        users: 500,
-        syncedAt: new Date().toISOString(),
+        id: crypto.randomUUID(), projectId, date: iso(300),
+        source: 'chatgpt.com', medium: 'referral', sourceDimension: 'session',
+        landingPage: '/', sessions: 500, users: 500, syncedAt: new Date().toISOString(),
       },
     ]).run()
 
@@ -1119,6 +1115,40 @@ describe('GET /api/v1/projects/:name/report', () => {
     const body = JSON.parse(res.body) as ProjectReportDto
     expect(body.aiReferrals).not.toBeNull()
     expect(body.aiReferrals!.totalSessions).toBe(5)
+  })
+
+  test('a quiet current window reports zero, even when historical referrals exist', async () => {
+    const projectId = insertProject(ctx.db, 'ai-quiet')
+    const iso = (daysAgo: number): string => {
+      const d = new Date()
+      d.setUTCDate(d.getUTCDate() - daysAgo)
+      return d.toISOString().slice(0, 10)
+    }
+    // ONLY historical referrals. Anchoring the window to the referral table's
+    // own MAX(date) would float it back to 200 days ago and render these as
+    // "last 30 days"; a GA sync only deletes rows inside its current range, so
+    // stale referrals legitimately outlive the window and the empty state has
+    // to stay reachable.
+    ctx.db.insert(gaAiReferrals).values([
+      {
+        id: crypto.randomUUID(), projectId, date: iso(200),
+        source: 'chatgpt.com', medium: 'referral', sourceDimension: 'session',
+        landingPage: '/', sessions: 900, users: 900, syncedAt: new Date().toISOString(),
+      },
+      {
+        id: crypto.randomUUID(), projectId, date: iso(210),
+        source: 'chatgpt.com', medium: 'referral', sourceDimension: 'session',
+        landingPage: '/', sessions: 900, users: 900, syncedAt: new Date().toISOString(),
+      },
+    ]).run()
+
+    await ctx.app.ready()
+    const res = await ctx.app.inject({
+      method: 'GET',
+      url: '/api/v1/projects/ai-quiet/report?period=30',
+    })
+    const body = JSON.parse(res.body) as ProjectReportDto
+    expect(body.aiReferrals?.totalSessions ?? 0).toBe(0)
   })
 
   test('indexing health prefers GSC and falls back to Bing', async () => {

--- a/packages/api-routes/test/report.test.ts
+++ b/packages/api-routes/test/report.test.ts
@@ -919,7 +919,6 @@ describe('GET /api/v1/projects/:name/report', () => {
 
     expect(body.aiReferrals).not.toBeNull()
     expect(body.aiReferrals!.totalSessions).toBe(30)
-    expect(body.aiReferrals!.totalUsers).toBe(25)
     expect(body.aiReferrals!.paidSessions).toBe(0)
     expect(body.aiReferrals!.organicSessions).toBe(30)
     // Invariant: the paid/organic split always partitions the deduped total.
@@ -1067,12 +1066,59 @@ describe('GET /api/v1/projects/:name/report', () => {
 
     expect(body.aiReferrals).not.toBeNull()
     expect(body.aiReferrals!.totalSessions).toBe(10)
-    expect(body.aiReferrals!.totalUsers).toBe(8)
     expect(body.aiReferrals!.paidSessions).toBe(0)
     expect(body.aiReferrals!.organicSessions).toBe(10)
     expect(body.aiReferrals!.bySource[0]!.sessions).toBe(10)
     expect(body.aiReferrals!.trend[0]!.sessions).toBe(10)
     expect(body.aiReferrals!.topLandingPages[0]!.sessions).toBe(10)
+  })
+
+  test('AI referrals count only the report window, not all retained history', async () => {
+    const projectId = insertProject(ctx.db, 'ai-window')
+    const iso = (daysAgo: number): string => {
+      const d = new Date()
+      d.setUTCDate(d.getUTCDate() - daysAgo)
+      return d.toISOString().slice(0, 10)
+    }
+    // 5 sessions inside the window, 500 far outside it. This read previously
+    // had NO date bound at all, so a report labelled "last 30 days" summed the
+    // project's entire retained history (measured 3,106 all-time against 52
+    // for the window on a live project).
+    ctx.db.insert(gaAiReferrals).values([
+      {
+        id: crypto.randomUUID(),
+        projectId,
+        date: iso(2),
+        source: 'chatgpt.com',
+        medium: 'referral',
+        sourceDimension: 'session',
+        landingPage: '/',
+        sessions: 5,
+        users: 5,
+        syncedAt: new Date().toISOString(),
+      },
+      {
+        id: crypto.randomUUID(),
+        projectId,
+        date: iso(300),
+        source: 'chatgpt.com',
+        medium: 'referral',
+        sourceDimension: 'session',
+        landingPage: '/',
+        sessions: 500,
+        users: 500,
+        syncedAt: new Date().toISOString(),
+      },
+    ]).run()
+
+    await ctx.app.ready()
+    const res = await ctx.app.inject({
+      method: 'GET',
+      url: '/api/v1/projects/ai-window/report?period=30',
+    })
+    const body = JSON.parse(res.body) as ProjectReportDto
+    expect(body.aiReferrals).not.toBeNull()
+    expect(body.aiReferrals!.totalSessions).toBe(5)
   })
 
   test('indexing health prefers GSC and falls back to Bing', async () => {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.126.0",
+  "version": "4.127.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/contracts/src/report.ts
+++ b/packages/contracts/src/report.ts
@@ -394,17 +394,28 @@ export const socialReferralSectionSchema = z.object({
 
 export type SocialReferralSection = z.infer<typeof socialReferralSectionSchema>
 
+/**
+ * AI-referral traffic for the report window.
+ *
+ * SESSIONS ONLY, deliberately. A `users` count was removed here: GA reports
+ * `totalUsers` as a COUNT DISTINCT at the grain it was asked for, and
+ * `ga_ai_referrals` is keyed by (date, source, medium, channelGroup,
+ * landingPage, sourceDimension). Summing that column re-counts the same
+ * visitor on every extra day, page and channel they appear in, and no
+ * un-dimensioned AI-referral fetch exists to ask Google for the real figure.
+ * The number could not be made true, so it is not reported.
+ *
+ * Sessions ARE additive here once the overlapping attribution lenses are
+ * deduped (GA4 attributes one landing page per session, and dates are
+ * disjoint), which is why every field below is session-based.
+ */
 export const aiReferralSectionSchema = z.object({
   totalSessions: z.number(),
-  totalUsers: z.number(),
   paidSessions: z.number(),
-  paidUsers: z.number(),
   organicSessions: z.number(),
-  organicUsers: z.number(),
   bySource: z.array(z.object({
     source: z.string(),
     sessions: z.number(),
-    users: z.number(),
     paidSessions: z.number(),
     organicSessions: z.number(),
     sharePct: z.number(),
@@ -413,7 +424,6 @@ export const aiReferralSectionSchema = z.object({
   topLandingPages: z.array(z.object({
     page: z.string(),
     sessions: z.number(),
-    users: z.number(),
   })),
 })
 

--- a/packages/contracts/src/report.ts
+++ b/packages/contracts/src/report.ts
@@ -413,9 +413,28 @@ export const aiReferralSectionSchema = z.object({
   totalSessions: z.number(),
   paidSessions: z.number(),
   organicSessions: z.number(),
+  /**
+   * @deprecated Never emitted since 4.127.0 and removed in the next major.
+   *
+   * GA reports `totalUsers` as a COUNT DISTINCT at the grain requested, and
+   * `ga_ai_referrals` is keyed by (date, source, medium, channelGroup,
+   * landingPage, sourceDimension), so summing it re-counted the same visitor on
+   * every extra day, page and channel. Unlike GA daily users, no
+   * un-dimensioned AI-referral fetch exists to ask Google for the true figure,
+   * so the number could not be corrected — only withdrawn. Optional rather than
+   * deleted so existing API / `canonry report --format json` / MCP consumers
+   * keep parsing; they now read `undefined` instead of an inflated number.
+   */
+  totalUsers: z.number().optional(),
+  /** @deprecated See `totalUsers`. Never emitted since 4.127.0. */
+  paidUsers: z.number().optional(),
+  /** @deprecated See `totalUsers`. Never emitted since 4.127.0. */
+  organicUsers: z.number().optional(),
   bySource: z.array(z.object({
     source: z.string(),
     sessions: z.number(),
+    /** @deprecated See `totalUsers`. Never emitted since 4.127.0. */
+    users: z.number().optional(),
     paidSessions: z.number(),
     organicSessions: z.number(),
     sharePct: z.number(),
@@ -424,6 +443,8 @@ export const aiReferralSectionSchema = z.object({
   topLandingPages: z.array(z.object({
     page: z.string(),
     sessions: z.number(),
+    /** @deprecated See `totalUsers`. Never emitted since 4.127.0. */
+    users: z.number().optional(),
   })),
 })
 


### PR DESCRIPTION
Two defects in one client-facing report section, both from the non-additive-metric audit.

## 1. No date filter at all

`buildAiReferrals` read **every** `ga_ai_referrals` row for the project, so a report labelled "last 30 days" summed the entire retained history into its tiles.

| client | tile showed (all-time) | actual 30d window | overstatement |
|---|---|---|---|
| **demand-iq** | **3,106** | 52 | **~60x** |
| gjelina | 783 | 75 | ~10x |

It now takes the report's `periodDays`, like every sibling section already did.

## 2. `users` could not be made truthful, so it is gone

GA returns `totalUsers` as a COUNT DISTINCT at the grain requested, and `ga_ai_referrals` is keyed by `(date, source, medium, channelGroup, landingPage, sourceDimension)`. Summing that column re-counts the same visitor on every extra day, page and channel they appear in.

Unlike the GA daily-users case fixed in #831, **there is no un-dimensioned AI-referral fetch** to ask Google for the deduplicated figure. The number could not be made correct, so it is not reported: `totalUsers` / `paidUsers` / `organicUsers`, `bySource[].users` and `topLandingPages[].users` are removed from the DTO and the HTML report.

Sessions are unaffected and remain correct — the existing attribution-lens dedup already collapses the overlapping `session` / `first_user` / `manual_utm` views, GA4 attributes one landing page per session, and dates are disjoint.

## Notes

- **Breaking DTO change**, covered by the version bump. The SPA never referenced these fields, so report parity is unchanged; only the HTML renderer's "Total users" tile and the AI landing-page table's Users column go away.
- While editing the renderer I initially removed the wrong table's users cell (the GA section, whose users figure is legitimate — it comes from the deduplicated window summary). Caught by typecheck, restored, and verified the GA table still renders four columns against a four-column header.
- Regression test verified against the unbounded read: **505 vs 5**.
- `pnpm typecheck` clean, `pnpm lint` 0 errors, full suite **462 files / 5696 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)