### PR TITLE
fix(web): mark the latest run in the query history strip

### DIFF
--- a/apps/web/src/components/project/CitationTimeline.tsx
+++ b/apps/web/src/components/project/CitationTimeline.tsx
@@ -17,35 +17,47 @@ export function CitationTimeline({ history, maxDots = 12 }: { history: RunHistor
     emerging: 'rounded-full',
   }
 
+  const lastIndex = dots.length - 1
   const firstDate = new Date(dots[0].createdAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
-  const lastDate = new Date(dots[dots.length - 1].createdAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
-  const timelineLabel = dots.map((dot) => {
+  const lastDate = new Date(dots[lastIndex].createdAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+  const timelineLabel = dots.map((dot, i) => {
     const date = new Date(dot.createdAt).toLocaleDateString()
-    return `${date}: ${dot.citationState}${dot.model ? `, model ${dot.model}` : ''}`
+    const prefix = i === lastIndex ? 'Latest run, ' : ''
+    return `${prefix}${date}: ${dot.citationState}${dot.model ? `, model ${dot.model}` : ''}`
   }).join('; ')
 
   return (
     <div className="flex items-center gap-1" role="img" aria-label={`Citation history across ${dots.length} runs. ${timelineLabel}`}>
       <span className="text-[9px] text-faint shrink-0" aria-hidden="true">{firstDate}</span>
       <div className="flex items-center gap-[3px]" title={`${dots.length} runs`} aria-hidden="true">
-        {dots.map((d, i) => (
-          <span
-            key={`${d.runId}:${d.createdAt}`}
-            className={`h-2.5 w-2.5 ${shapeMap[d.citationState] ?? 'rounded-sm'} ${colorMap[d.citationState] ?? 'bg-mono-700'} ${
-              d.model && i > 0 && dots[i - 1]?.model && dots[i - 1]!.model !== d.model
-                ? 'ring-1 ring-caution-300/80 ring-offset-1 ring-offset-bg'
-                : ''
-            }`}
-            title={[
-              d.citationState,
-              new Date(d.createdAt).toLocaleDateString(),
-              d.model ? `model ${d.model}` : null,
-              d.model && i > 0 && dots[i - 1]?.model && dots[i - 1]!.model !== d.model ? 'model changed' : null,
-            ].filter(Boolean).join(' · ')}
-          />
-        ))}
+        {dots.map((d, i) => {
+          // The ring means "the model changed on this run", NOT "this is the
+          // newest run". Without a separate marker for the latest run, a strip
+          // whose model changed mid-history reads as if an older run were the
+          // current one. The two markers use different CSS properties
+          // (box-shadow vs outline) so a run that is both still shows both.
+          const modelChanged = Boolean(d.model && i > 0 && dots[i - 1]?.model && dots[i - 1]!.model !== d.model)
+          const isLatest = i === lastIndex
+          return (
+            <span
+              key={`${d.runId}:${d.createdAt}`}
+              className={`h-2.5 w-2.5 ${shapeMap[d.citationState] ?? 'rounded-sm'} ${colorMap[d.citationState] ?? 'bg-mono-700'} ${
+                modelChanged ? 'ring-1 ring-caution-300/80 ring-offset-1 ring-offset-bg' : ''
+              } ${isLatest ? 'outline outline-1 outline-offset-2 outline-mono-400' : ''}`}
+              title={[
+                d.citationState,
+                new Date(d.createdAt).toLocaleDateString(),
+                d.model ? `model ${d.model}` : null,
+                modelChanged ? 'model changed' : null,
+                isLatest ? 'latest run' : null,
+              ].filter(Boolean).join(' · ')}
+            />
+          )
+        })}
       </div>
-      <span className="text-[9px] text-faint shrink-0" aria-hidden="true">{lastDate}</span>
+      <span className="text-[9px] shrink-0 text-secondary" aria-hidden="true">
+        {lastDate} <span className="text-faint">latest</span>
+      </span>
     </div>
   )
 }

--- a/apps/web/test/citation-timeline.test.tsx
+++ b/apps/web/test/citation-timeline.test.tsx
@@ -25,3 +25,69 @@ test('exposes citation history to assistive technology and uses distinct shapes'
   expect(container.querySelector('.rounded-sm')).not.toBeNull()
   expect(container.querySelector('.rotate-45')).not.toBeNull()
 })
+
+test('marks the newest run, and only the newest run', () => {
+  const { container } = render(
+    <CitationTimeline
+      history={[
+        { runId: 'run-1', citationState: 'cited', createdAt: '2026-07-01T12:00:00.000Z' },
+        { runId: 'run-2', citationState: 'cited', createdAt: '2026-07-08T12:00:00.000Z' },
+        { runId: 'run-3', citationState: 'cited', createdAt: '2026-07-14T12:00:00.000Z' },
+      ]}
+    />,
+  )
+
+  const marked = container.querySelectorAll('.outline-mono-400')
+  expect(marked).toHaveLength(1)
+  expect(marked[0]!.getAttribute('title')).toContain('latest run')
+  // The marker is on the newest point, which is rendered last.
+  const allDots = container.querySelectorAll('[title]')
+  expect(allDots[allDots.length - 1]).toBe(marked[0])
+  expect(screen.getByRole('img').getAttribute('aria-label')).toContain('Latest run')
+})
+
+test('a mid-history model change never reads as the current run', () => {
+  // The reported confusion: several sweeps land on one day, the model changes
+  // on the first of them, and the "model changed" ring was the only marker in
+  // the strip. It sat four dots from the right while the newest run had no
+  // marker at all.
+  const { container } = render(
+    <CitationTimeline
+      history={[
+        { runId: 'run-1', citationState: 'cited', createdAt: '2026-07-20T12:00:00.000Z', model: 'old-model' },
+        { runId: 'run-2', citationState: 'cited', createdAt: '2026-07-29T17:23:00.000Z', model: 'new-model' },
+        { runId: 'run-3', citationState: 'cited', createdAt: '2026-07-29T17:39:00.000Z', model: 'new-model' },
+        { runId: 'run-4', citationState: 'cited', createdAt: '2026-07-29T17:51:00.000Z', model: 'new-model' },
+      ]}
+    />,
+  )
+
+  const dots = [...container.querySelectorAll('[title]')].filter(el => el.getAttribute('title')?.includes('·'))
+  expect(dots).toHaveLength(4)
+  // The model-changed ring stays where the model actually changed...
+  expect(dots[1]!.getAttribute('title')).toContain('model changed')
+  expect(dots[1]!.className).not.toContain('outline-mono-400')
+  // ...and the newest run is marked independently of it.
+  expect(dots[3]!.getAttribute('title')).toContain('latest run')
+  expect(dots[3]!.getAttribute('title')).not.toContain('model changed')
+  expect(dots[3]!.className).toContain('outline-mono-400')
+})
+
+test('a run that is both newest and a model change shows both markers', () => {
+  const { container } = render(
+    <CitationTimeline
+      history={[
+        { runId: 'run-1', citationState: 'cited', createdAt: '2026-07-20T12:00:00.000Z', model: 'old-model' },
+        { runId: 'run-2', citationState: 'cited', createdAt: '2026-07-29T17:23:00.000Z', model: 'new-model' },
+      ]}
+    />,
+  )
+
+  const dots = [...container.querySelectorAll('[title]')].filter(el => el.getAttribute('title')?.includes('·'))
+  const newest = dots[dots.length - 1]!
+  expect(newest.getAttribute('title')).toContain('model changed')
+  expect(newest.getAttribute('title')).toContain('latest run')
+  // Distinct CSS properties, so neither marker suppresses the other.
+  expect(newest.className).toContain('ring-caution-300/80')
+  expect(newest.className).toContain('outline-mono-400')
+})


### PR DESCRIPTION
The mention/citation history strip on the query evidence table had exactly one marker, and it meant "the model changed on this run". Nothing marked the newest run.

On a query whose model changed partway through the visible window, that reads wrong: the only ringed dot sits several positions from the right, so it looks like the current observation. The case this came from had four sweeps land on one day with the model rolling over on the first of them, leaving the ring four dots from the right while the run that actually produced the displayed state carried no marker at all.

## Changes

- The newest dot takes a neutral outline and says `latest run` in its tooltip.
- The trailing date label names itself as the latest, instead of being an unlabelled date.
- The strip aria-label prefixes the newest entry with `Latest run`, so the distinction is not colour-only.

Outline rather than a second ring is deliberate. The model-changed marker is a box-shadow (`ring`), so the two use different CSS properties and a run that is both the newest and a model change shows both markers rather than one silently winning. There is a test for exactly that overlap.

## Not changed

The timeline deliberately includes failed sweeps ([history.ts](https://github.com/Canonry/canonry/blob/main/packages/api-routes/src/history.ts)), and a failed run currently renders identically to a clean one. Distinguishing it needs run status plumbed through the timeline response, the dashboard builder, and the view model, so it is left out of this fix.

## Verification

Every assertion proven load-bearing by reverting the component: 3 of the 4 tests go red, including the both-markers case. 62 files / 484 tests pass in `apps/web`; typecheck clean.