### PR TITLE
feat(analytics): version the query basket instead of guessing it from dates

### DIFF
--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -1275,6 +1275,7 @@ export type BrandMetricsDto = {
                 includesUnknown: boolean;
             };
         };
+        basketRevision: number | null;
     }>;
     overall: {
         citationRate: number;
@@ -1299,6 +1300,13 @@ export type BrandMetricsDto = {
         delta: number;
         label: string;
     }>;
+    basketChanges: Array<{
+        revision: number;
+        at: string;
+        added: Array<string>;
+        removed: Array<string>;
+    }>;
+    referenceBasketRevision: number | null;
     modelAttribution: {
         [key: string]: {
             latestObservation: {
@@ -2641,6 +2649,7 @@ export type LatestProjectRunDto = {
                 };
             };
         } | null;
+        queryBasketRevision?: number | null;
         createdAt: string;
         snapshots?: Array<{
             id: string;
@@ -3161,6 +3170,7 @@ export type ProjectOverviewDto = {
                     };
                 };
             } | null;
+            queryBasketRevision?: number | null;
             createdAt: string;
             snapshots?: Array<{
                 id: string;
@@ -4060,6 +4070,7 @@ export type RunDetailDto = {
             };
         };
     } | null;
+    queryBasketRevision?: number | null;
     createdAt: string;
     snapshots?: Array<{
         id: string;
@@ -4115,6 +4126,7 @@ export type RunDto = {
             };
         };
     } | null;
+    queryBasketRevision?: number | null;
     createdAt: string;
 };
 

--- a/packages/api-routes/src/analytics.ts
+++ b/packages/api-routes/src/analytics.ts
@@ -65,24 +65,6 @@ export async function analyticsRoutes(app: FastifyInstance) {
     }
 
     const runIds = projectRuns.map(r => r.id)
-    // Orphan snapshots (queryId NULL post-v58 — see schema.ts) can't be
-    // grouped by query; drop them at load so downstream `byQuery` keys stay
-    // valid `string`s.
-    const rawSnapshots = filterTrackedSnapshots(app.db
-      .select({
-        runId: querySnapshots.runId,
-        queryId: querySnapshots.queryId,
-        queryText: querySnapshots.queryText,
-        provider: querySnapshots.provider,
-        model: querySnapshots.model,
-        servedModel: querySnapshots.servedModel,
-        citationState: querySnapshots.citationState,
-        answerMentioned: querySnapshots.answerMentioned,
-        answerText: querySnapshots.answerText,
-      })
-      .from(querySnapshots)
-      .where(inArray(querySnapshots.runId, runIds))
-      .all())
 
     // Fetch query creation dates for the pre-basket fallback, and text so a
     // snapshot whose `query_id` was nulled by a delete still resolves an identity.
@@ -111,6 +93,40 @@ export async function analyticsRoutes(app: FastifyInstance) {
     const latestBasket = basketRevisions.at(-1) ?? null
     const referenceBasket = latestBasket ? new Set(latestBasket.members) : undefined
 
+    const loadedSnapshots = app.db
+      .select({
+        runId: querySnapshots.runId,
+        queryId: querySnapshots.queryId,
+        queryText: querySnapshots.queryText,
+        provider: querySnapshots.provider,
+        model: querySnapshots.model,
+        servedModel: querySnapshots.servedModel,
+        citationState: querySnapshots.citationState,
+        answerMentioned: querySnapshots.answerMentioned,
+        answerText: querySnapshots.answerText,
+      })
+      .from(querySnapshots)
+      .where(inArray(querySnapshots.runId, runIds))
+      .all()
+    // Deleting a query nulls `query_id` on its historical snapshots (post-v58,
+    // see schema.ts), and this route used to drop those rows outright — so
+    // removing a query erased its past from the chart even after the same
+    // question was re-added. With a recorded basket the snapshot's own
+    // `query_text` is enough identity to rejoin: if the text is a member of the
+    // set being measured NOW, its history belongs on the trend, whatever
+    // happened to the row id in between. Orphans whose text is not in the
+    // basket stay out — that query was deliberately dropped from measurement.
+    //
+    // Without a basket there is no membership to test against, so orphans are
+    // dropped exactly as before; the deploy changes nothing until a revision is
+    // recorded.
+    const rawSnapshots = referenceBasket
+      ? loadedSnapshots.filter(s =>
+          s.queryId !== null ||
+          (s.queryText !== null && referenceBasket.has(normalizeQueryText(s.queryText))),
+        )
+      : filterTrackedSnapshots(loadedSnapshots)
+
     // Resolve answerMentioned for each snapshot (handles null/legacy data)
     const runCreatedAt = new Map(projectRuns.map(run => [run.id, run.createdAt]))
     const runBasketRevision = new Map(projectRuns.map(run => [run.id, run.queryBasketRevision ?? null]))
@@ -119,8 +135,11 @@ export async function analyticsRoutes(app: FastifyInstance) {
       runCreatedAt: runCreatedAt.get(s.runId)!,
       resolvedMentioned: resolveSnapshotAnswerMentioned(s, project),
       // Falls back to the id if no text resolves, so two distinct queries can
-      // never collapse into one member on an empty key.
-      basketKey: normalizeQueryText(s.queryText ?? queryTextById.get(s.queryId) ?? '') || s.queryId,
+      // never collapse into one member on an empty key. (An orphan only gets
+      // this far when its text matched the basket, so its key is never empty.)
+      basketKey:
+        normalizeQueryText(s.queryText ?? (s.queryId ? queryTextById.get(s.queryId) ?? '' : '')) ||
+        s.queryId || '',
       runBasketRevision: runBasketRevision.get(s.runId) ?? null,
     }))
     const mentionShareCompetitors = app.db
