### PR TITLE
fix(web): call hooks before the loading return on Overview and Projects

### DIFF
--- a/apps/web/src/pages/OverviewPage.tsx
+++ b/apps/web/src/pages/OverviewPage.tsx
@@ -61,6 +61,16 @@ export function OverviewPage() {
   const { dashboard, isLoading } = useDashboard()
   const safeDashboard = dashboard ?? contextDashboard?.dashboard
 
+  // Every hook has to run on every render, so they all sit above the skeleton
+  // return. React identifies hooks by call order, so a return placed between
+  // two of them changes the count from one render to the next and throws
+  // "rendered more hooks than during the previous render". The embed shell has
+  // no server-rendered dashboard to fall back on, so it always takes the
+  // skeleton branch first and hit this on every cold load.
+  const enableLiveStatus = !contextDashboard
+  const healthQuery = useHealth(enableLiveStatus, contextDashboard?.health)
+  const { openRun } = useDrawer()
+
   if (!safeDashboard || isLoading) {
     return (
       <div className="page-skeleton">
@@ -87,12 +97,8 @@ export function OverviewPage() {
 
   const model = safeDashboard.portfolioOverview
 
-  const enableLiveStatus = !contextDashboard
-  const healthQuery = useHealth(enableLiveStatus, contextDashboard?.health)
   const healthSnapshot = healthQuery.data ?? contextDashboard?.health ?? { apiStatus: { label: 'API', state: 'checking', detail: 'Checking service health' }, workerStatus: { label: 'Worker', state: 'checking', detail: 'Checking service health' } }
   const systemHealth = buildSystemHealthCards(model.systemHealth, healthSnapshot, safeDashboard.settings)
-
-  const { openRun } = useDrawer()
 
   return (
     <div className="page-container">

--- a/apps/web/src/pages/ProjectsPage.tsx
+++ b/apps/web/src/pages/ProjectsPage.tsx
@@ -16,6 +16,20 @@ import { Link } from '@tanstack/react-router'
 export function ProjectsPage() {
   const { dashboard, isLoading, refetch } = useDashboard()
 
+  // Hooks run before the skeleton return for the reason described in
+  // OverviewPage: React counts them by call order, so a return placed between
+  // two of them changes the count between renders and throws.
+  const navigate = useNavigate()
+
+  const [showForm, setShowForm] = useState(false)
+  const [projectName, setProjectName] = useState('')
+  const [displayName, setDisplayName] = useState('')
+  const [domain, setDomain] = useState('')
+  const [country, setCountry] = useState('US')
+  const [language, setLanguage] = useState('en')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
   if (!dashboard || isLoading) {
     return (
       <div className="page-skeleton">
@@ -47,16 +61,6 @@ export function ProjectsPage() {
   }
 
   const projects = dashboard.projects
-  const navigate = useNavigate()
-
-  const [showForm, setShowForm] = useState(false)
-  const [projectName, setProjectName] = useState('')
-  const [displayName, setDisplayName] = useState('')
-  const [domain, setDomain] = useState('')
-  const [country, setCountry] = useState('US')
-  const [language, setLanguage] = useState('en')
-  const [saving, setSaving] = useState(false)
-  const [error, setError] = useState<string | null>(null)
 
   const slug = projectName.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '')
 

--- a/apps/web/test/viewer-write-controls.test.tsx
+++ b/apps/web/test/viewer-write-controls.test.tsx
@@ -103,8 +103,13 @@ describe('every mutation hook carries the guard', () => {
     const mutations = await import('../src/queries/mutations.js')
     const fs = await import('node:fs')
     const path = await import('node:path')
-    // Run from the workspace root, so name the app explicitly.
-    const source = fs.readFileSync(path.resolve('apps/web/src/queries/mutations.ts'), 'utf8')
+    const url = await import('node:url')
+    // Resolve from this file, not from the working directory. A cwd-relative
+    // path only holds when vitest is started at the workspace root, so the
+    // per-package run (`pnpm --filter … test`) reported this guard as broken
+    // when it was fine.
+    const here = path.dirname(url.fileURLToPath(import.meta.url))
+    const source = fs.readFileSync(path.join(here, '../src/queries/mutations.ts'), 'utf8')
 
     const hookNames = Object.keys(mutations).filter(name => /^use[A-Z]/.test(name))
     expect(hookNames.length).toBeGreaterThan(5)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -205,7 +205,7 @@ export default tseslint.config(
     // Rules of Hooks. A hook called after an early return changes the hook
     // count between renders and throws at runtime; the embed shell hit this on
     // every cold load because it always renders the loading branch first.
-    files: ['apps/web/**/*.tsx'],
+    files: ['apps/web/**/*.ts', 'apps/web/**/*.tsx'],
     plugins: { 'react-hooks': reactHooksPlugin },
     rules: {
       'react-hooks/rules-of-hooks': 'error',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,7 @@
 import js from '@eslint/js'
 import globals from 'globals'
 import regexpPlugin from 'eslint-plugin-regexp'
+import reactHooksPlugin from 'eslint-plugin-react-hooks'
 import tseslint from 'typescript-eslint'
 import { noLiteralPaletteRule } from './eslint-rules/no-literal-palette.js'
 
@@ -198,6 +199,16 @@ export default tseslint.config(
       '@typescript-eslint/require-await': 'off',
       '@typescript-eslint/only-throw-error': 'off',
       '@typescript-eslint/no-unnecessary-type-assertion': 'off',
+    },
+  },
+  {
+    // Rules of Hooks. A hook called after an early return changes the hook
+    // count between renders and throws at runtime; the embed shell hit this on
+    // every cold load because it always renders the loading branch first.
+    files: ['apps/web/**/*.tsx'],
+    plugins: { 'react-hooks': reactHooksPlugin },
+    rules: {
+      'react-hooks/rules-of-hooks': 'error',
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/node": "^24.5.1",
     "better-sqlite3": "^12.6.2",
     "eslint": "^9.0.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-regexp": "^3.1.0",
     "globals": "^17.4.0",
     "husky": "^9.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       eslint:
         specifier: ^9.0.0
         version: 9.39.4(jiti@2.6.1)
+      eslint-plugin-react-hooks:
+        specifier: ^7.1.1
+        version: 7.1.1(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-regexp:
         specifier: ^3.1.0
         version: 3.1.0(eslint@9.39.4(jiti@2.6.1))
@@ -561,7 +564,7 @@ importers:
         version: link:../contracts
       openai:
         specifier: ^4.85.0
-        version: 4.104.0(ws@8.21.0)
+        version: 4.104.0(ws@8.21.0)(zod@4.3.6)
 
   packages/provider-openai:
     dependencies:
@@ -2883,6 +2886,12 @@ packages:
     engines: {node: '>=6.0'}
     hasBin: true
 
+  eslint-plugin-react-hooks@7.1.1:
+    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
+
   eslint-plugin-regexp@3.1.0:
     resolution: {integrity: sha512-qGXIC3DIKZHcK1H9A9+Byz9gmndY6TTSRkSMTZpNXdyCw2ObSehRgccJv35n9AdUakEjQp5VFNLas6BMXizCZg==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -3209,6 +3218,12 @@ packages:
 
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
+
+  hermes-estree@0.25.1:
+    resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
+
+  hermes-parser@0.25.1:
+    resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
   hono@4.12.25:
     resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
@@ -4827,6 +4842,12 @@ packages:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
       zod: ^3.25.28 || ^4
+
+  zod-validation-error@4.0.2:
+    resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -7322,6 +7343,17 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
+  eslint-plugin-react-hooks@7.1.1(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.0
+      eslint: 9.39.4(jiti@2.6.1)
+      hermes-parser: 0.25.1
+      zod: 4.3.6
+      zod-validation-error: 4.0.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-regexp@3.1.0(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
@@ -7753,6 +7785,12 @@ snapshots:
       '@types/hast': 3.0.4
 
   help-me@5.0.0: {}
+
+  hermes-estree@0.25.1: {}
+
+  hermes-parser@0.25.1:
+    dependencies:
+      hermes-estree: 0.25.1
 
   hono@4.12.25: {}
 
@@ -8403,7 +8441,7 @@ snapshots:
       is-inside-container: 1.0.0
       is-wsl: 3.1.1
 
-  openai@4.104.0(ws@8.21.0):
+  openai@4.104.0(ws@8.21.0)(zod@4.3.6):
     dependencies:
       '@types/node': 18.19.130
       '@types/node-fetch': 2.6.13
@@ -8414,6 +8452,7 @@ snapshots:
       node-fetch: 2.7.0
     optionalDependencies:
       ws: 8.21.0
+      zod: 4.3.6
     transitivePeerDependencies:
       - encoding
 
@@ -9472,6 +9511,10 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
+
+  zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:
       zod: 4.3.6
 


### PR DESCRIPTION
Two pages called hooks after an early skeleton return, so the hook count changed between the loading render and the loaded one and React threw "rendered more hooks than during the previous render".

The embed shell has no server-rendered dashboard to fall back on, so it always takes the skeleton branch first and hit this on every cold load. Non-embed only escaped by an accident of ordering in `App.tsx`.

## What changed

- `OverviewPage.tsx` — `useHealth` and `useDrawer` moved above the return
- `ProjectsPage.tsx` — `useNavigate` and eight `useState` calls moved above the return
- `eslint.config.js` — enable `react-hooks/rules-of-hooks` for `apps/web`. The plugin was not installed and nothing caught this class of bug
- `viewer-write-controls.test.tsx` — resolve the source path from the test file rather than the working directory

## Why the lint rule is in the same PR

`ProjectsPage` was found by the rule, not by inspection. Fixing one page without the rule would have left an identical crash on a main nav destination. Nothing else in the tree violates it.

## The test path fix

The mutation-guard test read `path.resolve('apps/web/src/queries/mutations.ts')`, which only holds when vitest starts at the workspace root. CI does, so it has been green, but `pnpm --filter @ainyc/canonry-web test` reported the guard as broken when it was fine. Now resolved from `import.meta.url`, so both invocations agree.

## Verification

- Revert-proven: backing out the page change alone (keeping the rule) reports 2 violations; with it, 0
- `react-hooks/rules-of-hooks` across `apps/web`: 0 remaining
- Web suite 719/719, typecheck clean, lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)