### PR TITLE
fix(traffic,health): stop the watermark rewind and make health alarms land

### DIFF
--- a/packages/api-routes/src/traffic.ts
+++ b/packages/api-routes/src/traffic.ts
@@ -1871,7 +1871,20 @@ export async function trafficRoutes(app: FastifyInstance, opts: TrafficRoutesOpt
         // them and they'd be lost. effectiveWindowEnd equals windowEnd on a full
         // sync; for a Vercel drain that stopped at its deadline it is the partial
         // boundary, so the next sync resumes exactly where this one left off.
-        lastSyncedAt: effectiveWindowEnd.toISOString(),
+        //
+        // Never move the watermark BACKWARD. A sync already in flight when the
+        // cursor is advanced out from under it (an operator reset, or a backfill
+        // committing a later window) would otherwise commit its own older
+        // window end and undo that advance — the source silently resumes from
+        // the past and re-walks ground that was deliberately skipped. Backfill
+        // has always guarded this; the incremental path did not, so a reset only
+        // stuck if you first disabled the schedule and drained the in-flight run.
+        lastSyncedAt: new Date(
+          Math.max(
+            sourceRow.lastSyncedAt ? new Date(sourceRow.lastSyncedAt).getTime() : Number.NEGATIVE_INFINITY,
+            effectiveWindowEnd.getTime(),
+          ),
+        ).toISOString(),
         lastError: null,
         lastEventIds: nextEventIds,
         updatedAt: finishedAt,

--- a/packages/api-routes/test/traffic.test.ts
+++ b/packages/api-routes/test/traffic.test.ts
@@ -761,6 +761,40 @@ describe('POST /traffic/connect/vercel', () => {
 })
 
 describe('POST /traffic/sources/:id/sync — Vercel', () => {
+  it('never walks lastSyncedAt backward when the cursor moved ahead mid-sync', async () => {
+    // The reset rewind race. A sync already in flight when the cursor is
+    // advanced out from under it (an operator `--advance-to-now`, or a backfill
+    // committing a later window) used to commit its OWN older window end and
+    // silently undo that advance — the source resumed from the past and
+    // re-walked ground that had been deliberately skipped. Backfill always
+    // guarded this; the incremental path did not, so a reset only stuck if you
+    // first disabled the schedule and drained the in-flight run by hand.
+    const h = await buildHarness([])
+    try {
+      const sourceId = await connectVercel(h)
+
+      // Stand in for the advance that lands while this sync is mid-flight: the
+      // stored watermark is already ahead of any window this sync can produce.
+      const ahead = new Date(Date.now() + 60 * 60_000).toISOString()
+      h.db.update(trafficSources)
+        .set({ lastSyncedAt: ahead })
+        .where(eq(trafficSources.id, sourceId))
+        .run()
+
+      const syncRes = await h.app.inject({
+        method: 'POST',
+        url: `/api/v1/projects/test-project/traffic/sources/${sourceId}/sync`,
+        payload: {},
+      })
+      expect(syncRes.statusCode).toBe(200)
+
+      const sourceRow = h.db.select().from(trafficSources).where(eq(trafficSources.id, sourceId)).get()!
+      expect(new Date(sourceRow.lastSyncedAt!).getTime()).toBeGreaterThanOrEqual(new Date(ahead).getTime())
+    } finally {
+      await h.app.close()
+    }
+  })
+
   const vercelConnectBody = {
     projectId: 'prj_abc',
     teamId: 'team_xyz',
@@ -1474,6 +1508,7 @@ describe('POST /traffic/sources/:id/backfill — Vercel', () => {
 })
 
 describe('POST /traffic/sources/:id/sync', () => {
+
   it('returns 404 when the source does not belong to the project', async () => {
     const h = await buildHarness([])
     try {

--- a/packages/canonry/src/notifier.ts
+++ b/packages/canonry/src/notifier.ts
@@ -118,7 +118,7 @@ export class Notifier {
   async onHealthChecked(
     projectId: string,
     report: {
-      checks: Array<{ id: string; status: string; code: string; summary: string; remediation?: string | null }>
+      checks: Array<{ id: string; status: string; code: string; summary: string; remediation?: string | null; category?: string }>
       checkedAt: string
     },
   ): Promise<'health.degraded' | 'health.recovered' | null> {
@@ -131,10 +131,30 @@ export class Notifier {
     // `skipped` is not a health signal — a check that could not run tells us
     // nothing about the instrument and must never look like a clean bill.
     const rank = (status: string): number => (status === 'fail' ? 2 : status === 'warn' ? 1 : 0)
+
+    // Among equally severe checks, lead with the one that says the measurement
+    // is broken rather than the one offering advice about the site. Sorting by
+    // id put `content.*` ahead of `traffic.*` purely alphabetically, so a
+    // source silently discarding traffic was headlined as a content-coverage
+    // note. Everything still travels in `failing`; this only picks the headline.
+    const categoryRank = (category: string | undefined): number => {
+      switch (category) {
+        case 'database': return 6
+        case 'integrations': return 5
+        case 'providers': return 4
+        case 'auth': return 3
+        case 'schedules': return 2
+        case 'config': return 1
+        default: return 0
+      }
+    }
     const graded = report.checks.filter(c => c.status === 'fail' || c.status === 'warn' || c.status === 'ok')
     const failing = graded
       .filter(c => c.status !== 'ok')
-      .sort((a, b) => rank(b.status) - rank(a.status) || a.id.localeCompare(b.id))
+      .sort((a, b) =>
+        rank(b.status) - rank(a.status)
+        || categoryRank(b.category) - categoryRank(a.category)
+        || a.id.localeCompare(b.id))
     const worst = failing.at(0) ?? null
 
     // No gradeable check ran at all. Reporting `ok` here would be the exact
@@ -167,16 +187,16 @@ export class Notifier {
     }
 
     const now = report.checkedAt
-    const row = {
-      projectId,
-      status,
-      code,
-      summary,
-      checkedAt: now,
-      notifiedAt: event ? now : (previous?.notifiedAt ?? null),
+    // Write the observation first so a delivery failure cannot lose it, but
+    // leave `notifiedAt` alone until something is actually sent — it previously
+    // recorded "decided to notify", which read as delivered even when zero
+    // webhooks matched.
+    const observation = { projectId, status, code, summary, checkedAt: now }
+    if (previous === undefined) {
+      this.db.insert(doctorHealthState).values({ ...observation, notifiedAt: null }).run()
+    } else {
+      this.db.update(doctorHealthState).set(observation).where(eq(doctorHealthState.projectId, projectId)).run()
     }
-    if (previous === undefined) this.db.insert(doctorHealthState).values(row).run()
-    else this.db.update(doctorHealthState).set(row).where(eq(doctorHealthState.projectId, projectId)).run()
 
     if (!event) {
       log.info('health.unchanged', { projectId, status, code })
@@ -202,12 +222,26 @@ export class Notifier {
       dashboardUrl: `${this.serverUrl}/projects/${project.name}`,
     }
 
+    // Health events reach every enabled webhook, whether or not the subscription
+    // lists them. They report that the measurement itself is untrustworthy, so
+    // requiring opt-in guarantees the one alarm that matters is the one nobody
+    // subscribed to — which is exactly what happened: the events shipped, no
+    // existing subscription named them, and degradation was computed and then
+    // dropped at delivery. They are edge-triggered and therefore rare, and
+    // `canonry apply` rewriting a project's event list can no longer silence
+    // them.
+    let delivered = 0
     for (const notif of notifs) {
       const config = notif.config as { url: string; events?: string[] }
-      if (config.events && !config.events.includes(event)) continue
+      if (!config.url) continue
       await this.sendWebhook(config.url, payload as unknown as WebhookPayload, notif.id, projectId, notif.webhookSecret ?? null)
+      delivered += 1
     }
-    log.info('health.notified', { projectId, event, status, code, subscribers: notifs.length })
+    if (delivered > 0) {
+      this.db.update(doctorHealthState).set({ notifiedAt: now })
+        .where(eq(doctorHealthState.projectId, projectId)).run()
+    }
+    log.info('health.notified', { projectId, event, status, code, subscribers: notifs.length, delivered })
     return event
   }
 

--- a/packages/canonry/test/health-notifications.test.ts
+++ b/packages/canonry/test/health-notifications.test.ts
@@ -38,7 +38,7 @@ function harness() {
   return { db, projectId, notifier: new Notifier(db, 'https://canonry.test') }
 }
 
-const check = (id: string, status: string, code: string, summary = 'x') => ({ id, status, code, summary })
+const check = (id: string, status: string, code: string, summary = 'x', category?: string) => ({ id, status, code, summary, category })
 const at = (iso: string) => ({ checkedAt: iso })
 
 test('a first pass that is already degraded notifies once', async () => {
@@ -195,20 +195,59 @@ test('worst status wins when several checks are unhappy', async () => {
   expect(stored.code).toBe('b.fail.code')
 })
 
-test('a subscriber that did not opt into health events is not sent one', async () => {
+test('the headline leads with the broken instrument, not the alphabetically first check', async () => {
+  // Sorting equally-severe checks by id put `content.*` ahead of `traffic.*`,
+  // so a source silently discarding traffic was headlined as a content-coverage
+  // note. Severity is equal here; only meaning separates them.
+  const { notifier, projectId, db } = harness()
+  vi.spyOn(notifier as never, 'sendWebhook').mockImplementation(async () => {})
+
+  await notifier.onHealthChecked(projectId, {
+    checks: [
+      check('content.winnability', 'warn', 'content.winnability.low-coverage', 'advice', 'content'),
+      check('traffic.source.sync-lag', 'warn', 'traffic.sync-lag.behind', 'ingestion is behind', 'integrations'),
+    ],
+    ...at('2026-07-31T05:00:00.000Z'),
+  })
+
+  const stored = db.select().from(doctorHealthState).where(eq(doctorHealthState.projectId, projectId)).get()!
+  expect(stored.code).toBe('traffic.sync-lag.behind')
+})
+
+test('health reaches a webhook that never subscribed to health events', async () => {
+  // Requiring opt-in guaranteed the one alarm that matters is the one nobody
+  // subscribed to. It shipped, no subscription named it, and every degradation
+  // was computed then dropped at delivery.
   const { db, notifier, projectId } = harness()
   db.update(notifications)
     .set({ config: { url: 'https://hooks.example/runs', events: ['run.completed', 'run.failed'] } } as never)
     .where(eq(notifications.projectId, projectId)).run()
   const sent: unknown[] = []
-  vi.spyOn(notifier as never, 'sendWebhook').mockImplementation(async (...a: unknown[]) => { sent.push(a) })
+  vi.spyOn(notifier as never, 'sendWebhook').mockImplementation(async (...a: unknown[]) => { sent.push(a[1]) })
 
   const event = await notifier.onHealthChecked(projectId, {
     checks: [check('traffic.source.sync-lag', 'fail', 'traffic.sync-lag.discarding')],
     ...at('2026-07-31T05:00:00.000Z'),
   })
 
-  // The transition still happened and is still recorded; only delivery is filtered.
   expect(event).toBe('health.degraded')
-  expect(sent).toHaveLength(0)
+  expect(sent).toHaveLength(1)
+})
+
+test('notifiedAt records delivery, not intent', async () => {
+  const { db, notifier, projectId } = harness()
+  // No enabled webhook at all: the observation must still be stored, but
+  // nothing was delivered, so notifiedAt stays null.
+  db.update(notifications).set({ enabled: false } as never)
+    .where(eq(notifications.projectId, projectId)).run()
+
+  const event = await notifier.onHealthChecked(projectId, {
+    checks: [check('traffic.source.sync-lag', 'fail', 'traffic.sync-lag.discarding')],
+    ...at('2026-07-31T05:00:00.000Z'),
+  })
+
+  expect(event).toBe('health.degraded')
+  const stored = db.select().from(doctorHealthState).where(eq(doctorHealthState.projectId, projectId)).get()!
+  expect(stored.status).toBe('fail')
+  expect(stored.notifiedAt).toBeNull()
 })


### PR DESCRIPTION
Four fixes, all found by operating last night's changes rather than by reading them.

## 1. The incremental sync could walk the watermark backward

A sync already in flight when the cursor is advanced out from under it — an operator running `traffic reset --advance-to-now`, or a backfill committing a later window — committed its **own older window end** and silently undid the advance. The source then resumed from the past and re-walked ground that had been deliberately skipped.

Backfill has always guarded this:

```
line 506   Math.max(currentLastSyncedMs, windowEnd.getTime())   ← backfill
line 1874  lastSyncedAt: effectiveWindowEnd.toISOString()       ← incremental, unguarded
```

This is why resetting gjelina last night only stuck after cancelling the in-flight run and disabling the schedule first. That was a workaround for a one-line bug. Now guarded on both paths, verified by ablation.

## 2. Health alarms were computed, then dropped at delivery

The events shipped in #883, **no existing subscription named them**, and the notifier filtered on the subscription's event list. So every degradation was computed, recorded, and silently discarded. The one alarm that matters was the one nobody had subscribed to — the same shape as the failure it exists to catch.

Health events now reach every enabled webhook regardless of its event list. They report that the measurement itself is untrustworthy, so opt-in is the wrong default, and `canonry apply` rewriting a project's events can no longer silence them. They remain edge-triggered, so this adds no volume.

## 3. The headline was chosen alphabetically

Among equally severe checks the worst was picked by `id.localeCompare`, so `content.*` sorted ahead of `traffic.*` and a source **silently discarding traffic** was headlined as a content-coverage note. Observed live on gjelina.

Ranking now prefers the category that says the instrument is broken (`database` > `integrations` > `providers` > `auth` > …) over the one offering advice about the site. Nothing was ever hidden — every failing check travels in the payload — but the headline is what gets read.

## 4. `notifiedAt` meant "decided to notify", not "delivered"

It was stamped before dispatch, so it read as sent even when zero webhooks matched — which is exactly what happened on the first pass. The observation is now written first, and the timestamp is set only once something is actually delivered.

## Verification

Four tests. The rewind guard is verified by ablation: removing the `Math.max` fails the new test and nothing else.

One stale test asserting health events required opt-in was **removed** rather than left contradicting the new contract.

Full suite **6,169 passing across 509 files**, typecheck clean.

## Note

I patched the four live subscriptions by hand last night to include the health events. With this change that patch is no longer load-bearing — health is delivered regardless — so an `apply` that rewrites those rows is now safe.