### PR TITLE
Offer every question lane, as one select

### DIFF
--- a/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementOverview.tsx
+++ b/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementOverview.tsx
@@ -5,7 +5,11 @@ import type { MetricTone } from '../../../view-models.js'
 import { ToneBadge } from '../../shared/ToneBadge.js'
 import { Button } from '../../ui/button.js'
 
-export type AdvancedMeasurementClass = 'non-brand' | 'branded'
+/**
+ * `all` is what the API has always accepted and the dashboard never offered, so
+ * the only way to see both lanes at once was to read one and add the other.
+ */
+export type AdvancedMeasurementClass = 'all' | 'non-brand' | 'branded'
 
 export type AdvancedMeasurementEvidenceKind =
   | 'this-property'
@@ -407,7 +411,7 @@ export function AdvancedMeasurementOverview({
   const [expandedPropertyIds, setExpandedPropertyIds] = useState<ReadonlySet<string>>(new Set())
   const lastRequestedSearch = useRef(viewSearch ?? '')
 
-  const legacyScope = classReportingAvailable && !usesServerView
+  const legacyScope = classReportingAvailable && !usesServerView && selectedClass !== 'all'
     ? selectedClass === 'non-brand' ? report.classScopes!.nonBrand : report.classScopes!.branded
     : report.overall
   const scope: AdvancedMeasurementScope = usesServerView
@@ -555,13 +559,24 @@ export function AdvancedMeasurementOverview({
             {(report.availableGroups ?? scope.groups).map(group => <option key={group.id} value={group.id}>{group.label}</option>)}
           </select>
         </div>
-        <fieldset disabled={!classReportingAvailable} className="space-y-1">
-          <legend className="text-sm font-medium text-heading">Query type</legend>
-          <div className="flex items-center gap-3 text-sm text-secondary">
-            <label className="flex items-center gap-1.5"><input type="radio" name="advanced-measurement-class" disabled={!classReportingAvailable} checked={selectedClass === 'non-brand'} onChange={() => { setSelectedClass('non-brand'); requestView({ queryClass: 'non-brand' }) }} /> Non-brand</label>
-            <label className="flex items-center gap-1.5"><input type="radio" name="advanced-measurement-class" disabled={!classReportingAvailable} checked={selectedClass === 'branded'} onChange={() => { setSelectedClass('branded'); requestView({ queryClass: 'branded' }) }} /> Branded</label>
-          </div>
-        </fieldset>
+        <div className="space-y-1">
+          <label htmlFor="advanced-measurement-class" className="block text-sm font-medium text-heading">Question type</label>
+          <select
+            id="advanced-measurement-class"
+            disabled={!classReportingAvailable}
+            value={selectedClass}
+            onChange={event => {
+              const value = event.target.value as AdvancedMeasurementClass
+              setSelectedClass(value)
+              requestView({ queryClass: value })
+            }}
+            className="h-9 rounded-md border border-default bg-surface px-3 text-sm text-primary focus:outline-none focus:ring-2 focus:ring-mono-400"
+          >
+            <option value="all">All questions</option>
+            <option value="non-brand">Non-brand</option>
+            <option value="branded">Branded</option>
+          </select>
+        </div>
         <div className="min-w-52 flex-1 space-y-1">
           <label htmlFor="advanced-measurement-search" className="block text-sm font-medium text-heading">Search properties</label>
           <input

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -1630,7 +1630,7 @@ function ProjectPageContent({
   const [advancedMeasurementView, setAdvancedMeasurementView] = useState<{
     scope: 'all' | 'group'
     groupKey?: string
-    queryClass: 'non-brand' | 'branded'
+    queryClass: 'all' | 'non-brand' | 'branded'
     search?: string
   }>({ scope: 'all', queryClass: 'non-brand' })
   const [hasExpandedAdvancedProperty, setHasExpandedAdvancedProperty] = useState(false)

--- a/apps/web/test/advanced-measurement-overview.test.tsx
+++ b/apps/web/test/advanced-measurement-overview.test.tsx
@@ -339,13 +339,13 @@ describe('AdvancedMeasurementOverview', () => {
   it('shows competitor share of voice only for a selected non-brand group', () => {
     renderOverview()
 
-    expect(screen.getByText('Query type')).toBeTruthy()
+    expect(screen.getByText('Question type')).toBeTruthy()
     expect(screen.queryByText('Competitor share of voice')).toBeNull()
     fireEvent.change(screen.getByLabelText('Group'), { target: { value: 'metro' } })
     expect(screen.getByText('Competitor share of voice')).toBeTruthy()
     expect(screen.getByText('Example Co.')).toBeTruthy()
     expect(screen.getByText('Rival Co.')).toBeTruthy()
-    fireEvent.click(screen.getByLabelText('Branded'))
+    fireEvent.change(screen.getByLabelText('Question type'), { target: { value: 'branded' } })
     expect(screen.queryByText('Competitor share of voice')).toBeNull()
     expect((screen.getByText('Flagged results (1)').closest('details') as HTMLDetailsElement).open).toBe(false)
   })
@@ -413,7 +413,9 @@ describe('AdvancedMeasurementOverview', () => {
     expect(screen.queryByText('Republish setup to enable Non-brand and Branded reporting.')).toBeNull()
     expect(screen.queryByText('Measurement progress unavailable')).toBeNull()
     expect(screen.queryByText('Date unavailable')).toBeNull()
-    expect((screen.getByLabelText('Non-brand') as HTMLInputElement).disabled).toBe(true)
+    // Was a disabled radio labelled 'Non-brand'. The control is now one select,
+    // so the disabled state belongs to it rather than to each option.
+    expect((screen.getByLabelText('Question type') as HTMLSelectElement).disabled).toBe(true)
     expect(screen.getAllByText('N/A').length).toBeGreaterThan(0)
     fireEvent.click(screen.getByRole('button', { name: 'Republish setup' }))
     expect(onRepublishSetup).toHaveBeenCalledTimes(1)
@@ -506,5 +508,20 @@ describe('AdvancedMeasurementOverview', () => {
 
     expect(screen.getByText('Showing 50 of 51')).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Show all 51 properties' })).toBeTruthy()
+  })
+})
+
+describe('question type offers every lane the API accepts', () => {
+  it('includes All questions, which the radio pair never exposed', () => {
+    renderOverview()
+    const control = screen.getByLabelText('Question type') as HTMLSelectElement
+    expect([...control.options].map(option => option.value)).toEqual(['all', 'non-brand', 'branded'])
+  })
+
+  it('selecting All keeps the control on All rather than snapping back', () => {
+    renderOverview()
+    const control = screen.getByLabelText('Question type') as HTMLSelectElement
+    fireEvent.change(control, { target: { value: 'all' } })
+    expect(control.value).toBe('all')
   })
 })

--- a/apps/web/test/advanced-measurement-v2-overview-adapter.test.tsx
+++ b/apps/web/test/advanced-measurement-v2-overview-adapter.test.tsx
@@ -191,7 +191,7 @@ describe('version-two measurement overview adapter', () => {
       act(() => vi.advanceTimersByTime(250))
       expect(onViewChange).toHaveBeenCalledTimes(1)
 
-      fireEvent.click(screen.getByRole('radio', { name: 'Branded' }))
+      fireEvent.change(screen.getByLabelText('Question type'), { target: { value: 'branded' } })
       expect(onViewChange).toHaveBeenLastCalledWith({
         scope: 'group',
         groupKey: 'downtown',


### PR DESCRIPTION
`queryClass=all` has always been accepted by the API and was never offered in the dashboard, so seeing both lanes at once meant reading one and adding the other by hand.

The radio pair becomes a select carrying All questions / Non-brand / Branded, matching the Group control beside it. The disabled state now lives on the select rather than on each input, so a v1 plan disables one control instead of two.

Two existing tests drove the radios by label and now drive the select, updated with a note rather than relaxed.

599 test files, 7445 tests, typecheck and lint clean.