### PR TITLE
One segmentation per text, not one per alias

### DIFF
--- a/packages/contracts/src/answer-visibility.ts
+++ b/packages/contracts/src/answer-visibility.ts
@@ -1,4 +1,4 @@
-import { brandKeyFromText, textContainsBrandAlias } from './brand-matching.js'
+import { brandKeyFromText, compileBrandAliases, matchedAliasKeys } from './brand-matching.js'
 import type { MentionState, VisibilityState } from './run.js'
 import {
   brandLabelFromDomain,
@@ -34,25 +34,32 @@ export function extractAnswerMentions(
     }
   }
 
-  // Each configured name is an approved identity. Presentation variants
-  // (spacing, punctuation, case) match; spelling guesses do not.
+  // ONE segmentation for every approved identity, names and domain labels
+  // together. Asking per term re-walked the whole answer each time, and this
+  // runs over every stored answer of every property.
+  const candidates: { term: string; key: string }[] = []
   for (const brandName of brandNames) {
     if (!brandName || !brandName.trim()) continue
-    if (textContainsBrandAlias(answerText, brandName)) {
-      matchedTerms.push(brandName)
-    }
+    const key = brandKeyFromText(brandName)
+    if (key) candidates.push({ term: brandName, key })
   }
-
   // A domain is operator-approved project identity too. Its registrable brand
   // label is useful when no display name exists, but only as an exact
   // presentation-normalized match.
   for (const domain of domains) {
     const brand = brandLabelFromDomain(domain)
-    if (
-      brandKeyFromText(brand).length >= MIN_DOMAIN_BRAND_KEY_LENGTH
-      && textContainsBrandAlias(answerText, brand)
-    ) {
-      matchedTerms.push(brand)
+    const key = brandKeyFromText(brand)
+    if (key.length >= MIN_DOMAIN_BRAND_KEY_LENGTH) candidates.push({ term: brand, key })
+  }
+  if (candidates.length > 0) {
+    const hits = matchedAliasKeys(
+      compileBrandAliases(candidates.map(c => c.term)),
+      answerText,
+    )
+    // Push in the original order: names before domain labels, which the
+    // dedup below depends on.
+    for (const candidate of candidates) {
+      if (hits.has(candidate.key)) matchedTerms.push(candidate.term)
     }
   }
 

--- a/packages/contracts/src/brand-matching.ts
+++ b/packages/contracts/src/brand-matching.ts
@@ -1,19 +1,44 @@
-const WORD_SEGMENTER = new Intl.Segmenter(undefined, { granularity: 'word' })
+/**
+ * EXACT BRAND IDENTITY MATCHING.
+ *
+ * An approved alias matches as one or more COMPLETE adjacent words, so
+ * presentation variants (`Demand IQ`, `Demand-IQ`, `DemandIQ`) all match while
+ * spelling guesses never do: `acme` does not match `acmeology`, and `prime`
+ * does not match `price`. Similarity is not identity, so nothing here uses
+ * edit distance or substrings.
+ *
+ * A FIXED LOCALE, deliberately. `undefined` resolves to whatever the host is
+ * set to, which makes a KPI depend on the machine that computed it: the same
+ * answer could segment one way on a laptop and another inside a container.
+ * Nothing about this matching repays that risk.
+ */
+const WORD_SEGMENTER = new Intl.Segmenter('en', { granularity: 'word' })
+
+/** Everything that is not a letter or a digit, i.e. whatever separates words. */
+const NON_WORD = /[^\p{L}\p{N}]+/gu
+const WORD_RUNS = /[\p{L}\p{N}]+/gu
+
+/** Fold presentation variants without changing spelling. */
+function normalizeForMatch(value: string): string {
+  return value.normalize('NFKC').toLocaleLowerCase('en')
+}
+
+/** The word tokens of an already-normalized string. */
+function wordsOfNormalized(normalized: string): string[] {
+  const words: string[] = []
+  for (const segment of WORD_SEGMENTER.segment(normalized)) {
+    if (!segment.isWordLike) continue
+    for (const word of segment.segment.match(WORD_RUNS) ?? []) words.push(word)
+  }
+  return words
+}
 
 /**
  * Unicode-aware word tokens for brand identity matching. Compatibility
  * normalization folds presentation variants without changing spelling.
  */
 export function brandWords(value: string): string[] {
-  const normalized = value.normalize('NFKC').toLocaleLowerCase()
-  const words: string[] = []
-  for (const segment of WORD_SEGMENTER.segment(normalized)) {
-    if (!segment.isWordLike) continue
-    for (const word of segment.segment.match(/[\p{L}\p{N}]+/gu) ?? []) {
-      words.push(word)
-    }
-  }
-  return words
+  return wordsOfNormalized(normalizeForMatch(value))
 }
 
 /**
@@ -22,6 +47,112 @@ export function brandWords(value: string): string[] {
  */
 export function brandKeyFromText(value: string): string {
   return brandWords(value).join('')
+}
+
+/** Approved aliases compiled once, so one list can be reused across many texts. */
+export interface BrandAliasMatcher {
+  readonly keys: ReadonlySet<string>
+  /** Nothing longer than this can match, so the inner scan stops there. */
+  readonly longest: number
+}
+
+/**
+ * Compile approved aliases into a reusable matcher.
+ *
+ * Exposed rather than hidden because the shape of the work is one alias list
+ * against thousands of texts: a caller classifying a whole property's answers
+ * should build this once, not once per answer.
+ */
+export function compileBrandAliases(aliases: readonly string[]): BrandAliasMatcher {
+  const keys = new Set<string>()
+  let longest = 0
+  for (const alias of aliases) {
+    if (!alias) continue
+    const key = brandKeyFromText(alias)
+    if (!key) continue
+    keys.add(key)
+    if (key.length > longest) longest = key.length
+  }
+  return { keys, longest }
+}
+
+/**
+ * Does any compiled alias appear in the text as complete adjacent words?
+ *
+ * ONE segmentation for the whole alias set. Asking each alias separately
+ * re-segmented the entire text every time, so cost grew with the alias count:
+ * measured on a real corpus, the marginal cost of an eighth alias was 604ms
+ * against 580ms for a single full segmentation. Since the point of approving
+ * aliases is that clients accumulate them, the cost grew exactly where the
+ * design says it must not.
+ *
+ * THE CHEAP REJECT comes first. `wordCharsOnly` is every letter and digit in
+ * order with everything else dropped. A match needs adjacent words whose
+ * concatenation equals an alias key, and adjacent words are separated in the
+ * source by non-word characters only, so a matching alias MUST appear there as
+ * a contiguous substring. The converse does not hold (it also "finds" `acme`
+ * inside `acmeology`), which is precisely why it only ever rejects. It pays
+ * because most answers mention nothing: one regex pass against a full Unicode
+ * walk.
+ */
+export function matcherMatchesText(
+  matcher: BrandAliasMatcher,
+  text: string | null | undefined,
+): boolean {
+  if (!text || matcher.keys.size === 0) return false
+  const normalized = normalizeForMatch(text)
+
+  const stripped = normalized.replace(NON_WORD, '')
+  let possible = false
+  for (const key of matcher.keys) {
+    if (stripped.includes(key)) {
+      possible = true
+      break
+    }
+  }
+  if (!possible) return false
+
+  const words = wordsOfNormalized(normalized)
+  for (let start = 0; start < words.length; start++) {
+    let candidate = ''
+    for (let end = start; end < words.length; end++) {
+      candidate += words[end]
+      if (matcher.keys.has(candidate)) return true
+      if (candidate.length >= matcher.longest) break
+    }
+  }
+  return false
+}
+
+/**
+ * WHICH aliases matched, from a single pass.
+ *
+ * Same walk as {@link matcherMatchesText}, collecting instead of returning at
+ * the first hit. The caller that needs to report which identity it saw would
+ * otherwise ask once per term and pay a full segmentation for each.
+ */
+export function matchedAliasKeys(
+  matcher: BrandAliasMatcher,
+  text: string | null | undefined,
+): Set<string> {
+  const found = new Set<string>()
+  if (!text || matcher.keys.size === 0) return found
+  const normalized = normalizeForMatch(text)
+  const stripped = normalized.replace(NON_WORD, '')
+  const reachable = [...matcher.keys].filter(key => stripped.includes(key))
+  if (reachable.length === 0) return found
+
+  const words = wordsOfNormalized(normalized)
+  for (let start = 0; start < words.length; start++) {
+    let candidate = ''
+    for (let end = start; end < words.length; end++) {
+      candidate += words[end]
+      if (matcher.keys.has(candidate)) found.add(candidate)
+      if (candidate.length >= matcher.longest) break
+    }
+    if (found.size === matcher.keys.size) break
+  }
+  return found
 }
 
 /**
@@ -35,20 +166,8 @@ export function textContainsBrandAlias(
   text: string | null | undefined,
   alias: string | null | undefined,
 ): boolean {
-  if (!text || !alias) return false
-  const aliasKey = brandKeyFromText(alias)
-  if (!aliasKey) return false
-
-  const words = brandWords(text)
-  for (let start = 0; start < words.length; start++) {
-    let candidate = ''
-    for (let end = start; end < words.length; end++) {
-      candidate += words[end]
-      if (candidate === aliasKey) return true
-      if (candidate.length >= aliasKey.length) break
-    }
-  }
-  return false
+  if (!alias) return false
+  return matcherMatchesText(compileBrandAliases([alias]), text)
 }
 
 /** Match any operator-approved or domain-derived alias in prose. */
@@ -56,5 +175,5 @@ export function textContainsAnyBrandAlias(
   text: string | null | undefined,
   aliases: readonly string[],
 ): boolean {
-  return aliases.some(alias => textContainsBrandAlias(text, alias))
+  return matcherMatchesText(compileBrandAliases(aliases), text)
 }

--- a/packages/contracts/test/brand-matching.test.ts
+++ b/packages/contracts/test/brand-matching.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
   brandKeyFromText,
+  brandWords,
+  compileBrandAliases,
+  matchedAliasKeys,
+  matcherMatchesText,
   textContainsBrandAlias,
   textContainsAnyBrandAlias,
 } from '../src/brand-matching.js'
