### PR TITLE
Move Edit setup to Settings, name the share table honestly

### DIFF
--- a/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementLanding.tsx
+++ b/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementLanding.tsx
@@ -89,9 +89,15 @@ export function AdvancedMeasurementLanding({
 
   return (
     <div className="space-y-4">
-      {(mode.setupAction === 'edit' || (mode.setupAction === 'republish' && !report)) && canEdit && onOpenSetup ? (
+      {/*
+        Editing a published plan lives in Settings. On the results surface it
+        was a control with nothing to do with reading the numbers, breaking the
+        page between the headline and the table. Republish stays here because
+        it reports pending work rather than offering a detour.
+      */}
+      {mode.setupAction === 'republish' && !report && canEdit && onOpenSetup ? (
         <div className="flex flex-wrap items-center gap-3">
-          <Button type="button" size="sm" variant={mode.setupAction === 'republish' ? 'default' : 'outline'} disabled={isOpeningSetup} onClick={onOpenSetup}>
+          <Button type="button" size="sm" disabled={isOpeningSetup} onClick={onOpenSetup}>
             {isOpeningSetup ? 'Opening setup…' : setupActionLabel(mode)}
           </Button>
           <p className="supporting-copy m-0">{setupActionDetail(mode)}</p>

--- a/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementOverview.tsx
+++ b/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementOverview.tsx
@@ -368,7 +368,7 @@ function PropertyDetails({ property, onRetryEvidence }: { property: AdvancedMeas
 function CompetitorShareOfVoice({ values }: { values: readonly AdvancedMeasurementShareOfVoice[] }) {
   return (
     <section aria-labelledby="advanced-measurement-share-of-voice" className="border-y border-default py-4">
-      <h2 id="advanced-measurement-share-of-voice" className="text-sm font-medium text-heading">Competitor share of voice</h2>
+      <h2 id="advanced-measurement-share-of-voice" className="text-sm font-medium text-heading">Brand share of voice</h2>
       <div className="mt-3 overflow-x-auto">
         <table className="evidence-table min-w-[420px]">
           <thead><tr><th>Name</th><th>Share of voice</th></tr></thead>

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -1647,13 +1647,13 @@ function ProjectPageContent({
   })
   const activeMeasurementPlanQuery = useQuery({
     ...getApiV1ProjectsByNameMeasurementPlanOptions({ client: heyClient, path: { name: projectName } }),
-    enabled: !isEmbed() && (tab === 'portfolio' || tab === 'overview') && Boolean(projectName),
+    enabled: !isEmbed() && (tab === 'portfolio' || tab === 'overview' || tab === 'settings') && Boolean(projectName),
     staleTime: 0,
     refetchOnMount: 'always',
   })
   const measurementSetupQuery = useQuery({
     ...getApiV1ProjectsByNameMeasurementSetupOptions({ client: heyClient, path: { name: projectName } }),
-    enabled: !isEmbed() && (tab === 'portfolio' || tab === 'overview') && Boolean(projectName),
+    enabled: !isEmbed() && (tab === 'portfolio' || tab === 'overview' || tab === 'settings') && Boolean(projectName),
     staleTime: 0,
     refetchOnMount: 'always',
   })
@@ -2534,6 +2534,19 @@ function ProjectPageContent({
         <>
           <ProjectSettingsSection project={{ ...model.project, displayName: model.project.displayName ?? model.project.name, defaultLocation: model.project.defaultLocation ?? null }} onUpdateProject={async (name, updates) => { await handleUpdateProject(name, updates) }} onRefresh={() => void refetch()} />
           <ProjectEngineSettingsSection project={model.project} onSave={async next => { await handleUpdateProject(model.project.name, next) }} />
+          {canWrite && !isEmbed() && advancedMeasurementMode.surface !== 'simple-overview' ? (
+            <section className="page-section-divider">
+              <h2 className="text-lg font-semibold text-heading">Advanced measurement</h2>
+              <p className="supporting-copy mt-1 mb-3">Change which Properties and questions are measured.</p>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => { void navigate({ to: '/projects/$projectName/portfolio', params: { projectName } }) }}
+              >
+                Edit setup
+              </Button>
+            </section>
+          ) : null}
           <ScheduleSection projectName={model.project.name} />
           <NotificationsSection projectName={model.project.name} />
         </>

--- a/apps/web/test/advanced-measurement-landing.test.tsx
+++ b/apps/web/test/advanced-measurement-landing.test.tsx
@@ -130,7 +130,10 @@ describe('advanced measurement landing', () => {
     expect(screen.queryByRole('button')).toBeNull()
   })
 
-  it('renders the active current setup with Run measurement and a secondary Edit setup action', () => {
+  // Was: asserted an Edit setup action beside Run measurement. Editing a
+  // published plan moved to Settings — on the results surface it was a control
+  // unrelated to reading the numbers, sitting between headline and table.
+  it('renders the active current setup with Run measurement', () => {
     const onOpenSetup = vi.fn()
     const onRunMeasurement = vi.fn()
     render(
@@ -145,9 +148,8 @@ describe('advanced measurement landing', () => {
     )
 
     expect(screen.queryByText('Existing project overview')).toBeNull()
-    fireEvent.click(screen.getByRole('button', { name: 'Edit setup' }))
+    expect(screen.queryByRole('button', { name: 'Edit setup' })).toBeNull()
     fireEvent.click(screen.getByRole('button', { name: 'Run measurement' }))
-    expect(onOpenSetup).toHaveBeenCalledTimes(1)
     expect(onRunMeasurement).toHaveBeenCalledTimes(1)
   })
 
@@ -164,8 +166,7 @@ describe('advanced measurement landing', () => {
     )
 
     expect(screen.getByLabelText('Loading advanced measurement report')).toBeTruthy()
-    fireEvent.click(screen.getByRole('button', { name: 'Edit setup' }))
-    expect(onOpenSetup).toHaveBeenCalledTimes(1)
+    expect(screen.queryByRole('button', { name: 'Edit setup' })).toBeNull()
 
     const onRetryReport = vi.fn()
     view.rerender(
@@ -182,7 +183,7 @@ describe('advanced measurement landing', () => {
     expect(screen.getByRole('alert').textContent).toContain('Could not load the advanced measurement report.')
     fireEvent.click(screen.getByRole('button', { name: 'Retry report' }))
     expect(onRetryReport).toHaveBeenCalledTimes(1)
-    expect(screen.getByRole('button', { name: 'Edit setup' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Edit setup' })).toBeNull()
   })
 
   it('preserves loaded Properties and retries a failed later page inline', () => {
@@ -238,5 +239,32 @@ describe('the setup action leads its row instead of floating at the right', () =
       />,
     )
     expect(screen.getByText(/Measure each Property on its own questions/)).toBeTruthy()
+  })
+})
+
+describe('editing a published plan is not a control on the results page', () => {
+  it('does not offer Edit setup once results are being read', () => {
+    render(
+      <AdvancedMeasurementLanding
+        mode={{ surface: 'advanced', setupAction: 'edit' }}
+        canEdit
+        report={report}
+        onOpenSetup={vi.fn()}
+      />,
+    )
+    // Was a button between the headline numbers and the property table. It
+    // lives in Settings now; nothing here changes what is measured.
+    expect(screen.queryByRole('button', { name: 'Edit setup' })).toBeNull()
+  })
+
+  it('still surfaces unpublished changes, which report pending work', () => {
+    render(
+      <AdvancedMeasurementLanding
+        mode={{ surface: 'advanced', setupAction: 'republish' }}
+        canEdit
+        onOpenSetup={vi.fn()}
+      />,
+    )
+    expect(screen.getByRole('button', { name: 'Republish setup' })).toBeTruthy()
   })
 })

--- a/apps/web/test/advanced-measurement-overview.test.tsx
+++ b/apps/web/test/advanced-measurement-overview.test.tsx
@@ -340,13 +340,13 @@ describe('AdvancedMeasurementOverview', () => {
     renderOverview()
 
     expect(screen.getByText('Question type')).toBeTruthy()
-    expect(screen.queryByText('Competitor share of voice')).toBeNull()
+    expect(screen.queryByText('Brand share of voice')).toBeNull()
     fireEvent.change(screen.getByLabelText('Group'), { target: { value: 'metro' } })
-    expect(screen.getByText('Competitor share of voice')).toBeTruthy()
+    expect(screen.getByText('Brand share of voice')).toBeTruthy()
     expect(screen.getByText('Example Co.')).toBeTruthy()
     expect(screen.getByText('Rival Co.')).toBeTruthy()
     fireEvent.change(screen.getByLabelText('Question type'), { target: { value: 'branded' } })
-    expect(screen.queryByText('Competitor share of voice')).toBeNull()
+    expect(screen.queryByText('Brand share of voice')).toBeNull()
     expect((screen.getByText('Flagged results (1)').closest('details') as HTMLDetailsElement).open).toBe(false)
   })
 
@@ -367,7 +367,7 @@ describe('AdvancedMeasurementOverview', () => {
     })
 
     fireEvent.change(screen.getByLabelText('Group'), { target: { value: 'metro' } })
-    expect(screen.queryByText('Competitor share of voice')).toBeNull()
+    expect(screen.queryByText('Brand share of voice')).toBeNull()
   })
 
   it('treats an invalid metric denominator as unavailable', () => {

--- a/apps/web/test/portfolio-route.test.tsx
+++ b/apps/web/test/portfolio-route.test.tsx
@@ -321,7 +321,10 @@ test('a version-two setup never renders version-one class metrics as if they wer
     overview: measurementOverviewResponse(),
   })
 
-  expect(html).toContain('Edit setup')
+  // Was: asserted 'Edit setup' rendered here. Editing a published plan moved to
+  // Settings; on the results surface it was a control unrelated to reading the
+  // numbers, sitting between the headline and the table.
+  expect(html).not.toContain('Edit setup')
   expect(html).toContain('Harbor House')
   expect(html).toContain('1 of 1 (100%)')
   expect(html).not.toContain('Republish setup')


### PR DESCRIPTION
Editing a published plan sat between the headline numbers and the property table — a control unrelated to reading the numbers. It moves to Settings. Republish stays put because it reports pending work.

"Competitor share of voice" always listed the project's own brand as its first row; the identity builder puts kind 'project' at the top alongside competitors. It is now "Brand share of voice".

599 test files, 7451 tests, typecheck and lint clean.