### PR TITLE
Stop the review table stating a button name as a number

### DIFF
--- a/apps/web/src/components/project/advanced-measurement/SetupQueriesGroupsReview.tsx
+++ b/apps/web/src/components/project/advanced-measurement/SetupQueriesGroupsReview.tsx
@@ -615,6 +615,8 @@ function GroupMembershipImportPanel({ value }: { value: AdvancedMeasurementGroup
   )
 }
 
+const EM_DASH = '\u2014'
+
 export function AdvancedMeasurementQueriesStep({
   access,
   availability,
@@ -1406,10 +1408,25 @@ export function AdvancedMeasurementReviewStep({
             <td className="tabular-nums text-heading">{counts.queries}</td>
             <td className="tabular-nums text-heading">{counts.groups}</td>
             <td className="tabular-nums text-heading">{counts.assignments ?? '—'}</td>
-            <td className="tabular-nums text-heading">{counts.providerCalls ?? 'Review changes'}</td>
+            <td className="tabular-nums text-heading">{counts.providerCalls ?? EM_DASH}</td>
           </tr></tbody>
         </table>
       </div>
+      {counts.providerCalls === undefined ? (
+        <p className="supporting-copy">
+          Review changes to see how many provider requests one run will make.
+        </p>
+      ) : null}
+      {counts.assignments !== undefined && counts.assignments > counts.queries ? (
+        // Aiming one question at a market writes one assignment per Property in
+        // it, so this number outruns the question count and looks wrong without
+        // the reason beside it.
+        <p className="supporting-copy">
+          {counts.queries} question{counts.queries === 1 ? '' : 's'} aimed at markets and Properties
+          {' '}produce {counts.assignments} assignment{counts.assignments === 1 ? '' : 's'}:
+          {' '}a question aimed at a market is measured on every Property in it.
+        </p>
+      ) : null}
 
       {reviewedChanges ? (
         <section aria-labelledby="advanced-measurement-reviewed-changes-title" className="border-y border-default py-4" aria-live="polite">

--- a/apps/web/test/advanced-measurement-queries-groups-review.test.tsx
+++ b/apps/web/test/advanced-measurement-queries-groups-review.test.tsx
@@ -912,3 +912,18 @@ test('renders an unavailable state without controls', () => {
   expect(screen.getByRole('region', { name: 'Review and publish' })).toBeTruthy()
   expect(container.querySelectorAll('button, input, select, textarea')).toHaveLength(0)
 })
+
+test('review states why assignments outrun questions, and never puts a button name in a number column', () => {
+  renderReview({
+    counts: { properties: 6, queries: 1, groups: 3, assignments: 3 },
+  })
+
+  // Was: the provider-requests cell rendered the literal string 'Review changes'
+  // — the name of the button beside it — inside a numeric column, which reads as
+  // a value rather than as "not computed yet".
+  expect(screen.queryByText('Review changes', { selector: 'td' })).toBeNull()
+
+  // One question aimed at a market writes one assignment per Property in it, so
+  // 1 question and 3 assignments is correct and needs saying.
+  expect(screen.getByText(/a question aimed at a market is measured on every Property in it/)).toBeTruthy()
+})


### PR DESCRIPTION
Two things on the Review step, both found while walking the setup flow.

The provider-requests cell fell back to the literal string `Review changes` — the name of the button beside it — inside a numeric column, so it reads as a value rather than as "not computed yet". Now an em dash, with the instruction below the table.

The same screen showed `QUESTIONS 1` and `ASSIGNMENTS 3` with nothing connecting them. Aiming one question at a market writes one assignment per Property in it, which is exactly what #926 added, and the number looks like a bug without the reason beside it. Review now states it, and only when the counts actually diverge.

598 test files, 7438 tests, typecheck and lint clean.