### PR TITLE
fix(google): gather only submittable URLs for request-indexing

### DIFF
--- a/packages/api-routes/src/google.ts
+++ b/packages/api-routes/src/google.ts
@@ -39,6 +39,23 @@ import {
 } from '@ainyc/canonry-integration-google-business-profile'
 
 /**
+ * Does a URL sit on the project's canonical host?
+ *
+ * The Indexing API only accepts URLs on the exact verified host, so a
+ * subdomain is as unusable as an unrelated domain even when a `sc-domain:`
+ * property covers it. Shared by the request-indexing gather step and its
+ * validation so the two can never disagree about what "on the domain" means.
+ * `www.` is stripped on both sides; an unparseable URL is not on the domain.
+ */
+function isOnProjectDomain(url: string, projectDomain: string): boolean {
+  try {
+    return new URL(url).hostname.toLowerCase().replace(/^www\./, '') === projectDomain
+  } catch {
+    return false
+  }
+}
+
+/**
  * Scopes requested per connection type. Centralized so all OAuth surface
  * (connect + callback + token refresh) speaks the same language. Add new
  * connection types here, not as inline ternaries.
@@ -1303,15 +1320,29 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
         }
       }
 
+      // Inspection history accumulates hosts the Indexing API will not accept:
+      // URLs from a previous domain the project has since migrated off, and
+      // subdomains that a `sc-domain:` property legitimately reports. Skip them
+      // here rather than letting the canonical-domain check below reject the
+      // whole batch — one stale row must not make this endpoint unusable.
+      const gatherDomain = normalizeProjectDomain(project.canonicalDomain)
       const unindexedUrls: string[] = []
+      let skippedOtherHost = 0
       for (const [url, row] of latestByUrl) {
-        if (row.indexingState !== 'INDEXING_ALLOWED') {
-          unindexedUrls.push(url)
+        if (row.indexingState === 'INDEXING_ALLOWED') continue
+        if (!isOnProjectDomain(url, gatherDomain)) {
+          skippedOtherHost += 1
+          continue
         }
+        unindexedUrls.push(url)
       }
 
       if (unindexedUrls.length === 0) {
-        throw validationError('No unindexed URLs found. Run "canonry google inspect-sitemap" first.')
+        throw validationError(
+          skippedOtherHost > 0
+            ? `No unindexed URLs found on "${project.canonicalDomain}" (skipped ${skippedOtherHost} on other hosts). Run "canonry google inspect-sitemap" first.`
+            : 'No unindexed URLs found. Run "canonry google inspect-sitemap" first.',
+        )
       }
 
       urlsToNotify = unindexedUrls
@@ -1325,16 +1356,11 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
       throw validationError(`Cannot request indexing for more than ${INDEXING_API_DAILY_LIMIT} URLs per request (got ${urlsToNotify.length})`)
     }
 
-    // Validate that all URLs belong to the project's canonical domain
+    // Validate that all URLs belong to the project's canonical domain. Reached
+    // only for caller-supplied URLs now — the allUnindexed path filters above,
+    // so a stale inspection row cannot fail a request the caller did not make.
     const projectDomain = normalizeProjectDomain(project.canonicalDomain)
-    const invalidUrls = urlsToNotify.filter((url) => {
-      try {
-        const hostname = new URL(url).hostname.toLowerCase().replace(/^www\./, '')
-        return hostname !== projectDomain
-      } catch {
-        return true
-      }
-    })
+    const invalidUrls = urlsToNotify.filter((url) => !isOnProjectDomain(url, projectDomain))
     if (invalidUrls.length > 0) {
       throw validationError(
         `URLs must belong to project domain "${project.canonicalDomain}". Invalid: ${invalidUrls.slice(0, 5).join(', ')}`,

--- a/packages/api-routes/test/google-request-indexing-domain.test.ts
+++ b/packages/api-routes/test/google-request-indexing-domain.test.ts
@@ -1,0 +1,165 @@
+/**
+ * `allUnindexed` must gather only URLs the Indexing API can accept.
+ *
+ * Inspection history accumulates hosts that are no longer submittable: URLs
+ * from a domain the project has migrated off (which now 301 to the canonical
+ * host), and subdomains that a `sc-domain:` property legitimately reports. The
+ * gather step used to collect every inspected URL and the canonical-domain
+ * check then rejected the whole batch, so a single stale row made the endpoint
+ * permanently unusable on a migrated project — it gathered URLs it would then
+ * refuse. These tests pin the filter, and pin that an explicitly-supplied
+ * off-domain URL is still a loud error rather than being silently dropped.
+ */
+import { describe, it, beforeEach, afterEach, expect } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import Fastify from 'fastify'
+import type { FastifyInstance } from 'fastify'
+import { createClient, migrate, projects, gscUrlInspections } from '@ainyc/canonry-db'
+import { AppError } from '@ainyc/canonry-contracts'
+import { googleRoutes } from '../src/google.js'
+
+const PROJECT_ID = 'p-indexing-domain'
+const PROJECT_NAME = 'migrated-site'
+
+function buildApp() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsc-indexing-domain-'))
+  const db = createClient(path.join(tmpDir, 'test.db'))
+  migrate(db)
+
+  const now = new Date().toISOString()
+  db.insert(projects).values({
+    id: PROJECT_ID,
+    name: PROJECT_NAME,
+    displayName: 'Migrated Site',
+    // The project moved here from a previous domain.
+    canonicalDomain: 'canonical.example',
+    country: 'US',
+    language: 'en',
+    createdAt: now,
+    updatedAt: now,
+  }).run()
+
+  const app = Fastify()
+  app.decorate('db', db)
+  app.setErrorHandler((error, _request, reply) => {
+    if (error instanceof AppError) return reply.status(error.statusCode).send(error.toJSON())
+    throw error
+  })
+  app.register(googleRoutes, {
+    getGoogleAuthConfig: () => ({ clientId: 'id', clientSecret: 'secret' }),
+    googleConnectionStore: {
+      listConnections: () => [],
+      // A live GSC connection, so the route reaches the URL-gathering step.
+      getConnection: () => ({
+        domain: 'canonical.example',
+        connectionType: 'gsc' as const,
+        propertyId: 'sc-domain:canonical.example',
+        accessToken: 'token',
+        refreshToken: 'refresh',
+        tokenExpiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+        scopes: [],
+        createdAt: now,
+        updatedAt: now,
+      }),
+      upsertConnection: (c) => c,
+      updateConnection: () => undefined,
+      deleteConnection: () => false,
+    },
+    googleStateSecret: 'test-secret-32-bytes-long-enough!',
+  })
+
+  return { app, db, tmpDir }
+}
+
+function seedInspection(db: ReturnType<typeof createClient>, url: string, state: string): void {
+  const now = new Date().toISOString()
+  db.insert(gscUrlInspections).values({
+    id: `insp-${Buffer.from(url).toString('base64url').slice(0, 24)}`,
+    projectId: PROJECT_ID,
+    url,
+    indexingState: state,
+    inspectedAt: now,
+    createdAt: now,
+  }).run()
+}
+
+async function requestIndexing(app: FastifyInstance, body: Record<string, unknown>) {
+  return app.inject({
+    method: 'POST',
+    url: `/projects/${PROJECT_NAME}/google/indexing/request`,
+    payload: body,
+  })
+}
+
+describe('request-indexing: allUnindexed gathers only submittable URLs', () => {
+  let ctx: ReturnType<typeof buildApp>
+
+  beforeEach(() => { ctx = buildApp() })
+  afterEach(async () => {
+    await ctx.app.close()
+    fs.rmSync(ctx.tmpDir, { recursive: true, force: true })
+  })
+
+  it('skips a previous domain the project migrated away from', async () => {
+    seedInspection(ctx.db, 'https://previous.example/blog/one', 'NOT_INDEXED')
+    seedInspection(ctx.db, 'https://canonical.example/blog/one', 'NOT_INDEXED')
+
+    const res = await requestIndexing(ctx.app, { allUnindexed: true })
+
+    // The stale host must not surface as a validation failure. Before the fix
+    // this returned 400 "URLs must belong to project domain". Assert the
+    // specific rejection is gone rather than "not 400", which a 404 satisfies.
+    expect(res.body).not.toContain('must belong to project domain')
+    expect(res.body).not.toContain('previous.example')
+  })
+
+  it('skips a subdomain that a sc-domain property reports', async () => {
+    seedInspection(ctx.db, 'https://app.canonical.example/', 'NOT_INDEXED')
+    seedInspection(ctx.db, 'https://canonical.example/blog/one', 'NOT_INDEXED')
+
+    const res = await requestIndexing(ctx.app, { allUnindexed: true })
+
+    expect(res.body).not.toContain('must belong to project domain')
+    expect(res.body).not.toContain('app.canonical.example')
+  })
+
+  it('says so plainly when every unindexed URL is on another host', async () => {
+    seedInspection(ctx.db, 'https://previous.example/blog/one', 'NOT_INDEXED')
+    seedInspection(ctx.db, 'https://app.canonical.example/', 'NOT_INDEXED')
+
+    const res = await requestIndexing(ctx.app, { allUnindexed: true })
+
+    expect(res.statusCode).toBe(400)
+    const body = JSON.parse(res.body) as { error: { message: string } }
+    // The operator needs to know the rows existed but were not submittable,
+    // not just "none found".
+    expect(body.error.message).toContain('canonical.example')
+    expect(body.error.message).toContain('skipped 2')
+  })
+
+  it('still ignores URLs that are already indexed', async () => {
+    seedInspection(ctx.db, 'https://canonical.example/indexed', 'INDEXING_ALLOWED')
+
+    const res = await requestIndexing(ctx.app, { allUnindexed: true })
+
+    expect(res.statusCode).toBe(400)
+    const body = JSON.parse(res.body) as { error: { message: string } }
+    expect(body.error.message).toContain('No unindexed URLs found')
+    // Nothing was skipped for host reasons, so the message must not claim it.
+    expect(body.error.message).not.toContain('skipped')
+  })
+
+  it('rejects an off-domain URL the caller supplied explicitly', async () => {
+    // Filtering is for the gathered set only. A URL the caller typed is a
+    // real mistake and must still be reported rather than silently dropped.
+    const res = await requestIndexing(ctx.app, {
+      urls: ['https://canonical.example/ok', 'https://elsewhere.example/nope'],
+    })
+
+    expect(res.statusCode).toBe(400)
+    const body = JSON.parse(res.body) as { error: { message: string } }
+    expect(body.error.message).toContain('elsewhere.example')
+  })
+})

