### PR TITLE
Standardize searchable, paginated table controls

### DIFF
--- a/apps/web/src/components/project/ActivitySection.tsx
+++ b/apps/web/src/components/project/ActivitySection.tsx
@@ -69,6 +69,10 @@ const SOURCE_COLORS = CHART_SERIES_COLORS
 const SOCIAL_OTHER_COLOR = CHART_NEUTRAL.textDim
 const SOCIAL_TOTAL_COLOR = CHART_NEUTRAL.textFaint
 const SOCIAL_TABLE_DEFAULT_LIMIT = 25
+
+function aiLandingPageSearchText(row: ApiGaTrafficAiLandingPage): string {
+  return urlSearchText(row.landingPage)
+}
 const AI_LANDING_PAGE_SIZE = 25
 
 const EMPTY_AI_DAILY: GA4AiReferralDailyDto = {
@@ -425,7 +429,7 @@ export function ClickThroughActivity({ projectName }: { projectName: string }) {
 
   const aiLandingTable = useClientTable({
     rows: sortedAiLandingPages,
-    getSearchText: (row) => urlSearchText(row.landingPage),
+    getSearchText: aiLandingPageSearchText,
     pageSize: AI_LANDING_PAGE_SIZE,
   })
   const aiLandingRowCount = aiLandingTable.totalRows > 0

--- a/apps/web/src/components/project/ActivitySection.tsx
+++ b/apps/web/src/components/project/ActivitySection.tsx
@@ -21,6 +21,13 @@ import {
 import { Link } from '@tanstack/react-router'
 import { Button } from '../ui/button.js'
 import { Card } from '../ui/card.js'
+import {
+  DataTablePagination,
+  DataTableSearch,
+  MiddleTruncatedText,
+  urlSearchText,
+  useClientTable,
+} from '../shared/DataTableControls.js'
 import { InfoTooltip } from '../shared/InfoTooltip.js'
 import { ToneBadge } from '../shared/ToneBadge.js'
 import type { MetricsWindow } from '@ainyc/canonry-contracts'
@@ -62,7 +69,7 @@ const SOURCE_COLORS = CHART_SERIES_COLORS
 const SOCIAL_OTHER_COLOR = CHART_NEUTRAL.textDim
 const SOCIAL_TOTAL_COLOR = CHART_NEUTRAL.textFaint
 const SOCIAL_TABLE_DEFAULT_LIMIT = 25
-const AI_LANDING_PAGE_SIZE = 50
+const AI_LANDING_PAGE_SIZE = 25
 
 const EMPTY_AI_DAILY: GA4AiReferralDailyDto = {
   days: [],
@@ -228,7 +235,6 @@ export function ClickThroughActivity({ projectName }: { projectName: string }) {
   const [socialSortDir, setSocialSortDir] = useState<SortDir>('desc')
   const [aiLandingSortKey, setAiLandingSortKey] = useState<AiLandingPageSortKey>('sessions')
   const [aiLandingSortDir, setAiLandingSortDir] = useState<SortDir>('desc')
-  const [aiLandingPage, setAiLandingPage] = useState(1)
   const [aiDaily, setAiDaily] = useState<GA4AiReferralDailyDto>(EMPTY_AI_DAILY)
   const [sessionHistory, setSessionHistory] = useState<GA4SessionHistoryEntry[]>([])
   const [socialHistory, setSocialHistory] = useState<GA4SocialReferralHistoryEntry[]>([])
@@ -380,16 +386,6 @@ export function ClickThroughActivity({ projectName }: { projectName: string }) {
     }
   }
 
-  function handleAiLandingSort(key: AiLandingPageSortKey) {
-    setAiLandingPage(1)
-    if (aiLandingSortKey === key) {
-      setAiLandingSortDir((d) => (d === 'desc' ? 'asc' : 'desc'))
-    } else {
-      setAiLandingSortKey(key)
-      setAiLandingSortDir('desc')
-    }
-  }
-
   const sortedPages = useMemo(() => {
     if (!traffic?.topPages) return []
     return [...traffic.topPages].sort((a, b) => {
@@ -416,24 +412,41 @@ export function ClickThroughActivity({ projectName }: { projectName: string }) {
 
   const sortedAiLandingPages = useMemo(() => {
     if (!traffic?.aiReferralLandingPages) return []
-    return [...traffic.aiReferralLandingPages].sort((a, b) => {
-      const av = a[aiLandingSortKey]
-      const bv = b[aiLandingSortKey]
-      if (typeof av === 'string' && typeof bv === 'string') {
-        return aiLandingSortDir === 'asc' ? av.localeCompare(bv) : bv.localeCompare(av)
-      }
-      return aiLandingSortDir === 'asc' ? (av as number) - (bv as number) : (bv as number) - (av as number)
-    })
+    return [...traffic.aiReferralLandingPages]
+      .sort((a, b) => {
+        const av = a[aiLandingSortKey]
+        const bv = b[aiLandingSortKey]
+        if (typeof av === 'string' && typeof bv === 'string') {
+          return aiLandingSortDir === 'asc' ? av.localeCompare(bv) : bv.localeCompare(av)
+        }
+        return aiLandingSortDir === 'asc' ? (av as number) - (bv as number) : (bv as number) - (av as number)
+      })
   }, [traffic?.aiReferralLandingPages, aiLandingSortKey, aiLandingSortDir])
 
-  const aiLandingTotalPages = Math.max(1, Math.ceil(sortedAiLandingPages.length / AI_LANDING_PAGE_SIZE))
-  // Clamp to a valid page so a stale page index (e.g. after a resync shrinks the list) still renders.
-  const aiLandingCurrentPage = Math.min(Math.max(1, aiLandingPage), aiLandingTotalPages)
-  const aiLandingPageStart = (aiLandingCurrentPage - 1) * AI_LANDING_PAGE_SIZE
-  const pagedAiLandingPages = useMemo(
-    () => sortedAiLandingPages.slice(aiLandingPageStart, aiLandingPageStart + AI_LANDING_PAGE_SIZE),
-    [sortedAiLandingPages, aiLandingPageStart],
-  )
+  const aiLandingTable = useClientTable({
+    rows: sortedAiLandingPages,
+    getSearchText: (row) => urlSearchText(row.landingPage),
+    pageSize: AI_LANDING_PAGE_SIZE,
+  })
+  const aiLandingRowCount = aiLandingTable.totalRows > 0
+    ? `${aiLandingTable.totalRows.toLocaleString()} ${
+      aiLandingTable.hasQuery
+        ? (aiLandingTable.totalRows === 1 ? 'match' : 'matches')
+        : (aiLandingTable.totalRows === 1 ? 'row' : 'rows')
+    }`
+    : aiLandingTable.hasQuery && (traffic?.aiReferralLandingPages.length ?? 0) > 0
+      ? '0 matches'
+      : 'No landing-page rows'
+
+  function handleAiLandingSort(key: AiLandingPageSortKey) {
+    aiLandingTable.setPage(1)
+    if (aiLandingSortKey === key) {
+      setAiLandingSortDir((d) => (d === 'desc' ? 'asc' : 'desc'))
+    } else {
+      setAiLandingSortKey(key)
+      setAiLandingSortDir('desc')
+    }
+  }
 
   const sortedSocialReferrals = useMemo(() => {
     if (!traffic?.socialReferrals) return []
@@ -834,57 +847,61 @@ export function ClickThroughActivity({ projectName }: { projectName: string }) {
                   <h3 className="text-sm font-semibold text-heading">Known AI referrers by landing page</h3>
                 </div>
                 <p className="text-xs text-muted">
-                  {sortedAiLandingPages.length > AI_LANDING_PAGE_SIZE
-                    ? `${aiLandingPageStart + 1}–${aiLandingPageStart + pagedAiLandingPages.length} of ${sortedAiLandingPages.length} rows`
-                    : sortedAiLandingPages.length > 0
-                      ? `${sortedAiLandingPages.length} rows`
-                      : 'No landing-page rows'}
+                  {aiLandingRowCount}
                 </p>
               </div>
 
-              {sortedAiLandingPages.length > 0 ? (
+              {traffic.aiReferralLandingPages.length > 0 ? (
                 <>
-                  <div className="overflow-x-auto">
-                    <table className="w-full text-sm">
-                      <thead>
-                        <tr className="text-[10px] uppercase tracking-wider text-muted">
-                          <SortHeader label="Landing Page" sortKey="landingPage" current={aiLandingSortKey} dir={aiLandingSortDir} onSort={handleAiLandingSort} align="left" />
-                          <SortHeader label="Source" sortKey="source" current={aiLandingSortKey} dir={aiLandingSortDir} onSort={handleAiLandingSort} align="left" />
-                          <th className="py-1 font-medium text-left">Attribution</th>
-                          <SortHeader label="Sessions" sortKey="sessions" current={aiLandingSortKey} dir={aiLandingSortDir} onSort={handleAiLandingSort} align="right" />
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {pagedAiLandingPages.map((row) => (
-                          <AiReferralLandingPageRow
-                            key={`${row.landingPage}:${row.source}:${row.medium}:${row.sourceDimension}`}
-                            row={row}
-                          />
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
+                  <DataTableSearch
+                    value={aiLandingTable.query}
+                    onChange={aiLandingTable.setQuery}
+                    label="Filter landing page URLs or query parameters"
+                    placeholder="Filter URL or query parameters"
+                    className="mb-4 max-w-md"
+                  />
 
-                  {aiLandingTotalPages > 1 && (
-                    <div className="mt-3 flex items-center justify-center gap-2">
+                  {aiLandingTable.totalRows > 0 ? (
+                    <>
+                      <div className="overflow-x-auto">
+                        <table className="w-full text-sm">
+                          <thead>
+                            <tr className="text-[10px] uppercase tracking-wider text-muted">
+                              <SortHeader label="Landing Page" sortKey="landingPage" current={aiLandingSortKey} dir={aiLandingSortDir} onSort={handleAiLandingSort} align="left" />
+                              <SortHeader label="Source" sortKey="source" current={aiLandingSortKey} dir={aiLandingSortDir} onSort={handleAiLandingSort} align="left" />
+                              <th className="py-1 font-medium text-left">Attribution</th>
+                              <SortHeader label="Sessions" sortKey="sessions" current={aiLandingSortKey} dir={aiLandingSortDir} onSort={handleAiLandingSort} align="right" />
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {aiLandingTable.rows.map((row) => (
+                              <AiReferralLandingPageRow
+                                key={`${row.landingPage}:${row.source}:${row.medium}:${row.sourceDimension}`}
+                                row={row}
+                              />
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+
+                      <DataTablePagination
+                        page={aiLandingTable.page}
+                        pageSize={aiLandingTable.pageSize}
+                        visibleRows={aiLandingTable.rows.length}
+                        totalRows={aiLandingTable.totalRows}
+                        onPageChange={aiLandingTable.setPage}
+                        itemLabel={aiLandingTable.hasQuery ? 'matches' : 'rows'}
+                      />
+                    </>
+                  ) : (
+                    <div className="flex flex-col items-center justify-center py-8 text-center">
+                      <p className="text-sm text-secondary">No landing pages match this filter</p>
                       <button
                         type="button"
-                        onClick={() => setAiLandingPage(aiLandingCurrentPage - 1)}
-                        disabled={aiLandingCurrentPage <= 1}
-                        className="text-xs text-secondary hover:text-strong disabled:opacity-40 disabled:hover:text-secondary px-3 py-1 rounded-full border border-base hover:border-strong disabled:hover:border-base transition-colors"
+                        onClick={() => aiLandingTable.setQuery('')}
+                        className="mt-2 text-xs text-link hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-mono-500"
                       >
-                        Previous
-                      </button>
-                      <span className="text-xs text-muted tabular-nums">
-                        Page {aiLandingCurrentPage} of {aiLandingTotalPages}
-                      </span>
-                      <button
-                        type="button"
-                        onClick={() => setAiLandingPage(aiLandingCurrentPage + 1)}
-                        disabled={aiLandingCurrentPage >= aiLandingTotalPages}
-                        className="text-xs text-secondary hover:text-strong disabled:opacity-40 disabled:hover:text-secondary px-3 py-1 rounded-full border border-base hover:border-strong disabled:hover:border-base transition-colors"
-                      >
-                        Next
+                        Clear filter
                       </button>
                     </div>
                   )}
@@ -1498,8 +1515,8 @@ function AiReferralLandingPageRow({ row }: { row: ApiGaTrafficAiLandingPage }) {
 
   return (
     <tr className="border-t border-subtle">
-      <td className="py-1.5 text-neutral max-w-[360px] truncate" title={row.landingPage}>
-        {row.landingPage}
+      <td className="max-w-[400px] py-1.5 text-neutral">
+        <MiddleTruncatedText value={row.landingPage} className="whitespace-nowrap" />
       </td>
       <td className="py-1.5 text-strong max-w-[220px] truncate" title={row.source}>
         {row.source}

--- a/apps/web/src/components/project/BacklinksSection.tsx
+++ b/apps/web/src/components/project/BacklinksSection.tsx
@@ -19,6 +19,10 @@ import {
 } from '../shared/ChartPrimitives.js'
 import { Button } from '../ui/button.js'
 import { Card } from '../ui/card.js'
+import {
+  DataTablePagination,
+  DEFAULT_TABLE_PAGE_SIZE,
+} from '../shared/DataTableControls.js'
 import { ToneBadge } from '../shared/ToneBadge.js'
 import { asyncHandler } from '../../lib/async-handler.js'
 
@@ -106,7 +110,7 @@ import type {
   CcReleaseSyncDto,
 } from '../../api.js'
 
-const PAGE_SIZE = 50
+const PAGE_SIZE = DEFAULT_TABLE_PAGE_SIZE
 
 const SOURCE_LABELS: Record<BacklinkSource, string> = {
   commoncrawl: 'Common Crawl',
@@ -330,9 +334,7 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
   const pageRows = list?.rows ?? []
   const visibleTotal = list?.total ?? 0
   const hiddenCount = summary?.excludedLinkingDomains ?? 0
-  const canPage = visibleTotal > PAGE_SIZE
   const page = Math.floor(offset / PAGE_SIZE) + 1
-  const totalPages = Math.max(1, Math.ceil(visibleTotal / PAGE_SIZE))
 
   useEffect(() => {
     if (offset > 0 && offset >= visibleTotal) setOffset(0)
@@ -866,14 +868,7 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
         )}
 
         <div className="mt-4">
-          <div className="flex items-center justify-between mb-2">
-            <p className="eyebrow eyebrow-soft">Top referring domains</p>
-            {canPage && (
-              <p className="text-xs text-faint">
-                Page {page} of {totalPages} · {formatNumber(visibleTotal)} total
-              </p>
-            )}
-          </div>
+          <p className="eyebrow eyebrow-soft mb-2">Top referring domains</p>
           <Card className="surface-card overflow-hidden">
             <table className="w-full text-sm">
               <thead>
@@ -899,28 +894,13 @@ export function BacklinksSection({ projectName }: { projectName: string }) {
               </tbody>
             </table>
           </Card>
-          {canPage && (
-            <div className="flex items-center justify-end gap-2 mt-2">
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                disabled={offset === 0}
-                onClick={() => setOffset((v) => Math.max(0, v - PAGE_SIZE))}
-              >
-                Previous
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                disabled={offset + PAGE_SIZE >= visibleTotal}
-                onClick={() => setOffset((v) => v + PAGE_SIZE)}
-              >
-                Next
-              </Button>
-            </div>
-          )}
+          <DataTablePagination
+            page={page}
+            pageSize={PAGE_SIZE}
+            visibleRows={pageRows.length}
+            totalRows={visibleTotal}
+            onPageChange={(nextPage) => setOffset((nextPage - 1) * PAGE_SIZE)}
+          />
         </div>
 
         <div className="mt-4 flex items-center gap-3 flex-wrap">

--- a/apps/web/src/components/project/EvidenceTable.tsx
+++ b/apps/web/src/components/project/EvidenceTable.tsx
@@ -4,6 +4,11 @@ import { CitationStates, brandLabelFromDomain } from '@ainyc/canonry-contracts'
 
 import { Button } from '../ui/button.js'
 import { CitationBadge } from '../shared/CitationBadge.js'
+import {
+  DataTablePagination,
+  DataTableSearch,
+  useClientTable,
+} from '../shared/DataTableControls.js'
 import { ProviderBadge } from '../shared/ProviderBadge.js'
 import { CitationTimeline, mergeProviderHistories } from './CitationTimeline.js'
 import { useDrawer } from '../../hooks/use-drawer.js'
@@ -197,6 +202,17 @@ export function EvidenceTable({
     }
     return [...map.values()]
   }, [evidence, mode, compareLocations])
+  const groupsTable = useClientTable({
+    rows: groups,
+    getSearchText: (group) => [
+      group.phrase,
+      group.location ?? '',
+      ...group.rawItems.map((item) => item.provider),
+    ].join(' '),
+  })
+  const visibleGroupKeys = groupsTable.rows.map((group) => group.key)
+  const visibleGroupsExpanded = visibleGroupKeys.length > 0
+    && visibleGroupKeys.every((key) => expandedRows.has(key))
 
   const toggleRow = (key: string) => {
     setExpandedRows(prev => {
@@ -257,14 +273,17 @@ export function EvidenceTable({
             type="button"
             className="text-[11px] text-secondary hover:text-strong"
             onClick={() => {
-              setExpandedRows(prev =>
-                prev.size === groups.length
-                  ? new Set()
-                  : new Set(groups.map(g => g.key)),
-              )
+              setExpandedRows((previous) => {
+                const next = new Set(previous)
+                for (const key of visibleGroupKeys) {
+                  if (visibleGroupsExpanded) next.delete(key)
+                  else next.add(key)
+                }
+                return next
+              })
             }}
           >
-            {expandedRows.size === groups.length && groups.length > 0 ? 'Collapse all' : 'Expand all'}
+            {visibleGroupsExpanded ? 'Collapse page' : 'Expand page'}
           </button>
           <div className="flex items-center gap-2">
             <span className="text-[10px] uppercase tracking-wide text-muted">Density</span>
@@ -303,6 +322,15 @@ export function EvidenceTable({
           </div>
         </div>
       </div>
+      {groups.length > 0 ? (
+        <DataTableSearch
+          value={groupsTable.query}
+          onChange={groupsTable.setQuery}
+          label="Filter tracked queries"
+          placeholder="Filter query, location, or provider"
+          className="mb-3 max-w-md"
+        />
+      ) : null}
       <div className="evidence-table-wrap">
         <table className="evidence-table">
           <thead>
@@ -316,7 +344,7 @@ export function EvidenceTable({
             </tr>
           </thead>
           <tbody>
-            {groups.map(({ key: groupKey, phrase, location, items, rawItems }) => {
+            {groupsTable.rows.map(({ key: groupKey, phrase, location, items, rawItems }) => {
               const isExpanded = expandedRows.has(groupKey)
               const states = items.map(i => i.citationState)
               const aggState: CitationState =
@@ -435,6 +463,17 @@ export function EvidenceTable({
           </tbody>
         </table>
       </div>
+      {groupsTable.totalRows === 0 && groupsTable.hasQuery ? (
+        <p className="supporting-copy mt-3">No tracked queries match this filter.</p>
+      ) : null}
+      <DataTablePagination
+        page={groupsTable.page}
+        pageSize={groupsTable.pageSize}
+        visibleRows={groupsTable.rows.length}
+        totalRows={groupsTable.totalRows}
+        onPageChange={groupsTable.setPage}
+        itemLabel={groupsTable.hasQuery ? 'matches' : 'queries'}
+      />
       <p className="sr-only" aria-live="polite">
         Showing {presenceVerb === 'cited' ? 'citations (sources)' : 'mentions (answer text)'}.
       </p>

--- a/apps/web/src/components/project/EvidenceTable.tsx
+++ b/apps/web/src/components/project/EvidenceTable.tsx
@@ -25,7 +25,23 @@ export interface EvidenceSignalSummary {
   tone: SignalTone
 }
 
+interface EvidenceGroup {
+  key: string
+  phrase: string
+  location: string | null
+  items: CitationInsightVm[]
+  rawItems: CitationInsightVm[]
+}
+
 const ANSWER_PREVIEW_MAX = 320
+
+function evidenceGroupSearchText(group: EvidenceGroup): string {
+  return [
+    group.phrase,
+    group.location ?? '',
+    ...group.rawItems.map((item) => item.provider),
+  ].join(' ')
+}
 
 /** Map a snapshot to the state value driving the column for the active mode.
  *  In citations mode we read `citationState` directly. In mentions mode we
@@ -183,14 +199,7 @@ export function EvidenceTable({
   const [density, setDensity] = useState<Density>(defaultDensity)
 
   const groups = useMemo(() => {
-    type Group = {
-      key: string
-      phrase: string
-      location: string | null
-      items: CitationInsightVm[]
-      rawItems: CitationInsightVm[]
-    }
-    const map = new Map<string, Group>()
+    const map = new Map<string, EvidenceGroup>()
     for (const rawItem of evidence) {
       const phrase = rawItem.query
       const location = compareLocations ? (rawItem.location ?? null) : null
@@ -204,11 +213,7 @@ export function EvidenceTable({
   }, [evidence, mode, compareLocations])
   const groupsTable = useClientTable({
     rows: groups,
-    getSearchText: (group) => [
-      group.phrase,
-      group.location ?? '',
-      ...group.rawItems.map((item) => item.provider),
-    ].join(' '),
+    getSearchText: evidenceGroupSearchText,
   })
   const visibleGroupKeys = groupsTable.rows.map((group) => group.key)
   const visibleGroupsExpanded = visibleGroupKeys.length > 0

--- a/apps/web/src/components/project/GscSection.tsx
+++ b/apps/web/src/components/project/GscSection.tsx
@@ -1,11 +1,18 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import { useQueryClient } from '@tanstack/react-query'
-import { ChevronLeft, ChevronRight, RefreshCw } from 'lucide-react'
+import { RefreshCw } from 'lucide-react'
 import type { GscPerformanceDailyDto, MetricsWindow } from '@ainyc/canonry-contracts'
 
 import { Button } from '../ui/button.js'
 import { Card } from '../ui/card.js'
+import {
+  DataTablePagination,
+  DataTableSearch,
+  DEFAULT_TABLE_PAGE_SIZE,
+  MiddleTruncatedText,
+  useClientTable,
+} from '../shared/DataTableControls.js'
 import { ToneBadge } from '../shared/ToneBadge.js'
 import { CHART_NEUTRAL, CHART_TONE, CHART_SERIES_COLORS } from '../shared/ChartPrimitives.js'
 import { formatTimestamp, formatBooleanState, SearchMetric, SEARCH_METRIC_LABELS } from '../../lib/format-helpers.js'
@@ -81,7 +88,6 @@ export function GscSection({
     endDate: '',
     query: '',
     page: '',
-    limit: '20',
   })
   const [performanceOffset, setPerformanceOffset] = useState(0)
   const [performanceHasMore, setPerformanceHasMore] = useState(false)
@@ -126,6 +132,11 @@ export function GscSection({
       return dir === 'asc' ? av - bv : bv - av
     })
   }, [performance, perfSort])
+  const performanceTable = useClientTable({
+    rows: sortedPerformance,
+    pageSize: DEFAULT_TABLE_PAGE_SIZE,
+  })
+  const displayedPerformanceRows = performanceDisplayedExpanded ? performanceTable.rows : sortedPerformance
   const [coverageHistory, setCoverageHistory] = useState<Array<{ date: string; indexed: number; notIndexed: number; reasonBreakdown: Record<string, number> }>>([])
   const [selectedReason, setSelectedReason] = useState<string | null>(null)
   const [coveragePage, setCoveragePage] = useState<number>(1)
@@ -160,9 +171,6 @@ export function GscSection({
   const coverageTotalPages = Math.max(1, Math.ceil(coverageList.length / COVERAGE_PAGE_SIZE))
   const coverageCurrentPage = Math.min(Math.max(1, coveragePage), coverageTotalPages)
   const coveragePageStart = (coverageCurrentPage - 1) * COVERAGE_PAGE_SIZE
-  const coverageShowPagination = coverageList.length > COVERAGE_PAGE_SIZE
-  const coverageRangeStart = coverageList.length === 0 ? 0 : coveragePageStart + 1
-  const coverageRangeEnd = Math.min(coveragePageStart + COVERAGE_PAGE_SIZE, coverageList.length)
 
   const pagedIndexed = useMemo(
     () => coverage?.indexed.slice(coveragePageStart, coveragePageStart + COVERAGE_PAGE_SIZE) ?? [],
@@ -260,11 +268,10 @@ export function GscSection({
     setLoadingPerformance(true)
     const offset = offsetOverride ?? performanceOffset
     try {
-      const pageSize = parseInt(performanceFilters.limit, 10) || 20
       // Expanded mode (filter or sort active) fetches up to EXPANDED_PERFORMANCE_LIMIT
       // so client-side sort/filter sees the full matching set, not just one page.
       // Paged mode fetches pageSize+1 to detect "has more" without a COUNT query.
-      const fetchLimit = isPerformanceExpanded ? EXPANDED_PERFORMANCE_LIMIT : pageSize + 1
+      const fetchLimit = isPerformanceExpanded ? EXPANDED_PERFORMANCE_LIMIT : DEFAULT_TABLE_PAGE_SIZE + 1
       const fetchOffset = isPerformanceExpanded ? 0 : offset
       // URL-string query params per the spec — empty strings stripped so the
       // generated cache key only varies on values the server actually sees.
@@ -291,8 +298,8 @@ export function GscSection({
         setPerformanceTotalLoaded(rows.length)
         setPerformanceDisplayedExpanded(true)
       } else {
-        setPerformanceHasMore(rows.length > pageSize)
-        setPerformance(rows.slice(0, pageSize))
+        setPerformanceHasMore(rows.length > DEFAULT_TABLE_PAGE_SIZE)
+        setPerformance(rows.slice(0, DEFAULT_TABLE_PAGE_SIZE))
         setPerformanceTotalLoaded(0)
         setPerformanceDisplayedExpanded(false)
       }
@@ -1250,41 +1257,14 @@ export function GscSection({
                         <p className="text-sm text-muted">No URLs in this category.</p>
                       )}
 
-                      {coverageShowPagination && (
-                        <div className="mt-3 flex flex-wrap items-center justify-between gap-x-4 gap-y-2 text-xs text-secondary">
-                          <p className="tabular-nums">
-                            Showing <span className="text-neutral">{coverageRangeStart.toLocaleString('en-US')}</span>–
-                            <span className="text-neutral">{coverageRangeEnd.toLocaleString('en-US')}</span> of{' '}
-                            <span className="text-neutral">{coverageList.length.toLocaleString('en-US')}</span> URLs
-                          </p>
-                          <div className="flex items-center gap-2">
-                            <button
-                              type="button"
-                              onClick={() => setCoveragePage((p) => Math.max(1, p - 1))}
-                              disabled={coverageCurrentPage <= 1}
-                              aria-label="Previous page"
-                              className="inline-flex items-center gap-1 rounded-md border border-base bg-bg px-2.5 py-1.5 text-strong transition hover:border-strong hover:text-primary disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-mono-800 disabled:hover:text-strong"
-                            >
-                              <ChevronLeft className="size-3.5" />
-                              Prev
-                            </button>
-                            <span className="tabular-nums">
-                              Page <span className="text-strong">{coverageCurrentPage}</span> of{' '}
-                              <span className="text-strong">{coverageTotalPages}</span>
-                            </span>
-                            <button
-                              type="button"
-                              onClick={() => setCoveragePage((p) => Math.min(coverageTotalPages, p + 1))}
-                              disabled={coverageCurrentPage >= coverageTotalPages}
-                              aria-label="Next page"
-                              className="inline-flex items-center gap-1 rounded-md border border-base bg-bg px-2.5 py-1.5 text-strong transition hover:border-strong hover:text-primary disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-mono-800 disabled:hover:text-strong"
-                            >
-                              Next
-                              <ChevronRight className="size-3.5" />
-                            </button>
-                          </div>
-                        </div>
-                      )}
+                      <DataTablePagination
+                        page={coverageCurrentPage}
+                        pageSize={COVERAGE_PAGE_SIZE}
+                        visibleRows={Math.min(COVERAGE_PAGE_SIZE, coverageList.length - coveragePageStart)}
+                        totalRows={coverageList.length}
+                        onPageChange={setCoveragePage}
+                        itemLabel="URLs"
+                      />
                     </div>
                   </>
                 ) : (
@@ -1320,7 +1300,7 @@ export function GscSection({
                         </button>
                       ))}
                     </div>
-                    <Button type="button" variant="outline" size="sm" disabled={loadingPerformance} onClick={() => { setPerformanceOffset(0); void loadPerformanceRows(0); void loadPerformanceDaily() }}>
+                    <Button type="button" variant="outline" size="sm" disabled={loadingPerformance} onClick={() => { setPerformanceOffset(0); performanceTable.setPage(1); void loadPerformanceRows(0); void loadPerformanceDaily() }}>
                       <RefreshCw className={`h-3.5 w-3.5 ${loadingPerformance ? 'animate-spin' : ''}`} aria-hidden="true" />
                       {loadingPerformance ? 'Loading\u2026' : 'Apply filters'}
                     </Button>
@@ -1430,7 +1410,7 @@ export function GscSection({
                   )
                 })()}
 
-                <div className="mt-3 grid gap-2 lg:grid-cols-5">
+                <div className="mt-3 grid gap-2 lg:grid-cols-4">
                   <input
                     className="rounded border border-strong bg-transparent px-2 py-1.5 text-sm text-strong placeholder-mono-600 focus:border-mono-500 focus:outline-none"
                     type="date"
@@ -1447,38 +1427,22 @@ export function GscSection({
                     value={performanceFilters.endDate}
                     onChange={(e) => setPerformanceFilters((prev) => ({ ...prev, endDate: e.target.value }))}
                   />
-                  <input
-                    className="rounded border border-strong bg-transparent px-2 py-1.5 text-sm text-strong placeholder-mono-600 focus:border-mono-500 focus:outline-none"
-                    type="text"
-                    placeholder="Contains query…"
-                    aria-label="Filter query (substring match)"
-                    title="Case-insensitive substring match on the query column."
+                  <DataTableSearch
                     value={performanceFilters.query}
-                    onChange={(e) => setPerformanceFilters((prev) => ({ ...prev, query: e.target.value }))}
+                    onChange={(value) => setPerformanceFilters((prev) => ({ ...prev, query: value }))}
+                    label="Filter search queries"
+                    placeholder="Contains query…"
                   />
-                  <input
-                    className="rounded border border-strong bg-transparent px-2 py-1.5 text-sm text-strong placeholder-mono-600 focus:border-mono-500 focus:outline-none"
-                    type="text"
-                    placeholder="Contains page URL…"
-                    aria-label="Filter page (substring match)"
-                    title="Case-insensitive substring match on the page URL."
+                  <DataTableSearch
                     value={performanceFilters.page}
-                    onChange={(e) => setPerformanceFilters((prev) => ({ ...prev, page: e.target.value }))}
-                  />
-                  <input
-                    className="rounded border border-strong bg-transparent px-2 py-1.5 text-sm text-strong placeholder-mono-600 focus:border-mono-500 focus:outline-none"
-                    type="number"
-                    min="1"
-                    placeholder="Rows per page (20)"
-                    aria-label="Rows per page"
-                    title="Rows per page. Ignored while a filter or column sort is active — then up to 500 matches are loaded."
-                    value={performanceFilters.limit}
-                    onChange={(e) => setPerformanceFilters((prev) => ({ ...prev, limit: e.target.value }))}
+                    onChange={(value) => setPerformanceFilters((prev) => ({ ...prev, page: value }))}
+                    label="Filter page URLs"
+                    placeholder="Contains page URL…"
                   />
                 </div>
                 <p className="mt-2 text-xs text-muted">
                   Query and page filters match case-insensitive substrings. Click Apply filters to run.
-                  When a filter or column sort is active, up to {EXPANDED_PERFORMANCE_LIMIT.toLocaleString()} matching rows load so sorting covers the full set.
+                  Filtering and sorting examine up to {EXPANDED_PERFORMANCE_LIMIT.toLocaleString()} matching rows while the table stays at {DEFAULT_TABLE_PAGE_SIZE} rows per page.
                 </p>
                 {performance.length > 0 ? (
                   <>
@@ -1498,7 +1462,8 @@ export function GscSection({
                                 <button
                                   type="button"
                                   className="w-full cursor-pointer select-none text-right hover:text-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-mono-400 rounded px-1 -mx-1"
-                                  onClick={() =>
+                                  onClick={() => {
+                                    performanceTable.setPage(1)
                                     setPerfSort((prev) =>
                                       prev?.key === col
                                         ? prev.dir === 'desc'
@@ -1506,7 +1471,7 @@ export function GscSection({
                                           : null
                                         : { key: col, dir: 'desc' },
                                     )
-                                  }
+                                  }}
                                 >
                                   {SEARCH_METRIC_LABELS[col]}
                                   {perfSort?.key === col ? (perfSort.dir === 'desc' ? ' \u2193' : ' \u2191') : ''}
@@ -1516,11 +1481,13 @@ export function GscSection({
                           </tr>
                         </thead>
                         <tbody>
-                          {sortedPerformance.map((row, i) => (
+                          {displayedPerformanceRows.map((row, i) => (
                             <tr key={`${row.date}:${row.query}:${row.page}:${i}`}>
                               <td className="text-secondary">{row.date}</td>
                               <td className="max-w-xs truncate text-strong">{row.query}</td>
-                              <td className="max-w-xs truncate text-secondary">{row.page}</td>
+                              <td className="max-w-xs text-secondary">
+                                <MiddleTruncatedText value={row.page} />
+                              </td>
                               <td className="text-right tabular-nums text-neutral">{row.clicks.toLocaleString()}</td>
                               <td className="text-right tabular-nums text-secondary">{row.impressions.toLocaleString()}</td>
                               <td className="text-right tabular-nums text-secondary">{(Number.isFinite(row.ctr) ? row.ctr * 100 : 0).toFixed(1)}%</td>
@@ -1530,56 +1497,31 @@ export function GscSection({
                         </tbody>
                       </table>
                     </div>
-                    {performanceDisplayedExpanded ? (
-                      <div className="mt-3 text-xs text-muted">
-                        <span className="tabular-nums">
-                          Showing {performanceTotalLoaded.toLocaleString()} matching row{performanceTotalLoaded === 1 ? '' : 's'}
-                          {performanceTotalLoaded >= EXPANDED_PERFORMANCE_LIMIT
-                            ? ` (capped at ${EXPANDED_PERFORMANCE_LIMIT.toLocaleString()} \u2014 narrow the filter to see more)`
-                            : ''}
-                        </span>
-                      </div>
-                    ) : (performanceOffset > 0 || performanceHasMore) && (() => {
-                      const pageSize = parseInt(performanceFilters.limit, 10) || 20
-                      const from = performanceOffset + 1
-                      const to = performanceOffset + performance.length
-                      return (
-                        <div className="mt-3 flex items-center justify-between text-xs text-muted">
-                          <span className="tabular-nums">
-                            Showing {from.toLocaleString()}{' \u2013 '}{to.toLocaleString()}
-                            {performanceHasMore ? '+' : ''}
-                          </span>
-                          <div className="flex items-center gap-2">
-                            <Button
-                              type="button"
-                              variant="outline"
-                              size="sm"
-                              disabled={loadingPerformance || performanceOffset === 0}
-                              onClick={() => {
-                                const next = Math.max(0, performanceOffset - pageSize)
-                                setPerformanceOffset(next)
-                                void loadPerformanceRows(next)
-                              }}
-                            >
-                              Previous
-                            </Button>
-                            <Button
-                              type="button"
-                              variant="outline"
-                              size="sm"
-                              disabled={loadingPerformance || !performanceHasMore}
-                              onClick={() => {
-                                const next = performanceOffset + pageSize
-                                setPerformanceOffset(next)
-                                void loadPerformanceRows(next)
-                              }}
-                            >
-                              Next
-                            </Button>
-                          </div>
-                        </div>
-                      )
-                    })()}
+                    <DataTablePagination
+                      page={performanceDisplayedExpanded
+                        ? performanceTable.page
+                        : Math.floor(performanceOffset / DEFAULT_TABLE_PAGE_SIZE) + 1}
+                      pageSize={DEFAULT_TABLE_PAGE_SIZE}
+                      visibleRows={displayedPerformanceRows.length}
+                      totalRows={performanceDisplayedExpanded ? performanceTotalLoaded : undefined}
+                      hasNextPage={performanceDisplayedExpanded ? undefined : performanceHasMore}
+                      disabled={loadingPerformance}
+                      itemLabel={performanceDisplayedExpanded ? 'matches' : 'rows'}
+                      onPageChange={(nextPage) => {
+                        if (performanceDisplayedExpanded) {
+                          performanceTable.setPage(nextPage)
+                          return
+                        }
+                        const nextOffset = (nextPage - 1) * DEFAULT_TABLE_PAGE_SIZE
+                        setPerformanceOffset(nextOffset)
+                        void loadPerformanceRows(nextOffset)
+                      }}
+                    />
+                    {performanceDisplayedExpanded && performanceTotalLoaded >= EXPANDED_PERFORMANCE_LIMIT ? (
+                      <p className="mt-2 text-xs text-muted">
+                        Results are capped at {EXPANDED_PERFORMANCE_LIMIT.toLocaleString()}; narrow the filters to search beyond this set.
+                      </p>
+                    ) : null}
                   </>
                 ) : (
                   <p className="mt-3 text-sm text-muted">No performance rows match the current filters yet.</p>

--- a/apps/web/src/components/project/GscSection.tsx
+++ b/apps/web/src/components/project/GscSection.tsx
@@ -607,6 +607,7 @@ export function GscSection({
 
   useEffect(() => {
     setPerformanceOffset(0)
+    performanceTable.setPage(1)
     void loadPerformanceRows(0)
     void loadPerformanceDaily()
   }, [gscWindow])

--- a/apps/web/src/components/project/TechnicalAeoSection.tsx
+++ b/apps/web/src/components/project/TechnicalAeoSection.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react'
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { AlertTriangle, ChevronDown, ChevronRight, LoaderCircle, Play, RefreshCw, ScanSearch } from 'lucide-react'
 import type { MetricTone } from '../../view-models.js'
@@ -45,6 +45,11 @@ import { getRunTrackerState, subscribeRunTracker } from '../../lib/run-tracker-s
 
 const PAGES_FETCH_LIMIT = 100
 const FACTOR_DRILLDOWN_PAGE_CAP = 12
+const EMPTY_SITE_AUDIT_PAGES: SiteAuditPageDto[] = []
+
+function siteAuditPageSearchText(page: SiteAuditPageDto): string {
+  return urlSearchText(page.url)
+}
 
 function scoreTone(score: number): MetricTone {
   if (score >= 70) return 'positive'
@@ -201,13 +206,16 @@ export function TechnicalAeoSection({ projectName, projectId }: { projectName: s
       : 'Starting audit'
 
   const score = scoreQuery.data
-  const allPages = pagesQuery.data?.pages ?? []
+  const allPages = pagesQuery.data?.pages ?? EMPTY_SITE_AUDIT_PAGES
   const hasErrors = (score?.pagesErrored ?? 0) > 0
   const showErrorsOnly = errorsOnly && hasErrors
-  const tableSourcePages = showErrorsOnly ? allPages.filter((p) => p.status === 'error') : allPages
+  const tableSourcePages = useMemo(
+    () => showErrorsOnly ? allPages.filter((page) => page.status === 'error') : allPages,
+    [allPages, showErrorsOnly],
+  )
   const pagesTable = useClientTable({
     rows: tableSourcePages,
-    getSearchText: (page) => urlSearchText(page.url),
+    getSearchText: siteAuditPageSearchText,
   })
   const pagesCapped = score ? score.pagesAudited > allPages.length : false
 
@@ -623,7 +631,12 @@ export function TechnicalAeoSection({ projectName, projectId }: { projectName: s
                       <td>{p.status === 'error' ? <ToneBadge tone="negative">Error</ToneBadge> : <ToneBadge tone={scoreTone(p.overallScore)}>{statusLabel(p.overallScore)}</ToneBadge>}</td>
                       <td className="w-full max-w-0">
                         <a href={p.url} target="_blank" rel="noreferrer" className="block truncate text-neutral hover:text-heading" title={p.status === 'error' ? p.error ?? p.url : p.url}>
-                          <MiddleTruncatedText value={p.url} headLength={54} tailLength={20} />
+                          <MiddleTruncatedText
+                            value={p.url}
+                            headLength={54}
+                            tailLength={20}
+                            title={p.status === 'error' ? p.error ?? p.url : p.url}
+                          />
                         </a>
                       </td>
                     </tr>

--- a/apps/web/src/components/project/TechnicalAeoSection.tsx
+++ b/apps/web/src/components/project/TechnicalAeoSection.tsx
@@ -31,6 +31,13 @@ import {
 import { addToast } from '../../lib/toast-store.js'
 import { Button } from '../ui/button.js'
 import { Card } from '../ui/card.js'
+import {
+  DataTablePagination,
+  DataTableSearch,
+  MiddleTruncatedText,
+  urlSearchText,
+  useClientTable,
+} from '../shared/DataTableControls.js'
 import { ToneBadge } from '../shared/ToneBadge.js'
 import { InfoTooltip } from '../shared/InfoTooltip.js'
 import { useTriggerSiteAudit } from '../../queries/mutations.js'
@@ -194,6 +201,15 @@ export function TechnicalAeoSection({ projectName, projectId }: { projectName: s
       : 'Starting audit'
 
   const score = scoreQuery.data
+  const allPages = pagesQuery.data?.pages ?? []
+  const hasErrors = (score?.pagesErrored ?? 0) > 0
+  const showErrorsOnly = errorsOnly && hasErrors
+  const tableSourcePages = showErrorsOnly ? allPages.filter((p) => p.status === 'error') : allPages
+  const pagesTable = useClientTable({
+    rows: tableSourcePages,
+    getSearchText: (page) => urlSearchText(page.url),
+  })
+  const pagesCapped = score ? score.pagesAudited > allPages.length : false
 
   useEffect(() => {
     setErrorsOnly(false)
@@ -246,12 +262,7 @@ export function TechnicalAeoSection({ projectName, projectId }: { projectName: s
   const trendPoints = trendQuery.data?.points ?? []
   const trendRows = trendPoints.map((p) => ({ runId: p.runId, date: p.auditedAt, score: p.aggregateScore }))
   const viewingHistorical = selectedRunId !== null
-  const allPages = pagesQuery.data?.pages ?? []
   const successPages = allPages.filter((p) => p.status === 'success')
-  const hasErrors = score.pagesErrored > 0
-  const showErrorsOnly = errorsOnly && hasErrors
-  const visiblePages = showErrorsOnly ? allPages.filter((p) => p.status === 'error') : allPages
-  const pagesCapped = score.pagesAudited > allPages.length
 
   // For a factor, the audited pages scoring below pass (< 70) on that factor,
   // worst-first — the "what's failing" behind the pass/partial/fail counts.
@@ -554,7 +565,10 @@ export function TechnicalAeoSection({ projectName, projectId }: { projectName: s
             <div className="inline-flex items-center gap-1 rounded-full border border-default p-0.5" role="group" aria-label="Filter pages">
               <button
                 type="button"
-                onClick={() => setErrorsOnly(false)}
+                onClick={() => {
+                  setErrorsOnly(false)
+                  pagesTable.setPage(1)
+                }}
                 aria-pressed={!showErrorsOnly}
                 className={`min-h-11 rounded-full px-3 py-1 text-xs font-medium tabular-nums transition-colors ${!showErrorsOnly ? 'bg-mono-800 text-heading' : 'text-muted hover:text-neutral'}`}
               >
@@ -562,7 +576,10 @@ export function TechnicalAeoSection({ projectName, projectId }: { projectName: s
               </button>
               <button
                 type="button"
-                onClick={() => setErrorsOnly(true)}
+                onClick={() => {
+                  setErrorsOnly(true)
+                  pagesTable.setPage(1)
+                }}
                 aria-pressed={showErrorsOnly}
                 className={`min-h-11 rounded-full px-3 py-1 text-xs font-medium tabular-nums transition-colors ${showErrorsOnly ? 'bg-negative-500/15 text-negative' : 'text-muted hover:text-neutral'}`}
               >
@@ -571,8 +588,19 @@ export function TechnicalAeoSection({ projectName, projectId }: { projectName: s
             </div>
           ) : null}
         </div>
-        {visiblePages.length === 0 ? (
-          <p className="supporting-copy mt-3">No pages recorded.</p>
+        {allPages.length > 0 ? (
+          <DataTableSearch
+            value={pagesTable.query}
+            onChange={pagesTable.setQuery}
+            label="Filter audited page URLs"
+            placeholder="Filter page URL or query parameters"
+            className="mt-3 max-w-md"
+          />
+        ) : null}
+        {pagesTable.totalRows === 0 ? (
+          <p className="supporting-copy mt-3">
+            {pagesTable.hasQuery ? 'No pages match this filter.' : 'No pages recorded.'}
+          </p>
         ) : (
           <>
             <div className="evidence-table-wrap mt-3">
@@ -585,7 +613,7 @@ export function TechnicalAeoSection({ projectName, projectId }: { projectName: s
                   </tr>
                 </thead>
                 <tbody>
-                  {visiblePages.map((p: SiteAuditPageDto) => (
+                  {pagesTable.rows.map((p: SiteAuditPageDto) => (
                     <tr key={p.url}>
                       <td className="text-right tabular-nums">
                         {p.status === 'error'
@@ -595,7 +623,7 @@ export function TechnicalAeoSection({ projectName, projectId }: { projectName: s
                       <td>{p.status === 'error' ? <ToneBadge tone="negative">Error</ToneBadge> : <ToneBadge tone={scoreTone(p.overallScore)}>{statusLabel(p.overallScore)}</ToneBadge>}</td>
                       <td className="w-full max-w-0">
                         <a href={p.url} target="_blank" rel="noreferrer" className="block truncate text-neutral hover:text-heading" title={p.status === 'error' ? p.error ?? p.url : p.url}>
-                          {p.url}
+                          <MiddleTruncatedText value={p.url} headLength={54} tailLength={20} />
                         </a>
                       </td>
                     </tr>
@@ -603,6 +631,14 @@ export function TechnicalAeoSection({ projectName, projectId }: { projectName: s
                 </tbody>
               </table>
             </div>
+            <DataTablePagination
+              page={pagesTable.page}
+              pageSize={pagesTable.pageSize}
+              visibleRows={pagesTable.rows.length}
+              totalRows={pagesTable.totalRows}
+              onPageChange={pagesTable.setPage}
+              itemLabel={pagesTable.hasQuery ? 'matches' : 'rows'}
+            />
             {pagesCapped ? (
               <p className="mt-2 text-xs text-faint">Showing the worst {allPages.length} of {score.pagesAudited} audited pages.</p>
             ) : null}

--- a/apps/web/src/components/shared/DataTableControls.tsx
+++ b/apps/web/src/components/shared/DataTableControls.tsx
@@ -38,15 +38,24 @@ export function MiddleTruncatedText({
   headLength,
   tailLength,
   className,
+  title,
 }: {
   value: string
   headLength?: number
   tailLength?: number
   className?: string
+  title?: string
 }) {
+  const displayValue = truncateMiddleText(value, headLength, tailLength)
+
   return (
-    <span className={className} title={value} aria-label={value}>
-      {truncateMiddleText(value, headLength, tailLength)}
+    <span className={className} title={title ?? value}>
+      {displayValue === value ? value : (
+        <>
+          <span className="sr-only">{value}</span>
+          <span aria-hidden="true">{displayValue}</span>
+        </>
+      )}
     </span>
   )
 }
@@ -132,7 +141,7 @@ export function DataTableSearch({
         placeholder={placeholder}
         autoComplete="off"
         spellCheck={false}
-        className="h-9 w-full rounded-md border border-default bg-surface/50 pl-9 pr-9 text-sm text-strong placeholder:text-muted outline-none transition focus:border-mono-500 focus:ring-1 focus:ring-mono-500"
+        className="h-9 w-full rounded-md border border-default bg-surface/50 pl-9 pr-9 text-sm text-strong placeholder:text-muted outline-none transition focus:border-mono-500 focus:ring-1 focus:ring-mono-500 [&::-webkit-search-cancel-button]:appearance-none"
       />
       {value.trim().length > 0 ? (
         <button

--- a/apps/web/src/components/shared/DataTableControls.tsx
+++ b/apps/web/src/components/shared/DataTableControls.tsx
@@ -1,0 +1,215 @@
+import { useCallback, useMemo, useState } from 'react'
+import { ChevronLeft, ChevronRight, Search, X } from 'lucide-react'
+
+export const DEFAULT_TABLE_PAGE_SIZE = 25
+
+function queryTokens(query: string): string[] {
+  return query.trim().toLocaleLowerCase().split(/\s+/).filter(Boolean)
+}
+
+export function urlSearchText(value: string): string {
+  let decoded = value
+  try {
+    decoded = decodeURIComponent(value.replace(/\+/g, ' '))
+  } catch {
+    // Keep malformed URLs searchable by their raw value.
+  }
+
+  let parameters = ''
+  const queryStart = value.indexOf('?')
+  if (queryStart >= 0) {
+    const params = new URLSearchParams(value.slice(queryStart + 1))
+    params.forEach((parameterValue, key) => {
+      parameters += ` ${key} ${parameterValue}`
+    })
+  }
+
+  return `${value} ${decoded}${parameters}`
+}
+
+export function truncateMiddleText(value: string, headLength = 36, tailLength = 18): string {
+  const characters = [...value]
+  if (characters.length <= headLength + tailLength + 1) return value
+  return `${characters.slice(0, headLength).join('')}…${characters.slice(-tailLength).join('')}`
+}
+
+export function MiddleTruncatedText({
+  value,
+  headLength,
+  tailLength,
+  className,
+}: {
+  value: string
+  headLength?: number
+  tailLength?: number
+  className?: string
+}) {
+  return (
+    <span className={className} title={value} aria-label={value}>
+      {truncateMiddleText(value, headLength, tailLength)}
+    </span>
+  )
+}
+
+export function useClientTable<T>({
+  rows,
+  getSearchText,
+  pageSize = DEFAULT_TABLE_PAGE_SIZE,
+}: {
+  rows: readonly T[]
+  getSearchText?: (row: T) => string
+  pageSize?: number
+}) {
+  const [query, setQueryValue] = useState('')
+  const [pageValue, setPageValue] = useState(1)
+  const tokens = useMemo(() => queryTokens(query), [query])
+
+  const filteredRows = useMemo(() => {
+    if (tokens.length === 0 || !getSearchText) return rows
+    return rows.filter((row) => {
+      const searchableText = getSearchText(row).toLocaleLowerCase()
+      return tokens.every((token) => searchableText.includes(token))
+    })
+  }, [getSearchText, rows, tokens])
+
+  const totalPages = Math.max(1, Math.ceil(filteredRows.length / pageSize))
+  const page = Math.min(Math.max(1, pageValue), totalPages)
+  const pageStart = (page - 1) * pageSize
+  const pageRows = useMemo(
+    () => filteredRows.slice(pageStart, pageStart + pageSize),
+    [filteredRows, pageSize, pageStart],
+  )
+
+  const setQuery = useCallback((value: string) => {
+    setQueryValue(value)
+    setPageValue(1)
+  }, [])
+
+  const setPage = useCallback((value: number) => {
+    setPageValue(Math.max(1, value))
+  }, [])
+
+  return {
+    query,
+    setQuery,
+    page,
+    setPage,
+    rows: pageRows,
+    filteredRows,
+    totalRows: filteredRows.length,
+    totalPages,
+    pageSize,
+    rangeStart: filteredRows.length === 0 ? 0 : pageStart + 1,
+    rangeEnd: pageStart + pageRows.length,
+    hasQuery: query.trim().length > 0,
+  }
+}
+
+export function DataTableSearch({
+  value,
+  onChange,
+  label,
+  placeholder = 'Filter rows',
+  className,
+}: {
+  value: string
+  onChange: (value: string) => void
+  label: string
+  placeholder?: string
+  className?: string
+}) {
+  return (
+    <div className={`relative ${className ?? ''}`}>
+      <Search
+        aria-hidden="true"
+        className="pointer-events-none absolute left-3 top-1/2 size-3.5 -translate-y-1/2 text-muted"
+      />
+      <input
+        type="search"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        aria-label={label}
+        placeholder={placeholder}
+        autoComplete="off"
+        spellCheck={false}
+        className="h-9 w-full rounded-md border border-default bg-surface/50 pl-9 pr-9 text-sm text-strong placeholder:text-muted outline-none transition focus:border-mono-500 focus:ring-1 focus:ring-mono-500"
+      />
+      {value.trim().length > 0 ? (
+        <button
+          type="button"
+          onClick={() => onChange('')}
+          aria-label={`Clear ${label.toLocaleLowerCase()}`}
+          className="absolute right-2 top-1/2 inline-flex size-6 -translate-y-1/2 items-center justify-center rounded text-muted transition-colors hover:bg-surface-hover hover:text-strong focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-mono-500"
+        >
+          <X aria-hidden="true" className="size-3.5" />
+        </button>
+      ) : null}
+    </div>
+  )
+}
+
+export function DataTablePagination({
+  page,
+  pageSize = DEFAULT_TABLE_PAGE_SIZE,
+  visibleRows,
+  totalRows,
+  hasNextPage,
+  onPageChange,
+  itemLabel = 'rows',
+  className,
+  disabled = false,
+}: {
+  page: number
+  pageSize?: number
+  visibleRows: number
+  totalRows?: number
+  hasNextPage?: boolean
+  onPageChange: (page: number) => void
+  itemLabel?: string
+  className?: string
+  disabled?: boolean
+}) {
+  if (visibleRows === 0) return null
+
+  const rangeStart = (page - 1) * pageSize + 1
+  const rangeEnd = rangeStart + visibleRows - 1
+  const totalPages = totalRows === undefined ? undefined : Math.max(1, Math.ceil(totalRows / pageSize))
+  const canGoNext = hasNextPage ?? (totalPages !== undefined && page < totalPages)
+  const showPageControls = page > 1 || canGoNext
+
+  return (
+    <div className={`mt-3 flex flex-wrap items-center justify-between gap-x-4 gap-y-2 text-xs text-secondary ${className ?? ''}`}>
+      <p className="tabular-nums">
+        {rangeStart.toLocaleString('en-US')}–{rangeEnd.toLocaleString('en-US')}
+        {totalRows === undefined
+          ? `${canGoNext ? '+' : ''} ${itemLabel}`
+          : ` of ${totalRows.toLocaleString('en-US')} ${itemLabel}`}
+      </p>
+      {showPageControls ? (
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => onPageChange(page - 1)}
+            disabled={disabled || page <= 1}
+            className="inline-flex items-center gap-1 rounded-md border border-base bg-bg px-2.5 py-1.5 text-strong transition hover:border-strong hover:text-primary disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-base disabled:hover:text-strong"
+          >
+            <ChevronLeft aria-hidden="true" className="size-3.5" />
+            Previous
+          </button>
+          <span className="tabular-nums">
+            {totalPages === undefined ? `Page ${page}` : `Page ${page} of ${totalPages}`}
+          </span>
+          <button
+            type="button"
+            onClick={() => onPageChange(page + 1)}
+            disabled={disabled || !canGoNext}
+            className="inline-flex items-center gap-1 rounded-md border border-base bg-bg px-2.5 py-1.5 text-strong transition hover:border-strong hover:text-primary disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-base disabled:hover:text-strong"
+          >
+            Next
+            <ChevronRight aria-hidden="true" className="size-3.5" />
+          </button>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/test/activity-section-pagination.test.tsx
+++ b/apps/web/test/activity-section-pagination.test.tsx
@@ -132,39 +132,49 @@ function renderPanel(landingPages: ApiGaTrafficAiLandingPage[]) {
   )
 }
 
-test('shows 50 landing-page rows per page and paginates the rest', async () => {
+test('shows 25 landing-page rows per page and paginates the rest', async () => {
   renderPanel(makeLandingPages(60))
 
-  // Page 1: first 50 rows render, the 51st does not.
-  await waitFor(() => expect(screen.getByText('1–50 of 60 rows')).toBeTruthy())
+  // Page 1: first 25 rows render, the 26th does not.
+  await waitFor(() => expect(screen.getByText('1–25 of 60 rows')).toBeTruthy())
   expect(screen.getByText('/page-000')).toBeTruthy()
-  expect(screen.getByText('/page-049')).toBeTruthy()
-  expect(screen.queryByText('/page-050')).toBeNull()
+  expect(screen.getByText('/page-024')).toBeTruthy()
+  expect(screen.queryByText('/page-025')).toBeNull()
 
-  // Controls: Page 1 of 2, Previous disabled, Next enabled.
-  expect(screen.getByText('Page 1 of 2')).toBeTruthy()
+  // Controls: Page 1 of 3, Previous disabled, Next enabled.
+  expect(screen.getByText('Page 1 of 3')).toBeTruthy()
   const prev = screen.getByRole('button', { name: 'Previous' })
   const next = screen.getByRole('button', { name: 'Next' })
   expect(prev.hasAttribute('disabled')).toBe(true)
   expect(next.hasAttribute('disabled')).toBe(false)
 
-  // Advance: page 2 shows the remaining 10 rows, Next is now disabled.
+  // Advance: page 2 shows the next 25 rows.
   fireEvent.click(next)
+  await waitFor(() => expect(screen.getByText('26–50 of 60 rows')).toBeTruthy())
+  expect(screen.getByText('Page 2 of 3')).toBeTruthy()
+  expect(screen.getByText('/page-025')).toBeTruthy()
+  expect(screen.getByText('/page-049')).toBeTruthy()
+  expect(screen.queryByText('/page-024')).toBeNull()
+  expect(screen.getByRole('button', { name: 'Next' }).hasAttribute('disabled')).toBe(false)
+  expect(screen.getByRole('button', { name: 'Previous' }).hasAttribute('disabled')).toBe(false)
+
+  // Page 3 shows the remaining 10 rows, and Next is now disabled.
+  fireEvent.click(screen.getByRole('button', { name: 'Next' }))
   await waitFor(() => expect(screen.getByText('51–60 of 60 rows')).toBeTruthy())
-  expect(screen.getByText('Page 2 of 2')).toBeTruthy()
+  expect(screen.getByText('Page 3 of 3')).toBeTruthy()
   expect(screen.getByText('/page-050')).toBeTruthy()
   expect(screen.getByText('/page-059')).toBeTruthy()
   expect(screen.queryByText('/page-049')).toBeNull()
   expect(screen.getByRole('button', { name: 'Next' }).hasAttribute('disabled')).toBe(true)
-  expect(screen.getByRole('button', { name: 'Previous' }).hasAttribute('disabled')).toBe(false)
 })
 
-test('renders no pagination controls when there are 50 or fewer rows', async () => {
-  renderPanel(makeLandingPages(50))
+test('renders no pagination controls when there are 25 or fewer rows', async () => {
+  renderPanel(makeLandingPages(25))
 
-  await waitFor(() => expect(screen.getByText('50 rows')).toBeTruthy())
-  // No range caption and no pager for a single page.
-  expect(screen.queryByText('1–50 of 50 rows')).toBeNull()
+  await waitFor(() => expect(screen.getByText('25 rows')).toBeTruthy())
+  // The shared footer always reports the visible range, but omits page controls
+  // when there is only one page.
+  expect(screen.getByText('1–25 of 25 rows')).toBeTruthy()
   expect(screen.queryByRole('button', { name: 'Next' })).toBeNull()
   expect(screen.queryByRole('button', { name: 'Previous' })).toBeNull()
   expect(screen.queryByText(/Page \d+ of/)).toBeNull()
@@ -174,12 +184,47 @@ test('changing the sort resets to page 1', async () => {
   renderPanel(makeLandingPages(60))
 
   // Jump to page 2.
-  await waitFor(() => expect(screen.getByText('Page 1 of 2')).toBeTruthy())
+  await waitFor(() => expect(screen.getByText('Page 1 of 3')).toBeTruthy())
   fireEvent.click(screen.getByRole('button', { name: 'Next' }))
-  await waitFor(() => expect(screen.getByText('Page 2 of 2')).toBeTruthy())
+  await waitFor(() => expect(screen.getByText('Page 2 of 3')).toBeTruthy())
 
   // Re-sorting (click the "Landing Page" header) snaps back to page 1.
   fireEvent.click(screen.getByRole('button', { name: /Landing Page/ }))
-  await waitFor(() => expect(screen.getByText('Page 1 of 2')).toBeTruthy())
-  expect(screen.getByText('1–50 of 60 rows')).toBeTruthy()
+  await waitFor(() => expect(screen.getByText('Page 1 of 3')).toBeTruthy())
+  expect(screen.getByText('1–25 of 60 rows')).toBeTruthy()
+})
+
+test('middle-truncates long URLs while preserving the full value for filtering and accessibility', async () => {
+  const landingPage = `/audit?olref=${'summer-launch-'.repeat(8)}&campaign=summer-launch&content=footer-link`
+  renderPanel([
+    {
+      source: 'chatgpt.com',
+      medium: 'referral',
+      sourceDimension: 'manual_utm',
+      landingPage,
+      sessions: 12,
+      users: 9,
+    },
+    ...makeLandingPages(30),
+  ])
+
+  await waitFor(() => expect(screen.getByText('1–25 of 31 rows')).toBeTruthy())
+  const expectedDisplay = `${[...landingPage].slice(0, 36).join('')}…${[...landingPage].slice(-18).join('')}`
+  const displayedUrl = screen.getByText(expectedDisplay)
+  expect(displayedUrl.getAttribute('title')).toBe(landingPage)
+  expect(displayedUrl.getAttribute('aria-label')).toBe(landingPage)
+
+  const filter = screen.getByRole('searchbox', { name: 'Filter landing page URLs or query parameters' })
+  fireEvent.change(filter, { target: { value: 'olref campaign summer footer' } })
+
+  await waitFor(() => expect(screen.getByText('1 match')).toBeTruthy())
+  expect(screen.getByText(expectedDisplay)).toBeTruthy()
+  expect(screen.queryByRole('button', { name: 'Next' })).toBeNull()
+
+  fireEvent.change(filter, { target: { value: 'campaign=missing' } })
+  await waitFor(() => expect(screen.getByText('0 matches')).toBeTruthy())
+  expect(screen.getByText('No landing pages match this filter')).toBeTruthy()
+
+  fireEvent.click(screen.getByRole('button', { name: 'Clear filter' }))
+  await waitFor(() => expect(screen.getByText('1–25 of 31 rows')).toBeTruthy())
 })

--- a/apps/web/test/activity-section-pagination.test.tsx
+++ b/apps/web/test/activity-section-pagination.test.tsx
@@ -211,8 +211,9 @@ test('middle-truncates long URLs while preserving the full value for filtering a
   await waitFor(() => expect(screen.getByText('1–25 of 31 rows')).toBeTruthy())
   const expectedDisplay = `${[...landingPage].slice(0, 36).join('')}…${[...landingPage].slice(-18).join('')}`
   const displayedUrl = screen.getByText(expectedDisplay)
-  expect(displayedUrl.getAttribute('title')).toBe(landingPage)
-  expect(displayedUrl.getAttribute('aria-label')).toBe(landingPage)
+  expect(displayedUrl.getAttribute('aria-hidden')).toBe('true')
+  expect(displayedUrl.parentElement?.getAttribute('title')).toBe(landingPage)
+  expect(displayedUrl.parentElement?.querySelector('.sr-only')?.textContent).toBe(landingPage)
 
   const filter = screen.getByRole('searchbox', { name: 'Filter landing page URLs or query parameters' })
   fireEvent.change(filter, { target: { value: 'olref campaign summer footer' } })

--- a/apps/web/test/data-table-controls.test.tsx
+++ b/apps/web/test/data-table-controls.test.tsx
@@ -1,0 +1,111 @@
+import React from 'react'
+import { act, cleanup, fireEvent, render, renderHook, screen } from '@testing-library/react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import {
+  DataTablePagination,
+  DataTableSearch,
+  MiddleTruncatedText,
+  truncateMiddleText,
+  urlSearchText,
+  useClientTable,
+} from '../src/components/shared/DataTableControls.js'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('truncateMiddleText', () => {
+  test('preserves the boundary and truncates by Unicode code point', () => {
+    expect(truncateMiddleText('1234567', 3, 3)).toBe('1234567')
+    expect(truncateMiddleText('12345678', 3, 3)).toBe('123…678')
+    expect(truncateMiddleText('ab😀cd😀ef', 3, 3)).toBe('ab😀…😀ef')
+  })
+})
+
+describe('urlSearchText', () => {
+  test('keeps malformed URLs searchable and exposes decoded parameters', () => {
+    const malformed = '/audit?utm_source=%E0%A4%A&campaign=summer+launch'
+    const searchable = urlSearchText(malformed)
+
+    expect(searchable).toContain(malformed)
+    expect(searchable).toContain('campaign summer launch')
+    expect(urlSearchText('/audit?utm_content=footer%20link')).toContain('utm_content footer link')
+  })
+})
+
+describe('useClientTable', () => {
+  const searchText = (row: { label: string }) => row.label
+
+  test('uses token-AND matching, resets on search, and clamps a shrinking page', () => {
+    const initialRows = Array.from({ length: 7 }, (_, index) => ({
+      label: index === 6 ? 'Alpha final two' : `Alpha row ${index}`,
+    }))
+    const { result, rerender } = renderHook(
+      ({ rows }) => useClientTable({ rows, getSearchText: searchText, pageSize: 2 }),
+      { initialProps: { rows: initialRows } },
+    )
+
+    act(() => result.current.setPage(4))
+    expect(result.current.page).toBe(4)
+    expect(result.current.rows).toEqual([{ label: 'Alpha final two' }])
+
+    act(() => result.current.setQuery('alpha two'))
+    expect(result.current.page).toBe(1)
+    expect(result.current.rows).toEqual([{ label: 'Alpha final two' }])
+
+    act(() => result.current.setQuery(''))
+    act(() => result.current.setPage(4))
+    rerender({ rows: initialRows.slice(0, 3) })
+    expect(result.current.page).toBe(2)
+    expect(result.current.rows).toEqual([{ label: 'Alpha row 2' }])
+  })
+})
+
+describe('DataTablePagination', () => {
+  test('renders the server-mode suffix and hides controls for a single page', () => {
+    const onPageChange = vi.fn()
+    const { rerender } = render(
+      <DataTablePagination
+        page={1}
+        visibleRows={25}
+        hasNextPage
+        onPageChange={onPageChange}
+      />,
+    )
+
+    expect(screen.getByText('1–25+ rows')).not.toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    expect(onPageChange).toHaveBeenCalledWith(2)
+
+    rerender(
+      <DataTablePagination
+        page={1}
+        visibleRows={1}
+        totalRows={1}
+        onPageChange={onPageChange}
+      />,
+    )
+    expect(screen.getByText('1–1 of 1 rows')).not.toBeNull()
+    expect(screen.queryByRole('button', { name: 'Next' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Previous' })).toBeNull()
+  })
+})
+
+test('DataTableSearch suppresses the native WebKit clear control', () => {
+  render(<DataTableSearch value="summer" onChange={() => undefined} label="Filter URLs" />)
+
+  expect(screen.getByRole('searchbox').className).toContain(
+    '[&::-webkit-search-cancel-button]:appearance-none',
+  )
+})
+
+test('MiddleTruncatedText exposes full text accessibly and accepts a custom tooltip', () => {
+  const value = 'https://example.com/a/very/long/path'
+  render(<MiddleTruncatedText value={value} headLength={8} tailLength={4} title="Crawl failed" />)
+
+  const visible = screen.getByText('https://…path')
+  expect(visible.getAttribute('aria-hidden')).toBe('true')
+  expect(visible.parentElement?.getAttribute('title')).toBe('Crawl failed')
+  expect(visible.parentElement?.querySelector('.sr-only')?.textContent).toBe(value)
+})

--- a/apps/web/test/gsc-section-pagination.test.tsx
+++ b/apps/web/test/gsc-section-pagination.test.tsx
@@ -1,0 +1,128 @@
+import React from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, expect, onTestFinished, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+vi.mock('recharts', () => {
+  const passthrough = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>
+  return {
+    ResponsiveContainer: passthrough,
+    ComposedChart: passthrough,
+    Line: () => null,
+    XAxis: () => null,
+    YAxis: () => null,
+    Tooltip: () => null,
+    CartesianGrid: () => null,
+  }
+})
+
+import { GscSection } from '../src/components/project/GscSection.js'
+import type { ApiGscPerformanceRow } from '../src/api.js'
+import { jsonResponse, mockFetch, pathOf } from './mock-fetch.js'
+
+afterEach(() => {
+  cleanup()
+})
+
+function performanceRows(count: number, start = 0): ApiGscPerformanceRow[] {
+  return Array.from({ length: count }, (_, index) => {
+    const row = start + index
+    return {
+      date: '2026-07-25',
+      query: `search query ${String(row).padStart(3, '0')}`,
+      page: `https://example.com/page-${String(row).padStart(3, '0')}`,
+      clicks: count - index,
+      impressions: count * 10 - index,
+      ctr: 0.1,
+      position: 2.5,
+    }
+  })
+}
+
+function renderSection() {
+  const expandedRows = performanceRows(60)
+  const pagedRows = performanceRows(31)
+  const restoreFetch = mockFetch((url) => {
+    const path = pathOf(url)
+    if (path === '/api/v1/settings') {
+      return jsonResponse({
+        providers: [],
+        providerCatalog: [],
+        google: { configured: true },
+        bing: { configured: false },
+      })
+    }
+    if (path.endsWith('/google/connections')) {
+      return jsonResponse([{
+        id: 'gsc-1',
+        domain: 'example.com',
+        connectionType: 'gsc',
+        propertyId: 'sc-domain:example.com',
+        sitemapUrl: 'https://example.com/sitemap.xml',
+        scopes: [],
+        createdAt: '2026-07-01T00:00:00.000Z',
+        updatedAt: '2026-07-25T00:00:00.000Z',
+      }])
+    }
+    if (path.includes('/google/properties')) {
+      return jsonResponse([{ siteUrl: 'sc-domain:example.com', permissionLevel: 'siteOwner' }])
+    }
+    if (path.includes('/google/gsc/performance/daily')) {
+      return jsonResponse({
+        totals: { clicks: 0, impressions: 0, ctr: 0 },
+        daily: [],
+      })
+    }
+    if (path.includes('/google/gsc/performance')) {
+      const query = new URL(url).searchParams
+      if (query.get('limit') === '500') return jsonResponse(expandedRows)
+      const offset = Number(query.get('offset') ?? 0)
+      return jsonResponse(pagedRows.slice(offset, offset + 26))
+    }
+    if (path.includes('/google/gsc/inspections')) return jsonResponse([])
+    if (path.includes('/google/gsc/deindexed')) return jsonResponse([])
+    if (path.includes('/google/gsc/coverage/history')) return jsonResponse([])
+    if (path.includes('/google/gsc/coverage')) return jsonResponse(null)
+    throw new Error(`Unexpected fetch: ${path}`)
+  })
+  onTestFinished(restoreFetch)
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <GscSection projectName="test-project" refreshNonce={0} />
+    </QueryClientProvider>,
+  )
+}
+
+test('uses server pagination when unfiltered and client pagination for expanded results', async () => {
+  renderSection()
+
+  await waitFor(() => expect(screen.getByText('1–25+ rows')).not.toBeNull())
+  expect(screen.getByText('search query 000')).not.toBeNull()
+  expect(screen.queryByText('search query 025')).toBeNull()
+
+  fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+  await waitFor(() => expect(screen.getByText('26–31 rows')).not.toBeNull())
+  expect(screen.getByText('search query 025')).not.toBeNull()
+  expect((screen.getByRole('button', { name: 'Next' }) as HTMLButtonElement).disabled).toBe(true)
+
+  fireEvent.change(screen.getByRole('searchbox', { name: 'Filter search queries' }), {
+    target: { value: 'search' },
+  })
+  fireEvent.click(screen.getByRole('button', { name: 'Apply filters' }))
+
+  await waitFor(() => expect(screen.getByText('1–25 of 60 matches')).not.toBeNull())
+  expect(screen.getByText('search query 024')).not.toBeNull()
+  expect(screen.queryByText('search query 025')).toBeNull()
+
+  fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+  await waitFor(() => expect(screen.getByText('26–50 of 60 matches')).not.toBeNull())
+  expect(screen.getByText('search query 025')).not.toBeNull()
+  expect(screen.queryByText('search query 024')).toBeNull()
+
+  fireEvent.click(screen.getByRole('tab', { name: '7d' }))
+  await waitFor(() => expect(screen.getByText('1–25 of 60 matches')).not.toBeNull())
+  expect(screen.getByText('search query 000')).not.toBeNull()
+  expect(screen.queryByText('search query 025')).toBeNull()
+})

--- a/apps/web/test/technical-aeo-section.test.tsx
+++ b/apps/web/test/technical-aeo-section.test.tsx
@@ -191,3 +191,31 @@ test('loads the scorecard and pages for a selected historical audit', async () =
   expect(fetchedUrls.some((url) => url.includes('runId=audit_old'))).toBe(true)
   expect(fetchedUrls.filter((url) => url.includes('runId=audit_old'))).toHaveLength(2)
 })
+
+test('preserves the crawl error as the tooltip on a truncated page URL', () => {
+  const queryClient = makeClient()
+  queryClient.setQueryData(scoreKey, { ...score('audit_old'), pagesErrored: 1 })
+  const url = `https://citypoint.example/${'long-path-segment-'.repeat(8)}failed`
+  queryClient.setQueryData(pagesKey, {
+    project: projectName,
+    runId: 'audit_old',
+    auditedAt: null,
+    total: 1,
+    pages: [{
+      url,
+      status: 'error',
+      error: 'Crawl timed out after 30 seconds',
+      overallScore: 0,
+    }],
+  })
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <TechnicalAeoSection projectName={projectName} projectId={projectId} />
+    </QueryClientProvider>,
+  )
+
+  const visibleUrl = screen.getByText(`${[...url].slice(0, 54).join('')}…${[...url].slice(-20).join('')}`)
+  expect(visibleUrl.parentElement?.getAttribute('title')).toBe('Crawl timed out after 30 seconds')
+  expect(visibleUrl.parentElement?.querySelector('.sr-only')?.textContent).toBe(url)
+})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.135.0",
+  "version": "4.136.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.135.0",
+  "version": "4.136.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.135.0",
+  "version": "4.136.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.135.0",
+  "version": "4.136.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
## Summary
- add reusable client-side search, pagination, URL search, and URL truncation primitives
- standardize Activity, Search Console, Technical AEO, Evidence, and Backlinks tables
- reduce the default page size to 25 and prevent filtered Search Performance results from rendering the full expanded set
- bump Canonry and synchronized plugin manifests to `4.136.0`

## Why
Long, URL-heavy tables were inconsistent: some lacked queryability, pagination defaults were too large, and Search Performance rendered up to 500 rows while filtering or sorting.

## Impact
Operators get consistent 25-row pagination, range counts, text and URL/UTM filtering, and readable middle-truncated URLs across primary project tables.

## Review follow-up
- suppress the native WebKit search clear button when the custom control is present
- preserve Technical AEO crawl-error tooltips
- reset GSC client pagination on window changes
- stabilize table filtering memoization and URL accessibility
- add shared primitive and GSC pagination coverage
- rebase onto current `main`, preserving the upstream GA referral-session changes

## Validation
- `pnpm plugin:check --base-ref origin/main`
- `pnpm --filter @ainyc/canonry-web typecheck`
- `pnpm --filter @ainyc/canonry-web test` (58 files, 454 tests)
- `pnpm --filter @ainyc/canonry-web lint` (0 errors)
- `pnpm --filter @ainyc/canonry-web build`
- desktop and narrow viewport visual QA