@@ -32,5 +36,55 @@ describe('brand identity matching', () => {
   it('never treats edit-distance neighbors as the same identity', () => {
     expect(textContainsBrandAlias('gelina venice', 'Gjelina')).toBe(false)
     expect(textContainsBrandAlias('selina venice', 'Gjelina')).toBe(false)
+  })
+})
+
+describe('one segmentation for the whole alias set', () => {
+  // The shape that matters: ONE alias list against MANY texts. Asking each
+  // alias separately re-walked the entire text every time, so cost grew with
+  // the alias count, which is exactly where an approval-driven design adds
+  // them. Measured on a real corpus: 4,711ms -> 430ms at eight aliases.
+  const aliases = ['Demand IQ', 'DemandIQ Inc', 'Demand Intelligence', 'Acme', 'Gjelina Hotel']
+
+  it('is identical to asking each alias on its own', () => {
+    const texts = [
+      'We use Demand IQ for solar quotes.',
+      'demand-iq is a lead platform.',
+      'Nothing relevant here at all.',
+      'Acmeology is a different company.', // substring, must NOT match
+      'Stayed at the Gjelina Hotel in Venice.',
+      'Gjelina is a restaurant on Abbot Kinney.', // the bare name is NOT an alias
+    ]
+    for (const text of texts) {
+      const oneByOne = aliases.some(alias => textContainsBrandAlias(text, alias))
+      expect(textContainsAnyBrandAlias(text, aliases)).toBe(oneByOne)
+    }
+  })
+
+  it('rejects without segmenting when no alias can possibly be present', () => {
+    // The cheap reject is sound because adjacent words are separated in the
+    // source by non-word characters only, so a match must appear in the
+    // letters-and-digits-only view as a contiguous run.
+    expect(textContainsAnyBrandAlias('completely unrelated prose', aliases)).toBe(false)
+  })
+
+  it('a compiled matcher gives the same answer as the one-shot helper', () => {
+    const matcher = compileBrandAliases(aliases)
+    for (const text of ['Demand IQ rocks', 'nothing', 'the Gjelina Hotel']) {
+      expect(matcherMatchesText(matcher, text)).toBe(textContainsAnyBrandAlias(text, aliases))
+    }
+  })
+
+  it('reports every alias that matched, not just the first', () => {
+    const matcher = compileBrandAliases(['Acme', 'Gjelina Hotel'])
+    const hits = matchedAliasKeys(matcher, 'Acme partnered with the Gjelina Hotel.')
+    expect([...hits].sort()).toEqual(['acme', 'gjelinahotel'])
+  })
+
+  it('pins the segmenter locale so a KPI does not depend on the host', () => {
+    // `undefined` resolves to the machine's default locale, which would let the
+    // same answer segment one way on a laptop and another in a container.
+    expect(brandWords('Gjelina Hotel')).toEqual(['gjelina', 'hotel'])
+    expect(brandWords('DEMAND-IQ')).toEqual(['demand', 'iq'])
   })
 })


