### PR TITLE
fix(web): keep GSC connection state fresh

### DIFF
--- a/apps/web/src/components/project/ActivitySection.tsx
+++ b/apps/web/src/components/project/ActivitySection.tsx
@@ -52,6 +52,7 @@ import {
 } from '@ainyc/canonry-api-client/react-query'
 import type { ApiGaStatus, ApiGaTraffic, ApiGaTrafficAiLandingPage, ApiGaTrafficPage, ApiGaTrafficReferral, ApiGaSocialReferral, GA4AiReferralDailyDto, GA4SessionHistoryEntry, GA4SocialReferralHistoryEntry } from '../../api.js'
 import { TRAFFIC_STALE_MS } from '../../queries/query-client.js'
+import { invalidateProjectQueryDomain } from '../../queries/query-invalidation.js'
 import { asyncHandler } from '../../lib/async-handler.js'
 import {
   SOCIAL_OTHER_KEY,
@@ -339,7 +340,7 @@ export function ClickThroughActivity({ projectName }: { projectName: string }) {
     try {
       const result = await triggerGaSync(projectName)
       setNotice(`Synced ${result.rowCount.toLocaleString()} page rows, ${result.aiReferralCount.toLocaleString()} AI and ${result.socialReferralCount.toLocaleString()} social referral rows (${result.days} days)`)
-      await queryClient.invalidateQueries({ predicate: (query) => { const head = query.queryKey[0] as { _id?: string } | undefined; return typeof head?._id === "string" && head._id.startsWith("getApiV1ProjectsByNameGa") } })
+      await invalidateProjectQueryDomain(queryClient, 'ga')
       await loadData({ current: false })
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Sync failed')
@@ -354,7 +355,7 @@ export function ClickThroughActivity({ projectName }: { projectName: string }) {
     setNotice(null)
     try {
       await disconnectGa(projectName)
-      await queryClient.invalidateQueries({ predicate: (query) => { const head = query.queryKey[0] as { _id?: string } | undefined; return typeof head?._id === "string" && head._id.startsWith("getApiV1ProjectsByNameGa") } })
+      await invalidateProjectQueryDomain(queryClient, 'ga')
       setStatus({ connected: false, propertyId: null, clientEmail: null, lastSyncedAt: null, createdAt: null, updatedAt: null })
       setTraffic(null)
       setNotice('GA4 disconnected')
@@ -502,7 +503,7 @@ export function ClickThroughActivity({ projectName }: { projectName: string }) {
         projectName={projectName}
         onConnected={() => {
           void (async () => {
-            await queryClient.invalidateQueries({ predicate: (query) => { const head = query.queryKey[0] as { _id?: string } | undefined; return typeof head?._id === "string" && head._id.startsWith("getApiV1ProjectsByNameGa") } })
+            await invalidateProjectQueryDomain(queryClient, 'ga')
             await loadData({ current: false })
           })()
         }}

--- a/apps/web/src/components/project/DiscoverySection.tsx
+++ b/apps/web/src/components/project/DiscoverySection.tsx
@@ -18,6 +18,7 @@ import {
   getApiV1RunsQueryKey,
 } from '@ainyc/canonry-api-client/react-query'
 import { addToast } from '../../lib/toast-store.js'
+import { invalidateProjectQueryDomain } from '../../queries/query-invalidation.js'
 import { Button } from '../ui/button.js'
 import { Card } from '../ui/card.js'
 import { ToneBadge } from '../shared/ToneBadge.js'
@@ -540,12 +541,7 @@ async function refreshDiscovery(
   // variant. Runs list uses the exact key to avoid invalidating
   // run-detail caches unnecessarily.
   await Promise.all([
-    queryClient.invalidateQueries({
-      predicate: (query) => {
-        const head = query.queryKey[0] as { _id?: string } | undefined
-        return typeof head?._id === 'string' && head._id.startsWith('getApiV1ProjectsByNameDiscover')
-      },
-    }),
+    invalidateProjectQueryDomain(queryClient, 'discovery'),
     queryClient.invalidateQueries({ queryKey: getApiV1RunsQueryKey({ client: heyClient }) }),
   ])
 }

--- a/apps/web/src/components/project/GbpSection.tsx
+++ b/apps/web/src/components/project/GbpSection.tsx
@@ -55,6 +55,7 @@ import {
 import { fetchInsights, heyClient, isEmbed } from '../../api.js'
 import { addToast } from '../../lib/toast-store.js'
 import { getRunTrackerState, subscribeRunTracker, trackRun } from '../../lib/run-tracker-store.js'
+import { invalidateProjectQueryDomain } from '../../queries/query-invalidation.js'
 
 const GBP_ATTENTION_TYPES = new Set<InsightType>([
   'gbp-listing-discrepancy',
@@ -113,12 +114,7 @@ export function GbpSection({ projectName, projectId }: { projectName: string; pr
   })
 
   function invalidateGbp() {
-    void queryClient.invalidateQueries({
-      predicate: (query) => {
-        const head = query.queryKey[0] as { _id?: string } | undefined
-        return typeof head?._id === 'string' && head._id.startsWith('getApiV1ProjectsByNameGbp')
-      },
-    })
+    void invalidateProjectQueryDomain(queryClient, 'gbp')
   }
 
   // GBP sync is an async background run: POST /gbp/sync queues a `gbp-sync` run

--- a/apps/web/src/components/project/GscSection.tsx
+++ b/apps/web/src/components/project/GscSection.tsx
@@ -55,10 +55,12 @@ import {
   useTriggerInspectSitemap,
 } from '../../queries/mutations.js'
 import { GSC_STALE_MS } from '../../queries/query-client.js'
+import { invalidateProjectQueryDomain } from '../../queries/query-invalidation.js'
 
 const GSC_WINDOWS: MetricsWindow[] = ['7d', '30d', '90d', 'all']
 const EXPANDED_PERFORMANCE_LIMIT = 500
 const COVERAGE_PAGE_SIZE = 25
+const GOOGLE_OAUTH_COMPLETE_MESSAGE = 'canonry:google-oauth-complete'
 
 function sitemapDiscoveredUrlCount(sitemap: ApiGscSitemap): number {
   return sitemap.contents?.reduce((total, content) => total + Number(content.submitted || 0), 0) ?? 0
@@ -266,7 +268,7 @@ export function GscSection({
   const triggerGscSyncMutation = useTriggerGscSync()
   const triggerInspectSitemapMutation = useTriggerInspectSitemap()
 
-  async function loadProperties(currentConn: ApiGoogleConnection | undefined) {
+  async function loadProperties(currentConn: ApiGoogleConnection | undefined, force = false) {
     if (!currentConn) {
       setProperties([])
       setSelectedProperty('')
@@ -277,7 +279,7 @@ export function GscSection({
     try {
       const { sites } = await queryClient.fetchQuery({
         ...getApiV1ProjectsByNameGooglePropertiesOptions({ client: heyClient, path: { name: projectName } }),
-        staleTime: GSC_STALE_MS,
+        staleTime: force ? 0 : GSC_STALE_MS,
       })
       setProperties(sites)
       setSelectedProperty(currentConn.propertyId ?? sites[0]?.siteUrl ?? '')
@@ -359,7 +361,7 @@ export function GscSection({
     }
   }
 
-  async function loadInspectionHistory() {
+  async function loadInspectionHistory(force = false) {
     setLoadingInspections(true)
     try {
       const filterUrl = inspectionFilterUrl.trim() || undefined
@@ -372,11 +374,11 @@ export function GscSection({
             path: { name: projectName },
             query: inspectionsQuery as never,
           }),
-          staleTime: GSC_STALE_MS,
+          staleTime: force ? 0 : GSC_STALE_MS,
         }),
         queryClient.fetchQuery({
           ...getApiV1ProjectsByNameGoogleGscDeindexedOptions({ client: heyClient, path: { name: projectName } }),
-          staleTime: GSC_STALE_MS,
+          staleTime: force ? 0 : GSC_STALE_MS,
         }),
       ])
       setInspections(history)
@@ -390,17 +392,17 @@ export function GscSection({
     }
   }
 
-  async function loadCoverage() {
+  async function loadCoverage(force = false) {
     setLoadingCoverage(true)
     try {
       const [data, history] = await Promise.all([
         queryClient.fetchQuery({
           ...getApiV1ProjectsByNameGoogleGscCoverageOptions({ client: heyClient, path: { name: projectName } }),
-          staleTime: GSC_STALE_MS,
+          staleTime: force ? 0 : GSC_STALE_MS,
         }),
         queryClient.fetchQuery({
           ...getApiV1ProjectsByNameGoogleGscCoverageHistoryOptions({ client: heyClient, path: { name: projectName } }),
-          staleTime: GSC_STALE_MS,
+          staleTime: force ? 0 : GSC_STALE_MS,
         }).catch(() => []),
       ])
       setCoverage(data)
@@ -598,17 +600,18 @@ export function GscSection({
     }
   }
 
-  async function handleUseSitemapForAudits(sitemapUrl: string) {
+  async function handleSetDefaultSitemap(sitemapUrl: string) {
     setSavingSitemap(true)
     setError(null)
     try {
       await saveSitemapUrl(projectName, 'gsc', sitemapUrl)
+      await invalidateProjectQueryDomain(queryClient, 'google')
       setConnections((prev) => prev.map((connection) => (
         connection.connectionType === 'gsc' ? { ...connection, sitemapUrl } : connection
       )))
-      addToast({ title: 'Sitemap selected for audits', detail: sitemapUrl, tone: 'positive', dedupeKey: `gsc:sitemap-audit:${projectName}`, dedupeMode: 'replace' })
+      addToast({ title: 'Default sitemap updated', detail: sitemapUrl, tone: 'positive', dedupeKey: `gsc:sitemap-default:${projectName}`, dedupeMode: 'replace' })
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to select sitemap for audits')
+      setError(err instanceof Error ? err.message : 'Failed to set the default sitemap')
     } finally {
       setSavingSitemap(false)
     }
@@ -689,7 +692,7 @@ export function GscSection({
     setError(null)
     setNotice(null)
     try {
-      const { authUrl } = await googleConnect(projectName, 'gsc')
+      const { authUrl, redirectUri } = await googleConnect(projectName, 'gsc')
       if (!authUrl.startsWith('https://accounts.google.com/')) {
         setError('Unexpected OAuth redirect URL. Please try again.')
         return
@@ -699,13 +702,39 @@ export function GscSection({
         window.location.assign(authUrl)
         return
       }
-      setNotice('Finish the Google consent flow in the popup, then close it to refresh this project.')
-      const timer = window.setInterval(() => {
-        if (popup.closed) {
-          window.clearInterval(timer)
+      const callbackOrigin = redirectUri ? new URL(redirectUri).origin : window.location.origin
+      let refreshStarted = false
+      let timer: number | null = null
+
+      const cleanup = () => {
+        if (timer !== null) window.clearInterval(timer)
+        window.removeEventListener('message', handleOAuthComplete)
+      }
+      const refreshConnection = async (completed: boolean) => {
+        if (refreshStarted) return
+        refreshStarted = true
+        cleanup()
+        setNotice(completed ? 'Google connected. Refreshing access…' : 'Refreshing Google connection…')
+        try {
+          await invalidateProjectQueryDomain(queryClient, 'google')
+          await loadSection()
+        } finally {
           setNotice(null)
-          void queryClient.invalidateQueries({ predicate: (query) => { const head = query.queryKey[0] as { _id?: string } | undefined; return typeof head?._id === "string" && head._id.startsWith("getApiV1ProjectsByNameGoogleGsc") } })
-          void loadSection()
+        }
+      }
+      function handleOAuthComplete(event: MessageEvent) {
+        if (event.source !== popup || event.origin !== callbackOrigin) return
+        if (!event.data || typeof event.data !== 'object') return
+        const message = event.data as { type?: unknown; connectionType?: unknown }
+        if (message.type !== GOOGLE_OAUTH_COMPLETE_MESSAGE || message.connectionType !== 'gsc') return
+        void refreshConnection(true)
+      }
+
+      window.addEventListener('message', handleOAuthComplete)
+      setNotice('Finish the Google consent flow in the popup. This page will refresh automatically.')
+      timer = window.setInterval(() => {
+        if (popup.closed) {
+          void refreshConnection(false)
         }
       }, 1000)
     } catch (err) {
@@ -720,7 +749,7 @@ export function GscSection({
     setNotice(null)
     try {
       await googleDisconnect(projectName, 'gsc')
-      await queryClient.invalidateQueries({ predicate: (query) => { const head = query.queryKey[0] as { _id?: string } | undefined; return typeof head?._id === "string" && head._id.startsWith("getApiV1ProjectsByNameGoogleGsc") } })
+      await invalidateProjectQueryDomain(queryClient, 'google')
       setConnections((prev) => prev.filter((c) => c.connectionType !== 'gsc'))
       setProperties([])
       setSelectedProperty('')
@@ -735,7 +764,7 @@ export function GscSection({
     setError(null)
     try {
       await saveGoogleProperty(projectName, 'gsc', selectedProperty)
-      await queryClient.invalidateQueries({ predicate: (query) => { const head = query.queryKey[0] as { _id?: string } | undefined; return typeof head?._id === "string" && head._id.startsWith("getApiV1ProjectsByNameGoogleGsc") } })
+      await invalidateProjectQueryDomain(queryClient, 'google')
       setConnections((prev) => prev.map((connection) => (
         connection.connectionType === 'gsc'
           ? { ...connection, propertyId: selectedProperty }
@@ -767,7 +796,7 @@ export function GscSection({
           full: fullSync || undefined,
         },
       })
-      await queryClient.invalidateQueries({ predicate: (query) => { const head = query.queryKey[0] as { _id?: string } | undefined; return typeof head?._id === "string" && head._id.startsWith("getApiV1ProjectsByNameGoogleGsc") } })
+      await invalidateProjectQueryDomain(queryClient, 'gsc')
     } catch {
       // Mutation hook handles the toast-only failure path for queued syncs.
     }
@@ -780,7 +809,7 @@ export function GscSection({
     setNotice(null)
     try {
       const result = await inspectGscUrl(projectName, inspectionUrl.trim())
-      await queryClient.invalidateQueries({ predicate: (query) => { const head = query.queryKey[0] as { _id?: string } | undefined; return typeof head?._id === "string" && head._id.startsWith("getApiV1ProjectsByNameGoogleGsc") } })
+      await invalidateProjectQueryDomain(queryClient, 'gsc')
       setInspectionResult(result)
       setInspectionUrl('')
       await loadInspectionHistory()
@@ -1184,7 +1213,7 @@ export function GscSection({
                         {requestingIndexing ? 'Requesting\u2026' : `Request indexing (${coverage.notIndexed.length})`}
                       </Button>
                     )}
-                    <Button type="button" variant="outline" size="sm" disabled={loadingCoverage} onClick={() => void loadCoverage()}>
+                    <Button type="button" variant="outline" size="sm" disabled={loadingCoverage} onClick={() => void loadCoverage(true)}>
                       {loadingCoverage ? 'Loading\u2026' : 'Reload saved coverage'}
                     </Button>
                   </div>
@@ -1578,8 +1607,8 @@ export function GscSection({
                 </div>
                 <p className="mt-2 text-xs text-muted">Google is asked to refetch these sitemaps. Indexing is not guaranteed.</p>
                 {!canSubmitSitemaps && gscConn && (
-                  <div className="mt-2 flex items-center gap-2 text-xs text-caution-400">
-                    <span>Reconnect to allow sitemap submission. This connection has read-only Search Console access.</span>
+                  <div className="mt-2 flex items-center gap-2 text-xs text-caution">
+                    <span>Reconnect to let Canonry submit sitemaps. Your current Canonry OAuth grant is read-only.</span>
                     <button type="button" className="text-secondary underline hover:text-strong" onClick={asyncHandler(handleConnect)}>Reconnect</button>
                   </div>
                 )}
@@ -1617,7 +1646,7 @@ export function GscSection({
                                 <td className="text-secondary">{sitemap.lastDownloaded ? sitemap.lastDownloaded.split('T')[0] : '—'}</td>
                                 <td className="text-right tabular-nums text-neutral">{discoveredUrls.toLocaleString()}</td>
                                 <td className="max-w-48 text-secondary">{issues || '—'}</td>
-                                <td><div className="flex flex-wrap gap-2"><button type="button" className="text-xs text-secondary hover:text-strong" disabled={!canSubmitSitemaps || submittingSitemaps} onClick={() => void handleSubmitSitemaps([sitemap.path])}>{sitemap.lastSubmitted ? 'Resubmit to Google' : 'Submit to Google'}</button><button type="button" className="text-xs text-secondary hover:text-strong" disabled={savingSitemap} onClick={() => void handleUseSitemapForAudits(sitemap.path)}>Use for audits</button><button type="button" className="text-xs text-secondary hover:text-strong" disabled={triggerInspectSitemapMutation.isPending} onClick={() => void handleInspectSitemap(sitemap.path)}>Inspect URLs</button></div></td>
+                                <td><div className="flex flex-wrap gap-2"><button type="button" className="text-xs text-secondary hover:text-strong" disabled={!canSubmitSitemaps || submittingSitemaps} onClick={() => void handleSubmitSitemaps([sitemap.path])}>{sitemap.lastSubmitted ? 'Resubmit to Google' : 'Submit to Google'}</button>{gscConn?.sitemapUrl === sitemap.path ? <span className="text-xs text-muted" title="Used when no sitemap URL is provided for Canonry GSC operations.">Default sitemap</span> : <button type="button" className="text-xs text-secondary hover:text-strong" disabled={savingSitemap} title="Use this sitemap by default for Canonry GSC operations." onClick={() => void handleSetDefaultSitemap(sitemap.path)}>Set as default</button>}<button type="button" className="text-xs text-secondary hover:text-strong" disabled={triggerInspectSitemapMutation.isPending} onClick={() => void handleInspectSitemap(sitemap.path)}>Inspect URLs</button></div></td>
                               </tr>
                             )
                             const childRows = sitemap.isSitemapsIndex && expanded ? children.map((child) => (
@@ -1629,7 +1658,7 @@ export function GscSection({
                                 <td className="text-secondary">{child.lastDownloaded ? child.lastDownloaded.split('T')[0] : '—'}</td>
                                 <td className="text-right tabular-nums text-neutral">{sitemapDiscoveredUrlCount(child).toLocaleString()}</td>
                                 <td className="text-secondary">{sitemapIssueText(child) || '—'}</td>
-                                <td><div className="flex flex-wrap gap-2"><button type="button" className="text-xs text-secondary hover:text-strong" disabled={!canSubmitSitemaps || submittingSitemaps} onClick={() => void handleSubmitSitemaps([child.path])}>Resubmit</button><button type="button" className="text-xs text-secondary hover:text-strong" disabled={savingSitemap} onClick={() => void handleUseSitemapForAudits(child.path)}>Use for audits</button><button type="button" className="text-xs text-secondary hover:text-strong" disabled={triggerInspectSitemapMutation.isPending} onClick={() => void handleInspectSitemap(child.path)}>Inspect URLs</button></div></td>
+                                <td><div className="flex flex-wrap gap-2"><button type="button" className="text-xs text-secondary hover:text-strong" disabled={!canSubmitSitemaps || submittingSitemaps} onClick={() => void handleSubmitSitemaps([child.path])}>Resubmit</button>{gscConn?.sitemapUrl === child.path ? <span className="text-xs text-muted" title="Used when no sitemap URL is provided for Canonry GSC operations.">Default sitemap</span> : <button type="button" className="text-xs text-secondary hover:text-strong" disabled={savingSitemap} title="Use this sitemap by default for Canonry GSC operations." onClick={() => void handleSetDefaultSitemap(child.path)}>Set as default</button>}<button type="button" className="text-xs text-secondary hover:text-strong" disabled={triggerInspectSitemapMutation.isPending} onClick={() => void handleInspectSitemap(child.path)}>Inspect URLs</button></div></td>
                               </tr>
                             )) : []
                             return [row, ...childRows]
@@ -1693,7 +1722,7 @@ export function GscSection({
                     <p className="eyebrow eyebrow-soft">History</p>
                     <h3>Inspection log</h3>
                   </div>
-                  <Button type="button" variant="outline" size="sm" disabled={loadingInspections} onClick={() => void loadInspectionHistory()}>
+                  <Button type="button" variant="outline" size="sm" disabled={loadingInspections} onClick={() => void loadInspectionHistory(true)}>
                     {loadingInspections ? 'Loading\u2026' : 'Refresh history'}
                   </Button>
                 </div>
@@ -1705,7 +1734,7 @@ export function GscSection({
                     value={inspectionFilterUrl}
                     onChange={(e) => setInspectionFilterUrl(e.target.value)}
                   />
-                  <Button type="button" size="sm" variant="outline" disabled={loadingInspections} onClick={() => void loadInspectionHistory()}>
+                  <Button type="button" size="sm" variant="outline" disabled={loadingInspections} onClick={() => void loadInspectionHistory(true)}>
                     Apply filter
                   </Button>
                 </div>
@@ -1829,7 +1858,7 @@ export function GscSection({
                           )}
                         </select>
                         <div className="flex flex-wrap items-center gap-2">
-                          <Button type="button" size="sm" variant="outline" disabled={propertiesLoading} onClick={() => void loadProperties(gscConn)}>
+                          <Button type="button" size="sm" variant="outline" disabled={propertiesLoading} onClick={() => void loadProperties(gscConn, true)}>
                             {propertiesLoading ? 'Refreshing\u2026' : 'Refresh properties'}
                           </Button>
                           <Button type="button" size="sm" disabled={!selectedProperty || savingProperty} onClick={asyncHandler(handleSaveProperty)}>

--- a/apps/web/src/components/project/ResearchQueriesSection.tsx
+++ b/apps/web/src/components/project/ResearchQueriesSection.tsx
@@ -18,6 +18,7 @@ import {
   postApiV1ProjectsByNameResearchRunsMutation,
 } from '@ainyc/canonry-api-client/react-query'
 import { addToast } from '../../lib/toast-store.js'
+import { invalidateProjectQueryDomain } from '../../queries/query-invalidation.js'
 import { safeExternalUrl } from '../../lib/safe-url.js'
 import { Button } from '../ui/button.js'
 import { Card } from '../ui/card.js'
@@ -394,10 +395,5 @@ function toneForResearchQuery(status: ResearchRunQueryDto['status']) {
 }
 
 async function refreshResearch(queryClient: Pick<ReturnType<typeof useQueryClient>, 'invalidateQueries'>) {
-  await queryClient.invalidateQueries({
-    predicate: (query) => {
-      const head = query.queryKey[0] as { _id?: string } | undefined
-      return typeof head?._id === 'string' && head._id.startsWith('getApiV1ProjectsByNameResearchRuns')
-    },
-  })
+  await invalidateProjectQueryDomain(queryClient, 'researchRuns')
 }

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -79,6 +79,7 @@ import {
 } from '@ainyc/canonry-api-client/react-query'
 import { useAppendQueries, useTriggerRun } from '../queries/mutations.js'
 import { GSC_STALE_MS } from '../queries/query-client.js'
+import { invalidateProjectQueryDomain } from '../queries/query-invalidation.js'
 import { useQuery } from '@tanstack/react-query'
 import { getApiV1ProjectsOptions } from '@ainyc/canonry-api-client/react-query'
 import { useProjectDashboard } from '../queries/use-project-dashboard.js'
@@ -89,22 +90,6 @@ import type { ProjectCommandCenterVm, RunHistoryPoint } from '../view-models.js'
 export type ProjectPageTab = 'overview' | 'search-console' | 'local' | 'discovery' | 'report' | 'activity' | 'backlinks' | 'technical-aeo' | 'history' | 'settings'
 
 type SearchConsoleWorkspace = 'google' | 'bing'
-
-/**
- * Invalidate every generated TanStack query whose operation id starts
- * with `prefix`. Used to replace the legacy hierarchical `queryKeys.X.project(name)`
- * invalidations now that all cache keys come from the SDK helpers — the
- * generated keys are flat (`[{_id: 'getApiV1...', ...}]`) and don't share
- * a hierarchical prefix.
- */
-function invalidateByOpPrefix(queryClient: ReturnType<typeof useQueryClient>, prefix: string) {
-  return queryClient.invalidateQueries({
-    predicate: (query) => {
-      const head = query.queryKey[0] as { _id?: string } | undefined
-      return typeof head?._id === 'string' && head._id.startsWith(prefix)
-    },
-  })
-}
 
 /**
  * Patch the cached `useProjectDashboard` detail entries for a single project
@@ -210,7 +195,7 @@ function BingSection({
     setError(null)
     try {
       const result = await apiBingConnect(projectName, apiKeyInput.trim())
-      await invalidateByOpPrefix(queryClient, "getApiV1ProjectsByNameBing")
+      await invalidateProjectQueryDomain(queryClient, 'bing')
       setApiKeyInput('')
       if (result.availableSites.length > 0) {
         setSites(result.availableSites)
@@ -224,7 +209,7 @@ function BingSection({
   async function handleDisconnect() {
     try {
       await apiBingDisconnect(projectName)
-      await invalidateByOpPrefix(queryClient, "getApiV1ProjectsByNameBing")
+      await invalidateProjectQueryDomain(queryClient, 'bing')
       setConnection(null)
       setSites([])
       setCoverage(null)
@@ -242,7 +227,7 @@ function BingSection({
     if (!selectedSite) return
     try {
       await apiBingSetSite(projectName, selectedSite)
-      await invalidateByOpPrefix(queryClient, "getApiV1ProjectsByNameBing")
+      await invalidateProjectQueryDomain(queryClient, 'bing')
       await loadData()
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to set site')
@@ -253,7 +238,7 @@ function BingSection({
     if (!inspectionUrl.trim()) return
     try {
       const result = await inspectBingUrl(projectName, inspectionUrl.trim())
-      await invalidateByOpPrefix(queryClient, "getApiV1ProjectsByNameBing")
+      await invalidateProjectQueryDomain(queryClient, 'bing')
       setInspectionResult(result)
       setInspections((prev) => [result, ...prev])
     } catch (e) {
@@ -902,8 +887,8 @@ function SearchConsoleSection({
       // Reload both coverage summaries from fresh DB values
       setRefreshState('reloading')
       await Promise.all([
-        invalidateByOpPrefix(queryClient, "getApiV1ProjectsByNameGoogleGsc"),
-        invalidateByOpPrefix(queryClient, "getApiV1ProjectsByNameBing"),
+        invalidateProjectQueryDomain(queryClient, 'gsc'),
+        invalidateProjectQueryDomain(queryClient, 'bing'),
       ])
       await loadSummary(true)
       setWorkspaceRefreshNonce((current) => current + 1)

--- a/apps/web/src/queries/mutations.ts
+++ b/apps/web/src/queries/mutations.ts
@@ -23,6 +23,7 @@ import type { ContentTargetDismissRequest } from '@ainyc/canonry-contracts'
 import { createTrackedBatch, trackRun, type TrackedRunSourceAction } from '../lib/run-tracker-store.js'
 import { addToast } from '../lib/toast-store.js'
 import { invalidateQueriesForRunKind } from './run-invalidations.js'
+import { invalidateProjectQueryDomain } from './query-invalidation.js'
 
 /**
  * Invalidate the two top-level list endpoints. We use exact-key matches
@@ -364,19 +365,9 @@ export function useDismissContentTarget() {
     mutationFn: ({ projectName, body }: { projectName: string; body: ContentTargetDismissRequest }) =>
       dismissContentTarget(projectName, body),
     onSuccess: () => {
-      void queryClient.invalidateQueries({
-        // Match every per-project op-id; the report endpoint is one of many,
-        // and a content-target dismissal affects any DTO derived from
-        // `buildContentTargetRows` (report, /content/targets,
-        // /content/dismissals listing).
-        predicate: (query) =>
-          Array.isArray(query.queryKey)
-          && typeof query.queryKey[0] === 'object'
-          && query.queryKey[0] !== null
-          && '_id' in query.queryKey[0]
-          && typeof (query.queryKey[0] as { _id: unknown })._id === 'string'
-          && (query.queryKey[0] as { _id: string })._id.startsWith('getApiV1ProjectsByName'),
-      })
+      // Match every per-project generated operation; the report endpoint is
+      // one of many DTOs derived from `buildContentTargetRows`.
+      void invalidateProjectQueryDomain(queryClient, 'project')
       void queryClient.invalidateQueries({ predicate: isProjectDetailQuery })
     },
   })
@@ -389,15 +380,7 @@ export function useUndismissContentTarget() {
     mutationFn: ({ projectName, targetRef }: { projectName: string; targetRef: string }) =>
       undismissContentTarget(projectName, targetRef),
     onSuccess: () => {
-      void queryClient.invalidateQueries({
-        predicate: (query) =>
-          Array.isArray(query.queryKey)
-          && typeof query.queryKey[0] === 'object'
-          && query.queryKey[0] !== null
-          && '_id' in query.queryKey[0]
-          && typeof (query.queryKey[0] as { _id: unknown })._id === 'string'
-          && (query.queryKey[0] as { _id: string })._id.startsWith('getApiV1ProjectsByName'),
-      })
+      void invalidateProjectQueryDomain(queryClient, 'project')
       void queryClient.invalidateQueries({ predicate: isProjectDetailQuery })
     },
   })

--- a/apps/web/src/queries/query-invalidation.ts
+++ b/apps/web/src/queries/query-invalidation.ts
@@ -1,0 +1,37 @@
+import type { QueryClient } from '@tanstack/react-query'
+
+/**
+ * Generated TanStack keys are flat (`[{ _id: 'getApiV1...' }]`), so cache
+ * ownership is expressed by operation-id domains rather than array prefixes.
+ * Keep the mapping centralized: mutations should choose the domain whose
+ * response owns the changed field.
+ */
+export const PROJECT_QUERY_DOMAINS = {
+  project: 'getApiV1ProjectsByName',
+  google: 'getApiV1ProjectsByNameGoogle',
+  gsc: 'getApiV1ProjectsByNameGoogleGsc',
+  bing: 'getApiV1ProjectsByNameBing',
+  ga: 'getApiV1ProjectsByNameGa',
+  gbp: 'getApiV1ProjectsByNameGbp',
+  ads: 'getApiV1ProjectsByNameAds',
+  traffic: 'getApiV1ProjectsByNameTraffic',
+  discovery: 'getApiV1ProjectsByNameDiscover',
+  researchRuns: 'getApiV1ProjectsByNameResearchRuns',
+  technicalAeo: 'getApiV1ProjectsByNameTechnicalAeo',
+  runs: 'getApiV1ProjectsByNameRuns',
+} as const
+
+export type ProjectQueryDomain = keyof typeof PROJECT_QUERY_DOMAINS
+
+export function invalidateProjectQueryDomain(
+  queryClient: Pick<QueryClient, 'invalidateQueries'>,
+  domain: ProjectQueryDomain,
+): Promise<void> {
+  const prefix = PROJECT_QUERY_DOMAINS[domain]
+  return queryClient.invalidateQueries({
+    predicate: (query) => {
+      const head = query.queryKey[0] as { _id?: string } | undefined
+      return typeof head?._id === 'string' && head._id.startsWith(prefix)
+    },
+  })
+}

--- a/apps/web/src/queries/run-invalidations.ts
+++ b/apps/web/src/queries/run-invalidations.ts
@@ -7,27 +7,7 @@ import {
 } from '@ainyc/canonry-api-client/react-query'
 
 import { heyClient } from '../api.js'
-
-/**
- * Invalidate every generated TanStack query whose operation id starts
- * with `prefix`. The SDK-generated `<op>QueryKey` helpers produce flat
- * keys (`[{_id: 'getApiV1...', ...}]`) with no shared hierarchical
- * prefix, so we match by name pattern rather than referencing a
- * legacy `queryKeys.<domain>.project(name)` hierarchy.
- *
- * Caution: prefix matching is greedy — `'getApiV1Projects'` matches the
- * entire project sub-tree (Bing, GSC, GA, etc.), not just the bare
- * `/projects` list. For "exactly the top-level list" use the direct
- * `getApiV1ProjectsQueryKey` helper instead.
- */
-function invalidateByOpPrefix(queryClient: QueryClient, prefix: string) {
-  void queryClient.invalidateQueries({
-    predicate: (query) => {
-      const head = query.queryKey[0] as { _id?: string } | undefined
-      return typeof head?._id === 'string' && head._id.startsWith(prefix)
-    },
-  })
-}
+import { invalidateProjectQueryDomain } from './query-invalidation.js'
 
 /**
  * Map a run kind to the SDK operation prefixes it invalidates.
@@ -58,7 +38,7 @@ export function invalidateQueriesForRunKind(
   // must be invalidated too or the page won't refresh after a run completes.
   // `getApiV1ProjectsByNameRuns` matches only the runs sub-endpoint (there is
   // no per-project run-detail op), so the prefix is safe (not greedy).
-  invalidateByOpPrefix(queryClient, 'getApiV1ProjectsByNameRuns')
+  void invalidateProjectQueryDomain(queryClient, 'runs')
 
   switch (kind) {
     case RunKinds['answer-visibility']:
@@ -92,31 +72,31 @@ export function invalidateQueriesForRunKind(
     case RunKinds['backlink-extract']:
       return
     case RunKinds['site-audit']:
-      invalidateByOpPrefix(queryClient, 'getApiV1ProjectsByNameTechnicalAeo')
+      void invalidateProjectQueryDomain(queryClient, 'technicalAeo')
       return
     case RunKinds['gsc-sync']:
     case RunKinds['inspect-sitemap']:
-      invalidateByOpPrefix(queryClient, 'getApiV1ProjectsByNameGoogleGsc')
+      void invalidateProjectQueryDomain(queryClient, 'gsc')
       return
     case RunKinds['ga-sync']:
-      invalidateByOpPrefix(queryClient, 'getApiV1ProjectsByNameGa')
+      void invalidateProjectQueryDomain(queryClient, 'ga')
       return
     case RunKinds['traffic-sync']:
-      invalidateByOpPrefix(queryClient, 'getApiV1ProjectsByNameGa')
-      invalidateByOpPrefix(queryClient, 'getApiV1ProjectsByNameTraffic')
+      void invalidateProjectQueryDomain(queryClient, 'ga')
+      void invalidateProjectQueryDomain(queryClient, 'traffic')
       return
     case RunKinds['bing-inspect']:
     case RunKinds['bing-inspect-sitemap']:
-      invalidateByOpPrefix(queryClient, 'getApiV1ProjectsByNameBing')
+      void invalidateProjectQueryDomain(queryClient, 'bing')
       return
     case RunKinds['aeo-discover-seed']:
     case RunKinds['aeo-discover-probe']:
       return
     case RunKinds['gbp-sync']:
-      invalidateByOpPrefix(queryClient, 'getApiV1ProjectsByNameGbp')
+      void invalidateProjectQueryDomain(queryClient, 'gbp')
       return
     case RunKinds['ads-sync']:
-      invalidateByOpPrefix(queryClient, 'getApiV1ProjectsByNameAds')
+      void invalidateProjectQueryDomain(queryClient, 'ads')
       return
     default: {
       const _exhaustive: never = kind

--- a/apps/web/src/queries/server-traffic.ts
+++ b/apps/web/src/queries/server-traffic.ts
@@ -24,6 +24,7 @@ import {
 } from '../api.js'
 import type { MetricTone } from '../view-models.js'
 import { TRAFFIC_STALE_MS } from './query-client.js'
+import { invalidateProjectQueryDomain } from './query-invalidation.js'
 
 export function toneFromTrafficSourceStatus(status: TrafficSourceStatus): MetricTone {
   switch (status) {
@@ -77,12 +78,7 @@ function paramsForFilters(filters: ServerTrafficEventsFilters): {
  * new traffic endpoints landing in the SDK.
  */
 function invalidateTrafficQueries(queryClient: QueryClient) {
-  void queryClient.invalidateQueries({
-    predicate: (query) => {
-      const head = query.queryKey[0] as { _id?: string } | undefined
-      return typeof head?._id === 'string' && head._id.startsWith('getApiV1ProjectsByNameTraffic')
-    },
-  })
+  void invalidateProjectQueryDomain(queryClient, 'traffic')
 }
 
 export function useServerTrafficSources(project: string | null) {

--- a/apps/web/test/gsc-section-pagination.test.tsx
+++ b/apps/web/test/gsc-section-pagination.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, expect, onTestFinished, test, vi } from 'vitest'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 
 vi.mock('recharts', () => {
   const passthrough = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>
@@ -65,7 +65,7 @@ function renderSection() {
       }])
     }
     if (path.includes('/google/properties')) {
-      return jsonResponse([{ siteUrl: 'sc-domain:example.com', permissionLevel: 'siteOwner' }])
+      return jsonResponse({ sites: [{ siteUrl: 'sc-domain:example.com', permissionLevel: 'siteOwner' }] })
     }
     if (path.includes('/google/gsc/performance/daily')) {
       return jsonResponse({
@@ -153,7 +153,7 @@ function renderSitemapSection({
       id: 'gsc-1', domain: 'example.com', connectionType: 'gsc', propertyId: 'sc-domain:example.com', sitemapUrl: 'https://example.com/sitemap.xml',
       scopes: ['https://www.googleapis.com/auth/webmasters'], createdAt: '2026-07-01T00:00:00.000Z', updatedAt: '2026-07-25T00:00:00.000Z',
     }])
-    if (path.includes('/google/properties')) return jsonResponse([{ siteUrl: 'sc-domain:example.com', permissionLevel: 'siteOwner' }])
+    if (path.includes('/google/properties')) return jsonResponse({ sites: [{ siteUrl: 'sc-domain:example.com', permissionLevel: 'siteOwner' }] })
     if (path.includes('/google/gsc/performance/daily')) return jsonResponse({ totals: { clicks: 0, impressions: 0, ctr: 0 }, daily: [] })
     if (path.includes('/google/gsc/performance')) return jsonResponse([])
     if (path.includes('/google/gsc/inspections') || path.includes('/google/gsc/deindexed') || path.includes('/google/gsc/coverage/history')) return jsonResponse([])
@@ -217,4 +217,193 @@ test('resubmit all files excludes a parent index and includes standalone and chi
   await waitFor(() => expect(submitted).toHaveLength(1))
   expect(submitted[0]).toEqual(expect.arrayContaining([standalone, child]))
   expect(submitted[0]).not.toContain(index)
+})
+
+test('refreshes the cached OAuth connection immediately after popup authorization', async () => {
+  let fullScopeGranted = false
+  let connectionReads = 0
+  const sitemapUrl = 'https://example.com/sitemap.xml'
+  const popup = { closed: false } as unknown as Window
+  const openSpy = vi.spyOn(window, 'open').mockReturnValue(popup)
+  onTestFinished(() => openSpy.mockRestore())
+
+  const restoreFetch = mockFetch((url) => {
+    const path = pathOf(url)
+    if (path === '/api/v1/settings') return jsonResponse({ providers: [], providerCatalog: [], google: { configured: true }, bing: { configured: false } })
+    if (path.endsWith('/google/connect')) {
+      return jsonResponse({
+        authUrl: 'https://accounts.google.com/o/oauth2/v2/auth?client_id=test',
+        redirectUri: 'http://localhost:4100/api/v1/google/callback',
+      })
+    }
+    if (path.endsWith('/google/connections')) {
+      connectionReads += 1
+      return jsonResponse([{
+        id: 'gsc-1',
+        domain: 'example.com',
+        connectionType: 'gsc',
+        propertyId: 'sc-domain:example.com',
+        sitemapUrl,
+        scopes: [fullScopeGranted
+          ? 'https://www.googleapis.com/auth/webmasters'
+          : 'https://www.googleapis.com/auth/webmasters.readonly'],
+        createdAt: '2026-07-01T00:00:00.000Z',
+        updatedAt: '2026-07-25T00:00:00.000Z',
+      }])
+    }
+    if (path.includes('/google/properties')) return jsonResponse({ sites: [{ siteUrl: 'sc-domain:example.com', permissionLevel: 'siteOwner' }] })
+    if (path.includes('/google/gsc/performance/daily')) return jsonResponse({ totals: { clicks: 0, impressions: 0, ctr: 0 }, daily: [] })
+    if (path.includes('/google/gsc/performance')) return jsonResponse([])
+    if (path.includes('/google/gsc/inspections') || path.includes('/google/gsc/deindexed') || path.includes('/google/gsc/coverage/history')) return jsonResponse([])
+    if (path.includes('/google/gsc/coverage')) return jsonResponse(null)
+    if (path.includes('/google/gsc/sitemaps')) {
+      return jsonResponse({
+        sitemaps: [{ path: sitemapUrl, isSitemapsIndex: false }],
+        summary: { total: 1, indexes: 0, files: 1 },
+        preferredSubmissionUrls: [sitemapUrl],
+      })
+    }
+    throw new Error(`Unexpected fetch: ${path}`)
+  })
+  onTestFinished(restoreFetch)
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(<QueryClientProvider client={queryClient}><GscSection projectName="test-project" refreshNonce={0} /></QueryClientProvider>)
+
+  await waitFor(() => expect(screen.getByText(/current Canonry OAuth grant is read-only/i)).not.toBeNull())
+  expect(screen.getByText('Default sitemap')).not.toBeNull()
+  expect(screen.queryByText('Use for audits')).toBeNull()
+
+  fireEvent.click(screen.getByRole('button', { name: 'Reconnect' }))
+  await waitFor(() => expect(openSpy).toHaveBeenCalledOnce())
+
+  fullScopeGranted = true
+  fireEvent(window, new MessageEvent('message', {
+    origin: 'http://localhost:4100',
+    source: popup,
+    data: {
+      type: 'canonry:google-oauth-complete',
+      connectionType: 'gsc',
+    },
+  }))
+
+  await waitFor(() => expect(screen.queryByText(/current Canonry OAuth grant is read-only/i)).toBeNull())
+  expect(connectionReads).toBeGreaterThanOrEqual(2)
+})
+
+test('manual GSC refresh actions bypass the one-minute query cache', async () => {
+  let propertyReads = 0
+  let inspectionReads = 0
+  let coverageReads = 0
+  const restoreFetch = mockFetch((url) => {
+    const path = pathOf(url)
+    if (path === '/api/v1/settings') return jsonResponse({ providers: [], providerCatalog: [], google: { configured: true }, bing: { configured: false } })
+    if (path.endsWith('/google/connections')) return jsonResponse([{
+      id: 'gsc-1',
+      domain: 'example.com',
+      connectionType: 'gsc',
+      propertyId: 'sc-domain:example.com',
+      sitemapUrl: 'https://example.com/sitemap.xml',
+      scopes: ['https://www.googleapis.com/auth/webmasters'],
+      createdAt: '2026-07-01T00:00:00.000Z',
+      updatedAt: '2026-07-25T00:00:00.000Z',
+    }])
+    if (path.includes('/google/properties')) {
+      propertyReads += 1
+      return jsonResponse({ sites: [{ siteUrl: 'sc-domain:example.com', permissionLevel: 'siteOwner' }] })
+    }
+    if (path.includes('/google/gsc/performance/daily')) return jsonResponse({ totals: { clicks: 0, impressions: 0, ctr: 0 }, daily: [] })
+    if (path.includes('/google/gsc/performance')) return jsonResponse([])
+    if (path.includes('/google/gsc/inspections')) {
+      inspectionReads += 1
+      return jsonResponse([])
+    }
+    if (path.includes('/google/gsc/deindexed')) return jsonResponse([])
+    if (path.includes('/google/gsc/coverage/history')) return jsonResponse([])
+    if (path.includes('/google/gsc/coverage')) {
+      coverageReads += 1
+      return jsonResponse(null)
+    }
+    if (path.includes('/google/gsc/sitemaps')) return jsonResponse({ sitemaps: [], summary: { total: 0, indexes: 0, files: 0 }, preferredSubmissionUrls: [] })
+    throw new Error(`Unexpected fetch: ${path}`)
+  })
+  onTestFinished(restoreFetch)
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(<QueryClientProvider client={queryClient}><GscSection projectName="test-project" refreshNonce={0} /></QueryClientProvider>)
+
+  await waitFor(() => {
+    expect(propertyReads).toBe(1)
+    expect(inspectionReads).toBe(1)
+    expect(coverageReads).toBe(1)
+  })
+
+  fireEvent.click(screen.getByRole('button', { name: 'Setup & Configuration' }))
+  fireEvent.click(screen.getByRole('button', { name: 'Refresh properties' }))
+  await waitFor(() => expect(propertyReads).toBe(2))
+
+  fireEvent.click(screen.getByRole('button', { name: 'Refresh history' }))
+  await waitFor(() => expect(inspectionReads).toBe(2))
+
+  fireEvent.click(screen.getByRole('button', { name: 'Reload saved coverage' }))
+  await waitFor(() => expect(coverageReads).toBe(2))
+})
+
+test('connection-owned sitemap changes stay fresh after a remount', async () => {
+  const oldSitemap = 'https://example.com/old-sitemap.xml'
+  const newSitemap = 'https://example.com/new-sitemap.xml'
+  let savedSitemap = oldSitemap
+  let connectionReads = 0
+  const restoreFetch = mockFetch((url, init) => {
+    const path = pathOf(url)
+    if (path === '/api/v1/settings') return jsonResponse({ providers: [], providerCatalog: [], google: { configured: true }, bing: { configured: false } })
+    if (path.endsWith('/google/connections')) {
+      connectionReads += 1
+      return jsonResponse([{
+        id: 'gsc-1',
+        domain: 'example.com',
+        connectionType: 'gsc',
+        propertyId: 'sc-domain:example.com',
+        sitemapUrl: savedSitemap,
+        scopes: ['https://www.googleapis.com/auth/webmasters'],
+        createdAt: '2026-07-01T00:00:00.000Z',
+        updatedAt: '2026-07-25T00:00:00.000Z',
+      }])
+    }
+    if (path.endsWith('/google/connections/gsc/sitemap') && init?.method === 'PUT') {
+      savedSitemap = (JSON.parse(String(init.body)) as { sitemapUrl: string }).sitemapUrl
+      return jsonResponse({ sitemapUrl: savedSitemap })
+    }
+    if (path.includes('/google/properties')) return jsonResponse({ sites: [{ siteUrl: 'sc-domain:example.com', permissionLevel: 'siteOwner' }] })
+    if (path.includes('/google/gsc/performance/daily')) return jsonResponse({ totals: { clicks: 0, impressions: 0, ctr: 0 }, daily: [] })
+    if (path.includes('/google/gsc/performance')) return jsonResponse([])
+    if (path.includes('/google/gsc/inspections') || path.includes('/google/gsc/deindexed') || path.includes('/google/gsc/coverage/history')) return jsonResponse([])
+    if (path.includes('/google/gsc/coverage')) return jsonResponse(null)
+    if (path.includes('/google/gsc/sitemaps')) return jsonResponse({
+      sitemaps: [
+        { path: oldSitemap, isSitemapsIndex: false },
+        { path: newSitemap, isSitemapsIndex: false },
+      ],
+      summary: { total: 2, indexes: 0, files: 2 },
+      preferredSubmissionUrls: [oldSitemap, newSitemap],
+    })
+    throw new Error(`Unexpected fetch: ${path}`)
+  })
+  onTestFinished(restoreFetch)
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const firstRender = render(<QueryClientProvider client={queryClient}><GscSection projectName="test-project" refreshNonce={0} /></QueryClientProvider>)
+
+  const newSitemapRow = await screen.findByText(newSitemap).then((cell) => cell.closest('tr'))
+  if (!newSitemapRow) throw new Error('New sitemap row was not rendered')
+  fireEvent.click(within(newSitemapRow).getByRole('button', { name: 'Set as default' }))
+  await waitFor(() => expect(within(newSitemapRow).getByText('Default sitemap')).not.toBeNull())
+
+  firstRender.unmount()
+  render(<QueryClientProvider client={queryClient}><GscSection projectName="test-project" refreshNonce={0} /></QueryClientProvider>)
+
+  await waitFor(() => expect(connectionReads).toBeGreaterThanOrEqual(2))
+  const remountedRow = await screen.findByText(newSitemap).then((cell) => cell.closest('tr'))
+  if (!remountedRow) throw new Error('New sitemap row was not rendered after remount')
+  expect(within(remountedRow).getByText('Default sitemap')).not.toBeNull()
 })

--- a/apps/web/test/query-invalidation.test.ts
+++ b/apps/web/test/query-invalidation.test.ts
@@ -1,0 +1,50 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { expect, test, vi } from 'vitest'
+import { QueryClient } from '@tanstack/react-query'
+
+import {
+  invalidateProjectQueryDomain,
+  PROJECT_QUERY_DOMAINS,
+} from '../src/queries/query-invalidation.js'
+
+function sourceFiles(root: string): string[] {
+  return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(root, entry.name)
+    if (entry.isDirectory()) return sourceFiles(path)
+    return /\.(?:ts|tsx)$/.test(entry.name) ? [path] : []
+  })
+}
+
+test('the Google connection domain includes connection-owned and GSC queries', async () => {
+  const queryClient = new QueryClient()
+  const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+
+  await invalidateProjectQueryDomain(queryClient, 'google')
+
+  const predicate = invalidate.mock.calls[0]?.[0]?.predicate
+  expect(predicate).toBeTypeOf('function')
+  const matches = (id: string) => predicate?.({ queryKey: [{ _id: id }] } as never)
+
+  expect(matches('getApiV1ProjectsByNameGoogleConnections')).toBe(true)
+  expect(matches('getApiV1ProjectsByNameGoogleProperties')).toBe(true)
+  expect(matches('getApiV1ProjectsByNameGoogleGscCoverage')).toBe(true)
+  expect(matches('getApiV1ProjectsByNameGaStatus')).toBe(false)
+  expect(matches('getApiV1ProjectsByNameBingStatus')).toBe(false)
+})
+
+test('keeps generated operation-prefix matching in the typed domain registry', () => {
+  const sourceRoot = [
+    join(process.cwd(), 'src'),
+    join(process.cwd(), 'apps/web/src'),
+  ].find(existsSync)
+  if (!sourceRoot) throw new Error('Could not locate apps/web/src')
+  const registryPath = join(sourceRoot, 'queries/query-invalidation.ts')
+  const violations = sourceFiles(sourceRoot)
+    .filter((path) => path !== registryPath)
+    .filter((path) => /\.startsWith\(\s*['"]getApiV1/.test(readFileSync(path, 'utf8')))
+    .map((path) => path.slice(sourceRoot.length + 1))
+
+  expect(violations).toEqual([])
+  expect(Object.keys(PROJECT_QUERY_DOMAINS).length).toBeGreaterThan(0)
+})

--- a/packages/api-routes/src/google.ts
+++ b/packages/api-routes/src/google.ts
@@ -40,6 +40,27 @@ import {
   buildLocationProfileFields,
 } from '@ainyc/canonry-integration-google-business-profile'
 
+const GOOGLE_OAUTH_COMPLETE_MESSAGE = 'canonry:google-oauth-complete'
+
+export function googleOAuthSuccessHtml(type: GoogleConnectionType): string {
+  const message = JSON.stringify({
+    type: GOOGLE_OAUTH_COMPLETE_MESSAGE,
+    connectionType: type,
+  })
+
+  return `<html><body style="font-family:system-ui;text-align:center;padding:60px">
+    <h2>Connected successfully!</h2>
+    <p>Google ${type.toUpperCase()} has been linked to your domain.</p>
+    <p style="color:#888">This window closes automatically.</p>
+    <script>
+      if (window.opener && !window.opener.closed) {
+        window.opener.postMessage(${message}, '*')
+        window.close()
+      }
+    </script>
+  </body></html>`
+}
+
 /**
  * Does a URL sit on the project's canonical host?
  *
@@ -592,13 +613,7 @@ export async function googleRoutes(app: FastifyInstance, opts: GoogleRoutesOptio
       diff: { domain, type, propertyId },
     })
 
-    return reply.type('text/html').send(
-      `<html><body style="font-family:system-ui;text-align:center;padding:60px">
-        <h2>Connected successfully!</h2>
-        <p>Google ${type.toUpperCase()} has been linked to your domain.</p>
-        <p style="color:#888">You can close this tab.</p>
-      </body></html>`,
-    )
+    return reply.type('text/html').send(googleOAuthSuccessHtml(type as GoogleConnectionType))
   }
 
   // GET /google/callback — shared OAuth redirect target (excluded from auth middleware)

--- a/packages/api-routes/test/google.test.ts
+++ b/packages/api-routes/test/google.test.ts
@@ -7,7 +7,7 @@ import Fastify from 'fastify'
 import { eq } from 'drizzle-orm'
 import { createClient, migrate, projects, runs, auditLog, gscCoverageSnapshots, gscUrlInspections, gscSearchData, gscDailyTotals } from '@ainyc/canonry-db'
 import { AppError } from '@ainyc/canonry-contracts'
-import { googleRoutes } from '../src/google.js'
+import { googleOAuthSuccessHtml, googleRoutes } from '../src/google.js'
 
 // Reproduce state signing functions from google.ts to verify behavior
 function signState(payload: string, secret: string): string {
@@ -135,6 +135,18 @@ describe('state signing', () => {
   it('rejects garbage input', () => {
     const result = verifySignedState('not-valid-base64url!!!', 'secret')
     expect(result).toBeNull()
+  })
+})
+
+describe('Google OAuth success page', () => {
+  it('notifies and closes an OAuth popup without exposing token data', () => {
+    const html = googleOAuthSuccessHtml('gsc')
+
+    expect(html).toContain('canonry:google-oauth-complete')
+    expect(html).toContain('"connectionType":"gsc"')
+    expect(html).toContain('window.opener.postMessage')
+    expect(html).toContain('window.close()')
+    expect(html).not.toMatch(/accessToken|refreshToken/)
   })
 })
 


### PR DESCRIPTION
## Summary

- refresh the GSC workspace immediately when the OAuth callback completes, while retaining popup-close fallback behavior
- invalidate the Google connection cache that owns OAuth scopes, selected property, and default sitemap state
- make manual GSC refresh actions bypass the one-minute cache
- centralize generated query-domain invalidation and add a CI regression guard
- clarify the read-only OAuth warning and replace “Use for audits” with explicit default-sitemap language

## Root cause

The reconnect flow invalidated `GoogleGsc` data queries, but the granted scopes shown by the UI live in the separate `GoogleConnections` query. That connection response remained fresh in TanStack Query for one minute, so closing the OAuth popup could reload the same cached read-only grant and leave the warning visible until repeated refreshes. The same ownership mismatch affected selected-property, disconnect, and default-sitemap mutations. Several manual refresh buttons also reused cached reads.

## Impact

The warning now clears automatically after Google authorization completes. Connection-owned changes remain correct across navigation/remounts, and manual refresh controls always perform a fresh read. Future query invalidation uses one typed domain registry instead of duplicated operation-prefix predicates.

## Validation

- web tests: 60 files, 466 tests passed
- Google API route tests: 54 passed
- web and API-routes typechecks passed
- web production build passed
- web and API-routes lint passed with zero errors (existing warnings remain)
- `git diff --check` passed