### PR TITLE
feat(web): make dashboard resource links configurable

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -24,7 +24,13 @@ import {
 import { CitationStates, formatRunErrorOneLine } from '@ainyc/canonry-contracts'
 
 import { formatErrorLog } from './lib/format-helpers.js'
-import { getEmbedConfig, heyClient, type ApiProject, type ApiRun } from './api.js'
+import {
+  getEmbedConfig,
+  heyClient,
+  shouldShowDashboardResourceLinks,
+  type ApiProject,
+  type ApiRun,
+} from './api.js'
 import { embedThemeFontHref, embedThemeMode, embedThemeStyle, embedViewIdForPath } from './embed.js'
 import { getApiV1ProjectsOptions, getApiV1RunsOptions } from '@ainyc/canonry-api-client/react-query'
 import { serviceStatusTooltip } from './lib/health-helpers.js'
@@ -287,6 +293,7 @@ export function RootLayout() {
   // not fetch instance settings just to build nav/settings state it will not
   // render. The server-side embed tab policy intentionally blocks /settings.
   const embed = useMemo(() => getEmbedConfig(), [])
+  const resourceLinksVisible = useMemo(shouldShowDashboardResourceLinks, [])
 
   // ── Data fetching via TanStack Query ──
   const { dashboard, isLoading, refetch: refreshData } = useDashboard(undefined, { includeSettings: !embed })
@@ -644,21 +651,23 @@ export function RootLayout() {
           ) : null}
         </nav>
 
-        <div className="sidebar-footer">
-          {resources.map(({ label, href, Icon }) => (
-            <a
-              key={href}
-              className="sidebar-footer-icon"
-              href={href}
-              target="_blank"
-              rel="noopener noreferrer"
-              title={label}
-              aria-label={label}
-            >
-              <Icon className="size-4" />
-            </a>
-          ))}
-        </div>
+        {resourceLinksVisible ? (
+          <div className="sidebar-footer">
+            {resources.map(({ label, href, Icon }) => (
+              <a
+                key={href}
+                className="sidebar-footer-icon"
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                title={label}
+                aria-label={label}
+              >
+                <Icon className="size-4" />
+              </a>
+            ))}
+          </div>
+        ) : null}
       </aside>
       )}
 
@@ -821,21 +830,23 @@ export function RootLayout() {
               <span className="footer-version">v{healthSnapshot.apiStatus.version}</span>
             ) : null}
           </span>
