### PR TITLE
Fix traffic history charts truncated by event row limits

### DIFF
--- a/apps/web/src/pages/TrafficSourceDetailPage.tsx
+++ b/apps/web/src/pages/TrafficSourceDetailPage.tsx
@@ -2,7 +2,11 @@ import { useEffect, useMemo, useState } from 'react'
 import { Link, useCanGoBack, useParams } from '@tanstack/react-router'
 import { ArrowLeft, ChevronLeft, ChevronRight, RefreshCw, X } from 'lucide-react'
 
-import { TrafficEventKinds, type TrafficEventEntry } from '@ainyc/canonry-contracts'
+import {
+  TrafficEventKinds,
+  type TrafficEventEntry,
+  type TrafficSeriesPoint,
+} from '@ainyc/canonry-contracts'
 
 import { isEmbed } from '../api.js'
 import { Button } from '../components/ui/button.js'
@@ -35,7 +39,6 @@ import {
 import { localTimeZoneLabel } from '../lib/format-helpers.js'
 import {
   bucketForChartClick,
-  bucketKeyFor,
   filterTrafficEvents,
   identityOf,
   pathOf,
@@ -174,12 +177,14 @@ export function TrafficSourceDetailPage() {
     sourceId: sourceId || undefined,
     sinceMinutes: windowMinutes,
     limit: activeWindow.fetchLimit,
+    granularity: activeWindow.granularity,
   })
   const sync = useSyncServerTrafficSource(projectName || null, sourceId || null)
 
   const detail = sourceQuery.data
   const allEvents = eventsQuery.data?.events ?? []
   const totals = eventsQuery.data?.totals
+  const eventRows = eventsQuery.data?.eventRows
 
   const visibleEvents = useMemo(
     () =>
@@ -256,8 +261,8 @@ export function TrafficSourceDetailPage() {
   )
 
   const chartData = useMemo(
-    () => buildChartData(allEvents, activeWindow.granularity, eventsQuery.data?.windowStart, eventsQuery.data?.windowEnd),
-    [allEvents, activeWindow.granularity, eventsQuery.data?.windowStart, eventsQuery.data?.windowEnd],
+    () => buildChartData(eventsQuery.data?.series.points ?? [], activeWindow.granularity),
+    [eventsQuery.data?.series.points, activeWindow.granularity],
   )
 
   const toggleSeries = (series: SeriesKind) => {
@@ -551,7 +556,14 @@ export function TrafficSourceDetailPage() {
             <p className="text-[10px] font-semibold uppercase tracking-wider text-muted">Event rows</p>
             <p className="mt-1 text-xs text-muted">
               Showing <span className="tabular-nums text-neutral">{filteredEvents.length.toLocaleString('en-US')}</span> of{' '}
-              <span className="tabular-nums text-muted">{visibleEvents.length.toLocaleString('en-US')}</span> events · {LOCAL_TZ}
+              <span className="tabular-nums text-muted">{visibleEvents.length.toLocaleString('en-US')}</span>{' '}
+              {eventRows?.truncated ? 'loaded events' : 'events'}
+              {eventRows?.truncated ? (
+                <>
+                  {' '}· loaded <span className="tabular-nums text-neutral">{eventRows.returned.toLocaleString('en-US')}</span> of{' '}
+                  <span className="tabular-nums text-muted">{eventRows.total.toLocaleString('en-US')}</span> rows
+                </>
+              ) : null}{' '}· {LOCAL_TZ}
             </p>
           </div>
           <div className="flex flex-wrap items-center gap-2">
@@ -708,74 +720,21 @@ interface ChartRow {
   aiReferral: number
 }
 
-function emptyChartRow(bucket: string, label: string): ChartRow {
-  return { bucket, label, crawler: 0, aiUserFetch: 0, aiReferral: 0 }
-}
-
 function bucketLabelFor(key: string, granularity: Granularity): string {
   return granularity === 'day' ? formatDayLabel(key) : formatHourLabel(key)
 }
 
 function buildChartData(
-  events: readonly TrafficEventEntry[],
+  points: readonly TrafficSeriesPoint[],
   granularity: Granularity,
-  windowStart?: string,
-  windowEnd?: string,
 ): ChartRow[] {
-  const byBucket = new Map<string, ChartRow>()
-  for (const event of events) {
-    const key = bucketKeyFor(event.tsHour, granularity)
-    let row = byBucket.get(key)
-    if (!row) {
-      row = emptyChartRow(key, bucketLabelFor(key, granularity))
-      byBucket.set(key, row)
-    }
-    switch (event.kind) {
-      case TrafficEventKinds.crawler:
-        row.crawler += event.hits
-        break
-      case TrafficEventKinds['ai-user-fetch']:
-        row.aiUserFetch += event.hits
-        break
-      case TrafficEventKinds['ai-referral']:
-        row.aiReferral += event.hits
-        break
-    }
-  }
-
-  // Pad zero-value buckets for every partition in the window so the
-  // chart renders a bar for each day (30d/90d) or hour (1h–7d).
-  if (windowStart && windowEnd) {
-    const start = new Date(windowStart)
-    const end = new Date(windowEnd)
-
-    if (granularity === 'day') {
-      const current = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), start.getUTCDate()))
-      const endDay = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), end.getUTCDate()))
-      while (current <= endDay) {
-        const y = current.getUTCFullYear()
-        const m = String(current.getUTCMonth() + 1).padStart(2, '0')
-        const d = String(current.getUTCDate()).padStart(2, '0')
-        const key = `${y}-${m}-${d}`
-        if (!byBucket.has(key)) {
-          byBucket.set(key, emptyChartRow(key, bucketLabelFor(key, granularity)))
-        }
-        current.setUTCDate(current.getUTCDate() + 1)
-      }
-    } else {
-      const current = new Date(start)
-      current.setUTCMinutes(0, 0, 0)
-      while (current <= end) {
-        const key = current.toISOString()
-        if (!byBucket.has(key)) {
-          byBucket.set(key, emptyChartRow(key, bucketLabelFor(key, granularity)))
-        }
-        current.setUTCHours(current.getUTCHours() + 1)
-      }
-    }
-  }
-
-  return [...byBucket.values()].sort((a, b) => (a.bucket < b.bucket ? -1 : a.bucket > b.bucket ? 1 : 0))
+  return points.map((point) => ({
+    bucket: point.bucket,
+    label: bucketLabelFor(point.bucket, granularity),
+    crawler: point.crawlerHits,
+    aiUserFetch: point.aiUserFetchHits,
+    aiReferral: point.aiReferralHits,
+  }))
 }
 
 function labelForVerification(value: VerificationFilter): string {

--- a/apps/web/src/queries/server-traffic.ts
+++ b/apps/web/src/queries/server-traffic.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { useMutation, useQuery, useQueryClient, type QueryClient } from '@tanstack/react-query'
 
-import type { TrafficEventKind, TrafficSourceStatus } from '@ainyc/canonry-contracts'
+import type { TrafficEventKind, TrafficSeriesGranularity, TrafficSourceStatus } from '@ainyc/canonry-contracts'
 import { TrafficSourceStatuses } from '@ainyc/canonry-contracts'
 import {
   getApiV1ProjectsByNameTrafficEventsOptions,
@@ -43,6 +43,7 @@ export interface ServerTrafficEventsFilters {
   sourceId?: string
   sinceMinutes?: number
   limit?: number
+  granularity?: TrafficSeriesGranularity
 }
 
 /**
@@ -55,14 +56,16 @@ function paramsForFilters(filters: ServerTrafficEventsFilters): {
   sourceId?: string
   since?: string
   limit?: string
+  granularity?: TrafficSeriesGranularity
 } {
-  const params: { kind?: string; sourceId?: string; since?: string; limit?: string } = {}
+  const params: { kind?: string; sourceId?: string; since?: string; limit?: string; granularity?: TrafficSeriesGranularity } = {}
   if (filters.kind && filters.kind !== 'all') params.kind = filters.kind
   if (filters.sourceId) params.sourceId = filters.sourceId
   if (filters.sinceMinutes !== undefined) {
     params.since = new Date(Date.now() - filters.sinceMinutes * 60_000).toISOString()
   }
   if (filters.limit !== undefined) params.limit = String(filters.limit)
+  if (filters.granularity !== undefined) params.granularity = filters.granularity
   return params
 }
 
@@ -128,7 +131,7 @@ export function useServerTrafficEvents(
   // intent — it just doesn't tick forward on every render frame.
   const stableQuery = useMemo(
     () => paramsForFilters(filters),
-    [filters.kind, filters.sourceId, filters.sinceMinutes, filters.limit],
+    [filters.kind, filters.sourceId, filters.sinceMinutes, filters.limit, filters.granularity],
   )
   return useQuery({
     ...getApiV1ProjectsByNameTrafficEventsOptions({

--- a/apps/web/test/server-traffic-events-stable-key.test.ts
+++ b/apps/web/test/server-traffic-events-stable-key.test.ts
@@ -19,7 +19,7 @@ import { heyClient } from '../src/api.js'
  * every superseded query response alive in the cache.
  *
  * The fix wraps `paramsForFilters` in `useMemo` keyed on the actual filter
- * fields (kind / sourceId / sinceMinutes / limit), so `since` only changes
+ * fields (kind / sourceId / sinceMinutes / limit / granularity), so `since` only changes
  * when the user picks a different window — not on every render frame.
  *
  * This test asserts the query key stays referentially stable across
@@ -36,7 +36,13 @@ function Wrapper({ children }: { children: ReactNode }) {
 
 describe('useServerTrafficEvents — query key stability', () => {
   test('re-rendering with the same filters does not change the query key', () => {
-    const filters = { kind: 'all' as const, sourceId: 'abc', sinceMinutes: 10080, limit: 1000 }
+    const filters = {
+      kind: 'all' as const,
+      sourceId: 'abc',
+      sinceMinutes: 10080,
+      limit: 1000,
+      granularity: 'day' as const,
+    }
     const { result, rerender } = renderHook(
       ({ project, filters }) => useServerTrafficEvents(project, filters),
       {
@@ -62,7 +68,7 @@ describe('useServerTrafficEvents — query key stability', () => {
     // common case in a parent component that builds the object inline.
     rerender({
       project: 'demo',
-      filters: { kind: 'all', sourceId: 'abc', sinceMinutes: 10080, limit: 1000 },
+      filters: { kind: 'all', sourceId: 'abc', sinceMinutes: 10080, limit: 1000, granularity: 'day' },
     })
     const thirdKey = JSON.stringify(result.current.dataUpdatedAt)
     expect(thirdKey).toBe(firstKey)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.129.0",
+  "version": "4.129.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-client-generated/src/generated/@tanstack/react-query.gen.ts
+++ b/packages/api-client-generated/src/generated/@tanstack/react-query.gen.ts
@@ -4473,7 +4473,7 @@ export const getApiV1ProjectsByNameTrafficEventsQueryKey = (options: Options<Get
 /**
  * List rolled-up crawler hits, AI user-fetch hits, and AI-referral sessions within a window
  *
- * Returns hourly rollup rows from `crawler_events_hourly`, `ai_user_fetch_events_hourly`, and `ai_referral_events_hourly`. Defaults to the last 24h. Totals reflect the full window; the `events` array is capped by `limit` (default 500, max 5000).
+ * Returns full-window hourly or daily chart series plus newest-first detail rows from `crawler_events_hourly`, `ai_user_fetch_events_hourly`, and `ai_referral_events_hourly`. Defaults to the last 24h. Totals and `series.points` reflect the full window; only the `events` array is capped by `limit` (default 500, max 5000). `eventRows` reports the true pre-limit row count.
  */
 export const getApiV1ProjectsByNameTrafficEventsOptions = (options: Options<GetApiV1ProjectsByNameTrafficEventsData>) => {
     return queryOptions({

--- a/packages/api-client-generated/src/generated/sdk.gen.ts
+++ b/packages/api-client-generated/src/generated/sdk.gen.ts
@@ -3963,7 +3963,7 @@ export const getApiV1ProjectsByNameTrafficSourcesById = <ThrowOnError extends bo
 /**
  * List rolled-up crawler hits, AI user-fetch hits, and AI-referral sessions within a window
  *
- * Returns hourly rollup rows from `crawler_events_hourly`, `ai_user_fetch_events_hourly`, and `ai_referral_events_hourly`. Defaults to the last 24h. Totals reflect the full window; the `events` array is capped by `limit` (default 500, max 5000).
+ * Returns full-window hourly or daily chart series plus newest-first detail rows from `crawler_events_hourly`, `ai_user_fetch_events_hourly`, and `ai_referral_events_hourly`. Defaults to the last 24h. Totals and `series.points` reflect the full window; only the `events` array is capped by `limit` (default 500, max 5000). `eventRows` reports the true pre-limit row count.
  */
 export const getApiV1ProjectsByNameTrafficEvents = <ThrowOnError extends boolean = false>(options: Options<GetApiV1ProjectsByNameTrafficEventsData, ThrowOnError>) => {
     return (options.client ?? client).get<GetApiV1ProjectsByNameTrafficEventsResponses, GetApiV1ProjectsByNameTrafficEventsErrors, ThrowOnError>({

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -3668,6 +3668,15 @@ export type TrafficBackfillResponse = {
 export type TrafficEventsResponse = {
     windowStart: string;
     windowEnd: string;
+    series: {
+        granularity: 'hour' | 'day';
+        points: Array<{
+            bucket: string;
+            crawlerHits: number;
+            aiUserFetchHits: number;
+            aiReferralHits: number;
+        }>;
+    };
     totals: {
         crawlerHits: number;
         crawlerContentHits: number;
@@ -3684,6 +3693,11 @@ export type TrafficEventsResponse = {
         aiReferralPaidHits: number;
         aiReferralOrganicHits: number;
         aiReferralUnknownHits: number;
+    };
+    eventRows: {
+        total: number;
+        returned: number;
+        truncated: boolean;
     };
     events: Array<{
         kind: 'crawler';
@@ -12295,13 +12309,17 @@ export type GetApiV1ProjectsByNameTrafficEventsData = {
          */
         kind?: string;
         /**
-         * Max rows per kind in the events array (default 500, max 5000).
+         * Max newest combined detail rows in the events array (default 500, max 5000).
          */
         limit?: string;
         /**
          * Restrict to a single traffic source.
          */
         sourceId?: string;
+        /**
+         * Full-window series bucket size: "hour" (default) or "day".
+         */
+        granularity?: 'hour' | 'day';
     };
     url: '/api/v1/projects/{name}/traffic/events';
 };

--- a/packages/api-routes/src/openapi.ts
+++ b/packages/api-routes/src/openapi.ts
@@ -4534,15 +4534,16 @@ const routeCatalog: OpenApiOperation[] = [
     path: '/api/v1/projects/{name}/traffic/events',
     summary: 'List rolled-up crawler hits, AI user-fetch hits, and AI-referral sessions within a window',
     description:
-      'Returns hourly rollup rows from `crawler_events_hourly`, `ai_user_fetch_events_hourly`, and `ai_referral_events_hourly`. Defaults to the last 24h. Totals reflect the full window; the `events` array is capped by `limit` (default 500, max 5000).',
+      'Returns full-window hourly or daily chart series plus newest-first detail rows from `crawler_events_hourly`, `ai_user_fetch_events_hourly`, and `ai_referral_events_hourly`. Defaults to the last 24h. Totals and `series.points` reflect the full window; only the `events` array is capped by `limit` (default 500, max 5000). `eventRows` reports the true pre-limit row count.',
     tags: ['traffic'],
     parameters: [
       nameParameter,
       { name: 'since', in: 'query', description: 'ISO-8601 window start (defaults to 24h ago).', schema: stringSchema },
       { name: 'until', in: 'query', description: 'ISO-8601 window end (defaults to now).', schema: stringSchema },
       { name: 'kind', in: 'query', description: 'Filter to "crawler", "ai-user-fetch", "ai-referral", or "all" (default).', schema: stringSchema },
-      { name: 'limit', in: 'query', description: 'Max rows per kind in the events array (default 500, max 5000).', schema: stringSchema },
+      { name: 'limit', in: 'query', description: 'Max newest combined detail rows in the events array (default 500, max 5000).', schema: stringSchema },
       { name: 'sourceId', in: 'query', description: 'Restrict to a single traffic source.', schema: stringSchema },
+      { name: 'granularity', in: 'query', description: 'Full-window series bucket size: "hour" (default) or "day".', schema: { type: 'string', enum: ['hour', 'day'] } },
     ],
     responses: {
       200: jsonResponse('Events returned with windowed totals.', 'TrafficEventsResponse'),

--- a/packages/api-routes/src/traffic.ts
+++ b/packages/api-routes/src/traffic.ts
@@ -24,6 +24,7 @@ import {
   TrafficSourceTypes,
   TrafficSourceAuthModes,
   TrafficEventKinds,
+  TrafficSeriesGranularities,
   trafficConnectWordpressRequestSchema,
   trafficConnectVercelRequestSchema,
   trafficResetRequestSchema,
@@ -46,6 +47,8 @@ import type {
   TrafficEventEntry,
   TrafficEventKind,
   TrafficEventsResponse,
+  TrafficSeriesGranularity,
+  TrafficSeriesPoint,
 } from '@ainyc/canonry-contracts'
 import {
   listCloudRunTrafficEvents,
@@ -297,6 +300,49 @@ const DEFAULT_TRAFFIC_SYNC_CRON = '*/30 * * * *'
 const MAX_BACKFILL_DAYS = 90
 const BACKFILL_MAX_PAGES = 1_000
 const BACKFILL_SAMPLE_LIMIT = 500
+
+function emptyTrafficSeriesPoint(bucket: string): TrafficSeriesPoint {
+  return { bucket, crawlerHits: 0, aiUserFetchHits: 0, aiReferralHits: 0 }
+}
+
+function completeTrafficSeries(
+  windowStart: Date,
+  windowEnd: Date,
+  granularity: TrafficSeriesGranularity,
+  pointsByBucket: ReadonlyMap<string, TrafficSeriesPoint>,
+): TrafficSeriesPoint[] {
+  const cursor = new Date(windowStart)
+  const last = new Date(windowEnd)
+  if (granularity === TrafficSeriesGranularities.day) {
+    cursor.setUTCHours(0, 0, 0, 0)
+    last.setUTCHours(0, 0, 0, 0)
+  } else {
+    cursor.setUTCMinutes(0, 0, 0)
+    last.setUTCMinutes(0, 0, 0)
+  }
+
+  const points: TrafficSeriesPoint[] = []
+  while (cursor <= last) {
+    const bucket = granularity === TrafficSeriesGranularities.day
+      ? cursor.toISOString().slice(0, 10)
+      : cursor.toISOString()
+    points.push(pointsByBucket.get(bucket) ?? emptyTrafficSeriesPoint(bucket))
+    if (granularity === TrafficSeriesGranularities.day) cursor.setUTCDate(cursor.getUTCDate() + 1)
+    else cursor.setUTCHours(cursor.getUTCHours() + 1)
+  }
+  return points
+}
+
+function trafficSeriesPoint(
+  pointsByBucket: Map<string, TrafficSeriesPoint>,
+  bucket: string,
+): TrafficSeriesPoint {
+  const existing = pointsByBucket.get(bucket)
+  if (existing) return existing
+  const created = emptyTrafficSeriesPoint(bucket)
+  pointsByBucket.set(bucket, created)
+  return created
+}
 
 function parseSourceConfig(row: typeof trafficSources.$inferSelect): Record<string, unknown> {
   return row.configJson
@@ -2380,7 +2426,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
   // GET /projects/:name/traffic/events
   app.get<{
     Params: { name: string }
-    Querystring: { since?: string; until?: string; kind?: string; limit?: string; sourceId?: string }
+    Querystring: { since?: string; until?: string; kind?: string; limit?: string; sourceId?: string; granularity?: string }
   }>('/projects/:name/traffic/events', async (request) => {
     const project = resolveProject(app.db, request.params.name)
 
@@ -2425,6 +2471,21 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
     }
     const limit = Math.min(requestedLimit, 5000)
 
+    const granularityParam = request.query?.granularity
+    let granularity: TrafficSeriesGranularity = TrafficSeriesGranularities.hour
+    if (granularityParam !== undefined) {
+      if (
+        granularityParam === TrafficSeriesGranularities.hour
+        || granularityParam === TrafficSeriesGranularities.day
+      ) {
+        granularity = granularityParam
+      } else {
+        throw validationError(
+          `"granularity" must be one of: ${TrafficSeriesGranularities.hour}, ${TrafficSeriesGranularities.day}`,
+        )
+      }
+    }
+
     const sourceIdParam = request.query?.sourceId
     const sinceIso = since.toISOString()
     const untilIso = until.toISOString()
@@ -2434,6 +2495,8 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
     let crawlerSegments = { content: 0, sitemap: 0, robots: 0, asset: 0, other: 0 }
     let aiUserFetchTotal = 0
     let aiReferralCounts = aiReferralClassCounts(0, 0, 0)
+    let totalEventRows = 0
+    const seriesByBucket = new Map<string, TrafficSeriesPoint>()
 
     if (kind === 'all' || kind === TrafficEventKinds.crawler) {
       const crawlerFilters = [
@@ -2451,6 +2514,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
         .select({
           pathNormalized: crawlerEventsHourly.pathNormalized,
           hits: sql<number>`COALESCE(SUM(${crawlerEventsHourly.hits}), 0)`,
+          rows: sql<number>`COUNT(*)`,
         })
         .from(crawlerEventsHourly)
         .where(crawlerWhere)
@@ -2465,6 +2529,23 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
         + crawlerSegments.robots
         + crawlerSegments.asset
         + crawlerSegments.other
+      totalEventRows += pathTotals.reduce((sum, row) => sum + Number(row.rows), 0)
+
+      const crawlerSeriesBucket = granularity === TrafficSeriesGranularities.day
+        ? sql<string>`substr(${crawlerEventsHourly.tsHour}, 1, 10)`
+        : crawlerEventsHourly.tsHour
+      const crawlerSeries = app.db
+        .select({
+          bucket: crawlerSeriesBucket,
+          hits: sql<number>`COALESCE(SUM(${crawlerEventsHourly.hits}), 0)`,
+        })
+        .from(crawlerEventsHourly)
+        .where(crawlerWhere)
+        .groupBy(crawlerSeriesBucket)
+        .all()
+      for (const row of crawlerSeries) {
+        trafficSeriesPoint(seriesByBucket, row.bucket).crawlerHits = Number(row.hits)
+      }
 
       const rows = app.db
         .select()
@@ -2499,11 +2580,31 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
       const userFetchWhere = and(...userFetchFilters)
 
       const total = app.db
-        .select({ total: sql<number>`COALESCE(SUM(${aiUserFetchEventsHourly.hits}), 0)` })
+        .select({
+          total: sql<number>`COALESCE(SUM(${aiUserFetchEventsHourly.hits}), 0)`,
+          rows: sql<number>`COUNT(*)`,
+        })
         .from(aiUserFetchEventsHourly)
         .where(userFetchWhere)
         .get()
       aiUserFetchTotal = Number(total?.total ?? 0)
+      totalEventRows += Number(total?.rows ?? 0)
+
+      const userFetchSeriesBucket = granularity === TrafficSeriesGranularities.day
+        ? sql<string>`substr(${aiUserFetchEventsHourly.tsHour}, 1, 10)`
+        : aiUserFetchEventsHourly.tsHour
+      const userFetchSeries = app.db
+        .select({
+          bucket: userFetchSeriesBucket,
+          hits: sql<number>`COALESCE(SUM(${aiUserFetchEventsHourly.hits}), 0)`,
+        })
+        .from(aiUserFetchEventsHourly)
+        .where(userFetchWhere)
+        .groupBy(userFetchSeriesBucket)
+        .all()
+      for (const row of userFetchSeries) {
+        trafficSeriesPoint(seriesByBucket, row.bucket).aiUserFetchHits = Number(row.hits)
+      }
 
       const rows = app.db
         .select()
@@ -2541,6 +2642,7 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
           total: sql<number>`COALESCE(SUM(${aiReferralEventsHourly.sessionsOrHits}), 0)`,
           paid: sql<number>`COALESCE(SUM(${aiReferralEventsHourly.paidSessionsOrHits}), 0)`,
           organic: sql<number>`COALESCE(SUM(${aiReferralEventsHourly.organicSessionsOrHits}), 0)`,
+          rows: sql<number>`COUNT(*)`,
         })
         .from(aiReferralEventsHourly)
         .where(aiWhere)
@@ -2550,6 +2652,23 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
         Number(total?.paid ?? 0),
         Number(total?.organic ?? 0),
       )
+      totalEventRows += Number(total?.rows ?? 0)
+
+      const referralSeriesBucket = granularity === TrafficSeriesGranularities.day
+        ? sql<string>`substr(${aiReferralEventsHourly.tsHour}, 1, 10)`
+        : aiReferralEventsHourly.tsHour
+      const referralSeries = app.db
+        .select({
+          bucket: referralSeriesBucket,
+          hits: sql<number>`COALESCE(SUM(${aiReferralEventsHourly.sessionsOrHits}), 0)`,
+        })
+        .from(aiReferralEventsHourly)
+        .where(aiWhere)
+        .groupBy(referralSeriesBucket)
+        .all()
+      for (const row of referralSeries) {
+        trafficSeriesPoint(seriesByBucket, row.bucket).aiReferralHits = Number(row.hits)
+      }
 
       const rows = app.db
         .select()
@@ -2584,6 +2703,10 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
     const response: TrafficEventsResponse = {
       windowStart: sinceIso,
       windowEnd: untilIso,
+      series: {
+        granularity,
+        points: completeTrafficSeries(since, until, granularity, seriesByBucket),
+      },
       totals: {
         crawlerHits: crawlerTotal,
         crawlerContentHits: crawlerSegments.content,
@@ -2594,6 +2717,11 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
         aiReferralPaidHits: aiReferralCounts.paid,
         aiReferralOrganicHits: aiReferralCounts.organic,
         aiReferralUnknownHits: aiReferralCounts.unknown,
+      },
+      eventRows: {
+        total: totalEventRows,
+        returned: trimmed.length,
+        truncated: trimmed.length < totalEventRows,
       },
       events: trimmed,
     }

--- a/packages/api-routes/test/traffic.test.ts
+++ b/packages/api-routes/test/traffic.test.ts
@@ -3707,6 +3707,18 @@ describe('GET /traffic/events', () => {
       expect(res.statusCode).toBe(200)
       const body = JSON.parse(res.payload)
       expect(body.totals).toMatchObject({ crawlerHits: 1, aiUserFetchHits: 1, aiReferralHits: 1 })
+      expect(body.eventRows).toEqual({ total: 3, returned: 3, truncated: false })
+      expect(body.series.granularity).toBe('hour')
+      expect(
+        body.series.points.reduce(
+          (sum: { crawlerHits: number; aiUserFetchHits: number; aiReferralHits: number }, point: typeof sum) => ({
+            crawlerHits: sum.crawlerHits + point.crawlerHits,
+            aiUserFetchHits: sum.aiUserFetchHits + point.aiUserFetchHits,
+            aiReferralHits: sum.aiReferralHits + point.aiReferralHits,
+          }),
+          { crawlerHits: 0, aiUserFetchHits: 0, aiReferralHits: 0 },
+        ),
+      ).toEqual({ crawlerHits: 1, aiUserFetchHits: 1, aiReferralHits: 1 })
       const kinds = body.events.map((e: { kind: string }) => e.kind).sort()
       expect(kinds).toEqual(['ai-referral', 'ai-user-fetch', 'crawler'])
       const userFetch = body.events.find((e: { kind: string }) => e.kind === 'ai-user-fetch')
@@ -3816,6 +3828,12 @@ describe('GET /traffic/events', () => {
         url: '/api/v1/projects/test-project/traffic/events?since=2026-05-07T00:00:00Z&until=2026-05-06T00:00:00Z',
       })
       expect(reversed.statusCode).toBe(400)
+
+      const badGranularity = await h.app.inject({
+        method: 'GET',
+        url: '/api/v1/projects/test-project/traffic/events?granularity=week',
+      })
+      expect(badGranularity.statusCode).toBe(400)
     } finally { await h.close() }
   })
 
@@ -3828,10 +3846,81 @@ describe('GET /traffic/events', () => {
       })
       expect(res.statusCode).toBe(200)
       const body = JSON.parse(res.payload)
-      // limit=1 trims the events array but totals must still reflect the full window.
+      // limit=1 trims the events array but totals and truncation metadata must
+      // still reflect the full window.
       expect(body.events.length).toBe(1)
       expect(body.totals.crawlerHits).toBe(2)
       expect(body.totals.aiReferralHits).toBe(1)
+      expect(body.eventRows).toEqual({ total: 2, returned: 1, truncated: true })
+    } finally { await h.close() }
+  })
+
+  it('keeps the complete 90-day series when the detail-row limit truncates old rows', async () => {
+    const { h, sourceId } = await syncedHarness()
+    try {
+      const source = h.db
+        .select()
+        .from(trafficSources)
+        .where(eq(trafficSources.id, sourceId))
+        .get()!
+      const end = new Date()
+      const start = new Date(end)
+      start.setUTCDate(start.getUTCDate() - 90)
+      start.setUTCHours(0, 0, 0, 0)
+      const middle = new Date(start)
+      middle.setUTCDate(middle.getUTCDate() + 45)
+      const writtenAt = end.toISOString()
+
+      h.db.insert(crawlerEventsHourly).values([
+        {
+          projectId: source.projectId,
+          sourceId,
+          tsHour: start.toISOString(),
+          botId: 'openai-gptbot',
+          operator: 'OpenAI',
+          verificationStatus: 'claimed_unverified',
+          pathNormalized: '/oldest',
+          status: 200,
+          hits: 7,
+          sampledUserAgent: 'GPTBot/1.0',
+          createdAt: writtenAt,
+          updatedAt: writtenAt,
+        },
+        {
+          projectId: source.projectId,
+          sourceId,
+          tsHour: middle.toISOString(),
+          botId: 'openai-gptbot',
+          operator: 'OpenAI',
+          verificationStatus: 'claimed_unverified',
+          pathNormalized: '/middle',
+          status: 200,
+          hits: 11,
+          sampledUserAgent: 'GPTBot/1.0',
+          createdAt: writtenAt,
+          updatedAt: writtenAt,
+        },
+      ]).run()
+
+      const res = await h.app.inject({
+        method: 'GET',
+        url: `/api/v1/projects/test-project/traffic/events?since=${encodeURIComponent(start.toISOString())}&until=${encodeURIComponent(end.toISOString())}&granularity=day&limit=1`,
+      })
+      expect(res.statusCode).toBe(200)
+      const body = JSON.parse(res.payload)
+      expect(body.events).toHaveLength(1)
+      expect(body.eventRows).toEqual({ total: 4, returned: 1, truncated: true })
+      expect(body.series.granularity).toBe('day')
+      expect(body.series.points).toHaveLength(91)
+      expect(body.series.points[0]).toEqual({
+        bucket: start.toISOString().slice(0, 10),
+        crawlerHits: 7,
+        aiUserFetchHits: 0,
+        aiReferralHits: 0,
+      })
+      expect(body.series.points[45].crawlerHits).toBe(11)
+      expect(body.series.points.reduce((sum: number, point: { crawlerHits: number }) => sum + point.crawlerHits, 0))
+        .toBe(body.totals.crawlerHits)
     } finally { await h.close() }
   })
 

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.129.0",
+  "version": "4.129.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/cli-commands/traffic.ts
+++ b/packages/canonry/src/cli-commands/traffic.ts
@@ -226,7 +226,7 @@ export const TRAFFIC_CLI_COMMANDS: readonly CliCommandSpec[] = [
   },
   {
     path: ['traffic', 'events'],
-    usage: 'canonry traffic events <project> [--kind crawler|ai-referral|all] [--source <id>] [--since-minutes 1440] [--since <iso>] [--until <iso>] [--limit 500] [--format json]',
+    usage: 'canonry traffic events <project> [--kind crawler|ai-referral|all] [--source <id>] [--since-minutes 1440] [--since <iso>] [--until <iso>] [--limit 500] [--granularity hour|day] [--format json]',
     options: {
       kind: stringOption(),
       source: stringOption(),
@@ -234,6 +234,7 @@ export const TRAFFIC_CLI_COMMANDS: readonly CliCommandSpec[] = [
       since: stringOption(),
       until: stringOption(),
       limit: stringOption(),
+      granularity: stringOption(),
     },
     run: async (input) => {
       const project = requireProject(
@@ -255,6 +256,7 @@ export const TRAFFIC_CLI_COMMANDS: readonly CliCommandSpec[] = [
       await trafficEvents(project, {
         kind: getString(input.values, 'kind'),
         source: getString(input.values, 'source'),
+        granularity: getString(input.values, 'granularity'),
         sinceMinutes,
         since: getString(input.values, 'since'),
         until: getString(input.values, 'until'),

--- a/packages/canonry/src/client.ts
+++ b/packages/canonry/src/client.ts
@@ -127,6 +127,7 @@ import type {
   TrafficSourceListResponse,
   TrafficStatusResponse,
   TrafficEventsResponse,
+  TrafficSeriesGranularity,
   TrafficConnectCloudRunRequest,
   TrafficConnectWordpressRequest,
   TrafficConnectVercelRequest,
@@ -2144,7 +2145,7 @@ export class ApiClient {
 
   async trafficListEvents(
     project: string,
-    params?: { since?: string; until?: string; kind?: string; limit?: number; sourceId?: string },
+    params?: { since?: string; until?: string; kind?: string; limit?: number; sourceId?: string; granularity?: TrafficSeriesGranularity },
   ): Promise<TrafficEventsResponse> {
     return this.invoke<TrafficEventsResponse>(() =>
       getApiV1ProjectsByNameTrafficEvents({
@@ -2156,6 +2157,7 @@ export class ApiClient {
           kind: params?.kind,
           limit: params?.limit !== undefined ? String(params.limit) : undefined,
           sourceId: params?.sourceId,
+          granularity: params?.granularity,
         } as never,
       }),
     )

--- a/packages/canonry/src/commands/traffic.ts
+++ b/packages/canonry/src/commands/traffic.ts
@@ -3,12 +3,13 @@ import type {
   TrafficBackfillResponse,
   TrafficEventEntry,
   TrafficEventsResponse,
+  TrafficSeriesGranularity,
   TrafficSourceDto,
   TrafficSourceListResponse,
   TrafficStatusResponse,
   TrafficSyncResponse,
 } from '@ainyc/canonry-contracts'
-import { RunStatuses, TrafficEventKinds } from '@ainyc/canonry-contracts'
+import { RunStatuses, TrafficEventKinds, TrafficSeriesGranularities } from '@ainyc/canonry-contracts'
 import { createApiClient } from '../client.js'
 import { CliError, isMachineFormat } from '../cli-error.js'
 import { emitJsonl } from '../cli-output.js'
@@ -561,6 +562,7 @@ export async function trafficEvents(project: string, opts: {
   until?: string
   limit?: number
   source?: string
+  granularity?: string
   format?: string
 }): Promise<void> {
   if (
@@ -578,10 +580,24 @@ export async function trafficEvents(project: string, opts: {
     })
   }
 
-  const params: { since?: string; until?: string; kind?: string; limit?: number; sourceId?: string } = {}
+  if (
+    opts.granularity
+    && opts.granularity !== TrafficSeriesGranularities.hour
+    && opts.granularity !== TrafficSeriesGranularities.day
+  ) {
+    throw new CliError({
+      code: 'TRAFFIC_INVALID_GRANULARITY',
+      message: `--granularity must be one of: ${TrafficSeriesGranularities.hour}, ${TrafficSeriesGranularities.day}`,
+      displayMessage: `Error: --granularity must be "${TrafficSeriesGranularities.hour}" or "${TrafficSeriesGranularities.day}"`,
+      details: { project, granularity: opts.granularity },
+    })
+  }
+
+  const params: { since?: string; until?: string; kind?: string; limit?: number; sourceId?: string; granularity?: TrafficSeriesGranularity } = {}
   if (opts.kind && opts.kind !== 'all') params.kind = opts.kind
   if (opts.source) params.sourceId = opts.source
   if (opts.limit !== undefined) params.limit = opts.limit
+  if (opts.granularity) params.granularity = opts.granularity as TrafficSeriesGranularity
   if (opts.sinceMinutes !== undefined) {
     const since = new Date(Date.now() - opts.sinceMinutes * 60_000).toISOString()
     params.since = since

--- a/packages/canonry/src/mcp/tool-registry.ts
+++ b/packages/canonry/src/mcp/tool-registry.ts
@@ -38,6 +38,7 @@ import {
   trafficConnectWordpressRequestSchema,
   trafficConnectVercelRequestSchema,
   trafficEventKindSchema,
+  trafficSeriesGranularitySchema,
   type NotificationEvent,
 } from '@ainyc/canonry-contracts'
 import { z } from 'zod'
@@ -469,9 +470,10 @@ const trafficEventsInputSchema = z.object({
   project: projectNameSchema,
   since: z.string().optional().describe('ISO 8601 lower bound. Defaults to 24h ago when omitted.'),
   until: z.string().optional().describe('ISO 8601 upper bound. Defaults to now when omitted.'),
-  kind: z.union([trafficEventKindSchema, z.literal('all')]).optional().describe('Filter to "crawler" or "ai-referral"; "all" (default) returns both.'),
+  kind: z.union([trafficEventKindSchema, z.literal('all')]).optional().describe('Filter to one traffic kind; "all" (default) returns every kind.'),
   sourceId: z.string().min(1).optional().describe('Restrict to a single traffic source ID.'),
   limit: z.number().int().positive().max(5000).optional().describe('Max combined rows. Defaults to 500, max 5000. Totals always reflect the full window.'),
+  granularity: trafficSeriesGranularitySchema.optional().describe('Full-window chart series bucket size: hour (default) or day.'),
 })
 // ai-referral rows and totals split sessions into paid / organic / unclassified.
 // `unclassified` are rows ingested before the classifier shipped; their UTM tags
@@ -1437,19 +1439,20 @@ export const canonryMcpTools = [
   defineTool({
     name: 'canonry_traffic_events',
     title: 'List traffic events',
-    description: 'Read crawler and AI-referral hourly rollups from server-side traffic sources. Returns a discriminated list (kind="crawler" rows carry botId/operator/verificationStatus; kind="ai-referral" rows carry product/sourceDomain/evidenceType) plus totals over the full window even when limit truncates rows. Window defaults to last 24h.',
+    description: 'Read crawler, AI user-fetch, and AI-referral rollups from server-side traffic sources. Returns complete full-window chart series and totals plus a capped discriminated detail list with explicit truncation metadata. Window defaults to last 24h.',
     access: 'read',
     tier: 'traffic',
     inputSchema: trafficEventsInputSchema,
     annotations: readAnnotations(),
     openApiOperations: ['GET /api/v1/projects/{name}/traffic/events'],
     handler: (client, input) => {
-      const params: { since?: string; until?: string; kind?: string; limit?: number; sourceId?: string } = {}
+      const params: NonNullable<Parameters<ApiClient['trafficListEvents']>[1]> = {}
       if (input.since) params.since = input.since
       if (input.until) params.until = input.until
       if (input.kind) params.kind = input.kind
       if (input.sourceId) params.sourceId = input.sourceId
       if (input.limit !== undefined) params.limit = input.limit
+      if (input.granularity) params.granularity = input.granularity
       return client.trafficListEvents(input.project, params)
     },
   }),

--- a/packages/canonry/test/mcp-registry.test.ts
+++ b/packages/canonry/test/mcp-registry.test.ts
@@ -753,7 +753,12 @@ const handlerCases: HandlerCase[] = [
   { tool: 'canonry_traffic_sources_list', input: projectInput, methods: ['trafficListSources'] },
   { tool: 'canonry_traffic_source_get', input: { project: 'acme', sourceId: 'src-1' }, methods: ['trafficGetSource'] },
   { tool: 'canonry_traffic_status', input: projectInput, methods: ['trafficStatus'] },
-  { tool: 'canonry_traffic_events', input: { project: 'acme', kind: 'crawler', limit: 50 }, methods: ['trafficListEvents'] },
+  {
+    tool: 'canonry_traffic_events',
+    input: { project: 'acme', kind: 'crawler', limit: 50, granularity: 'day' },
+    methods: ['trafficListEvents'],
+    expectedArgs: [['acme', { kind: 'crawler', limit: 50, granularity: 'day' }]],
+  },
   {
     tool: 'canonry_traffic_connect_cloud_run',
     input: {

--- a/packages/canonry/test/traffic-commands.test.ts
+++ b/packages/canonry/test/traffic-commands.test.ts
@@ -369,12 +369,17 @@ describe('traffic CLI commands', () => {
       windowStart: string
       windowEnd: string
       totals: { crawlerHits: number; aiReferralHits: number }
+      series: { granularity: string; points: unknown[] }
+      eventRows: { total: number; returned: number; truncated: boolean }
       events: unknown[]
     }
     expect(body.windowStart).toBeTruthy()
     expect(body.windowEnd).toBeTruthy()
     expect(body.totals.crawlerHits).toBe(0)
     expect(body.totals.aiReferralHits).toBe(0)
+    expect(body.series.granularity).toBe('hour')
+    expect(body.series.points.length).toBeGreaterThan(0)
+    expect(body.eventRows).toEqual({ total: 0, returned: 0, truncated: false })
     expect(body.events.length).toBe(0)
   })
 
@@ -384,6 +389,14 @@ describe('traffic CLI commands', () => {
     ])
     expect(result.exitCode).not.toBe(0)
     expect(result.stderr).toMatch(/--kind must be/i)
+  })
+
+  it('rejects an invalid --granularity value', async () => {
+    const result = await invokeCli([
+      'traffic', 'events', 'test-proj', '--granularity', 'week',
+    ])
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toMatch(/--granularity must be/i)
   })
 
   it('rejects a non-numeric --since-minutes without crashing', async () => {

--- a/packages/canonry/test/traffic-jsonl.test.ts
+++ b/packages/canonry/test/traffic-jsonl.test.ts
@@ -46,6 +46,15 @@ const { trafficEvents, trafficSources, trafficStatus } = await import('../src/co
 const eventsResponse: TrafficEventsResponse = {
   windowStart: '2026-05-01T00:00:00.000Z',
   windowEnd: '2026-05-02T00:00:00.000Z',
+  series: {
+    granularity: 'day',
+    points: [{
+      bucket: '2026-05-01',
+      crawlerHits: 5,
+      aiUserFetchHits: 2,
+      aiReferralHits: 1,
+    }],
+  },
   totals: {
     crawlerHits: 5,
     crawlerContentHits: 3,
@@ -53,7 +62,11 @@ const eventsResponse: TrafficEventsResponse = {
     crawlerSegments: { content: 3, sitemap: 2, robots: 0, asset: 0, other: 0 },
     aiUserFetchHits: 2,
     aiReferralHits: 1,
+    aiReferralPaidHits: 0,
+    aiReferralOrganicHits: 1,
+    aiReferralUnknownHits: 0,
   },
+  eventRows: { total: 2, returned: 2, truncated: false },
   events: [
     {
       kind: 'crawler',
@@ -189,7 +202,19 @@ describe('traffic jsonl output', () => {
       mockTrafficListEvents.mockResolvedValue({
         windowStart: '2026-05-01T00:00:00.000Z',
         windowEnd: '2026-05-02T00:00:00.000Z',
-        totals: { crawlerHits: 0, aiUserFetchHits: 0, aiReferralHits: 0 },
+        series: { granularity: 'day', points: [] },
+        totals: {
+          crawlerHits: 0,
+          crawlerContentHits: 0,
+          crawlerInfraHits: 0,
+          crawlerSegments: { content: 0, sitemap: 0, robots: 0, asset: 0, other: 0 },
+          aiUserFetchHits: 0,
+          aiReferralHits: 0,
+          aiReferralPaidHits: 0,
+          aiReferralOrganicHits: 0,
+          aiReferralUnknownHits: 0,
+        },
+        eventRows: { total: 0, returned: 0, truncated: false },
         events: [],
       } satisfies TrafficEventsResponse)
       const cap = captureStdout(() => trafficEvents('demo', { format: 'jsonl' }))

--- a/packages/contracts/src/traffic.ts
+++ b/packages/contracts/src/traffic.ts
@@ -301,6 +301,22 @@ export const trafficEventKindSchema = z.enum(['crawler', 'ai-user-fetch', 'ai-re
 export type TrafficEventKind = z.infer<typeof trafficEventKindSchema>
 export const TrafficEventKinds = trafficEventKindSchema.enum
 
+export const trafficSeriesGranularitySchema = z.enum(['hour', 'day'])
+export type TrafficSeriesGranularity = z.infer<typeof trafficSeriesGranularitySchema>
+export const TrafficSeriesGranularities = trafficSeriesGranularitySchema.enum
+
+export const trafficSeriesPointSchema = z.object({
+  /**
+   * UTC bucket key: an ISO hour for hourly series, or `YYYY-MM-DD` for daily
+   * series. The response includes zero-value buckets across the full window.
+   */
+  bucket: z.string(),
+  crawlerHits: z.number().int().nonnegative(),
+  aiUserFetchHits: z.number().int().nonnegative(),
+  aiReferralHits: z.number().int().nonnegative(),
+})
+export type TrafficSeriesPoint = z.infer<typeof trafficSeriesPointSchema>
+
 export const trafficCrawlerEventEntrySchema = z.object({
   kind: z.literal(TrafficEventKinds.crawler),
   sourceId: z.string(),
@@ -368,6 +384,14 @@ export type TrafficEventEntry = z.infer<typeof trafficEventEntrySchema>
 export const trafficEventsResponseSchema = z.object({
   windowStart: z.string(),
   windowEnd: z.string(),
+  /**
+   * Full-window chart data, aggregated independently from the capped detail
+   * rows below. This prevents dense windows from silently losing old buckets.
+   */
+  series: z.object({
+    granularity: trafficSeriesGranularitySchema,
+    points: z.array(trafficSeriesPointSchema),
+  }),
   totals: z.object({
     /** Total classified-crawler hits across the window. UNCHANGED contract. */
     crawlerHits: z.number().int().nonnegative(),
@@ -386,6 +410,13 @@ export const trafficEventsResponseSchema = z.object({
     aiReferralOrganicHits: z.number().int().nonnegative(),
     /** AI-referral sessions ingested before the classifier shipped; unresolvable, never organic. */
     aiReferralUnknownHits: z.number().int().nonnegative(),
+  }),
+  eventRows: z.object({
+    /** Total detail rows matching the window/source/kind filters before `limit`. */
+    total: z.number().int().nonnegative(),
+    /** Number of newest detail rows included in `events`. */
+    returned: z.number().int().nonnegative(),
+    truncated: z.boolean(),
   }),
   events: z.array(trafficEventEntrySchema),
 })

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.129.0",
+  "version": "4.129.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.129.0",
+  "version": "4.129.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
## Summary

- return complete server-aggregated hourly or daily traffic series independently of capped detail rows
- render dashboard charts from the complete series and disclose detail-row truncation
- expose series granularity through OpenAPI, generated SDK, CLI, and MCP
- add a 90-day regression proving old buckets remain visible when the detail limit is exceeded

## Root cause

The API totals covered the full selected window, but the dashboard rebuilt its chart from the newest capped detail rows. Dense sources therefore lost older chart buckets even though the underlying traffic data was retained.

## Validation

- `pnpm typecheck`
- `pnpm build`
- `pnpm plugin:check`
- `pnpm exec vitest run --maxWorkers=4 --silent=passed-only` — 466 files, 5,742 tests passed
- focused traffic/API/web/CLI/MCP suite — 168 tests passed
- generated SDK refreshed deterministically
- `git diff --check`
