### PR TITLE
chore(db): create missing named unique indexes for measurement plan versions and segments

### DIFF
--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -2824,6 +2824,20 @@ export const MIGRATION_VERSIONS: ReadonlyArray<MigrationVersion> = [
         ON measurement_operation_receipts(expires_at)`,
     ],
   },
+  {
+    version: 124,
+    name: 'measurement-foundation-named-indexes',
+    statements: [
+      `CREATE UNIQUE INDEX IF NOT EXISTS idx_measurement_plan_versions_project_revision
+        ON measurement_plan_versions(project_id, revision)`,
+      `CREATE UNIQUE INDEX IF NOT EXISTS idx_measurement_plan_versions_project_id
+        ON measurement_plan_versions(project_id, id)`,
+      `CREATE UNIQUE INDEX IF NOT EXISTS idx_measurement_segments_project_key
+        ON measurement_segments(project_id, stable_key)`,
+      `CREATE UNIQUE INDEX IF NOT EXISTS idx_measurement_segments_project_id
+        ON measurement_segments(project_id, id)`,
+    ],
+  },
 ]
 
 function addRunsMeasurementPlanVersionForeignKey(tx: MigrationDb): void {

--- a/packages/db/test/index-parity.test.ts
+++ b/packages/db/test/index-parity.test.ts
@@ -1,0 +1,65 @@
+import { test, expect } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import Database from 'better-sqlite3'
+import { getTableConfig } from 'drizzle-orm/sqlite-core'
+import { is } from 'drizzle-orm'
+import { SQLiteTable } from 'drizzle-orm/sqlite-core'
+import { createClient, migrate } from '../src/index.js'
+import * as schema from '../src/schema.js'
+
+test('every schema.ts index exists in the migrated database', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-idx-parity-'))
+  const dbPath = path.join(tmpDir, 'parity.db')
+
+  try {
+    const drizzleDb = createClient(dbPath)
+    migrate(drizzleDb)
+
+    const raw = new Database(dbPath, { readonly: true })
+
+    const schemaTables: SQLiteTable[] = []
+    for (const value of Object.values(schema)) {
+      if (is(value, SQLiteTable)) {
+        schemaTables.push(value)
+      }
+    }
+
+    expect(schemaTables.length).toBeGreaterThan(0)
+
+    const missingIndexes: string[] = []
+
+    for (const table of schemaTables) {
+      const config = getTableConfig(table)
+      const tableName = config.name
+
+      // Get indexes of this table from sqlite_master
+      const dbIndexes = raw
+        .prepare(`SELECT name, sql FROM sqlite_master WHERE type='index' AND tbl_name = ?`)
+        .all(tableName) as Array<{ name: string, sql: string | null }>
+
+      const dbIndexNames = new Set(dbIndexes.map((i) => i.name.toLowerCase()))
+
+      for (const idx of config.indexes) {
+        const name = idx.name || (idx as Record<string, unknown>).config ? ((idx as Record<string, unknown>).config as Record<string, string>).name : undefined;
+        if (!name) {
+          console.log('Index without name found:', idx);
+          continue;
+        }
+        const idxName = name.toLowerCase()
+        if (!dbIndexNames.has(idxName)) {
+          // Check if there is an index with matching column signature, or just by name.
+          // Since migrations typically use CREATE INDEX IF NOT EXISTS idx_..., they should match exactly by name.
+          missingIndexes.push(`Table: ${tableName}, Index: ${name}`)
+        }
+      }
+    }
+
+    raw.close()
+
+    expect(missingIndexes, `Indexes declared in schema.ts but not created by MIGRATIONS:\n  ${missingIndexes.join('\n  ')}`).toEqual([])
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
### Overnight Database Layer Audit Report

An overnight audit of the database package (`packages/db/`) was performed to ensure schema consistency, alignment with the migrations, and overall query performance and safety.

#### Issues Identified
While checking alignment between the database schema (`schema.ts`) and migrations (`migrate.ts`), we identified a discrepancy in the index layer (specifically validating CLAUDE.md guidelines regarding missing indexes in migrations that are defined in the schema):
- In the `schema.ts`, the tables `measurement_plan_versions` and `measurement_segments` define custom-named unique indexes:
  - `idx_measurement_plan_versions_project_revision`
  - `idx_measurement_plan_versions_project_id`
  - `idx_measurement_segments_project_key`
  - `idx_measurement_segments_project_id`
- In `migrate.ts` migration version 117 (`target-measurement-plan-foundation`), these tables were defined with inline `UNIQUE (...)` constraints instead of explicit `CREATE UNIQUE INDEX` statements.
- As a result, SQLite automatically created internal anonymous indexes (`sqlite_autoindex_...`) rather than creating the indexes under the expected custom names defined in the schema. This caused a naming drift between the schema definitions and the actual database state on disk.

#### Fixes & Enhancements
1. **Created Migration Version 124 (`measurement-foundation-named-indexes`)**: Appended a new migration version to the end of the `MIGRATION_VERSIONS` array that explicitly creates the named unique indexes using `CREATE UNIQUE INDEX IF NOT EXISTS ...` matching the Drizzle schema declarations exactly.
2. **Added Index Parity Test Suite**: Created a comprehensive new parity test in `packages/db/test/index-parity.test.ts` that programmatically parses all schema tables defined in `schema.ts`, checks their declared index properties, and verifies that matching named indexes exist in the migrated SQLite database. This ensures that any future naming drifts or missing indexes will be caught immediately in CI.
3. **Validated Codebase Compliance**: Ran complete types, lints, and the full test suite (`pnpm typecheck && pnpm lint && pnpm test`) to ensure absolute safety, backward compatibility, and downgrade-safety. All checks passed flawlessly.