### PR TITLE
feat(ga): ingest native acquisition and lead events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.130.0",
+  "version": "4.131.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -1849,6 +1849,21 @@ export type Ga4SyncResponseDto = {
     socialReferralCount: number;
     days: number;
     syncedAt: string;
+    measurement: {
+        acquisition: {
+            days: number;
+            status: 'ready' | 'error';
+            rowCount: number;
+            error?: string;
+        };
+        leads: {
+            days: number;
+            status: 'ready' | 'error' | 'not-configured';
+            rowCount: number;
+            attributionScope?: 'landing-page' | 'channel';
+            error?: string;
+        };
+    };
     syncedComponents?: Array<string>;
 };
 

--- a/packages/api-routes/src/ga.ts
+++ b/packages/api-routes/src/ga.ts
@@ -122,33 +122,16 @@ function emptyAiCounts() {
 
 type GaDatabase = FastifyInstance['db']
 
-function measurementDateBounds(days: number): { startDate: string; endDate: string } {
-  const end = new Date()
-  const start = new Date(end)
-  start.setUTCDate(start.getUTCDate() - days)
-  return {
-    startDate: start.toISOString().slice(0, 10),
-    endDate: end.toISOString().slice(0, 10),
-  }
-}
-
-function hasMeasurementSuccess(
-  state: typeof gaMeasurementSyncStates.$inferSelect | undefined,
-): boolean {
-  return state?.acquisitionSyncedAt != null || state?.leadSyncedAt != null
-}
-
 function persistAcquisitionMeasurement(
   db: GaDatabase,
   input: {
     projectId: string
     runId: string
-    days: number
     syncedAt: string
-    rows: Awaited<ReturnType<typeof fetchAcquisitionByChannel>>
+    report: Awaited<ReturnType<typeof fetchAcquisitionByChannel>>
   },
 ): void {
-  const { startDate, endDate } = measurementDateBounds(input.days)
+  const { startDate, endDate } = input.report
   db.transaction((tx) => {
     tx.delete(gaAcquisitionDaily)
       .where(and(
@@ -158,7 +141,7 @@ function persistAcquisitionMeasurement(
       ))
       .run()
 
-    for (const row of input.rows) {
+    for (const row of input.report.rows) {
       tx.insert(gaAcquisitionDaily).values({
         id: crypto.randomUUID(),
         projectId: input.projectId,
@@ -199,12 +182,11 @@ function persistLeadMeasurement(
   input: {
     projectId: string
     runId: string
-    days: number
     syncedAt: string
     report: Awaited<ReturnType<typeof fetchLeadEvents>>
   },
 ): void {
-  const { startDate, endDate } = measurementDateBounds(input.days)
+  const { startDate, endDate } = input.report
   db.transaction((tx) => {
     tx.delete(gaLeadEventsDaily)
       .where(and(
@@ -252,6 +234,16 @@ function persistLeadMeasurement(
         leadAttributionScope: input.report.attributionScope,
         updatedAt: input.syncedAt,
       },
+    }).run()
+  })
+}
+
+function resetLeadMeasurement(db: GaDatabase, projectId: string, updatedAt: string): void {
+  db.transaction((tx) => {
+    tx.delete(gaLeadEventsDaily).where(eq(gaLeadEventsDaily.projectId, projectId)).run()
+    tx.insert(gaMeasurementSyncStates).values({ projectId, leadStatus: 'never-synced', leadError: null, leadSyncedAt: null, leadAttributionScope: null, updatedAt }).onConflictDoUpdate({
+      target: gaMeasurementSyncStates.projectId,
+      set: { leadStatus: 'never-synced', leadError: null, leadSyncedAt: null, leadAttributionScope: null, updatedAt },
     }).run()
   })
 }
@@ -734,9 +726,8 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
 
     const measurementState = app.db.select().from(gaMeasurementSyncStates)
       .where(eq(gaMeasurementSyncStates.projectId, project.id)).get()
-    const measurementDays = hasMeasurementSuccess(measurementState)
-      ? Math.min(Math.max(1, days), 90)
-      : 90
+    const acquisitionDays = measurementState?.acquisitionSyncedAt != null ? Math.min(Math.max(1, days), 90) : 90
+    const leadDays = measurementState?.leadSyncedAt != null ? Math.min(Math.max(1, days), 90) : 90
     const leadEventNames = project.measurement.leadEventNames
 
     const startedAt = new Date().toISOString()
@@ -776,9 +767,9 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       if (syncSocial) fetches.push(fetchSocialReferrals(accessToken, propertyId, days))
 
       const measurementFetch = Promise.allSettled([
-        fetchAcquisitionByChannel(accessToken, propertyId, measurementDays),
+        fetchAcquisitionByChannel(accessToken, propertyId, acquisitionDays),
         leadEventNames.length > 0
-          ? fetchLeadEvents(accessToken, propertyId, leadEventNames, measurementDays)
+          ? fetchLeadEvents(accessToken, propertyId, leadEventNames, leadDays)
           : Promise.resolve(null),
       ])
 
@@ -981,7 +972,7 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
             error: stateError instanceof Error ? stateError.message : String(stateError),
           })
         }
-        return { status: 'error' as const, rowCount: 0, error: message }
+        return { status: 'error' as const, days: component === 'acquisition' ? acquisitionDays : leadDays, rowCount: 0, error: message }
       }
 
       const acquisitionResult = (() => {
@@ -992,13 +983,13 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
           persistAcquisitionMeasurement(app.db, {
             projectId: project.id,
             runId,
-            days: measurementDays,
             syncedAt: measurementNow,
-            rows: acquisitionSettled.value,
+            report: acquisitionSettled.value,
           })
           return {
             status: 'ready' as const,
-            rowCount: acquisitionSettled.value.length,
+            days: acquisitionDays,
+            rowCount: acquisitionSettled.value.rows.length,
           }
         } catch (error) {
           return recordMeasurementFailure('acquisition', error)
@@ -1010,18 +1001,19 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
           return recordMeasurementFailure('leads', leadsSettled.reason)
         }
         if (leadsSettled.value === null) {
-          return { status: 'not-configured' as const, rowCount: 0 }
+          resetLeadMeasurement(app.db, project.id, measurementNow)
+          return { status: 'not-configured' as const, days: 0, rowCount: 0 }
         }
         try {
           persistLeadMeasurement(app.db, {
             projectId: project.id,
             runId,
-            days: measurementDays,
             syncedAt: measurementNow,
             report: leadsSettled.value,
           })
           return {
             status: 'ready' as const,
+            days: leadDays,
             rowCount: leadsSettled.value.rows.length,
             attributionScope: leadsSettled.value.attributionScope,
           }
@@ -1066,7 +1058,6 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         days,
         syncedAt: now,
         measurement: {
-          days: measurementDays,
           acquisition: acquisitionResult,
           leads: leadResult,
         },

--- a/packages/api-routes/src/ga.ts
+++ b/packages/api-routes/src/ga.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto'
 import { eq, desc, and, sql } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
-import { gaTrafficSnapshots, gaTrafficSummaries, gaTrafficWindowSummaries, gaDailyTotals, gaAiReferrals, gaSocialReferrals, runs } from '@ainyc/canonry-db'
+import { gaTrafficSnapshots, gaTrafficSummaries, gaTrafficWindowSummaries, gaDailyTotals, gaAiReferrals, gaSocialReferrals, gaAcquisitionDaily, gaLeadEventsDaily, gaMeasurementSyncStates, runs } from '@ainyc/canonry-db'
 import { AiReferralTrafficClasses, classifyAiReferralTrafficClass, validationError, notFound, RunKinds, RunStatuses, RunTriggers, parseWindow, windowCutoff, normalizeUrlPath } from '@ainyc/canonry-contracts'
 import type { AiReferralTrafficClass, GA4ChannelBreakdownDto } from '@ainyc/canonry-contracts'
 import { resolveProject, writeAuditLog } from './helpers.js'
@@ -14,6 +14,8 @@ import {
   fetchDailyTotals,
   fetchAiReferrals,
   fetchSocialReferrals,
+  fetchAcquisitionByChannel,
+  fetchLeadEvents,
   verifyConnection,
   verifyConnectionWithToken,
 } from '@ainyc/canonry-integration-google-analytics'
@@ -116,6 +118,181 @@ function normalizeAiTrafficClass(value: string | null | undefined): AiReferralTr
 
 function emptyAiCounts() {
   return { sessions: 0, users: 0 }
+}
+
+type GaDatabase = FastifyInstance['db']
+
+function measurementDateBounds(days: number): { startDate: string; endDate: string } {
+  const end = new Date()
+  const start = new Date(end)
+  start.setUTCDate(start.getUTCDate() - days)
+  return {
+    startDate: start.toISOString().slice(0, 10),
+    endDate: end.toISOString().slice(0, 10),
+  }
+}
+
+function hasMeasurementSuccess(
+  state: typeof gaMeasurementSyncStates.$inferSelect | undefined,
+): boolean {
+  return state?.acquisitionSyncedAt != null || state?.leadSyncedAt != null
+}
+
+function persistAcquisitionMeasurement(
+  db: GaDatabase,
+  input: {
+    projectId: string
+    runId: string
+    days: number
+    syncedAt: string
+    rows: Awaited<ReturnType<typeof fetchAcquisitionByChannel>>
+  },
+): void {
+  const { startDate, endDate } = measurementDateBounds(input.days)
+  db.transaction((tx) => {
+    tx.delete(gaAcquisitionDaily)
+      .where(and(
+        eq(gaAcquisitionDaily.projectId, input.projectId),
+        sql`${gaAcquisitionDaily.date} >= ${startDate}`,
+        sql`${gaAcquisitionDaily.date} <= ${endDate}`,
+      ))
+      .run()
+
+    for (const row of input.rows) {
+      tx.insert(gaAcquisitionDaily).values({
+        id: crypto.randomUUID(),
+        projectId: input.projectId,
+        date: row.date,
+        channelGroup: row.channelGroup,
+        source: row.source,
+        medium: row.medium,
+        hostName: row.hostName,
+        landingPage: row.landingPage,
+        landingPageNormalized: normalizeUrlPath(row.landingPage),
+        sessions: row.sessions,
+        syncedAt: input.syncedAt,
+        syncRunId: input.runId,
+        createdAt: input.syncedAt,
+      }).run()
+    }
+
+    tx.insert(gaMeasurementSyncStates).values({
+      projectId: input.projectId,
+      acquisitionStatus: 'ready',
+      acquisitionError: null,
+      acquisitionSyncedAt: input.syncedAt,
+      updatedAt: input.syncedAt,
+    }).onConflictDoUpdate({
+      target: gaMeasurementSyncStates.projectId,
+      set: {
+        acquisitionStatus: 'ready',
+        acquisitionError: null,
+        acquisitionSyncedAt: input.syncedAt,
+        updatedAt: input.syncedAt,
+      },
+    }).run()
+  })
+}
+
+function persistLeadMeasurement(
+  db: GaDatabase,
+  input: {
+    projectId: string
+    runId: string
+    days: number
+    syncedAt: string
+    report: Awaited<ReturnType<typeof fetchLeadEvents>>
+  },
+): void {
+  const { startDate, endDate } = measurementDateBounds(input.days)
+  db.transaction((tx) => {
+    tx.delete(gaLeadEventsDaily)
+      .where(and(
+        eq(gaLeadEventsDaily.projectId, input.projectId),
+        sql`${gaLeadEventsDaily.date} >= ${startDate}`,
+        sql`${gaLeadEventsDaily.date} <= ${endDate}`,
+      ))
+      .run()
+
+    for (const row of input.report.rows) {
+      tx.insert(gaLeadEventsDaily).values({
+        id: crypto.randomUUID(),
+        projectId: input.projectId,
+        date: row.date,
+        eventName: row.eventName,
+        channelGroup: row.channelGroup,
+        source: row.source,
+        medium: row.medium,
+        hostName: row.hostName,
+        landingPage: row.landingPage,
+        landingPageNormalized: input.report.attributionScope === 'landing-page'
+          ? normalizeUrlPath(row.landingPage)
+          : null,
+        attributionScope: input.report.attributionScope,
+        eventCount: row.eventCount,
+        syncedAt: input.syncedAt,
+        syncRunId: input.runId,
+        createdAt: input.syncedAt,
+      }).run()
+    }
+
+    tx.insert(gaMeasurementSyncStates).values({
+      projectId: input.projectId,
+      leadStatus: 'ready',
+      leadError: null,
+      leadSyncedAt: input.syncedAt,
+      leadAttributionScope: input.report.attributionScope,
+      updatedAt: input.syncedAt,
+    }).onConflictDoUpdate({
+      target: gaMeasurementSyncStates.projectId,
+      set: {
+        leadStatus: 'ready',
+        leadError: null,
+        leadSyncedAt: input.syncedAt,
+        leadAttributionScope: input.report.attributionScope,
+        updatedAt: input.syncedAt,
+      },
+    }).run()
+  })
+}
+
+function persistMeasurementError(
+  db: GaDatabase,
+  projectId: string,
+  component: 'acquisition' | 'leads',
+  message: string,
+  updatedAt: string,
+): void {
+  if (component === 'acquisition') {
+    db.insert(gaMeasurementSyncStates).values({
+      projectId,
+      acquisitionStatus: 'error',
+      acquisitionError: message,
+      updatedAt,
+    }).onConflictDoUpdate({
+      target: gaMeasurementSyncStates.projectId,
+      set: {
+        acquisitionStatus: 'error',
+        acquisitionError: message,
+        updatedAt,
+      },
+    }).run()
+    return
+  }
+
+  db.insert(gaMeasurementSyncStates).values({
+    projectId,
+    leadStatus: 'error',
+    leadError: message,
+    updatedAt,
+  }).onConflictDoUpdate({
+    target: gaMeasurementSyncStates.projectId,
+    set: {
+      leadStatus: 'error',
+      leadError: message,
+      updatedAt,
+    },
+  }).run()
 }
 
 interface DimensionClassCounts {
@@ -555,6 +732,13 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
     const syncAi = !only || only === 'ai'
     const syncSocial = !only || only === 'social'
 
+    const measurementState = app.db.select().from(gaMeasurementSyncStates)
+      .where(eq(gaMeasurementSyncStates.projectId, project.id)).get()
+    const measurementDays = hasMeasurementSuccess(measurementState)
+      ? Math.min(Math.max(1, days), 90)
+      : 90
+    const leadEventNames = project.measurement.leadEventNames
+
     const startedAt = new Date().toISOString()
     const runId = crypto.randomUUID()
     app.db.insert(runs).values({
@@ -590,6 +774,13 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
       if (syncTraffic) fetches.push(fetchTrafficByLandingPage(accessToken, propertyId, days))
       if (syncAi) fetches.push(fetchAiReferrals(accessToken, propertyId, days))
       if (syncSocial) fetches.push(fetchSocialReferrals(accessToken, propertyId, days))
+
+      const measurementFetch = Promise.allSettled([
+        fetchAcquisitionByChannel(accessToken, propertyId, measurementDays),
+        leadEventNames.length > 0
+          ? fetchLeadEvents(accessToken, propertyId, leadEventNames, measurementDays)
+          : Promise.resolve(null),
+      ])
 
       const results = await Promise.all(fetches)
       const summary: Awaited<ReturnType<typeof fetchAggregateSummary>> = results[0] as Awaited<ReturnType<typeof fetchAggregateSummary>>
@@ -766,8 +957,81 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         }
       })
 
+      const [acquisitionSettled, leadsSettled] = await measurementFetch
+      const measurementNow = new Date().toISOString()
+
+      const recordMeasurementFailure = (
+        component: 'acquisition' | 'leads',
+        reason: unknown,
+      ) => {
+        const message = reason instanceof Error ? reason.message : String(reason)
+        gaLog('warn', 'measurement.component-failed', {
+          projectId: project.id,
+          runId,
+          component,
+          error: message,
+        })
+        try {
+          persistMeasurementError(app.db, project.id, component, message, measurementNow)
+        } catch (stateError) {
+          gaLog('error', 'measurement.state-write-failed', {
+            projectId: project.id,
+            runId,
+            component,
+            error: stateError instanceof Error ? stateError.message : String(stateError),
+          })
+        }
+        return { status: 'error' as const, rowCount: 0, error: message }
+      }
+
+      const acquisitionResult = (() => {
+        if (acquisitionSettled.status === 'rejected') {
+          return recordMeasurementFailure('acquisition', acquisitionSettled.reason)
+        }
+        try {
+          persistAcquisitionMeasurement(app.db, {
+            projectId: project.id,
+            runId,
+            days: measurementDays,
+            syncedAt: measurementNow,
+            rows: acquisitionSettled.value,
+          })
+          return {
+            status: 'ready' as const,
+            rowCount: acquisitionSettled.value.length,
+          }
+        } catch (error) {
+          return recordMeasurementFailure('acquisition', error)
+        }
+      })()
+
+      const leadResult = (() => {
+        if (leadsSettled.status === 'rejected') {
+          return recordMeasurementFailure('leads', leadsSettled.reason)
+        }
+        if (leadsSettled.value === null) {
+          return { status: 'not-configured' as const, rowCount: 0 }
+        }
+        try {
+          persistLeadMeasurement(app.db, {
+            projectId: project.id,
+            runId,
+            days: measurementDays,
+            syncedAt: measurementNow,
+            report: leadsSettled.value,
+          })
+          return {
+            status: 'ready' as const,
+            rowCount: leadsSettled.value.rows.length,
+            attributionScope: leadsSettled.value.attributionScope,
+          }
+        } catch (error) {
+          return recordMeasurementFailure('leads', error)
+        }
+      })()
+
       app.db.update(runs)
-        .set({ status: RunStatuses.completed, finishedAt: now })
+        .set({ status: RunStatuses.completed, finishedAt: measurementNow })
         .where(eq(runs.id, runId))
         .run()
 
@@ -801,6 +1065,11 @@ export async function ga4Routes(app: FastifyInstance, opts: GA4RoutesOptions) {
         socialReferralCount: socialReferrals.length,
         days,
         syncedAt: now,
+        measurement: {
+          days: measurementDays,
+          acquisition: acquisitionResult,
+          leads: leadResult,
+        },
         ...(syncedComponents ? { syncedComponents } : {}),
       }
     } catch (e) {

--- a/packages/api-routes/test/ga-measurement-ingestion.test.ts
+++ b/packages/api-routes/test/ga-measurement-ingestion.test.ts
@@ -1,0 +1,398 @@
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import Fastify from 'fastify'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { eq } from 'drizzle-orm'
+import {
+  RunStatuses,
+} from '@ainyc/canonry-contracts'
+import {
+  createClient,
+  gaAcquisitionDaily,
+  gaLeadEventsDaily,
+  gaMeasurementSyncStates,
+  migrate,
+  runs,
+} from '@ainyc/canonry-db'
+import { apiRoutes } from '../src/index.js'
+import type { Ga4CredentialRecord, Ga4CredentialStore } from '../src/ga.js'
+
+function dateDaysAgo(days: number): string {
+  const date = new Date()
+  date.setUTCDate(date.getUTCDate() - days)
+  return date.toISOString().slice(0, 10)
+}
+
+function buildApp(leadEventNames: string[] = ['generate_lead', 'book_demo']) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-ga-measurement-ingestion-'))
+  const db = createClient(path.join(tmpDir, 'test.db'))
+  migrate(db)
+  const credentials = new Map<string, Ga4CredentialRecord>()
+  const ga4CredentialStore: Ga4CredentialStore = {
+    getConnection: projectName => credentials.get(projectName),
+    upsertConnection: connection => {
+      credentials.set(connection.projectName, connection)
+      return connection
+    },
+    deleteConnection: projectName => credentials.delete(projectName),
+  }
+  const app = Fastify()
+  app.register(apiRoutes, { db, skipAuth: true, ga4CredentialStore })
+  return { app, db, credentials, tmpDir, leadEventNames }
+}
+
+type Context = ReturnType<typeof buildApp> & { projectId: string }
+
+async function seedProject(ctx: ReturnType<typeof buildApp>): Promise<string> {
+  const response = await ctx.app.inject({
+    method: 'PUT',
+    url: '/api/v1/projects/measurement-ingestion',
+    payload: {
+      displayName: 'Measurement Ingestion',
+      canonicalDomain: 'example.com',
+      country: 'US',
+      language: 'en',
+      measurement: {
+        marketingHosts: ['offers.example.com'],
+        brandTerms: ['Example'],
+        leadEventNames: ctx.leadEventNames,
+      },
+    },
+  })
+  expect(response.statusCode).toBe(201)
+  const projectId = (JSON.parse(response.body) as { id: string }).id
+  const now = new Date().toISOString()
+  ctx.credentials.set('measurement-ingestion', {
+    projectName: 'measurement-ingestion',
+    propertyId: '123456',
+    clientEmail: 'measurement@test.iam.gserviceaccount.com',
+    privateKey: 'fake-key',
+    createdAt: now,
+    updatedAt: now,
+  })
+  return projectId
+}
+
+async function mockLegacyGa() {
+  const ga = await import('@ainyc/canonry-integration-google-analytics')
+  vi.spyOn(ga, 'getAccessToken').mockResolvedValue('fake-token')
+  vi.spyOn(ga, 'fetchAggregateSummary').mockResolvedValue({
+    periodStart: dateDaysAgo(29),
+    periodEnd: dateDaysAgo(0),
+    totalSessions: 10,
+    totalOrganicSessions: 4,
+    totalUsers: 8,
+  })
+  vi.spyOn(ga, 'fetchWindowSummary').mockImplementation(async (_token, _property, windowKey) => ({
+    windowKey,
+    periodStart: dateDaysAgo(windowKey === '7d' ? 6 : windowKey === '30d' ? 29 : 89),
+    periodEnd: dateDaysAgo(0),
+    totalSessions: 10,
+    totalOrganicSessions: 4,
+    totalDirectSessions: 2,
+    totalUsers: 8,
+  }))
+  vi.spyOn(ga, 'fetchDailyTotals').mockResolvedValue([
+    { date: dateDaysAgo(1), sessions: 10, users: 8 },
+  ])
+  vi.spyOn(ga, 'fetchTrafficByLandingPage').mockResolvedValue([
+    {
+      date: dateDaysAgo(1),
+      landingPage: '/',
+      sessions: 10,
+      organicSessions: 4,
+      directSessions: 2,
+      users: 8,
+    },
+  ])
+  vi.spyOn(ga, 'fetchAiReferrals').mockResolvedValue([])
+  vi.spyOn(ga, 'fetchSocialReferrals').mockResolvedValue([])
+  return ga
+}
+
+describe('GA measurement ingestion', () => {
+  let ctx: Context
+
+  beforeEach(async () => {
+    const base = buildApp()
+    await base.app.ready()
+    const projectId = await seedProject(base)
+    ctx = { ...base, projectId }
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await ctx.app.close()
+    fs.rmSync(ctx.tmpDir, { recursive: true, force: true })
+  })
+
+  it('backfills 90 days on first sync, ingests every host, and records independent ready states', async () => {
+    const ga = await mockLegacyGa()
+    const acquisitionSpy = vi.spyOn(ga, 'fetchAcquisitionByChannel').mockResolvedValue([
+      {
+        date: dateDaysAgo(2),
+        channelGroup: 'Paid Search',
+        source: 'google',
+        medium: 'cpc',
+        hostName: 'offers.example.com',
+        landingPage: '/quote?utm_campaign=summer',
+        sessions: 6,
+      },
+      {
+        date: dateDaysAgo(1),
+        channelGroup: 'Organic Search',
+        source: 'google',
+        medium: 'organic',
+        hostName: 'docs.example.net',
+        landingPage: '/guides/solar',
+        sessions: 4,
+      },
+    ])
+    const leadsSpy = vi.spyOn(ga, 'fetchLeadEvents').mockResolvedValue({
+      attributionScope: 'landing-page',
+      rows: [{
+        date: dateDaysAgo(1),
+        eventName: 'book_demo',
+        channelGroup: 'Paid Search',
+        source: 'google',
+        medium: 'cpc',
+        hostName: 'offers.example.com',
+        landingPage: '/demo?utm_source=google',
+        eventCount: 2,
+      }],
+    })
+
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/measurement-ingestion/ga/sync',
+      payload: { days: 30 },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(acquisitionSpy).toHaveBeenCalledWith('fake-token', '123456', 90)
+    expect(leadsSpy).toHaveBeenCalledWith(
+      'fake-token',
+      '123456',
+      ['generate_lead', 'book_demo'],
+      90,
+    )
+    expect(JSON.parse(response.body)).toMatchObject({
+      synced: true,
+      measurement: {
+        days: 90,
+        acquisition: { status: 'ready', rowCount: 2 },
+        leads: { status: 'ready', rowCount: 1, attributionScope: 'landing-page' },
+      },
+    })
+
+    const acquisition = ctx.db.select().from(gaAcquisitionDaily)
+      .where(eq(gaAcquisitionDaily.projectId, ctx.projectId)).all()
+      .sort((a, b) => a.hostName.localeCompare(b.hostName))
+    expect(acquisition.map(row => row.hostName)).toEqual([
+      'docs.example.net',
+      'offers.example.com',
+    ])
+    expect(acquisition.find(row => row.hostName === 'offers.example.com')).toMatchObject({
+      channelGroup: 'Paid Search',
+      landingPageNormalized: '/quote',
+      sessions: 6,
+    })
+
+    expect(ctx.db.select().from(gaLeadEventsDaily)
+      .where(eq(gaLeadEventsDaily.projectId, ctx.projectId)).get()).toMatchObject({
+      eventName: 'book_demo',
+      landingPageNormalized: '/demo',
+      attributionScope: 'landing-page',
+      eventCount: 2,
+    })
+    expect(ctx.db.select().from(gaMeasurementSyncStates)
+      .where(eq(gaMeasurementSyncStates.projectId, ctx.projectId)).get()).toMatchObject({
+      acquisitionStatus: 'ready',
+      acquisitionError: null,
+      leadStatus: 'ready',
+      leadError: null,
+      leadAttributionScope: 'landing-page',
+    })
+  })
+
+  it('uses the requested window after first success and treats an empty report as resolved zero', async () => {
+    const ga = await mockLegacyGa()
+    const acquisitionSpy = vi.spyOn(ga, 'fetchAcquisitionByChannel').mockResolvedValue([])
+    const leadsSpy = vi.spyOn(ga, 'fetchLeadEvents').mockResolvedValue({
+      attributionScope: 'landing-page',
+      rows: [],
+    })
+    const now = new Date().toISOString()
+    ctx.db.insert(gaMeasurementSyncStates).values({
+      projectId: ctx.projectId,
+      acquisitionStatus: 'ready',
+      acquisitionSyncedAt: now,
+      leadStatus: 'ready',
+      leadSyncedAt: now,
+      leadAttributionScope: 'landing-page',
+      updatedAt: now,
+    }).run()
+    ctx.db.insert(gaAcquisitionDaily).values([
+      {
+        id: crypto.randomUUID(),
+        projectId: ctx.projectId,
+        date: dateDaysAgo(5),
+        channelGroup: 'Organic Search',
+        source: 'google',
+        medium: 'organic',
+        hostName: 'example.com',
+        landingPage: '/stale',
+        sessions: 9,
+        syncedAt: now,
+        createdAt: now,
+      },
+      {
+        id: crypto.randomUUID(),
+        projectId: ctx.projectId,
+        date: dateDaysAgo(60),
+        channelGroup: 'Organic Search',
+        source: 'google',
+        medium: 'organic',
+        hostName: 'example.com',
+        landingPage: '/outside-window',
+        sessions: 3,
+        syncedAt: now,
+        createdAt: now,
+      },
+    ]).run()
+    ctx.db.insert(gaLeadEventsDaily).values({
+      id: crypto.randomUUID(),
+      projectId: ctx.projectId,
+      date: dateDaysAgo(5),
+      eventName: 'generate_lead',
+      channelGroup: 'Organic Search',
+      source: 'google',
+      medium: 'organic',
+      hostName: 'example.com',
+      landingPage: '/stale-lead',
+      attributionScope: 'landing-page',
+      eventCount: 1,
+      syncedAt: now,
+      createdAt: now,
+    }).run()
+
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/measurement-ingestion/ga/sync',
+      payload: { days: 30 },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(acquisitionSpy).toHaveBeenCalledWith('fake-token', '123456', 30)
+    expect(leadsSpy).toHaveBeenCalledWith(
+      'fake-token',
+      '123456',
+      ['generate_lead', 'book_demo'],
+      30,
+    )
+    expect(JSON.parse(response.body)).toMatchObject({
+      measurement: {
+        days: 30,
+        acquisition: { status: 'ready', rowCount: 0 },
+        leads: { status: 'ready', rowCount: 0, attributionScope: 'landing-page' },
+      },
+    })
+    expect(ctx.db.select().from(gaAcquisitionDaily)
+      .where(eq(gaAcquisitionDaily.projectId, ctx.projectId)).all()).toMatchObject([
+      { landingPage: '/outside-window', sessions: 3 },
+    ])
+    expect(ctx.db.select().from(gaLeadEventsDaily)
+      .where(eq(gaLeadEventsDaily.projectId, ctx.projectId)).all()).toEqual([])
+    expect(ctx.db.select().from(gaMeasurementSyncStates)
+      .where(eq(gaMeasurementSyncStates.projectId, ctx.projectId)).get()).toMatchObject({
+      acquisitionStatus: 'ready',
+      acquisitionError: null,
+      leadStatus: 'ready',
+      leadError: null,
+    })
+  })
+
+  it('preserves last-good acquisition data on component failure while successful lead and legacy syncs commit', async () => {
+    const ga = await mockLegacyGa()
+    vi.spyOn(ga, 'fetchAcquisitionByChannel').mockRejectedValue(new Error('acquisition quota exhausted'))
+    vi.spyOn(ga, 'fetchLeadEvents').mockResolvedValue({
+      attributionScope: 'channel',
+      rows: [{
+        date: dateDaysAgo(1),
+        eventName: 'generate_lead',
+        channelGroup: 'Organic Search',
+        source: 'google',
+        medium: 'organic',
+        hostName: '(not available)',
+        landingPage: '(not available)',
+        eventCount: 2,
+      }],
+    })
+    const lastGood = '2026-07-01T00:00:00.000Z'
+    const now = new Date().toISOString()
+    ctx.db.insert(gaMeasurementSyncStates).values({
+      projectId: ctx.projectId,
+      acquisitionStatus: 'ready',
+      acquisitionSyncedAt: lastGood,
+      leadStatus: 'ready',
+      leadSyncedAt: lastGood,
+      leadAttributionScope: 'landing-page',
+      updatedAt: now,
+    }).run()
+    ctx.db.insert(gaAcquisitionDaily).values({
+      id: crypto.randomUUID(),
+      projectId: ctx.projectId,
+      date: dateDaysAgo(5),
+      channelGroup: 'Organic Search',
+      source: 'google',
+      medium: 'organic',
+      hostName: 'example.com',
+      landingPage: '/last-good',
+      sessions: 12,
+      syncedAt: lastGood,
+      createdAt: lastGood,
+    }).run()
+
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/measurement-ingestion/ga/sync',
+      payload: { days: 30 },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(JSON.parse(response.body)).toMatchObject({
+      synced: true,
+      measurement: {
+        days: 30,
+        acquisition: { status: 'error', rowCount: 0, error: 'acquisition quota exhausted' },
+        leads: { status: 'ready', rowCount: 1, attributionScope: 'channel' },
+      },
+    })
+    expect(ctx.db.select().from(gaAcquisitionDaily)
+      .where(eq(gaAcquisitionDaily.projectId, ctx.projectId)).all()).toMatchObject([
+      { landingPage: '/last-good', sessions: 12 },
+    ])
+    expect(ctx.db.select().from(gaLeadEventsDaily)
+      .where(eq(gaLeadEventsDaily.projectId, ctx.projectId)).get()).toMatchObject({
+      attributionScope: 'channel',
+      hostName: '(not available)',
+      landingPage: '(not available)',
+      landingPageNormalized: null,
+      eventCount: 2,
+    })
+    expect(ctx.db.select().from(gaMeasurementSyncStates)
+      .where(eq(gaMeasurementSyncStates.projectId, ctx.projectId)).get()).toMatchObject({
+      acquisitionStatus: 'error',
+      acquisitionError: 'acquisition quota exhausted',
+      acquisitionSyncedAt: lastGood,
+      leadStatus: 'ready',
+      leadError: null,
+      leadAttributionScope: 'channel',
+    })
+    expect(ctx.db.select().from(runs).orderBy(runs.createdAt).all().at(-1)).toMatchObject({
+      status: RunStatuses.completed,
+    })
+  })
+})

--- a/packages/api-routes/test/ga-measurement-ingestion.test.ts
+++ b/packages/api-routes/test/ga-measurement-ingestion.test.ts
@@ -25,6 +25,13 @@ function dateDaysAgo(days: number): string {
   return date.toISOString().slice(0, 10)
 }
 
+function measurementRange(days: number) {
+  return {
+    startDate: dateDaysAgo(days),
+    endDate: dateDaysAgo(0),
+  }
+}
+
 function buildApp(leadEventNames: string[] = ['generate_lead', 'book_demo']) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-ga-measurement-ingestion-'))
   const db = createClient(path.join(tmpDir, 'test.db'))
@@ -130,7 +137,8 @@ describe('GA measurement ingestion', () => {
 
   it('backfills 90 days on first sync, ingests every host, and records independent ready states', async () => {
     const ga = await mockLegacyGa()
-    const acquisitionSpy = vi.spyOn(ga, 'fetchAcquisitionByChannel').mockResolvedValue([
+    const acquisitionSpy = vi.spyOn(ga, 'fetchAcquisitionByChannel').mockResolvedValue({
+      ...measurementRange(90), rows: [
       {
         date: dateDaysAgo(2),
         channelGroup: 'Paid Search',
@@ -149,8 +157,9 @@ describe('GA measurement ingestion', () => {
         landingPage: '/guides/solar',
         sessions: 4,
       },
-    ])
+    ] })
     const leadsSpy = vi.spyOn(ga, 'fetchLeadEvents').mockResolvedValue({
+      ...measurementRange(90),
       attributionScope: 'landing-page',
       rows: [{
         date: dateDaysAgo(1),
@@ -181,9 +190,8 @@ describe('GA measurement ingestion', () => {
     expect(JSON.parse(response.body)).toMatchObject({
       synced: true,
       measurement: {
-        days: 90,
-        acquisition: { status: 'ready', rowCount: 2 },
-        leads: { status: 'ready', rowCount: 1, attributionScope: 'landing-page' },
+        acquisition: { days: 90, status: 'ready', rowCount: 2 },
+        leads: { days: 90, status: 'ready', rowCount: 1, attributionScope: 'landing-page' },
       },
     })
 
@@ -219,8 +227,11 @@ describe('GA measurement ingestion', () => {
 
   it('uses the requested window after first success and treats an empty report as resolved zero', async () => {
     const ga = await mockLegacyGa()
-    const acquisitionSpy = vi.spyOn(ga, 'fetchAcquisitionByChannel').mockResolvedValue([])
+    const acquisitionSpy = vi.spyOn(ga, 'fetchAcquisitionByChannel').mockResolvedValue({
+      ...measurementRange(30), rows: [],
+    })
     const leadsSpy = vi.spyOn(ga, 'fetchLeadEvents').mockResolvedValue({
+      ...measurementRange(30),
       attributionScope: 'landing-page',
       rows: [],
     })
@@ -294,9 +305,8 @@ describe('GA measurement ingestion', () => {
     )
     expect(JSON.parse(response.body)).toMatchObject({
       measurement: {
-        days: 30,
-        acquisition: { status: 'ready', rowCount: 0 },
-        leads: { status: 'ready', rowCount: 0, attributionScope: 'landing-page' },
+        acquisition: { days: 30, status: 'ready', rowCount: 0 },
+        leads: { days: 30, status: 'ready', rowCount: 0, attributionScope: 'landing-page' },
       },
     })
     expect(ctx.db.select().from(gaAcquisitionDaily)
@@ -318,6 +328,7 @@ describe('GA measurement ingestion', () => {
     const ga = await mockLegacyGa()
     vi.spyOn(ga, 'fetchAcquisitionByChannel').mockRejectedValue(new Error('acquisition quota exhausted'))
     vi.spyOn(ga, 'fetchLeadEvents').mockResolvedValue({
+      ...measurementRange(30),
       attributionScope: 'channel',
       rows: [{
         date: dateDaysAgo(1),
@@ -365,9 +376,8 @@ describe('GA measurement ingestion', () => {
     expect(JSON.parse(response.body)).toMatchObject({
       synced: true,
       measurement: {
-        days: 30,
-        acquisition: { status: 'error', rowCount: 0, error: 'acquisition quota exhausted' },
-        leads: { status: 'ready', rowCount: 1, attributionScope: 'channel' },
+        acquisition: { days: 30, status: 'error', rowCount: 0, error: 'acquisition quota exhausted' },
+        leads: { days: 30, status: 'ready', rowCount: 1, attributionScope: 'channel' },
       },
     })
     expect(ctx.db.select().from(gaAcquisitionDaily)
@@ -393,6 +403,167 @@ describe('GA measurement ingestion', () => {
     })
     expect(ctx.db.select().from(runs).orderBy(runs.createdAt).all().at(-1)).toMatchObject({
       status: RunStatuses.completed,
+    })
+  })
+
+  it('backfills each measurement component independently until that component succeeds', async () => {
+    const ga = await mockLegacyGa()
+    const acquisitionSpy = vi.spyOn(ga, 'fetchAcquisitionByChannel')
+      .mockRejectedValueOnce(new Error('temporary acquisition failure'))
+      .mockResolvedValueOnce({ ...measurementRange(90), rows: [] })
+    const leadsSpy = vi.spyOn(ga, 'fetchLeadEvents')
+      .mockResolvedValueOnce({
+        ...measurementRange(90),
+        attributionScope: 'landing-page',
+        rows: [],
+      })
+      .mockResolvedValueOnce({
+        ...measurementRange(30),
+        attributionScope: 'landing-page',
+        rows: [],
+      })
+
+    const first = await ctx.app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/measurement-ingestion/ga/sync',
+      payload: { days: 30 },
+    })
+    expect(first.statusCode).toBe(200)
+
+    const second = await ctx.app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/measurement-ingestion/ga/sync',
+      payload: { days: 30 },
+    })
+    expect(second.statusCode).toBe(200)
+    expect(acquisitionSpy.mock.calls.map(call => call[2])).toEqual([90, 90])
+    expect(leadsSpy.mock.calls.map(call => call[3])).toEqual([90, 30])
+    expect(JSON.parse(second.body)).toMatchObject({
+      measurement: {
+        acquisition: { days: 90, status: 'ready' },
+        leads: { days: 30, status: 'ready' },
+      },
+    })
+  })
+
+  it('deletes only the exact date range returned by the GA4 acquisition report', async () => {
+    const ga = await mockLegacyGa()
+    vi.spyOn(ga, 'fetchAcquisitionByChannel').mockResolvedValue({
+      startDate: dateDaysAgo(10),
+      endDate: dateDaysAgo(3),
+      rows: [],
+    })
+    vi.spyOn(ga, 'fetchLeadEvents').mockResolvedValue({
+      ...measurementRange(30),
+      attributionScope: 'landing-page',
+      rows: [],
+    })
+    const now = new Date().toISOString()
+    ctx.db.insert(gaMeasurementSyncStates).values({
+      projectId: ctx.projectId,
+      acquisitionStatus: 'ready',
+      acquisitionSyncedAt: now,
+      leadStatus: 'ready',
+      leadSyncedAt: now,
+      leadAttributionScope: 'landing-page',
+      updatedAt: now,
+    }).run()
+    for (const daysAgo of [11, 5, 2]) {
+      ctx.db.insert(gaAcquisitionDaily).values({
+        id: crypto.randomUUID(),
+        projectId: ctx.projectId,
+        date: dateDaysAgo(daysAgo),
+        channelGroup: 'Organic Search',
+        source: 'google',
+        medium: 'organic',
+        hostName: 'example.com',
+        landingPage: `/existing-${daysAgo}`,
+        sessions: daysAgo,
+        syncedAt: now,
+        createdAt: now,
+      }).run()
+    }
+
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/measurement-ingestion/ga/sync',
+      payload: { days: 30 },
+    })
+    expect(response.statusCode).toBe(200)
+    expect(ctx.db.select().from(gaAcquisitionDaily)
+      .where(eq(gaAcquisitionDaily.projectId, ctx.projectId)).all()
+      .map(row => row.landingPage)
+      .sort()).toEqual(['/existing-11', '/existing-2'])
+  })
+
+  it('clears stale lead evidence and resets lead sync state when lead events are disabled', async () => {
+    const ga = await mockLegacyGa()
+    vi.spyOn(ga, 'fetchAcquisitionByChannel').mockResolvedValue({
+      ...measurementRange(30), rows: [],
+    })
+    const leadsSpy = vi.spyOn(ga, 'fetchLeadEvents')
+    const now = new Date().toISOString()
+    ctx.db.insert(gaLeadEventsDaily).values({
+      id: crypto.randomUUID(),
+      projectId: ctx.projectId,
+      date: dateDaysAgo(2),
+      eventName: 'generate_lead',
+      channelGroup: 'Organic Search',
+      source: 'google',
+      medium: 'organic',
+      hostName: 'example.com',
+      landingPage: '/old-lead',
+      attributionScope: 'landing-page',
+      eventCount: 4,
+      syncedAt: now,
+      createdAt: now,
+    }).run()
+    ctx.db.insert(gaMeasurementSyncStates).values({
+      projectId: ctx.projectId,
+      acquisitionStatus: 'ready',
+      acquisitionSyncedAt: now,
+      leadStatus: 'ready',
+      leadSyncedAt: now,
+      leadAttributionScope: 'landing-page',
+      updatedAt: now,
+    }).run()
+    const update = await ctx.app.inject({
+      method: 'PUT',
+      url: '/api/v1/projects/measurement-ingestion',
+      payload: {
+        displayName: 'Measurement Ingestion',
+        canonicalDomain: 'example.com',
+        country: 'US',
+        language: 'en',
+        measurement: {
+          marketingHosts: ['offers.example.com'],
+          brandTerms: ['Example'],
+          leadEventNames: [],
+        },
+      },
+    })
+    expect(update.statusCode).toBe(200)
+
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/api/v1/projects/measurement-ingestion/ga/sync',
+      payload: { days: 30 },
+    })
+    expect(response.statusCode).toBe(200)
+    expect(leadsSpy).not.toHaveBeenCalled()
+    expect(JSON.parse(response.body)).toMatchObject({
+      measurement: {
+        leads: { days: 0, status: 'not-configured', rowCount: 0 },
+      },
+    })
+    expect(ctx.db.select().from(gaLeadEventsDaily)
+      .where(eq(gaLeadEventsDaily.projectId, ctx.projectId)).all()).toEqual([])
+    expect(ctx.db.select().from(gaMeasurementSyncStates)
+      .where(eq(gaMeasurementSyncStates.projectId, ctx.projectId)).get()).toMatchObject({
+      leadStatus: 'never-synced',
+      leadError: null,
+      leadSyncedAt: null,
+      leadAttributionScope: null,
     })
   })
 })

--- a/packages/api-routes/test/openapi-contract.test.ts
+++ b/packages/api-routes/test/openapi-contract.test.ts
@@ -200,6 +200,29 @@ describe('openapi contract', () => {
     expect(missingBodies, `Routes missing a 2xx response body schema:\n  ${missingBodies.join('\n  ')}`).toEqual([])
   })
 
+  it('documents independent native measurement results on the GA sync response', async () => {
+    const ctx = buildObservedApp()
+    contexts.push(ctx)
+    await ctx.app.ready()
+
+    const res = await ctx.app.inject({ method: 'GET', url: '/api/v1/openapi.json' })
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as {
+      components?: {
+        schemas?: Record<string, {
+          required?: string[]
+          properties?: Record<string, unknown>
+        }>
+      }
+    }
+    const schema = body.components?.schemas?.GA4SyncResponseDto
+    expect(schema?.required).toContain('measurement')
+    expect(schema?.properties).toHaveProperty('measurement')
+    expect(JSON.stringify(schema?.properties?.measurement)).toContain('acquisition')
+    expect(JSON.stringify(schema?.properties?.measurement)).toContain('leads')
+    expect(JSON.stringify(schema?.properties?.measurement)).toContain('days')
+  })
+
   it('every registered component schema is referenced by at least one route', async () => {
     // Keeps the schema table honest: removing a schema from a route without
     // removing it from `openapi-schemas.ts` is a slow leak. This test

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.130.0",
+  "version": "4.131.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/contracts/src/ga.ts
+++ b/packages/contracts/src/ga.ts
@@ -216,6 +216,10 @@ export const ga4SyncResponseDtoSchema = z.object({
   socialReferralCount: z.number().int().nonnegative(),
   days: z.number().int().nonnegative(),
   syncedAt: z.string(),
+  measurement: z.object({
+    acquisition: z.object({ days: z.number().int().nonnegative(), status: z.enum(['ready', 'error']), rowCount: z.number().int().nonnegative(), error: z.string().optional() }),
+    leads: z.object({ days: z.number().int().nonnegative(), status: z.enum(['ready', 'error', 'not-configured']), rowCount: z.number().int().nonnegative(), attributionScope: z.enum(['landing-page', 'channel']).optional(), error: z.string().optional() }),
+  }),
   /**
    * Components that were written this run. Present when `only` is set.
    * Always includes `traffic` and `summary` (the share denominator) plus

--- a/packages/contracts/test/ga-sync-response.test.ts
+++ b/packages/contracts/test/ga-sync-response.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { ga4SyncResponseDtoSchema } from '../src/index.js'
+
+describe('ga4SyncResponseDtoSchema', () => {
+  it('documents independent acquisition and lead measurement outcomes', () => {
+    const response = {
+      synced: true,
+      rowCount: 5,
+      aiReferralCount: 1,
+      socialReferralCount: 2,
+      days: 30,
+      syncedAt: '2026-07-23T12:00:00.000Z',
+      measurement: {
+        acquisition: {
+          days: 90,
+          status: 'ready',
+          rowCount: 42,
+        },
+        leads: {
+          days: 30,
+          status: 'error',
+          rowCount: 0,
+          error: 'GA4 quota exhausted',
+        },
+      },
+    }
+
+    expect(ga4SyncResponseDtoSchema.parse(response)).toEqual(response)
+    expect(() => ga4SyncResponseDtoSchema.parse({
+      ...response,
+      measurement: {
+        acquisition: { status: 'ready', rowCount: 42 },
+        leads: { status: 'ready', rowCount: 3 },
+      },
+    })).toThrow()
+  })
+})

--- a/packages/integration-google-analytics/src/constants.ts
+++ b/packages/integration-google-analytics/src/constants.ts
@@ -45,10 +45,13 @@ export const GA4_DIMENSIONS = {
   firstUserMedium: 'firstUserMedium',
   sessionDefaultChannelGrouping: 'sessionDefaultChannelGrouping',
   sessionDefaultChannelGroup: 'sessionDefaultChannelGroup',
+  hostName: 'hostName',
+  eventName: 'eventName',
 } as const
 
 /** GA4 metric names used in `runReport` requests. Same rationale as `GA4_DIMENSIONS`. */
 export const GA4_METRICS = {
   sessions: 'sessions',
   totalUsers: 'totalUsers',
+  eventCount: 'eventCount',
 } as const

--- a/packages/integration-google-analytics/src/ga4-client.ts
+++ b/packages/integration-google-analytics/src/ga4-client.ts
@@ -21,6 +21,9 @@ import type {
   GA4RunReportResponse,
   GA4SourceDimension,
   GA4TrafficRow,
+  GA4AcquisitionRow,
+  GA4LeadEventReport,
+  GA4LeadEventRow,
 } from './types.js'
 import { GA4ApiError } from './types.js'
 
@@ -362,6 +365,119 @@ async function batchRunReports(
 
 function formatDate(d: Date): string {
   return d.toISOString().slice(0, 10)
+}
+
+function measurementDateRange(days?: number) {
+  const syncDays = Math.min(Math.max(1, days ?? GA4_DEFAULT_SYNC_DAYS), GA4_MAX_SYNC_DAYS)
+  const endDate = new Date()
+  const startDate = new Date()
+  startDate.setUTCDate(startDate.getUTCDate() - syncDays)
+  return { syncDays, dateRange: { startDate: formatDate(startDate), endDate: formatDate(endDate) } }
+}
+
+async function fetchPagedReport(
+  accessToken: string,
+  propertyId: string,
+  baseRequest: Omit<GA4RunReportRequest, 'limit' | 'offset'>,
+  pageSize = 10_000,
+): Promise<NonNullable<GA4RunReportResponse['rows']>> {
+  const rows: NonNullable<GA4RunReportResponse['rows']> = []
+  let offset = 0
+  for (let page = 0; page < GA4_MAX_PAGES; page++) {
+    const response = await runReport(accessToken, propertyId, { ...baseRequest, limit: pageSize, offset })
+    const pageRows = response.rows ?? []
+    rows.push(...pageRows)
+    offset += pageRows.length
+    if (pageRows.length < pageSize || (response.rowCount !== undefined && offset >= response.rowCount)) break
+  }
+  return rows
+}
+
+export async function fetchAcquisitionByChannel(
+  accessToken: string,
+  propertyId: string,
+  days?: number,
+  options?: { pageSize?: number },
+): Promise<GA4AcquisitionRow[]> {
+  validateAccessToken(accessToken)
+  validatePropertyId(propertyId)
+  const { syncDays, dateRange } = measurementDateRange(days)
+  const rows = await fetchPagedReport(accessToken, propertyId, {
+    dateRanges: [dateRange],
+    dimensions: [
+      { name: DIM.date },
+      { name: DIM.sessionDefaultChannelGroup },
+      { name: DIM.sessionSource },
+      { name: DIM.sessionMedium },
+      { name: DIM.hostName },
+      { name: DIM.landingPagePlusQueryString },
+    ],
+    metrics: [{ name: MET.sessions }],
+  }, options?.pageSize)
+  ga4Log('info', 'fetch-acquisition.done', { propertyId, days: syncDays, rowCount: rows.length })
+  return rows.map((row) => ({
+    date: compactDateToIso(row.dimensionValues[0]?.value ?? ''),
+    channelGroup: row.dimensionValues[1]?.value ?? '(not set)',
+    source: row.dimensionValues[2]?.value ?? '(not set)',
+    medium: row.dimensionValues[3]?.value ?? '(not set)',
+    hostName: row.dimensionValues[4]?.value ?? '(not set)',
+    landingPage: row.dimensionValues[5]?.value ?? '(not set)',
+    sessions: parseInt(row.metricValues[0]?.value ?? '0', 10) || 0,
+  }))
+}
+
+function isLandingPageDimensionIncompatibility(error: unknown): boolean {
+  return error instanceof GA4ApiError
+    && error.status === 400
+    && /landingPagePlusQueryString/i.test(error.message)
+    && /incompatib/i.test(error.message)
+}
+
+export async function fetchLeadEvents(
+  accessToken: string,
+  propertyId: string,
+  eventNames: string[],
+  days?: number,
+): Promise<GA4LeadEventReport> {
+  validateAccessToken(accessToken)
+  validatePropertyId(propertyId)
+  const { dateRange } = measurementDateRange(days)
+  const filter = { orGroup: { expressions: eventNames.map((value) => ({ filter: {
+    fieldName: DIM.eventName,
+    stringFilter: { matchType: 'EXACT', value },
+  } })) } }
+  const dimensions = [
+    { name: DIM.date }, { name: DIM.eventName }, { name: DIM.sessionDefaultChannelGroup },
+    { name: DIM.sessionSource }, { name: DIM.sessionMedium },
+  ]
+  const request = (landingPage: boolean): Omit<GA4RunReportRequest, 'limit' | 'offset'> => ({
+    dateRanges: [dateRange],
+    dimensions: landingPage
+      ? [...dimensions, { name: DIM.hostName }, { name: DIM.landingPagePlusQueryString }]
+      : dimensions,
+    metrics: [{ name: MET.eventCount }],
+    dimensionFilter: filter,
+  })
+  let attributionScope: GA4LeadEventReport['attributionScope'] = 'landing-page'
+  let rawRows: NonNullable<GA4RunReportResponse['rows']>
+  try {
+    rawRows = await fetchPagedReport(accessToken, propertyId, request(true))
+  } catch (error) {
+    if (!isLandingPageDimensionIncompatibility(error)) throw error
+    attributionScope = 'channel'
+    rawRows = await fetchPagedReport(accessToken, propertyId, request(false))
+  }
+  const rows: GA4LeadEventRow[] = rawRows.map((row) => ({
+    date: compactDateToIso(row.dimensionValues[0]?.value ?? ''),
+    eventName: row.dimensionValues[1]?.value ?? '(not set)',
+    channelGroup: row.dimensionValues[2]?.value ?? '(not set)',
+    source: row.dimensionValues[3]?.value ?? '(not set)',
+    medium: row.dimensionValues[4]?.value ?? '(not set)',
+    hostName: attributionScope === 'landing-page' ? row.dimensionValues[5]?.value ?? '(not available)' : '(not available)',
+    landingPage: attributionScope === 'landing-page' ? row.dimensionValues[6]?.value ?? '(not available)' : '(not available)',
+    eventCount: parseInt(row.metricValues[0]?.value ?? '0', 10) || 0,
+  }))
+  return { attributionScope, rows }
 }
 
 // AI referral source patterns matched against both sessionSource and firstUserSource.

--- a/packages/integration-google-analytics/src/ga4-client.ts
+++ b/packages/integration-google-analytics/src/ga4-client.ts
@@ -21,7 +21,7 @@ import type {
   GA4RunReportResponse,
   GA4SourceDimension,
   GA4TrafficRow,
-  GA4AcquisitionRow,
+  GA4AcquisitionReport,
   GA4LeadEventReport,
   GA4LeadEventRow,
 } from './types.js'
@@ -389,6 +389,9 @@ async function fetchPagedReport(
     rows.push(...pageRows)
     offset += pageRows.length
     if (pageRows.length < pageSize || (response.rowCount !== undefined && offset >= response.rowCount)) break
+    if (page === GA4_MAX_PAGES - 1) {
+      throw new Error(`GA4 report truncated: page limit (${GA4_MAX_PAGES}) reached before all rows were fetched`)
+    }
   }
   return rows
 }
@@ -398,7 +401,7 @@ export async function fetchAcquisitionByChannel(
   propertyId: string,
   days?: number,
   options?: { pageSize?: number },
-): Promise<GA4AcquisitionRow[]> {
+): Promise<GA4AcquisitionReport> {
   validateAccessToken(accessToken)
   validatePropertyId(propertyId)
   const { syncDays, dateRange } = measurementDateRange(days)
@@ -415,7 +418,7 @@ export async function fetchAcquisitionByChannel(
     metrics: [{ name: MET.sessions }],
   }, options?.pageSize)
   ga4Log('info', 'fetch-acquisition.done', { propertyId, days: syncDays, rowCount: rows.length })
-  return rows.map((row) => ({
+  return { ...dateRange, rows: rows.map((row) => ({
     date: compactDateToIso(row.dimensionValues[0]?.value ?? ''),
     channelGroup: row.dimensionValues[1]?.value ?? '(not set)',
     source: row.dimensionValues[2]?.value ?? '(not set)',
@@ -423,7 +426,7 @@ export async function fetchAcquisitionByChannel(
     hostName: row.dimensionValues[4]?.value ?? '(not set)',
     landingPage: row.dimensionValues[5]?.value ?? '(not set)',
     sessions: parseInt(row.metricValues[0]?.value ?? '0', 10) || 0,
-  }))
+  })) }
 }
 
 function isLandingPageDimensionIncompatibility(error: unknown): boolean {
@@ -477,7 +480,7 @@ export async function fetchLeadEvents(
     landingPage: attributionScope === 'landing-page' ? row.dimensionValues[6]?.value ?? '(not available)' : '(not available)',
     eventCount: parseInt(row.metricValues[0]?.value ?? '0', 10) || 0,
   }))
-  return { attributionScope, rows }
+  return { ...dateRange, attributionScope, rows }
 }
 
 // AI referral source patterns matched against both sessionSource and firstUserSource.

--- a/packages/integration-google-analytics/src/index.ts
+++ b/packages/integration-google-analytics/src/index.ts
@@ -2,6 +2,8 @@ export {
   createServiceAccountJwt,
   getAccessToken,
   fetchTrafficByLandingPage,
+  fetchAcquisitionByChannel,
+  fetchLeadEvents,
   fetchAggregateSummary,
   fetchWindowSummary,
   fetchDailyTotals,

--- a/packages/integration-google-analytics/src/types.ts
+++ b/packages/integration-google-analytics/src/types.ts
@@ -78,7 +78,15 @@ export interface GA4LeadEventRow {
   eventCount: number
 }
 
+export interface GA4AcquisitionReport {
+  startDate: string
+  endDate: string
+  rows: GA4AcquisitionRow[]
+}
+
 export interface GA4LeadEventReport {
+  startDate: string
+  endDate: string
   attributionScope: 'landing-page' | 'channel'
   rows: GA4LeadEventRow[]
 }

--- a/packages/integration-google-analytics/src/types.ts
+++ b/packages/integration-google-analytics/src/types.ts
@@ -57,6 +57,33 @@ export interface GA4TrafficRow {
   users: number
 }
 
+export interface GA4AcquisitionRow {
+  date: string
+  channelGroup: string
+  source: string
+  medium: string
+  hostName: string
+  landingPage: string
+  sessions: number
+}
+
+export interface GA4LeadEventRow {
+  date: string
+  eventName: string
+  channelGroup: string
+  source: string
+  medium: string
+  hostName: string
+  landingPage: string
+  eventCount: number
+}
+
+export interface GA4LeadEventReport {
+  attributionScope: 'landing-page' | 'channel'
+  rows: GA4LeadEventRow[]
+}
+
+
 export type { AiReferralTrafficClass, GA4SourceDimension } from '@ainyc/canonry-contracts'
 import type { AiReferralTrafficClass, GA4SourceDimension } from '@ainyc/canonry-contracts'
 

--- a/packages/integration-google-analytics/test/ga4-measurement-client.test.ts
+++ b/packages/integration-google-analytics/test/ga4-measurement-client.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  fetchAcquisitionByChannel,
+  fetchLeadEvents,
+} from '../src/ga4-client.js'
+import { GA4_DIMENSIONS, GA4_METRICS } from '../src/constants.js'
+
+function jsonResponse(body: object, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('GA4 measurement reports', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  it('fetches the complete native acquisition grain and paginates without collapsing channels into Other', async () => {
+    const requests: Array<Record<string, unknown>> = []
+    fetchSpy.mockImplementation(async (_input, init) => {
+      const request = JSON.parse(String(init?.body)) as Record<string, unknown>
+      requests.push(request)
+      const offset = Number(request.offset ?? 0)
+      if (offset === 0) {
+        return jsonResponse({
+          rows: [{
+            dimensionValues: [
+              { value: '20260721' },
+              { value: 'Paid Search' },
+              { value: 'google' },
+              { value: 'cpc' },
+              { value: 'offers.example.com' },
+              { value: '/quote?utm_campaign=summer' },
+            ],
+            metricValues: [{ value: '11' }],
+          }],
+          rowCount: 2,
+        })
+      }
+      return jsonResponse({
+        rows: [{
+          dimensionValues: [
+            { value: '20260722' },
+            { value: 'Organic Search' },
+            { value: 'bing' },
+            { value: 'organic' },
+            { value: 'www.example.com' },
+            { value: '/blog/answer-engine-optimization' },
+          ],
+          metricValues: [{ value: '7' }],
+        }],
+        rowCount: 2,
+      })
+    })
+
+    const rows = await fetchAcquisitionByChannel('fake-token', '123456', 90, { pageSize: 1 })
+
+    expect(requests).toHaveLength(2)
+    expect(requests.map(request => request.offset)).toEqual([0, 1])
+    expect(requests[0]).toMatchObject({
+      dimensions: [
+        { name: GA4_DIMENSIONS.date },
+        { name: GA4_DIMENSIONS.sessionDefaultChannelGroup },
+        { name: GA4_DIMENSIONS.sessionSource },
+        { name: GA4_DIMENSIONS.sessionMedium },
+        { name: GA4_DIMENSIONS.hostName },
+        { name: GA4_DIMENSIONS.landingPagePlusQueryString },
+      ],
+      metrics: [{ name: GA4_METRICS.sessions }],
+    })
+    expect(rows).toEqual([
+      {
+        date: '2026-07-21',
+        channelGroup: 'Paid Search',
+        source: 'google',
+        medium: 'cpc',
+        hostName: 'offers.example.com',
+        landingPage: '/quote?utm_campaign=summer',
+        sessions: 11,
+      },
+      {
+        date: '2026-07-22',
+        channelGroup: 'Organic Search',
+        source: 'bing',
+        medium: 'organic',
+        hostName: 'www.example.com',
+        landingPage: '/blog/answer-engine-optimization',
+        sessions: 7,
+      },
+    ])
+  })
+
+  it('requests only configured lead events and preserves landing-page attribution when GA4 accepts it', async () => {
+    let request: Record<string, unknown> | undefined
+    fetchSpy.mockImplementation(async (_input, init) => {
+      request = JSON.parse(String(init?.body)) as Record<string, unknown>
+      return jsonResponse({
+        rows: [{
+          dimensionValues: [
+            { value: '20260722' },
+            { value: 'book_demo' },
+            { value: 'Paid Search' },
+            { value: 'google' },
+            { value: 'cpc' },
+            { value: 'offers.example.com' },
+            { value: '/demo?utm_source=google' },
+          ],
+          metricValues: [{ value: '3' }],
+        }],
+        rowCount: 1,
+      })
+    })
+
+    const report = await fetchLeadEvents(
+      'fake-token',
+      '123456',
+      ['generate_lead', 'book_demo'],
+      60,
+    )
+
+    expect(request).toMatchObject({
+      dimensions: [
+        { name: GA4_DIMENSIONS.date },
+        { name: GA4_DIMENSIONS.eventName },
+        { name: GA4_DIMENSIONS.sessionDefaultChannelGroup },
+        { name: GA4_DIMENSIONS.sessionSource },
+        { name: GA4_DIMENSIONS.sessionMedium },
+        { name: GA4_DIMENSIONS.hostName },
+        { name: GA4_DIMENSIONS.landingPagePlusQueryString },
+      ],
+      metrics: [{ name: GA4_METRICS.eventCount }],
+      dimensionFilter: {
+        orGroup: {
+          expressions: [
+            {
+              filter: {
+                fieldName: GA4_DIMENSIONS.eventName,
+                stringFilter: { matchType: 'EXACT', value: 'generate_lead' },
+              },
+            },
+            {
+              filter: {
+                fieldName: GA4_DIMENSIONS.eventName,
+                stringFilter: { matchType: 'EXACT', value: 'book_demo' },
+              },
+            },
+          ],
+        },
+      },
+    })
+    expect(report).toEqual({
+      attributionScope: 'landing-page',
+      rows: [{
+        date: '2026-07-22',
+        eventName: 'book_demo',
+        channelGroup: 'Paid Search',
+        source: 'google',
+        medium: 'cpc',
+        hostName: 'offers.example.com',
+        landingPage: '/demo?utm_source=google',
+        eventCount: 3,
+      }],
+    })
+  })
+
+  it('falls back to channel attribution only for GA4 dimension incompatibility and labels unavailable page dimensions honestly', async () => {
+    const requests: Array<Record<string, unknown>> = []
+    fetchSpy.mockImplementation(async (_input, init) => {
+      const request = JSON.parse(String(init?.body)) as Record<string, unknown>
+      requests.push(request)
+      if (requests.length === 1) {
+        return jsonResponse({
+          error: {
+            code: 400,
+            status: 'INVALID_ARGUMENT',
+            message: 'Please remove landingPagePlusQueryString because the requested dimensions and metrics are incompatible.',
+          },
+        }, 400)
+      }
+      return jsonResponse({
+        rows: [{
+          dimensionValues: [
+            { value: '20260722' },
+            { value: 'generate_lead' },
+            { value: 'Organic Search' },
+            { value: 'google' },
+            { value: 'organic' },
+          ],
+          metricValues: [{ value: '2' }],
+        }],
+        rowCount: 1,
+      })
+    })
+
+    const report = await fetchLeadEvents('fake-token', '123456', ['generate_lead'], 30)
+
+    expect(requests).toHaveLength(2)
+    expect(requests[0]?.dimensions).toContainEqual({
+      name: GA4_DIMENSIONS.landingPagePlusQueryString,
+    })
+    expect(requests[1]?.dimensions).toEqual([
+      { name: GA4_DIMENSIONS.date },
+      { name: GA4_DIMENSIONS.eventName },
+      { name: GA4_DIMENSIONS.sessionDefaultChannelGroup },
+      { name: GA4_DIMENSIONS.sessionSource },
+      { name: GA4_DIMENSIONS.sessionMedium },
+    ])
+    expect(report).toEqual({
+      attributionScope: 'channel',
+      rows: [{
+        date: '2026-07-22',
+        eventName: 'generate_lead',
+        channelGroup: 'Organic Search',
+        source: 'google',
+        medium: 'organic',
+        hostName: '(not available)',
+        landingPage: '(not available)',
+        eventCount: 2,
+      }],
+    })
+  })
+
+  it('does not hide unrelated GA4 400 errors behind the channel fallback', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({
+      error: {
+        code: 400,
+        status: 'INVALID_ARGUMENT',
+        message: 'Unknown metric eventCountt.',
+      },
+    }, 400))
+
+    await expect(fetchLeadEvents('fake-token', '123456', ['generate_lead'], 30))
+      .rejects.toMatchObject({ name: 'GA4ApiError', status: 400 })
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/integration-google-analytics/test/ga4-measurement-client.test.ts
+++ b/packages/integration-google-analytics/test/ga4-measurement-client.test.ts
@@ -16,11 +16,14 @@ describe('GA4 measurement reports', () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-23T23:59:59.999Z'))
     fetchSpy = vi.spyOn(globalThis, 'fetch')
   })
 
   afterEach(() => {
     fetchSpy.mockRestore()
+    vi.useRealTimers()
   })
 
   it('fetches the complete native acquisition grain and paginates without collapsing channels into Other', async () => {
@@ -61,7 +64,7 @@ describe('GA4 measurement reports', () => {
       })
     })
 
-    const rows = await fetchAcquisitionByChannel('fake-token', '123456', 90, { pageSize: 1 })
+    const report = await fetchAcquisitionByChannel('fake-token', '123456', 90, { pageSize: 1 })
 
     expect(requests).toHaveLength(2)
     expect(requests.map(request => request.offset)).toEqual([0, 1])
@@ -76,7 +79,10 @@ describe('GA4 measurement reports', () => {
       ],
       metrics: [{ name: GA4_METRICS.sessions }],
     })
-    expect(rows).toEqual([
+    expect(report).toEqual({
+      startDate: '2026-04-24',
+      endDate: '2026-07-23',
+      rows: [
       {
         date: '2026-07-21',
         channelGroup: 'Paid Search',
@@ -95,7 +101,8 @@ describe('GA4 measurement reports', () => {
         landingPage: '/blog/answer-engine-optimization',
         sessions: 7,
       },
-    ])
+      ],
+    })
   })
 
   it('requests only configured lead events and preserves landing-page attribution when GA4 accepts it', async () => {
@@ -157,6 +164,8 @@ describe('GA4 measurement reports', () => {
       },
     })
     expect(report).toEqual({
+      startDate: '2026-05-24',
+      endDate: '2026-07-23',
       attributionScope: 'landing-page',
       rows: [{
         date: '2026-07-22',
@@ -214,6 +223,8 @@ describe('GA4 measurement reports', () => {
       { name: GA4_DIMENSIONS.sessionMedium },
     ])
     expect(report).toEqual({
+      startDate: '2026-06-23',
+      endDate: '2026-07-23',
       attributionScope: 'channel',
       rows: [{
         date: '2026-07-22',
@@ -240,5 +251,31 @@ describe('GA4 measurement reports', () => {
     await expect(fetchLeadEvents('fake-token', '123456', ['generate_lead'], 30))
       .rejects.toMatchObject({ name: 'GA4ApiError', status: 400 })
     expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('fails instead of silently returning a truncated report at the pagination cap', async () => {
+    fetchSpy.mockImplementation(async (_input, init) => {
+      const request = JSON.parse(String(init?.body)) as { offset?: number }
+      const offset = Number(request.offset ?? 0)
+      return jsonResponse({
+        rows: [{
+          dimensionValues: [
+            { value: '20260722' },
+            { value: 'Organic Search' },
+            { value: 'google' },
+            { value: 'organic' },
+            { value: 'example.com' },
+            { value: `/page-${offset}` },
+          ],
+          metricValues: [{ value: '1' }],
+        }],
+        rowCount: 51,
+      })
+    })
+
+    await expect(fetchAcquisitionByChannel(
+      'fake-token', '123456', 30, { pageSize: 1 },
+    )).rejects.toThrow(/truncat|page limit/i)
+    expect(fetchSpy).toHaveBeenCalledTimes(50)
   })
 })

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.130.0",
+  "version": "4.131.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.130.0",
+  "version": "4.131.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
## Context

Stacked on #853 (`feat/ga-measurement-contract`). Canonry’s legacy GA summary fetch stores a small fixed channel subset, which makes paid/display/referral traffic collapse into an unhelpful residual and does not ingest lead/key-event attribution. This PR fills the new measurement tables defined by #853 without changing the existing GA dashboard contract.

## Summary

- Fetches GA4 acquisition at the native `date × default channel group × source × medium × host × landing page` grain, with bounded pagination and no synthetic `Other` classification.
- Fetches only configured lead events (defaulting upstream to `generate_lead`) with `eventCount` and landing-page attribution.
- Falls back to channel-level lead attribution only for GA4’s precise landing-page dimension incompatibility; unrelated 400 responses still fail honestly.
- Backfills 90 days on the first measurement sync, then refreshes the requested bounded window.
- Replaces only rows inside that window, ingests every host, and treats a successful empty GA report as resolved zero.
- Tracks acquisition and lead ingestion independently. A component failure preserves its last-good rows/timestamp while the other measurement component and legacy GA sync can still complete.
- Returns structured per-component measurement status from the existing GA sync endpoint and logs partial failures.

## Test coverage

TDD contract was committed first in `0bb2d61d` (7 initially failing tests), before delegated implementation:

- exact native GA request dimensions/metrics, pagination, and no `Other` collapse
- configured lead-event filtering and landing-page attribution
- precise compatibility fallback and unrelated-400 rejection
- first-sync 90-day backfill and subsequent requested windows
- all-host ingestion, bounded replacement, and successful empty reports
- independent component failure semantics with last-good preservation

## Validation

- `pnpm --filter @ainyc/canonry-api-client run gen:check`
- `pnpm typecheck`
- `pnpm lint` (0 errors; existing repository warnings only)
- `pnpm test` — 471 files, 5,765 tests passed
- `pnpm build`
- `pnpm plugin:check`
- final focused rerun: 2 files, 7 tests passed
- final API route typecheck and lint: passed (0 errors)
