### PR TITLE
chore(release): bump canonry to 4.127.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.126.0",
+  "version": "4.127.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.126.0",
+  "version": "4.127.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Context

Canonry Engine PR #838 added bounded read-only verification retries for OpenAI Ads activation without resending lifecycle mutations. The merged behavioral change needs a package version change before the publish workflow will emit npm and Docker artifacts.

## What ships

- Bumps the root package version from `4.126.0` to `4.127.0`.
- Bumps `@canonry/canonry` from `4.126.0` to `4.127.0`.
- Triggers the existing publish workflow after merge to `main`.

## Test coverage

No runtime code changes. PR #838 passed the full 5,697-test suite before merge.

## Validation

- [x] Root and publishable package versions match
- [x] Latest npm version verified as `4.126.0`
- [x] Full repository typecheck
- [x] Full repository lint, zero errors
- [x] `git diff --check`