### PR TITLE
feat: add organic growth evidence dashboard

### DIFF
--- a/apps/web/src/components/project/ActivitySection.tsx
+++ b/apps/web/src/components/project/ActivitySection.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query'
 import { RefreshCw, Unplug, Upload } from 'lucide-react'
 import {
   Area,
@@ -1703,7 +1703,7 @@ function EvidenceTable({
               </th>
               {row.values.map((value, index) => (
                 <td key={columns[index]?.key ?? index} className="px-3 py-2 text-right tabular-nums text-secondary">
-                  {value === null ? '—' : value.toLocaleString()}
+                  {value === null ? '—' : value.toLocaleString('en-US')}
                 </td>
               ))}
             </tr>
@@ -1736,11 +1736,14 @@ function EvidenceCard({
 
 export function OrganicEvidencePanel({ projectName }: { projectName: string }) {
   const [period, setPeriod] = useState<60 | 90>(90)
-  const query = useQuery(getApiV1ProjectsByNameOrganicEvidenceOptions({
-    client: heyClient,
-    path: { name: projectName },
-    query: { period },
-  }))
+  const query = useQuery({
+    ...getApiV1ProjectsByNameOrganicEvidenceOptions({
+      client: heyClient,
+      path: { name: projectName },
+      query: { period },
+    }),
+    placeholderData: keepPreviousData,
+  })
 
   const header = (
     <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -1796,38 +1799,24 @@ export function OrganicEvidencePanel({ projectName }: { projectName: string }) {
   const measurement = evidence.measurement
   const acquisition = measurement.acquisition
   const leads = measurement.leads
-  const blogColumns: EvidenceColumn[] = evidence.cohorts.map(cohort => ({
+  const gscCohorts = evidence.gsc?.cohorts ?? []
+  const gscColumns: EvidenceColumn[] = gscCohorts.map(cohort => ({
     key: cohort.name,
     label: evidencePeriodLabel(cohort.name),
     detail: `${cohort.startDate} – ${cohort.endDate}`,
   }))
-  const blogGsc = new Map<string, NonNullable<typeof evidence.blog.gsc>['cohorts'][number]>(
-    evidence.blog.gsc?.cohorts.map(row => [row.name, row]) ?? [],
+  const gscByCohort = new Map<string, (typeof gscCohorts)[number]>(
+    gscCohorts.map(row => [row.name, row]),
   )
-  const blogGa4 = new Map<string, NonNullable<typeof evidence.blog.ga4>['cohorts'][number]>(
-    evidence.blog.ga4?.cohorts.map(row => [row.name, row]) ?? [],
-  )
-  const blogRows: EvidenceRow[] = [
-    ...(evidence.blog.gsc
-      ? [
-          {
-            label: 'Impressions',
-            values: blogColumns.map(column => blogGsc.get(column.key)?.totals.impressions ?? null),
-          },
-          {
-            label: 'Google clicks',
-            values: blogColumns.map(column => blogGsc.get(column.key)?.totals.clicks ?? null),
-          },
-        ]
-      : []),
-    ...(evidence.blog.ga4
-      ? [
-          {
-            label: 'GA4 organic sessions',
-            values: blogColumns.map(column => blogGa4.get(column.key)?.organicSessions ?? null),
-          },
-        ]
-      : []),
+  const gscRows: EvidenceRow[] = [
+    {
+      label: 'Impressions',
+      values: gscColumns.map(column => gscByCohort.get(column.key)?.totals.impressions ?? null),
+    },
+    {
+      label: 'Google clicks',
+      values: gscColumns.map(column => gscByCohort.get(column.key)?.totals.clicks ?? null),
+    },
   ]
 
   const acquisitionPeriods = acquisition.periods.length > 0
@@ -1857,12 +1846,12 @@ export function OrganicEvidencePanel({ projectName }: { projectName: string }) {
     detail: `${row.startDate} – ${row.endDate}`,
   }))
   const leadRows: EvidenceRow[] = [
-    {
+    ...(leads.periods.length > 0 ? [{
       label: 'All measured leads',
       values: leadColumns.map(column => (
         leads.periods.find(row => row.label === column.key)?.eventCount ?? null
       )),
-    },
+    }] : []),
     ...leads.channels.map(channel => ({
       label: channel.channelGroup,
       values: leadColumns.map(column => (
@@ -1873,6 +1862,18 @@ export function OrganicEvidencePanel({ projectName }: { projectName: string }) {
 
   const latestDemand = measurement.searchDemand.periods.at(-1)
   const visibleLimitations = evidence.limitations.filter(item => item.code !== 'lead-channel-scope')
+  const hasAcquisitionRows = acquisitionColumns.length > 0 && acquisitionRows.length > 0
+  const hasLeadRows = leadColumns.length > 0 && leadRows.length > 0
+  const pageRows: EvidenceRow[] = evidence.pages.map(page => ({
+    label: page.path,
+    values: [
+      page.gsc?.clicks ?? null,
+      page.gsc?.impressions ?? null,
+      page.ga4OrganicSessions ?? null,
+      page.server?.userFetchHits.verified ?? null,
+      page.server?.referralSessions.organic ?? null,
+    ],
+  }))
 
   return (
     <section aria-labelledby="organic-evidence-heading">
@@ -1882,34 +1883,35 @@ export function OrganicEvidencePanel({ projectName }: { projectName: string }) {
           <span>Window: {evidence.periodDays} days</span>
           <span>As of: {evidence.asOfDate ?? 'source dates vary'}</span>
           <span>Host scope: {measurement.filters.hostScope}</span>
+          {query.isFetching && <span>Updating organic evidence…</span>}
         </div>
 
         {acquisition.status === 'error' && (
           <Card className="border-caution-800/60 bg-caution-900/10 p-3 text-sm text-caution">
             <div>GA4 acquisition sync error: {acquisition.error ?? 'unknown error'}</div>
-            <div className="mt-1 text-xs">Showing last-good acquisition data</div>
+            {hasAcquisitionRows && <div className="mt-1 text-xs">Showing last-good acquisition data</div>}
           </Card>
         )}
 
         {leads.status === 'error' && (
           <Card className="border-caution-800/60 bg-caution-900/10 p-3 text-sm text-caution">
             <div>GA4 lead sync error: {leads.error ?? 'unknown error'}</div>
-            <div className="mt-1 text-xs">Showing last-good lead data</div>
+            {hasLeadRows && <div className="mt-1 text-xs">Showing last-good lead data</div>}
           </Card>
         )}
 
         <EvidenceCard
-          title="Blog visibility and organic visits"
-          description="Google Search Console visibility and clicks alongside GA4 organic sessions for /blog."
+          title="Google Search Console cohorts"
+          description="Property-wide Google Search Console clicks and impressions using Google’s source-specific dates."
         >
-          {blogColumns.length > 0 && blogRows.length > 0 ? (
+          {gscColumns.length > 0 && gscRows.length > 0 ? (
             <EvidenceTable
-              ariaLabel="Blog search and traffic cohorts"
-              columns={blogColumns}
-              rows={blogRows}
+              ariaLabel="Google Search Console cohorts"
+              columns={gscColumns}
+              rows={gscRows}
             />
           ) : (
-            <p className="text-sm text-muted">No blog search or organic-session evidence is available.</p>
+            <p className="text-sm text-muted">No Google Search Console cohort evidence is available.</p>
           )}
         </EvidenceCard>
 
@@ -1949,7 +1951,7 @@ export function OrganicEvidencePanel({ projectName }: { projectName: string }) {
               </span>
             )}
           </div>
-          {leadColumns.length > 0 && leads.periods.length > 0 ? (
+          {hasLeadRows ? (
             <EvidenceTable
               ariaLabel="GA4 lead events by cohort"
               firstColumnLabel="Lead scope"
@@ -2022,6 +2024,28 @@ export function OrganicEvidencePanel({ projectName }: { projectName: string }) {
             />
           ) : (
             <p className="text-sm text-muted">No server-side traffic evidence is available.</p>
+          )}
+        </EvidenceCard>
+
+        <EvidenceCard
+          title="All-page organic and AI evidence"
+          description="Evidence is shown for every reported page path; each source keeps its own measurement rules."
+        >
+          {pageRows.length > 0 ? (
+            <EvidenceTable
+              ariaLabel="All-page organic and AI evidence"
+              firstColumnLabel="Page"
+              columns={[
+                { key: 'gsc-clicks', label: 'GSC clicks' },
+                { key: 'gsc-impressions', label: 'GSC impressions' },
+                { key: 'ga4-organic', label: 'GA4 organic sessions' },
+                { key: 'ai-fetches', label: 'Verified AI user fetches' },
+                { key: 'ai-referrals', label: 'Organic AI referrals' },
+              ]}
+              rows={pageRows}
+            />
+          ) : (
+            <p className="text-sm text-muted">No page-level organic or AI evidence is available.</p>
           )}
         </EvidenceCard>
 

--- a/apps/web/src/components/project/ActivitySection.tsx
+++ b/apps/web/src/components/project/ActivitySection.tsx
@@ -1867,11 +1867,11 @@ export function OrganicEvidencePanel({ projectName }: { projectName: string }) {
   const pageRows: EvidenceRow[] = evidence.pages.map(page => ({
     label: page.path,
     values: [
-      page.gsc?.clicks ?? null,
-      page.gsc?.impressions ?? null,
-      page.ga4OrganicSessions ?? null,
-      page.server?.userFetchHits.verified ?? null,
-      page.server?.referralSessions.organic ?? null,
+      page.gsc.clicks,
+      page.gsc.impressions,
+      page.ga4OrganicSessions,
+      page.server.userFetchHits.verified,
+      page.server.referralSessions.organic,
     ],
   }))
 

--- a/apps/web/src/components/project/ActivitySection.tsx
+++ b/apps/web/src/components/project/ActivitySection.tsx
@@ -1650,6 +1650,90 @@ function SocialChartLegend({
   )
 }
 
+type EvidenceColumn = {
+  key: string
+  label: string
+  detail?: string
+}
+
+type EvidenceRow = {
+  label: string
+  values: Array<number | null>
+}
+
+function evidencePeriodLabel(label: string): string {
+  if (label === 'previous' || label === 'prior') return 'Previous'
+  return `${label.slice(0, 1).toUpperCase()}${label.slice(1)}`
+}
+
+function EvidenceTable({
+  ariaLabel,
+  firstColumnLabel = 'Metric',
+  columns,
+  rows,
+}: {
+  ariaLabel: string
+  firstColumnLabel?: string
+  columns: EvidenceColumn[]
+  rows: EvidenceRow[]
+}) {
+  return (
+    <div className="overflow-x-auto">
+      <table aria-label={ariaLabel} className="w-full text-sm">
+        <thead className="bg-bg-elevated/50 text-[10px] uppercase tracking-wide text-muted">
+          <tr>
+            <th className="px-3 py-2 text-left font-medium">{firstColumnLabel}</th>
+            {columns.map(column => (
+              <th key={column.key} className="px-3 py-2 text-right font-medium">
+                <span className="block">{column.label}</span>
+                {column.detail && (
+                  <span className="mt-0.5 block normal-case tracking-normal text-[10px] font-normal text-muted">
+                    {column.detail}
+                  </span>
+                )}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(row => (
+            <tr key={row.label} className="border-t border-default">
+              <th scope="row" className="px-3 py-2 text-left font-medium text-primary">
+                {row.label}
+              </th>
+              {row.values.map((value, index) => (
+                <td key={columns[index]?.key ?? index} className="px-3 py-2 text-right tabular-nums text-secondary">
+                  {value === null ? '—' : value.toLocaleString()}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function EvidenceCard({
+  title,
+  description,
+  children,
+}: {
+  title: string
+  description: string
+  children: React.ReactNode
+}) {
+  return (
+    <Card className="overflow-hidden">
+      <div className="border-b border-default px-4 py-3">
+        <h3 className="text-sm font-semibold text-heading">{title}</h3>
+        <p className="mt-0.5 text-xs text-muted">{description}</p>
+      </div>
+      <div className="p-4">{children}</div>
+    </Card>
+  )
+}
+
 export function OrganicEvidencePanel({ projectName }: { projectName: string }) {
   const [period, setPeriod] = useState<60 | 90>(90)
   const query = useQuery(getApiV1ProjectsByNameOrganicEvidenceOptions({
@@ -1657,31 +1741,320 @@ export function OrganicEvidencePanel({ projectName }: { projectName: string }) {
     path: { name: projectName },
     query: { period },
   }))
-  const evidence = query.data
-  if (query.isLoading) return <Card className="p-5"><div className="text-sm text-muted">Loading organic growth evidence…</div></Card>
-  if (query.isError || !evidence) return null
-  const measurement = evidence.measurement
-  const labels = measurement.acquisition.periods.map(row => row.label === 'previous' ? 'Previous' : row.label[0]!.toUpperCase() + row.label.slice(1))
-  const table = (name: string, rows: Array<{ label: string; values: number[] }>) => (
-    <div className="overflow-x-auto"><table aria-label={name} className="w-full text-sm"><thead className="bg-bg-elevated/50 text-muted"><tr><th className="px-3 py-2 text-left">Metric</th>{labels.map(label => <th key={label} className="px-3 py-2 text-right">{label}</th>)}</tr></thead><tbody>{rows.map(row => <tr key={row.label} className="border-t border-default"><th scope="row" className="px-3 py-2 text-left font-medium text-primary">{row.label}</th>{row.values.map((value, index) => <td key={index} className="px-3 py-2 text-right tabular-nums">{formatCompact(value)}</td>)}</tr>)}</tbody></table></div>
-  )
-  const blog = evidence.blog
-  const latestDemand = measurement.searchDemand.periods.at(-1)
-  const server = evidence.server
-  return <section aria-labelledby="organic-evidence-heading">
-    <div className="flex items-start justify-between gap-4 mb-3"><div><div className="eyebrow">Organic evidence</div><h2 id="organic-evidence-heading" className="text-lg font-semibold text-primary">Organic growth evidence</h2></div><div className="flex gap-2">{([60, 90] as const).map(days => <Button key={days} type="button" variant={period === days ? 'default' : 'outline'} size="sm" aria-pressed={period === days} onClick={() => setPeriod(days)}>{days} days</Button>)}</div></div>
-    <div className="space-y-4">
-      {measurement.acquisition.status === 'error' && <Card className="p-3 text-sm text-caution"><div>GA4 acquisition sync error: {measurement.acquisition.error ?? 'unknown error'}</div><div>Showing last-good acquisition data</div></Card>}
-      <Card className="p-4">{table('Blog search and traffic cohorts', [
-        { label: 'Impressions', values: blog.gsc?.cohorts.map(row => row.totals.impressions) ?? [] },
-        { label: 'Google clicks', values: blog.gsc?.cohorts.map(row => row.totals.clicks) ?? [] },
-        { label: 'GA4 organic sessions', values: blog.ga4?.cohorts.map(row => row.organicSessions) ?? [] },
-      ])}</Card>
-      <Card className="p-4">{table('GA4 sessions by native channel', measurement.acquisition.channels.map(row => ({ label: row.channelGroup, values: row.periods.map(p => p.sessions) })))}</Card>
-      <Card className="p-4"><div className="mb-2 text-sm text-secondary">{measurement.leads.attributionScope === 'channel' ? 'Channel-level attribution' : 'Landing-page attribution'}</div>{measurement.leads.attributionScope === 'channel' && <div className="mb-2 text-xs text-caution">marketing-host and path filters do not apply</div>}{table('GA4 lead events by cohort', [{ label: 'All measured leads', values: measurement.leads.periods.map(row => row.eventCount) }, ...measurement.leads.channels.map(row => ({ label: row.channelGroup, values: row.periods.map(p => p.eventCount) }))])}</Card>
-      <Card className="p-4">{table('Latest Google search demand mix', [{ label: 'Branded', values: [latestDemand?.brandedClicks ?? 0, latestDemand?.brandedImpressions ?? 0] }, { label: 'Non-branded', values: [latestDemand?.nonBrandedClicks ?? 0, latestDemand?.nonBrandedImpressions ?? 0] }, { label: 'Suppressed or unreported', values: [latestDemand?.unreportedClicks ?? 0, latestDemand?.unreportedImpressions ?? 0] }])}</Card>
-      <Card className="p-4">{table('Server-side AI evidence', [{ label: 'Verified crawler hits', values: [server?.crawlerHits.verified ?? 0] }, { label: 'Verified user fetches', values: [server?.userFetchHits.verified ?? 0] }, { label: 'Organic AI referral sessions', values: [server?.referralSessions.organic ?? 0] }])}</Card>
-      <div className="space-y-2">{evidence.findings.map(finding => <Card key={finding.title} className="p-3"><div className="flex gap-2"><ToneBadge tone={finding.tone}>{finding.tone}</ToneBadge><div><div className="font-medium text-primary">{finding.title}</div><p className="text-sm text-secondary">{finding.detail}</p></div></div></Card>)}{evidence.limitations.filter(item => item.code !== 'lead-channel-scope').map(item => <p key={item.code} className="text-xs text-muted">{item.detail}</p>)}</div>
+
+  const header = (
+    <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <div>
+        <div className="eyebrow">Organic evidence</div>
+        <h2 id="organic-evidence-heading" className="text-lg font-semibold text-primary">
+          Organic growth evidence
+        </h2>
+        <p className="mt-1 max-w-3xl text-xs text-muted">
+          Reconciles Google search demand, native GA4 channels and leads, and server-observed AI activity.
+          The sources keep their own units and attribution limits.
+        </p>
+      </div>
+      <div className="flex gap-2" aria-label="Organic evidence period">
+        {([60, 90] as const).map(days => (
+          <Button
+            key={days}
+            type="button"
+            variant={period === days ? 'default' : 'outline'}
+            size="sm"
+            aria-pressed={period === days}
+            onClick={() => setPeriod(days)}
+          >
+            {days} days
+          </Button>
+        ))}
+      </div>
     </div>
-  </section>
+  )
+
+  if (query.isLoading) {
+    return (
+      <Card className="p-5">
+        <div className="text-sm text-muted">Loading organic growth evidence…</div>
+      </Card>
+    )
+  }
+
+  if (query.isError || !query.data) {
+    return (
+      <section aria-labelledby="organic-evidence-heading">
+        {header}
+        <Card className="p-5" role="status">
+          <p className="text-sm text-negative-400">
+            Organic evidence is temporarily unavailable.
+          </p>
+        </Card>
+      </section>
+    )
+  }
+
+  const evidence = query.data
+  const measurement = evidence.measurement
+  const acquisition = measurement.acquisition
+  const leads = measurement.leads
+  const blogColumns: EvidenceColumn[] = evidence.cohorts.map(cohort => ({
+    key: cohort.name,
+    label: evidencePeriodLabel(cohort.name),
+    detail: `${cohort.startDate} – ${cohort.endDate}`,
+  }))
+  const blogGsc = new Map<string, NonNullable<typeof evidence.blog.gsc>['cohorts'][number]>(
+    evidence.blog.gsc?.cohorts.map(row => [row.name, row]) ?? [],
+  )
+  const blogGa4 = new Map<string, NonNullable<typeof evidence.blog.ga4>['cohorts'][number]>(
+    evidence.blog.ga4?.cohorts.map(row => [row.name, row]) ?? [],
+  )
+  const blogRows: EvidenceRow[] = [
+    ...(evidence.blog.gsc
+      ? [
+          {
+            label: 'Impressions',
+            values: blogColumns.map(column => blogGsc.get(column.key)?.totals.impressions ?? null),
+          },
+          {
+            label: 'Google clicks',
+            values: blogColumns.map(column => blogGsc.get(column.key)?.totals.clicks ?? null),
+          },
+        ]
+      : []),
+    ...(evidence.blog.ga4
+      ? [
+          {
+            label: 'GA4 organic sessions',
+            values: blogColumns.map(column => blogGa4.get(column.key)?.organicSessions ?? null),
+          },
+        ]
+      : []),
+  ]
+
+  const acquisitionPeriods = acquisition.periods.length > 0
+    ? acquisition.periods
+    : (acquisition.channels[0]?.periods ?? [])
+  const acquisitionColumns: EvidenceColumn[] = acquisitionPeriods.map(row => ({
+    key: row.label,
+    label: evidencePeriodLabel(row.label),
+    detail: `${row.startDate} – ${row.endDate}`,
+  }))
+  const acquisitionRows: EvidenceRow[] = acquisition.channels.map(channel => {
+    const periodsByLabel = new Map<string, (typeof channel.periods)[number]>(
+      channel.periods.map(row => [row.label, row]),
+    )
+    return {
+      label: channel.channelGroup,
+      values: acquisitionColumns.map(column => periodsByLabel.get(column.key)?.sessions ?? null),
+    }
+  })
+
+  const leadPeriods = leads.periods.length > 0
+    ? leads.periods
+    : (leads.channels[0]?.periods ?? [])
+  const leadColumns: EvidenceColumn[] = leadPeriods.map(row => ({
+    key: row.label,
+    label: evidencePeriodLabel(row.label),
+    detail: `${row.startDate} – ${row.endDate}`,
+  }))
+  const leadRows: EvidenceRow[] = [
+    {
+      label: 'All measured leads',
+      values: leadColumns.map(column => (
+        leads.periods.find(row => row.label === column.key)?.eventCount ?? null
+      )),
+    },
+    ...leads.channels.map(channel => ({
+      label: channel.channelGroup,
+      values: leadColumns.map(column => (
+        channel.periods.find(row => row.label === column.key)?.eventCount ?? null
+      )),
+    })),
+  ]
+
+  const latestDemand = measurement.searchDemand.periods.at(-1)
+  const visibleLimitations = evidence.limitations.filter(item => item.code !== 'lead-channel-scope')
+
+  return (
+    <section aria-labelledby="organic-evidence-heading">
+      {header}
+      <div className="space-y-4">
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted">
+          <span>Window: {evidence.periodDays} days</span>
+          <span>As of: {evidence.asOfDate ?? 'source dates vary'}</span>
+          <span>Host scope: {measurement.filters.hostScope}</span>
+        </div>
+
+        {acquisition.status === 'error' && (
+          <Card className="border-caution-800/60 bg-caution-900/10 p-3 text-sm text-caution">
+            <div>GA4 acquisition sync error: {acquisition.error ?? 'unknown error'}</div>
+            <div className="mt-1 text-xs">Showing last-good acquisition data</div>
+          </Card>
+        )}
+
+        {leads.status === 'error' && (
+          <Card className="border-caution-800/60 bg-caution-900/10 p-3 text-sm text-caution">
+            <div>GA4 lead sync error: {leads.error ?? 'unknown error'}</div>
+            <div className="mt-1 text-xs">Showing last-good lead data</div>
+          </Card>
+        )}
+
+        <EvidenceCard
+          title="Blog visibility and organic visits"
+          description="Google Search Console visibility and clicks alongside GA4 organic sessions for /blog."
+        >
+          {blogColumns.length > 0 && blogRows.length > 0 ? (
+            <EvidenceTable
+              ariaLabel="Blog search and traffic cohorts"
+              columns={blogColumns}
+              rows={blogRows}
+            />
+          ) : (
+            <p className="text-sm text-muted">No blog search or organic-session evidence is available.</p>
+          )}
+        </EvidenceCard>
+
+        <EvidenceCard
+          title="GA4 acquisition"
+          description="Sessions retain their native GA4 default channel group; no residual Other bucket is synthesized."
+        >
+          {acquisitionColumns.length > 0 && acquisitionRows.length > 0 ? (
+            <EvidenceTable
+              ariaLabel="GA4 sessions by native channel"
+              firstColumnLabel="Native channel"
+              columns={acquisitionColumns}
+              rows={acquisitionRows}
+            />
+          ) : (
+            <p className="text-sm text-muted">
+              {acquisition.status === 'never-synced'
+                ? 'Native GA4 acquisition has not been synced yet.'
+                : 'No native GA4 acquisition rows matched this scope.'}
+            </p>
+          )}
+        </EvidenceCard>
+
+        <EvidenceCard
+          title="GA4 leads"
+          description="Configured GA4 lead events by cohort and native acquisition channel."
+        >
+          <div className="mb-3 flex flex-wrap items-center gap-2">
+            <ToneBadge tone={leads.attributionScope === 'landing-page' ? 'positive' : 'caution'}>
+              {leads.attributionScope === 'channel'
+                ? 'Channel-level attribution'
+                : 'Landing-page attribution'}
+            </ToneBadge>
+            {leads.attributionScope === 'channel' && (
+              <span className="text-xs text-caution">
+                marketing-host and path filters do not apply
+              </span>
+            )}
+          </div>
+          {leadColumns.length > 0 && leads.periods.length > 0 ? (
+            <EvidenceTable
+              ariaLabel="GA4 lead events by cohort"
+              firstColumnLabel="Lead scope"
+              columns={leadColumns}
+              rows={leadRows}
+            />
+          ) : (
+            <p className="text-sm text-muted">
+              {leads.status === 'never-synced'
+                ? 'GA4 lead events have not been synced yet.'
+                : 'No configured lead events matched this scope.'}
+            </p>
+          )}
+        </EvidenceCard>
+
+        <EvidenceCard
+          title="Google search demand mix"
+          description={`Latest reported query mix${measurement.searchDemand.latestDate ? ` through ${measurement.searchDemand.latestDate}` : ''}; suppressed rows remain explicit.`}
+        >
+          {measurement.searchDemand.status === 'ready' && latestDemand ? (
+            <EvidenceTable
+              ariaLabel="Latest Google search demand mix"
+              firstColumnLabel="Query class"
+              columns={[
+                { key: 'clicks', label: 'Clicks' },
+                { key: 'impressions', label: 'Impressions' },
+              ]}
+              rows={[
+                {
+                  label: 'Branded',
+                  values: [latestDemand.brandedClicks, latestDemand.brandedImpressions],
+                },
+                {
+                  label: 'Non-branded',
+                  values: [latestDemand.nonBrandedClicks, latestDemand.nonBrandedImpressions],
+                },
+                {
+                  label: 'Suppressed or unreported',
+                  values: [latestDemand.unreportedClicks, latestDemand.unreportedImpressions],
+                },
+              ]}
+            />
+          ) : (
+            <p className="text-sm text-muted">Google search query demand is unavailable.</p>
+          )}
+        </EvidenceCard>
+
+        <EvidenceCard
+          title="Server-side AI evidence"
+          description="Verified crawler requests, on-demand AI user fetches, and organic AI referral sessions."
+        >
+          {evidence.server ? (
+            <EvidenceTable
+              ariaLabel="Server-side AI evidence"
+              columns={[{ key: 'count', label: 'Count' }]}
+              rows={[
+                {
+                  label: 'Verified crawler hits',
+                  values: [evidence.server.crawlerHits.verified],
+                },
+                {
+                  label: 'Verified user fetches',
+                  values: [evidence.server.userFetchHits.verified],
+                },
+                {
+                  label: 'Organic AI referral sessions',
+                  values: [evidence.server.referralSessions.organic],
+                },
+              ]}
+            />
+          ) : (
+            <p className="text-sm text-muted">No server-side traffic evidence is available.</p>
+          )}
+        </EvidenceCard>
+
+        {evidence.findings.length > 0 && (
+          <div>
+            <h3 className="mb-2 text-sm font-semibold text-heading">What the evidence supports</h3>
+            <div className="grid gap-2 lg:grid-cols-2">
+              {evidence.findings.map(finding => (
+                <Card key={finding.title} className="p-3">
+                  <div className="flex items-start gap-2">
+                    <ToneBadge tone={finding.tone}>{finding.tone}</ToneBadge>
+                    <div>
+                      <div className="font-medium text-primary">{finding.title}</div>
+                      <p className="mt-0.5 text-sm text-secondary">{finding.detail}</p>
+                    </div>
+                  </div>
+                </Card>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {visibleLimitations.length > 0 && (
+          <Card className="p-4">
+            <h3 className="text-sm font-semibold text-heading">Measurement caveats</h3>
+            <ul className="mt-2 space-y-1.5 text-xs text-muted">
+              {visibleLimitations.map(item => (
+                <li key={item.code}>{item.detail}</li>
+              ))}
+            </ul>
+          </Card>
+        )}
+      </div>
+    </section>
+  )
 }

--- a/apps/web/src/components/project/ActivitySection.tsx
+++ b/apps/web/src/components/project/ActivitySection.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useQueryClient } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { RefreshCw, Unplug, Upload } from 'lucide-react'
 import {
   Area,
@@ -42,6 +42,7 @@ import {
   getApiV1ProjectsByNameGaSocialReferralHistoryOptions,
   getApiV1ProjectsByNameGaStatusOptions,
   getApiV1ProjectsByNameGaTrafficOptions,
+  getApiV1ProjectsByNameOrganicEvidenceOptions,
 } from '@ainyc/canonry-api-client/react-query'
 import type { ApiGaStatus, ApiGaTraffic, ApiGaTrafficAiLandingPage, ApiGaTrafficPage, ApiGaTrafficReferral, ApiGaSocialReferral, GA4AiReferralHistoryEntry, GA4SessionHistoryEntry, GA4SocialReferralHistoryEntry } from '../../api.js'
 import { TRAFFIC_STALE_MS } from '../../queries/query-client.js'
@@ -193,6 +194,7 @@ export function ActivitySection({ projectName }: { projectName: string }) {
   return (
     <div className="space-y-10">
       <ServerActivityPanel projectName={projectName} />
+      <OrganicEvidencePanel projectName={projectName} />
       <ClickThroughActivity projectName={projectName} />
     </div>
   )
@@ -1646,4 +1648,40 @@ function SocialChartLegend({
       ))}
     </div>
   )
+}
+
+export function OrganicEvidencePanel({ projectName }: { projectName: string }) {
+  const [period, setPeriod] = useState<60 | 90>(90)
+  const query = useQuery(getApiV1ProjectsByNameOrganicEvidenceOptions({
+    client: heyClient,
+    path: { name: projectName },
+    query: { period },
+  }))
+  const evidence = query.data
+  if (query.isLoading) return <Card className="p-5"><div className="text-sm text-muted">Loading organic growth evidence…</div></Card>
+  if (query.isError || !evidence) return null
+  const measurement = evidence.measurement
+  const labels = measurement.acquisition.periods.map(row => row.label === 'previous' ? 'Previous' : row.label[0]!.toUpperCase() + row.label.slice(1))
+  const table = (name: string, rows: Array<{ label: string; values: number[] }>) => (
+    <div className="overflow-x-auto"><table aria-label={name} className="w-full text-sm"><thead className="bg-bg-elevated/50 text-muted"><tr><th className="px-3 py-2 text-left">Metric</th>{labels.map(label => <th key={label} className="px-3 py-2 text-right">{label}</th>)}</tr></thead><tbody>{rows.map(row => <tr key={row.label} className="border-t border-default"><th scope="row" className="px-3 py-2 text-left font-medium text-primary">{row.label}</th>{row.values.map((value, index) => <td key={index} className="px-3 py-2 text-right tabular-nums">{formatCompact(value)}</td>)}</tr>)}</tbody></table></div>
+  )
+  const blog = evidence.blog
+  const latestDemand = measurement.searchDemand.periods.at(-1)
+  const server = evidence.server
+  return <section aria-labelledby="organic-evidence-heading">
+    <div className="flex items-start justify-between gap-4 mb-3"><div><div className="eyebrow">Organic evidence</div><h2 id="organic-evidence-heading" className="text-lg font-semibold text-primary">Organic growth evidence</h2></div><div className="flex gap-2">{([60, 90] as const).map(days => <Button key={days} type="button" variant={period === days ? 'default' : 'outline'} size="sm" aria-pressed={period === days} onClick={() => setPeriod(days)}>{days} days</Button>)}</div></div>
+    <div className="space-y-4">
+      {measurement.acquisition.status === 'error' && <Card className="p-3 text-sm text-caution"><div>GA4 acquisition sync error: {measurement.acquisition.error ?? 'unknown error'}</div><div>Showing last-good acquisition data</div></Card>}
+      <Card className="p-4">{table('Blog search and traffic cohorts', [
+        { label: 'Impressions', values: blog.gsc?.cohorts.map(row => row.totals.impressions) ?? [] },
+        { label: 'Google clicks', values: blog.gsc?.cohorts.map(row => row.totals.clicks) ?? [] },
+        { label: 'GA4 organic sessions', values: blog.ga4?.cohorts.map(row => row.organicSessions) ?? [] },
+      ])}</Card>
+      <Card className="p-4">{table('GA4 sessions by native channel', measurement.acquisition.channels.map(row => ({ label: row.channelGroup, values: row.periods.map(p => p.sessions) })))}</Card>
+      <Card className="p-4"><div className="mb-2 text-sm text-secondary">{measurement.leads.attributionScope === 'channel' ? 'Channel-level attribution' : 'Landing-page attribution'}</div>{measurement.leads.attributionScope === 'channel' && <div className="mb-2 text-xs text-caution">marketing-host and path filters do not apply</div>}{table('GA4 lead events by cohort', [{ label: 'All measured leads', values: measurement.leads.periods.map(row => row.eventCount) }, ...measurement.leads.channels.map(row => ({ label: row.channelGroup, values: row.periods.map(p => p.eventCount) }))])}</Card>
+      <Card className="p-4">{table('Latest Google search demand mix', [{ label: 'Branded', values: [latestDemand?.brandedClicks ?? 0, latestDemand?.brandedImpressions ?? 0] }, { label: 'Non-branded', values: [latestDemand?.nonBrandedClicks ?? 0, latestDemand?.nonBrandedImpressions ?? 0] }, { label: 'Suppressed or unreported', values: [latestDemand?.unreportedClicks ?? 0, latestDemand?.unreportedImpressions ?? 0] }])}</Card>
+      <Card className="p-4">{table('Server-side AI evidence', [{ label: 'Verified crawler hits', values: [server?.crawlerHits.verified ?? 0] }, { label: 'Verified user fetches', values: [server?.userFetchHits.verified ?? 0] }, { label: 'Organic AI referral sessions', values: [server?.referralSessions.organic ?? 0] }])}</Card>
+      <div className="space-y-2">{evidence.findings.map(finding => <Card key={finding.title} className="p-3"><div className="flex gap-2"><ToneBadge tone={finding.tone}>{finding.tone}</ToneBadge><div><div className="font-medium text-primary">{finding.title}</div><p className="text-sm text-secondary">{finding.detail}</p></div></div></Card>)}{evidence.limitations.filter(item => item.code !== 'lead-channel-scope').map(item => <p key={item.code} className="text-xs text-muted">{item.detail}</p>)}</div>
+    </div>
+  </section>
 }

--- a/apps/web/test/organic-evidence-panel.test.tsx
+++ b/apps/web/test/organic-evidence-panel.test.tsx
@@ -1,0 +1,332 @@
+import React from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, expect, onTestFinished, test } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { OrganicEvidencePanel } from '../src/components/project/ActivitySection.js'
+import { jsonResponse, mockFetch } from './mock-fetch.js'
+
+afterEach(cleanup)
+
+type Period = {
+  label: 'earliest' | 'middle' | 'previous' | 'latest'
+  startDate: string
+  endDate: string
+}
+
+function periods(period: 60 | 90): Period[] {
+  if (period === 60) {
+    return [
+      { label: 'previous', startDate: '2026-05-22', endDate: '2026-06-20' },
+      { label: 'latest', startDate: '2026-06-21', endDate: '2026-07-20' },
+    ]
+  }
+  return [
+    { label: 'earliest', startDate: '2026-04-22', endDate: '2026-05-21' },
+    { label: 'middle', startDate: '2026-05-22', endDate: '2026-06-20' },
+    { label: 'latest', startDate: '2026-06-21', endDate: '2026-07-20' },
+  ]
+}
+
+function makeEvidence(
+  period: 60 | 90,
+  overrides?: {
+    acquisitionStatus?: 'ready' | 'error'
+    acquisitionError?: string | null
+    leadScope?: 'landing-page' | 'channel'
+  },
+) {
+  const sourcePeriods = periods(period)
+  const sessionValues = period === 90 ? [10, 35, 16] : [35, 16]
+  const paidValues = period === 90 ? [0, 0, 50] : [0, 50]
+  const leadValues = period === 90 ? [2, 4, 0] : [4, 0]
+  const impressionValues = period === 90 ? [384, 313, 495] : [313, 495]
+  const clickValues = period === 90 ? [2, 4, 0] : [4, 0]
+  const acquisitionStatus = overrides?.acquisitionStatus ?? 'ready'
+  const leadScope = overrides?.leadScope ?? 'landing-page'
+
+  const sessionPeriods = (values: number[]) => sourcePeriods.map((row, index) => ({
+    ...row,
+    sessions: values[index] ?? 0,
+  }))
+  const eventPeriods = (values: number[]) => sourcePeriods.map((row, index) => ({
+    ...row,
+    eventCount: values[index] ?? 0,
+  }))
+  return {
+    contractVersion: 'organic-evidence/v1',
+    periodDays: period,
+    asOfDate: '2026-07-20',
+    cohorts: sourcePeriods.map(row => ({ name: row.label, ...row })),
+    coverage: { gsc: true, ga4: true, server: true, visibility: false },
+    sourceCoverage: {
+      gsc: { startDate: '2026-04-22', endDate: '2026-07-20', observedDays: 90 },
+      ga4: { startDate: '2026-04-24', endDate: '2026-07-22', observedDays: 90 },
+      server: { startDate: '2026-07-11', endDate: '2026-07-22', observedDays: 12 },
+      visibility: null,
+    },
+    measurement: {
+      window: `${period}d`,
+      bucketDays: 30,
+      filters: {
+        hostScope: 'marketing',
+        marketingHosts: ['demand-iq.com', 'demandiq.com'],
+        pathPrefix: null,
+        brandTerms: ['DemandIQ', 'Demand IQ'],
+        queryMixScope: 'property',
+      },
+      acquisition: {
+        status: acquisitionStatus,
+        error: overrides?.acquisitionError ?? null,
+        syncedAt: '2026-07-23T12:00:00.000Z',
+        periods: sessionPeriods(sessionValues.map((value, index) => value + (paidValues[index] ?? 0))),
+        channels: [
+          { channelGroup: 'Paid Search', periods: sessionPeriods(paidValues) },
+          { channelGroup: 'Organic Search', periods: sessionPeriods(sessionValues) },
+        ],
+        pages: [],
+      },
+      leads: {
+        status: 'ready',
+        error: null,
+        syncedAt: '2026-07-23T12:00:00.000Z',
+        attributionScope: leadScope,
+        hostAndPathFiltersApplied: leadScope === 'landing-page',
+        periods: eventPeriods(leadValues),
+        channels: [
+          { channelGroup: 'Organic Search', periods: eventPeriods(leadValues) },
+        ],
+      },
+      searchDemand: {
+        status: 'ready',
+        latestDate: '2026-07-20',
+        periods: sourcePeriods.map((row, index) => ({
+          ...row,
+          propertyClicks: period === 90 ? [5, 10, 10][index] : [10, 10][index],
+          propertyImpressions: period === 90 ? [400, 500, 700][index] : [500, 700][index],
+          reportedQueryClicks: period === 90 ? [4, 10, 10][index] : [10, 10][index],
+          reportedQueryImpressions: period === 90 ? [300, 313, 500][index] : [313, 500][index],
+          brandedClicks: period === 90 ? [3, 6, 8][index] : [6, 8][index],
+          brandedImpressions: period === 90 ? [100, 120, 150][index] : [120, 150][index],
+          nonBrandedClicks: period === 90 ? [1, 4, 2][index] : [4, 2][index],
+          nonBrandedImpressions: period === 90 ? [200, 193, 350][index] : [193, 350][index],
+          unreportedClicks: period === 90 ? [1, 0, 0][index] : [0, 0][index],
+          unreportedImpressions: period === 90 ? [100, 187, 200][index] : [187, 200][index],
+        })),
+        queries: [],
+        pages: [],
+      },
+    },
+    gsc: {
+      propertyTotals: { clicks: 25, impressions: 1_600 },
+      namedBrand: { clicks: 17, impressions: 370 },
+      namedNonBrand: { clicks: 7, impressions: 743 },
+      suppressedOrUnreportedResidual: { clicks: 1, impressions: 487 },
+      cohorts: sourcePeriods.map((row, index) => ({
+        name: row.label,
+        ...row,
+        totals: {
+          clicks: period === 90 ? [5, 10, 10][index] : [10, 10][index],
+          impressions: period === 90 ? [400, 500, 700][index] : [500, 700][index],
+        },
+      })),
+    },
+    ga4: {
+      organicSessions: sessionValues.reduce((sum, value) => sum + value, 0),
+      blogOrganicSessions: sessionValues.reduce((sum, value) => sum + value, 0),
+      cohorts: sourcePeriods.map((row, index) => ({
+        name: row.label,
+        ...row,
+        organicSessions: sessionValues[index] ?? 0,
+      })),
+    },
+    gaAiReferrals: null,
+    blog: {
+      pathRule: '/blog and descendants',
+      gsc: {
+        cohorts: sourcePeriods.map((row, index) => ({
+          name: row.label,
+          ...row,
+          totals: {
+            clicks: clickValues[index] ?? 0,
+            impressions: impressionValues[index] ?? 0,
+          },
+        })),
+      },
+      ga4: {
+        cohorts: sourcePeriods.map((row, index) => ({
+          name: row.label,
+          ...row,
+          organicSessions: sessionValues[index] ?? 0,
+        })),
+      },
+      server: {
+        crawlerHits: { verified: 7, claimedUnverified: 0, unknownAiLike: 0 },
+        userFetchHits: { verified: 5, claimedUnverified: 0, unknownAiLike: 0 },
+        referralSessions: { total: 3, paid: 0, organic: 3, unknown: 0 },
+      },
+    },
+    server: {
+      crawlerHits: { verified: 7, claimedUnverified: 0, unknownAiLike: 0 },
+      userFetchHits: { verified: 5, claimedUnverified: 0, unknownAiLike: 0 },
+      referralSessions: { total: 3, paid: 0, organic: 3, unknown: 0 },
+    },
+    visibility: null,
+    pages: [],
+    findings: [
+      {
+        tone: 'positive',
+        title: 'Blog search visibility increased',
+        detail: 'Google showed blog pages 495 in the latest cohort versus 313 prior (+58%).',
+      },
+      {
+        tone: 'caution',
+        title: 'Blog clicks have not followed visibility yet',
+        detail: 'Blog pages recorded 0 Google clicks in the latest cohort versus 4 prior.',
+      },
+      {
+        tone: 'neutral',
+        title: 'Lead trend is measured, not causal',
+        detail: 'GA4 recorded 0 lead events in the latest cohort versus 4 prior; this does not establish cause.',
+      },
+      {
+        tone: 'neutral',
+        title: 'Paid-assisted brand search remains plausible',
+        detail: 'GA4 recorded 50 Paid Search sessions and GSC reported 8 branded clicks; this is not proof of an assisted path.',
+      },
+    ],
+    limitations: [
+      {
+        code: 'lead-attribution-not-causal',
+        detail: 'Lead attribution is observational and does not prove SEO caused leads.',
+      },
+      ...(acquisitionStatus === 'error'
+        ? [{
+            code: 'acquisition-sync-error',
+            detail: 'GA acquisition sync failed; last-good rows remain visible.',
+          }]
+        : []),
+      ...(leadScope === 'channel'
+        ? [{
+            code: 'lead-channel-scope',
+            detail: 'Lead attribution is channel-level; marketing-host and path filters do not apply.',
+          }]
+        : []),
+    ],
+  }
+}
+
+function renderPanel(handler?: Parameters<typeof mockFetch>[0]) {
+  const restoreFetch = mockFetch(handler ?? ((url) => {
+    const parsed = new URL(url, 'http://canonry.test')
+    if (parsed.pathname.endsWith('/projects/test-project/organic-evidence')) {
+      const period = Number(parsed.searchParams.get('period') ?? '90') as 60 | 90
+      return jsonResponse(makeEvidence(period))
+    }
+    throw new Error(`Unexpected fetch: ${url}`)
+  }))
+  onTestFinished(restoreFetch)
+
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <OrganicEvidencePanel projectName="test-project" />
+    </QueryClientProvider>,
+  )
+}
+
+test('shows decision-ready 90-day evidence without collapsing native GA channels into Other', async () => {
+  renderPanel()
+
+  await waitFor(() => {
+    expect(screen.getByRole('heading', { name: 'Organic growth evidence' })).toBeTruthy()
+  })
+
+  expect(screen.getByRole('button', { name: '90 days' }).getAttribute('aria-pressed')).toBe('true')
+  expect(screen.getByText('Blog search visibility increased')).toBeTruthy()
+  expect(screen.getByText('Blog clicks have not followed visibility yet')).toBeTruthy()
+
+  const blog = within(screen.getByRole('table', { name: 'Blog search and traffic cohorts' }))
+  expect(within(blog.getByRole('row', { name: /Impressions/ })).getByText('495')).toBeTruthy()
+  expect(within(blog.getByRole('row', { name: /Impressions/ })).getByText('313')).toBeTruthy()
+  expect(within(blog.getByRole('row', { name: /Google clicks/ })).getByText('0')).toBeTruthy()
+  expect(within(blog.getByRole('row', { name: /Google clicks/ })).getByText('4')).toBeTruthy()
+
+  const acquisition = within(screen.getByRole('table', { name: 'GA4 sessions by native channel' }))
+  const organic = within(acquisition.getByRole('row', { name: /Organic Search/ }))
+  expect(organic.getByText('10')).toBeTruthy()
+  expect(organic.getByText('35')).toBeTruthy()
+  expect(organic.getByText('16')).toBeTruthy()
+  const paid = within(acquisition.getByRole('row', { name: /Paid Search/ }))
+  expect(paid.getByText('50')).toBeTruthy()
+  expect(acquisition.queryByText('Other')).toBeNull()
+
+  const leads = within(screen.getByRole('table', { name: 'GA4 lead events by cohort' }))
+  expect(within(leads.getByRole('row', { name: /All measured leads/ })).getByText('0')).toBeTruthy()
+  expect(within(leads.getByRole('row', { name: /All measured leads/ })).getByText('4')).toBeTruthy()
+  expect(screen.getByText('Landing-page attribution')).toBeTruthy()
+
+  const demand = within(screen.getByRole('table', { name: 'Latest Google search demand mix' }))
+  expect(within(demand.getByRole('row', { name: /Branded/ })).getByText('8')).toBeTruthy()
+  expect(within(demand.getByRole('row', { name: /Non-branded/ })).getByText('2')).toBeTruthy()
+  expect(within(demand.getByRole('row', { name: /Suppressed or unreported/ })).getByText('200')).toBeTruthy()
+
+  const server = within(screen.getByRole('table', { name: 'Server-side AI evidence' }))
+  expect(within(server.getByRole('row', { name: /Verified crawler hits/ })).getByText('7')).toBeTruthy()
+  expect(within(server.getByRole('row', { name: /Verified user fetches/ })).getByText('5')).toBeTruthy()
+  expect(within(server.getByRole('row', { name: /Organic AI referral sessions/ })).getByText('3')).toBeTruthy()
+})
+
+test('refetches the composite as a real 60-day comparison', async () => {
+  const requestedPeriods: string[] = []
+  renderPanel((url) => {
+    const parsed = new URL(url, 'http://canonry.test')
+    if (parsed.pathname.endsWith('/projects/test-project/organic-evidence')) {
+      const requested = parsed.searchParams.get('period') ?? '90'
+      requestedPeriods.push(requested)
+      return jsonResponse(makeEvidence(Number(requested) as 60 | 90))
+    }
+    throw new Error(`Unexpected fetch: ${url}`)
+  })
+
+  await waitFor(() => expect(screen.getByText('Blog search visibility increased')).toBeTruthy())
+  fireEvent.click(screen.getByRole('button', { name: '60 days' }))
+
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: '60 days' }).getAttribute('aria-pressed')).toBe('true')
+    expect(requestedPeriods).toContain('60')
+  })
+
+  const acquisition = within(screen.getByRole('table', { name: 'GA4 sessions by native channel' }))
+  expect(acquisition.getByText('Previous')).toBeTruthy()
+  expect(acquisition.getByText('Latest')).toBeTruthy()
+  expect(acquisition.queryByText('Earliest')).toBeNull()
+  expect(within(acquisition.getByRole('row', { name: /Organic Search/ })).getByText('35')).toBeTruthy()
+  expect(within(acquisition.getByRole('row', { name: /Organic Search/ })).getByText('16')).toBeTruthy()
+})
+
+test('shows last-good sync errors, channel-only lead scope, and causal caveats beside the data', async () => {
+  renderPanel((url) => {
+    const parsed = new URL(url, 'http://canonry.test')
+    if (parsed.pathname.endsWith('/projects/test-project/organic-evidence')) {
+      return jsonResponse(makeEvidence(90, {
+        acquisitionStatus: 'error',
+        acquisitionError: 'quota exhausted',
+        leadScope: 'channel',
+      }))
+    }
+    throw new Error(`Unexpected fetch: ${url}`)
+  })
+
+  await waitFor(() => expect(screen.getByText('Blog search visibility increased')).toBeTruthy())
+
+  expect(screen.getByText(/GA4 acquisition sync error: quota exhausted/)).toBeTruthy()
+  expect(screen.getByText('Showing last-good acquisition data')).toBeTruthy()
+  expect(screen.getByText('Channel-level attribution')).toBeTruthy()
+  expect(screen.getByText(/marketing-host and path filters do not apply/i)).toBeTruthy()
+  expect(screen.getByText(/Lead attribution is observational and does not prove SEO caused leads/)).toBeTruthy()
+  expect(screen.getByText('Paid-assisted brand search remains plausible')).toBeTruthy()
+  expect(screen.getByText(/not proof of an assisted path/)).toBeTruthy()
+  expect(screen.queryByText(/SEO generated leads/i)).toBeNull()
+})

--- a/apps/web/test/organic-evidence-panel.test.tsx
+++ b/apps/web/test/organic-evidence-panel.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { afterEach, expect, onTestFinished, test } from 'vitest'
+import { afterEach, expect, onTestFinished, test, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { OrganicEvidencePanel } from '../src/components/project/ActivitySection.js'
 import { jsonResponse, mockFetch } from './mock-fetch.js'
@@ -32,23 +32,32 @@ function makeEvidence(
   overrides?: {
     acquisitionStatus?: 'ready' | 'error'
     acquisitionError?: string | null
+    acquisitionEmpty?: boolean
+    leadStatus?: 'ready' | 'error'
+    leadError?: string | null
+    leadPeriodsEmpty?: boolean
+    leadEmpty?: boolean
     leadScope?: 'landing-page' | 'channel'
   },
 ) {
-  const sourcePeriods = periods(period)
-  const sessionValues = period === 90 ? [10, 35, 16] : [35, 16]
+  const gscPeriods = periods(period)
+  const gaPeriods = periods(period).map(row => ({
+    ...row,
+    startDate: row.startDate.replace(/-(\d{2})$/, (_, day: string) => `-${String(Number(day) + 2).padStart(2, '0')}`),
+    endDate: row.endDate.replace(/-(\d{2})$/, (_, day: string) => `-${String(Number(day) + 2).padStart(2, '0')}`),
+  }))
+  const sessionValues = period === 90 ? [10, 35, 1_234] : [35, 1_234]
   const paidValues = period === 90 ? [0, 0, 50] : [0, 50]
   const leadValues = period === 90 ? [2, 4, 0] : [4, 0]
-  const impressionValues = period === 90 ? [384, 313, 495] : [313, 495]
-  const clickValues = period === 90 ? [2, 4, 0] : [4, 0]
   const acquisitionStatus = overrides?.acquisitionStatus ?? 'ready'
+  const leadStatus = overrides?.leadStatus ?? 'ready'
   const leadScope = overrides?.leadScope ?? 'landing-page'
 
-  const sessionPeriods = (values: number[]) => sourcePeriods.map((row, index) => ({
+  const sessionPeriods = (values: number[]) => gaPeriods.map((row, index) => ({
     ...row,
     sessions: values[index] ?? 0,
   }))
-  const eventPeriods = (values: number[]) => sourcePeriods.map((row, index) => ({
+  const eventPeriods = (values: number[]) => gaPeriods.map((row, index) => ({
     ...row,
     eventCount: values[index] ?? 0,
   }))
@@ -56,7 +65,6 @@ function makeEvidence(
     contractVersion: 'organic-evidence/v1',
     periodDays: period,
     asOfDate: '2026-07-20',
-    cohorts: sourcePeriods.map(row => ({ name: row.label, ...row })),
     coverage: { gsc: true, ga4: true, server: true, visibility: false },
     sourceCoverage: {
       gsc: { startDate: '2026-04-22', endDate: '2026-07-20', observedDays: 90 },
@@ -78,28 +86,34 @@ function makeEvidence(
         status: acquisitionStatus,
         error: overrides?.acquisitionError ?? null,
         syncedAt: '2026-07-23T12:00:00.000Z',
-        periods: sessionPeriods(sessionValues.map((value, index) => value + (paidValues[index] ?? 0))),
-        channels: [
-          { channelGroup: 'Paid Search', periods: sessionPeriods(paidValues) },
-          { channelGroup: 'Organic Search', periods: sessionPeriods(sessionValues) },
-        ],
+        periods: overrides?.acquisitionEmpty
+          ? []
+          : sessionPeriods(sessionValues.map((value, index) => value + (paidValues[index] ?? 0))),
+        channels: overrides?.acquisitionEmpty
+          ? []
+          : [
+              { channelGroup: 'Paid Search', periods: sessionPeriods(paidValues) },
+              { channelGroup: 'Organic Search', periods: sessionPeriods(sessionValues) },
+            ],
         pages: [],
       },
       leads: {
-        status: 'ready',
-        error: null,
+        status: leadStatus,
+        error: overrides?.leadError ?? null,
         syncedAt: '2026-07-23T12:00:00.000Z',
         attributionScope: leadScope,
         hostAndPathFiltersApplied: leadScope === 'landing-page',
-        periods: eventPeriods(leadValues),
-        channels: [
-          { channelGroup: 'Organic Search', periods: eventPeriods(leadValues) },
-        ],
+        periods: overrides?.leadPeriodsEmpty ? [] : eventPeriods(leadValues),
+        channels: overrides?.leadEmpty
+          ? []
+          : [
+              { channelGroup: 'Organic Search', periods: eventPeriods(leadValues) },
+            ],
       },
       searchDemand: {
         status: 'ready',
         latestDate: '2026-07-20',
-        periods: sourcePeriods.map((row, index) => ({
+        periods: gscPeriods.map((row, index) => ({
           ...row,
           propertyClicks: period === 90 ? [5, 10, 10][index] : [10, 10][index],
           propertyImpressions: period === 90 ? [400, 500, 700][index] : [500, 700][index],
@@ -121,7 +135,7 @@ function makeEvidence(
       namedBrand: { clicks: 17, impressions: 370 },
       namedNonBrand: { clicks: 7, impressions: 743 },
       suppressedOrUnreportedResidual: { clicks: 1, impressions: 487 },
-      cohorts: sourcePeriods.map((row, index) => ({
+      cohorts: gscPeriods.map((row, index) => ({
         name: row.label,
         ...row,
         totals: {
@@ -132,56 +146,51 @@ function makeEvidence(
     },
     ga4: {
       organicSessions: sessionValues.reduce((sum, value) => sum + value, 0),
-      blogOrganicSessions: sessionValues.reduce((sum, value) => sum + value, 0),
-      cohorts: sourcePeriods.map((row, index) => ({
+      cohorts: gaPeriods.map((row, index) => ({
         name: row.label,
         ...row,
         organicSessions: sessionValues[index] ?? 0,
       })),
     },
     gaAiReferrals: null,
-    blog: {
-      pathRule: '/blog and descendants',
-      gsc: {
-        cohorts: sourcePeriods.map((row, index) => ({
-          name: row.label,
-          ...row,
-          totals: {
-            clicks: clickValues[index] ?? 0,
-            impressions: impressionValues[index] ?? 0,
-          },
-        })),
-      },
-      ga4: {
-        cohorts: sourcePeriods.map((row, index) => ({
-          name: row.label,
-          ...row,
-          organicSessions: sessionValues[index] ?? 0,
-        })),
-      },
-      server: {
-        crawlerHits: { verified: 7, claimedUnverified: 0, unknownAiLike: 0 },
-        userFetchHits: { verified: 5, claimedUnverified: 0, unknownAiLike: 0 },
-        referralSessions: { total: 3, paid: 0, organic: 3, unknown: 0 },
-      },
-    },
     server: {
       crawlerHits: { verified: 7, claimedUnverified: 0, unknownAiLike: 0 },
       userFetchHits: { verified: 5, claimedUnverified: 0, unknownAiLike: 0 },
       referralSessions: { total: 3, paid: 0, organic: 3, unknown: 0 },
     },
     visibility: null,
-    pages: [],
+    pages: [
+      {
+        path: '/resources/old-guide',
+        gsc: { clicks: 12, impressions: 1_234 },
+        ga4OrganicSessions: 18,
+        server: {
+          crawlerHits: { verified: 3, claimedUnverified: 0, unknownAiLike: 0 },
+          userFetchHits: { verified: 2, claimedUnverified: 0, unknownAiLike: 0 },
+          referralSessions: { total: 1, paid: 0, organic: 1, unknown: 0 },
+        },
+      },
+      {
+        path: '/answer-library/new-guide',
+        gsc: { clicks: 4, impressions: 690 },
+        ga4OrganicSessions: 7,
+        server: {
+          crawlerHits: { verified: 4, claimedUnverified: 0, unknownAiLike: 0 },
+          userFetchHits: { verified: 3, claimedUnverified: 0, unknownAiLike: 0 },
+          referralSessions: { total: 2, paid: 0, organic: 2, unknown: 0 },
+        },
+      },
+    ],
     findings: [
       {
         tone: 'positive',
-        title: 'Blog search visibility increased',
-        detail: 'Google showed blog pages 495 in the latest cohort versus 313 prior (+58%).',
+        title: 'Search visibility increased',
+        detail: 'Google showed the site 700 times in the latest GSC cohort versus 500 prior (+40%).',
       },
       {
         tone: 'caution',
-        title: 'Blog clicks have not followed visibility yet',
-        detail: 'Blog pages recorded 0 Google clicks in the latest cohort versus 4 prior.',
+        title: 'Clicks have not followed visibility yet',
+        detail: 'The site recorded 10 Google clicks in both the latest and prior GSC cohorts.',
       },
       {
         tone: 'neutral',
@@ -191,13 +200,17 @@ function makeEvidence(
       {
         tone: 'neutral',
         title: 'Paid-assisted brand search remains plausible',
-        detail: 'GA4 recorded 50 Paid Search sessions and GSC reported 8 branded clicks; this is not proof of an assisted path.',
+        detail: 'GA4 recorded 50 Paid Search sessions from 2026-06-23 to 2026-07-22, while GSC reported 8 branded clicks from 2026-06-21 to 2026-07-20; this is not proof of an assisted path.',
       },
     ],
     limitations: [
       {
         code: 'lead-attribution-not-causal',
         detail: 'Lead attribution is observational and does not prove SEO caused leads.',
+      },
+      {
+        code: 'source-specific-cohort-anchors',
+        detail: 'GA4 and GSC cohorts use their own latest available dates.',
       },
       ...(acquisitionStatus === 'error'
         ? [{
@@ -238,29 +251,39 @@ function renderPanel(handler?: Parameters<typeof mockFetch>[0]) {
 
 test('shows decision-ready 90-day evidence without collapsing native GA channels into Other', async () => {
   renderPanel()
+  const localeString = vi.spyOn(Number.prototype, 'toLocaleString')
+  onTestFinished(() => localeString.mockRestore())
 
   await waitFor(() => {
     expect(screen.getByRole('heading', { name: 'Organic growth evidence' })).toBeTruthy()
   })
 
   expect(screen.getByRole('button', { name: '90 days' }).getAttribute('aria-pressed')).toBe('true')
-  expect(screen.getByText('Blog search visibility increased')).toBeTruthy()
-  expect(screen.getByText('Blog clicks have not followed visibility yet')).toBeTruthy()
+  expect(screen.getByText('Search visibility increased')).toBeTruthy()
+  expect(screen.getByText('Clicks have not followed visibility yet')).toBeTruthy()
 
-  const blog = within(screen.getByRole('table', { name: 'Blog search and traffic cohorts' }))
-  expect(within(blog.getByRole('row', { name: /Impressions/ })).getByText('495')).toBeTruthy()
-  expect(within(blog.getByRole('row', { name: /Impressions/ })).getByText('313')).toBeTruthy()
-  expect(within(blog.getByRole('row', { name: /Google clicks/ })).getByText('0')).toBeTruthy()
-  expect(within(blog.getByRole('row', { name: /Google clicks/ })).getByText('4')).toBeTruthy()
+  const gsc = within(screen.getByRole('table', { name: 'Google Search Console cohorts' }))
+  expect(within(gsc.getByRole('row', { name: /Impressions/ })).getByText('700')).toBeTruthy()
+  expect(within(gsc.getByRole('row', { name: /Impressions/ })).getByText('500')).toBeTruthy()
+  expect(within(gsc.getByRole('row', { name: /Google clicks/ })).getAllByText('10')).toHaveLength(2)
+  expect(gsc.getByRole('columnheader', { name: /Latest.*2026-06-21.*2026-07-20/ })).toBeTruthy()
 
   const acquisition = within(screen.getByRole('table', { name: 'GA4 sessions by native channel' }))
   const organic = within(acquisition.getByRole('row', { name: /Organic Search/ }))
   expect(organic.getByText('10')).toBeTruthy()
   expect(organic.getByText('35')).toBeTruthy()
-  expect(organic.getByText('16')).toBeTruthy()
+  expect(organic.getByText('1,234')).toBeTruthy()
   const paid = within(acquisition.getByRole('row', { name: /Paid Search/ }))
   expect(paid.getByText('50')).toBeTruthy()
   expect(acquisition.queryByText('Other')).toBeNull()
+  expect(acquisition.getByRole('columnheader', { name: /Latest.*2026-06-23.*2026-07-22/ })).toBeTruthy()
+
+  const pages = within(screen.getByRole('table', { name: 'All-page organic and AI evidence' }))
+  expect(pages.getByRole('row', { name: /\/resources\/old-guide/ })).toBeTruthy()
+  expect(pages.getByRole('row', { name: /\/answer-library\/new-guide/ })).toBeTruthy()
+  expect(within(pages.getByRole('row', { name: /\/resources\/old-guide/ })).getByText('1,234')).toBeTruthy()
+  expect(screen.queryByText(/for \/blog/i)).toBeNull()
+  expect(localeString).toHaveBeenCalledWith('en-US')
 
   const leads = within(screen.getByRole('table', { name: 'GA4 lead events by cohort' }))
   expect(within(leads.getByRole('row', { name: /All measured leads/ })).getByText('0')).toBeTruthy()
@@ -290,7 +313,7 @@ test('refetches the composite as a real 60-day comparison', async () => {
     throw new Error(`Unexpected fetch: ${url}`)
   })
 
-  await waitFor(() => expect(screen.getByText('Blog search visibility increased')).toBeTruthy())
+  await waitFor(() => expect(screen.getByText('Search visibility increased')).toBeTruthy())
   fireEvent.click(screen.getByRole('button', { name: '60 days' }))
 
   await waitFor(() => {
@@ -303,7 +326,7 @@ test('refetches the composite as a real 60-day comparison', async () => {
   expect(acquisition.getByText('Latest')).toBeTruthy()
   expect(acquisition.queryByText('Earliest')).toBeNull()
   expect(within(acquisition.getByRole('row', { name: /Organic Search/ })).getByText('35')).toBeTruthy()
-  expect(within(acquisition.getByRole('row', { name: /Organic Search/ })).getByText('16')).toBeTruthy()
+  expect(within(acquisition.getByRole('row', { name: /Organic Search/ })).getByText('1,234')).toBeTruthy()
 })
 
 test('shows last-good sync errors, channel-only lead scope, and causal caveats beside the data', async () => {
@@ -319,7 +342,7 @@ test('shows last-good sync errors, channel-only lead scope, and causal caveats b
     throw new Error(`Unexpected fetch: ${url}`)
   })
 
-  await waitFor(() => expect(screen.getByText('Blog search visibility increased')).toBeTruthy())
+  await waitFor(() => expect(screen.getByText('Search visibility increased')).toBeTruthy())
 
   expect(screen.getByText(/GA4 acquisition sync error: quota exhausted/)).toBeTruthy()
   expect(screen.getByText('Showing last-good acquisition data')).toBeTruthy()
@@ -339,11 +362,12 @@ test('uses source-specific columns and keeps every evidence table structurally a
   })
 
   const tableNames = [
-    'Blog search and traffic cohorts',
+    'Google Search Console cohorts',
     'GA4 sessions by native channel',
     'GA4 lead events by cohort',
     'Latest Google search demand mix',
     'Server-side AI evidence',
+    'All-page organic and AI evidence',
   ]
 
   for (const name of tableNames) {
@@ -362,4 +386,91 @@ test('uses source-specific columns and keeps every evidence table structurally a
 
   const server = within(screen.getByRole('table', { name: 'Server-side AI evidence' }))
   expect(server.getByRole('columnheader', { name: 'Count' })).toBeTruthy()
+})
+
+test('keeps the last-good comparison visible while a period change is loading', async () => {
+  let resolveSixty: ((response: Response) => void) | undefined
+  const delayedSixty = new Promise<Response>((resolve) => {
+    resolveSixty = resolve
+  })
+
+  renderPanel((url) => {
+    const parsed = new URL(url, 'http://canonry.test')
+    if (!parsed.pathname.endsWith('/projects/test-project/organic-evidence')) {
+      throw new Error(`Unexpected fetch: ${url}`)
+    }
+    return parsed.searchParams.get('period') === '60'
+      ? delayedSixty
+      : jsonResponse(makeEvidence(90))
+  })
+
+  await waitFor(() => expect(screen.getByText('Search visibility increased')).toBeTruthy())
+  fireEvent.click(screen.getByRole('button', { name: '60 days' }))
+
+  await waitFor(() => expect(screen.getByText('Updating organic evidence…')).toBeTruthy())
+  const lastGood = within(screen.getByRole('table', { name: 'Google Search Console cohorts' }))
+  expect(lastGood.getByText('Earliest')).toBeTruthy()
+
+  resolveSixty?.(jsonResponse(makeEvidence(60)))
+  await waitFor(() => {
+    expect(screen.queryByText('Updating organic evidence…')).toBeNull()
+    expect(within(screen.getByRole('table', { name: 'Google Search Console cohorts' })).queryByText('Earliest')).toBeNull()
+  })
+})
+
+test('renders a stable initial request error instead of an empty dashboard', async () => {
+  renderPanel(() => jsonResponse({ error: 'upstream unavailable' }, 503))
+
+  await waitFor(() => {
+    expect(screen.getByRole('heading', { name: 'Organic growth evidence' })).toBeTruthy()
+    expect(screen.getByText('Organic evidence is temporarily unavailable.')).toBeTruthy()
+  })
+  expect(screen.queryByRole('table')).toBeNull()
+})
+
+test('does not claim last-good data exists when failed GA syncs have no rows', async () => {
+  renderPanel((url) => {
+    const parsed = new URL(url, 'http://canonry.test')
+    if (!parsed.pathname.endsWith('/projects/test-project/organic-evidence')) {
+      throw new Error(`Unexpected fetch: ${url}`)
+    }
+    return jsonResponse(makeEvidence(90, {
+      acquisitionStatus: 'error',
+      acquisitionError: 'quota exhausted',
+      acquisitionEmpty: true,
+      leadStatus: 'error',
+      leadError: 'property denied',
+      leadPeriodsEmpty: true,
+      leadEmpty: true,
+    }))
+  })
+
+  await waitFor(() => expect(screen.getByText('Search visibility increased')).toBeTruthy())
+  expect(screen.getByText(/GA4 acquisition sync error: quota exhausted/)).toBeTruthy()
+  expect(screen.getByText(/GA4 lead sync error: property denied/)).toBeTruthy()
+  expect(screen.queryByText('Showing last-good acquisition data')).toBeNull()
+  expect(screen.queryByText('Showing last-good lead data')).toBeNull()
+  expect(screen.getByText('No native GA4 acquisition rows matched this scope.')).toBeTruthy()
+  expect(screen.getByText('No configured lead events matched this scope.')).toBeTruthy()
+})
+
+test('uses channel periods when lead totals are absent and identifies them as last-good rows', async () => {
+  renderPanel((url) => {
+    const parsed = new URL(url, 'http://canonry.test')
+    if (!parsed.pathname.endsWith('/projects/test-project/organic-evidence')) {
+      throw new Error(`Unexpected fetch: ${url}`)
+    }
+    return jsonResponse(makeEvidence(90, {
+      leadStatus: 'error',
+      leadError: 'partial sync failed',
+      leadPeriodsEmpty: true,
+    }))
+  })
+
+  await waitFor(() => expect(screen.getByText('Search visibility increased')).toBeTruthy())
+  expect(screen.getByText('Showing last-good lead data')).toBeTruthy()
+  const leads = within(screen.getByRole('table', { name: 'GA4 lead events by cohort' }))
+  const organic = within(leads.getByRole('row', { name: /Organic Search/ }))
+  expect(organic.getByText('4')).toBeTruthy()
+  expect(organic.getByText('0')).toBeTruthy()
 })

--- a/apps/web/test/organic-evidence-panel.test.tsx
+++ b/apps/web/test/organic-evidence-panel.test.tsx
@@ -330,3 +330,36 @@ test('shows last-good sync errors, channel-only lead scope, and causal caveats b
   expect(screen.getByText(/not proof of an assisted path/)).toBeTruthy()
   expect(screen.queryByText(/SEO generated leads/i)).toBeNull()
 })
+
+test('uses source-specific columns and keeps every evidence table structurally aligned', async () => {
+  renderPanel()
+
+  await waitFor(() => {
+    expect(screen.getByRole('heading', { name: 'Organic growth evidence' })).toBeTruthy()
+  })
+
+  const tableNames = [
+    'Blog search and traffic cohorts',
+    'GA4 sessions by native channel',
+    'GA4 lead events by cohort',
+    'Latest Google search demand mix',
+    'Server-side AI evidence',
+  ]
+
+  for (const name of tableNames) {
+    const table = within(screen.getByRole('table', { name }))
+    const columnCount = table.getAllByRole('columnheader').length
+    for (const row of table.getAllByRole('row').slice(1)) {
+      const cells = within(row).getAllByRole('cell').length
+      const rowHeaders = within(row).getAllByRole('rowheader').length
+      expect(cells + rowHeaders).toBe(columnCount)
+    }
+  }
+
+  const demand = within(screen.getByRole('table', { name: 'Latest Google search demand mix' }))
+  expect(demand.getByRole('columnheader', { name: 'Clicks' })).toBeTruthy()
+  expect(demand.getByRole('columnheader', { name: 'Impressions' })).toBeTruthy()
+
+  const server = within(screen.getByRole('table', { name: 'Server-side AI evidence' }))
+  expect(server.getByRole('columnheader', { name: 'Count' })).toBeTruthy()
+})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.133.0",
+  "version": "4.133.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.133.0",
+  "version": "4.133.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.133.0",
+  "version": "4.133.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.133.0",
+  "version": "4.133.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
## Context

The native organic-evidence contract from #856 gives humans and agents the same reconciled GA4, GSC, lead, and server-AI facts, but the Activity tab still exposes those sources as separate specialist panels.

This PR adds the decision view on top of that frozen contract. It is intentionally UI-only and stacked after #856.

## Summary

- adds an Organic growth evidence section between server activity and the legacy GA4 detail panel
- defaults to a 90-day comparison and performs a real refetch for 60 days
- shows GSC visibility/click cohorts and GA4 organic-session cohorts with their own source dates
- lists every native GA4 channel without synthesizing an `Other` row
- shows configured lead events with landing-page or channel-level attribution scope
- separates branded, non-branded, and suppressed/unreported Google demand
- reconciles verified crawlers, AI user fetches, and organic AI referral sessions
- renders findings, causal caveats, source-unavailable states, and last-good sync errors beside the data
- uses source-specific accessible table dimensions so headers and values cannot be silently misaligned

## Test coverage

The behavior contract was committed red before delegated implementation. Primary review then added a second red structural contract after finding malformed generic table headers.

- complete 90-day decision view and native-channel preservation
- real 60-day query/refetch and two-cohort rendering
- last-good acquisition errors and channel-only lead caveats
- paid-assisted brand search explicitly framed as plausible, not proof
- accessible source-specific columns and row/header alignment for all five tables
- existing Activity section and pagination regressions

## Validation

- `pnpm --filter @ainyc/canonry-api-client run gen:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` — 479 files, 5,792 tests
- `pnpm build`
- `pnpm plugin:check`

Depends on #856.
