### PR TITLE
Make dashboard update notification configurable

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -28,6 +28,7 @@ import {
   getEmbedConfig,
   heyClient,
   shouldShowDashboardResourceLinks,
+  shouldShowDashboardUpdateNotification,
   type ApiProject,
   type ApiRun,
 } from './api.js'
@@ -294,6 +295,7 @@ export function RootLayout() {
   // render. The server-side embed tab policy intentionally blocks /settings.
   const embed = useMemo(() => getEmbedConfig(), [])
   const resourceLinksVisible = useMemo(shouldShowDashboardResourceLinks, [])
+  const updateNotificationVisible = useMemo(shouldShowDashboardUpdateNotification, [])
 
   // ── Data fetching via TanStack Query ──
   const { dashboard, isLoading, refetch: refreshData } = useDashboard(undefined, { includeSettings: !embed })
@@ -343,7 +345,7 @@ export function RootLayout() {
         upgradeCommand: 'npm install -g @canonry/canonry',
       }
     : healthSnapshot.apiStatus.updateAvailable
-  const showUpdatePill = updateAvailable && updateAvailable.latest !== dismissedUpdateVersion
+  const showUpdatePill = updateNotificationVisible && updateAvailable && updateAvailable.latest !== dismissedUpdateVersion
   const dismissUpdatePill = () => {
     if (!updateAvailable) return
     try {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -170,6 +170,7 @@ declare global {
       /** Present only when dashboard chrome differs from its defaults. */
       dashboard?: {
         showResourceLinks?: boolean
+        showUpdateNotification?: boolean
       }
       /**
        * Read-only embed block injected by `canonry serve --embed` (#716). Present
@@ -250,6 +251,12 @@ export function getEmbedConfig(): EmbedClientConfig | null {
 export function shouldShowDashboardResourceLinks(): boolean {
   if (typeof window === 'undefined') return true
   return window.__CANONRY_CONFIG__?.dashboard?.showResourceLinks !== false
+}
+
+/** Whether the available-version notification renders in the sidebar. */
+export function shouldShowDashboardUpdateNotification(): boolean {
+  if (typeof window === 'undefined') return true
+  return window.__CANONRY_CONFIG__?.dashboard?.showUpdateNotification !== false
 }
 
 /**

--- a/apps/web/src/components/shared/BrandLockup.tsx
+++ b/apps/web/src/components/shared/BrandLockup.tsx
@@ -48,10 +48,10 @@ export function BrandLockup({ compact = false, version, updateAvailable, onDismi
     )
   }
 
-  // Sidebar layout: split the Link so the version slot can host interactive
-  // elements (the bubble's npm link + dismiss button) without nesting <a>/<button>
-  // inside another <a>. The bird image and the "Canonry" wordmark are both
-  // separate Links to home — accessible to keyboard users either way.
+  // Sidebar layout: split the Links so the version notification can host
+  // interactive elements without nesting <a>/<button> inside another <a>.
+  // The bubble spans the whole lockup below the wordmark, keeping long version
+  // strings within the sidebar instead of squeezing them beside the mascot.
   return (
     <div className="brand-lockup brand-lockup-wrapper">
       <Link
@@ -64,37 +64,38 @@ export function BrandLockup({ compact = false, version, updateAvailable, onDismi
       </Link>
       <div className="brand-copy">
         <Link to="/" className="brand-mark">Canonry</Link>
-        {showBubble ? (
-          <span
-            className={`brand-update-bubble ${closing ? 'brand-update-bubble-closing' : ''}`}
-            role="status"
-            aria-live="polite"
-          >
-            <a
-              className="brand-update-bubble-link"
-              href={updateAvailable.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              title={`Open release: ${updateAvailable.upgradeCommand}`}
-              aria-label={`New version v${updateAvailable.latest} available — open release page`}
-            >
-              <span className="brand-update-bubble-from">v{updateAvailable.current}</span>
-              <ArrowRight className="brand-update-bubble-arrow size-3" aria-hidden="true" />
-              <span className="brand-update-bubble-to">v{updateAvailable.latest}</span>
-            </a>
-            <button
-              type="button"
-              className="brand-update-bubble-dismiss"
-              onClick={handleDismiss}
-              aria-label={`Dismiss update notification for v${updateAvailable.latest}`}
-            >
-              <X className="size-3" aria-hidden="true" />
-            </button>
-          </span>
-        ) : showVersion ? (
+        {!showBubble && showVersion ? (
           <span className="brand-version">v{version}</span>
         ) : null}
       </div>
+      {showBubble ? (
+        <span
+          className={`brand-update-bubble ${closing ? 'brand-update-bubble-closing' : ''}`}
+          role="status"
+          aria-live="polite"
+        >
+          <a
+            className="brand-update-bubble-link"
+            href={updateAvailable.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={`Open release: ${updateAvailable.upgradeCommand}`}
+            aria-label={`New version v${updateAvailable.latest} available — open release page`}
+          >
+            <span className="brand-update-bubble-from">v{updateAvailable.current}</span>
+            <ArrowRight className="brand-update-bubble-arrow size-3" aria-hidden="true" />
+            <span className="brand-update-bubble-to">v{updateAvailable.latest}</span>
+          </a>
+          <button
+            type="button"
+            className="brand-update-bubble-dismiss"
+            onClick={handleDismiss}
+            aria-label={`Dismiss update notification for v${updateAvailable.latest}`}
+          >
+            <X className="size-3" aria-hidden="true" />
+          </button>
+        </span>
+      ) : null}
     </div>
   )
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -580,23 +580,32 @@
 
   /* ── Update bubble ── */
   /*
-   * Inline speech bubble that REPLACES the static "v4.35.0" label below
-   * "Canonry" when a new canonry version is available. Compact horizontal
-   * pill showing the current → latest transition; click opens npm, × dismisses
-   * (per-version, persisted to localStorage). Tail on the bubble's left side
-   * points at the bird mascot. The bird plays a one-shot chirp animation when
-   * the bubble appears.
+   * A version notification replaces the static label when a newer Canonry
+   * version is available. It spans the sidebar lockup so long version strings
+   * can wrap without escaping the sidebar; click opens npm, × dismisses
+   * (per-version, persisted to localStorage). The bird plays a one-shot chirp
+   * animation when the notification appears.
    */
   .brand-lockup-wrapper {
-    @apply inline-flex items-center gap-3;
+    @apply grid w-full max-w-full grid-cols-[2.5rem_minmax(0,1fr)] items-center gap-x-3;
   }
 
   .brand-icon-link {
     @apply block shrink-0 outline-none focus-visible:ring-2 focus-visible:ring-caution-400/60 rounded-full;
   }
 
+  .brand-lockup-wrapper .brand-icon-link {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .brand-lockup-wrapper .brand-copy {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
   .brand-update-bubble {
-    @apply relative mt-2 inline-flex w-max items-center gap-1 rounded-full border border-caution bg-caution-soft py-0.5 pl-2 pr-1 font-mono text-[11px] leading-none text-caution-100 transition;
+    @apply relative col-span-2 mt-2 flex w-full min-w-0 items-center gap-1 rounded-full border border-caution bg-caution-soft py-0.5 pl-2 pr-1 font-mono text-[11px] leading-none text-caution-100 transition;
     box-shadow:
       0 8px 20px -10px var(--color-caution-glow),
       inset 0 0 0 1px var(--color-caution-glow-inset);
@@ -610,7 +619,7 @@
   }
 
   .brand-update-bubble-link {
-    @apply inline-flex items-center gap-1 rounded-full text-caution-100 no-underline outline-none;
+    @apply flex min-w-0 flex-1 flex-wrap items-center gap-x-1 gap-y-0.5 rounded-full text-caution-100 no-underline outline-none;
   }
 
   .brand-update-bubble-link:focus-visible {
@@ -619,6 +628,12 @@
 
   .brand-update-bubble-closing {
     animation: brand-bubble-out 220ms cubic-bezier(0.4, 0, 1, 1) forwards;
+  }
+
+  .brand-update-bubble-from,
+  .brand-update-bubble-to {
+    @apply min-w-0;
+    overflow-wrap: anywhere;
   }
 
   .brand-update-bubble-from {

--- a/apps/web/test/app-embed.test.tsx
+++ b/apps/web/test/app-embed.test.tsx
@@ -10,7 +10,7 @@ import { DashboardProvider } from '../src/contexts/dashboard-context.js'
 import { preloadAllLazyRoutes } from '../src/router/routes.js'
 
 type EmbedBlock = { enabled: boolean; views?: string[]; theme?: Record<string, string> }
-type DashboardBlock = { showResourceLinks?: boolean }
+type DashboardBlock = { showResourceLinks?: boolean; showUpdateNotification?: boolean }
 
 beforeAll(async () => {
   await preloadAllLazyRoutes()
@@ -23,7 +23,12 @@ afterEach(() => {
   delete window.__CANONRY_CONFIG__
 })
 
-async function renderAt(pathname: string, embed?: EmbedBlock, dashboard?: DashboardBlock): Promise<string> {
+async function renderAt(
+  pathname: string,
+  embed?: EmbedBlock,
+  dashboard?: DashboardBlock,
+  withUpdateNotification = false,
+): Promise<string> {
   if (embed || dashboard) {
     window.__CANONRY_CONFIG__ = {
       ...(embed ? { embed } : {}),
@@ -34,6 +39,14 @@ async function renderAt(pathname: string, embed?: EmbedBlock, dashboard?: Dashbo
   }
 
   const fixture = createDashboardFixture({})
+  if (withUpdateNotification) {
+    fixture.health.apiStatus.updateAvailable = {
+      current: '4.139.0',
+      latest: '4.139.1',
+      url: 'https://www.npmjs.com/package/@canonry/canonry',
+      upgradeCommand: 'npm install -g @canonry/canonry',
+    }
+  }
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   const router = createAppRouter(queryClient, { initialEntries: [pathname] })
   await router.load()
@@ -80,6 +93,17 @@ test('dashboard resource-link opt-out removes the sidebar and footer icon cluste
   expect(html).not.toContain('aria-label="GitHub"')
   expect(html).not.toContain('aria-label="Docs"')
   expect(html).not.toContain('aria-label="Changelog"')
+})
+
+test('dashboard update-notification opt-out removes the version badge without disabling the static version', async () => {
+  const visible = await renderAt('/', undefined, undefined, true)
+  const hidden = await renderAt('/', undefined, { showUpdateNotification: false }, true)
+
+  expect(visible).toContain('New version v4.139.1 available')
+  expect(visible).toContain('brand-update-bubble')
+  expect(hidden).not.toContain('New version v4.139.1 available')
+  expect(hidden).not.toContain('brand-update-bubble')
+  expect(hidden).toContain('vphase-1')
 })
 
 test('embed mode renders chromeless: no nav / topbar / footer / toaster, only the view', async () => {

--- a/apps/web/test/design-tokens.test.ts
+++ b/apps/web/test/design-tokens.test.ts
@@ -202,6 +202,17 @@ test('highlight and effect primitives consume tokens', async () => {
   expect(css).toContain('background: var(--color-scrollbar-thumb)')
 })
 
+test('update notification fits the sidebar and wraps long version strings', async () => {
+  const css = await compileAppStyles([])
+
+  expect(ruleFor(css, '.brand-lockup-wrapper')).toContain('max-width: 100%')
+  expect(ruleFor(css, '.brand-update-bubble')).toContain('grid-column: span 2 / span 2')
+  expect(ruleFor(css, '.brand-update-bubble')).toContain('width: 100%')
+  expect(ruleFor(css, '.brand-update-bubble-link')).toContain('flex-wrap: wrap')
+  expect(ruleFor(css, '.brand-update-bubble-from')).toContain('overflow-wrap: anywhere')
+  expect(ruleFor(css, '.brand-update-bubble-to')).toContain('overflow-wrap: anywhere')
+})
+
 test('filter chips preserve a 44px touch target and visible keyboard focus', async () => {
   const css = await compileAppStyles([])
   const chip = ruleFor(css, '.filter-chip')

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -48,15 +48,21 @@ Opens at [http://127.0.0.1:4100](http://127.0.0.1:4100). No configuration needed
 > proxy. Never expose an engine with `requirePassword: false` directly to the
 > internet.
 
-To remove the GitHub, documentation, and changelog icons from the dashboard
-sidebar and page footer, set the resource-link option to false:
+To remove optional dashboard chrome, set either option to false:
 
 ```yaml
 dashboard:
   showResourceLinks: false
+  showUpdateNotification: false
 ```
 
-For container deployments, set `CANONRY_DASHBOARD_SHOW_RESOURCE_LINKS=0`.
+`showResourceLinks` removes the GitHub, documentation, and changelog icons
+from the sidebar and page footer. `showUpdateNotification` removes the
+available-version badge from the sidebar but keeps update checks and CLI
+notices active.
+
+For container deployments, set `CANONRY_DASHBOARD_SHOW_RESOURCE_LINKS=0` or
+`CANONRY_DASHBOARD_SHOW_UPDATE_NOTIFICATION=0`.
 
 ---
 

--- a/packages/canonry/src/config.ts
+++ b/packages/canonry/src/config.ts
@@ -227,6 +227,13 @@ export interface DashboardConfigEntry {
    * quieter branded UI.
    */
   showResourceLinks?: boolean
+
+  /**
+   * Whether the dashboard sidebar shows the available-version notification.
+   * Defaults to true. Disable without turning off the underlying update check
+   * or CLI update notice.
+   */
+  showUpdateNotification?: boolean
 }
 
 /**

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -233,6 +233,12 @@ function resolveDashboardShowResourceLinks(env: NodeJS.ProcessEnv, config: Canon
     ?? true;
 }
 
+function resolveDashboardShowUpdateNotification(env: NodeJS.ProcessEnv, config: CanonryConfig): boolean {
+  return parseBooleanEnv(env.CANONRY_DASHBOARD_SHOW_UPDATE_NOTIFICATION)
+    ?? config.dashboard?.showUpdateNotification
+    ?? true;
+}
+
 /** All known API adapters — add new providers here */
 const API_ADAPTERS: ProviderAdapter[] = [
   geminiAdapter,
@@ -1619,6 +1625,7 @@ export async function createServer(opts: {
   }
   const dashboardRequirePassword = resolveDashboardRequirePassword(process.env, opts.config);
   const dashboardShowResourceLinks = resolveDashboardShowResourceLinks(process.env, opts.config);
+  const dashboardShowUpdateNotification = resolveDashboardShowUpdateNotification(process.env, opts.config);
   app.log.info(
     { dashboardRequirePassword },
     "Dashboard password gate resolved",
@@ -2608,9 +2615,16 @@ export async function createServer(opts: {
       const clientConfig: Record<string, unknown> = {};
       if (basePath) clientConfig.basePath = basePath;
       // Keep the default client config byte-for-byte unchanged. Only inject the
-      // dashboard block when the operator opts out of the resource links.
+      // dashboard block when the operator opts out of dashboard chrome.
+      const dashboardConfig: Record<string, boolean> = {};
       if (!dashboardShowResourceLinks) {
-        clientConfig.dashboard = { showResourceLinks: false };
+        dashboardConfig.showResourceLinks = false;
+      }
+      if (!dashboardShowUpdateNotification) {
+        dashboardConfig.showUpdateNotification = false;
+      }
+      if (Object.keys(dashboardConfig).length > 0) {
+        clientConfig.dashboard = dashboardConfig;
       }
       // Embed block is appended LAST and only when enabled, so the default
       // (non-embed) serve emits byte-for-byte the same `{}` / `{basePath}`.

--- a/packages/canonry/test/server-embed.test.ts
+++ b/packages/canonry/test/server-embed.test.ts
@@ -18,6 +18,7 @@ const EMBED_ENV = [
   'CANONRY_EMBED_PROJECT_TABS',
   'CANONRY_DASHBOARD_REQUIRE_PASSWORD',
   'CANONRY_DASHBOARD_SHOW_RESOURCE_LINKS',
+  'CANONRY_DASHBOARD_SHOW_UPDATE_NOTIFICATION',
 ] as const
 
 interface Built {
@@ -186,6 +187,37 @@ describe('server embed mode (#716)', () => {
       const res = await app.inject({ method: 'GET', url: '/' })
       expect(res.body).toContain(
         '<script>window.__CANONRY_CONFIG__={"dashboard":{"showResourceLinks":false}}</script>',
+      )
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('dashboard.showUpdateNotification=false injects the update-notification opt-out', async () => {
+    const { app, cleanup } = await buildServer(undefined, true, {
+      dashboard: { showUpdateNotification: false },
+    })
+    try {
+      for (const url of ['/', '/projects/acme']) {
+        const res = await app.inject({ method: 'GET', url })
+        expect(res.body).toContain(
+          '<script>window.__CANONRY_CONFIG__={"dashboard":{"showUpdateNotification":false}}</script>',
+        )
+      }
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('CANONRY_DASHBOARD_SHOW_UPDATE_NOTIFICATION overrides config for container deploys', async () => {
+    process.env.CANONRY_DASHBOARD_SHOW_UPDATE_NOTIFICATION = '0'
+    const { app, cleanup } = await buildServer(undefined, true, {
+      dashboard: { showUpdateNotification: true },
+    })
+    try {
+      const res = await app.inject({ method: 'GET', url: '/' })
+      expect(res.body).toContain(
+        '<script>window.__CANONRY_CONFIG__={"dashboard":{"showUpdateNotification":false}}</script>',
       )
     } finally {
       await cleanup()


### PR DESCRIPTION
## Summary

- Add a dashboard-only update-notification toggle via config or environment.
- Keep update checks and CLI notices enabled.
- Keep long version badges within the sidebar.

## Why

Operators may want a quieter or white-labeled dashboard without losing update awareness elsewhere.

## Validation

- Focused web tests (20)
- Server config tests (33)
- Web and Canonry typechecks
- Web production build
- Browser check with long version metadata