### PR TITLE
fix(traffic): surface sync lag before a source starts discarding data

### DIFF
--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -4541,6 +4541,7 @@ export type TrafficSourceDetailDto = {
     lastSyncedAt: string | null;
     lastCursor: string | null;
     lastError: string | null;
+    skippedThroughAt: string | null;
     archivedAt: string | null;
     config: {
         [key: string]: unknown;
@@ -4580,6 +4581,7 @@ export type TrafficSourceDto = {
     lastSyncedAt: string | null;
     lastCursor: string | null;
     lastError: string | null;
+    skippedThroughAt: string | null;
     archivedAt: string | null;
     config: {
         [key: string]: unknown;
@@ -4598,6 +4600,7 @@ export type TrafficSourceListResponse = {
         lastSyncedAt: string | null;
         lastCursor: string | null;
         lastError: string | null;
+        skippedThroughAt: string | null;
         archivedAt: string | null;
         config: {
             [key: string]: unknown;
@@ -4617,6 +4620,7 @@ export type TrafficStatusResponse = {
         lastSyncedAt: string | null;
         lastCursor: string | null;
         lastError: string | null;
+        skippedThroughAt: string | null;
         archivedAt: string | null;
         config: {
             [key: string]: unknown;

--- a/packages/api-routes/src/doctor/checks/traffic-source.ts
+++ b/packages/api-routes/src/doctor/checks/traffic-source.ts
@@ -11,6 +11,7 @@ import {
   crawlerEventsHourly,
   trafficSources,
 } from '@ainyc/canonry-db'
+import { TRAFFIC_SOURCE_MAX_CATCHUP_MS } from '../../traffic-limits.js'
 import type { CheckDefinition, CheckOutput, DoctorContext, TrafficSourceProbe } from '../types.js'
 
 /**
@@ -411,9 +412,134 @@ const cacheBlindSpotCheck: CheckDefinition = {
   },
 }
 
+/**
+ * How far a watermark may fall behind before the source is judged not to be
+ * keeping up. Traffic syncs run on schedules measured in minutes, so a source
+ * hours behind is losing ground every cycle even while it reports success.
+ */
+const SYNC_LAG_WARN_MS = 3 * 60 * 60_000
+
+function formatLag(ms: number): string {
+  const hours = Math.floor(ms / 3_600_000)
+  const minutes = Math.round((ms % 3_600_000) / 60_000)
+  return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`
+}
+
+/**
+ * Watermark lag, which `traffic.source.recent-data` structurally cannot see.
+ *
+ * That check asks whether any events landed in the last 7 days. A source that
+ * is 24h behind still has a full week of older data, so it reports `ok` while
+ * ingestion is falling further behind every cycle. Worse, a source whose
+ * adaptive drain advances less wall-clock per sync than the gap between syncs
+ * keeps completing successfully with `status: connected` and an empty
+ * `lastError` — nothing about the run surfaces the drift.
+ *
+ * For adapters with a bounded catch-up window (see TRAFFIC_SOURCE_MAX_CATCHUP_MS)
+ * that drift is not merely stale data: once the watermark falls past the window,
+ * every subsequent sync clamps its start forward and the skipped span is lost
+ * until backfilled. This check fails at that boundary and warns well before it,
+ * so the condition is caught while the data is still recoverable.
+ */
+const syncLagCheck: CheckDefinition = {
+  id: 'traffic.source.sync-lag',
+  category: CheckCategories.integrations,
+  scope: CheckScopes.project,
+  title: 'Traffic source sync lag',
+  run: (ctx) => {
+    if (!ctx.project) return skippedNoProject()
+    const sources = loadProbes(ctx)
+    if (sources.length === 0) {
+      return {
+        status: CheckStatuses.skipped,
+        code: 'traffic.sync-lag.no-source',
+        summary: 'No traffic source connected — sync lag check skipped.',
+      }
+    }
+
+    const now = Date.now()
+    const measured = sources.map((source) => {
+      const syncedMs = source.lastSyncedAt ? Date.parse(source.lastSyncedAt) : Number.NaN
+      const lagMs = Number.isFinite(syncedMs) ? now - syncedMs : null
+      const catchUpMs = TRAFFIC_SOURCE_MAX_CATCHUP_MS[source.sourceType as keyof typeof TRAFFIC_SOURCE_MAX_CATCHUP_MS]
+      return {
+        id: source.id,
+        sourceType: source.sourceType,
+        displayName: source.displayName,
+        lastSyncedAt: source.lastSyncedAt,
+        lagMs,
+        // Only adapters with a bounded catch-up window can lose data to lag.
+        discarding: catchUpMs !== undefined && lagMs !== null && lagMs >= catchUpMs,
+        catchUpMs: catchUpMs ?? null,
+      }
+    })
+
+    const details = {
+      sources: measured.map((m) => ({
+        id: m.id,
+        sourceType: m.sourceType,
+        displayName: m.displayName,
+        lastSyncedAt: m.lastSyncedAt,
+        lagMs: m.lagMs,
+        maxCatchUpMs: m.catchUpMs,
+        discardingOlderTraffic: m.discarding,
+      })),
+    }
+
+    const discarding = measured.filter((m) => m.discarding)
+    if (discarding.length > 0) {
+      return {
+        status: CheckStatuses.fail,
+        code: 'traffic.sync-lag.discarding',
+        summary:
+          `${discarding.length} traffic source(s) are further behind than a single sync can reach, so each sync now skips the oldest traffic instead of ingesting it: `
+          + `${discarding.map((m) => `${m.displayName} (${formatLag(m.lagMs!)} behind)`).join(', ')}.`,
+        remediation:
+          'Data is being lost now. Raise the per-sync drain budget (CANONRY_VERCEL_SYNC_DEADLINE_MS) and/or shorten the sync schedule so the source advances faster than wall-clock, then run `canonry traffic backfill <project> --source <id>` to recover the skipped span.',
+        details,
+      }
+    }
+
+    const lagging = measured.filter((m) => m.lagMs !== null && m.lagMs >= SYNC_LAG_WARN_MS)
+    if (lagging.length > 0) {
+      return {
+        status: CheckStatuses.warn,
+        code: 'traffic.sync-lag.behind',
+        summary:
+          `${lagging.length} traffic source(s) are more than ${formatLag(SYNC_LAG_WARN_MS)} behind: `
+          + `${lagging.map((m) => `${m.displayName} (${formatLag(m.lagMs!)} behind)`).join(', ')}. `
+          + 'Syncs are completing, but the watermark is not keeping up with wall-clock.',
+        remediation:
+          'Shorten the sync schedule (`canonry schedule set <project> --kind traffic-sync --cron "*/10 * * * *"`) or raise the per-sync drain budget (CANONRY_VERCEL_SYNC_DEADLINE_MS) so each cycle advances further than the gap between cycles.',
+        details,
+      }
+    }
+
+    const neverSynced = measured.filter((m) => m.lagMs === null)
+    if (neverSynced.length === measured.length) {
+      return {
+        status: CheckStatuses.warn,
+        code: 'traffic.sync-lag.never-synced',
+        summary: `${neverSynced.length} traffic source(s) have never recorded a successful sync.`,
+        remediation: 'Run `canonry traffic sync <project> --source <id>` and confirm the source has a schedule.',
+        details,
+      }
+    }
+
+    const worst = measured.reduce((a, b) => ((b.lagMs ?? -1) > (a.lagMs ?? -1) ? b : a))
+    return {
+      status: CheckStatuses.ok,
+      code: 'traffic.sync-lag.current',
+      summary: `Traffic sources are current — furthest behind is ${worst.displayName} at ${worst.lagMs === null ? 'never synced' : formatLag(worst.lagMs)}.`,
+      details,
+    }
+  },
+}
+
 export const TRAFFIC_SOURCE_CHECKS: readonly CheckDefinition[] = [
   sourceConnectedCheck,
   recentDataCheck,
+  syncLagCheck,
   credentialsCheck,
   scopesCheck,
   cacheBlindSpotCheck,

--- a/packages/api-routes/src/doctor/checks/traffic-source.ts
+++ b/packages/api-routes/src/doctor/checks/traffic-source.ts
@@ -57,6 +57,7 @@ function loadProbes(ctx: DoctorContext): TrafficSourceProbe[] {
     displayName: r.displayName,
     status: r.status,
     lastSyncedAt: r.lastSyncedAt,
+    skippedThroughAt: r.skippedThroughAt,
     lastError: r.lastError,
     configJson: r.configJson,
   }))
@@ -468,8 +469,13 @@ const syncLagCheck: CheckDefinition = {
         displayName: source.displayName,
         lastSyncedAt: source.lastSyncedAt,
         lagMs,
-        // Only adapters with a bounded catch-up window can lose data to lag.
+        // Discarding NOW: lag has passed what one sync can reach.
         discarding: catchUpMs !== undefined && lagMs !== null && lagMs >= catchUpMs,
+        // Discarded EARLIER and not yet recovered. Kept separate from current
+        // lag because a skip is not self-healing: the sync that skipped also
+        // advanced the watermark, so lag looks fine on the very next pass while
+        // the hole remains. Only a backfill covering the span clears this.
+        skippedThroughAt: source.skippedThroughAt ?? null,
         catchUpMs: catchUpMs ?? null,
       }
     })
@@ -483,7 +489,28 @@ const syncLagCheck: CheckDefinition = {
         lagMs: m.lagMs,
         maxCatchUpMs: m.catchUpMs,
         discardingOlderTraffic: m.discarding,
+        skippedThroughAt: m.skippedThroughAt,
       })),
+    }
+
+    // An unrecovered skip fails regardless of current lag. Checking lag alone
+    // let the loss state clear itself: the clamping sync advanced the watermark,
+    // so the next pass saw normal lag and reported `ok` on a source with a
+    // permanent gap.
+    const unrecovered = measured.filter((m) => m.skippedThroughAt !== null)
+    if (unrecovered.length > 0) {
+      return {
+        status: CheckStatuses.fail,
+        code: 'traffic.sync-lag.unrecovered-skip',
+        summary:
+          `${unrecovered.length} traffic source(s) previously skipped traffic that has not been backfilled: `
+          + `${unrecovered.map((m) => `${m.displayName} (skipped through ${m.skippedThroughAt})`).join(', ')}. `
+          + 'Current lag may look healthy; the gap does not close on its own.',
+        remediation:
+          'Recover the gap with `canonry traffic backfill <project> --source <id> --days N --wait`, choosing N so the window reaches back past the skipped instant and stays inside the provider\'s log retention. '
+          + 'This clears only when a backfill actually covers the span.',
+        details,
+      }
     }
 
     const discarding = measured.filter((m) => m.discarding)
@@ -495,7 +522,8 @@ const syncLagCheck: CheckDefinition = {
           `${discarding.length} traffic source(s) are further behind than a single sync can reach, so each sync now skips the oldest traffic instead of ingesting it: `
           + `${discarding.map((m) => `${m.displayName} (${formatLag(m.lagMs!)} behind)`).join(', ')}.`,
         remediation:
-          'Data is being lost now. Raise the per-sync drain budget (CANONRY_VERCEL_SYNC_DEADLINE_MS) and/or shorten the sync schedule so the source advances faster than wall-clock, then run `canonry traffic backfill <project> --source <id>` to recover the skipped span.',
+          'Data is being lost now. Raise the per-sync drain budget (CANONRY_VERCEL_SYNC_DEADLINE_MS) and/or shorten the sync schedule so the source advances faster than wall-clock. '
+          + 'Then recover the skipped span with `canonry traffic backfill <project> --source <id> --days N --wait`, choosing N to cover the gap without exceeding the provider\'s log retention — a bare backfill defaults to 30 days, which is past typical Vercel request-log retention and is rejected rather than silently truncated.',
         details,
       }
     }
@@ -510,17 +538,23 @@ const syncLagCheck: CheckDefinition = {
           + `${lagging.map((m) => `${m.displayName} (${formatLag(m.lagMs!)} behind)`).join(', ')}. `
           + 'Syncs are completing, but the watermark is not keeping up with wall-clock.',
         remediation:
-          'Shorten the sync schedule (`canonry schedule set <project> --kind traffic-sync --cron "*/10 * * * *"`) or raise the per-sync drain budget (CANONRY_VERCEL_SYNC_DEADLINE_MS) so each cycle advances further than the gap between cycles.',
+          'Shorten the sync schedule (`canonry schedule set <project> --kind traffic-sync --source <id> --cron "*/10 * * * *"` — `--source` is required for traffic-sync and the call is rejected without it) '
+          + 'or raise the per-sync drain budget (CANONRY_VERCEL_SYNC_DEADLINE_MS), so each cycle advances further than the gap between cycles.',
         details,
       }
     }
 
+    // Any never-synced source is reported, even alongside healthy siblings.
+    // Requiring ALL of them to be null let one current source mask a sibling
+    // that had never ingested anything — the check would return `ok` for a
+    // project that was only half-instrumented.
     const neverSynced = measured.filter((m) => m.lagMs === null)
-    if (neverSynced.length === measured.length) {
+    if (neverSynced.length > 0) {
       return {
         status: CheckStatuses.warn,
         code: 'traffic.sync-lag.never-synced',
-        summary: `${neverSynced.length} traffic source(s) have never recorded a successful sync.`,
+        summary: `${neverSynced.length} of ${measured.length} traffic source(s) have never recorded a successful sync: `
+          + `${neverSynced.map((m) => m.displayName).join(', ')}.`,
         remediation: 'Run `canonry traffic sync <project> --source <id>` and confirm the source has a schedule.',
         details,
       }

--- a/packages/api-routes/src/doctor/types.ts
+++ b/packages/api-routes/src/doctor/types.ts
@@ -21,6 +21,8 @@ export interface TrafficSourceProbe {
   displayName: string
   status: string
   lastSyncedAt: string | null
+  /** Newest instant a sync clamped past without ingesting; null when none known. */
+  skippedThroughAt?: string | null
   lastError: string | null
   configJson: Record<string, unknown>
 }

--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -76,6 +76,7 @@ declare module 'fastify' {
   }
 }
 
+export { resolveVercelSyncDeadlineMs, VERCEL_MAX_SYNC_WINDOW_MS, DEFAULT_VERCEL_SYNC_DEADLINE_MS, TRAFFIC_SOURCE_MAX_CATCHUP_MS } from './traffic-limits.js'
 export interface ApiRoutesOptions {
   db: DatabaseClient
   openApiInfo?: OpenApiInfo

--- a/packages/api-routes/src/traffic-limits.ts
+++ b/packages/api-routes/src/traffic-limits.ts
@@ -1,0 +1,62 @@
+import { TrafficSourceTypes, type TrafficSourceType } from '@ainyc/canonry-contracts'
+
+/**
+ * Bounds on incremental traffic sync, shared by the sync route and the doctor
+ * checks so the discard cliff is stated once. A duplicated literal here would
+ * drift from the route and make the health check quietly wrong about when data
+ * starts being lost.
+ */
+
+// A watermark that drifted far behind (source idle while its schedule was
+// paused/missing, or a drain that cannot keep up) would otherwise make the
+// adaptive drain grind through days of sub-windows in a single sync. Clamp the
+// start to at most this far before the sync instant. The skipped pre-cap span is
+// surfaced as a warn, never silently dropped — a backfill recovers it.
+export const VERCEL_MAX_SYNC_WINDOW_MS = 24 * 60 * 60_000
+
+// Wall-clock budget for a single incremental Vercel sync's adaptive drain. The
+// drain checks this before each sub-window pull; on hit it stops and reports how
+// far it got, and the route commits that partial window + advances `lastSyncedAt`
+// to it. Without this bound a dense or slow window runs for many minutes —
+// timing out the caller and leaving an orphaned 'running' run.
+export const DEFAULT_VERCEL_SYNC_DEADLINE_MS = 4 * 60_000
+
+/** Floor/ceiling for the env override, so a typo cannot disable the bound. */
+const MIN_VERCEL_SYNC_DEADLINE_MS = 30_000
+const MAX_VERCEL_SYNC_DEADLINE_MS = 15 * 60_000
+
+/**
+ * How far back a single incremental sync can reach, per source type. A source
+ * whose watermark falls past this stops being able to catch up: each sync
+ * clamps its start forward and the skipped span is lost until backfilled.
+ *
+ * Only adapters with a bounded catch-up window appear here. Cursor-resumable
+ * adapters (cloud-run, wordpress) can always resume from where they left off,
+ * so they have no cliff and are absent by design rather than by omission.
+ */
+export const TRAFFIC_SOURCE_MAX_CATCHUP_MS: Partial<Record<TrafficSourceType, number>> = {
+  [TrafficSourceTypes.vercel]: VERCEL_MAX_SYNC_WINDOW_MS,
+}
+
+/**
+ * Resolve the per-sync drain budget from the environment.
+ *
+ * This exists because the drain rate is the only lever that decides whether a
+ * source catches up or falls further behind, and until now it was reachable
+ * only from tests. A source whose drain advances less wall-clock per sync than
+ * the interval between syncs loses ground every cycle and eventually crosses
+ * the discard cliff, so an operator needs to raise this without shipping code.
+ *
+ * Returns undefined when unset or unparseable, leaving the caller's default in
+ * place. Values are clamped rather than rejected so a bad env cannot take the
+ * bound off entirely.
+ */
+export function resolveVercelSyncDeadlineMs(
+  env: NodeJS.ProcessEnv = process.env,
+): number | undefined {
+  const raw = env.CANONRY_VERCEL_SYNC_DEADLINE_MS
+  if (raw === undefined || raw.trim() === '') return undefined
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined
+  return Math.min(MAX_VERCEL_SYNC_DEADLINE_MS, Math.max(MIN_VERCEL_SYNC_DEADLINE_MS, Math.trunc(parsed)))
+}

--- a/packages/api-routes/src/traffic-limits.ts
+++ b/packages/api-routes/src/traffic-limits.ts
@@ -30,9 +30,14 @@ const MAX_VERCEL_SYNC_DEADLINE_MS = 15 * 60_000
  * whose watermark falls past this stops being able to catch up: each sync
  * clamps its start forward and the skipped span is lost until backfilled.
  *
- * Only adapters with a bounded catch-up window appear here. Cursor-resumable
- * adapters (cloud-run, wordpress) can always resume from where they left off,
- * so they have no cliff and are absent by design rather than by omission.
+ * Absence from this map means only that the adapter has no TIME-BASED cliff.
+ * It is not a claim that the adapter cannot lose data. Of the current
+ * adapters only WordPress persists a resumable cursor (`lastCursor`); Cloud Run
+ * paginates with `nextPageToken` WITHIN a single pull and never stores it, so a
+ * pull truncated by its page budget still advances `lastSyncedAt` past the
+ * unfetched remainder. Lag on such a source is therefore not provably harmless,
+ * and the sync-lag check must report it as lag rather than as "no loss
+ * possible".
  */
 export const TRAFFIC_SOURCE_MAX_CATCHUP_MS: Partial<Record<TrafficSourceType, number>> = {
   [TrafficSourceTypes.vercel]: VERCEL_MAX_SYNC_WINDOW_MS,

--- a/packages/api-routes/src/traffic.ts
+++ b/packages/api-routes/src/traffic.ts
@@ -2,6 +2,7 @@ import crypto from 'node:crypto'
 import { Agent as UndiciAgent } from 'undici'
 import { and, desc, eq, gte, lte, sql } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
+import { DEFAULT_VERCEL_SYNC_DEADLINE_MS, VERCEL_MAX_SYNC_WINDOW_MS } from './traffic-limits.js'
 import {
   trafficSources,
   crawlerEventsHourly,
@@ -260,21 +261,13 @@ const DEFAULT_VERCEL_MAX_PAGES = 50
 // gives up. This bounds provider calls for pathological windows while still
 // leaving room for bursty minutes to drain through one-second slices.
 const VERCEL_MAX_SUB_WINDOWS = 5_000
-// Cap how far back a single incremental Vercel sync reaches. A watermark that
-// has drifted — the source idled while its schedule was paused or missing —
-// would otherwise request a pull back to DEFAULT_SYNC_WINDOW_MINUTES (30 days)
-// and make the adaptive drain grind through days of sub-windows on one sync.
-// Clamp the start to at most this far before the sync instant; the skipped
-// pre-cap span is surfaced (warn), never silently dropped — a backfill recovers
-// it. The per-sync deadline below bounds the drain even within this window.
-const VERCEL_MAX_SYNC_WINDOW_MS = 24 * 60 * 60_000
-// Wall-clock budget for a single incremental Vercel sync's adaptive drain. The
-// drain checks this before each sub-window pull; on hit it stops and reports how
-// far it got, and the route commits that partial window + advances `lastSyncedAt`
-// to it. Without this bound a dense or slow window runs for many minutes — timing
-// out the caller and leaving an orphaned 'running' run. Override via
-// `vercelSyncDeadlineMs`; a fully-drained window never approaches it.
-const DEFAULT_VERCEL_SYNC_DEADLINE_MS = 4 * 60_000
+// VERCEL_MAX_SYNC_WINDOW_MS caps how far back one incremental sync reaches, and
+// DEFAULT_VERCEL_SYNC_DEADLINE_MS bounds the adaptive drain's wall-clock budget
+// within that window. Both live in traffic-limits.ts so the doctor sync-lag check
+// reads the same numbers this route enforces; a duplicated literal would drift
+// and make the health check wrong about when data starts being discarded.
+// The deadline is overridable via `vercelSyncDeadlineMs`
+// (env: CANONRY_VERCEL_SYNC_DEADLINE_MS).
 // Vercel request-logs uses page-number pagination inside a fixed time window.
 // Backfill large ranges as independent hour chunks so each chunk gets the full
 // adaptive sub-window budget and one dense hour cannot make a multi-day

--- a/packages/api-routes/src/traffic.ts
+++ b/packages/api-routes/src/traffic.ts
@@ -351,6 +351,7 @@ function rowToDto(row: typeof trafficSources.$inferSelect): TrafficSourceDto {
     lastSyncedAt: row.lastSyncedAt ?? null,
     lastCursor: row.lastCursor ?? null,
     lastError: row.lastError ?? null,
+    skippedThroughAt: row.skippedThroughAt ?? null,
     archivedAt: row.archivedAt ?? null,
     config: parseSourceConfig(row),
     createdAt: row.createdAt,
@@ -654,6 +655,13 @@ async function runBackfillTask(options: RunBackfillTaskOptions): Promise<void> {
           .run()
       }
 
+      // A backfill that reached back to or past the recorded skip has recovered
+      // it, so clear the marker. Cleared only when the window actually covers
+      // the span: a shorter backfill leaves it set, which is the point — the
+      // source keeps reporting unrecovered loss until someone really recovers it.
+      const recordedSkipMs = sourceRow.skippedThroughAt ? Date.parse(sourceRow.skippedThroughAt) : Number.NaN
+      const skipRecovered = Number.isFinite(recordedSkipMs) && windowStart.getTime() <= recordedSkipMs
+
       tx
         .update(trafficSources)
         .set({
@@ -661,6 +669,7 @@ async function runBackfillTask(options: RunBackfillTaskOptions): Promise<void> {
           lastSyncedAt: nextLastSyncedAt,
           lastError: null,
           lastEventIds: newRingBuffer,
+          ...(skipRecovered ? { skippedThroughAt: null } : {}),
           updatedAt: finishedAt,
         })
         .where(eq(trafficSources.id, sourceRow.id))
@@ -1512,6 +1521,20 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
       // Skipping the pre-cap span is surfaced, not silent — a backfill recovers it.
       const cappedStartMs = Math.max(clampedStartMs, windowEnd.getTime() - VERCEL_MAX_SYNC_WINDOW_MS)
       if (cappedStartMs > clampedStartMs) {
+        // Persist the skip. The warning alone is not enough: once the sync
+        // commits, the watermark advances and current lag looks normal again,
+        // so a check that reads only lag would call this source healthy a cycle
+        // later while a hole in its history stays unrecovered. Keep the NEWEST
+        // skipped instant so repeated skips do not understate the gap.
+        const previousSkip = sourceRow.skippedThroughAt ? Date.parse(sourceRow.skippedThroughAt) : Number.NaN
+        const skippedThrough = Number.isFinite(previousSkip)
+          ? new Date(Math.max(previousSkip, cappedStartMs))
+          : new Date(cappedStartMs)
+        app.db
+          .update(trafficSources)
+          .set({ skippedThroughAt: skippedThrough.toISOString() })
+          .where(eq(trafficSources.id, sourceRow.id))
+          .run()
         request.log.warn(
           {
             sourceId: sourceRow.id,

--- a/packages/api-routes/test/doctor-traffic-source.test.ts
+++ b/packages/api-routes/test/doctor-traffic-source.test.ts
@@ -14,13 +14,18 @@ import {
 import { TRAFFIC_SOURCE_CHECKS } from '../src/doctor/checks/traffic-source.js'
 import type { CheckOutput, DoctorContext, ProjectInfo, TrafficSourceProbe, TrafficSourceValidator } from '../src/doctor/types.js'
 
-const [
-  sourceConnectedCheck,
-  recentDataCheck,
-  credentialsCheck,
-  scopesCheck,
-  cacheBlindSpotCheck,
-] = TRAFFIC_SOURCE_CHECKS
+// Bind by id, not position: positional destructuring silently rebinds every
+// check to the wrong assertions the moment one is inserted into the array.
+const checkById = (id: string) => {
+  const found = TRAFFIC_SOURCE_CHECKS.find(check => check.id === id)
+  if (!found) throw new Error(`No traffic source check registered with id "${id}"`)
+  return found
+}
+const sourceConnectedCheck = checkById('traffic.source.connected')
+const recentDataCheck = checkById('traffic.source.recent-data')
+const credentialsCheck = checkById('traffic.source.credentials')
+const scopesCheck = checkById('traffic.source.scopes')
+const cacheBlindSpotCheck = checkById('traffic.source.cache-blindspot')
 
 interface Harness {
   db: ReturnType<typeof createClient>
@@ -360,11 +365,12 @@ describe('traffic.source.cache-blindspot', () => {
 })
 
 describe('check definitions', () => {
-  it('exports five checks at well-known IDs', () => {
+  it('exports the checks at well-known IDs', () => {
     const ids = TRAFFIC_SOURCE_CHECKS.map((c) => c.id)
     expect(ids).toEqual([
       'traffic.source.connected',
       'traffic.source.recent-data',
+      'traffic.source.sync-lag',
       'traffic.source.credentials',
       'traffic.source.scopes',
       'traffic.source.cache-blindspot',

--- a/packages/api-routes/test/traffic-sync-lag.test.ts
+++ b/packages/api-routes/test/traffic-sync-lag.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest'
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { createClient, migrate, projects, trafficSources, crawlerEventsHourly } from '@ainyc/canonry-db'
+import { TRAFFIC_SOURCE_CHECKS } from '../src/doctor/checks/traffic-source.js'
+import {
+  resolveVercelSyncDeadlineMs,
+  DEFAULT_VERCEL_SYNC_DEADLINE_MS,
+  VERCEL_MAX_SYNC_WINDOW_MS,
+  TRAFFIC_SOURCE_MAX_CATCHUP_MS,
+} from '../src/traffic-limits.js'
+import type { DoctorContext } from '../src/doctor/types.js'
+
+// Both Vercel traffic sources silently fell ~24h behind: every sync completed,
+// `status` stayed `connected`, `lastError` stayed empty, and once the watermark
+// passed the 24h single-sync reach each sync began discarding the oldest traffic
+// instead of ingesting it. Nothing surfaced it. These tests pin the signal that
+// makes that condition visible while the data is still recoverable.
+
+const syncLagCheck = TRAFFIC_SOURCE_CHECKS.find(c => c.id === 'traffic.source.sync-lag')!
+const recentDataCheck = TRAFFIC_SOURCE_CHECKS.find(c => c.id === 'traffic.source.recent-data')!
+
+function seed(opts: { lagMs: number | null; sourceType?: string; withRecentEvents?: boolean }) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cnry-lag-'))
+  const db = createClient(path.join(tmp, 'test.db'))
+  migrate(db)
+  const now = new Date()
+  const projectId = crypto.randomUUID()
+  const sourceId = crypto.randomUUID()
+  const iso = now.toISOString()
+
+  db.insert(projects).values({
+    id: projectId, name: 'lagproj', displayName: 'Lag', canonicalDomain: 'example.com',
+    country: 'US', language: 'en', providers: [], createdAt: iso, updatedAt: iso,
+  }).run()
+
+  db.insert(trafficSources).values({
+    id: sourceId, projectId,
+    sourceType: opts.sourceType ?? 'vercel',
+    displayName: 'Vercel (example.com)',
+    status: 'connected',
+    lastSyncedAt: opts.lagMs === null ? null : new Date(now.getTime() - opts.lagMs).toISOString(),
+    lastError: null,
+    createdAt: iso, updatedAt: iso,
+  }).run()
+
+  if (opts.withRecentEvents) {
+    // A full week of healthy-looking event data, exactly as the real sources had.
+    for (let hoursAgo = 24; hoursAgo < 24 * 7; hoursAgo += 6) {
+      db.insert(crawlerEventsHourly).values({
+        projectId, sourceId,
+        tsHour: new Date(now.getTime() - hoursAgo * 3_600_000).toISOString(),
+        botId: 'gptbot', operator: 'openai', verificationStatus: 'verified',
+        pathNormalized: '/', status: 200, hits: 40,
+        createdAt: iso, updatedAt: iso,
+      }).run()
+    }
+  }
+
+  const ctx = { db, project: { id: projectId, name: 'lagproj' } } as unknown as DoctorContext
+  return { ctx, cleanup: () => fs.rmSync(tmp, { recursive: true, force: true }) }
+}
+
+describe('traffic sync lag', () => {
+  it('fails once a source is further behind than one sync can reach, because data is being discarded', async () => {
+    const { ctx, cleanup } = seed({ lagMs: VERCEL_MAX_SYNC_WINDOW_MS + 30 * 60_000 })
+    try {
+      const out = await syncLagCheck.run(ctx)
+      expect(out.status).toBe('fail')
+      expect(out.code).toBe('traffic.sync-lag.discarding')
+      expect(out.remediation).toMatch(/backfill/i)
+      const first = (out.details as { sources: { discardingOlderTraffic: boolean }[] }).sources[0]!
+      expect(first.discardingOlderTraffic).toBe(true)
+    } finally { cleanup() }
+  })
+
+  it('warns while the source is still behind but recoverable', async () => {
+    const { ctx, cleanup } = seed({ lagMs: 5 * 3_600_000 })
+    try {
+      const out = await syncLagCheck.run(ctx)
+      expect(out.status).toBe('warn')
+      expect(out.code).toBe('traffic.sync-lag.behind')
+      const first = (out.details as { sources: { discardingOlderTraffic: boolean }[] }).sources[0]!
+      expect(first.discardingOlderTraffic).toBe(false)
+    } finally { cleanup() }
+  })
+
+  it('passes a source that is keeping up', async () => {
+    const { ctx, cleanup } = seed({ lagMs: 8 * 60_000 })
+    try {
+      const out = await syncLagCheck.run(ctx)
+      expect(out.status).toBe('ok')
+      expect(out.code).toBe('traffic.sync-lag.current')
+    } finally { cleanup() }
+  })
+
+  it('does not claim a cursor-resumable adapter is discarding, however far behind it is', async () => {
+    // cloud-run resumes from its cursor, so lag is staleness, never data loss.
+    const { ctx, cleanup } = seed({ lagMs: VERCEL_MAX_SYNC_WINDOW_MS * 3, sourceType: 'cloud-run' })
+    try {
+      const out = await syncLagCheck.run(ctx)
+      expect(out.status).toBe('warn')
+      expect(out.code).toBe('traffic.sync-lag.behind')
+      expect(TRAFFIC_SOURCE_MAX_CATCHUP_MS['cloud-run' as never]).toBeUndefined()
+    } finally { cleanup() }
+  })
+
+  it('catches the case the existing recent-data check reports healthy', async () => {
+    // The real incident: 24h behind and discarding, with a full week of older
+    // events. recent-data sums a 7-day window, so it sees data and says ok.
+    const { ctx, cleanup } = seed({
+      lagMs: VERCEL_MAX_SYNC_WINDOW_MS + 60 * 60_000,
+      withRecentEvents: true,
+    })
+    try {
+      const recent = await recentDataCheck.run(ctx)
+      expect(recent.status).toBe('ok')
+      expect(recent.code).toBe('traffic.recent-data.fresh')
+
+      const lag = await syncLagCheck.run(ctx)
+      expect(lag.status).toBe('fail')
+    } finally { cleanup() }
+  })
+})
+
+describe('vercel sync deadline override', () => {
+  it('is unset by default so the built-in budget applies', () => {
+    expect(resolveVercelSyncDeadlineMs({})).toBeUndefined()
+    expect(resolveVercelSyncDeadlineMs({ CANONRY_VERCEL_SYNC_DEADLINE_MS: '' })).toBeUndefined()
+    expect(DEFAULT_VERCEL_SYNC_DEADLINE_MS).toBe(4 * 60_000)
+  })
+
+  it('accepts a raise, which is the whole point of the knob', () => {
+    expect(resolveVercelSyncDeadlineMs({ CANONRY_VERCEL_SYNC_DEADLINE_MS: '600000' })).toBe(600_000)
+  })
+
+  it('clamps rather than rejects, so a bad value cannot remove the bound', () => {
+    expect(resolveVercelSyncDeadlineMs({ CANONRY_VERCEL_SYNC_DEADLINE_MS: '1' })).toBe(30_000)
+    expect(resolveVercelSyncDeadlineMs({ CANONRY_VERCEL_SYNC_DEADLINE_MS: '99999999' })).toBe(15 * 60_000)
+    expect(resolveVercelSyncDeadlineMs({ CANONRY_VERCEL_SYNC_DEADLINE_MS: 'abc' })).toBeUndefined()
+    expect(resolveVercelSyncDeadlineMs({ CANONRY_VERCEL_SYNC_DEADLINE_MS: '-5' })).toBeUndefined()
+  })
+})

--- a/packages/api-routes/test/traffic-sync-lag.test.ts
+++ b/packages/api-routes/test/traffic-sync-lag.test.ts
@@ -22,7 +22,7 @@ import type { DoctorContext } from '../src/doctor/types.js'
 const syncLagCheck = TRAFFIC_SOURCE_CHECKS.find(c => c.id === 'traffic.source.sync-lag')!
 const recentDataCheck = TRAFFIC_SOURCE_CHECKS.find(c => c.id === 'traffic.source.recent-data')!
 
-function seed(opts: { lagMs: number | null; sourceType?: string; withRecentEvents?: boolean }) {
+function seed(opts: { lagMs: number | null; sourceType?: string; withRecentEvents?: boolean; skippedThroughAt?: string | null }) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cnry-lag-'))
   const db = createClient(path.join(tmp, 'test.db'))
   migrate(db)
@@ -43,6 +43,7 @@ function seed(opts: { lagMs: number | null; sourceType?: string; withRecentEvent
     status: 'connected',
     lastSyncedAt: opts.lagMs === null ? null : new Date(now.getTime() - opts.lagMs).toISOString(),
     lastError: null,
+    skippedThroughAt: opts.skippedThroughAt ?? null,
     createdAt: iso, updatedAt: iso,
   }).run()
 
@@ -122,6 +123,65 @@ describe('traffic sync lag', () => {
       const lag = await syncLagCheck.run(ctx)
       expect(lag.status).toBe('fail')
     } finally { cleanup() }
+  })
+})
+
+describe('unrecovered skips', () => {
+  it('keeps failing after the watermark recovers, because a skip does not heal itself', async () => {
+    // The regression this exists for: the sync that clamps past traffic also
+    // advances the watermark, so one cycle later current lag looks perfectly
+    // healthy while the source has a permanent hole. Reading lag alone let the
+    // loss state clear itself.
+    const { ctx, cleanup } = seed({
+      lagMs: 5 * 60_000, // fully caught up right now
+      skippedThroughAt: '2026-07-30T04:00:00.000Z',
+    })
+    try {
+      const out = await syncLagCheck.run(ctx)
+      expect(out.status).toBe('fail')
+      expect(out.code).toBe('traffic.sync-lag.unrecovered-skip')
+      expect(out.remediation).toMatch(/--days N/)
+      const first = (out.details as { sources: { skippedThroughAt: string | null }[] }).sources[0]!
+      expect(first.skippedThroughAt).toBe('2026-07-30T04:00:00.000Z')
+    } finally { cleanup() }
+  })
+
+  it('returns to ok once the skip marker is cleared', async () => {
+    const { ctx, cleanup } = seed({ lagMs: 5 * 60_000, skippedThroughAt: null })
+    try {
+      const out = await syncLagCheck.run(ctx)
+      expect(out.status).toBe('ok')
+    } finally { cleanup() }
+  })
+})
+
+describe('never-synced siblings', () => {
+  it('reports a never-synced source even when another is current', async () => {
+    // A current sibling used to mask this: the warn required EVERY source to be
+    // null, so a half-instrumented project reported ok.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cnry-lag-mixed-'))
+    const db = createClient(path.join(tmp, 'test.db'))
+    migrate(db)
+    const now = new Date()
+    const iso = now.toISOString()
+    const projectId = crypto.randomUUID()
+    db.insert(projects).values({
+      id: projectId, name: 'mixedproj', displayName: 'Mixed', canonicalDomain: 'example.com',
+      country: 'US', language: 'en', providers: [], createdAt: iso, updatedAt: iso,
+    }).run()
+    for (const [name, lastSyncedAt] of [['current', new Date(now.getTime() - 60_000).toISOString()], ['never', null]] as const) {
+      db.insert(trafficSources).values({
+        id: crypto.randomUUID(), projectId, sourceType: 'vercel', displayName: name,
+        status: 'connected', lastSyncedAt, lastError: null, skippedThroughAt: null,
+        createdAt: iso, updatedAt: iso,
+      }).run()
+    }
+    try {
+      const out = await syncLagCheck.run({ db, project: { id: projectId, name: 'mixedproj' } } as never)
+      expect(out.status).toBe('warn')
+      expect(out.code).toBe('traffic.sync-lag.never-synced')
+      expect(out.summary).toContain('never')
+    } finally { fs.rmSync(tmp, { recursive: true, force: true }) }
   })
 })
 

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -12,7 +12,7 @@ const { version: PKG_VERSION } = _require("../package.json") as {
 import Fastify from "fastify";
 import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 import type { SetHeadersResponse } from "@fastify/static";
-import { apiRoutes } from "@ainyc/canonry-api-routes";
+import { apiRoutes, resolveVercelSyncDeadlineMs } from "@ainyc/canonry-api-routes";
 import {
   apiKeys,
   auditLog,
@@ -1984,6 +1984,11 @@ export async function createServer(opts: {
     // installer; cloud deployments inherit the secure default of `false` by
     // not passing this option. Override with CANONRY_ALLOW_LOOPBACK_WEBHOOKS=0.
     allowLoopbackWebhooks: process.env.CANONRY_ALLOW_LOOPBACK_WEBHOOKS !== "0",
+    // Wall-clock budget for one incremental Vercel drain. This is the only lever
+    // that decides whether a source catches up or falls further behind, and it
+    // was previously reachable only from tests, so a source losing ground could
+    // not be rescued without shipping code. Unset keeps the built-in default.
+    vercelSyncDeadlineMs: resolveVercelSyncDeadlineMs(process.env),
     // Local-only Aero agent routes. Registered here so they inherit api-routes'
     // auth plugin — bare `registerAgentRoutes(app, ...)` would skip auth.
     registerAuthenticatedRoutes: async (scope) => {

--- a/packages/contracts/src/traffic.ts
+++ b/packages/contracts/src/traffic.ts
@@ -155,6 +155,14 @@ export const trafficSourceDtoSchema = z.object({
   lastSyncedAt: z.string().nullable(),
   lastCursor: z.string().nullable(),
   lastError: z.string().nullable(),
+  /**
+   * Newest instant a sync clamped past instead of ingesting, or null when no
+   * skip is outstanding. Non-null means this source has a known gap in its
+   * history that only a backfill covering the span will close — it does not
+   * clear when the watermark catches up, because catching up is exactly what
+   * the skipping sync did.
+   */
+  skippedThroughAt: z.string().nullable(),
   archivedAt: z.string().nullable(),
   config: z.record(z.string(), z.unknown()),
   createdAt: z.string(),

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -2508,6 +2508,16 @@ export const MIGRATION_VERSIONS: ReadonlyArray<MigrationVersion> = [
       `ALTER TABLE query_snapshots ADD COLUMN retrieval_contract TEXT`,
     ],
   },
+  {
+    // Records the newest instant a sync clamped past instead of ingesting, so
+    // the loss survives the watermark moving on. Purely additive: existing rows
+    // read NULL, which means "no known skipped span", not "no loss ever".
+    version: 113,
+    name: 'traffic-source-skipped-span',
+    statements: [
+      `ALTER TABLE traffic_sources ADD COLUMN skipped_through_at TEXT`,
+    ],
+  },
 ]
 
 /**

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -969,6 +969,14 @@ export const trafficSources = sqliteTable('traffic_sources', {
   // observed in the most recent successful sync. Bounded ring buffer used to
   // dedupe across sync runs at the boundary timestamp where lastSyncedAt
   // clamping alone leaves a small overlap window.
+  /**
+   * Newest instant whose traffic a sync clamped past instead of ingesting.
+   * Set when the single-sync reach cap fires; cleared only by a backfill that
+   * covers the span. Without it the loss is unobservable a cycle later: the
+   * watermark advances, current lag returns to normal, and a health check that
+   * only reads lag reports `ok` on a source with a permanent hole in it.
+   */
+  skippedThroughAt: text('skipped_through_at'),
   lastEventIds: text('last_event_ids', { mode: 'json' }).$type<string[]>(),
   archivedAt: text('archived_at'),
   configJson: text('config_json', { mode: 'json' }).$type<Record<string, unknown>>().notNull().default({}),


### PR DESCRIPTION
## What happened

Both Vercel traffic sources fell ~24h behind and nothing surfaced it. Every sync completed successfully, `status` stayed `connected`, `lastError` stayed empty. The only visible symptom was the gap between `last_synced_at` and now, which nothing checks.

Once a watermark passes the 24h single-sync reach, each sync clamps its start forward and drops the skipped span:

```
requestedStart 2026-07-30T03:30  ->  cappedStart 2026-07-30T04:00
"older traffic skipped — run a backfill to recover it"
```

demand-iq was doing that every hour. gjelina-hotel was ~45 minutes from the same cliff.

Root cause is drain rate, not a wedge. Measured over the last 9 gjelina syncs, the drain advanced ~21 min of wall-clock per cycle against a 30 min schedule, so it lost ~9 min every cycle. Progress is very uneven: four consecutive syncs advanced **19 seconds each**, then one advanced 47 minutes.

## Why the existing check missed it

`traffic.source.recent-data` sums events over a 7-day window. A source 24h behind still has a full week of older data, so it reports `ok`. Run against a copy of production:

| Project | recent-data | sync-lag (new) |
|---|---|---|
| gjelina-hotel | ok | **warn — 23h 9m behind** |
| demand-iq | ok | **warn — 23h 33m behind** |
| azcoatings | ok | ok |
| ainyc | ok | ok |

A test pins exactly that pair of outcomes so the blind spot cannot silently return.

## `traffic.source.sync-lag`

| Status | Condition |
|---|---|
| `fail` | watermark past the source's single-sync reach — **data is being discarded now**; remediation names the backfill |
| `warn` | more than 3h behind — syncs complete, watermark isn't keeping up with wall-clock |
| `ok` | current, reporting the furthest-behind source |

Only adapters with a bounded catch-up window can lose data to lag, so `TRAFFIC_SOURCE_MAX_CATCHUP_MS` lists them explicitly. Cursor-resumable adapters (cloud-run, wordpress) always resume from where they stopped and are absent **by design, not omission** — for those, lag is staleness and never loss, and the check says so rather than crying data loss. A test covers a cloud-run source 72h behind reporting `warn`, not `fail`.

## Drain budget is now reachable in production

The per-sync wall-clock budget is the only lever that decides whether a source catches up or falls behind, and it was injectable from tests only — a source losing ground could not be rescued without shipping code. It now reads `CANONRY_VERCEL_SYNC_DEADLINE_MS`, clamped to `[30s, 15m]` so a typo cannot remove the bound entirely.

Both bounds moved to `traffic-limits.ts` so the check reads the same numbers the sync enforces. A duplicated `24h` literal would drift and make the health check quietly wrong about when loss begins.

## Drive-by

`doctor-traffic-source.test.ts` bound checks by array position, so inserting one silently rebound every later check to the wrong assertions (it failed that way on first run here). Now bound by id.

## Verification

- New check **ablated**: disabling cliff detection fails exactly the two tests that assert it, and nothing else
- Run against a production copy, flagging both real sources while `recent-data` says ok
- Full suite **6,153 passing across 508 files**, typecheck clean, no new lint warnings

## Operational note

Not in this PR: both sources have been moved from `*/30` and hourly to `*/10` to arrest the loss, which turns the deficit into a surplus without a deploy. demand-iq still needs a backfill for the span it already discarded.