### PR TITLE
Hide Technical AEO CLI hint

### DIFF
--- a/apps/web/src/components/project/TechnicalAeoSection.tsx
+++ b/apps/web/src/components/project/TechnicalAeoSection.tsx
@@ -255,9 +255,6 @@ export function TechnicalAeoSection({ projectName, projectId }: { projectName: s
             The dashboard will refresh automatically when the audit finishes.
           </p>
         ) : null}
-        <p className="mt-3 text-xs text-faint">
-          Or from the CLI: <code className="text-secondary">canonry technical-aeo run {projectName} --wait</code>
-        </p>
       </Card>
     )
   }


### PR DESCRIPTION
## Summary

- Remove the CLI fallback hint from the empty Technical AEO audit state.
- Keep the primary audit action and progress feedback unchanged.

## Why

The dashboard exposed implementation-oriented CLI copy in a customer-facing empty state. This keeps the page concise without changing audit behavior.

## Validation

- `pnpm --filter @ainyc/canonry-web run typecheck`
- `pnpm exec eslint apps/web/src/components/project/TechnicalAeoSection.tsx`
- `pnpm exec vitest run --project web` (665 tests)