### PR TITLE
fix(analytics): say when the trend headline is a subset of what ran

### DIFF
--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -1249,6 +1249,15 @@ export type BrandMetricsDto = {
         queryCount: number;
         mentionRate: number;
         mentionedCount: number;
+        excludedQueryCount: number;
+        allQueries?: {
+            mentionRate: number;
+            mentionedCount: number;
+            citationRate: number;
+            cited: number;
+            total: number;
+            queryCount: number;
+        };
         mentionShare: {
             rate: number | null;
             projectMentionSnapshots: number;

--- a/packages/api-routes/src/analytics.ts
+++ b/packages/api-routes/src/analytics.ts
@@ -819,6 +819,19 @@ function computeBuckets(
 
       const metric = computeProviderMetric(usable)
       const queryCount = new Set(usable.map(s => s.queryId)).size
+      // The comparable set drives the trend line, because a bucket whose query
+      // set differs from its neighbour is not a trend. But excluding a query
+      // silently hid REAL visibility: a branded query added mid-window carried
+      // mentions on three engines while the chart read 0% for two of them, and
+      // nothing on screen said the denominator had moved.
+      //
+      // So report both. `metric` stays the comparable view; `allQueries` is
+      // every query actually swept in this bucket, and `excludedQueryCount` is
+      // the gap between them. A reader can see that a number is a subset
+      // without having to infer it.
+      const allQueries = computeProviderMetric(inBucket)
+      const excludedQueryCount =
+        new Set(inBucket.map(s => s.queryId)).size - queryCount
       // Per-provider breakdown over the SAME normalized `usable` set, so the
       // dashboard can plot a line per provider over time. Reusing
       // computeProviderMetric inherits the 4dp rounding and probe exclusion,
@@ -849,6 +862,21 @@ function computeBuckets(
         queryCount,
         mentionRate: metric.mentionRate,
         mentionedCount: metric.mentionedCount,
+        // Queries swept in this bucket but excluded from the comparable set
+        // because they were added after the bucket began. Zero means the
+        // headline covers everything that ran.
+        excludedQueryCount,
+        // The same bucket over EVERY query that ran, comparability aside. When
+        // this diverges from the headline, the difference is entirely the
+        // excluded queries — which is exactly the thing that was invisible.
+        allQueries: {
+          mentionRate: allQueries.mentionRate,
+          mentionedCount: allQueries.mentionedCount,
+          citationRate: allQueries.citationRate,
+          cited: allQueries.cited,
+          total: allQueries.total,
+          queryCount: new Set(inBucket.map(s => s.queryId)).size,
+        },
         mentionShare: computeMentionShareBucketMetric(usable, mentionShareCompetitors),
         byProvider,
         modelEvidenceByProvider,

--- a/packages/api-routes/test/analytics.test.ts
+++ b/packages/api-routes/test/analytics.test.ts
@@ -1051,6 +1051,20 @@ describe('analytics routes', () => {
       const lastBucket = body.buckets[body.buckets.length - 1]
       expect(lastBucket.citationRate).toBe(1) // 2/2 = 100%
       expect(lastBucket.queryCount).toBe(2)
+      // The comparable headline is a SUBSET, and the bucket now says so. Before
+      // this, a query added mid-window was dropped from the rate with nothing
+      // on screen indicating the denominator had moved — a branded query
+      // carrying real mentions could read as 0%.
+      expect(lastBucket.excludedQueryCount).toBe(3)
+      expect(lastBucket.allQueries).toEqual({
+        // Every query that actually ran: 2 of 5 cited.
+        citationRate: 0.4,
+        cited: 2,
+        total: 5,
+        mentionRate: 0,
+        mentionedCount: 0,
+        queryCount: 5,
+      })
       // Per-provider rides the SAME normalized `usable` set — gemini's bucket
       // slice excludes the 3 newly-added queries too (total 2, not 5).
       expect(lastBucket.byProvider.gemini.total).toBe(2)

--- a/packages/contracts/src/analytics.ts
+++ b/packages/contracts/src/analytics.ts
@@ -235,9 +235,35 @@ export const timeBucketSchema = z.object({
   citationRate: z.number(),
   cited: z.number().int(),
   total: z.number().int(),
+  /** Queries in the COMPARABLE set — those that existed before the bucket began. */
   queryCount: z.number().int(),
   mentionRate: z.number(),
   mentionedCount: z.number().int(),
+  /**
+   * Queries swept in this bucket but held out of the comparable set because
+   * they were added after it began. Zero means the headline covers everything
+   * that ran; non-zero means the headline is a subset and `allQueries` shows
+   * the rest.
+   */
+  excludedQueryCount: z.number().int().nonnegative().default(0),
+  /**
+   * The same bucket computed over EVERY query that ran, comparability aside.
+   *
+   * The trend line has to hold its query set constant or it is not a trend, but
+   * excluding a query silently hid real visibility: a branded query added
+   * mid-window carried mentions on three engines while the chart read 0% for
+   * two of them, with nothing on screen saying the denominator had moved.
+   * Reporting both lets a reader see that the headline is a subset instead of
+   * having to infer it.
+   */
+  allQueries: z.object({
+    mentionRate: z.number(),
+    mentionedCount: z.number().int(),
+    citationRate: z.number(),
+    cited: z.number().int(),
+    total: z.number().int(),
+    queryCount: z.number().int(),
+  }).optional(),
   mentionShare: mentionShareBucketMetricSchema,
   byProvider: z.record(z.string(), providerMetricSchema),
   /** Evidence from the exact normalized snapshots that produced each provider rate. */


### PR DESCRIPTION
## The problem

A bucket drops any query added after it began, so the trend holds its query set constant. That is correct for a trend — a bucket whose query set differs from its neighbour is not a comparison — but **the exclusion was invisible**, and it hid real visibility.

Observed live on azcoatings: two branded queries added mid-window carried mentions on **OpenAI, Perplexity and Gemini**. The chart read **0%** for OpenAI and Perplexity and said nothing about a moved denominator. It looked like visibility had been lost on two engines when it had not.

## What this adds

| field | meaning |
|---|---|
| `excludedQueryCount` | queries that ran but are held out of the headline |
| `allQueries` | the same bucket over **every** query that ran |

The headline is unchanged, so **no trend shifts**. When the two diverge, the difference is entirely the excluded queries — and a reader can see the headline is a subset instead of inferring it.

## This is a stopgap, not the fix

Eligibility is decided by `created_at < bucketStart`. That is a proxy for *"was this query in the same measurement set"*, and it gets it wrong in ways that matter:

- **re-adding a query looks brand new** — new row, new timestamp, excluded again
- a rename is a delete + add, so history detaches
- eligibility shifts silently as bucket boundaries move
- nothing records *what set was being measured* at any point

The real model is a **versioned query basket** that runs are stamped with — membership by identity, not by date, and a basket change becomes a visible event rather than an inference. Same shape as `measurement_plan_versions`. That lands next.

## Verification

One test extended, verified by ablation — reporting the comparable set as if it were everything fails it.

6,180 passing across 510 files, typecheck clean, no new lint warnings, generated client regenerated.