### PR TITLE
fix(plugin): advance version after merged inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.133.2",
+  "version": "4.133.3",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.133.2",
+  "version": "4.133.3",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.133.2",
+  "version": "4.133.3",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.133.2",
+  "version": "4.133.3",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
## Summary

Advance the synchronized Canonry and native-plugin manifests from `4.133.2` to `4.133.3`.

## Root cause

PR #852 first published `4.133.2`. PR #858 then added plugin inputs after that merge but retained the same version, so the post-merge plugin-drift gate correctly rejected `main` because changed plugin inputs require a version advance.

## Impact

Restores a passing CI/Publish pipeline and permits the next Canonry/plugin release. No application behavior, API surface, or workflow logic changes.

## Validation

- `pnpm plugin:check --base-ref origin/main`
- `git diff --check`
