### PR TITLE
test(contracts): fail CI when a new integration ships without retry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -878,6 +878,22 @@ This is not optional. If you add a table to the schema but omit the migration, t
 - [ ] Matching migration added to `MIGRATIONS` in `migrate.ts`
 - [ ] `pnpm typecheck && pnpm lint && pnpm test` all pass before committing
 
+## Third-party HTTP calls (Critical)
+
+**Every integration that talks to a third party over HTTP must back off when that service pushes back.** Wrap the package's HTTP layer in `withRetry` from `@ainyc/canonry-contracts` — one private `fetchOnce`, one exported wrapper — so retry is the default rather than something each call site remembers. `packages/integration-bing/src/bing-client.ts` is the reference shape.
+
+### Rules
+
+1. **Retry is a property of the client, not the caller.** If a call site can forget it, it will.
+2. **Do not write a status-code check by hand.** Use `isRetryableHttpError`, which retries rate limiting, 5xx, and network errors, and refuses auth/validation/not-found.
+3. **Rate limiting is not always HTTP 429.** A service may report a throttle on a 4xx, or a 200, with the condition in the body — Bing answers `400` with `{"ErrorCode":5,"Message":"ERROR!!! ThrottleHost"}`. `isRateLimitError` therefore tests semantically: `Retry-After`, then 429, then documented throttle markers in the message. If a service signals throttling through a private numeric code, surface that code's meaning in the error message or set `retryAfter` on the error, or the shared predicate cannot see it (see `BingApiError`).
+4. **Honour `Retry-After`.** Pass `computeDelayMs: (_a, err, defaultMs) => retryAfterDelayMs(err) ?? defaultMs`. Backing off 1s against a limiter asking for 60 just burns the remaining attempts.
+5. **Tune the base delay to the service.** The 1s default is for one-off blips. A service that throttles a burst needs a base above the window it throttles over — Bing uses 2s doubling to a 30s ceiling.
+6. **Test both directions.** A retry test that only proves "transient failure eventually succeeds" is half a test. Also assert that auth and validation failures are *not* retried — retrying a permanent failure multiplies load for nothing.
+
+`packages/contracts/test/integration-retry-coverage.test.ts` enforces this: a new HTTP-calling integration without `withRetry` fails CI. Packages that predate the rule are listed there explicitly, and the list may only shrink.
+
+
 ## Authentication Storage
 
 - The local config file at `~/.canonry/config.yaml` is the source of truth for authentication credentials.
@@ -1059,7 +1075,7 @@ This repo uses per-package `AGENTS.md` files for local context. **These must sta
 | Add a new MCP toolkit | Add the toolkit name to `packages/canonry/src/mcp/toolkits.ts`, tag the relevant tools with the new tier, and update the toolkit table in `docs/mcp.md` |
 | Add a new UI dashboard section or widget | Verify backing API endpoint + CLI command exist first (UI/CLI parity rule) |
 | Add a new provider package | Update `docs/providers/README.md` and create `docs/providers/<name>.md` |
-| Add a new integration package | Create `packages/integration-<name>/AGENTS.md` |
+| Add a new integration package | Create `packages/integration-<name>/AGENTS.md`; wrap its HTTP layer in `withRetry` (see "Third-party HTTP calls" below) |
 | Change a critical pattern (error handling, DB access, auth) | Update the relevant package's AGENTS.md patterns section |
 | Add a new dependency between packages | Update `docs/architecture.md` module dependency graph |
 | Add a generic utility (formatter, parser, normalizer) | Add it to `packages/contracts/src/<topic>.ts`, re-export from `index.ts`, add tests in `packages/contracts/test/<topic>.test.ts`. Update the "Where utilities live" table in this file if introducing a new category. |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.148.4",
