### PR TITLE
fix(apply): stop config-as-code resuming a schedule someone paused

### DIFF
--- a/packages/api-client-generated/src/generated/types.gen.ts
+++ b/packages/api-client-generated/src/generated/types.gen.ts
@@ -3084,6 +3084,7 @@ export type ProjectConfig = {
             cron?: string;
             timezone: string;
             providers: Array<string>;
+            enabled?: boolean;
         };
         notifications: Array<{
             channel: 'webhook';

--- a/packages/api-routes/src/apply.ts
+++ b/packages/api-routes/src/apply.ts
@@ -249,13 +249,19 @@ export async function applyRoutes(app: FastifyInstance, opts?: ApplyRoutesOption
           .from(schedules)
           .where(and(eq(schedules.projectId, projectId), eq(schedules.kind, AV_KIND)))
           .get()
+        // `enabled` is only written when the spec says so. Omitting it leaves a
+        // paused schedule paused: someone disabled it from the dashboard or the
+        // API for a reason, and an apply that touches the cron expression is not
+        // a request to resume the sweeps. A schedule this apply creates has no
+        // prior state to preserve, so it defaults to enabled.
+        const specEnabled = config.spec.schedule?.enabled
         if (existingSched) {
           tx.update(schedules).set({
             cronExpr: resolvedSchedule.cronExpr,
             preset: resolvedSchedule.preset,
             timezone: resolvedSchedule.timezone,
             providers: config.spec.schedule?.providers ?? [],
-            enabled: true,
+            ...(specEnabled === undefined ? {} : { enabled: specEnabled }),
             updatedAt: now,
           }).where(eq(schedules.id, existingSched.id)).run()
         } else {
@@ -266,7 +272,7 @@ export async function applyRoutes(app: FastifyInstance, opts?: ApplyRoutesOption
             cronExpr: resolvedSchedule.cronExpr,
             preset: resolvedSchedule.preset,
             timezone: resolvedSchedule.timezone,
-            enabled: true,
+            enabled: specEnabled ?? true,
             providers: config.spec.schedule?.providers ?? [],
             createdAt: now,
             updatedAt: now,

--- a/packages/api-routes/test/schedule-enabled-identity.test.ts
+++ b/packages/api-routes/test/schedule-enabled-identity.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import Fastify from 'fastify'
+import { and, eq } from 'drizzle-orm'
+import { createClient, migrate, projects, schedules } from '@ainyc/canonry-db'
+import { apiRoutes } from '../src/index.js'
+
+// A schedule's `enabled` flag is operator state, not config-as-code state.
+// Someone pauses a schedule from the dashboard or the API because the sweeps
+// were costing money, hitting a broken provider, or running against a client
+// who churned. An apply that changes the cron expression is not a request to
+// resume that work, so a declarative write must NOT silently flip it back on.
+//
+// `enabled` is therefore only written when the spec says so: omit it and the
+// existing state survives; set it and it is authoritative. A schedule that
+// apply CREATES has no prior state to preserve and defaults to enabled.
+//
+// These tests pin both halves. Delete the `specEnabled === undefined` guard in
+// apply.ts and the first test fails.
+
+const cleanups: Array<() => void> = []
+afterEach(() => {
+  for (const fn of cleanups.splice(0)) fn()
+})
+
+function buildApp() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'schedule-enabled-identity-'))
+  cleanups.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }))
+  const dbPath = path.join(tmpDir, 'test.db')
+  const db = createClient(dbPath)
+  migrate(db)
+  const app = Fastify()
+  app.register(apiRoutes, { db, skipAuth: true })
+  return { app, db }
+}
+
+function applyBody(name: string, schedule: Record<string, unknown> | undefined, over: Record<string, unknown> = {}) {
+  return {
+    apiVersion: 'canonry/v1',
+    kind: 'Project',
+    metadata: { name },
+    spec: {
+      displayName: 'Demo',
+      canonicalDomain: 'demo.example',
+      country: 'US',
+      language: 'en',
+      queries: ['best aeo agency'],
+      ...(schedule === undefined ? {} : { schedule }),
+      ...over,
+    },
+  }
+}
+
+function avSchedule(db: ReturnType<typeof createClient>, projectId: string) {
+  return db
+    .select()
+    .from(schedules)
+    .where(and(eq(schedules.projectId, projectId), eq(schedules.kind, 'answer-visibility')))
+    .get()
+}
+
+function projectId(db: ReturnType<typeof createClient>, name: string): string {
+  const row = db.select().from(projects).where(eq(projects.name, name)).get()
+  if (!row) throw new Error(`project ${name} not found`)
+  return row.id
+}
+
+describe('schedule enabled state — POST /apply', () => {
+  it('leaves a paused schedule paused when the spec omits enabled', async () => {
+    const { app, db } = buildApp()
+
+    await app.inject({ method: 'POST', url: '/api/v1/apply', payload: applyBody('demo', { preset: 'daily' }) })
+    const id = projectId(db, 'demo')
+    expect(avSchedule(db, id)?.enabled).toBe(true)
+
+    // The operator pauses it out of band, the way the dashboard does.
+    db.update(schedules).set({ enabled: false }).where(eq(schedules.projectId, id)).run()
+    expect(avSchedule(db, id)?.enabled).toBe(false)
+
+    const res = await app.inject({ method: 'POST', url: '/api/v1/apply', payload: applyBody('demo', { preset: 'daily' }) })
+    expect(res.statusCode).toBe(200)
+    expect(avSchedule(db, id)?.enabled).toBe(false)
+  })
+
+  it('still updates cron, timezone and providers while the paused state survives', async () => {
+    const { app, db } = buildApp()
+
+    await app.inject({ method: 'POST', url: '/api/v1/apply', payload: applyBody('demo', { preset: 'daily' }) })
+    const id = projectId(db, 'demo')
+    db.update(schedules).set({ enabled: false }).where(eq(schedules.projectId, id)).run()
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/apply',
+      payload: applyBody('demo', { cron: '0 6 * * *', timezone: 'America/New_York', providers: ['openai'] }),
+    })
+
+    const row = avSchedule(db, id)
+    expect(row?.enabled).toBe(false)
+    expect(row?.cronExpr).toBe('0 6 * * *')
+    expect(row?.timezone).toBe('America/New_York')
+    expect(row?.providers).toEqual(['openai'])
+  })
+
+  it('pauses an active schedule when the spec sets enabled: false', async () => {
+    const { app, db } = buildApp()
+
+    await app.inject({ method: 'POST', url: '/api/v1/apply', payload: applyBody('demo', { preset: 'daily' }) })
+    const id = projectId(db, 'demo')
+    expect(avSchedule(db, id)?.enabled).toBe(true)
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/apply',
+      payload: applyBody('demo', { preset: 'daily', enabled: false }),
+    })
+    expect(avSchedule(db, id)?.enabled).toBe(false)
+  })
+
+  it('resumes a paused schedule when the spec sets enabled: true', async () => {
+    const { app, db } = buildApp()
+
+    await app.inject({ method: 'POST', url: '/api/v1/apply', payload: applyBody('demo', { preset: 'daily' }) })
+    const id = projectId(db, 'demo')
+    db.update(schedules).set({ enabled: false }).where(eq(schedules.projectId, id)).run()
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/v1/apply',
+      payload: applyBody('demo', { preset: 'daily', enabled: true }),
+    })
+    expect(avSchedule(db, id)?.enabled).toBe(true)
+  })
+
+  it('creates a schedule enabled by default, and paused when the spec asks', async () => {
+    const { app, db } = buildApp()
+
+    await app.inject({ method: 'POST', url: '/api/v1/apply', payload: applyBody('on', { preset: 'daily' }) })
+    expect(avSchedule(db, projectId(db, 'on'))?.enabled).toBe(true)
+
+    await app.inject({ method: 'POST', url: '/api/v1/apply', payload: applyBody('off', { preset: 'daily', enabled: false }) })
+    expect(avSchedule(db, projectId(db, 'off'))?.enabled).toBe(false)
+  })
+})

