### PR TITLE
feat(health): run the health checks on a schedule and alarm on degradation

### DIFF
--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -2693,7 +2693,7 @@ export type NotificationDto = {
     url: string;
     urlDisplay: string;
     urlHost: string;
-    events: Array<'citation.lost' | 'citation.gained' | 'run.completed' | 'run.failed' | 'insight.critical' | 'insight.high'>;
+    events: Array<'citation.lost' | 'citation.gained' | 'run.completed' | 'run.failed' | 'insight.critical' | 'insight.high' | 'health.degraded' | 'health.recovered'>;
     enabled: boolean;
     source?: string;
     webhookSecret?: string;
@@ -3088,7 +3088,7 @@ export type ProjectConfig = {
         notifications: Array<{
             channel: 'webhook';
             url: string;
-            events: Array<'citation.lost' | 'citation.gained' | 'run.completed' | 'run.failed' | 'insight.critical' | 'insight.high'>;
+            events: Array<'citation.lost' | 'citation.gained' | 'run.completed' | 'run.failed' | 'insight.critical' | 'insight.high' | 'health.degraded' | 'health.recovered'>;
         }>;
         google?: {
             gsc?: {
@@ -4118,7 +4118,7 @@ export type RunDto = {
     createdAt: string;
 };
 
-export type SchedulableRunKind = 'answer-visibility' | 'traffic-sync' | 'gbp-sync' | 'data-refresh' | 'backlinks-sync' | 'site-audit' | 'ads-sync';
+export type SchedulableRunKind = 'answer-visibility' | 'traffic-sync' | 'gbp-sync' | 'data-refresh' | 'backlinks-sync' | 'site-audit' | 'ads-sync' | 'doctor';
 
 export type ScheduleDto = {
     id: string;

--- a/packages/api-routes/src/notifications.ts
+++ b/packages/api-routes/src/notifications.ts
@@ -8,7 +8,7 @@ import { resolveProject, writeAuditLog } from './helpers.js'
 import { redactNotificationUrl } from './notification-redaction.js'
 import { deliverWebhook, resolveWebhookTarget } from './webhooks.js'
 
-const VALID_EVENTS: NotificationEvent[] = ['citation.lost', 'citation.gained', 'run.completed', 'run.failed', 'insight.critical', 'insight.high']
+const VALID_EVENTS: NotificationEvent[] = ['citation.lost', 'citation.gained', 'run.completed', 'run.failed', 'insight.critical', 'insight.high', 'health.degraded', 'health.recovered']
 
 export interface NotificationRoutesOptions {
   /** Allow webhook URLs that resolve to loopback addresses. Defaults to false. */

--- a/packages/api-routes/test/db-dto-coverage.test.ts
+++ b/packages/api-routes/test/db-dto-coverage.test.ts
@@ -282,6 +282,10 @@ const COVERAGE: Record<string, CoverageEntry> = {
       syncRunId: 'Internal join key.',
     },
   },
+  doctorHealthState: {
+    kind: 'internal-only',
+    reason: 'Last observed doctor outcome per project, kept only so health alerting can fire on transitions rather than on every scheduled pass. It is alerting bookkeeping, not a measurement: the report itself is served live by GET /projects/:name/doctor, and exposing a cached copy would invite readers to trust a stale health verdict.',
+  },
   gbpKeywordMonthly: {
     kind: 'internal-only',
     reason: 'Accumulating per-month keyword series; an internal trend-history aggregate consumed by the intelligence engine (month-over-month keyword-drop insights), not exposed as its own DTO. The current snapshot is served by gbpKeywordImpressions.',

--- a/packages/api-routes/test/openapi-contract.test.ts
+++ b/packages/api-routes/test/openapi-contract.test.ts
@@ -144,7 +144,7 @@ describe('openapi contract', () => {
     // union isn't repeated across every schedule param, body, and the DTO.
     const KIND_REF = '#/components/schemas/SchedulableRunKind'
     expect(body.components?.schemas?.SchedulableRunKind?.enum).toEqual(
-      ['answer-visibility', 'traffic-sync', 'gbp-sync', 'data-refresh', 'backlinks-sync', 'site-audit', 'ads-sync'],
+      ['answer-visibility', 'traffic-sync', 'gbp-sync', 'data-refresh', 'backlinks-sync', 'site-audit', 'ads-sync', 'doctor'],
     )
 
     const schedulePath = body.paths['/api/v1/projects/{name}/schedule']!

--- a/packages/canonry/src/commands/notify.ts
+++ b/packages/canonry/src/commands/notify.ts
@@ -96,6 +96,8 @@ const EVENT_DESCRIPTIONS: Record<string, string> = {
   'run.failed': 'An AEO sweep failed',
   'insight.critical': 'A critical-severity insight was generated',
   'insight.high': 'A high-severity insight was generated',
+  'health.degraded': 'A scheduled health check found the measurement itself degraded (sent on change, not every pass)',
+  'health.recovered': 'A previously degraded health check is passing again',
 }
 
 export function listEvents(format?: string): void {

--- a/packages/canonry/src/notifier.ts
+++ b/packages/canonry/src/notifier.ts
@@ -1,8 +1,8 @@
 import { eq, desc, and, inArray, or } from 'drizzle-orm'
 import { deliverWebhook, redactNotificationUrl, resolveWebhookTarget } from '@ainyc/canonry-api-routes'
 import type { DatabaseClient } from '@ainyc/canonry-db'
-import { auditLog, groupRunsByCreatedAt, notifications, projects, queries, querySnapshots, runs } from '@ainyc/canonry-db'
-import type { NotificationEvent, WebhookPayload, InsightWebhookPayload } from '@ainyc/canonry-contracts'
+import { auditLog, doctorHealthState, groupRunsByCreatedAt, notifications, projects, queries, querySnapshots, runs } from '@ainyc/canonry-db'
+import type { NotificationEvent, WebhookPayload, InsightWebhookPayload, HealthWebhookPayload } from '@ainyc/canonry-contracts'
 import type { AnalysisResult } from '@ainyc/canonry-intelligence'
 import crypto from 'node:crypto'
 import { createLogger } from './logger.js'
@@ -100,6 +100,115 @@ export class Notifier {
         await this.sendWebhook(config.url, payload, notif.id, projectId, notif.webhookSecret ?? null)
       }
     }
+  }
+
+  /**
+   * Record the outcome of a scheduled health pass and notify on transitions.
+   *
+   * Edge-triggered on `(status, code)`. A pass that finds the same problem as
+   * last time is stored but not re-sent: an operator who receives the same
+   * warning every day stops reading the channel, which is how a real
+   * degradation goes unnoticed. A pass whose worst code CHANGES does notify,
+   * even at the same severity, because a different cause is different news.
+   *
+   * Returns the event emitted, or null when nothing changed — the return value
+   * is what tests assert against, so "stayed quiet" is observable rather than
+   * inferred from the absence of a webhook.
+   */
+  async onHealthChecked(
+    projectId: string,
+    report: {
+      checks: Array<{ id: string; status: string; code: string; summary: string; remediation?: string | null }>
+      checkedAt: string
+    },
+  ): Promise<'health.degraded' | 'health.recovered' | null> {
+    const project = this.db.select().from(projects).where(eq(projects.id, projectId)).get()
+    if (!project) {
+      log.error('project.not-found', { projectId, msg: 'skipping health notification' })
+      return null
+    }
+
+    // `skipped` is not a health signal — a check that could not run tells us
+    // nothing about the instrument and must never look like a clean bill.
+    const rank = (status: string): number => (status === 'fail' ? 2 : status === 'warn' ? 1 : 0)
+    const graded = report.checks.filter(c => c.status === 'fail' || c.status === 'warn' || c.status === 'ok')
+    const failing = graded
+      .filter(c => c.status !== 'ok')
+      .sort((a, b) => rank(b.status) - rank(a.status) || a.id.localeCompare(b.id))
+    const worst = failing.at(0) ?? null
+
+    // No gradeable check ran at all. Reporting `ok` here would be the exact
+    // failure this channel exists to catch: a green signal produced by an
+    // instrument that measured nothing. Absence of a signal is not health.
+    const noSignal = graded.length === 0
+    const status: 'ok' | 'warn' | 'fail' = noSignal
+      ? 'warn'
+      : worst
+        ? (worst.status as 'warn' | 'fail')
+        : 'ok'
+    const code = noSignal ? 'health.no-signal' : (worst?.code ?? 'health.ok')
+    const summary = noSignal
+      ? `No health check produced a result (${report.checks.length} skipped) — health is unknown, not confirmed.`
+      : (worst?.summary ?? `All ${graded.length} health check(s) passing.`)
+
+    const previous = this.db.select().from(doctorHealthState)
+      .where(eq(doctorHealthState.projectId, projectId)).get()
+    const previousStatus = (previous?.status ?? null) as 'ok' | 'warn' | 'fail' | null
+
+    // Transition rules: a first observation only speaks up if it is already
+    // bad, so installing this does not announce healthy projects.
+    let event: 'health.degraded' | 'health.recovered' | null = null
+    if (previous === undefined) {
+      if (status !== 'ok') event = 'health.degraded'
+    } else if (status === 'ok' && previousStatus !== 'ok') {
+      event = 'health.recovered'
+    } else if (status !== 'ok' && (previousStatus === 'ok' || previous.code !== code)) {
+      event = 'health.degraded'
+    }
+
+    const now = report.checkedAt
+    const row = {
+      projectId,
+      status,
+      code,
+      summary,
+      checkedAt: now,
+      notifiedAt: event ? now : (previous?.notifiedAt ?? null),
+    }
+    if (previous === undefined) this.db.insert(doctorHealthState).values(row).run()
+    else this.db.update(doctorHealthState).set(row).where(eq(doctorHealthState.projectId, projectId)).run()
+
+    if (!event) {
+      log.info('health.unchanged', { projectId, status, code })
+      return null
+    }
+
+    const notifs = this.db.select().from(notifications)
+      .where(eq(notifications.projectId, projectId)).all().filter(n => n.enabled)
+
+    const payload: HealthWebhookPayload = {
+      source: 'canonry',
+      event,
+      project: { name: project.name, canonicalDomain: project.canonicalDomain },
+      health: {
+        status,
+        code,
+        summary,
+        remediation: worst?.remediation ?? null,
+        checkedAt: now,
+        previousStatus,
+        failing: failing.map(c => ({ id: c.id, status: c.status, code: c.code, summary: c.summary })),
+      },
+      dashboardUrl: `${this.serverUrl}/projects/${project.name}`,
+    }
+
+    for (const notif of notifs) {
+      const config = notif.config as { url: string; events?: string[] }
+      if (config.events && !config.events.includes(event)) continue
+      await this.sendWebhook(config.url, payload as unknown as WebhookPayload, notif.id, projectId, notif.webhookSecret ?? null)
+    }
+    log.info('health.notified', { projectId, event, status, code, subscribers: notifs.length })
+    return event
   }
 
   /** Dispatch insight webhooks for critical/high severity insights after a run. */

--- a/packages/canonry/src/scheduler.ts
+++ b/packages/canonry/src/scheduler.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto'
 import cron from 'node-cron'
-import { and, eq, inArray } from 'drizzle-orm'
+import { and, eq, inArray, notExists, sql } from 'drizzle-orm'
 import { queueRunIfProjectIdle, nextRunFromCron } from '@ainyc/canonry-api-routes'
 import type { DatabaseClient } from '@ainyc/canonry-db'
 import { schedules, projects, runs } from '@ainyc/canonry-db'
@@ -9,6 +9,9 @@ import { SchedulableRunKinds, RunKinds, RunStatuses, RunTriggers } from '@ainyc/
 import { createLogger } from './logger.js'
 
 const log = createLogger('Scheduler')
+
+/** Default cadence for the health schedule seeded on first start. */
+const DEFAULT_HEALTH_CRON = '0 */6 * * *'
 
 export interface SchedulerCallbacks {
   /** Fired when an answer-visibility schedule triggers. Existing canonry callsites wire this to the JobRunner. */
@@ -44,6 +47,14 @@ export interface SchedulerCallbacks {
    * by the host, not the scheduler. Fire-and-forget.
    */
   onDataRefreshRequested?: (projectName: string) => void
+  /**
+   * Fired when a doctor schedule triggers. The host runs the health checks and
+   * decides whether the outcome is worth notifying. No run row: doctor measures
+   * the instrument rather than producing findings, so it has nothing to attach
+   * results to and must never displace a real sweep on the dashboard.
+   * Fire-and-forget.
+   */
+  onDoctorRequested?: (projectName: string) => void
   /**
    * Fired when a backlinks-sync schedule triggers. The host re-probes Common
    * Crawl for the latest hyperlink-graph release and, when a newer rolling
@@ -82,8 +93,56 @@ export class Scheduler {
     this.callbacks = callbacks
   }
 
+  /**
+   * Give every project a health schedule if it has never had one.
+   *
+   * Ships the schedule with the feature. The six checks that existed before
+   * this had never run on a live instance because nothing scheduled them, and
+   * a health check nobody enables is indistinguishable from no health check.
+   *
+   * Keyed on the row EXISTING, not on it being enabled, so an operator who
+   * deliberately turns this off keeps it off across restarts. Seeded here
+   * rather than in a migration because migrations must stay additive to remain
+   * downgrade-safe, and inserting rows is a data mutation.
+   *
+   * Every 6h, not daily: the cadence has to be shorter than the time-to-damage
+   * it guards. A Vercel source begins discarding traffic once it is 24h behind,
+   * so a daily pass could only ever observe the loss after it started.
+   */
+  private ensureHealthSchedules(): void {
+    const projectsWithoutHealth = this.db
+      .select({ id: projects.id })
+      .from(projects)
+      .where(notExists(
+        this.db.select({ one: sql`1` }).from(schedules).where(and(
+          eq(schedules.projectId, projects.id),
+          eq(schedules.kind, SchedulableRunKinds.doctor),
+        )),
+      ))
+      .all()
+    if (projectsWithoutHealth.length === 0) return
+    const now = new Date().toISOString()
+    for (const project of projectsWithoutHealth) {
+      this.db.insert(schedules).values({
+        id: crypto.randomUUID(),
+        projectId: project.id,
+        kind: SchedulableRunKinds.doctor,
+        cronExpr: DEFAULT_HEALTH_CRON,
+        timezone: 'UTC',
+        enabled: true,
+        providers: [],
+        nextRunAt: nextRunFromCron(DEFAULT_HEALTH_CRON, 'UTC'),
+        createdAt: now,
+        updatedAt: now,
+      }).run()
+    }
+    log.info('health-schedule.seeded', { projectCount: projectsWithoutHealth.length, cron: DEFAULT_HEALTH_CRON })
+  }
+
   /** Load all enabled schedules from DB and register cron jobs. */
   start(): void {
+    this.ensureHealthSchedules()
+
     const allSchedules = this.db
       .select()
       .from(schedules)
@@ -321,6 +380,24 @@ export class Scheduler {
         }).where(eq(schedules.id, currentSchedule.id)).run()
         log.info('data-refresh.triggered', { projectName: project.name })
         this.callbacks.onDataRefreshRequested(project.name)
+        return
+      }
+
+      if (kind === SchedulableRunKinds.doctor) {
+        // Health checks read existing state and emit at most one notification;
+        // they create no run row, so the schedule row itself is the only thing
+        // that advances here.
+        if (!this.callbacks.onDoctorRequested) {
+          log.warn('doctor.no-callback', { scheduleId, projectId, msg: 'host did not register onDoctorRequested' })
+          return
+        }
+        this.db.update(schedules).set({
+          lastRunAt: now,
+          nextRunAt,
+          updatedAt: now,
+        }).where(eq(schedules.id, currentSchedule.id)).run()
+        log.info('doctor.triggered', { projectName: project.name })
+        this.callbacks.onDoctorRequested(project.name)
         return
       }
 

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -1193,6 +1193,35 @@ export async function createServer(opts: {
       // The scheduler already created the ads-sync run row; run the worker.
       runAdsSync(runId, projectId);
     },
+    onDoctorRequested: (projectName) => {
+      // Run the health checks and notify only on a transition. This is the loop
+      // that was missing: the checks existed and nothing executed them, so a
+      // degraded instrument kept emitting `run.completed` and looked healthy.
+      void (async () => {
+        try {
+          const report = await aeroClient.runDoctor({ project: projectName });
+          const project = opts.db
+            .select()
+            .from(projects)
+            .where(eq(projects.name, projectName))
+            .get();
+          if (!project) {
+            app.log.warn({ projectName }, "doctor schedule fired for an unknown project");
+            return;
+          }
+          await notifier.onHealthChecked(project.id, {
+            checks: report.checks,
+            checkedAt: report.generatedAt,
+          });
+        } catch (err: unknown) {
+          // A health check that cannot run must not take the scheduler down,
+          // but it also must not look like a clean pass — leaving the stored
+          // state untouched means the next successful pass still sees the real
+          // previous status and transitions correctly.
+          app.log.warn({ projectName, err }, "scheduled doctor pass failed");
+        }
+      })();
+    },
     onDataRefreshRequested: (projectName) => {
       // Fan out to every connected data integration (GSC, Bing, GA, GBP) via
       // the same in-process client. refreshAllIntegrations isolates each

--- a/packages/canonry/test/health-notifications.test.ts
+++ b/packages/canonry/test/health-notifications.test.ts
@@ -1,0 +1,214 @@
+import { test, expect, onTestFinished, vi } from 'vitest'
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { eq } from 'drizzle-orm'
+import { createClient, migrate, doctorHealthState, notifications, projects } from '@ainyc/canonry-db'
+import { Notifier } from '../src/notifier.js'
+
+// Canonry alarmed when the measurement reported bad news and never when the
+// measurement itself was broken. Every notifiable event described a finding
+// (citation.lost, run.failed, insight.*), so a Vercel source that silently
+// discarded traffic for 24h kept emitting `run.completed` — a success signal —
+// the whole time, and a provider that quietly stopped retrieving looked
+// identical to a brand that genuinely was not mentioned.
+//
+// These tests pin the health channel that closes that gap, and specifically pin
+// that it stays quiet when nothing changed: an operator who gets the same
+// warning every day stops reading the channel, which recreates the original
+// failure with extra steps.
+
+function harness() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cnry-health-'))
+  onTestFinished(() => fs.rmSync(tmp, { recursive: true, force: true }))
+  const db = createClient(path.join(tmp, 'test.db'))
+  migrate(db)
+  const now = new Date().toISOString()
+  const projectId = crypto.randomUUID()
+  db.insert(projects).values({
+    id: projectId, name: 'healthproj', displayName: 'Health', canonicalDomain: 'example.com',
+    country: 'US', language: 'en', providers: [], createdAt: now, updatedAt: now,
+  }).run()
+  db.insert(notifications).values({
+    id: crypto.randomUUID(), projectId, channel: 'webhook',
+    config: { url: 'https://hooks.example/health', events: ['health.degraded', 'health.recovered'] },
+    enabled: true, createdAt: now, updatedAt: now,
+  } as never).run()
+  return { db, projectId, notifier: new Notifier(db, 'https://canonry.test') }
+}
+
+const check = (id: string, status: string, code: string, summary = 'x') => ({ id, status, code, summary })
+const at = (iso: string) => ({ checkedAt: iso })
+
+test('a first pass that is already degraded notifies once', async () => {
+  const { notifier, projectId, db } = harness()
+  const sent: unknown[] = []
+  vi.spyOn(notifier as never, 'sendWebhook').mockImplementation(async (...args: unknown[]) => { sent.push(args[1]) })
+
+  const event = await notifier.onHealthChecked(projectId, {
+    checks: [check('traffic.source.sync-lag', 'fail', 'traffic.sync-lag.discarding', 'discarding now')],
+    ...at('2026-07-31T05:00:00.000Z'),
+  })
+
+  expect(event).toBe('health.degraded')
+  expect(sent).toHaveLength(1)
+  const payload = sent[0] as { event: string; health: { status: string; previousStatus: null; code: string } }
+  expect(payload.event).toBe('health.degraded')
+  expect(payload.health.status).toBe('fail')
+  expect(payload.health.previousStatus).toBeNull()
+  expect(payload.health.code).toBe('traffic.sync-lag.discarding')
+  // The payload deliberately carries no `run` — this is not a finding.
+  expect(payload).not.toHaveProperty('run')
+
+  const stored = db.select().from(doctorHealthState).where(eq(doctorHealthState.projectId, projectId)).get()!
+  expect(stored.status).toBe('fail')
+})
+
+test('a repeat of the same problem stays silent so the channel keeps meaning something', async () => {
+  const { notifier, projectId } = harness()
+  const sent: unknown[] = []
+  vi.spyOn(notifier as never, 'sendWebhook').mockImplementation(async (...args: unknown[]) => { sent.push(args[1]) })
+
+  const checks = [check('traffic.source.sync-lag', 'warn', 'traffic.sync-lag.behind')]
+  const first = await notifier.onHealthChecked(projectId, { checks, ...at('2026-07-31T05:00:00.000Z') })
+  const second = await notifier.onHealthChecked(projectId, { checks, ...at('2026-08-01T05:00:00.000Z') })
+  const third = await notifier.onHealthChecked(projectId, { checks, ...at('2026-08-02T05:00:00.000Z') })
+
+  expect(first).toBe('health.degraded')
+  expect(second).toBeNull()
+  expect(third).toBeNull()
+  expect(sent).toHaveLength(1)
+})
+
+test('a different cause at the same severity does notify, because it is different news', async () => {
+  const { notifier, projectId } = harness()
+  vi.spyOn(notifier as never, 'sendWebhook').mockImplementation(async () => {})
+
+  const first = await notifier.onHealthChecked(projectId, {
+    checks: [check('traffic.source.sync-lag', 'warn', 'traffic.sync-lag.behind')],
+    ...at('2026-07-31T05:00:00.000Z'),
+  })
+  const second = await notifier.onHealthChecked(projectId, {
+    checks: [check('traffic.source.connected', 'warn', 'traffic.source.partially-errored')],
+    ...at('2026-08-01T05:00:00.000Z'),
+  })
+
+  expect(first).toBe('health.degraded')
+  expect(second).toBe('health.degraded')
+})
+
+test('recovery closes the loop', async () => {
+  const { notifier, projectId } = harness()
+  const sent: { event: string; health: { previousStatus: string | null } }[] = []
+  vi.spyOn(notifier as never, 'sendWebhook').mockImplementation(async (...args: unknown[]) => {
+    sent.push(args[1] as never)
+  })
+
+  await notifier.onHealthChecked(projectId, {
+    checks: [check('traffic.source.sync-lag', 'fail', 'traffic.sync-lag.discarding')],
+    ...at('2026-07-31T05:00:00.000Z'),
+  })
+  const recovered = await notifier.onHealthChecked(projectId, {
+    checks: [check('traffic.source.sync-lag', 'ok', 'traffic.sync-lag.current')],
+    ...at('2026-08-01T05:00:00.000Z'),
+  })
+
+  expect(recovered).toBe('health.recovered')
+  expect(sent.at(-1)!.event).toBe('health.recovered')
+  expect(sent.at(-1)!.health.previousStatus).toBe('fail')
+})
+
+test('a healthy first pass says nothing, so enabling this does not announce working projects', async () => {
+  const { notifier, projectId } = harness()
+  const sent: unknown[] = []
+  vi.spyOn(notifier as never, 'sendWebhook').mockImplementation(async (...a: unknown[]) => { sent.push(a) })
+
+  const event = await notifier.onHealthChecked(projectId, {
+    checks: [check('traffic.source.sync-lag', 'ok', 'traffic.sync-lag.current')],
+    ...at('2026-07-31T05:00:00.000Z'),
+  })
+
+  expect(event).toBeNull()
+  expect(sent).toHaveLength(0)
+})
+
+test('a skipped check does not mask a failing one', async () => {
+  const { notifier, projectId, db } = harness()
+  vi.spyOn(notifier as never, 'sendWebhook').mockImplementation(async () => {})
+
+  await notifier.onHealthChecked(projectId, {
+    checks: [
+      check('traffic.source.sync-lag', 'skipped', 'traffic.sync-lag.no-source'),
+      check('traffic.source.credentials', 'fail', 'traffic.credentials.failed'),
+    ],
+    ...at('2026-07-31T05:00:00.000Z'),
+  })
+
+  const stored = db.select().from(doctorHealthState).where(eq(doctorHealthState.projectId, projectId)).get()!
+  expect(stored.status).toBe('fail')
+  expect(stored.code).toBe('traffic.credentials.failed')
+})
+
+test('a pass where every check skipped is unknown, never healthy', async () => {
+  // The whole point of this channel is that a green signal must mean something
+  // was measured. If every check skips there is no signal at all, and calling
+  // that `ok` reproduces green-while-blind — an instrument reporting health
+  // having measured nothing. It must warn, and it must say why.
+  const { notifier, projectId, db } = harness()
+  const sent: { event: string; health: { code: string } }[] = []
+  vi.spyOn(notifier as never, 'sendWebhook').mockImplementation(async (...a: unknown[]) => {
+    sent.push(a[1] as never)
+  })
+
+  const event = await notifier.onHealthChecked(projectId, {
+    checks: [
+      check('traffic.source.sync-lag', 'skipped', 'traffic.sync-lag.no-source'),
+      check('traffic.source.credentials', 'skipped', 'traffic.credentials.no-source'),
+    ],
+    ...at('2026-07-31T05:00:00.000Z'),
+  })
+
+  expect(event).toBe('health.degraded')
+  const stored = db.select().from(doctorHealthState).where(eq(doctorHealthState.projectId, projectId)).get()!
+  expect(stored.status).toBe('warn')
+  expect(stored.code).toBe('health.no-signal')
+  expect(stored.summary).toMatch(/unknown, not confirmed/)
+  expect(sent.at(-1)!.health.code).toBe('health.no-signal')
+})
+
+test('worst status wins when several checks are unhappy', async () => {
+  const { notifier, projectId, db } = harness()
+  vi.spyOn(notifier as never, 'sendWebhook').mockImplementation(async () => {})
+
+  await notifier.onHealthChecked(projectId, {
+    checks: [
+      check('a.warn', 'warn', 'a.warn.code'),
+      check('b.fail', 'fail', 'b.fail.code'),
+      check('c.ok', 'ok', 'c.ok.code'),
+    ],
+    ...at('2026-07-31T05:00:00.000Z'),
+  })
+
+  const stored = db.select().from(doctorHealthState).where(eq(doctorHealthState.projectId, projectId)).get()!
+  expect(stored.status).toBe('fail')
+  expect(stored.code).toBe('b.fail.code')
+})
+
+test('a subscriber that did not opt into health events is not sent one', async () => {
+  const { db, notifier, projectId } = harness()
+  db.update(notifications)
+    .set({ config: { url: 'https://hooks.example/runs', events: ['run.completed', 'run.failed'] } } as never)
+    .where(eq(notifications.projectId, projectId)).run()
+  const sent: unknown[] = []
+  vi.spyOn(notifier as never, 'sendWebhook').mockImplementation(async (...a: unknown[]) => { sent.push(a) })
+
+  const event = await notifier.onHealthChecked(projectId, {
+    checks: [check('traffic.source.sync-lag', 'fail', 'traffic.sync-lag.discarding')],
+    ...at('2026-07-31T05:00:00.000Z'),
+  })
+
+  // The transition still happened and is still recorded; only delivery is filtered.
+  expect(event).toBe('health.degraded')
+  expect(sent).toHaveLength(0)
+})

--- a/packages/canonry/test/notify-events.test.ts
+++ b/packages/canonry/test/notify-events.test.ts
@@ -1,3 +1,4 @@
+import { notificationEventSchema } from '@ainyc/canonry-contracts'
 import { it, expect } from 'vitest'
 import { listEvents } from '../src/commands/notify.js'
 
@@ -32,6 +33,6 @@ it('listEvents outputs valid JSON with --format json', () => {
 
   const parsed = JSON.parse(logs.join('\n'))
   expect(Array.isArray(parsed)).toBeTruthy()
-  expect(parsed.length).toBe(6)
+  expect(parsed.length).toBe(notificationEventSchema.options.length)
   expect(parsed.every((e: { event: string; description: string }) => e.event && e.description)).toBeTruthy()
 })

--- a/packages/canonry/test/scheduler.test.ts
+++ b/packages/canonry/test/scheduler.test.ts
@@ -6,6 +6,19 @@ import { eq } from 'drizzle-orm'
 import { createClient, migrate, projects, schedules, runs } from '@ainyc/canonry-db'
 import { Scheduler } from '../src/scheduler.js'
 
+/**
+ * Count registered cron tasks, ignoring the health schedule the scheduler seeds
+ * for every project on start. These tests are about orphan cleanup and per-kind
+ * keying; an absolute size assertion would couple them to how many schedules
+ * ship by default.
+ */
+function taskCount(scheduler: unknown, opts: { includeHealth?: boolean } = {}): number {
+  const tasks = (scheduler as { tasks: Map<string, unknown> }).tasks
+  if (opts.includeHealth) return tasks.size
+  return [...tasks.keys()].filter(key => !key.endsWith('::doctor')).length
+}
+
+
 function createTempDb() {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-scheduler-test-'))
   const dbPath = path.join(tmpDir, 'test.db')
@@ -46,14 +59,14 @@ test('scheduler removes orphaned tasks after project deletion', () => {
   })
 
   scheduler.start()
-  expect((scheduler as unknown as { tasks: Map<string, unknown> }).tasks.size).toBe(1)
+  expect(taskCount(scheduler)).toBe(1)
 
   db.delete(projects).where(eq(projects.id, 'proj_1')).run()
   ;(scheduler as unknown as { triggerRun: (scheduleId: string, projectId: string, kind: 'answer-visibility' | 'traffic-sync') => void })
     .triggerRun('sched_1', 'proj_1', 'answer-visibility')
 
   expect(createdRunIds.length).toBe(0)
-  expect((scheduler as unknown as { tasks: Map<string, unknown> }).tasks.size).toBe(0)
+  expect(taskCount(scheduler)).toBe(0)
 
   scheduler.stop()
   fs.rmSync(tmpDir, { recursive: true, force: true })
@@ -104,15 +117,15 @@ test('scheduler keys tasks by (projectId, kind) — both kinds can register inde
   const scheduler = new Scheduler(db, { onRunCreated: () => {} })
   scheduler.start()
   // Both schedules registered.
-  expect((scheduler as unknown as { tasks: Map<string, unknown> }).tasks.size).toBe(2)
+  expect(taskCount(scheduler)).toBe(2)
 
   // Remove only the traffic-sync one — the answer-visibility task survives.
   scheduler.remove('proj_2', 'traffic-sync')
-  expect((scheduler as unknown as { tasks: Map<string, unknown> }).tasks.size).toBe(1)
+  expect(taskCount(scheduler)).toBe(1)
 
   // removeAllForProject clears both.
   scheduler.removeAllForProject('proj_2')
-  expect((scheduler as unknown as { tasks: Map<string, unknown> }).tasks.size).toBe(0)
+  expect(taskCount(scheduler)).toBe(0)
 
   scheduler.stop()
   fs.rmSync(tmpDir, { recursive: true, force: true })

--- a/packages/contracts/src/notification.ts
+++ b/packages/contracts/src/notification.ts
@@ -7,6 +7,18 @@ export const notificationEventSchema = z.enum([
   'run.failed',
   'insight.critical',
   'insight.high',
+  /**
+   * Instrument health, as opposed to findings. Every other event above reports
+   * what the measurement SAW; these two report whether the measurement is
+   * trustworthy at all. They exist because a degraded pipeline keeps emitting
+   * `run.completed` — a success signal — while producing wrong numbers.
+   *
+   * Edge-triggered: emitted when the worst check status changes, never on every
+   * scheduled pass, so a persistent warning does not train the operator to
+   * ignore the channel.
+   */
+  'health.degraded',
+  'health.recovered',
 ])
 export type NotificationEvent = z.infer<typeof notificationEventSchema>
 
@@ -50,6 +62,32 @@ export interface InsightWebhookPayload {
     query: string
     provider: string
   }>
+  dashboardUrl: string
+}
+
+/**
+ * Health events carry no `run`: they report on the measurement apparatus, not
+ * on a sweep. Deliberately a separate payload rather than a run payload with a
+ * null run, because a subscriber that keys off `run.id` should fail loudly on
+ * a health event instead of silently treating it as a finding about the site.
+ */
+export interface HealthWebhookPayload {
+  source: 'canonry'
+  event: 'health.degraded' | 'health.recovered'
+  project: { name: string; canonicalDomain: string }
+  health: {
+    /** Worst check status observed on this pass. */
+    status: 'ok' | 'warn' | 'fail'
+    /** Stable code of the worst check, e.g. "traffic.sync-lag.discarding". */
+    code: string
+    summary: string
+    remediation: string | null
+    checkedAt: string
+    /** What the status was before this pass, so the transition is explicit. */
+    previousStatus: 'ok' | 'warn' | 'fail' | null
+    /** Every non-ok check on this pass, worst first. */
+    failing: Array<{ id: string; status: string; code: string; summary: string }>
+  }
   dashboardUrl: string
 }
 

--- a/packages/contracts/src/schedule.ts
+++ b/packages/contracts/src/schedule.ts
@@ -17,7 +17,15 @@ import { providerNameSchema } from './provider.js'
  * - `ads-sync` — OpenAI Advertiser API (ChatGPT ads) pull: entity snapshots + daily paid-performance
  *   rollups for the project's connected ad account. No `sourceId`, no `providers`.
  */
-export const schedulableRunKindSchema = z.enum(['answer-visibility', 'traffic-sync', 'gbp-sync', 'data-refresh', 'backlinks-sync', 'site-audit', 'ads-sync'])
+/**
+ * `doctor` is the only kind here that measures the instrument rather than the
+ * site. Every other kind produces findings; a failure in one of them is visible
+ * because the run itself fails. Instrument degradation is not: a source that
+ * silently discards data, or a provider that quietly stops retrieving, still
+ * reports `run.completed`. Without a scheduled health kind the checks that
+ * detect those conditions only run when a human types `canonry doctor`.
+ */
+export const schedulableRunKindSchema = z.enum(['answer-visibility', 'traffic-sync', 'gbp-sync', 'data-refresh', 'backlinks-sync', 'site-audit', 'ads-sync', 'doctor'])
 export type SchedulableRunKind = z.infer<typeof schedulableRunKindSchema>
 export const SchedulableRunKinds = schedulableRunKindSchema.enum
 

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -2518,6 +2518,29 @@ export const MIGRATION_VERSIONS: ReadonlyArray<MigrationVersion> = [
       `ALTER TABLE traffic_sources ADD COLUMN skipped_through_at TEXT`,
     ],
   },
+  {
+    // Scheduled health checks need somewhere to remember the previous outcome so
+    // alerting fires on transitions rather than on every pass. Fresh installs and
+    // upgrades both start empty, which reads as "no prior observation" and makes
+    // the first degraded pass notify exactly once.
+    //
+    // The default doctor schedule is NOT seeded here. Migrations after v88 must
+    // stay additive so a downgrade is safe, and inserting rows is a data
+    // mutation. Scheduler.start() ensures the schedule instead, which also lets
+    // an operator who disables it keep it disabled.
+    version: 114,
+    name: 'doctor-health-state',
+    statements: [
+      `CREATE TABLE IF NOT EXISTS doctor_health_state (
+        project_id  TEXT PRIMARY KEY REFERENCES projects(id) ON DELETE CASCADE,
+        status      TEXT NOT NULL,
+        code        TEXT NOT NULL,
+        summary     TEXT NOT NULL,
+        checked_at  TEXT NOT NULL,
+        notified_at TEXT
+      )`,
+    ],
+  },
 ]
 
 /**

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -201,6 +201,24 @@ export const schedules = sqliteTable('schedules', {
   uniqueIndex('idx_schedules_project_kind').on(table.projectId, table.kind),
 ])
 
+/**
+ * Last observed doctor outcome per project, so health alerting is
+ * edge-triggered. Without this the scheduled pass would re-notify every day a
+ * warning persists, and an operator who learns to ignore the channel is worse
+ * than no channel at all.
+ */
+export const doctorHealthState = sqliteTable('doctor_health_state', {
+  projectId: text('project_id').primaryKey(),
+  /** Worst check status observed on the last pass: ok | warn | fail. */
+  status: text('status').notNull(),
+  /** Stable code of the worst check, so a changed cause re-notifies. */
+  code: text('code').notNull(),
+  summary: text('summary').notNull(),
+  checkedAt: text('checked_at').notNull(),
+  /** When we last emitted for this (status, code). Null until first emit. */
+  notifiedAt: text('notified_at'),
+})
+
 export const notifications = sqliteTable('notifications', {
   id: text('id').primaryKey(),
   projectId: text('project_id').notNull().references(() => projects.id, { onDelete: 'cascade' }),


### PR DESCRIPTION
Follow-up to #882. That PR added a check; this one makes checks actually run.

## The gap

Canonry alarms when the measurement reports bad news, never when the measurement itself is broken. Three failures this week shared that shape — Claude silently stopped searching, and two Vercel sources silently began discarding traffic. **All of them completed successfully.**

Three gaps, each verified against the live instance:

| Gap | Evidence |
|---|---|
| Nothing ran the checks | `doctor` was not in `schedulableRunKindSchema`; the audit log shows doctor had **never once run** |
| No vocabulary for degradation | Notifiable events were `citation.lost/gained`, `run.completed/failed`, `insight.critical/high` — all findings, none health |
| The success signal was misleading | Runs completed, so gjelina sent a **`run.completed` success notification every 30 minutes for 24 hours** while losing data |

## What this adds

- `doctor` as a schedulable kind
- `health.degraded` / `health.recovered` notification events
- A 6-hourly health schedule seeded for every project on scheduler start

**Every 6h, not daily**, because the cadence has to be shorter than the time-to-damage it guards. A Vercel source starts discarding once it is 24h behind, so a daily pass could only ever observe the loss after it began.

**Seeded in `Scheduler.start()`, not the migration.** I initially seeded it in migration 113 and the repo's own guard rejected it: migrations after v88 must stay additive to remain downgrade-safe, and inserting rows is a data mutation. Seeding keys on the row *existing* rather than being enabled, so an operator who deliberately disables it keeps it disabled across restarts.

## Alerting that stays worth reading

Edge-triggered on `(status, code)`. A pass finding the same problem as the last is recorded but not re-sent — an operator who receives the same warning daily stops reading the channel, which recreates the original failure with extra steps. A changed code at the same severity **does** notify, because a different cause is different news.

Health payloads deliberately carry no `run`. A subscriber keying off `run.id` should fail loudly on a health event rather than silently treat it as a finding about the site.

## An ablation caught a real bug here

Writing the ablation for "skipped is not ok" exposed that my own fold was wrong: with **every** check skipped, it produced `ok` and reported `All 0 health check(s) passing` — an instrument declaring itself healthy having measured nothing. Exactly the failure this channel exists to catch. A pass with no gradeable result is now `warn` / `health.no-signal`, with a test pinning it.

## Verification

9 health tests, each verified by ablation:
- level-triggering instead of edge-triggering → fails the silence test
- treating `skipped` as gradeable → fails the no-signal test

Migration 113 verified against a 1 GB production copy: 8ms, idempotent, integrity clean. Full suite **6,155 passing across 508 files**, typecheck clean.

Scheduler tests were asserting absolute task-map sizes, which coupled them to how many schedules ship by default; now counted by kind.

---

## Merge order

**Merge #882 first.** Both PRs currently define migration **113** on the same base (main is at 112). #882 owns `traffic-source-skipped-span`; this PR's `doctor-health-state` renumbers to **114** on rebase once #882 lands. Merging this one first would leave #882 with a version collision.

I verified the ordering rather than assuming it: renumbering this branch to 114 in place fails the repo's contiguity guard (`unjustified gap: version 113 is missing`), which is exactly the intended behaviour.