### PR TITLE
feat(web): add sidebar privacy toggle

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -347,19 +347,17 @@ export function RootLayout() {
     setDismissedUpdateVersion(updateAvailable.latest)
   }
   const toggleSidebar = () => {
-    setSidebarHidden((hidden) => {
-      const next = !hidden
-      try {
-        if (next) {
-          window.localStorage.setItem('canonry:sidebarHidden', 'true')
-        } else {
-          window.localStorage.removeItem('canonry:sidebarHidden')
-        }
-      } catch {
-        // Best-effort persistence. The control still works for this session.
+    const next = !sidebarHidden
+    try {
+      if (next) {
+        window.localStorage.setItem('canonry:sidebarHidden', 'true')
+      } else {
+        window.localStorage.removeItem('canonry:sidebarHidden')
       }
-      return next
-    })
+    } catch {
+      // Best-effort persistence. The control still works for this session.
+    }
+    setSidebarHidden(next)
   }
 
   // ── Run detail for drawer ──
@@ -676,7 +674,7 @@ export function RootLayout() {
                 size="icon"
                 type="button"
                 aria-label={sidebarHidden ? 'Show sidebar' : 'Hide sidebar'}
-                aria-controls="desktop-sidebar"
+                aria-controls={sidebarHidden ? undefined : 'desktop-sidebar'}
                 aria-expanded={!sidebarHidden}
                 title={sidebarHidden ? 'Show sidebar' : 'Hide sidebar'}
                 onClick={toggleSidebar}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -11,6 +11,8 @@ import {
   LayoutDashboard,
   Link2,
   Menu,
+  PanelLeftClose,
+  PanelLeftOpen,
   Play,
   Radar,
   Rocket,
@@ -298,6 +300,14 @@ export function RootLayout() {
 
   // ── UI state ──
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
+  const [sidebarHidden, setSidebarHidden] = useState(() => {
+    if (typeof window === 'undefined') return false
+    try {
+      return window.localStorage.getItem('canonry:sidebarHidden') === 'true'
+    } catch {
+      return false
+    }
+  })
   // Per-version dismiss for the update pill. Read once on mount; updates only
   // when the user clicks ×. When a newer version ships, the dismissed value
   // no longer matches `updateAvailable.latest`, so the pill reappears.
@@ -335,6 +345,21 @@ export function RootLayout() {
       // best-effort — Safari private mode etc.
     }
     setDismissedUpdateVersion(updateAvailable.latest)
+  }
+  const toggleSidebar = () => {
+    setSidebarHidden((hidden) => {
+      const next = !hidden
+      try {
+        if (next) {
+          window.localStorage.setItem('canonry:sidebarHidden', 'true')
+        } else {
+          window.localStorage.removeItem('canonry:sidebarHidden')
+        }
+      } catch {
+        // Best-effort persistence. The control still works for this session.
+      }
+      return next
+    })
   }
 
   // ── Run detail for drawer ──
@@ -386,6 +411,11 @@ export function RootLayout() {
   const isFirstRunSetup = location.pathname === '/setup'
     && safeDashboard !== null
     && safeDashboard.portfolioOverview.projects.length === 0
+  const shellModifier = isFirstRunSetup
+    ? 'app-shell-focus'
+    : sidebarHidden
+      ? 'app-shell-sidebar-hidden'
+      : ''
 
   const selectedRun = runId
     ? (safeDashboard ? findRunById(safeDashboard, runId) : undefined)
@@ -490,14 +520,14 @@ export function RootLayout() {
   }
 
   return (
-    <div className={`app-shell ${isFirstRunSetup ? 'app-shell-focus' : ''}`}>
+    <div className={`app-shell ${shellModifier}`}>
       <a className="skip-link" href="#content">
         Skip to content
       </a>
 
       {/* ── Sidebar (desktop) ── */}
-      {!isFirstRunSetup && (
-      <aside className="sidebar" aria-label="Primary navigation">
+      {!isFirstRunSetup && !sidebarHidden && (
+      <aside id="desktop-sidebar" className="sidebar" aria-label="Primary navigation">
         <div className="sidebar-brand">
           <BrandLockup
             version={healthSnapshot.apiStatus.version}
@@ -639,6 +669,25 @@ export function RootLayout() {
         {/* Topbar */}
         <header className="topbar">
           <div className="topbar-left">
+            {!isFirstRunSetup && (
+              <Button
+                className="sidebar-privacy-toggle"
+                variant="ghost"
+                size="icon"
+                type="button"
+                aria-label={sidebarHidden ? 'Show sidebar' : 'Hide sidebar'}
+                aria-controls="desktop-sidebar"
+                aria-expanded={!sidebarHidden}
+                title={sidebarHidden ? 'Show sidebar' : 'Hide sidebar'}
+                onClick={toggleSidebar}
+              >
+                {sidebarHidden ? (
+                  <PanelLeftOpen className="size-4" />
+                ) : (
+                  <PanelLeftClose className="size-4" />
+                )}
+              </Button>
+            )}
             <div className="topbar-brand-mobile">
               <BrandLockup compact />
             </div>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -740,6 +740,12 @@
     @apply flex min-h-screen min-w-0 flex-1 flex-col lg:pl-56;
   }
 
+  /* Presentation privacy: removing the sidebar also removes its desktop
+     gutter, giving the active project view the full viewport width. */
+  .app-shell-sidebar-hidden .main-area {
+    @apply lg:pl-0;
+  }
+
   /* First-run focus mode (sidebar hidden) — drop the 224px sidebar gutter
      so the wizard centers across the full viewport instead of being
      offset right. Applied via the `app-shell-focus` modifier set by
@@ -754,6 +760,10 @@
 
   .topbar-left {
     @apply flex items-center gap-3;
+  }
+
+  .sidebar-privacy-toggle {
+    @apply hidden lg:inline-flex;
   }
 
   .topbar-brand-mobile {

--- a/apps/web/test/sidebar-privacy.test.tsx
+++ b/apps/web/test/sidebar-privacy.test.tsx
@@ -1,0 +1,89 @@
+import { afterEach, beforeAll, beforeEach, expect, test } from 'vitest'
+import { fireEvent, render } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { RouterProvider } from '@tanstack/react-router'
+
+import { DashboardProvider } from '../src/contexts/dashboard-context.js'
+import { createDashboardFixture } from '../src/mock-data.js'
+import { createAppRouter } from '../src/router/router.js'
+import { preloadAllLazyRoutes } from '../src/router/routes.js'
+
+beforeAll(async () => {
+  await preloadAllLazyRoutes()
+})
+
+const storedValues = new Map<string, string>()
+const localStorageMock: Storage = {
+  get length() {
+    return storedValues.size
+  },
+  clear() {
+    storedValues.clear()
+  },
+  getItem(key) {
+    return storedValues.get(key) ?? null
+  },
+  key(index) {
+    return [...storedValues.keys()][index] ?? null
+  },
+  removeItem(key) {
+    storedValues.delete(key)
+  },
+  setItem(key, value) {
+    storedValues.set(key, value)
+  },
+}
+
+beforeEach(() => {
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: localStorageMock,
+  })
+})
+
+afterEach(() => {
+  storedValues.clear()
+})
+
+async function renderRoute(pathname: string) {
+  const fixture = createDashboardFixture({})
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const router = createAppRouter(queryClient, { initialEntries: [pathname] })
+  await router.load()
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <DashboardProvider value={{ dashboard: fixture.dashboard, health: fixture.health }}>
+        <RouterProvider router={router} />
+      </DashboardProvider>
+    </QueryClientProvider>,
+  )
+}
+
+test('sidebar can be hidden and restored from the desktop topbar', async () => {
+  const { container, getByRole } = await renderRoute('/projects/project_citypoint/report')
+
+  expect(container.querySelector('#desktop-sidebar')).not.toBeNull()
+
+  fireEvent.click(getByRole('button', { name: 'Hide sidebar' }))
+
+  expect(container.querySelector('#desktop-sidebar')).toBeNull()
+  expect(container.querySelector('.app-shell-sidebar-hidden')).not.toBeNull()
+  expect(window.localStorage.getItem('canonry:sidebarHidden')).toBe('true')
+
+  fireEvent.click(getByRole('button', { name: 'Show sidebar' }))
+
+  expect(container.querySelector('#desktop-sidebar')).not.toBeNull()
+  expect(container.querySelector('.app-shell-sidebar-hidden')).toBeNull()
+  expect(window.localStorage.getItem('canonry:sidebarHidden')).toBeNull()
+})
+
+test('hidden sidebar preference survives a reload', async () => {
+  window.localStorage.setItem('canonry:sidebarHidden', 'true')
+
+  const { container, getByRole } = await renderRoute('/projects/project_citypoint/report')
+
+  expect(container.querySelector('#desktop-sidebar')).toBeNull()
+  expect(container.querySelector('.app-shell-sidebar-hidden')).not.toBeNull()
+  expect(getByRole('button', { name: 'Show sidebar' })).toBeDefined()
+})

--- a/apps/web/test/sidebar-privacy.test.tsx
+++ b/apps/web/test/sidebar-privacy.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeAll, beforeEach, expect, test } from 'vitest'
-import { fireEvent, render } from '@testing-library/react'
+import { cleanup, fireEvent, render } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { RouterProvider } from '@tanstack/react-router'
 
@@ -12,6 +12,7 @@ beforeAll(async () => {
   await preloadAllLazyRoutes()
 })
 
+const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(window, 'localStorage')
 const storedValues = new Map<string, string>()
 const localStorageMock: Storage = {
   get length() {
@@ -34,19 +35,29 @@ const localStorageMock: Storage = {
   },
 }
 
-beforeEach(() => {
+function installLocalStorage(storage: Storage) {
   Object.defineProperty(window, 'localStorage', {
     configurable: true,
-    value: localStorageMock,
+    value: storage,
   })
+}
+
+beforeEach(() => {
+  installLocalStorage(localStorageMock)
 })
 
 afterEach(() => {
+  cleanup()
   storedValues.clear()
+  if (originalLocalStorageDescriptor) {
+    Object.defineProperty(window, 'localStorage', originalLocalStorageDescriptor)
+  } else {
+    Reflect.deleteProperty(window, 'localStorage')
+  }
 })
 
-async function renderRoute(pathname: string) {
-  const fixture = createDashboardFixture({})
+async function renderRoute(pathname: string, options: Parameters<typeof createDashboardFixture>[0] = {}) {
+  const fixture = createDashboardFixture(options)
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   const router = createAppRouter(queryClient, { initialEntries: [pathname] })
   await router.load()
@@ -64,18 +75,21 @@ test('sidebar can be hidden and restored from the desktop topbar', async () => {
   const { container, getByRole } = await renderRoute('/projects/project_citypoint/report')
 
   expect(container.querySelector('#desktop-sidebar')).not.toBeNull()
+  expect(getByRole('button', { name: 'Hide sidebar' }).getAttribute('aria-controls')).toBe('desktop-sidebar')
 
   fireEvent.click(getByRole('button', { name: 'Hide sidebar' }))
 
   expect(container.querySelector('#desktop-sidebar')).toBeNull()
   expect(container.querySelector('.app-shell-sidebar-hidden')).not.toBeNull()
   expect(window.localStorage.getItem('canonry:sidebarHidden')).toBe('true')
+  expect(getByRole('button', { name: 'Show sidebar' }).getAttribute('aria-controls')).toBeNull()
 
   fireEvent.click(getByRole('button', { name: 'Show sidebar' }))
 
   expect(container.querySelector('#desktop-sidebar')).not.toBeNull()
   expect(container.querySelector('.app-shell-sidebar-hidden')).toBeNull()
   expect(window.localStorage.getItem('canonry:sidebarHidden')).toBeNull()
+  expect(getByRole('button', { name: 'Hide sidebar' }).getAttribute('aria-controls')).toBe('desktop-sidebar')
 })
 
 test('hidden sidebar preference survives a reload', async () => {
@@ -86,4 +100,42 @@ test('hidden sidebar preference survives a reload', async () => {
   expect(container.querySelector('#desktop-sidebar')).toBeNull()
   expect(container.querySelector('.app-shell-sidebar-hidden')).not.toBeNull()
   expect(getByRole('button', { name: 'Show sidebar' })).toBeDefined()
+})
+
+test('falls back to a visible sidebar when stored preference cannot be read', async () => {
+  installLocalStorage({
+    ...localStorageMock,
+    getItem() {
+      throw new Error('storage unavailable')
+    },
+  })
+
+  const { container, getByRole } = await renderRoute('/projects/project_citypoint/report')
+
+  expect(container.querySelector('#desktop-sidebar')).not.toBeNull()
+  expect(getByRole('button', { name: 'Hide sidebar' })).toBeDefined()
+})
+
+test('still hides the sidebar when the preference cannot be written', async () => {
+  installLocalStorage({
+    ...localStorageMock,
+    setItem() {
+      throw new Error('storage unavailable')
+    },
+  })
+
+  const { container, getByRole } = await renderRoute('/projects/project_citypoint/report')
+
+  fireEvent.click(getByRole('button', { name: 'Hide sidebar' }))
+
+  expect(container.querySelector('#desktop-sidebar')).toBeNull()
+  expect(container.querySelector('.app-shell-sidebar-hidden')).not.toBeNull()
+  expect(getByRole('button', { name: 'Show sidebar' }).getAttribute('aria-controls')).toBeNull()
+})
+
+test('does not render the sidebar toggle during first-run setup', async () => {
+  const { container, queryByRole } = await renderRoute('/setup', { emptyPortfolio: true })
+
+  expect(container.querySelector('#desktop-sidebar')).toBeNull()
+  expect(queryByRole('button', { name: /sidebar/i })).toBeNull()
 })


### PR DESCRIPTION
## Summary

- add a desktop top-bar control to hide and restore the Canonry sidebar
- remove the sidebar from the rendered shell and expand the active view to full width
- persist the hidden state across reloads for presentation privacy
- cover hide, restore, accessibility, storage-failure, and first-run behavior with regression tests

## Why

Presenting or screen sharing a client report can expose other client and project names in the sidebar. This provides a one-click privacy control without changing mobile navigation or embed behavior.

## Validation

- focused web tests: 16 passed
- web typecheck
- web lint: 0 errors (existing warnings only)
- web production build
- `git diff --check`