### PR TITLE
chore(ci): quiet the pre-commit lint hook on success

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,17 @@
-pnpm run lint
+# Lint gate. Output is captured, not streamed: `pnpm run lint` prints ~99KB of
+# pre-existing warnings from unrelated packages on every commit, which buries
+# the commit result, and for an agent driving this repo it overflows the output
+# budget so the real result has to be re-fetched.
+#
+# Behaviour is unchanged where it matters: a lint ERROR still fails the commit.
+# Only the success path goes quiet. Run `pnpm run lint` directly to see warnings.
+log="$(mktemp -t canonry-precommit-lint.XXXXXX)"
+if pnpm run lint > "$log" 2>&1; then
+  rm -f "$log"
+else
+  echo "pre-commit: lint FAILED" >&2
+  tail -40 "$log" >&2
+  echo "" >&2
+  echo "pre-commit: full lint output -> $log" >&2
+  exit 1
+fi


### PR DESCRIPTION
The hook was a bare `pnpm run lint`, so every commit streamed the full workspace lint output — **measured 100,828 bytes** of pre-existing warnings from packages the commit never touched.

That buries the commit result for a human. For an agent driving this repo it overflows the output budget, so the real result gets truncated into a file and has to be re-fetched on a second call. It happened repeatedly across a long session today.

## Change

Capture to a temp log; stay silent on success.

A lint **error** still fails the commit exactly as before, now printing the last 40 lines plus the path to the full log. Warnings stay available via `pnpm run lint` directly.

## Verification

Both paths exercised in isolation:

```
FAIL path → exit 1, prints "pre-commit: lint FAILED" + log path
PASS path → exit 0, prints nothing
```

And end-to-end: the commit that created this PR produced no lint output at all.

One honest note — I first tried to prove the gate by injecting a banned literal, and lint passed, which briefly looked like I'd broken it. Lint genuinely does not error on that rule in that path, so the gate was never bypassed; I then tested the hook's control flow directly rather than relying on guessing which rule errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)