### PR TITLE
feat(scheduler): record each project's query basket at boot

### DIFF
--- a/packages/api-routes/src/index.ts
+++ b/packages/api-routes/src/index.ts
@@ -532,6 +532,7 @@ export async function apiRoutes(app: FastifyInstance, opts: ApiRoutesOptions) {
 
 export type { DatabaseClient } from '@ainyc/canonry-db'
 export { queueRunIfProjectIdle } from './run-queue.js'
+export { ensureCurrentQueryBasketRevision, latestQueryBasketRevision } from './query-basket.js'
 export { nextRunFromCron } from './schedule-utils.js'
 export {
   executeDiscovery,

--- a/packages/canonry/src/scheduler.ts
+++ b/packages/canonry/src/scheduler.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto'
 import cron from 'node-cron'
 import { and, eq, inArray, notExists, sql } from 'drizzle-orm'
-import { queueRunIfProjectIdle, nextRunFromCron } from '@ainyc/canonry-api-routes'
+import { queueRunIfProjectIdle, nextRunFromCron, ensureCurrentQueryBasketRevision, latestQueryBasketRevision } from '@ainyc/canonry-api-routes'
 import type { DatabaseClient } from '@ainyc/canonry-db'
 import { schedules, projects, runs } from '@ainyc/canonry-db'
 import type { ProviderName, LocationContext, SchedulableRunKind } from '@ainyc/canonry-contracts'
@@ -139,9 +139,37 @@ export class Scheduler {
     log.info('health-schedule.seeded', { projectCount: projectsWithoutHealth.length, cron: DEFAULT_HEALTH_CRON })
   }
 
+  /**
+   * Record each project's current query set as basket revision 1 if it has
+   * never been recorded. Minting normally happens when a sweep is queued, but a
+   * project whose sweeps are manual (the common cadence: twice a month) would
+   * otherwise keep its analytics on the pre-basket date heuristic for weeks
+   * after the feature ships — with the chart still hiding exactly the history
+   * the basket exists to recover. Boot is the moment the current set is known
+   * and nothing has to be guessed, and ensureCurrentQueryBasketRevision is
+   * idempotent, so restarts are no-ops and an unchanged set never churns
+   * revisions. Runs are NOT stamped retroactively: the revision describes the
+   * set as of now, and historical runs keep their null stamp.
+   */
+  private ensureQueryBaskets(): void {
+    const allProjects = this.db.select({ id: projects.id }).from(projects).all()
+    let minted = 0
+    for (const project of allProjects) {
+      try {
+        const previous = latestQueryBasketRevision(this.db, project.id)?.revision ?? null
+        const current = ensureCurrentQueryBasketRevision(this.db, project.id)
+        if (current !== null && current.revision !== previous) minted += 1
+      } catch (err) {
+        log.warn('query-basket.mint-failed', { projectId: project.id, err: String(err) })
+      }
+    }
+    if (minted > 0) log.info('query-basket.ensured', { projectCount: minted })
+  }
+
   /** Load all enabled schedules from DB and register cron jobs. */
   start(): void {
     this.ensureHealthSchedules()
+    this.ensureQueryBaskets()
 
     const allSchedules = this.db
       .select()

--- a/packages/canonry/test/scheduler-basket-mint.test.ts
+++ b/packages/canonry/test/scheduler-basket-mint.test.ts
@@ -1,0 +1,108 @@
+import { test, expect, onTestFinished } from 'vitest'
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { eq } from 'drizzle-orm'
+import { createClient, migrate, projects, queries, queryBasketVersions } from '@ainyc/canonry-db'
+import { Scheduler } from '../src/scheduler.js'
+
+// Basket revisions are normally minted when a sweep is queued. That left a gap:
+// a project whose sweeps are manual (the real cadence is about twice a month)
+// shipped the basket feature and then sat on the pre-basket date heuristic for
+// weeks, with its chart still hiding exactly the history the basket recovers.
+// Nothing was broken, but the fix everyone deployed for was inert.
+//
+// These tests pin the boot-time mint that closes the gap: start() records the
+// current set for every project that has one, without churning revisions on
+// restart and without touching projects that have nothing to record.
+
+function harness() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-basket-mint-'))
+  onTestFinished(() => fs.rmSync(tmpDir, { recursive: true, force: true }))
+  const db = createClient(path.join(tmpDir, 'test.db'))
+  migrate(db)
+  return db
+}
+
+function seedProject(db: ReturnType<typeof createClient>, name: string, queryTexts: string[]) {
+  const id = crypto.randomUUID()
+  const now = new Date().toISOString()
+  db.insert(projects).values({
+    id, name, displayName: name, canonicalDomain: `${name}.com`,
+    country: 'US', language: 'en', createdAt: now, updatedAt: now,
+  }).run()
+  for (const text of queryTexts) {
+    db.insert(queries).values({ id: crypto.randomUUID(), projectId: id, query: text, createdAt: now }).run()
+  }
+  return id
+}
+
+function startScheduler(db: ReturnType<typeof createClient>) {
+  const scheduler = new Scheduler(db, { onRunCreated: () => {} })
+  scheduler.start()
+  onTestFinished(() => scheduler.stop())
+  return scheduler
+}
+
+function revisions(db: ReturnType<typeof createClient>, projectId: string) {
+  // Explicit order: SQLite is free to walk the (project_id, revision) PK in
+  // either direction, and this helper's callers index into the result.
+  return db.select().from(queryBasketVersions)
+    .where(eq(queryBasketVersions.projectId, projectId))
+    .orderBy(queryBasketVersions.revision).all()
+}
+
+test('start() records revision 1 for every project with queries', () => {
+  const db = harness()
+  const withQueries = seedProject(db, 'swept-manually', ['best roof coating', 'az coatings reviews'])
+  const alsoQueries = seedProject(db, 'another', ['some question'])
+
+  startScheduler(db)
+
+  expect(revisions(db, withQueries)).toHaveLength(1)
+  expect(revisions(db, alsoQueries)).toHaveLength(1)
+  const members = JSON.parse(revisions(db, withQueries)[0]!.membersJson) as string[]
+  expect(members).toEqual(['az coatings reviews', 'best roof coating'])
+})
+
+test('a restart mints nothing new, so revision numbers keep counting real changes', () => {
+  const db = harness()
+  const projectId = seedProject(db, 'stable', ['unchanged query'])
+
+  startScheduler(db)
+  startScheduler(db)
+  startScheduler(db)
+
+  expect(revisions(db, projectId)).toHaveLength(1)
+  expect(revisions(db, projectId)[0]!.revision).toBe(1)
+})
+
+test('a query edit made while the server was down is picked up as a new revision on boot', () => {
+  const db = harness()
+  const projectId = seedProject(db, 'edited-offline', ['original query'])
+  startScheduler(db)
+
+  // Server "down": operator edits queries directly (apply, replace, etc).
+  db.insert(queries).values({
+    id: crypto.randomUUID(), projectId, query: 'added while down',
+    createdAt: new Date().toISOString(),
+  }).run()
+
+  startScheduler(db)
+
+  const revs = revisions(db, projectId)
+  expect(revs).toHaveLength(2)
+  expect(JSON.parse(revs[1]!.membersJson)).toContain('added while down')
+})
+
+test('a project with no queries is left unversioned', () => {
+  // An empty basket would make "not configured yet" look like a deliberate
+  // measurement set of size zero.
+  const db = harness()
+  const emptyProject = seedProject(db, 'empty', [])
+
+  startScheduler(db)
+
+  expect(revisions(db, emptyProject)).toHaveLength(0)
+})


### PR DESCRIPTION
## What

Mint each project's basket revision 1 at `Scheduler.start()` instead of waiting for the next queued sweep. Same seam as the v114 health-schedule seeding.

## Why

#894 shipped, deployed cleanly, and then did nothing: minting only happened when an answer-visibility run was queued, and projects with manual sweep cadence (azcoatings, gjelina: about twice a month) had no reason to queue one for weeks. 90 runs were queued in the first hour post-deploy, zero of them sweeps, zero revisions minted. The chart stayed on the date heuristic, still showing openai/perplexity at a false 0% for azcoatings.

Boot is the moment the current set is fully known and nothing has to be guessed. `ensureCurrentQueryBasketRevision` is idempotent, so restarts are no-ops, revision numbers keep counting real changes, and an edit made while the server was down mints a real revision on next boot. Runs are still never stamped retroactively.

## Effect on deploy

Restart mints revision 1 for every project with queries. Analytics switches from the date rule to basket membership immediately: azcoatings' May-July buckets go from 5-7% to 16-19% mention rate and the 47 orphaned-but-current snapshots rejoin, with no sweep required.

## Validation

- 4 new tests: mints for every project with queries, restart idempotence, offline-edit picked up as a new revision, empty project left unversioned
- 6211 tests across 516 files, lint and typecheck clean