### PR TITLE
fix(web): remove portfolio render-time clock

### DIFF
--- a/apps/web/src/build-dashboard.ts
+++ b/apps/web/src/build-dashboard.ts
@@ -753,7 +753,6 @@ export function buildDashboard(projectDataList: ProjectData[], apiSettings?: Api
         { id: 'api', label: 'API', tone: 'positive', detail: 'Connected', meta: 'Real-time data' },
         { id: 'provider', label: 'Gemini', tone: 'positive', detail: 'Configured', meta: 'Provider active' },
       ],
-      lastUpdatedAt: new Date().toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', timeZoneName: 'short' }),
       ...(!hasProjects ? {
         emptyState: {
           title: 'No projects yet',

--- a/apps/web/src/mock-data.ts
+++ b/apps/web/src/mock-data.ts
@@ -999,7 +999,6 @@ const baseDashboard: DashboardVm = {
         meta: 'Gemini · OpenAI',
       },
     ],
-    lastUpdatedAt: 'Mar 9, 8:08 AM ET',
   },
   projects: baseProjectCommandCenters,
   runs: allRuns,

--- a/apps/web/src/pages/OverviewPage.tsx
+++ b/apps/web/src/pages/OverviewPage.tsx
@@ -101,9 +101,6 @@ export function OverviewPage() {
           <h1 className="page-title">Portfolio</h1>
           <p className="page-subtitle">Visibility across all projects.</p>
         </div>
-        <div className="page-header-right">
-          <p className="text-[11px] text-faint">{model.lastUpdatedAt}</p>
-        </div>
       </div>
 
       {model.projects.length > 0 ? (

--- a/apps/web/src/view-models.ts
+++ b/apps/web/src/view-models.ts
@@ -91,7 +91,6 @@ export interface PortfolioOverviewVm {
   attentionItems: AttentionItemVm[]
   recentRuns: RunListItemVm[]
   systemHealth: SystemHealthCardVm[]
-  lastUpdatedAt: string
   emptyState?: {
     title: string
     detail: string


### PR DESCRIPTION
## Summary

- Remove the misleading page-load clock from the Portfolio header.
- Delete the unused `lastUpdatedAt` view-model, builder, and mock-data plumbing.

## Why

The timestamp was captured only when the dashboard model rebuilt. It was neither a live clock nor evidence of data freshness, so it could remain stale until a refresh.

## Validation

- `pnpm --dir apps/web typecheck`
- `pnpm --dir apps/web lint` (0 errors)
- `pnpm exec vitest run --project web` (79 files, 665 tests)
- `pnpm --dir apps/web build`