### PR TITLE
fix(ads): tolerate activation read-after-write lag

### DIFF
--- a/packages/api-routes/src/ads-activation.ts
+++ b/packages/api-routes/src/ads-activation.ts
@@ -263,6 +263,8 @@ export interface AdsActivationDependencies {
   now?: () => Date
   randomId?: () => string
   leaseMs?: number
+  sleep?: (ms: number) => Promise<void>
+  activationVerificationRetryDelaysMs?: readonly number[]
 }
 
 export interface AdsActivationResult {
@@ -288,7 +290,10 @@ interface ActivationTarget {
 }
 
 interface ActivationContext {
-  deps: Required<Pick<AdsActivationDependencies, 'now' | 'randomId' | 'leaseMs'>>
+  deps: Required<Pick<
+    AdsActivationDependencies,
+    'now' | 'randomId' | 'leaseMs' | 'sleep' | 'activationVerificationRetryDelaysMs'
+  >>
     & Pick<AdsActivationDependencies, 'store' | 'provider'>
   request: AdsActivationRequest
   manifest: AdsActivationManifest
@@ -299,6 +304,7 @@ interface ActivationContext {
 }
 
 const DEFAULT_LEASE_MS = 5 * 60_000
+const DEFAULT_ACTIVATION_VERIFICATION_RETRY_DELAYS_MS = [100, 250, 500, 1_000, 2_000, 2_000] as const
 const PROVIDER_PAUSED = 'paused'
 const PROVIDER_ACTIVE = 'active'
 
@@ -1475,6 +1481,85 @@ async function validateActiveDescendants(
   }
 }
 
+type VerifiedActiveEntitySnapshot = AdsActivationEntitySnapshot & {
+  status: typeof PROVIDER_ACTIVE
+  updatedAt: number
+}
+
+type ActivationVerificationResult =
+  | { ok: true; entity: VerifiedActiveEntitySnapshot }
+  | { ok: false; error: AdsActivationError; providerUpdatedAt: number | null }
+
+async function verifyActiveAfterMutation(
+  ctx: ActivationContext,
+  target: ActivationTarget,
+): Promise<ActivationVerificationResult> {
+  let lastUpdatedAt: number | null = null
+  for (let attempt = 0; ; attempt++) {
+    let entity: AdsActivationEntitySnapshot | null = null
+    try {
+      entity = await readTarget(ctx.deps.provider, target)
+      lastUpdatedAt = entity.updatedAt
+    } catch {
+      // A dropped verification read is retryable. The activation is never resent.
+    }
+
+    if (entity) {
+      try {
+        validateIdentity(target, entity)
+        validateAdApproval(target, entity)
+      } catch (cause) {
+        return {
+          ok: false,
+          error: cause instanceof AdsActivationError
+            ? cause
+            : targetError(
+                AdsActivationErrorCodes.providerMutationFailed,
+                'Provider activation validation failed',
+                502,
+                target,
+              ),
+          providerUpdatedAt: entity.updatedAt,
+        }
+      }
+      if (entity.status === PROVIDER_ACTIVE && entity.updatedAt !== null) {
+        return { ok: true, entity: entity as VerifiedActiveEntitySnapshot }
+      }
+      const exactPreMutationSnapshot = entity.status === PROVIDER_PAUSED
+        && entity.updatedAt === target.expectedUpdatedAt
+      if (!exactPreMutationSnapshot) {
+        return {
+          ok: false,
+          error: targetError(
+            AdsActivationErrorCodes.providerMutationFailed,
+            'Provider did not confirm the required active state',
+            502,
+            target,
+          ),
+          providerUpdatedAt: entity.updatedAt,
+        }
+      }
+    }
+
+    if (attempt >= ctx.deps.activationVerificationRetryDelaysMs.length) {
+      return {
+        ok: false,
+        error: targetError(
+          AdsActivationErrorCodes.providerMutationFailed,
+          'Provider activation outcome could not be verified',
+          502,
+          target,
+        ),
+        providerUpdatedAt: lastUpdatedAt,
+      }
+    }
+    const delayMs = ctx.deps.activationVerificationRetryDelaysMs[attempt]!
+    await renewLease(ctx)
+    await ctx.deps.sleep(delayMs)
+    await renewLease(ctx)
+  }
+}
+
 async function activateOne(ctx: ActivationContext, original: AdsActivationStepRecord): Promise<void> {
   let step = currentStep(ctx, original.id)
   if (step.state === AdsOperationStepStates.active) {
@@ -1533,27 +1618,16 @@ async function activateOne(ctx: ActivationContext, original: AdsActivationStepRe
   // request timeouts, and this renewal gives the read a fresh full window.
   await renewLease(ctx)
 
-  let entity: AdsActivationEntitySnapshot
-  try {
-    entity = await readTarget(ctx.deps.provider, target)
-  } catch {
-    const error = targetError(AdsActivationErrorCodes.providerMutationFailed, 'Provider activation outcome could not be verified', 502, target)
-    await transitionStep(ctx, step, unknownStep(step, error, null, ctx.deps.now().toISOString()))
-    throw error
+  const verification = await verifyActiveAfterMutation(ctx, target)
+  if (!verification.ok) {
+    await transitionStep(
+      ctx,
+      step,
+      unknownStep(step, verification.error, verification.providerUpdatedAt, ctx.deps.now().toISOString()),
+    )
+    throw verification.error
   }
-  try {
-    validateIdentity(target, entity)
-    validateAdApproval(target, entity)
-    if (entity.status !== PROVIDER_ACTIVE || entity.updatedAt === null) {
-      throw targetError(AdsActivationErrorCodes.providerMutationFailed, 'Provider did not confirm the required active state', 502, target)
-    }
-  } catch (cause) {
-    const error = cause instanceof AdsActivationError
-      ? cause
-      : targetError(AdsActivationErrorCodes.providerMutationFailed, 'Provider activation validation failed', 502, target)
-    await transitionStep(ctx, step, unknownStep(step, error, entity.updatedAt, ctx.deps.now().toISOString()))
-    throw error
-  }
+  const { entity } = verification
   await validateExactDescendants(
     ctx.deps.provider,
     ctx.manifest,
@@ -1778,9 +1852,23 @@ export async function executeApprovedAdsActivation(
     now: dependencies.now ?? (() => new Date()),
     randomId: dependencies.randomId ?? (() => crypto.randomUUID()),
     leaseMs: dependencies.leaseMs ?? DEFAULT_LEASE_MS,
+    sleep: dependencies.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms))),
+    activationVerificationRetryDelaysMs: dependencies.activationVerificationRetryDelaysMs
+      ?? DEFAULT_ACTIVATION_VERIFICATION_RETRY_DELAYS_MS,
   }
   if (!Number.isSafeInteger(deps.leaseMs) || deps.leaseMs <= 0) {
     throw new AdsActivationError(AdsActivationErrorCodes.invalidManifest, 'Activation lease duration is invalid', 400)
+  }
+  if (
+    deps.activationVerificationRetryDelaysMs.some((delay) =>
+      !Number.isSafeInteger(delay) || delay < 0,
+    )
+  ) {
+    throw new AdsActivationError(
+      AdsActivationErrorCodes.invalidManifest,
+      'Activation verification retry delays are invalid',
+      400,
+    )
   }
 
   const now = deps.now()

--- a/packages/api-routes/test/ads-activation-routes.test.ts
+++ b/packages/api-routes/test/ads-activation-routes.test.ts
@@ -54,7 +54,7 @@ interface ActivationHarnessOptions {
   activationLeaseMs?: number
   blockAdActivation?: boolean
   blockAdActivationBeforeMutation?: boolean
-  failCampaignReadAfterActivation?: boolean
+  driftCampaignVersionAfterActivation?: boolean
   failDescendantReadAfterCampaignActivation?: boolean
   injectDescendantAfterCampaignActivation?: boolean
   sweepBatchSize?: number
@@ -147,7 +147,6 @@ function buildHarness(options: ActivationHarnessOptions = {}) {
   const calls: string[] = []
   let verifyMustFail = false
   let verifyFailureCountdown: number | undefined
-  let campaignReadMustFail = false
   let campaignDescendantReadMustFail = false
   let signalActivationStarted: (() => void) | undefined
   let releaseBlockedActivation: (() => void) | undefined
@@ -160,10 +159,6 @@ function buildHarness(options: ActivationHarnessOptions = {}) {
 
   function read(kind: string, id: string): AdsOperatorEntityResult {
     calls.push(`get:${kind}:${id}`)
-    if (kind === 'campaign' && campaignReadMustFail) {
-      campaignReadMustFail = false
-      throw new Error('provider read failed with sk-secret')
-    }
     const entity = entities.get(id)
     if (!entity) throw new Error('missing test entity')
     return { ...entity }
@@ -178,9 +173,13 @@ function buildHarness(options: ActivationHarnessOptions = {}) {
     if (
       status === 'active'
       && kind === 'campaign'
-      && options.failCampaignReadAfterActivation
+      && options.driftCampaignVersionAfterActivation
     ) {
-      campaignReadMustFail = true
+      entities.set(id, {
+        ...next,
+        status: 'paused',
+        updatedAt: next.updatedAt + 1,
+      })
     }
     if (
       status === 'active'
@@ -1524,7 +1523,7 @@ describe('ads approval-bound activation routes', () => {
     await ctx.app.close()
     fs.rmSync(ctx.tmpDir, { recursive: true, force: true })
     ctx = buildHarness({
-      failCampaignReadAfterActivation: true,
+      driftCampaignVersionAfterActivation: true,
       sweepIntervalMs: 10,
     })
     await ctx.app.ready()

--- a/packages/api-routes/test/ads-activation.test.ts
+++ b/packages/api-routes/test/ads-activation.test.ts
@@ -570,6 +570,74 @@ describe('approval-bound ads activation core', () => {
     ])
   })
 
+  it('waits for read-after-write lag without resending any activation', async () => {
+    const provider = new FakeProvider()
+    const store = new MemoryActivationStore()
+    const sleeps: number[] = []
+    provider.afterActivate = (entityType, entityId) => {
+      const active = provider.entities.get(entityKey(entityType, entityId))!
+      const stale = {
+        ...active,
+        status: 'paused',
+        updatedAt: (active.updatedAt ?? 1) - 1,
+      }
+      provider.queueReads(entityType, entityId, stale, stale)
+    }
+
+    const result = await executeApprovedAdsActivation({
+      provider,
+      store,
+      now: fixedNow,
+      randomId: deterministicIds(),
+      sleep: async (ms) => {
+        sleeps.push(ms)
+      },
+      activationVerificationRetryDelaysMs: [10, 20],
+    }, activationRequest())
+
+    expect(mutationCalls(provider)).toEqual([
+      'activate:ad:ad_1',
+      'activate:ad_group:adgrp_1',
+      'activate:campaign:cmpn_1',
+    ])
+    expect(sleeps).toEqual([10, 20, 10, 20, 10, 20])
+    expect(result.operation.state).toBe(AdsOperationStates.succeeded)
+    expect(result.steps.every((step) => step.state === AdsOperationStepStates.active)).toBe(true)
+  })
+
+  it('does not retry a post-mutation version drift', async () => {
+    const provider = new FakeProvider()
+    const store = new MemoryActivationStore()
+    const sleeps: number[] = []
+    provider.afterActivate = (entityType, entityId) => {
+      if (entityType !== AdsActivationEntityTypes.ad) return
+      provider.queueReads(entityType, entityId, {
+        id: entityId,
+        adGroupId: 'adgrp_1',
+        reviewStatus: 'approved',
+        status: 'paused',
+        updatedAt: 999,
+      })
+    }
+
+    await expect(executeApprovedAdsActivation({
+      provider,
+      store,
+      now: fixedNow,
+      randomId: deterministicIds(),
+      sleep: async (ms) => {
+        sleeps.push(ms)
+      },
+      activationVerificationRetryDelaysMs: [10],
+    }, activationRequest())).rejects.toMatchObject({
+      code: AdsActivationErrorCodes.manualRemediationRequired,
+    })
+
+    expect(sleeps).toEqual([])
+    expect(mutationCalls(provider)).toEqual(['activate:ad:ad_1'])
+    expect(store.operation?.state).toBe(AdsOperationStates.unknown)
+  })
+
   it('recovers an executing step with GET only and never resends its activation', async () => {
     const provider = new FakeProvider()
     provider.setEntity(AdsActivationEntityTypes.ad, {
@@ -942,6 +1010,7 @@ describe('approval-bound ads activation core', () => {
       store,
       now: fixedNow,
       randomId: deterministicIds(),
+      activationVerificationRetryDelaysMs: [],
     }, activationRequest())).rejects.toMatchObject({
       code: AdsActivationErrorCodes.manualRemediationRequired,
     })


### PR DESCRIPTION
## What happened

The live Canonry Ads beta activation reached OpenAI without an HTTP error, but the immediate verification read still returned the exact pre-mutation `paused` snapshot. The activation core treated that single stale read as an ambiguous mutation, failed closed, and safety-paused the campaign tree.

OpenAI documents the lifecycle endpoints as returning updated objects, and its partner flow activates a prepared campaign after the child resources are ready. The provider read surface can still lag the accepted lifecycle mutation.

## Fix

- Retry **read-only verification** for about 5.85 seconds after the single activation request.
- Retry only while OpenAI returns the exact approved pre-mutation `paused` version, or a verification read temporarily fails.
- Renew the fenced activation lease before and after every wait.
- Never resend the activation mutation.
- Fail closed immediately on identity, review, version, or unexpected status drift.
- Preserve the last provider version in the unknown receipt when verification exhausts.

## Safety invariants

- Human grant, manifest hash, advertiser account, executor identity, expiry, and optimistic concurrency checks are unchanged.
- Activation ordering and rollback ordering are unchanged.
- Exhausted verification still becomes `unknown` and enters the existing containment path.
- A changed provider version is never retried as eventual consistency.

## Validation

- `pnpm exec vitest run packages/api-routes/test/ads-activation.test.ts` (21 passed)
- `pnpm run typecheck`
- `pnpm run lint` (no errors; existing warnings only)
- `git diff --check`

Regression coverage proves delayed reads converge without duplicate activation calls and provider version drift fails closed without waiting.