-          <div className="footer-links">
-            {resources.map(({ label, href, Icon }) => (
-              <a
-                key={href}
-                href={href}
-                target="_blank"
-                rel="noopener noreferrer"
-                title={label}
-                aria-label={label}
-                className="footer-icon"
-              >
-                <Icon className="size-3.5" />
-              </a>
-            ))}
-          </div>
+          {resourceLinksVisible ? (
+            <div className="footer-links">
+              {resources.map(({ label, href, Icon }) => (
+                <a
+                  key={href}
+                  href={href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title={label}
+                  aria-label={label}
+                  className="footer-icon"
+                >
+                  <Icon className="size-3.5" />
+                </a>
+              ))}
+            </div>
+          ) : null}
         </footer>
       </div>
 

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -167,6 +167,10 @@ declare global {
        * Example: '/canonry/' → API calls go to '/canonry/api/v1/...'
        */
       basePath?: string
+      /** Present only when dashboard chrome differs from its defaults. */
+      dashboard?: {
+        showResourceLinks?: boolean
+      }
       /**
        * Read-only embed block injected by `canonry serve --embed` (#716). Present
        * only when embed mode is enabled; drives the chromeless render + the
@@ -240,6 +244,12 @@ export function getEmbedConfig(): EmbedClientConfig | null {
   if (typeof window === 'undefined') return null
   const embed = window.__CANONRY_CONFIG__?.embed
   return embed?.enabled ? embed : null
+}
+
+/** Whether the optional GitHub, documentation, and changelog links render. */
+export function shouldShowDashboardResourceLinks(): boolean {
+  if (typeof window === 'undefined') return true
+  return window.__CANONRY_CONFIG__?.dashboard?.showResourceLinks !== false
 }
 
 /**

--- a/apps/web/test/app-embed.test.tsx
+++ b/apps/web/test/app-embed.test.tsx
@@ -10,6 +10,7 @@ import { DashboardProvider } from '../src/contexts/dashboard-context.js'
 import { preloadAllLazyRoutes } from '../src/router/routes.js'
 
 type EmbedBlock = { enabled: boolean; views?: string[]; theme?: Record<string, string> }
+type DashboardBlock = { showResourceLinks?: boolean }
 
 beforeAll(async () => {
   await preloadAllLazyRoutes()
@@ -22,9 +23,15 @@ afterEach(() => {
   delete window.__CANONRY_CONFIG__
 })
 
-async function renderAt(pathname: string, embed?: EmbedBlock): Promise<string> {
-  if (embed) window.__CANONRY_CONFIG__ = { embed }
-  else delete window.__CANONRY_CONFIG__
+async function renderAt(pathname: string, embed?: EmbedBlock, dashboard?: DashboardBlock): Promise<string> {
+  if (embed || dashboard) {
+    window.__CANONRY_CONFIG__ = {
+      ...(embed ? { embed } : {}),
+      ...(dashboard ? { dashboard } : {}),
+    }
+  } else {
+    delete window.__CANONRY_CONFIG__
+  }
 
   const fixture = createDashboardFixture({})
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
@@ -52,10 +59,27 @@ function detailsForTitle(doc: Document, title: string): HTMLDetailsElement | nul
 test('without embed config the full application chrome renders', async () => {
   const html = await renderAt('/')
   expect(html).toContain('class="sidebar"')
+  expect(html).toContain('class="sidebar-footer"')
+  expect(html).toContain('class="footer-links"')
+  expect(html).toContain('aria-label="GitHub"')
+  expect(html).toContain('aria-label="Docs"')
+  expect(html).toContain('aria-label="Changelog"')
   expect(html).toContain('class="topbar"')
   expect(html).toContain('class="footer"')
   expect(html).toContain('id="mobile-nav"')
   expect(html).not.toContain('app-shell-embed')
+})
+
+test('dashboard resource-link opt-out removes the sidebar and footer icon clusters', async () => {
+  const html = await renderAt('/', undefined, { showResourceLinks: false })
+  expect(html).toContain('class="sidebar"')
+  expect(html).toContain('class="footer"')
+  expect(html).toContain('class="footer-brand"')
+  expect(html).not.toContain('class="sidebar-footer"')
+  expect(html).not.toContain('class="footer-links"')
+  expect(html).not.toContain('aria-label="GitHub"')
+  expect(html).not.toContain('aria-label="Docs"')
+  expect(html).not.toContain('aria-label="Changelog"')
 })
 
 test('embed mode renders chromeless: no nav / topbar / footer / toaster, only the view', async () => {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -48,6 +48,16 @@ Opens at [http://127.0.0.1:4100](http://127.0.0.1:4100). No configuration needed
 > proxy. Never expose an engine with `requirePassword: false` directly to the
 > internet.
 
+To remove the GitHub, documentation, and changelog icons from the dashboard
+sidebar and page footer, set the resource-link option to false:
+
+```yaml
+dashboard:
+  showResourceLinks: false
+```
+
+For container deployments, set `CANONRY_DASHBOARD_SHOW_RESOURCE_LINKS=0`.
+
 ---
 
 ## Behind a Reverse Proxy

--- a/packages/canonry/src/config.ts
+++ b/packages/canonry/src/config.ts
@@ -220,6 +220,13 @@ export interface DashboardConfigEntry {
    * and the engine is not directly internet-reachable.
    */
   requirePassword?: boolean
+
+  /**
+   * Whether the dashboard sidebar and page footer show the Canonry GitHub,
+   * documentation, and changelog links. Defaults to true. Disable for a
+   * quieter branded UI.
+   */
+  showResourceLinks?: boolean
 }
 
 /**

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -227,6 +227,12 @@ function resolveDashboardRequirePassword(env: NodeJS.ProcessEnv, config: Canonry
     ?? true;
 }
 
+function resolveDashboardShowResourceLinks(env: NodeJS.ProcessEnv, config: CanonryConfig): boolean {
+  return parseBooleanEnv(env.CANONRY_DASHBOARD_SHOW_RESOURCE_LINKS)
+    ?? config.dashboard?.showResourceLinks
+    ?? true;
+}
+
 /** All known API adapters — add new providers here */
 const API_ADAPTERS: ProviderAdapter[] = [
   geminiAdapter,
@@ -1612,6 +1618,7 @@ export async function createServer(opts: {
     );
   }
   const dashboardRequirePassword = resolveDashboardRequirePassword(process.env, opts.config);
+  const dashboardShowResourceLinks = resolveDashboardShowResourceLinks(process.env, opts.config);
   app.log.info(
     { dashboardRequirePassword },
     "Dashboard password gate resolved",
@@ -2600,6 +2607,11 @@ export async function createServer(opts: {
     ): string => {
       const clientConfig: Record<string, unknown> = {};
       if (basePath) clientConfig.basePath = basePath;
+      // Keep the default client config byte-for-byte unchanged. Only inject the
+      // dashboard block when the operator opts out of the resource links.
+      if (!dashboardShowResourceLinks) {
+        clientConfig.dashboard = { showResourceLinks: false };
+      }
       // Embed block is appended LAST and only when enabled, so the default
       // (non-embed) serve emits byte-for-byte the same `{}` / `{basePath}`.
       // `projectTabs` + `theme` may be overridden PER REQUEST by the

--- a/packages/canonry/test/server-embed.test.ts
+++ b/packages/canonry/test/server-embed.test.ts
@@ -17,6 +17,7 @@ const EMBED_ENV = [
   'CANONRY_EMBED_VIEWS',
   'CANONRY_EMBED_PROJECT_TABS',
   'CANONRY_DASHBOARD_REQUIRE_PASSWORD',
+  'CANONRY_DASHBOARD_SHOW_RESOURCE_LINKS',
 ] as const
 
 interface Built {
@@ -155,6 +156,37 @@ describe('server embed mode (#716)', () => {
     try {
       const res = await app.inject({ method: 'GET', url: '/api/v1/session' })
       expect(JSON.parse(res.body)).toEqual({ authenticated: true, setupRequired: false })
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('dashboard.showResourceLinks=false injects the resource-link opt-out', async () => {
+    const { app, cleanup } = await buildServer(undefined, true, {
+      dashboard: { showResourceLinks: false },
+    })
+    try {
+      for (const url of ['/', '/projects/acme']) {
+        const res = await app.inject({ method: 'GET', url })
+        expect(res.body).toContain(
+          '<script>window.__CANONRY_CONFIG__={"dashboard":{"showResourceLinks":false}}</script>',
+        )
+      }
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('CANONRY_DASHBOARD_SHOW_RESOURCE_LINKS overrides config for container deploys', async () => {
+    process.env.CANONRY_DASHBOARD_SHOW_RESOURCE_LINKS = '0'
+    const { app, cleanup } = await buildServer(undefined, true, {
+      dashboard: { showResourceLinks: true },
+    })
+    try {
+      const res = await app.inject({ method: 'GET', url: '/' })
+      expect(res.body).toContain(
+        '<script>window.__CANONRY_CONFIG__={"dashboard":{"showResourceLinks":false}}</script>',
+      )
     } finally {
       await cleanup()
     }


### PR DESCRIPTION
## Summary

Add a runtime dashboard setting for hiding open-source resource links in branded deployments.

- Add `dashboard.showResourceLinks`, defaulting to `true`, with a `CANONRY_DASHBOARD_SHOW_RESOURCE_LINKS` environment override.
- Hide the GitHub, Docs, and Changelog icon clusters from both the desktop sidebar and responsive page footer when disabled.
- Preserve navigation, Canonry branding, and version display.
- Document the YAML and environment forms and add server and web regression coverage.

## Why

The resource links are useful in the default open-source dashboard, but branded deployments need a quieter, professional UI. Previously there was no runtime opt-out.

## Validation

- `pnpm --filter @ainyc/canonry-web run test` (489 tests)
- `npx --yes node@22.14.0 node_modules/vitest/vitest.mjs run packages/canonry/test/server-embed.test.ts` (31 tests)
- Web and Canonry package typechecks
- Web and Canonry package lint (0 errors)
- Production Vite build
- `git diff --check`