--- a/packages/contracts/src/config-schema.ts
+++ b/packages/contracts/src/config-schema.ts
@@ -16,6 +16,14 @@ export const configScheduleSchema = z.object({
   cron: z.string().optional(),
   timezone: z.string().optional().default('UTC'),
   providers: z.array(providerNameSchema).optional().default([]),
+  /**
+   * Whether the schedule fires. Omit to leave an existing schedule's state
+   * alone — a schedule paused from the dashboard or the API stays paused
+   * across an apply, so config-as-code does not silently resume billing work
+   * someone deliberately stopped. A schedule created by this apply defaults
+   * to enabled.
+   */
+  enabled: z.boolean().optional(),
 }).refine(
   (data) => (data.preset && !data.cron) || (!data.preset && data.cron),
   { message: 'Exactly one of "preset" or "cron" must be provided' },


### PR DESCRIPTION
## Summary

`canonry apply` hardcoded `enabled: true` on the schedule update path, so any apply with a `schedule:` block turned a paused schedule back on. The apply file also had no way to express "paused", so the flag was unreachable from the one surface meant to be declarative.

Two consequences:

- A schedule paused from the dashboard or the API resumed the next time anyone applied a config. Nothing reported it.
- Running apply on a timer for drift correction was unsafe: an apply that only meant to change a cron expression silently resumed the sweeps, and sweeps cost money.

## Change

`enabled` is now optional on the schedule spec.

| Spec | Existing schedule | New schedule |
|---|---|---|
| omitted | state preserved | enabled |
| `enabled: false` | paused | created paused |
| `enabled: true` | resumed | enabled |

Backward compatible: every existing config file omits `enabled`, so the only behavior that changes is the case that was wrong. Insert still defaults to enabled, and cron, timezone and providers keep updating on a paused schedule.

Scoped to the `answer-visibility` schedule, same as the rest of the apply block.

## Validation

- `packages/api-routes/test/schedule-enabled-identity.test.ts`, 5 cases. Reverting the guard in `apply.ts` fails 3 of them, including the one asserting a paused schedule still gets its cron expression updated.
- api-routes 104 files / 1844 tests, contracts + canonry 43 files / 838 tests, all passing
- `pnpm typecheck` clean
- lint 0 errors, warning count unchanged at 222