### PR TITLE
chore(release): bump canonry to 4.128.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.127.0",
+  "version": "4.128.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.127.0",
+  "version": "4.128.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",


### PR DESCRIPTION
## Release

Bump Canonry Engine from 4.127.0 to 4.128.0 so the activation recovery fix merged in #842 is published to npm and container registries.

## Included fix

Explicitly revoked unknown campaign-tree activations remain under recurring pause containment for a full settlement window. Once the live provider tree is completely enumerated and every entity is verified paused, the Engine atomically settles the receipt as failed and consumes the single-use grant. Any incomplete verification remains unknown and fail-closed.

## Validation

- #842 CI: all required checks passed
- API route suite: 1,666/1,666 passed
- Full typecheck passed
- Full lint passed with zero errors