### PR TITLE
fix(notify): never let one bad link discard the whole alert

### DIFF
--- a/packages/api-routes/src/notifications.ts
+++ b/packages/api-routes/src/notifications.ts
@@ -129,7 +129,10 @@ export async function notificationRoutes(app: FastifyInstance, opts: Notificatio
       transitions: [
         { query: 'test query', from: 'not-cited', to: 'cited', provider: 'gemini' },
       ],
-      dashboardUrl: `/projects/${project.name}`,
+      // Absolute where possible: a chat receiver rejects a relative link.
+      // The renderers drop an unusable one rather than failing the message,
+      // but a test that exercises the real shape should carry a real link.
+      dashboardUrl: `${request.protocol}://${request.hostname}/projects/${project.name}`,
     }
 
     // Send exactly what a real notification would send. This route used to POST

--- a/packages/api-routes/src/notifications/destinations.ts
+++ b/packages/api-routes/src/notifications/destinations.ts
@@ -67,6 +67,25 @@ function clamp(value: string, max: number): string {
   return value.length <= max ? value : `${value.slice(0, max - 1)}…`
 }
 
+/**
+ * Chat receivers require an ABSOLUTE http(s) link and reject the whole message
+ * when given anything else — Discord answers a relative `embed.url` with a 400
+ * and `{"embeds": ["0"]}`, discarding the entire alert over the one field.
+ *
+ * A link the reader cannot click is worth less than no link, and it must never
+ * cost them the message it was attached to. Callers that build a relative
+ * dashboard path still get their alert delivered, minus the link.
+ */
+function absoluteLink(url: string | undefined): string | undefined {
+  if (!url) return undefined
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === 'https:' || parsed.protocol === 'http:' ? url : undefined
+  } catch {
+    return undefined
+  }
+}
+
 export interface DiscordWebhookBody {
   username: string
   embeds: Array<{
@@ -92,7 +111,7 @@ export function renderDiscord(view: AlertView): DiscordWebhookBody {
         value: clamp(field.value, DISCORD_MAX_FIELD),
         ...(field.compact ? { inline: true } : {}),
       })),
-      url: view.url,
+      ...(absoluteLink(view.url) ? { url: absoluteLink(view.url) } : {}),
       ...(view.timestamp ? { timestamp: view.timestamp } : {}),
       ...(view.footer ? { footer: { text: view.footer } } : {}),
     }],
@@ -134,7 +153,7 @@ export function renderSlack(view: AlertView): SlackWebhookBody {
     attachments: [{
       color: SLACK_COLORS[view.severity],
       title: headline,
-      title_link: view.url,
+      ...(absoluteLink(view.url) ? { title_link: absoluteLink(view.url) } : {}),
       ...(view.body ? { text: clamp(view.body, SLACK_MAX_TEXT) } : {}),
       fields: view.fields.map(field => ({
         title: field.label,

--- a/packages/api-routes/test/notification-destinations.test.ts
+++ b/packages/api-routes/test/notification-destinations.test.ts
@@ -178,3 +178,26 @@ test('the test route renders for the destination, exactly as a real send does', 
   expect(own.render).toBeUndefined()
   expect(own.signed).toBe(true)
 })
+
+test('an unusable link is dropped, never allowed to fail the whole message', () => {
+  // Discord answers a relative `embed.url` with 400 `{"embeds": ["0"]}` and
+  // discards the entire alert over that one field. Losing the link is a far
+  // smaller loss than losing the alert.
+  const relative = toAlertView({ ...healthPayloadFor('/projects/demo') })
+  const discord = renderDiscord(relative)
+  expect(discord.embeds[0]).not.toHaveProperty('url')
+  expect(discord.embeds[0]!.title).toBeTruthy()  // the message still stands
+
+  const slack = renderSlack(relative)
+  expect(slack.attachments[0]).not.toHaveProperty('title_link')
+  expect(slack.text).toBeTruthy()
+
+  // An absolute link is kept.
+  const absolute = toAlertView({ ...healthPayloadFor('https://canonry.test/projects/demo') })
+  expect(renderDiscord(absolute).embeds[0]!.url).toBe('https://canonry.test/projects/demo')
+  expect(renderSlack(absolute).attachments[0]!.title_link).toBe('https://canonry.test/projects/demo')
+})
+
+function healthPayloadFor(dashboardUrl: string): HealthWebhookPayload {
+  return { ...health(), dashboardUrl }
+}


### PR DESCRIPTION
## Still 400 after #889

#889 was necessary — the test route was posting verbatim JSON — but not sufficient. I deployed it, ran `cnry notify test`, and got **400** again. The remaining fault is in the renderer.

```
embed.url = "/projects/gjelina-hotel"     ← relative
discord   = 400 {"embeds": ["0"]}         ← entire embed rejected
```

Chat receivers require an **absolute** http(s) link. Discord discards the whole alert over that one field.

The test route built `dashboardUrl` as `/projects/<name>`, while the real notifier builds `<serverUrl>/projects/…`. That asymmetry is exactly why **live alerting worked and the test never could** — the two paths were never sending the same shape.

## Two changes

**Renderers drop a link they cannot use** rather than emitting it. A link the reader cannot click is worth less than no link, and it must never cost them the message it was attached to.

This closes the class rather than the instance: any caller that builds a relative dashboard path still gets its alert delivered, minus the link. A formatting mistake should degrade the message, not delete it.

**The test route builds an absolute URL from the request**, so the test exercises the shape a real alert has instead of leaning on the new guard.

## Verified against the live webhook

| dashboardUrl | before | after |
|---|---|---|
| `/projects/gjelina-hotel` (relative) | **400** | **204** |
| `https://canonry.ai/projects/…` | 204 | 204, link kept |

Ablating the guard — emitting the link unconditionally — fails the new test.

Full suite **6,180 passing across 510 files**, typecheck clean, lint clean, generated client unchanged.