### PR TITLE
Hide the command bar when the agent is switched off

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -28,6 +28,7 @@ import { formatErrorLog } from './lib/format-helpers.js'
 import {
   getEmbedConfig,
   heyClient,
+  shouldShowDashboardAgentBar,
   shouldShowDashboardResourceLinks,
   shouldShowDashboardUpdateNotification,
   signOutOfAccount,
@@ -303,6 +304,7 @@ export function RootLayout() {
   // render. The server-side embed tab policy intentionally blocks /settings.
   const embed = useMemo(() => getEmbedConfig(), [])
   const resourceLinksVisible = useMemo(shouldShowDashboardResourceLinks, [])
+  const agentBarVisible = useMemo(shouldShowDashboardAgentBar, [])
   const updateNotificationVisible = useMemo(shouldShowDashboardUpdateNotification, [])
 
   // ── Data fetching via TanStack Query ──
@@ -1044,7 +1046,7 @@ export function RootLayout() {
 
       <RunNotificationObserver />
       <Toaster />
-      <AeroBarHost />
+      {agentBarVisible ? <AeroBarHost /> : null}
     </div>
   )
 }

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -171,6 +171,7 @@ declare global {
       dashboard?: {
         showResourceLinks?: boolean
         showUpdateNotification?: boolean
+        showAgentBar?: boolean
       }
       /**
        * Read-only embed block injected by `canonry serve --embed` (#716). Present
@@ -251,6 +252,16 @@ export function getEmbedConfig(): EmbedClientConfig | null {
 export function shouldShowDashboardResourceLinks(): boolean {
   if (typeof window === 'undefined') return true
   return window.__CANONRY_CONFIG__?.dashboard?.showResourceLinks !== false
+}
+
+/**
+ * Whether the Aero command bar renders. The server clears this when the agent
+ * kill-switch is on, because the routes are gone and a bar that only 404s is
+ * worse than no bar.
+ */
+export function shouldShowDashboardAgentBar(): boolean {
+  if (typeof window === 'undefined') return true
+  return window.__CANONRY_CONFIG__?.dashboard?.showAgentBar !== false
 }
 
 /** Whether the available-version notification renders in the sidebar. */

--- a/apps/web/test/app-embed.test.tsx
+++ b/apps/web/test/app-embed.test.tsx
@@ -10,7 +10,7 @@ import { DashboardProvider } from '../src/contexts/dashboard-context.js'
 import { preloadAllLazyRoutes } from '../src/router/routes.js'
 
 type EmbedBlock = { enabled: boolean; views?: string[]; theme?: Record<string, string> }
-type DashboardBlock = { showResourceLinks?: boolean; showUpdateNotification?: boolean }
+type DashboardBlock = { showResourceLinks?: boolean; showUpdateNotification?: boolean; showAgentBar?: boolean }
 
 beforeAll(async () => {
   await preloadAllLazyRoutes()

--- a/apps/web/test/dashboard-flags.test.ts
+++ b/apps/web/test/dashboard-flags.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { shouldShowDashboardAgentBar } from '../src/api.js'
+
+/**
+ * The agent kill-switch removes the server routes. Before this flag reached the
+ * browser, the command bar still rendered and every request 404'd in front of
+ * the operator — the dashboard had no way to know the capability was gone.
+ */
+describe('agent bar visibility', () => {
+  afterEach(() => {
+    delete (window as unknown as { __CANONRY_CONFIG__?: unknown }).__CANONRY_CONFIG__
+  })
+
+  it('renders by default, when the server injects nothing', () => {
+    expect(shouldShowDashboardAgentBar()).toBe(true)
+  })
+
+  it('hides only when the server says the agent is off', () => {
+    ;(window as unknown as { __CANONRY_CONFIG__: unknown }).__CANONRY_CONFIG__ = {
+      dashboard: { showAgentBar: false },
+    }
+    expect(shouldShowDashboardAgentBar()).toBe(false)
+  })
+
+  it('is unaffected by the sibling chrome flags', () => {
+    ;(window as unknown as { __CANONRY_CONFIG__: unknown }).__CANONRY_CONFIG__ = {
+      dashboard: { showResourceLinks: false, showUpdateNotification: false },
+    }
+    expect(shouldShowDashboardAgentBar()).toBe(true)
+  })
+})

--- a/packages/canonry/src/server.ts
+++ b/packages/canonry/src/server.ts
@@ -2689,6 +2689,13 @@ export async function createServer(opts: {
       if (!dashboardShowUpdateNotification) {
         dashboardConfig.showUpdateNotification = false;
       }
+      // The agent kill-switch removes the routes; without telling the browser,
+      // the command bar still rendered and every request 404'd in front of the
+      // operator. The dashboard has to know the capability is gone, not discover
+      // it one failed fetch at a time.
+      if (!agentEnabled) {
+        dashboardConfig.showAgentBar = false;
+      }
       if (Object.keys(dashboardConfig).length > 0) {
         clientConfig.dashboard = dashboardConfig;
       }


### PR DESCRIPTION
`CANONRY_AGENT_DISABLED` removes the agent routes, but nothing told the browser. The dashboard kept rendering the Aero bar, which 404'd on every request — a visible failure exactly where the operator had deliberately turned the capability off.

The server now clears `dashboard.showAgentBar` in the injected client config when the kill-switch is on, matching how `showResourceLinks` and `showUpdateNotification` already work, and the shell gates the bar on it.

599 test files, 7441 tests, typecheck and lint clean.