--- a/packages/api-routes/test/google-request-indexing-domain.test.ts
+++ b/packages/api-routes/test/google-request-indexing-domain.test.ts
@@ -95,9 +95,30 @@ async function requestIndexing(app: FastifyInstance, body: Record<string, unknow
 
 describe('request-indexing: allUnindexed gathers only submittable URLs', () => {
   let ctx: ReturnType<typeof buildApp>
+  let originalFetch: typeof globalThis.fetch
+  let notifiedUrls: string[]
 
-  beforeEach(() => { ctx = buildApp() })
+  beforeEach(() => {
+    ctx = buildApp()
+    originalFetch = globalThis.fetch
+    notifiedUrls = []
+    globalThis.fetch = async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? '{}')) as { url: string }
+      notifiedUrls.push(body.url)
+      return new Response(JSON.stringify({
+        urlNotificationMetadata: {
+          url: body.url,
+          latestUpdate: {
+            url: body.url,
+            type: 'URL_UPDATED',
+            notifyTime: '2026-07-22T00:00:00.000Z',
+          },
+        },
+      }), { status: 200 })
+    }
+  })
   afterEach(async () => {
+    globalThis.fetch = originalFetch
     await ctx.app.close()
     fs.rmSync(ctx.tmpDir, { recursive: true, force: true })
   })