+  "version": "4.148.5",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.148.4",
+  "version": "4.148.5",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/contracts/test/integration-retry-coverage.test.ts
+++ b/packages/contracts/test/integration-retry-coverage.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const PACKAGES_DIR = path.join(__dirname, '..', '..')
+
+/**
+ * Every integration that talks to a third party over HTTP should back off when
+ * that service pushes back. `withRetry` in this package is the shared way to do
+ * it, and `isRetryableHttpError` is the shared predicate.
+ *
+ * This is a ratchet, not a wish. `integration-bing` shipped without any retry
+ * and nobody noticed until Bing's throttle turned a routine refresh into 229
+ * hard failures over three days. Nothing in review catches an absence — so the
+ * absences are enumerated below, and a NEW one fails this test.
+ *
+ * To REMOVE a package from the list: wrap its HTTP layer in `withRetry` (see
+ * `packages/integration-bing/src/bing-client.ts` for the shape — one private
+ * `fetchOnce`, one exported wrapper, so retry is the default rather than
+ * something each call site remembers), add tests covering "retries the
+ * transient failure" and "does NOT retry auth/validation", then delete the
+ * entry. Never add one back.
+ *
+ * To ADD a package: don't. Wire up `withRetry` instead. If a service genuinely
+ * cannot be retried (a non-idempotent write with no idempotency key, say), add
+ * it here in the same PR with a comment saying why — so the exemption is a
+ * visible decision rather than an oversight.
+ */
+const KNOWN_WITHOUT_RETRY = new Set([
+  // Each of these predates the rule. They are exposed to exactly the failure
+  // mode that motivated it, and are worth fixing in their own PRs.
+  'integration-cloud-run',
+  'integration-google', // Google Search Console — same dashboard refresh as Bing
+  'integration-openai-ads',
+  'integration-vercel',
+  'integration-wordpress',
+  'integration-wordpress-traffic',
+])
+
+/** Integration packages whose `src/` issues outbound HTTP calls. */
+function integrationPackagesMakingHttpCalls(): string[] {
+  const names: string[] = []
+
+  for (const entry of fs.readdirSync(PACKAGES_DIR, { withFileTypes: true })) {
+    if (!entry.isDirectory() || !entry.name.startsWith('integration-')) continue
+    const srcDir = path.join(PACKAGES_DIR, entry.name, 'src')
+    if (!fs.existsSync(srcDir)) continue
+    if (sourceFiles(srcDir).some((file) => /\bfetch\s*\(/.test(fs.readFileSync(file, 'utf8')))) {
+      names.push(entry.name)
+    }
+  }
+
+  return names.sort()
+}
+
+function usesWithRetry(pkg: string): boolean {
+  return sourceFiles(path.join(PACKAGES_DIR, pkg, 'src')).some((file) =>
+    fs.readFileSync(file, 'utf8').includes('withRetry'),
+  )
+}
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) out.push(...sourceFiles(full))
+    else if (entry.name.endsWith('.ts')) out.push(full)
+  }
+  return out
+}
+
+describe('integration retry coverage', () => {
+  it('every HTTP-calling integration either retries or is a known, listed gap', () => {
+    const unprotected = integrationPackagesMakingHttpCalls()
+      .filter((pkg) => !usesWithRetry(pkg))
+      .filter((pkg) => !KNOWN_WITHOUT_RETRY.has(pkg))
+
+    expect(
+      unprotected,
+      `These integrations make HTTP calls but never use withRetry:\n` +
+      `  ${unprotected.join('\n  ')}\n\n` +
+      `A third party that rate-limits or blips will fail the call outright. Wrap the ` +
+      `HTTP layer in withRetry from @ainyc/canonry-contracts (see ` +
+      `packages/integration-bing/src/bing-client.ts), or, if it genuinely cannot be ` +
+      `retried, add it to KNOWN_WITHOUT_RETRY in this file with a reason.`,
+    ).toEqual([])
+  })
+
+  it('the known-gap list does not grow, and shrinks as packages are fixed', () => {
+    const stillMissing = [...KNOWN_WITHOUT_RETRY].filter(
+      (pkg) => fs.existsSync(path.join(PACKAGES_DIR, pkg, 'src')) && !usesWithRetry(pkg),
+    )
+
+    // A package that has since been fixed (or removed) must be deleted from the
+    // list, so the list always names real, outstanding work.
+    expect(
+      [...KNOWN_WITHOUT_RETRY].filter((pkg) => !stillMissing.includes(pkg)),
+      'These packages are in KNOWN_WITHOUT_RETRY but no longer need to be — remove them from the set.',
+    ).toEqual([])
+  })
+
+  it('integration-bing retries, since its outage is why this test exists', () => {
+    expect(usesWithRetry('integration-bing')).toBe(true)
+    expect(KNOWN_WITHOUT_RETRY.has('integration-bing')).toBe(false)
+  })
+})

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.148.4",
+  "version": "4.148.5",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.148.4",
+  "version": "4.148.5",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
Stacked on #949 (which replaces the auto-closed #947). Review that first; this diff is only the third commit.

This is the part that answers "make sure we don't run into this again."

## Why a test and not a note

`integration-bing` shipped with no retry at all, and nobody noticed until Bing started throttling — 229 hard failures over three days. Nothing in code review reliably catches an *absence*. A missing retry looks exactly like a file that simply doesn't need one.

So the absences get enumerated, and a new one fails CI.

## What it does

`packages/contracts/test/integration-retry-coverage.test.ts` walks every `packages/integration-*` whose `src/` issues a `fetch(`, and asserts it either uses `withRetry` or appears in an explicit `KNOWN_WITHOUT_RETRY` list. A new unprotected integration fails with the package name, the rule, and the reference implementation to copy.

Two assertions, so the list can only shrink:

| Assertion | Fails when |
|---|---|
| every HTTP-calling integration retries or is listed | a **new** unprotected integration appears |
| the known-gap list does not grow, and shrinks | a listed package **has been fixed** but left on the list |

The second one is what stops the list rotting into a permanent exemption.

## What it found

Six packages currently make HTTP calls with no retry, all predating the rule:

```
integration-cloud-run
integration-google            ← Search Console, the same refresh path as Bing
integration-openai-ads
integration-vercel
integration-wordpress
integration-wordpress-traffic
```

`integration-google` is the notable one: the dashboard refresh button that surfaced this whole issue drives GSC sync and Bing inspection side by side, and only one of them now backs off.

**This PR fixes none of them.** It makes them visible and stops the list growing. Each deserves its own change with its own retryable predicate and tests — retry policy is service-specific and a blanket wrap would be worse than none.

## Docs

`AGENTS.md` gains a "Third-party HTTP calls (Critical)" section stating the rules, including the one that caused the outage:

> Rate limiting is not always HTTP 429. A service may report a throttle on a 4xx, or a 200, with the condition in the body. If a service signals throttling through a private numeric code, surface that code's meaning in the error message or set `retryAfter` on the error, or the shared predicate cannot see it.

Plus: retry belongs to the client not the caller; don't hand-roll status checks; honour `Retry-After`; tune the base delay to the service; and test both directions — a retry test that only proves "transient failure eventually succeeds" is half a test, because retrying a *permanent* failure multiplies load for nothing.

The doc-maintenance table now points new integration packages at that section.

## Verification

Mutation-tested in both directions:

```
# dropped integration-vercel from the list
× every HTTP-calling integration either retries or is a known, listed gap
    expected [ 'integration-vercel' ] to deeply equal []

# added integration-bing back after it was fixed
× the known-gap list does not grow, and shrinks as packages are fixed
    expected [ 'integration-bing' ] to deeply equal []
× integration-bing retries, since its outage is why this test exists
```