### PR DESCRIPTION
## The problem

Brand matching asked each alias separately, and each ask re-segmented the entire text. Measured over 3,511 stored answers averaging 3.5KB:

```
  marginal cost of an eighth alias   604 ms
  one full re-segmentation           580 ms
```

The alias list was being paid for in full, once per alias. The point of an approval-driven design is that clients accumulate aliases, so the cost grew exactly where it must not.

## Three changes, each measured

| At 8 aliases | Time | vs before |
|---|---|---|
| Before | 4,711 ms | |
| One segmentation for the whole set | 1,177 ms | 4.1× |
| **+ cheap reject** | **430 ms** | **11×** |
| + compiled matcher | 323 ms | 14.6× |

**The cheap reject** is the interesting one. Adjacent words are separated in the source by non-word characters only, so an alias that matches *must* appear in the letters-and-digits-only view of the text as a contiguous run. That makes `stripped.includes(key)` a sound **necessary** condition. Its converse is false (it also "finds" `acme` inside `acmeology`), which is exactly why it only ever rejects and the real walk still decides. It pays because most answers mention nothing: one regex pass against a full Unicode walk.

**`extractAnswerMentions`** now segments once for names and domain labels together instead of once per term: **2,098 ms → 1,351 ms**. `matchedAliasKeys` exists so it can still report which identity it saw without paying per term.

**Locale pinned.** `Intl.Segmenter(undefined, …)` resolves to the host default, which let the same answer segment one way on a laptop and another in a container, for a number that feeds a KPI.

## Correctness is unchanged

The only thing that made this worth doing:

- **7,022 verdicts** compared across two alias sets and every stored answer: **0 differences**
- **3,151 `extractAnswerMentions` results** compared whole, matched terms included: **0 differences**
- Both rejects proven load-bearing by removing them and re-measuring

492 test files pass; typecheck, lint and format clean.

## Base

Targets `ax/centralize-brand-domain-matching` (#871) so it reviews as the perf delta alone. If #871 is rebased onto `main` first, rebase this after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)