### PR TITLE
fix(web): let setup create what it asks for, and stop it dead-ending

### DIFF
--- a/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementSection.tsx
+++ b/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementSection.tsx
@@ -997,6 +997,10 @@ export function AdvancedMeasurementSection({
       // The server says which question was rejected and why. Replacing that with
       // a house string is what sent an operator round in circles on the sitemap.
       setCreateQueriesError(extractErrorMessage(error))
+      // Rethrow so the step keeps what the operator typed. Resolving here would
+      // report failure and clear the box in the same breath, and they would have
+      // to retype every question to try again.
+      throw error
     } finally {
       setBusyAction(null)
     }

--- a/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementSection.tsx
+++ b/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementSection.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { extractErrorMessage } from '../../../lib/extract-error-message.js'
 import type {
   MeasurementDraftAuthoring,
   MeasurementDraftCompileCheck,
@@ -51,6 +52,8 @@ export interface AdvancedMeasurementSectionProps {
   onRetryQueries?: () => void
   publishedPlan?: MeasurementPlanResponse['active']
   canEdit?: boolean
+  /** Adds tracked questions to the project from inside setup. */
+  onCreateQueries?: (texts: readonly string[]) => Promise<void>
   onManageProjectQueries?: () => void
   onPublished?: () => void
   service?: AdvancedMeasurementService
@@ -755,6 +758,7 @@ export function AdvancedMeasurementSection({
   onRetryQueries,
   publishedPlan,
   canEdit = true,
+  onCreateQueries,
   onManageProjectQueries,
   onPublished,
   service = advancedMeasurementService,
@@ -776,6 +780,7 @@ export function AdvancedMeasurementSection({
   const [groupDraft, setGroupDraft] = useState<AdvancedMeasurementGroupDraft>({ ...DEFAULT_GROUP_DRAFT })
   const [editingGroupId, setEditingGroupId] = useState<string | null>(null)
   const [busyAction, setBusyAction] = useState<string | null>(null)
+  const [createQueriesError, setCreateQueriesError] = useState<string | null>(null)
   const [reviewed, setReviewed] = useState<ReviewedSetup | null>(null)
   const requestVersionRef = useRef(0)
 
@@ -979,6 +984,21 @@ export function AdvancedMeasurementSection({
       setReviewState('idle')
     } else {
       setReviewState('error')
+    }
+  }
+
+  async function addProjectQueries(texts: readonly string[]): Promise<void> {
+    if (!onCreateQueries || texts.length === 0 || busyAction) return
+    setBusyAction('create-queries')
+    setCreateQueriesError(null)
+    try {
+      await onCreateQueries(texts)
+    } catch (error) {
+      // The server says which question was rejected and why. Replacing that with
+      // a house string is what sent an operator round in circles on the sitemap.
+      setCreateQueriesError(extractErrorMessage(error))
+    } finally {
+      setBusyAction(null)
     }
   }
 
@@ -1313,6 +1333,11 @@ export function AdvancedMeasurementSection({
           onDiscard={() => { void discardDraft() }}
           onManageProjectQueries={onManageProjectQueries}
           queries={{
+            onCreateQueries: onCreateQueries
+              ? texts => addProjectQueries(texts)
+              : undefined,
+            isCreatingQueries: busyAction === 'create-queries',
+            createQueriesError: createQueriesError,
             availability: queryAvailability,
             properties: confirmedProperties,
             queries: setupQueries,

--- a/apps/web/src/components/project/advanced-measurement/SetupQueriesGroupsReview.tsx
+++ b/apps/web/src/components/project/advanced-measurement/SetupQueriesGroupsReview.tsx
@@ -54,7 +54,15 @@ export interface AdvancedMeasurementQueriesStepProps {
   onClearQueryAssignments?: (queryId: string) => void | Promise<void>
   /** Compatibility fallback for callers that have not split clearing from removal yet. */
   onRemoveQuery: (queryId: string) => void | Promise<void>
-  /** Opens the project's normal query-management surface when the library is empty. */
+  /**
+   * Adds new tracked questions to the project from inside setup. Without this the
+   * step can only consume questions that already exist, which sends a first-time
+   * operator out of the wizard to create them and back again.
+   */
+  onCreateQueries?: (texts: readonly string[]) => void | Promise<void>
+  isCreatingQueries?: boolean
+  createQueriesError?: string | null
+  /** Opens the project's normal query-management surface for anything setup does not cover. */
   onManageProjectQueries?: () => void
   onBack?: () => void
   onContinue: () => void
@@ -297,12 +305,16 @@ export function AdvancedMeasurementQueriesStep({
   onApplySelectedQueries,
   onClearQueryAssignments,
   onRemoveQuery,
+  onCreateQueries,
+  isCreatingQueries = false,
+  createQueriesError = null,
   onManageProjectQueries,
   onBack,
   onContinue,
 }: AdvancedMeasurementQueriesStepProps) {
   const [querySearch, setQuerySearch] = useState('')
   const [showAllQueries, setShowAllQueries] = useState(false)
+  const [newQueriesText, setNewQueriesText] = useState('')
   if (isUnavailable(availability)) {
     return <section aria-label="Queries"><UnavailableState message={availability.message} /></section>
   }
@@ -320,6 +332,9 @@ export function AdvancedMeasurementQueriesStep({
     : queries
   const visibleQueries = showAllQueries ? filteredQueries : filteredQueries.slice(0, QUERY_LIST_PAGE_SIZE)
   const selectableVisibleQueries = visibleQueries.filter(query => !isMissingQuery(query))
+  const parsedNewQueries = [...new Set(
+    newQueriesText.split('\n').map(line => line.trim()).filter(Boolean),
+  )]
 
   function selectAllShownQueries(): void {
     const selected = new Set([...selectedQueryIds, ...selectableVisibleQueries.map(query => query.id)])
@@ -465,12 +480,47 @@ export function AdvancedMeasurementQueriesStep({
         <Button type="button" size="sm" variant="outline" onClick={() => setShowAllQueries(true)}>Show all queries</Button>
       ) : null}
 
-      {queries.length === 0 ? (
+      {viewer || !onCreateQueries ? null : (
         <div className="border-y border-default py-4">
-          <p className="text-sm text-secondary">Add queries to this project first. Then return here to apply them to Properties.</p>
-          {!viewer && onManageProjectQueries ? <Button type="button" variant="outline" size="sm" className="mt-3" onClick={onManageProjectQueries}>Manage project queries</Button> : null}
+          <h4 className="m-0 text-sm font-medium text-heading">
+            {queries.length === 0 ? 'Add the questions you want to track' : 'Add more questions'}
+          </h4>
+          <p className="mt-1 mb-2 text-sm text-secondary">
+            One per line. These are added to the project, then you choose which
+            Properties to apply them to. You can edit or add more at any time.
+          </p>
+          <textarea
+            aria-label="New questions, one per line"
+            className="w-full rounded border border-strong bg-transparent px-3 py-2 text-sm text-strong placeholder-mono-600 focus:border-mono-500 focus:outline-none"
+            rows={4}
+            value={newQueriesText}
+            onChange={event => setNewQueriesText(event.target.value)}
+            placeholder={'best apartments in dallas\nluxury apartments atlanta\npet friendly apartments austin'}
+          />
+          {createQueriesError ? (
+            <p role="alert" className="mt-2 text-sm text-negative">{createQueriesError}</p>
+          ) : null}
+          <div className="mt-2 flex flex-wrap items-center gap-3">
+            <Button
+              type="button"
+              size="sm"
+              disabled={parsedNewQueries.length === 0 || isCreatingQueries}
+              onClick={() => {
+                void Promise.resolve(onCreateQueries(parsedNewQueries)).then(() => setNewQueriesText(''))
+              }}
+            >
+              {isCreatingQueries
+                ? 'Adding…'
+                : `Add ${parsedNewQueries.length || ''} question${parsedNewQueries.length === 1 ? '' : 's'}`.replace('  ', ' ')}
+            </Button>
+            {onManageProjectQueries ? (
+              <Button type="button" size="sm" variant="ghost" onClick={onManageProjectQueries}>
+                Manage all project questions
+              </Button>
+            ) : null}
+          </div>
         </div>
-      ) : null}
+      )}
 
       {viewer ? null : (
         <>

--- a/apps/web/src/components/project/advanced-measurement/SetupQueriesGroupsReview.tsx
+++ b/apps/web/src/components/project/advanced-measurement/SetupQueriesGroupsReview.tsx
@@ -392,6 +392,10 @@ export function AdvancedMeasurementQueriesStep({
               />
             </div>
           </details>
+          {/* With an empty basket these three controls can only ever be disabled,
+              and they sat above the form that creates the questions they act on.
+              The Property checklist stays: the pattern form below needs it. */}
+          {queries.length === 0 ? null : (
           <div className="flex flex-wrap items-center gap-3">
             <Button
               type="button"
@@ -422,6 +426,7 @@ export function AdvancedMeasurementQueriesStep({
             </Button>
             <p className="text-sm text-secondary">{selectedQueryIds.length} selected, {selectedPropertyIds.length} Properties selected.</p>
           </div>
+          )}
         </div>
       )}
 

--- a/apps/web/src/components/project/advanced-measurement/SetupQueriesGroupsReview.tsx
+++ b/apps/web/src/components/project/advanced-measurement/SetupQueriesGroupsReview.tsx
@@ -521,7 +521,8 @@ export function AdvancedMeasurementQueriesStep({
               size="sm"
               disabled={parsedNewQueries.length === 0 || isCreatingQueries}
               onClick={() => {
-                void Promise.resolve(onCreateQueries(parsedNewQueries)).then(() => setNewQueriesText(''))
+                void Promise.resolve(onCreateQueries(parsedNewQueries))
+                  .then(() => setNewQueriesText(''), () => {})
               }}
             >
               {isCreatingQueries
@@ -577,7 +578,8 @@ export function AdvancedMeasurementQueriesStep({
               className="mt-2"
               disabled={patternExpansions.length === 0 || isCreatingQueries}
               onClick={() => {
-                void Promise.resolve(onCreateQueries(patternExpansions)).then(() => setPatternText(''))
+                void Promise.resolve(onCreateQueries(patternExpansions))
+                  .then(() => setPatternText(''), () => {})
               }}
             >
               {isCreatingQueries

--- a/apps/web/src/components/project/advanced-measurement/SetupQueriesGroupsReview.tsx
+++ b/apps/web/src/components/project/advanced-measurement/SetupQueriesGroupsReview.tsx
@@ -315,6 +315,7 @@ export function AdvancedMeasurementQueriesStep({
   const [querySearch, setQuerySearch] = useState('')
   const [showAllQueries, setShowAllQueries] = useState(false)
   const [newQueriesText, setNewQueriesText] = useState('')
+  const [patternText, setPatternText] = useState('')
   if (isUnavailable(availability)) {
     return <section aria-label="Queries"><UnavailableState message={availability.message} /></section>
   }
@@ -335,6 +336,20 @@ export function AdvancedMeasurementQueriesStep({
   const parsedNewQueries = [...new Set(
     newQueriesText.split('\n').map(line => line.trim()).filter(Boolean),
   )]
+  // One pattern, one question per selected Property. This is the portfolio
+  // shape: nobody types "apartments near Harbor Point" two hundred times, and
+  // typing two hundred generic questions measures the portfolio rather than the
+  // Properties in it.
+  const patternPlaceholders = [...patternText.matchAll(/\{([a-z][\w-]*)\}/gi)].map(match => match[1]!)
+  const patternTargets = properties.filter(property => selectedPropertyIds.includes(property.id))
+  const patternExpansions = patternPlaceholders.length === 0 || patternText.trim() === ''
+    ? []
+    : [...new Set(patternTargets.map(property => (
+      patternPlaceholders.reduce(
+        (text, name) => text.replaceAll(`{${name}}`, property.label),
+        patternText.trim(),
+      )
+    )))]
 
   function selectAllShownQueries(): void {
     const selected = new Set([...selectedQueryIds, ...selectableVisibleQueries.map(query => query.id)])
@@ -518,6 +533,57 @@ export function AdvancedMeasurementQueriesStep({
                 Manage all project questions
               </Button>
             ) : null}
+          </div>
+
+          <div className="mt-4 border-t border-default pt-4">
+            <h4 className="m-0 text-sm font-medium text-heading">Or write one question for every Property</h4>
+            <p className="mt-1 mb-2 text-sm text-secondary">
+              Put <code className="rounded bg-bg-elevated px-1">{'{property}'}</code> where the
+              Property name belongs. You get one question per selected Property.
+            </p>
+            <input
+              aria-label="Question pattern"
+              className="w-full rounded border border-strong bg-transparent px-3 py-2 text-sm text-strong placeholder-mono-600 focus:border-mono-500 focus:outline-none"
+              value={patternText}
+              onChange={event => setPatternText(event.target.value)}
+              placeholder="apartments near {property}"
+            />
+            {patternText.trim() === '' ? null : patternPlaceholders.length === 0 ? (
+              <p className="mt-2 text-sm text-caution">
+                Add {'{property}'} to the pattern, or use the box above for a single question.
+              </p>
+            ) : patternTargets.length === 0 ? (
+              <p className="mt-2 text-sm text-caution">Select at least one Property to write questions for.</p>
+            ) : (
+              <div className="mt-2 rounded-md border border-base bg-bg-elevated p-3">
+                <p className="m-0 text-sm text-secondary">
+                  {patternExpansions.length} question{patternExpansions.length === 1 ? '' : 's'}, one per selected Property:
+                </p>
+                <ul className="mt-1 mb-0 list-none space-y-0.5 p-0">
+                  {patternExpansions.slice(0, 3).map(text => (
+                    <li key={text} className="text-sm text-strong">{text}</li>
+                  ))}
+                </ul>
+                {patternExpansions.length > 3 ? (
+                  <p className="mt-1 mb-0 text-sm text-secondary">
+                    and {patternExpansions.length - 3} more
+                  </p>
+                ) : null}
+              </div>
+            )}
+            <Button
+              type="button"
+              size="sm"
+              className="mt-2"
+              disabled={patternExpansions.length === 0 || isCreatingQueries}
+              onClick={() => {
+                void Promise.resolve(onCreateQueries(patternExpansions)).then(() => setPatternText(''))
+              }}
+            >
+              {isCreatingQueries
+                ? 'Adding…'
+                : `Add ${patternExpansions.length || ''} question${patternExpansions.length === 1 ? '' : 's'}`.replace('  ', ' ')}
+            </Button>
           </div>
         </div>
       )}

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { ChevronDown, RefreshCw, Trash2 } from 'lucide-react'
-import { useParams, useNavigate } from '@tanstack/react-router'
+import { useNavigate, useParams, useSearch } from '@tanstack/react-router'
 import { Link } from '@tanstack/react-router'
 import { useQueryClient } from '@tanstack/react-query'
 import { RunKinds, RunStatuses } from '@ainyc/canonry-contracts'
@@ -1613,7 +1613,8 @@ function ProjectPageContent({
   // connecting one rather than being hidden until after connection.
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [deleting, setDeleting] = useState(false)
-  const [managingQueries, setManagingQueries] = useState(false)
+  const manageQueriesRequested = (useSearch({ strict: false }) as { manageQueries?: boolean }).manageQueries === true
+  const [managingQueries, setManagingQueries] = useState(manageQueriesRequested)
   const [newQueryText, setNewQueryText] = useState('')
   const [querySaving, setQuerySaving] = useState(false)
   const [removingQuery, setRemovingQuery] = useState<string | null>(null)
@@ -2175,8 +2176,14 @@ function ProjectPageContent({
             await portfolioQueriesQuery.refetch()
           }}
           onManageProjectQueries={() => {
-            setManagingQueries(true)
-            void navigate({ to: '/projects/$projectName', params: { projectName } })
+            // Local state does not survive this navigation: it remounts the page
+            // and resets, which left the operator on Overview with the manager
+            // shut. The URL carries the intent instead.
+            void navigate({
+              to: '/projects/$projectName',
+              params: { projectName },
+              search: { manageQueries: true },
+            })
           }}
           onPublished={() => {
             void Promise.all([

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -1613,6 +1613,7 @@ function ProjectPageContent({
   // connecting one rather than being hidden until after connection.
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [deleting, setDeleting] = useState(false)
+  const appendQueries = useAppendQueries()
   const manageQueriesRequested = (useSearch({ strict: false }) as { manageQueries?: boolean }).manageQueries === true
   const [managingQueries, setManagingQueries] = useState(manageQueriesRequested)
   const [newQueryText, setNewQueryText] = useState('')
@@ -2170,10 +2171,15 @@ function ProjectPageContent({
           onRetryQueries={() => { void portfolioQueriesQuery.refetch() }}
           publishedPlan={activeMeasurementPlan}
           onCreateQueries={async texts => {
-            await apiAppendQueries(projectName, [...texts])
+            // The shared mutation carries the write guard and invalidates both
+            // the projects list and the per-project detail. Calling the raw
+            // client skipped all of that, so other surfaces kept showing the
+            // old basket.
+            await appendQueries.mutateAsync({ projectName, queries: [...texts] })
             // The step selects from this list, so it has to reflect the new
-            // questions before the operator can apply them.
-            await portfolioQueriesQuery.refetch()
+            // questions before the operator can apply them. A refetch failure
+            // must not read as success, hence throwOnError.
+            await portfolioQueriesQuery.refetch({ throwOnError: true })
           }}
           onManageProjectQueries={() => {
             // Local state does not survive this navigation: it remounts the page

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -2168,6 +2168,12 @@ function ProjectPageContent({
           isQueryError={isPortfolioQueriesError}
           onRetryQueries={() => { void portfolioQueriesQuery.refetch() }}
           publishedPlan={activeMeasurementPlan}
+          onCreateQueries={async texts => {
+            await apiAppendQueries(projectName, [...texts])
+            // The step selects from this list, so it has to reflect the new
+            // questions before the operator can apply them.
+            await portfolioQueriesQuery.refetch()
+          }}
           onManageProjectQueries={() => {
             setManagingQueries(true)
             void navigate({ to: '/projects/$projectName', params: { projectName } })

--- a/apps/web/src/pages/SetupPage.tsx
+++ b/apps/web/src/pages/SetupPage.tsx
@@ -68,6 +68,8 @@ export function deriveSetupStep(input: {
 }): SetupStep {
   if (!input.launchReady) return 0
   if (!input.hasProject) return 1
+  // Where an operator RESUMES. Skipping is a session choice handled by the step
+  // control itself; this only decides where a reload drops you.
   if (input.queryCount === 0) return 2
   if (input.competitorCount === 0 && !input.hasRunAttempt) return 3
   return 4
@@ -673,6 +675,18 @@ function ReadySetupPage({
     setStep(nextStep)
   }
 
+  const skipQueries = () => {
+    emitOnboardingEvent({
+      flowVersion: ONBOARDING_FLOW_VERSION,
+      onboardingSessionId,
+      event: 'onboarding.step_completed',
+      step: 'queries',
+      method: 'skipped',
+      countBucket: '0',
+    }, 'onboarding.step_completed:queries')
+    setStep(3)
+  }
+
   const skipCompetitors = () => {
     emitOnboardingEvent({
       flowVersion: ONBOARDING_FLOW_VERSION,
@@ -881,7 +895,29 @@ function ReadySetupPage({
                 <ToneBadge tone="neutral">{parsedQueries.length} quer{parsedQueries.length !== 1 ? 'ies' : 'y'}</ToneBadge>
               )}
             </div>
-            <p className="supporting-copy">Enter the search queries you want to track. One per line.</p>
+            <p className="supporting-copy">
+              Enter the questions you want to track, one per line. A rough first list is
+              fine: you can edit them, research more, and add to them at any time from the
+              project.
+            </p>
+            <div className="rounded-md border border-base bg-bg-elevated p-3 text-sm">
+              <p className="m-0 font-medium text-heading">Tracking more than one location or property?</p>
+              <p className="mt-1 mb-2 text-secondary">
+                Questions attach to each property separately in Advanced measurement, so
+                there is nothing useful to add here. Skip this and set it up on the project.
+              </p>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  skipQueries()
+                  void navigate({ to: createdProjectName ? `/projects/${encodeURIComponent(createdProjectName)}` : '/' })
+                }}
+              >
+                Set up Advanced measurement instead
+              </Button>
+            </div>
             {resumeQueriesQuery.isError ? (
               <div className="compact-stack">
                 <div role="alert" className="rounded-md border border-negative bg-negative-soft p-3 text-sm text-negative">
@@ -971,6 +1007,7 @@ function ReadySetupPage({
                 {queriesError ? <p className="text-negative-400 text-sm">{queriesError}</p> : null}
                 <div className="setup-nav">
                   <Button type="button" variant="outline" onClick={goBack}>Back</Button>
+                  <Button type="button" variant="ghost" onClick={skipQueries}>Skip for now</Button>
                   <Button type="button" disabled={parsedQueries.length === 0 || queriesSaving} onClick={asyncHandler(handleSaveQueries)}>
                     {queriesSaving ? 'Saving...' : `Save ${parsedQueries.length} quer${parsedQueries.length !== 1 ? 'ies' : 'y'}`}
                   </Button>
@@ -1090,7 +1127,10 @@ function ReadySetupPage({
             ) : !runTriggered ? (
               <div className="compact-stack">
                 <p className="supporting-copy">
-                  Everything is configured. Launch an answer-visibility sweep to start tracking citations for <span className="text-heading font-medium">{createdProjectName}</span>.
+                  Setup is done. You can run a first sweep now to get a baseline for{' '}
+                  <span className="text-heading font-medium">{createdProjectName}</span>, or
+                  finish and run it later from the project. A sweep calls the answer
+                  engines, so it costs provider usage.
                 </p>
                 {(launchBlockedReason || runError) && (
                   <div role="alert" className="rounded-md border border-negative bg-negative-soft p-3 text-sm text-negative">
@@ -1100,6 +1140,13 @@ function ReadySetupPage({
                 )}
                 <div className="setup-nav">
                   <Button type="button" variant="outline" onClick={goBack}>Back</Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={() => { void navigate({ to: createdProjectName ? `/projects/${encodeURIComponent(createdProjectName)}` : '/' }) }}
+                  >
+                    Finish without running
+                  </Button>
                   <Button
                     type="button"
                     disabled={runSaving || !!launchBlockedReason}

--- a/apps/web/src/pages/SetupPage.tsx
+++ b/apps/web/src/pages/SetupPage.tsx
@@ -912,7 +912,10 @@ function ReadySetupPage({
                 size="sm"
                 onClick={() => {
                   skipQueries()
-                  void navigate({ to: createdProjectName ? `/projects/${encodeURIComponent(createdProjectName)}` : '/' })
+                  // Advanced measurement lives on the portfolio tab. Landing on the
+                  // project root dropped the operator on Overview and made them hunt
+                  // for the thing this button just offered them.
+                  void navigate({ to: createdProjectName ? `/projects/${encodeURIComponent(createdProjectName)}/portfolio` : '/' })
                 }}
               >
                 Set up Advanced measurement instead

--- a/apps/web/src/router/routes.tsx
+++ b/apps/web/src/router/routes.tsx
@@ -64,6 +64,8 @@ export interface RouterContext {
 }
 
 type SearchParams = {
+  /** Opens the project's query manager after a navigation, so setup can hand off to it. */
+  manageQueries?: boolean
   runId?: string
   evidenceId?: string
   runStatus?: string
@@ -84,6 +86,7 @@ function RootLayoutWithErrorBoundary() {
 export const rootRoute = createRootRouteWithContext<RouterContext>()({
   component: RootLayoutWithErrorBoundary,
   validateSearch: (search: Record<string, unknown>): SearchParams => ({
+    manageQueries: search.manageQueries === true || search.manageQueries === 'true' ? true : undefined,
     runId: typeof search.runId === 'string' ? search.runId : undefined,
     evidenceId: typeof search.evidenceId === 'string' ? search.evidenceId : undefined,
     runStatus: typeof search.runStatus === 'string' ? search.runStatus : undefined,

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1905,7 +1905,9 @@
   }
 
   .setup-nav {
-    @apply flex items-center justify-between gap-3 pt-2;
+    /* Three buttons overflow a 320-375px viewport on one line. Wrapping keeps
+       every control reachable instead of pushing the last one off-screen. */
+    @apply flex flex-wrap items-center justify-between gap-3 pt-2;
   }
 
   .setup-field {

--- a/apps/web/test/advanced-measurement-queries-groups-review.test.tsx
+++ b/apps/web/test/advanced-measurement-queries-groups-review.test.tsx
@@ -1,6 +1,6 @@
 import type { ComponentProps } from 'react'
 import { afterEach, expect, test, vi } from 'vitest'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import {
   AdvancedMeasurementGroupsStep,
@@ -298,6 +298,32 @@ test('asks for a placeholder rather than writing the same question repeatedly', 
   })
 
   expect(screen.getByText(/Add \{property\} to the pattern/)).toBeTruthy()
+})
+
+// Clearing the box on failure means retyping every question to retry, which is
+// worst for the pattern case where the operator may have written one line that
+// expanded to two hundred.
+test('keeps what was typed when creation fails', async () => {
+  const onCreateQueries = vi.fn().mockRejectedValue(new Error('Query is already tracked.'))
+  renderQueries({ queries: [], selectedQueryIds: [], onCreateQueries })
+
+  const box = screen.getByLabelText('New questions, one per line')
+  fireEvent.change(box, { target: { value: 'best apartments in dallas' } })
+  fireEvent.click(screen.getByRole('button', { name: /Add 1 question/ }))
+
+  await waitFor(() => expect(onCreateQueries).toHaveBeenCalled())
+  expect((box as HTMLTextAreaElement).value).toBe('best apartments in dallas')
+})
+
+test('clears the box only once creation succeeds', async () => {
+  const onCreateQueries = vi.fn().mockResolvedValue(undefined)
+  renderQueries({ queries: [], selectedQueryIds: [], onCreateQueries })
+
+  const box = screen.getByLabelText('New questions, one per line')
+  fireEvent.change(box, { target: { value: 'best apartments in dallas' } })
+  fireEvent.click(screen.getByRole('button', { name: /Add 1 question/ }))
+
+  await waitFor(() => expect((box as HTMLTextAreaElement).value).toBe(''))
 })
 
 test('surfaces the server reason when adding questions fails', () => {

--- a/apps/web/test/advanced-measurement-queries-groups-review.test.tsx
+++ b/apps/web/test/advanced-measurement-queries-groups-review.test.tsx
@@ -264,6 +264,42 @@ test('lets an empty query library add questions without leaving setup', () => {
   ])
 })
 
+// The portfolio shape. Typing one generic question and applying it to 213
+// Properties measures the portfolio; a question per Property measures the
+// Properties. The count is shown before the click because 213 is a surprising
+// number to produce from one line of text.
+test('writes one question per selected Property from a pattern', () => {
+  const onCreateQueries = vi.fn()
+  renderQueries({
+    queries: [],
+    selectedQueryIds: [],
+    onCreateQueries,
+  })
+
+  fireEvent.change(screen.getByLabelText('Question pattern'), {
+    target: { value: 'apartments near {property}' },
+  })
+
+  // The expansion is visible before it is committed.
+  expect(screen.getByText('apartments near Harbor House')).toBeTruthy()
+
+  fireEvent.click(screen.getByRole('button', { name: /Add \d+ questions?/ }))
+
+  const created = onCreateQueries.mock.calls[0]![0] as string[]
+  expect(created.every(text => text.startsWith('apartments near '))).toBe(true)
+  expect(new Set(created).size).toBe(created.length)
+})
+
+test('asks for a placeholder rather than writing the same question repeatedly', () => {
+  renderQueries({ queries: [], selectedQueryIds: [], onCreateQueries: vi.fn() })
+
+  fireEvent.change(screen.getByLabelText('Question pattern'), {
+    target: { value: 'best apartments' },
+  })
+
+  expect(screen.getByText(/Add \{property\} to the pattern/)).toBeTruthy()
+})
+
 test('surfaces the server reason when adding questions fails', () => {
   renderQueries({
     queries: [],

--- a/apps/web/test/advanced-measurement-queries-groups-review.test.tsx
+++ b/apps/web/test/advanced-measurement-queries-groups-review.test.tsx
@@ -239,29 +239,55 @@ test('shares the bounded, searchable Property picker with group setup', () => {
   expect(screen.getByText('Showing 1 of 1 Properties')).toBeTruthy()
 })
 
-test('gives an empty query library a clear way to manage project queries', () => {
-  const onManageProjectQueries = vi.fn()
+// Previously this asserted the copy "Add queries to this project first. Then
+// return here to apply them to Properties." — an instruction to leave the
+// wizard. On a new project that was a dead end: the step consumed questions and
+// could not create them, so the only way forward was out and back. It now
+// creates them in place, and the assertion moves with the behaviour.
+test('lets an empty query library add questions without leaving setup', () => {
+  const onCreateQueries = vi.fn()
   renderQueries({
     queries: [],
     selectedQueryIds: [],
-    onManageProjectQueries,
+    onCreateQueries,
   })
 
-  expect(screen.getByText('Add queries to this project first. Then return here to apply them to Properties.')).toBeTruthy()
-  fireEvent.click(screen.getByRole('button', { name: 'Manage project queries' }))
-  expect(onManageProjectQueries).toHaveBeenCalledTimes(1)
+  fireEvent.change(screen.getByLabelText('New questions, one per line'), {
+    target: { value: 'best apartments in dallas\nluxury apartments atlanta' },
+  })
+  fireEvent.click(screen.getByRole('button', { name: /Add 2 questions/ }))
+
+  expect(onCreateQueries).toHaveBeenCalledTimes(1)
+  expect(onCreateQueries.mock.calls[0]![0]).toEqual([
+    'best apartments in dallas',
+    'luxury apartments atlanta',
+  ])
 })
 
-test('keeps the empty-library action hidden from viewers', () => {
+test('surfaces the server reason when adding questions fails', () => {
+  renderQueries({
+    queries: [],
+    selectedQueryIds: [],
+    onCreateQueries: vi.fn(),
+    createQueriesError: 'Query "best apartments in dallas" is already tracked.',
+  })
+
+  expect(screen.getByRole('alert').textContent)
+    .toContain('Query "best apartments in dallas" is already tracked.')
+})
+
+test('keeps question creation away from viewers', () => {
   renderQueries({
     access: 'viewer',
     queries: [],
     selectedQueryIds: [],
+    onCreateQueries: vi.fn(),
     onManageProjectQueries: vi.fn(),
   })
 
-  expect(screen.getByText('Add queries to this project first. Then return here to apply them to Properties.')).toBeTruthy()
-  expect(screen.queryByRole('button', { name: 'Manage project queries' })).toBeNull()
+  expect(screen.queryByLabelText('New questions, one per line')).toBeNull()
+  expect(screen.queryByRole('button', { name: /Add .* question/ })).toBeNull()
+  expect(screen.queryByRole('button', { name: 'Manage all project questions' })).toBeNull()
 })
 
 test('uses an accessible hit target for each table query checkbox', () => {

--- a/apps/web/test/advanced-measurement-setup.test.tsx
+++ b/apps/web/test/advanced-measurement-setup.test.tsx
@@ -88,7 +88,10 @@ describe('advanced measurement setup composition', () => {
     expect(screen.getAllByText(expectedText).length).toBeGreaterThan(0)
   })
 
-  it('threads the empty-library action into the Queries step', () => {
+  // Renamed from "threads the empty-library action". The button it clicked was
+  // "Manage project queries", the old exit out of the wizard; the escape hatch
+  // is now secondary to creating questions in place, so the label moved with it.
+  it('threads the project-query actions into the Queries step', () => {
     const onManageProjectQueries = vi.fn()
     render(
       <AdvancedMeasurementSetup
@@ -96,11 +99,11 @@ describe('advanced measurement setup composition', () => {
         canEdit
         hasDraft
         onManageProjectQueries={onManageProjectQueries}
-        queries={queries}
+        queries={{ ...queries, onCreateQueries: vi.fn() }}
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'Manage project queries' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Manage all project questions' }))
     expect(onManageProjectQueries).toHaveBeenCalledTimes(1)
   })
 


### PR DESCRIPTION
Setup had two dead ends that only show up on a genuinely new project, which is
why they survived: both flows work fine once a project already has questions.

**Advanced setup could not create the thing it required.** The Queries step reads
"Choose queries already tracked for this project", and on a new project there are
none. The only way forward was to leave the wizard, add questions on the project
page, and come back. `onCreateQueries` appeared zero times in the entire
advanced-measurement directory, and the "Generated drafts from templates" entry in
the legend described a source nothing could produce. The step now adds questions
in place, one per line, and they become selectable immediately.

Failures there surface the server's own message through the shared
`extractErrorMessage`, rather than a house string. That helper already existed and
was simply not used on this path. Related: a sitemap import failing with
"Could not import this sitemap" cost about ten minutes of debugging this week
while the server had been saying exactly what was wrong the whole time.

**Simple onboarding never mentioned that Advanced exists**, and pinned you on
Queries until you entered some. A portfolio operator attaches questions per
property, so there is nothing useful to type at that step, yet it was mandatory
and it was the only path offered. The step now says a rough list is fine and can
be edited or added to later, offers Skip for now, and offers a direct route to
Advanced measurement for anyone tracking more than one location.

**The last step no longer implies you must spend to finish.** It read
"Launch an answer-visibility sweep", with running as the only exit. It now says
setup is done, that a sweep calls the answer engines and costs provider usage, and
offers Finish without running.

Three existing tests asserted the old dead-end copy. They encoded behaviour this
change deliberately removes, so they are updated rather than deleted, each with a
comment naming what changed and why. One test is added for the new failure path.

No new visual vocabulary: the form reuses the input styling already used twice in
this file, and `border-base` / `bg-bg-elevated` are existing tokens that carry
both themes.

Frontend only. 79 test files, 661 tests, typecheck and lint clean.
