### PR TITLE
Let the setup action lead its row instead of floating right

### DIFF
--- a/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementLanding.tsx
+++ b/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementLanding.tsx
@@ -38,6 +38,18 @@ function setupActionLabel(mode: AdvancedMeasurementMode): string {
   return 'Set up advanced measurement'
 }
 
+/**
+ * The control sat alone at the right of an empty row, so it read as a stray
+ * affordance rather than the next step. Leading with it and saying what it does
+ * puts the action where the eye starts and stops the row being empty.
+ */
+function setupActionDetail(mode: AdvancedMeasurementMode): string {
+  if (mode.setupAction === 'continue') return 'Setup is unfinished. Pick up where you left off.'
+  if (mode.setupAction === 'edit') return 'Change which Properties and questions are measured.'
+  if (mode.setupAction === 'republish') return 'Unpublished changes are waiting to go live.'
+  return 'Measure each Property on its own questions, not just the project as a whole.'
+}
+
 export function AdvancedMeasurementLanding({
   mode,
   canEdit,
@@ -63,10 +75,11 @@ export function AdvancedMeasurementLanding({
     return (
       <>
         {canEdit && onOpenSetup ? (
-          <div className="mb-5 flex justify-end">
+          <div className="mb-5 flex flex-wrap items-center gap-3">
             <Button type="button" variant="outline" disabled={isOpeningSetup} onClick={onOpenSetup}>
               {isOpeningSetup ? 'Opening setup…' : setupActionLabel(mode)}
             </Button>
+            <p className="supporting-copy m-0">{setupActionDetail(mode)}</p>
           </div>
         ) : null}
         {simpleOverview}
@@ -77,10 +90,11 @@ export function AdvancedMeasurementLanding({
   return (
     <div className="space-y-4">
       {(mode.setupAction === 'edit' || (mode.setupAction === 'republish' && !report)) && canEdit && onOpenSetup ? (
-        <div className="flex justify-end">
+        <div className="flex flex-wrap items-center gap-3">
           <Button type="button" size="sm" variant={mode.setupAction === 'republish' ? 'default' : 'outline'} disabled={isOpeningSetup} onClick={onOpenSetup}>
             {isOpeningSetup ? 'Opening setup…' : setupActionLabel(mode)}
           </Button>
+          <p className="supporting-copy m-0">{setupActionDetail(mode)}</p>
         </div>
       ) : null}
       {reportState === 'loading' ? (

--- a/apps/web/test/advanced-measurement-landing.test.tsx
+++ b/apps/web/test/advanced-measurement-landing.test.tsx
@@ -206,3 +206,37 @@ describe('advanced measurement landing', () => {
     expect(onLoadMore).toHaveBeenCalledWith('next-page')
   })
 })
+
+describe('the setup action leads its row instead of floating at the right', () => {
+  it('puts the control first and says what it does', () => {
+    render(
+      <AdvancedMeasurementLanding
+        mode={{ surface: 'simple-overview', setupAction: 'continue' }}
+        canEdit
+        simpleOverview={<p>Existing project overview</p>}
+        onOpenSetup={vi.fn()}
+      />,
+    )
+
+    const action = screen.getByRole('button', { name: 'Continue advanced setup' })
+    // Was a lone right-aligned button in an empty row, which reads as a stray
+    // affordance rather than the next step.
+    expect(action.parentElement?.className).not.toContain('justify-end')
+    expect(screen.getByText('Setup is unfinished. Pick up where you left off.')).toBeTruthy()
+    // The button comes before its explanation in the DOM, so it leads the row.
+    expect(action.compareDocumentPosition(screen.getByText('Setup is unfinished. Pick up where you left off.')))
+      .toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+  })
+
+  it('explains each setup state differently', () => {
+    render(
+      <AdvancedMeasurementLanding
+        mode={{ surface: 'simple-overview', setupAction: 'set-up' }}
+        canEdit
+        simpleOverview={<p>Existing project overview</p>}
+        onOpenSetup={vi.fn()}
+      />,
+    )
+    expect(screen.getByText(/Measure each Property on its own questions/)).toBeTruthy()
+  })
+})


### PR DESCRIPTION
The advanced-setup control sat alone at the right of an empty row above the overview, so it read as a stray affordance rather than the next step.

It now leads the row and says what it does, worded per state — unfinished setup, editing what is measured, unpublished changes waiting, or what advanced measurement is for when none exists yet. Both render paths move together.

599 test files, 7443 tests, typecheck and lint clean.