### PR TITLE
ci: align runtime on Node 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Use the public ECR mirror of Docker Official Images to avoid Docker Hub
 # auth/rate-limit failures on GitHub-hosted runners.
-FROM public.ecr.aws/docker/library/node:20-bookworm-slim AS build
+FROM public.ecr.aws/docker/library/node:22-bookworm-slim AS build
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
@@ -17,7 +17,7 @@ RUN pnpm install --frozen-lockfile
 RUN pnpm --filter @canonry/canonry build
 RUN pnpm deploy --legacy --filter @canonry/canonry --prod /prod/app
 
-FROM public.ecr.aws/docker/library/node:20-bookworm-slim
+FROM public.ecr.aws/docker/library/node:22-bookworm-slim
 
 ENV NODE_ENV=production
 ENV CANONRY_CONFIG_DIR=/data/canonry
@@ -36,7 +36,7 @@ EXPOSE 4100
 
 # Liveness probe. Deliberately NOT `node -e`: booting a second Node runtime costs
 # ~51 MiB RSS and ~106 ms EVERY interval, in EVERY container (measured on a live
-# 20-bookworm-slim engine container). bash's /dev/tcp does the same HTTP GET for
+# bookworm-slim engine container). bash's /dev/tcp does the same HTTP GET for
 # ~1.6 MiB and ~3 ms with no added packages: the slim base ships bash but has no
 # curl, wget, or netcat.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,4 +1,4 @@
-FROM node:20-bookworm-slim AS build
+FROM node:22-bookworm-slim AS build
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
@@ -14,7 +14,7 @@ COPY packages ./packages
 RUN pnpm install --frozen-lockfile
 RUN pnpm deploy --legacy --filter @ainyc/canonry-api --prod /prod/app
 
-FROM node:20-bookworm-slim
+FROM node:22-bookworm-slim
 
 ENV NODE_ENV=production
 ENV PORT=4100

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,4 +1,4 @@
-FROM node:20-bookworm-slim AS build
+FROM node:22-bookworm-slim AS build
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,4 +1,4 @@
-FROM node:20-bookworm-slim AS build
+FROM node:22-bookworm-slim AS build
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
@@ -14,7 +14,7 @@ COPY packages ./packages
 RUN pnpm install --frozen-lockfile
 RUN pnpm deploy --legacy --filter @ainyc/canonry-worker --prod /prod/app
 