@@ -792,7 +811,8 @@ function bucketSizeForSpan(spanDays: number): number {
 }
 
 interface SnapshotLike {
-  queryId: string
+  /** Null on a rejoined orphan: the query row is gone, `basketKey` carries identity. */
+  queryId: string | null
   provider: string
   model: string | null
   citationState: string
@@ -883,7 +903,7 @@ function computeBuckets(
         // Fall back to the date heuristic so existing charts keep their shape
         // instead of silently widening the moment this deploys.
         const eligible = inBucket.filter(s => {
-          const qCreated = queryCreatedAt.get(s.queryId)
+          const qCreated = s.queryId ? queryCreatedAt.get(s.queryId) : undefined
           return qCreated !== undefined && qCreated < startISO
         })
         if (eligible.length > 0) usable = eligible

--- a/packages/api-routes/src/analytics.ts
+++ b/packages/api-routes/src/analytics.ts
@@ -1,11 +1,11 @@
 import { and, desc, eq, gte, inArray, lt } from 'drizzle-orm'
 import type { FastifyInstance } from 'fastify'
-import { filterTrackedSnapshots, groupRunsByCreatedAt, pickGroupRepresentative, querySnapshots, runs, queries, competitors, domainClassifications, parseJsonColumn } from '@ainyc/canonry-db'
+import { filterTrackedSnapshots, groupRunsByCreatedAt, pickGroupRepresentative, querySnapshots, runs, queries, queryBasketVersions, competitors, domainClassifications, parseJsonColumn } from '@ainyc/canonry-db'
 import {
   AI_PROVIDER_INFRA_DOMAINS, brandLabelFromDomain, categorizeSource, categoryLabel, CitationStates,
   classifySurfaceFromCategory, surfaceClassFromCompetitorType, surfaceClassLabel,
   effectiveDomains, evaluateModelPointerExposure, normalizeProjectDomain, parseWindow, RunKinds, RunStatuses,
-  windowCutoff, validationError, hostMatchesAnyDomain,
+  windowCutoff, validationError, hostMatchesAnyDomain, normalizeQueryText,
 } from '@ainyc/canonry-contracts'
 import type {
   BrandMetricsDto, GapAnalysisDto, SourceBreakdownDto,
@@ -55,6 +55,8 @@ export async function analyticsRoutes(app: FastifyInstance) {
         trend: 'stable',
         mentionTrend: 'stable',
         queryChanges: [],
+        basketChanges: [],
+        referenceBasketRevision: null,
         modelAttribution: {},
         servedModelAttribution: {},
         modelServiceMismatch: {},
@@ -70,6 +72,7 @@ export async function analyticsRoutes(app: FastifyInstance) {
       .select({
         runId: querySnapshots.runId,
         queryId: querySnapshots.queryId,
+        queryText: querySnapshots.queryText,
         provider: querySnapshots.provider,
         model: querySnapshots.model,
         servedModel: querySnapshots.servedModel,
@@ -81,21 +84,45 @@ export async function analyticsRoutes(app: FastifyInstance) {
       .where(inArray(querySnapshots.runId, runIds))
       .all())
 
-    // Resolve answerMentioned for each snapshot (handles null/legacy data)
-    const runCreatedAt = new Map(projectRuns.map(run => [run.id, run.createdAt]))
-    const allSnapshots = rawSnapshots.map(s => ({
-      ...s,
-      runCreatedAt: runCreatedAt.get(s.runId)!,
-      resolvedMentioned: resolveSnapshotAnswerMentioned(s, project),
-    }))
-
-    // Fetch query creation dates for normalization
+    // Fetch query creation dates for the pre-basket fallback, and text so a
+    // snapshot whose `query_id` was nulled by a delete still resolves an identity.
     const projectQueries = app.db
-      .select({ id: queries.id, createdAt: queries.createdAt })
+      .select({ id: queries.id, query: queries.query, createdAt: queries.createdAt })
       .from(queries)
       .where(eq(queries.projectId, project.id))
       .all()
     const queryCreatedAt = new Map(projectQueries.map(q => [q.id, q.createdAt]))
+    const queryTextById = new Map(projectQueries.map(q => [q.id, q.query]))
+
+    // Recorded query-set versions. The reference basket is the current one:
+    // the set the project is measuring now, which is what the trend line has to
+    // hold constant to be a trend at all.
+    const basketRevisions = app.db
+      .select()
+      .from(queryBasketVersions)
+      .where(eq(queryBasketVersions.projectId, project.id))
+      .orderBy(queryBasketVersions.revision)
+      .all()
+      .map(row => ({
+        revision: row.revision,
+        createdAt: row.createdAt,
+        members: JSON.parse(row.membersJson) as string[],
+      }))
+    const latestBasket = basketRevisions.at(-1) ?? null
+    const referenceBasket = latestBasket ? new Set(latestBasket.members) : undefined
+
+    // Resolve answerMentioned for each snapshot (handles null/legacy data)
+    const runCreatedAt = new Map(projectRuns.map(run => [run.id, run.createdAt]))
+    const runBasketRevision = new Map(projectRuns.map(run => [run.id, run.queryBasketRevision ?? null]))
+    const allSnapshots = rawSnapshots.map(s => ({
+      ...s,
+      runCreatedAt: runCreatedAt.get(s.runId)!,
+      resolvedMentioned: resolveSnapshotAnswerMentioned(s, project),
+      // Falls back to the id if no text resolves, so two distinct queries can
+      // never collapse into one member on an empty key.
+      basketKey: normalizeQueryText(s.queryText ?? queryTextById.get(s.queryId) ?? '') || s.queryId,
+      runBasketRevision: runBasketRevision.get(s.runId) ?? null,
+    }))
     const mentionShareCompetitors = app.db
       .select({ domain: competitors.domain })
       .from(competitors)
@@ -121,7 +148,7 @@ export async function analyticsRoutes(app: FastifyInstance) {
     const latest = new Date(projectRuns[projectRuns.length - 1]!.createdAt)
     const spanDays = Math.max(1, Math.ceil((latest.getTime() - earliest.getTime()) / 86_400_000))
     const bucketSize = bucketSizeForSpan(spanDays)
-    const buckets = computeBuckets(allSnapshots, projectRuns, bucketSize, queryCreatedAt, mentionShareCompetitors)
+    const buckets = computeBuckets(allSnapshots, projectRuns, bucketSize, queryCreatedAt, mentionShareCompetitors, referenceBasket)
 
     // Model observations are evidence, not configuration. To avoid a false
     // "first seen" transition at the start of a bounded window, anchor each
@@ -365,8 +392,25 @@ export async function analyticsRoutes(app: FastifyInstance) {
 
     // Query change annotations
     const queryChanges = computeQueryChanges(projectQueries, cutoff)
+    // A real change event, diffed between consecutive recorded revisions rather
+    // than inferred from row timestamps. Revision 1 is not a change — it is the
+    // first observation of a set that already existed — so the diff starts at 2.
+    const basketChanges = basketRevisions
+      .slice(1)
+      .map((rev, i) => {
+        const previous = new Set(basketRevisions[i]!.members)
+        const current = new Set(rev.members)
+        return {
+          revision: rev.revision,
+          at: rev.createdAt,
+          added: rev.members.filter(m => !previous.has(m)),
+          removed: basketRevisions[i]!.members.filter(m => !current.has(m)),
+        }
+      })
+      // A null cutoff is the all-time window, where every recorded change is in scope.
+      .filter(change => !cutoff || change.at >= cutoff)
 
-    return reply.send({ window, buckets, overall, byProvider, trend, mentionTrend, queryChanges, modelAttribution, servedModelAttribution, modelServiceMismatch, modelPointerChanges } satisfies BrandMetricsDto)
+    return reply.send({ window, buckets, overall, byProvider, trend, mentionTrend, queryChanges, basketChanges, referenceBasketRevision: latestBasket?.revision ?? null, modelAttribution, servedModelAttribution, modelServiceMismatch, modelPointerChanges } satisfies BrandMetricsDto)
   })
 
   // GET /projects/:name/analytics/gaps — brand gap analysis
@@ -756,6 +800,15 @@ interface SnapshotLike {
   answerText: string | null
   /** Canonical observation time: the parent run's logical sweep timestamp. */
   runCreatedAt: string
+  /**
+   * Normalized query text — the identity basket membership is tested against.
+   * Text rather than `queryId` on purpose: deleting a query nulls the snapshot's
+   * `query_id`, and re-adding it mints a new one, so an id comparison loses the
+   * history of exactly the queries most likely to move.
+   */
+  basketKey: string
+  /** Query-set version the parent run measured, null when the run was never stamped. */
+  runBasketRevision: number | null
 }
 
 interface MentionShareCompetitorInput {
@@ -782,6 +835,19 @@ function computeBuckets(
   bucketDays: number,
   queryCreatedAt?: Map<string, string>,
   mentionShareCompetitors: MentionShareCompetitorInput[] = [],
+  /**
+   * Normalized membership of the project's CURRENT query basket. When present it
+   * replaces the `createdAt < bucketStart` heuristic outright: comparability is a
+   * recorded fact rather than a date proxy that mistook a rename for a new query.
+   *
+   * Note this restates history — a query removed today leaves the comparable line
+   * in every past bucket too. That is deliberate. The alternative (each bucket
+   * judged against its own revision) keeps old points frozen but makes any two
+   * points incomparable across a basket change, which is the failure the chart
+   * already had. Holding one set of identities across the series is what makes it
+   * a trend, and `basketChanges` keeps the restatement visible rather than silent.
+   */
+  referenceBasket?: Set<string>,
 ): TimeBucket[] {
   if (projectRuns.length === 0) return []
 
@@ -806,19 +872,29 @@ function computeBuckets(
 
     // Only emit buckets that contain actual sweep data
     if (inBucket.length > 0) {
-      // Normalize: only include queries that existed before this bucket started
+      // Hold the query set still, so consecutive points are a comparison rather
+      // than two different measurements plotted next to each other.
       let usable = inBucket
-      if (queryCreatedAt) {
+      if (referenceBasket) {
+        const eligible = inBucket.filter(s => referenceBasket.has(s.basketKey))
+        if (eligible.length > 0) usable = eligible
+      } else if (queryCreatedAt) {
+        // No recorded basket (project has not run since versioning shipped).
+        // Fall back to the date heuristic so existing charts keep their shape
+        // instead of silently widening the moment this deploys.
         const eligible = inBucket.filter(s => {
           const qCreated = queryCreatedAt.get(s.queryId)
           return qCreated !== undefined && qCreated < startISO
         })
-        // Fallback: if ALL queries are new (e.g. first bucket), use full set
         if (eligible.length > 0) usable = eligible
       }
 
       const metric = computeProviderMetric(usable)
-      const queryCount = new Set(usable.map(s => s.queryId)).size
+      const queryCount = new Set(usable.map(s => s.basketKey)).size
+      // One revision or none. A bucket spanning a basket change has no single
+      // set to name, and picking either end would assert something untrue.
+      const revisions = new Set(inBucket.map(s => s.runBasketRevision))
+      const basketRevision = revisions.size === 1 ? [...revisions][0]! : null
       // Per-provider breakdown over the SAME normalized `usable` set, so the
       // dashboard can plot a line per provider over time. Reusing
       // computeProviderMetric inherits the 4dp rounding and probe exclusion,
@@ -852,6 +928,7 @@ function computeBuckets(
         mentionShare: computeMentionShareBucketMetric(usable, mentionShareCompetitors),
         byProvider,
         modelEvidenceByProvider,
+        basketRevision,
       })
     }
 

--- a/packages/api-routes/src/query-basket.ts
+++ b/packages/api-routes/src/query-basket.ts
@@ -1,0 +1,129 @@
+import crypto from 'node:crypto'
+import { and, desc, eq } from 'drizzle-orm'
+import { normalizeQueryText } from '@ainyc/canonry-contracts'
+import type { DatabaseClient } from '@ainyc/canonry-db'
+import { queries, queryBasketVersions } from '@ainyc/canonry-db'
+
+/**
+ * The set of queries a project was measuring, versioned.
+ *
+ * Analytics has to hold its query set constant to produce a trend — a bucket
+ * whose queries differ from its neighbour is not a comparison. That constraint
+ * used to be enforced with `query.createdAt < bucketStart`, a proxy for "was
+ * this query in the same measurement set" that is wrong in ways that cost real
+ * signal:
+ *
+ *   - re-adding a query mints a new row, so it looks brand new and its own
+ *     history detaches from it
+ *   - a rename is a delete plus an add, with the same effect
+ *   - eligibility shifts silently whenever bucket boundaries move
+ *   - nothing anywhere recorded WHICH set was being measured
+ *
+ * A revision makes membership explicit. Runs are stamped with the revision that
+ * was current when they started, so a comparison is like-for-like by
+ * construction, and a change of basket becomes a visible event rather than an
+ * inference from timestamps.
+ *
+ * Revisions are minted LAZILY from the live query set rather than hooked onto
+ * every mutation site. Query mutations live in at least three routes today and
+ * a fourth would silently skip the hook — the failure would be an unversioned
+ * basket that still looks fine. Deriving from the current set has no call site
+ * to forget.
+ */
+
+/** Membership is by normalized text, so re-adding the same query rejoins its own history. */
+export function queryBasketMembers(db: DatabaseClient, projectId: string): string[] {
+  const rows = db
+    .select({ query: queries.query })
+    .from(queries)
+    .where(eq(queries.projectId, projectId))
+    .all()
+  // Sorted + deduped so the checksum depends on the SET, never on insert order.
+  return [...new Set(rows.map(row => normalizeQueryText(row.query)))].sort()
+}
+
+export function queryBasketChecksum(members: readonly string[]): string {
+  return crypto.createHash('sha256').update(JSON.stringify(members)).digest('hex')
+}
+
+export interface QueryBasketRevision {
+  revision: number
+  checksum: string
+  members: string[]
+  createdAt: string
+}
+
+/** The newest recorded revision, or null when this project has never been stamped. */
+export function latestQueryBasketRevision(
+  db: DatabaseClient,
+  projectId: string,
+): QueryBasketRevision | null {
+  const row = db
+    .select()
+    .from(queryBasketVersions)
+    .where(eq(queryBasketVersions.projectId, projectId))
+    .orderBy(desc(queryBasketVersions.revision))
+    .limit(1)
+    .get()
+  if (!row) return null
+  return {
+    revision: row.revision,
+    checksum: row.checksum,
+    members: JSON.parse(row.membersJson) as string[],
+    createdAt: row.createdAt,
+  }
+}
+
+export function queryBasketRevisionAt(
+  db: DatabaseClient,
+  projectId: string,
+  revision: number,
+): QueryBasketRevision | null {
+  const row = db
+    .select()
+    .from(queryBasketVersions)
+    .where(and(eq(queryBasketVersions.projectId, projectId), eq(queryBasketVersions.revision, revision)))
+    .get()
+  if (!row) return null
+  return {
+    revision: row.revision,
+    checksum: row.checksum,
+    members: JSON.parse(row.membersJson) as string[],
+    createdAt: row.createdAt,
+  }
+}
+
+/**
+ * The revision describing the project's CURRENT query set, minting one when the
+ * set has changed since the last stamp.
+ *
+ * Idempotent: an unchanged basket returns the existing revision rather than
+ * churning a new one on every run, so revision numbers count real changes and
+ * a basket-change marker means something happened.
+ *
+ * Returns null for a project with no queries — there is no basket to version,
+ * and stamping an empty one would make "no queries yet" look like a deliberate
+ * measurement set.
+ */
+export function ensureCurrentQueryBasketRevision(
+  db: DatabaseClient,
+  projectId: string,
+  now: string = new Date().toISOString(),
+): QueryBasketRevision | null {
+  const members = queryBasketMembers(db, projectId)
+  if (members.length === 0) return null
+
+  const checksum = queryBasketChecksum(members)
+  const latest = latestQueryBasketRevision(db, projectId)
+  if (latest && latest.checksum === checksum) return latest
+
+  const revision = (latest?.revision ?? 0) + 1
+  db.insert(queryBasketVersions).values({
+    projectId,
+    revision,
+    membersJson: JSON.stringify(members),
+    checksum,
+    createdAt: now,
+  }).run()
+  return { revision, checksum, members, createdAt: now }
+}

--- a/packages/api-routes/src/run-queue.ts
+++ b/packages/api-routes/src/run-queue.ts
@@ -2,6 +2,7 @@ import crypto from 'node:crypto'
 import { and, eq, or } from 'drizzle-orm'
 import type { DatabaseClient } from '@ainyc/canonry-db'
 import { runs } from '@ainyc/canonry-db'
+import { ensureCurrentQueryBasketRevision } from './query-basket.js'
 
 export interface QueueRunParams {
   projectId: string
@@ -39,6 +40,19 @@ export function queueRunIfProjectIdle(db: DatabaseClient, params: QueueRunParams
       return { conflict: true, activeRunId: activeRun.id } as const
     }
 
+    // Stamp the query set this run is about to measure, so analytics can compare
+    // like-for-like later without inferring membership from row timestamps.
+    //
+    // Only a FULL sweep is stamped. A scoped run (`queries` non-null) deliberately
+    // measures a subset, and labelling it with the full basket would let a
+    // 3-query spot check land in a bucket as though all 16 had been measured —
+    // the same denominator error the basket exists to prevent, arriving by a
+    // different route. Scoped runs keep a null revision and analytics treats them
+    // as unversioned.
+    const basket = params.queries == null
+      ? ensureCurrentQueryBasketRevision(tx as unknown as DatabaseClient, params.projectId, createdAt)
+      : null
+
     tx.insert(runs).values({
       id: runId,
       projectId: params.projectId,
@@ -47,6 +61,7 @@ export function queueRunIfProjectIdle(db: DatabaseClient, params: QueueRunParams
       trigger,
       location: params.location ?? null,
       queries: params.queries ?? null,
+      queryBasketRevision: basket?.revision ?? null,
       createdAt,
     }).run()
 

--- a/packages/api-routes/test/db-derived-dtos.test.ts
+++ b/packages/api-routes/test/db-derived-dtos.test.ts
@@ -132,6 +132,7 @@ describe('drizzle-zod derived row schemas', () => {
       startedAt: '2026-05-17T00:00:00Z',
       finishedAt: '2026-05-17T00:01:00Z',
       error: null,
+      queryBasketRevision: null,
       createdAt: '2026-05-17T00:00:00Z',
     }
     const parsed = runRowSchema.parse(row)
@@ -151,6 +152,7 @@ describe('drizzle-zod derived row schemas', () => {
       startedAt: '2026-05-17T00:00:00Z',
       finishedAt: '2026-05-17T00:01:00Z',
       error: null,
+      queryBasketRevision: null,
       createdAt: '2026-05-17T00:00:00Z',
     }
     const parsed = runRowSchema.parse(row)

--- a/packages/api-routes/test/db-dto-coverage.test.ts
+++ b/packages/api-routes/test/db-dto-coverage.test.ts
@@ -282,6 +282,10 @@ const COVERAGE: Record<string, CoverageEntry> = {
       syncRunId: 'Internal join key.',
     },
   },
+  queryBasketVersions: {
+    kind: 'internal-only',
+    reason: 'Immutable snapshots of a project\'s tracked query set, recorded so analytics can compare like-for-like instead of inferring measurement-set membership from query row timestamps. Consumed only by the analytics response, which surfaces the parts a reader needs (`referenceBasketRevision`, per-bucket `basketRevision`, and `basketChanges`); the raw membership blob is an internal comparison key.',
+  },
   doctorHealthState: {
     kind: 'internal-only',
     reason: 'Last observed doctor outcome per project, kept only so health alerting can fire on transitions rather than on every scheduled pass. It is alerting bookkeeping, not a measurement: the report itself is served live by GET /projects/:name/doctor, and exposing a cached copy would invite readers to trust a stale health verdict.',

--- a/packages/api-routes/test/query-basket.test.ts
+++ b/packages/api-routes/test/query-basket.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import crypto from 'node:crypto'
+import { eq } from 'drizzle-orm'
+import Fastify from 'fastify'
+import { createClient, migrate, projects, queries, runs, querySnapshots } from '@ainyc/canonry-db'
+import { apiRoutes } from '../src/index.js'
+import {
+  ensureCurrentQueryBasketRevision,
+  latestQueryBasketRevision,
+  queryBasketMembers,
+} from '../src/query-basket.js'
+import { queueRunIfProjectIdle } from '../src/run-queue.js'
+
+// The trend chart read 0% mention on two of three engines for a whole window
+// while those engines were, in fact, mentioning the brand. Nothing was broken in
+// the providers: analytics was normalizing the bucket to "queries that existed
+// before this bucket started", a date proxy for measurement-set membership. A
+// branded query added mid-window failed that test, its real mentions were
+// dropped from the denominator AND the numerator, and the chart said 0% with no
+// indication the set had moved.
+//
+// The proxy is wrong in more ways than that one. A rename is a delete plus an
+// insert, so it reads as a brand new query. A remove-then-re-add detaches a
+// query from its own history. Eligibility silently shifts whenever bucket
+// boundaries move. And nothing anywhere recorded which set was actually measured,
+// so none of this was visible after the fact.
+//
+// These tests pin the replacement: membership is a recorded fact, compared by
+// query identity, and a change of set is an event rather than an inference.
+
+function harness() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'basket-test-'))
+  const db = createClient(path.join(tmpDir, 'test.db'))
+  migrate(db)
+  const projectId = crypto.randomUUID()
+  const now = new Date().toISOString()
+  db.insert(projects).values({
+    id: projectId, name: 'basket-site', displayName: 'Basket', canonicalDomain: 'example.com',
+    ownedDomains: '[]', country: 'US', language: 'en', tags: '[]', labels: '{}',
+    providers: '["gemini","openai","claude"]', locations: '[]', defaultLocation: null,
+    configSource: 'api', configRevision: 1, createdAt: now, updatedAt: now,
+  } as never).run()
+  return { db, projectId, tmpDir }
+}
+
+const addQuery = (db: ReturnType<typeof createClient>, projectId: string, text: string, createdAt: string) => {
+  const id = crypto.randomUUID()
+  db.insert(queries).values({ id, projectId, query: text, createdAt }).run()
+  return id
+}
+
+describe('query basket versioning', () => {
+  it('does not mint a new revision when the query set has not changed', () => {
+    // Revision numbers have to count real changes. If every run minted one, a
+    // "basket changed" marker would fire on every sweep and mean nothing.
+    const { db, projectId } = harness()
+    addQuery(db, projectId, 'best roof coatings', '2026-07-01T00:00:00.000Z')
+
+    const first = ensureCurrentQueryBasketRevision(db, projectId, '2026-07-01T01:00:00.000Z')
+    const second = ensureCurrentQueryBasketRevision(db, projectId, '2026-07-02T01:00:00.000Z')
+    const third = ensureCurrentQueryBasketRevision(db, projectId, '2026-07-03T01:00:00.000Z')
+
+    expect(first!.revision).toBe(1)
+    expect(second!.revision).toBe(1)
+    expect(third!.revision).toBe(1)
+  })
+
+  it('mints a revision when a query is added, and again when one is removed', () => {
+    const { db, projectId } = harness()
+    addQuery(db, projectId, 'query a', '2026-07-01T00:00:00.000Z')
+    expect(ensureCurrentQueryBasketRevision(db, projectId)!.revision).toBe(1)
+
+    const bId = addQuery(db, projectId, 'query b', '2026-07-02T00:00:00.000Z')
+    expect(ensureCurrentQueryBasketRevision(db, projectId)!.revision).toBe(2)
+
+    db.delete(queries).where(eq(queries.id, bId)).run()
+    expect(ensureCurrentQueryBasketRevision(db, projectId)!.revision).toBe(3)
+    expect(latestQueryBasketRevision(db, projectId)!.members).toEqual(['query a'])
+  })
+
+  it('treats a removed-then-re-added query as the SAME member, not a new one', () => {
+    // The date rule cannot do this: re-adding mints a fresh `created_at`, so the
+    // query looks brand new and detaches from its own history. Membership by
+    // normalized text is what makes a re-add a no-op.
+    const { db, projectId } = harness()
+    addQuery(db, projectId, 'roof coating cost', '2026-07-01T00:00:00.000Z')
+    const rev1 = ensureCurrentQueryBasketRevision(db, projectId)!
+
+    db.delete(queries).where(eq(queries.projectId, projectId)).run()
+    ensureCurrentQueryBasketRevision(db, projectId)
+    // Re-added months later, different id, different created_at, same question.
+    addQuery(db, projectId, '  Roof Coating Cost  ', '2026-09-01T00:00:00.000Z')
+    const readded = ensureCurrentQueryBasketRevision(db, projectId)!
+
+    expect(readded.checksum).toBe(rev1.checksum)
+    expect(readded.members).toEqual(rev1.members)
+  })
+
+  it('depends on the set, not on insert order', () => {
+    const { db, projectId } = harness()
+    addQuery(db, projectId, 'zebra', '2026-07-01T00:00:00.000Z')
+    addQuery(db, projectId, 'apple', '2026-07-02T00:00:00.000Z')
+    const forward = ensureCurrentQueryBasketRevision(db, projectId)!
+
+    const other = harness()
+    addQuery(other.db, other.projectId, 'apple', '2026-07-05T00:00:00.000Z')
+    addQuery(other.db, other.projectId, 'zebra', '2026-07-06T00:00:00.000Z')
+    const reverse = ensureCurrentQueryBasketRevision(other.db, other.projectId)!
+
+    expect(forward.checksum).toBe(reverse.checksum)
+  })
+
+  it('does not version a project with no queries', () => {
+    // Stamping an empty basket would make "no queries configured yet" look like
+    // a deliberate measurement set of size zero.
+    const { db, projectId } = harness()
+    expect(ensureCurrentQueryBasketRevision(db, projectId)).toBeNull()
+    expect(queryBasketMembers(db, projectId)).toEqual([])
+  })
+})
+
+describe('runs are stamped with the set they measure', () => {
+  it('stamps a full sweep with the current revision', () => {
+    const { db, projectId } = harness()
+    addQuery(db, projectId, 'query a', '2026-07-01T00:00:00.000Z')
+
+    const result = queueRunIfProjectIdle(db, { projectId, createdAt: '2026-07-02T00:00:00.000Z' })
+    expect(result.conflict).toBe(false)
+    const row = db.select().from(runs).all()[0]!
+    expect(row.queryBasketRevision).toBe(1)
+  })
+
+  it('leaves a SCOPED run unstamped, because it did not measure the whole basket', () => {
+    // Labelling a 1-query spot check with the full basket revision would let it
+    // land in a bucket as though all of them had been swept — the same
+    // denominator error, arriving by a different route.
+    const { db, projectId } = harness()
+    addQuery(db, projectId, 'query a', '2026-07-01T00:00:00.000Z')
+    addQuery(db, projectId, 'query b', '2026-07-01T00:00:00.000Z')
+
+    queueRunIfProjectIdle(db, {
+      projectId,
+      createdAt: '2026-07-02T00:00:00.000Z',
+      queries: ['query a'],
+    })
+    const row = db.select().from(runs).all()[0]!
+    expect(row.queryBasketRevision).toBeNull()
+  })
+})
+
+describe('analytics uses the basket instead of query creation dates', () => {
+  let app: ReturnType<typeof Fastify>
+  let db: ReturnType<typeof createClient>
+  let projectId: string
+
+  beforeEach(async () => {
+    const ctx = harness()
+    db = ctx.db
+    projectId = ctx.projectId
+    app = Fastify()
+    app.register(apiRoutes, { db, skipAuth: true })
+    await app.ready()
+  })
+
+  afterEach(async () => { await app.close() })
+
+  /** One completed sweep covering `texts`, every one mentioned on every provider. */
+  function sweep(at: string, texts: Array<{ id: string; text: string }>, revision: number | null) {
+    const runId = crypto.randomUUID()
+    db.insert(runs).values({
+      id: runId, projectId, kind: 'answer-visibility', status: 'completed', trigger: 'manual',
+      location: null, startedAt: at, finishedAt: at, error: null,
+      queryBasketRevision: revision, createdAt: at,
+    } as never).run()
+    for (const q of texts) {
+      for (const provider of ['gemini', 'openai', 'claude']) {
+        db.insert(querySnapshots).values({
+          id: crypto.randomUUID(), runId, queryId: q.id, queryText: q.text, provider,
+          model: `${provider}-model`, citationState: 'cited', answerMentioned: true,
+          answerText: 'Example.com is a good option.', citedDomains: ['example.com'],
+          competitorOverlap: [], location: null, rawResponse: '{}', createdAt: at,
+        } as never).run()
+      }
+    }
+  }
+
+  const metrics = async () => {
+    const res = await app.inject({ method: 'GET', url: `/api/v1/projects/basket-site/analytics/metrics?window=all` })
+    return res.json()
+  }
+
+  it('counts a query added mid-window, instead of reading 0% while it was mentioned', async () => {
+    // The reported bug, end to end. Two queries measured from July 1; a branded
+    // query added July 15 and swept July 20 with mentions on all three engines.
+    const a = addQuery(db, projectId, 'roof coating contractors', '2026-07-01T00:00:00.000Z')
+    const b = addQuery(db, projectId, 'best roof coating', '2026-07-01T00:00:00.000Z')
+    ensureCurrentQueryBasketRevision(db, projectId, '2026-07-01T00:00:00.000Z')
+    sweep('2026-07-01T09:00:00.000Z', [{ id: a, text: 'roof coating contractors' }, { id: b, text: 'best roof coating' }], 1)
+
+    const c = addQuery(db, projectId, 'az coatings reviews', '2026-07-15T12:00:00.000Z')
+    ensureCurrentQueryBasketRevision(db, projectId, '2026-07-15T12:00:00.000Z')
+    sweep('2026-07-20T09:00:00.000Z', [
+      { id: a, text: 'roof coating contractors' },
+      { id: b, text: 'best roof coating' },
+      { id: c, text: 'az coatings reviews' },
+    ], 2)
+
+    const body = await metrics()
+    const last = body.buckets.at(-1)
+
+    // Under the date rule this bucket kept only a and b: `c` was created
+    // 2026-07-15T12:00Z and the bucket starts 2026-07-15T00:00Z, so it failed
+    // `created_at < bucketStart` and its three real mentions vanished.
+    expect(last.queryCount).toBe(3)
+    expect(last.mentionedCount).toBe(9)
+    expect(last.mentionRate).toBe(1)
+    expect(last.basketRevision).toBe(2)
+    // Every provider is present, rather than two of them reading zero.
+    expect(Object.keys(last.byProvider).sort()).toEqual(['claude', 'gemini', 'openai'])
+    expect(last.byProvider.claude.mentionRate).toBe(1)
+  })
+
+  it('does not penalise an early bucket for queries that did not exist yet', async () => {
+    // The July 1 bucket only ever swept two queries. It must report those two,
+    // not three-with-a-third-missing, or adding a query would retroactively
+    // crater every historical point.
+    const a = addQuery(db, projectId, 'query a', '2026-07-01T00:00:00.000Z')
+    const b = addQuery(db, projectId, 'query b', '2026-07-01T00:00:00.000Z')
+    ensureCurrentQueryBasketRevision(db, projectId, '2026-07-01T00:00:00.000Z')
+    sweep('2026-07-01T09:00:00.000Z', [{ id: a, text: 'query a' }, { id: b, text: 'query b' }], 1)
+
+    const c = addQuery(db, projectId, 'query c', '2026-07-15T12:00:00.000Z')
+    ensureCurrentQueryBasketRevision(db, projectId, '2026-07-15T12:00:00.000Z')
+    sweep('2026-07-20T09:00:00.000Z', [
+      { id: a, text: 'query a' }, { id: b, text: 'query b' }, { id: c, text: 'query c' },
+    ], 2)
+
+    const body = await metrics()
+    expect(body.buckets[0].queryCount).toBe(2)
+    expect(body.buckets[0].mentionRate).toBe(1)
+    expect(body.buckets[0].basketRevision).toBe(1)
+  })
+
+  it('never silently shrinks the swept set, which is what produced the 0% readings', async () => {
+    // The regression guard. Under the date rule a bucket could quietly measure
+    // fewer queries than the sweep actually covered, and nothing said so. With
+    // the basket, everything swept is by construction a basket member, so the
+    // comparable set and the swept set must agree exactly. If this ever fails,
+    // a headline has become a subset again.
+    const a = addQuery(db, projectId, 'query a', '2026-07-01T00:00:00.000Z')
+    const b = addQuery(db, projectId, 'query b', '2026-07-14T00:00:00.000Z')
+    const c = addQuery(db, projectId, 'query c', '2026-07-19T23:00:00.000Z')
+    ensureCurrentQueryBasketRevision(db, projectId, '2026-07-19T23:30:00.000Z')
+    // All three swept together, including two created inside their own bucket.
+    sweep('2026-07-01T09:00:00.000Z', [{ id: a, text: 'query a' }], 1)
+    sweep('2026-07-20T09:00:00.000Z', [
+      { id: a, text: 'query a' }, { id: b, text: 'query b' }, { id: c, text: 'query c' },
+    ], 1)
+
+    const body = await metrics()
+    const last = body.buckets.at(-1)
+    expect(last.queryCount).toBe(3)
+    expect(last.total).toBe(9)
+    expect(last.mentionRate).toBe(1)
+  })
+
+  it('surfaces a basket change as an event with what moved', async () => {
+    const a = addQuery(db, projectId, 'query a', '2026-07-01T00:00:00.000Z')
+    ensureCurrentQueryBasketRevision(db, projectId, '2026-07-01T00:00:00.000Z')
+    sweep('2026-07-01T09:00:00.000Z', [{ id: a, text: 'query a' }], 1)
+    addQuery(db, projectId, 'query b', '2026-07-15T00:00:00.000Z')
+    ensureCurrentQueryBasketRevision(db, projectId, '2026-07-15T00:00:00.000Z')
+
+    const body = await metrics()
+    expect(body.referenceBasketRevision).toBe(2)
+    expect(body.basketChanges).toHaveLength(1)
+    expect(body.basketChanges[0]).toMatchObject({
+      revision: 2, at: '2026-07-15T00:00:00.000Z', added: ['query b'], removed: [],
+    })
+  })
+
+  it('falls back to the date rule for a project with no recorded basket', async () => {
+    // Projects that have not run since versioning shipped have no basket. They
+    // must keep the behaviour they had rather than silently changing shape the
+    // moment this deploys.
+    const a = addQuery(db, projectId, 'query a', '2026-07-01T00:00:00.000Z')
+    const c = addQuery(db, projectId, 'query c', '2026-07-15T12:00:00.000Z')
+    sweep('2026-07-01T09:00:00.000Z', [{ id: a, text: 'query a' }], null)
+    sweep('2026-07-20T09:00:00.000Z', [{ id: a, text: 'query a' }, { id: c, text: 'query c' }], null)
+
+    const body = await metrics()
+    expect(body.referenceBasketRevision).toBeNull()
+    expect(body.basketChanges).toEqual([])
+    const last = body.buckets.at(-1)
+    // `query c` created 2026-07-15T12:00Z, bucket starts 2026-07-15T00:00Z, so
+    // the old heuristic still drops it. Preserved deliberately.
+    expect(last.queryCount).toBe(1)
+    expect(last.basketRevision).toBeNull()
+  })
+})

--- a/packages/api-routes/test/query-basket.test.ts
+++ b/packages/api-routes/test/query-basket.test.ts
@@ -301,3 +301,111 @@ describe('analytics uses the basket instead of query creation dates', () => {
     expect(last.basketRevision).toBeNull()
   })
 })
+
+describe('deleted-query history rejoins through the basket', () => {
+  let app: ReturnType<typeof Fastify>
+  let db: ReturnType<typeof createClient>
+  let projectId: string
+
+  beforeEach(async () => {
+    const ctx = harness()
+    db = ctx.db
+    projectId = ctx.projectId
+    app = Fastify()
+    app.register(apiRoutes, { db, skipAuth: true })
+    await app.ready()
+  })
+
+  afterEach(async () => { await app.close() })
+
+  function sweep(at: string, texts: Array<{ id: string; text: string }>, revision: number | null) {
+    const runId = crypto.randomUUID()
+    db.insert(runs).values({
+      id: runId, projectId, kind: 'answer-visibility', status: 'completed', trigger: 'manual',
+      location: null, startedAt: at, finishedAt: at, error: null,
+      queryBasketRevision: revision, createdAt: at,
+    } as never).run()
+    for (const q of texts) {
+      for (const provider of ['gemini', 'openai', 'claude']) {
+        db.insert(querySnapshots).values({
+          id: crypto.randomUUID(), runId, queryId: q.id, queryText: q.text, provider,
+          model: `${provider}-model`, citationState: 'cited', answerMentioned: true,
+          answerText: 'Example.com is a good option.', citedDomains: ['example.com'],
+          competitorOverlap: [], location: null, rawResponse: '{}', createdAt: at,
+        } as never).run()
+      }
+    }
+  }
+
+  const metrics = async () => {
+    const res = await app.inject({ method: 'GET', url: `/api/v1/projects/basket-site/analytics/metrics?window=all` })
+    return res.json()
+  }
+
+  it('recovers the history of a query that was deleted and re-added', async () => {
+    // Deleting a query nulls query_id on its historical snapshots, and the
+    // metrics route used to drop those rows before analytics saw them. So a
+    // cleanup that removed and re-added a question erased months of real
+    // measurements from the chart. Identity by text is what makes the old rows
+    // recoverable: same question, same history.
+    const a = addQuery(db, projectId, 'az coatings reviews', '2026-03-01T00:00:00.000Z')
+    ensureCurrentQueryBasketRevision(db, projectId, '2026-03-01T00:00:00.000Z')
+    sweep('2026-03-05T09:00:00.000Z', [{ id: a, text: 'az coatings reviews' }], 1)
+
+    // The cleanup: row deleted, snapshots orphaned. Prove the orphaning
+    // actually happened so this test cannot pass with intact foreign keys.
+    db.delete(queries).where(eq(queries.id, a)).run()
+    const orphans = db.select().from(querySnapshots).all()
+    expect(orphans).toHaveLength(3)
+    for (const o of orphans) expect(o.queryId).toBeNull()
+
+    // Re-added months later under a fresh row id, then swept again.
+    const b = addQuery(db, projectId, 'az coatings reviews', '2026-07-01T00:00:00.000Z')
+    ensureCurrentQueryBasketRevision(db, projectId, '2026-07-01T00:00:00.000Z')
+    sweep('2026-07-05T09:00:00.000Z', [{ id: b, text: 'az coatings reviews' }], 2)
+
+    const body = await metrics()
+    // Both eras are on the chart: March's 3 mentions came back.
+    expect(body.buckets).toHaveLength(2)
+    expect(body.buckets[0]).toMatchObject({ total: 3, mentionedCount: 3, queryCount: 1 })
+    expect(body.buckets.at(-1)).toMatchObject({ total: 3, mentionedCount: 3, queryCount: 1 })
+    expect(body.overall.total).toBe(6)
+    expect(body.overall.mentionedCount).toBe(6)
+  })
+
+  it('keeps a genuinely removed query out, orphaned history included', async () => {
+    // Rejoining is by membership, not by existence of old rows. A query the
+    // operator dropped from measurement stays dropped: resurfacing its history
+    // would un-do the removal.
+    const keep = addQuery(db, projectId, 'kept query', '2026-03-01T00:00:00.000Z')
+    const drop = addQuery(db, projectId, 'dropped query', '2026-03-01T00:00:00.000Z')
+    ensureCurrentQueryBasketRevision(db, projectId, '2026-03-01T00:00:00.000Z')
+    sweep('2026-03-05T09:00:00.000Z', [
+      { id: keep, text: 'kept query' }, { id: drop, text: 'dropped query' },
+    ], 1)
+
+    db.delete(queries).where(eq(queries.id, drop)).run()
+    ensureCurrentQueryBasketRevision(db, projectId, '2026-04-01T00:00:00.000Z')
+
+    const body = await metrics()
+    expect(body.buckets[0].queryCount).toBe(1)
+    expect(body.buckets[0].total).toBe(3)
+    expect(body.overall.total).toBe(3)
+  })
+
+  it('leaves orphans dropped when no basket is recorded, so deploy day changes nothing', async () => {
+    // Without a recorded set there is no membership to test against, and
+    // guessing from text alone would resurrect every deleted query's history
+    // the moment this code ships. Fall back to the old behaviour until the
+    // first revision exists.
+    const a = addQuery(db, projectId, 'some query', '2026-03-01T00:00:00.000Z')
+    sweep('2026-03-05T09:00:00.000Z', [{ id: a, text: 'some query' }], null)
+    db.delete(queries).where(eq(queries.id, a)).run()
+    addQuery(db, projectId, 'some query', '2026-07-01T00:00:00.000Z')
+
+    const body = await metrics()
+    expect(body.referenceBasketRevision).toBeNull()
+    expect(body.buckets).toHaveLength(0)
+    expect(body.overall.total).toBe(0)
+  })
+})

--- a/packages/contracts/src/analytics.ts
+++ b/packages/contracts/src/analytics.ts
@@ -242,8 +242,30 @@ export const timeBucketSchema = z.object({
   byProvider: z.record(z.string(), providerMetricSchema),
   /** Evidence from the exact normalized snapshots that produced each provider rate. */
   modelEvidenceByProvider: z.record(z.string(), modelEvidenceStateSchema).default({}),
+  /**
+   * Which query-set version the runs in this bucket measured. `null` when the
+   * bucket's runs predate basket versioning, were scoped to a subset, or span
+   * more than one revision — in each case there is no single set to name, and
+   * naming one anyway would be the guess this field exists to remove.
+   */
+  basketRevision: z.number().int().nullable().default(null),
 })
 export type TimeBucket = z.infer<typeof timeBucketSchema>
+
+/**
+ * A point where the measured query set actually changed, derived from recorded
+ * basket revisions rather than from query row timestamps. Unlike
+ * `queryChangeEvent` this survives a rename or a remove-then-re-add, because
+ * membership is compared by normalized query text.
+ */
+export const basketChangeEventSchema = z.object({
+  revision: z.number().int(),
+  /** When the new revision was first recorded. A real instant, safe to render. */
+  at: z.string(),
+  added: z.array(z.string()),
+  removed: z.array(z.string()),
+})
+export type BasketChangeEvent = z.infer<typeof basketChangeEventSchema>
 
 export const queryChangeEventSchema = z.object({
   date: z.string(),
@@ -260,6 +282,18 @@ export const brandMetricsDtoSchema = z.object({
   trend: trendDirectionSchema,
   mentionTrend: trendDirectionSchema,
   queryChanges: z.array(queryChangeEventSchema),
+  /**
+   * Recorded changes to the measured query set inside this window, newest last.
+   * Empty for a project whose basket never moved, and for one that has not run
+   * since versioning shipped.
+   */
+  basketChanges: z.array(basketChangeEventSchema).default([]),
+  /**
+   * The query-set version the comparable trend line is measured against —
+   * the project's current basket. Null when no basket has been recorded yet,
+   * which is also when the buckets fall back to the older date heuristic.
+   */
+  referenceBasketRevision: z.number().int().nullable().default(null),
   /** Window-scoped historical evidence, distinct from any configured provider model. */
   modelAttribution: modelAttributionSchema.default({}),
   /**

--- a/packages/contracts/src/run.ts
+++ b/packages/contracts/src/run.ts
@@ -128,6 +128,12 @@ export const runDtoSchema = z.object({
   startedAt: z.string().nullable().optional(),
   finishedAt: z.string().nullable().optional(),
   error: runErrorSchema.nullable().optional(),
+  /**
+   * Which version of the project's query set this run measured. Null on runs
+   * that predate basket versioning and on runs scoped to a subset of queries,
+   * neither of which measured a whole recorded set.
+   */
+  queryBasketRevision: z.number().int().nullable().optional(),
   createdAt: z.string(),
 })
 

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -2541,6 +2541,37 @@ export const MIGRATION_VERSIONS: ReadonlyArray<MigrationVersion> = [
       )`,
     ],
   },
+  {
+    // A trend is only a trend if the query set held still. Analytics used to
+    // approximate that with `query.created_at < bucket_start`, which is a date
+    // proxy for measurement-set membership and gets it wrong whenever a query is
+    // re-added or renamed (both mint a fresh row that reads as brand new).
+    //
+    // Recording the basket makes membership a fact instead of an inference, and
+    // turns a basket change into a visible event on the chart.
+    //
+    // Nothing is backfilled. A revision is minted lazily the next time each
+    // project runs, and rows written before that stamp keep a NULL revision that
+    // analytics reads as "unversioned" and falls back to the date rule for. A
+    // synthesised revision-1 covering today's queries would claim historical runs
+    // measured a set they did not measure, which is the precise error this table
+    // exists to stop.
+    version: 115,
+    name: 'query-basket-versions',
+    statements: [
+      `CREATE TABLE IF NOT EXISTS query_basket_versions (
+        project_id   TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+        revision     INTEGER NOT NULL,
+        members_json TEXT NOT NULL,
+        checksum     TEXT NOT NULL,
+        created_at   TEXT NOT NULL,
+        PRIMARY KEY (project_id, revision)
+      )`,
+      `CREATE INDEX IF NOT EXISTS idx_query_basket_checksum
+         ON query_basket_versions(project_id, checksum)`,
+      `ALTER TABLE runs ADD COLUMN query_basket_revision INTEGER`,
+    ],
+  },
 ]
 
 /**

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -64,11 +64,33 @@ export const runs = sqliteTable('runs', {
   startedAt: text('started_at'),
   finishedAt: text('finished_at'),
   error: text('error'),
+  /**
+   * Which version of the project's query set this run measured. Null on runs
+   * that predate versioning; analytics treats null as "unversioned" rather than
+   * guessing a revision.
+   */
+  queryBasketRevision: integer('query_basket_revision'),
   createdAt: text('created_at').notNull(),
 }, (table) => [
   index('idx_runs_project').on(table.projectId),
   index('idx_runs_status').on(table.status),
   index('idx_runs_source').on(table.sourceId),
+])
+
+/**
+ * Immutable snapshots of a project's query set, one row per distinct set.
+ * Membership is stored as normalized query text so a query that is removed and
+ * re-added rejoins its own history instead of looking new.
+ */
+export const queryBasketVersions = sqliteTable('query_basket_versions', {
+  projectId: text('project_id').notNull().references(() => projects.id, { onDelete: 'cascade' }),
+  revision: integer('revision').notNull(),
+  membersJson: text('members_json').notNull(),
+  checksum: text('checksum').notNull(),
+  createdAt: text('created_at').notNull(),
+}, (table) => [
+  primaryKey({ columns: [table.projectId, table.revision] }),
+  index('idx_query_basket_checksum').on(table.projectId, table.checksum),
 ])
 
 export const querySnapshots = sqliteTable('query_snapshots', {

--- a/packages/db/test/cited-url-migration-upgrade.test.ts
+++ b/packages/db/test/cited-url-migration-upgrade.test.ts
@@ -4,7 +4,7 @@ import os from 'node:os'
 import path from 'node:path'
 import crypto from 'node:crypto'
 import { sql } from 'drizzle-orm'
-import { createClient, migrate, MIGRATION_VERSIONS, projects, runs } from '../src/index.js'
+import { createClient, migrate, MIGRATION_VERSIONS, projects } from '../src/index.js'
 
 const V111 = 111
 
@@ -19,7 +19,10 @@ test('v111 adds nullable cited-URL capture columns without backfilling historica
   const snapshotId = crypto.randomUUID()
   const now = new Date().toISOString()
   db.insert(projects).values({ id: projectId, name: 'legacy-capture', displayName: 'Legacy capture', canonicalDomain: 'example.com', country: 'US', language: 'en', createdAt: now, updatedAt: now }).run()
-  db.insert(runs).values({ id: runId, projectId, status: 'completed', createdAt: now }).run()
+  // Raw SQL like the snapshot insert below: drizzle's `runs` names every
+  // declared column, including ones added after the version under test here.
+  db.run(sql`INSERT INTO runs (id, project_id, status, created_at)
+    VALUES (${runId}, ${projectId}, 'completed', ${now})`)
   db.run(sql`INSERT INTO query_snapshots (id, run_id, provider, citation_state, created_at)
     VALUES (${snapshotId}, ${runId}, 'gemini', 'not-cited', ${now})`)
 

--- a/packages/db/test/served-model-migration-upgrade.test.ts
+++ b/packages/db/test/served-model-migration-upgrade.test.ts
@@ -7,7 +7,6 @@ import { sql } from 'drizzle-orm'
 import {
   createClient,
   migrate,
-  runs,
   MIGRATION_VERSIONS,
   type MigrationVersion,
 } from '../src/index.js'
@@ -47,10 +46,14 @@ function seedRun(db: Db): string {
     VALUES
       (${projectId}, ${`p-${projectId.slice(0, 8)}`}, 'p', 'example.com', 'US', 'en', ${now}, ${now})
   `)
-  db.insert(runs).values({
-    id: runId, projectId, kind: 'answer-visibility', status: 'completed',
-    trigger: 'manual', startedAt: now, createdAt: now,
-  }).run()
+  // Raw SQL for the same reason the snapshot seed below uses it: drizzle's
+  // `runs` declares columns added by LATER migrations (v115's
+  // `query_basket_revision`), and its INSERT names every declared column, so it
+  // cannot write into the pre-v105 table this test deliberately starts from.
+  db.run(sql`
+    INSERT INTO runs (id, project_id, kind, status, trigger, started_at, created_at)
+    VALUES (${runId}, ${projectId}, 'answer-visibility', 'completed', 'manual', ${now}, ${now})
+  `)
   return runId
 }
 


### PR DESCRIPTION
## What

Replaces the `query.createdAt < bucketStart` eligibility rule in analytics with a recorded, versioned query basket.

- `query_basket_versions` — immutable, checksummed snapshot per distinct query set (migration v115)
- `runs.query_basket_revision` — the set each run actually measured
- Analytics compares by query identity against the basket, not by row timestamp
- `basketChanges` / `referenceBasketRevision` on the metrics response, and `basketRevision` per bucket

## Why

The trend chart read 0% mention on two of three engines for a whole window while those engines were mentioning the brand. The providers were fine. Each bucket was normalized to "queries that existed before this bucket started", which is a date proxy for measurement-set membership. A branded query added mid-window failed that test, so its real mentions were dropped from both the numerator and the denominator, and the chart showed 0% with nothing saying the query set had moved.

The proxy is wrong in other ways too. A rename is a delete plus an insert, so it reads as brand new. A remove-then-re-add detaches a query from its own history. Eligibility shifts silently whenever bucket boundaries move. And nothing recorded which set was measured, so none of it was visible after the fact.

## Design notes

**Lazy minting, not mutation hooks.** Revisions are derived from the live query set when a run is queued. Query mutations live in three routes today; a fourth would silently skip a hook and leave an unversioned basket that still looks fine.

**Scoped runs stay unstamped.** They measure a subset. Labelling one with the full basket would let a 3-query spot check land in a bucket as though all 16 had been swept — the same denominator error by another route.

**No backfill.** Projects with no recorded basket keep the old date behaviour, so existing charts do not change shape on deploy. A synthesised revision 1 would claim historical runs measured today's set, which is the error this table exists to stop.

**History is restated, on purpose.** Holding one set of identities across the series means a query removed today leaves the comparable line in every past bucket. The alternative (each bucket judged against its own revision) freezes old points but makes any two incomparable across a change, which is the failure the chart already had. `basketChanges` keeps the restatement visible.

**Dropped from an earlier draft:** an `excludedQueryCount` / `allQueries` pair reporting what the headline left out. `filterTrackedSnapshots` already drops snapshots whose `query_id` was nulled by a delete, so with mint-before-sweep ordering the value is provably always zero. Shipping an always-zero field is worse than not shipping it. (PR #893 was the stopgap version of this and is now closed.)

## Orphaned-history recovery (second commit)

Deleting a query nulls `query_id` on its historical snapshots, and the metrics route dropped those rows before analytics saw them — so removing a query erased its past from the chart even when the same question was re-added later. Because basket membership is by normalized text, those rows are now recoverable: an orphaned snapshot whose `query_text` is in the reference basket rejoins the trend. Orphans whose text is not in the basket stay out (that query was deliberately dropped, and resurrecting its history would un-do the removal). Without a recorded basket, orphans are dropped exactly as before, so deploy day still changes nothing.

Measured against live azcoatings data: 47 of 653 orphaned snapshots rejoin, and the May-July buckets go from 5-7% to 16-17% mention rate — history of currently tracked queries that a past cleanup had erased.

Scoped to the metrics route; gaps/composites/cdp/content-data keep tracked-only semantics. Ablation: reverting the rejoin fails exactly the recovery test while both guard tests keep passing.

## Verification

- Ablation: reverting to the date rule fails exactly the two regression tests describing the reported bug, and only those.
- 6193 tests pass across 511 files. Lint, typecheck, and the OpenAPI codegen drift gate all clean.
