### PR TITLE
Stop the impact line moving the question table

### DIFF
--- a/apps/web/src/components/project/advanced-measurement/SetupQueriesGroupsReview.tsx
+++ b/apps/web/src/components/project/advanced-measurement/SetupQueriesGroupsReview.tsx
@@ -968,6 +968,13 @@ export function AdvancedMeasurementQueriesStep({
                 ? 'Assigning questions…'
                 : `Assign ${selectedQueryIds.length || ''} question${selectedQueryIds.length === 1 ? '' : 's'} to ${audienceLabel(activeAudience, groups, selectedPropertyCount)}`.replace('  ', ' ')}
             </Button>
+            {/*
+              Four states share this slot and each is a different height, and the
+              impact sentence itself rewraps as the counts change. Without a
+              reserved two lines, ticking a box moved the question table under
+              the cursor.
+            */}
+            <div className="min-h-[2.75rem]">
             {isPreviewingAssignmentImpact ? <p role="status" className="text-sm text-secondary">Calculating assignment impact…</p> : null}
             {assignmentImpact ? (
               <p className="text-sm text-secondary">
@@ -987,6 +994,7 @@ export function AdvancedMeasurementQueriesStep({
             ) : (
               <p className="text-sm text-secondary">{selectedQueryIds.length} question{selectedQueryIds.length === 1 ? '' : 's'} × {selectedPropertyCount} Properties = {selectedQueryIds.length * selectedPropertyCount} assignments</p>
             )}
+            </div>
             {assignmentNotice ? <p role="status" className="text-sm text-secondary">{assignmentNotice}</p> : null}
           </div>
           )}

--- a/apps/web/test/advanced-measurement-queries-groups-review.test.tsx
+++ b/apps/web/test/advanced-measurement-queries-groups-review.test.tsx
@@ -927,3 +927,17 @@ test('review states why assignments outrun questions, and never puts a button na
   // 1 question and 3 assignments is correct and needs saying.
   expect(screen.getByText(/a question aimed at a market is measured on every Property in it/)).toBeTruthy()
 })
+
+test('the assignment impact slot keeps a reserved height so ticking a box cannot move the table', () => {
+  // Four mutually exclusive states share this slot — calculating, the impact
+  // sentence, an error with buttons, and the fallback count — and the sentence
+  // itself rewraps as the counts grow. Without a reserved height, selecting a
+  // question shifted the table under the operator's cursor.
+  // The apply controls only render once questions exist, so use the defaults.
+  const { container } = renderQueries({ onCreateQueries: vi.fn() })
+
+  const slot = container.querySelector('.min-h-\\[2\\.75rem\\]')
+  expect(slot).toBeTruthy()
+  // The fallback count lives inside it, so every state shares the reservation.
+  expect(slot!.textContent).toContain('assignments')
+})


### PR DESCRIPTION
Four mutually exclusive states share the slot above the question table — calculating, the impact sentence, an error with two buttons, and the fallback count — and the sentence itself rewraps as counts grow past a digit.

So ticking a checkbox changed the height of the text above the table and moved the table under the cursor mid-selection.

The slot now reserves two lines, so the common transitions cannot shift anything below it.

599 test files, 7449 tests, typecheck and lint clean.