-FROM node:20-bookworm-slim
+FROM node:22-bookworm-slim
 
 ENV NODE_ENV=production
 

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -36,7 +36,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=22.14.0"
+    "node": ">=22.14.0 <26"
   },
   "scripts": {
     "build": "tsx scripts/copy-agent-assets.ts && tsup && tsx build-web.ts",

--- a/packages/db/test/node-support-range.test.ts
+++ b/packages/db/test/node-support-range.test.ts
@@ -8,13 +8,12 @@ import { test, expect, describe } from 'vitest'
  * has no prebuilt binary for, converting a couple hundred lines of node-gyp C++
  * output into one legible line.
  *
- * Its `SUPPORTED_MAJORS` list is a hand-maintained mirror of better-sqlite3's own
- * `engines.node`. A dependency bump that widens or narrows that range would leave
- * the guard silently wrong — either rejecting a Node that now works, or admitting
- * one that does not and handing the reader back the node-gyp wall of text the
- * guard exists to prevent.
+ * Its `SUPPORTED_MAJORS` list applies Canonry's Node 22+ policy to
+ * better-sqlite3's own `engines.node`. A dependency bump that narrows that range
+ * would otherwise leave the guard silently wrong and hand the reader back the
+ * node-gyp wall of text the guard exists to prevent.
  *
- * So the mirror is asserted rather than trusted.
+ * So the compatible subset is asserted rather than trusted.
  */
 
 const require = createRequire(import.meta.url)
@@ -49,17 +48,35 @@ function betterSqlite3Majors(): number[] {
 }
 
 describe('Node support range', () => {
-  test('the install guard mirrors better-sqlite3 exactly', () => {
-    expect(guardMajors()).toEqual(betterSqlite3Majors())
+  test('the install guard matches Canonry-supported better-sqlite3 majors', () => {
+    const expected = betterSqlite3Majors().filter((major) => major >= 22 && major < 26)
+    expect(guardMajors()).toEqual(expected)
   })
 
-  test('the guard admits the Docker base and the CI major', () => {
-    // Dockerfiles run node:20-bookworm-slim; CI workflows pin node-version 22.
-    // Both must pass the guard or `pnpm install` breaks the build and the
-    // pipeline rather than the unsupported case it targets.
+  test('the guard and declared engine range enforce Node 22+', () => {
     const majors = guardMajors()
-    expect(majors).toContain(20)
     expect(majors).toContain(22)
+    expect(majors).not.toContain(20)
+
+    const rootPkg = JSON.parse(
+      fs.readFileSync(path.join(repoRoot(), 'package.json'), 'utf8'),
+    ) as { engines?: { node?: string } }
+    const publishedPkg = JSON.parse(
+      fs.readFileSync(path.join(repoRoot(), 'packages', 'canonry', 'package.json'), 'utf8'),
+    ) as { engines?: { node?: string } }
+    expect(rootPkg.engines?.node).toBe('>=22.14.0 <26')
+    expect(publishedPkg.engines?.node).toBe(rootPkg.engines?.node)
+  })
+
+  test('every Dockerfile uses the Node 22 base', () => {
+    for (const dockerfile of ['Dockerfile', 'Dockerfile.api', 'Dockerfile.worker', 'Dockerfile.web']) {
+      const source = fs.readFileSync(path.join(repoRoot(), dockerfile), 'utf8')
+      const majors = [...source.matchAll(/^FROM .*node:(\d+)-bookworm-slim(?:\s|$)/gm)].map(
+        (match) => Number.parseInt(match[1]!, 10),
+      )
+      expect(majors.length).toBeGreaterThan(0)
+      expect(majors.every((major) => major === 22)).toBe(true)
+    }
   })
 
   test('the guard rejects a major with no prebuilt binary', () => {

--- a/scripts/check-node.mjs
+++ b/scripts/check-node.mjs
@@ -10,15 +10,9 @@
  * cannot see the terminal scrollback a human would — concludes the repo is
  * broken and starts changing dependencies.
  *
- * The declared `engines.node` range did not help, for two reasons:
- *   - it was unbounded upward (`>=22.14.0`), so it actively asserted that a
- *     brand-new Node major was supported when the native dep had no prebuild;
- *   - pnpm does not enforce `engines` unless `engine-strict` is set, and turning
- *     that on globally would break the Docker build, which runs on node:20 and
- *     therefore sits BELOW the declared floor.
- *
- * So the check lives here instead: keyed to what the native dependency actually
- * supports, which is a superset of both the Docker base and CI.
+ * Canonry declares its supported Node range in package metadata. This guard
+ * adds a focused diagnostic for a Node major whose native dependency prebuild
+ * is unavailable, rather than leaving the user in node-gyp output.
  *
  * WHY `preinstall` TOLERATES THIS FILE BEING ABSENT
  * The wiring is `test ! -f scripts/check-node.mjs || node scripts/check-node.mjs`,
@@ -27,21 +21,18 @@
  * this file does not exist at install time inside the image and a bare
  * invocation fails the Docker build with "Cannot find module".
  *
- * Skipping there is correct, not a workaround: the images pin their own base
- * (node:20-bookworm-slim), so the Node version is fixed by the Dockerfile and
- * cannot be the arbitrary local version this guard exists to catch. Copying the
- * file into every image instead would re-break the build the next time a
- * Dockerfile is added or its COPY order changes.
+ * Skipping there is correct, not a workaround: every image pins Node 22, so the
+ * Dockerfile, rather than an arbitrary local runtime, controls that version.
  *
  * KEEPING THIS HONEST
- * `SUPPORTED_MAJORS` mirrors better-sqlite3's own `engines.node`. It is asserted
- * against the installed package by `packages/db/test/node-support-range.test.ts`,
- * so a dependency bump that widens or narrows support fails a test rather than
- * silently drifting.
+ * `SUPPORTED_MAJORS` is the intersection of Canonry's Node 22+ policy and
+ * better-sqlite3's supported majors. It is asserted against the installed
+ * package by `packages/db/test/node-support-range.test.ts`, so a dependency
+ * bump that narrows support fails a test rather than silently drifting.
  */
 
-// Mirrors better-sqlite3 engines: "20.x || 22.x || 23.x || 24.x || 25.x"
-const SUPPORTED_MAJORS = [20, 22, 23, 24, 25]
+// Canonry supports Node 22+ while better-sqlite3 supports 22.x through 25.x.
+const SUPPORTED_MAJORS = [22, 23, 24, 25]
 
 const major = Number.parseInt(process.versions.node.split('.')[0], 10)
 const bypassed = process.env.CANONRY_SKIP_NODE_CHECK === '1'
@@ -68,7 +59,7 @@ if (!SUPPORTED_MAJORS.includes(major) && bypassed) {
       '',
       '    Fix: switch Node, do NOT change dependencies.',
       `      nvm use 22        (or fnm/volta/asdf — see .nvmrc)`,
-      '      CI runs Node 22; the Docker images run Node 20.',
+      '      CI and Docker images run Node 22.',
       '',
       '    If you are intentionally testing a newer Node, set',
       '    CANONRY_SKIP_NODE_CHECK=1 to bypass this and expect the native build',


### PR DESCRIPTION
## Summary

- Align all Canonry Docker build/runtime stages on Node 22.
- Bound the published package runtime to `>=22.14.0 <26`, matching the root package.
- Restrict the install guard to Canonry-supported `better-sqlite3` majors and test every Docker Node stage.

This replaces the previous broad validation/publish hardening scope. CI, publish workflows, WordPress validation, smoke tests, affected-test selection, package scripts, and plugin manifests are unchanged.

## Why

Canonry's root package and CI require Node 22, but Docker still used Node 20, the install guard admitted Node 20, and the published package had no upper bound. This makes the runtime contract consistent without adding global `engine-strict` behavior.

## Validation

- Focused Node support regression: 5 tests passed
- `pnpm run typecheck`
- ESLint: zero errors
- `git diff --check`
- Locked install completed under Node 24

The full local suite could not bind its loopback test servers in the sandbox. Docker builds were unavailable because the local Docker daemon was stopped; CI remains the authoritative full run.