### PR TITLE
Make the All question lane work instead of crashing

### DIFF
--- a/apps/web/src/components/project/advanced-measurement/v2-overview-adapter.ts
+++ b/apps/web/src/components/project/advanced-measurement/v2-overview-adapter.ts
@@ -154,9 +154,6 @@ export function adaptV2MeasurementOverview({
   if (activePlan.plan.schemaVersion !== 2 || overview.mode !== 'active-v2') {
     throw new Error('The current overview requires an active version-two setup.')
   }
-  if (overview.queryClass === 'all') {
-    throw new Error('The current overview requires a Branded or Non-brand query filter.')
-  }
   if (overview.scope.kind !== 'all' && overview.scope.kind !== 'group') {
     throw new Error('The current overview requires an All Properties or group scope.')
   }
@@ -166,7 +163,9 @@ export function adaptV2MeasurementOverview({
   const queryById = new Map(plan.querySnapshots.map(query => [query.queryId, query.queryText]))
   const assignmentsByTarget = new Map<string, Set<string>>()
   for (const assignment of plan.assignments) {
-    if (assignment.queryClass !== overview.queryClass) continue
+    // `all` means every lane, so it filters nothing. Comparing it to a stored
+    // class matched nothing and left every Property with no questions.
+    if (overview.queryClass !== 'all' && assignment.queryClass !== overview.queryClass) continue
     const text = queryById.get(assignment.queryId)
     if (!text) continue
     const values = assignmentsByTarget.get(assignment.targetKey) ?? new Set<string>()
@@ -185,7 +184,11 @@ export function adaptV2MeasurementOverview({
     : reportState === 'error' || report !== undefined && report !== null
       ? 'error' as const
       : 'loading' as const
-  const evidenceByTarget = indexV2EvidenceByTarget(plan, pinnedReport, overview.queryClass)
+  const evidenceByTarget = indexV2EvidenceByTarget(
+    plan,
+    pinnedReport,
+    overview.queryClass === 'all' ? undefined : overview.queryClass,
+  )
   const properties = overview.properties.items.map(row => {
     const configured = targetByKey.get(row.targetKey)
     const evidence = evidenceByTarget.get(row.targetKey) ?? []

--- a/apps/web/test/advanced-measurement-v2-overview-adapter.test.tsx
+++ b/apps/web/test/advanced-measurement-v2-overview-adapter.test.tsx
@@ -315,3 +315,34 @@ describe('version-two measurement overview adapter', () => {
     expect(screen.getByText('Evidence could not be loaded.')).toBeTruthy()
   })
 })
+
+describe('the All question lane', () => {
+  // Shipping the All option without teaching the adapter about it crashed the
+  // page with "requires a Branded or Non-brand query filter" the moment it was
+  // selected. These cover the places that assumed exactly one class.
+  it('adapts an all-class overview instead of throwing', () => {
+    const { activePlan, overview } = fixture()
+    expect(() => adaptV2MeasurementOverview({
+      overview: { ...overview, queryClass: 'all' },
+      activePlan,
+    })).not.toThrow()
+  })
+
+  it('carries the all class through to the rendered view', () => {
+    const { activePlan, overview } = fixture()
+    const report = adaptV2MeasurementOverview({
+      overview: { ...overview, queryClass: 'all' },
+      activePlan,
+    })
+    expect(report.currentView?.queryClass).toBe('all')
+  })
+
+  it('lists questions from every lane rather than none', () => {
+    const { activePlan, overview } = fixture()
+    const all = adaptV2MeasurementOverview({ overview: { ...overview, queryClass: 'all' }, activePlan })
+    const branded = adaptV2MeasurementOverview({ overview: { ...overview, queryClass: 'branded' }, activePlan })
+    const count = (r: typeof all) => r.currentView!.aggregate.properties.reduce((n, p) => n + p.assignedQueries.length, 0)
+    // All must be a superset: filtering to one lane can only ever remove questions.
+    expect(count(all)).toBeGreaterThanOrEqual(count(branded))
+  })
+})


### PR DESCRIPTION
#932 shipped the All option without teaching the adapter about it. Selecting it replaced the page with "The current overview requires a Branded or Non-brand query filter." — thrown for a value the API has always accepted.

Three places assumed exactly one class:

- a hard `throw` on `all`
- listing a Property's questions compared stored class to requested class, so `all` matched nothing and every Property came back empty
- evidence indexing takes an optional class, so `all` must pass undefined rather than the string

Each is covered by a test that fails when the guard is restored. Verified by reverting.

599 test files, 7448 tests, typecheck and lint clean.