### PR TITLE
fix(db): scope the measurement-plan foreign-key check to the table it rebuilt

### DIFF
--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -2667,7 +2667,13 @@ function addRunsMeasurementPlanVersionForeignKey(tx: MigrationDb): void {
   const indexes = tx.all(sql.raw("SELECT name, sql FROM sqlite_master WHERE type = 'index' AND tbl_name = 'runs' AND sql IS NOT NULL")) as Array<{ name: string; sql: string }>
 
   rebuildMeasurementTable(tx, 'runs', repairedSql, columnList, indexes)
-  const violations = tx.all(sql.raw('PRAGMA foreign_key_check'))
+  // Scoped to the table this function rebuilt. Unscoped, the pragma walks every
+  // table in the database, so one pre-existing orphan anywhere aborts the
+  // migration and the install can never boot again. Those orphans are not
+  // hypothetical here: v98 exists to relink FK-orphaned query_snapshots, and
+  // migrations run with foreign keys disabled, so older rows can predate any
+  // constraint. This check is meant to catch damage the rebuild itself caused.
+  const violations = tx.all(sql.raw("PRAGMA foreign_key_check('runs')"))
   if (violations.length > 0) throw new Error('Measurement-plan migration left foreign-key violations')
 }
 

--- a/packages/db/test/measurement-fk-check-scope.test.ts
+++ b/packages/db/test/measurement-fk-check-scope.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { rmSync } from 'node:fs'
+import { sql } from 'drizzle-orm'
+import { createClient } from '../src/client.js'
+import { migrate, MIGRATION_VERSIONS } from '../src/migrate.js'
+
+// The measurement-plan migration rebuilds `runs` to add a foreign key, then
+// verifies it did no damage. That verification used an unscoped
+// `PRAGMA foreign_key_check`, which walks EVERY table: one pre-existing orphan
+// anywhere in the database aborted the migration, and since the migration is
+// re-attempted on every boot, the install could never start again.
+//
+// Such orphans are ordinary here. Migrations run with foreign keys disabled, and
+// v98 exists specifically to relink FK-orphaned query_snapshots rows.
+
+function requiredColumns(db: ReturnType<typeof createClient>, table: string): string[] {
+  const cols = db.all(sql.raw(`PRAGMA table_info('${table}')`)) as Array<{
+    name: string
+    notnull: number
+    dflt_value: unknown
+  }>
+  return cols.filter(column => column.notnull && column.dflt_value === null).map(column => column.name)
+}
+
+describe('measurement-plan foreign-key verification', () => {
+  it('upgrades a database that already contains an unrelated orphan', () => {
+    const file = '/tmp/canonry-fk-scope-orphan.db'
+    rmSync(file, { force: true })
+    const db = createClient(file)
+
+    // Stop one version short of the rebuild.
+    migrate(db, MIGRATION_VERSIONS.filter(version => version.version <= 117))
+
+    // An orphaned snapshot: its run is long gone. Nothing to do with the
+    // measurement-plan foreign key being added.
+    db.run(sql.raw('PRAGMA foreign_keys=OFF'))
+    const columns = requiredColumns(db, 'query_snapshots')
+    const values = columns.map(name => (name === 'run_id' ? "'run-since-deleted'" : "'x'"))
+    db.run(sql.raw(`INSERT INTO query_snapshots (${columns.join(', ')}) VALUES (${values.join(', ')})`))
+
+    expect(() => migrate(db)).not.toThrow()
+
+    const applied = db.all(sql`SELECT version FROM _migrations ORDER BY version`) as Array<{ version: number }>
+    expect(applied.at(-1)!.version).toBeGreaterThanOrEqual(118)
+  })
+
+  it('still refuses when the rebuild itself orphans a run', () => {
+    const file = '/tmp/canonry-fk-scope-runs.db'
+    rmSync(file, { force: true })
+    const db = createClient(file)
+    migrate(db, MIGRATION_VERSIONS.filter(version => version.version <= 117))
+
+    // A run pointing at a project that does not exist is damage in the very
+    // table the rebuild touches, which is what the check is for.
+    db.run(sql.raw('PRAGMA foreign_keys=OFF'))
+    const columns = requiredColumns(db, 'runs')
+    const values = columns.map(name => (name === 'project_id' ? "'project-missing'" : "'x'"))
+    db.run(sql.raw(`INSERT INTO runs (${columns.join(', ')}) VALUES (${values.join(', ')})`))
+
+    expect(() => migrate(db)).toThrow(/foreign-key violations/)
+  })
+})


### PR DESCRIPTION
The measurement-plan migration rebuilds `runs` to add a foreign key, then
verifies the rebuild did no damage. That verification used an unscoped
`PRAGMA foreign_key_check`, which walks every table in the database. One
pre-existing orphan anywhere, in any table, therefore aborted the migration.
Migrations re-run on every boot, so an affected install could never start again.

Those orphans are ordinary rather than hypothetical: migrations run with foreign
keys disabled, and v98 exists specifically to relink FK-orphaned query_snapshots
rows. An install carrying one would have upgraded straight into a boot loop.

Reproduced before fixing: a database at v117 with a single orphaned snapshot,
unrelated to the foreign key being added, fails to upgrade with
"Measurement-plan migration left foreign-key violations".

The check now names `runs`, the table the rebuild touched and the only damage it
could have caused. Two tests cover it: an unrelated orphan upgrades cleanly, and
a run orphaned by the rebuild still fails. Both were proven by reverting the
change and watching them fail.

Found by an adversarial backend audit of the merged measurement stack.