@@ -108,11 +129,10 @@ describe('request-indexing: allUnindexed gathers only submittable URLs', () => {
 
     const res = await requestIndexing(ctx.app, { allUnindexed: true })
 
-    // The stale host must not surface as a validation failure. Before the fix
-    // this returned 400 "URLs must belong to project domain". Assert the
-    // specific rejection is gone rather than "not 400", which a 404 satisfies.
-    expect(res.body).not.toContain('must belong to project domain')
-    expect(res.body).not.toContain('previous.example')
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as { summary: { total: number; succeeded: number } }
+    expect(body.summary).toMatchObject({ total: 1, succeeded: 1 })
+    expect(notifiedUrls).toEqual(['https://canonical.example/blog/one'])
   })
 
   it('skips a subdomain that a sc-domain property reports', async () => {
@@ -121,8 +141,10 @@ describe('request-indexing: allUnindexed gathers only submittable URLs', () => {
 
     const res = await requestIndexing(ctx.app, { allUnindexed: true })
 
-    expect(res.body).not.toContain('must belong to project domain')
-    expect(res.body).not.toContain('app.canonical.example')
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as { summary: { total: number; succeeded: number } }
+    expect(body.summary).toMatchObject({ total: 1, succeeded: 1 })
+    expect(notifiedUrls).toEqual(['https://canonical.example/blog/one'])
   })
 
   it('says so plainly when every unindexed URL is on another host', async () => {
@@ -137,6 +159,7 @@ describe('request-indexing: allUnindexed gathers only submittable URLs', () => {
     // not just "none found".
     expect(body.error.message).toContain('canonical.example')
     expect(body.error.message).toContain('skipped 2')
+    expect(notifiedUrls).toEqual([])
   })
 
   it('still ignores URLs that are already indexed', async () => {
@@ -149,6 +172,7 @@ describe('request-indexing: allUnindexed gathers only submittable URLs', () => {
     expect(body.error.message).toContain('No unindexed URLs found')
     // Nothing was skipped for host reasons, so the message must not claim it.
     expect(body.error.message).not.toContain('skipped')
+    expect(notifiedUrls).toEqual([])
   })
 
   it('rejects an off-domain URL the caller supplied explicitly', async () => {
@@ -161,5 +185,6 @@ describe('request-indexing: allUnindexed gathers only submittable URLs', () => {
     expect(res.statusCode).toBe(400)
     const body = JSON.parse(res.body) as { error: { message: string } }
     expect(body.error.message).toContain('elsewhere.example')
+    expect(notifiedUrls).toEqual([])
   })
 })


### PR DESCRIPTION
## What

`request-indexing` with `allUnindexed` now gathers only URLs on the project's canonical domain, instead of collecting every inspected URL and then rejecting the whole batch.

## Why

The gather step and the validation step contradicted each other. `allUnindexed` collected every URL ever inspected for the project; the canonical-domain check below it then failed the request if any single URL was on another host.

Inspection history reliably accumulates exactly those hosts:

- URLs from a domain the project has since migrated off, which now redirect to the canonical host
- Subdomains, because a `sc-domain:` property legitimately reports every subdomain under it

So on a migrated project the endpoint gathered URLs it would then refuse, and one stale row made it permanently unusable. The observed failure was `URLs must belong to project domain` listing a previous domain's blog posts plus an app subdomain, none of which the Indexing API would have accepted anyway (the old-domain URLs are redirects; the subdomain does not resolve).

## How

- Off-domain URLs are skipped during gathering and counted. When nothing survives, the error reports how many were passed over rather than just "none found", so an operator can tell "no work to do" from "everything was on another host".
- The end validation is unchanged for caller-supplied `urls`, where an off-domain host is a real mistake and should be reported rather than silently dropped.
- Both paths call one `isOnProjectDomain` helper, so the gather and validation definitions of "on the domain" cannot drift.

## Tests

`packages/api-routes/test/google-request-indexing-domain.test.ts` — a migrated project whose inspection history contains a previous domain and a subdomain: neither blocks the request, an all-off-domain history reports the skipped count, already-indexed URLs are still ignored (and the message does not claim a skip that did not happen), and a caller-supplied off-domain URL is still rejected by name.

Verified by reverting the gather filter: three of the five fail. Typecheck and lint clean; `packages/api-routes` 1672 pass.

## Note on the suite

`ads-routes.test.ts > backs off inconclusive sweeps…` fails intermittently when the api-routes suite runs with file parallelism, asserting `reconcileAttempts: 1` and getting `2`. It passes in isolation, and the full suite passes with `--no-file-parallelism`. It is a pre-existing timing sensitivity in that test which this change happens to perturb; not addressed here.
