### PR TITLE
fix(bing): retry throttled Bing calls instead of failing them

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.148.3",
+  "version": "4.148.4",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.148.3",
+  "version": "4.148.4",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/integration-bing/package.json
+++ b/packages/integration-bing/package.json
@@ -16,5 +16,7 @@
     "test": "vitest run --config ../../vitest.package.config.ts",
     "lint": "eslint src/ test/"
   },
-  "dependencies": {}
+  "dependencies": {
+    "@ainyc/canonry-contracts": "workspace:*"
+  }
 }

--- a/packages/integration-bing/src/bing-client.ts
+++ b/packages/integration-bing/src/bing-client.ts
@@ -1,4 +1,5 @@
-import { BING_WMT_API_BASE, BING_SUBMIT_URL_BATCH_LIMIT, BING_SUBMIT_URL_DAILY_LIMIT, BING_REQUEST_TIMEOUT_MS } from './constants.js'
+import { withRetry, isRetryableHttpError, retryAfterDelayMs } from '@ainyc/canonry-contracts'
+import { BING_WMT_API_BASE, BING_SUBMIT_URL_BATCH_LIMIT, BING_SUBMIT_URL_DAILY_LIMIT, BING_REQUEST_TIMEOUT_MS, BING_MAX_RETRIES, BING_RETRY_BASE_DELAY_MS, BING_RETRY_MAX_DELAY_MS } from './constants.js'
 import type {
   BingSite,
   BingUrlInfo,
@@ -51,7 +52,7 @@ function validateUrls(urls: string[]): void {
   }
 }
 
-function bingClientLog(level: 'info' | 'error', action: string, ctx?: Record<string, unknown>): void {
+function bingClientLog(level: 'info' | 'warn' | 'error', action: string, ctx?: Record<string, unknown>): void {
   const entry: Record<string, unknown> = {
     ts: new Date().toISOString(),
     level,
@@ -71,7 +72,30 @@ function escapeRegExp(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
-async function bingFetch<T>(apiKey: string, endpoint: string, opts?: { method?: string; body?: unknown }): Promise<T> {
+/**
+ * Pull Bing's `ErrorCode` out of an error body.
+ *
+ * Bing sometimes wraps the payload (`{"d":{...}}`) and sometimes does not, and
+ * a throttle body is small, so a tolerant parse beats a schema here — the
+ * caller only needs the number, and a miss degrades to "not a throttle".
+ */
+function parseBingErrorCode(body: string): number | null {
+  try {
+    const parsed = JSON.parse(body) as unknown
+    const root = parsed != null && typeof parsed === 'object' && 'd' in parsed
+      ? (parsed as { d: unknown }).d
+      : parsed
+    if (root != null && typeof root === 'object' && 'ErrorCode' in root) {
+      const code = (root as { ErrorCode: unknown }).ErrorCode
+      if (typeof code === 'number') return code
+    }
+  } catch {
+    // Non-JSON body (an HTML error page, say) — nothing to read.
+  }
+  return null
+}
+
+async function bingFetchOnce<T>(apiKey: string, endpoint: string, opts?: { method?: string; body?: unknown }): Promise<T> {
   const method = opts?.method ?? 'GET'
   const separator = endpoint.includes('?') ? '&' : '?'
   const url = `${BING_WMT_API_BASE}/${endpoint}${separator}apikey=${encodeURIComponent(apiKey)}`
@@ -99,11 +123,22 @@ async function bingFetch<T>(apiKey: string, endpoint: string, opts?: { method?: 
 
   if (!res.ok) {
     const body = await res.text()
-    bingClientLog('error', 'http.error', { endpoint, method, httpStatus: res.status })
     // Sanitize: avoid leaking API key from error messages if it appears in the body
     let detail = body.length <= 500 ? body : `${body.slice(0, 500)}... [truncated]`
     detail = detail.replace(new RegExp(escapeRegExp(apiKey), 'g'), '***')
-    throw new BingApiError(`Bing API error (${res.status}): ${detail}`, res.status)
+
+    // Bing reports throttling as a 400 with the condition in the body, so the
+    // status alone cannot tell a throttle from a bad request. Pull out its
+    // ErrorCode and let BingApiError classify it.
+    const bingErrorCode = parseBingErrorCode(body)
+    const err = new BingApiError(`Bing API error (${res.status}): ${detail}`, res.status, bingErrorCode)
+    bingClientLog('error', err.isThrottle ? 'http.throttled' : 'http.error', {
+      endpoint,
+      method,
+      httpStatus: res.status,
+      bingErrorCode,
+    })
+    throw err
   }
 
   const text = await res.text()
@@ -121,6 +156,55 @@ async function bingFetch<T>(apiKey: string, endpoint: string, opts?: { method?: 
   } catch {
     throw new BingApiError('Bing API returned invalid JSON', 502)
   }
+}
+
+/**
+ * Every Bing call goes through here, so retry is the default rather than
+ * something each call site remembers.
+ *
+ * Bing throttles per host and per API key, and a host limit is shared by every
+ * project on the instance — so a refresh that inspects a few dozen URLs will
+ * hit it no matter how careful one project is. Without backoff those calls
+ * simply failed: a live instance logged 229 throttle failures in three days,
+ * the first ten calls succeeding and the rest giving up immediately.
+ *
+ * `isRetryableHttpError` recognizes the throttle through `BingApiError`, which
+ * carries Bing's own ErrorCode, and honours a `Retry-After` when one is sent.
+ * Auth, validation, and not-found still fail on the first attempt.
+ *
+ * **What is retried depends on the method**, because not every Bing call is
+ * safe to replay. `SubmitUrl` / `SubmitUrlBatch` spend a daily quota
+ * (`BING_SUBMIT_URL_DAILY_LIMIT`) and `AddSite` mutates the account:
+ *
+ *   - A **throttle** is retried on any method. Bing rejects a throttled request
+ *     at the gate rather than acting on it, so a repeat cannot double-submit.
+ *     This is the case the retry exists for.
+ *   - A **5xx or network failure** is retried only on GET. Those are ambiguous
+ *     — the request may have been processed and the response lost — so
+ *     replaying a POST could submit the same URLs twice and burn quota that
+ *     cannot be reclaimed. A read costs nothing to repeat.
+ */
+async function bingFetch<T>(apiKey: string, endpoint: string, opts?: { method?: string; body?: unknown }): Promise<T> {
+  const isIdempotent = (opts?.method ?? 'GET') === 'GET'
+
+  return withRetry(() => bingFetchOnce<T>(apiKey, endpoint, opts), {
+    maxRetries: BING_MAX_RETRIES,
+    baseDelayMs: BING_RETRY_BASE_DELAY_MS,
+    maxDelayMs: BING_RETRY_MAX_DELAY_MS,
+    isRetryable: (err) => {
+      if (err instanceof BingApiError && err.isThrottle) return true
+      return isIdempotent && isRetryableHttpError(err)
+    },
+    computeDelayMs: (_attempt, err, defaultMs) => retryAfterDelayMs(err) ?? defaultMs,
+    onRetry: ({ attempt, err, delayMs }) => {
+      bingClientLog('warn', 'http.retry', {
+        endpoint,
+        attempt,
+        delayMs: Math.round(delayMs),
+        throttled: err instanceof BingApiError ? err.isThrottle : false,
+      })
+    },
+  })
 }
 
 export async function getSites(apiKey: string): Promise<BingSite[]> {

--- a/packages/integration-bing/src/constants.ts
+++ b/packages/integration-bing/src/constants.ts
@@ -7,3 +7,15 @@ export const BING_SUBMIT_URL_DAILY_LIMIT = 10000
 // HTTP request timeout (30 s) — prevents the process from hanging indefinitely
 // on a slow or unresponsive Bing Webmaster Tools endpoint.
 export const BING_REQUEST_TIMEOUT_MS = 30_000
+
+// Retry policy for throttled Bing calls.
+//
+// Bing's host limit is shared by every project on the instance, so a throttle
+// is a wait-and-succeed condition rather than a failure. The base delay is
+// deliberately well above the 1s default: the observed pattern is a burst
+// succeeding and everything behind it throttling within the same second, which
+// a sub-second backoff walks straight back into. Four retries at 2s doubling to
+// a 30s ceiling covers roughly a minute of throttling per call.
+export const BING_MAX_RETRIES = 4
+export const BING_RETRY_BASE_DELAY_MS = 2_000
+export const BING_RETRY_MAX_DELAY_MS = 30_000

--- a/packages/integration-bing/src/types.ts
+++ b/packages/integration-bing/src/types.ts
@@ -75,11 +75,33 @@ export interface BingSubmitUrlBatchResponse {
   d?: null
 }
 
+/**
+ * Bing Webmaster Tools error codes that mean "you are going too fast".
+ *
+ * Bing does not use HTTP 429 for this. A throttled request comes back as a
+ * `400` whose body carries the real condition, e.g.
+ * `{"ErrorCode":5,"Message":"ERROR!!! ThrottleHost"}` — 5 is a per-host limit
+ * (every project on this instance shares it) and 4 is per-API-key.
+ */
+export const BING_THROTTLE_ERROR_CODES = new Set([4, 5])
+
 export class BingApiError extends Error {
   public status: number
-  constructor(message: string, status: number) {
+  /** Bing's own `ErrorCode` from the response body, when it sent one. */
+  public bingErrorCode: number | null
+  /**
+   * True when Bing was throttling. Kept as a field rather than re-derived from
+   * the message so `isRetryableHttpError` sees the condition structurally and
+   * callers do not have to parse prose.
+   */
+  public isThrottle: boolean
+
+  constructor(message: string, status: number, bingErrorCode: number | null = null) {
     super(message)
     this.name = 'BingApiError'
     this.status = status
+    this.bingErrorCode = bingErrorCode
+    // 429 is rate limiting by definition; Bing's own codes cover the 400 form.
+    this.isThrottle = status === 429 || (bingErrorCode != null && BING_THROTTLE_ERROR_CODES.has(bingErrorCode))
   }
 }

--- a/packages/integration-bing/test/bing-client.test.ts
+++ b/packages/integration-bing/test/bing-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { getSites, addSite, getUrlInfo, submitUrl, submitUrlBatch, getKeywordStats, getCrawlStats, getCrawlIssues } from '../src/bing-client.js'
 import { BING_WMT_API_BASE } from '../src/constants.js'
 
@@ -66,10 +66,32 @@ describe('getSites', () => {
     await expect(() => getSites('bad-key')).rejects.toMatchObject({ name: 'BingApiError' })
   })
 
-  it('throws BingApiError on 429', async () => {
-    globalThis.fetch = async () => new Response('Rate limited', { status: 429 })
+  it('throws BingApiError on 429 after exhausting retries', async () => {
+    // 429 is retryable now, so this asserts the error still surfaces once the
+    // budget is spent rather than on the first attempt. Fake timers keep the
+    // backoff sleeps from making the test wait for real.
+    vi.useFakeTimers()
+    try {
+      let calls = 0
+      globalThis.fetch = async () => {
+        calls++
+        return new Response('Rate limited', { status: 429 })
+      }
 
-    await expect(() => getSites('key')).rejects.toThrow(/rate limit/)
+      const settled = getSites('key').then(
+        () => ({ ok: true as const }),
+        (err: unknown) => ({ ok: false as const, err }),
+      )
+      await vi.runAllTimersAsync()
+      const outcome = await settled
+
+      expect(outcome.ok).toBe(false)
+      expect(outcome.ok === false && outcome.err).toMatchObject({ name: 'BingApiError', isThrottle: true })
+      expect(String(outcome.ok === false ? outcome.err : '')).toMatch(/rate limit/)
+      expect(calls).toBe(5)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/packages/integration-bing/test/bing-throttle-retry.test.ts
+++ b/packages/integration-bing/test/bing-throttle-retry.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { getUrlInfo, getSites, submitUrlBatch } from '../src/bing-client.js'
+import { BingApiError, BING_THROTTLE_ERROR_CODES } from '../src/types.js'
+import { isRetryableHttpError } from '@ainyc/canonry-contracts'
+
+/**
+ * Bing does not use HTTP 429 to report throttling. It answers `400` and puts
+ * the condition in the body, so the status alone cannot distinguish a throttle
+ * from a bad request. These bodies are verbatim from a production instance,
+ * where the missing retry turned a routine refresh into 229 hard failures over
+ * three days.
+ */
+const THROTTLE_HOST_BODY = '{"ErrorCode":5,"Message":"ERROR!!! ThrottleHost"}'
+const THROTTLE_USER_BODY = '{"ErrorCode":4,"Message":"ERROR!!! ThrottleUser"}'
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } })
+}
+
+function errorResponse(status: number, body: string): Response {
+  return new Response(body, { status, headers: { 'Content-Type': 'application/json' } })
+}
+
+describe('Bing throttle classification', () => {
+  it('marks Bing\'s throttle codes as throttles', () => {
+    expect(new BingApiError('x', 400, 5).isThrottle).toBe(true)
+    expect(new BingApiError('x', 400, 4).isThrottle).toBe(true)
+    expect([...BING_THROTTLE_ERROR_CODES].sort()).toEqual([4, 5])
+  })
+
+  it('does not mark other Bing error codes as throttles', () => {
+    // 14 is NotAuthorized — a real failure that must not be retried.
+    expect(new BingApiError('x', 400, 14).isThrottle).toBe(false)
+    expect(new BingApiError('x', 400, null).isThrottle).toBe(false)
+  })
+
+  it('is retryable through the shared predicate despite the 400', () => {
+    const err = new BingApiError(`Bing API error (400): ${THROTTLE_HOST_BODY}`, 400, 5)
+    expect(isRetryableHttpError(err)).toBe(true)
+  })
+
+  it('leaves a genuine 400 non-retryable', () => {
+    const err = new BingApiError('Bing API error (400): {"ErrorCode":2,"Message":"Invalid site"}', 400, 2)
+    expect(isRetryableHttpError(err)).toBe(false)
+  })
+})
+
+describe('bingFetch retry behaviour', () => {
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    vi.useRealTimers()
+  })
+
+  /** Run `p` while auto-advancing timers, so backoff sleeps do not stall the test. */
+  async function withTimersRun<T>(p: Promise<T>): Promise<T> {
+    const settled = p.then(
+      (value) => ({ ok: true as const, value }),
+      (err: unknown) => ({ ok: false as const, err }),
+    )
+    await vi.runAllTimersAsync()
+    const outcome = await settled
+    if (!outcome.ok) throw outcome.err
+    return outcome.value
+  }
+
+  it('retries a throttled call and succeeds', async () => {
+    let calls = 0
+    globalThis.fetch = vi.fn(async () => {
+      calls++
+      if (calls <= 2) return errorResponse(400, THROTTLE_HOST_BODY)
+      return jsonResponse({ d: { HttpStatus: 200, DocumentSize: 1234 } })
+    }) as unknown as typeof globalThis.fetch
+
+    const info = await withTimersRun(getUrlInfo('key', 'https://example.com', 'https://example.com/page'))
+
+    expect(calls).toBe(3)
+    expect(info.DocumentSize).toBe(1234)
+  })
+
+  it('retries the per-key throttle too', async () => {
+    let calls = 0
+    globalThis.fetch = vi.fn(async () => {
+      calls++
+      if (calls === 1) return errorResponse(400, THROTTLE_USER_BODY)
+      return jsonResponse({ d: [] })
+    }) as unknown as typeof globalThis.fetch
+
+    await withTimersRun(getSites('key'))
+    expect(calls).toBe(2)
+  })
+
+  it('gives up after the retry budget and surfaces the throttle', async () => {
+    let calls = 0
+    globalThis.fetch = vi.fn(async () => {
+      calls++
+      return errorResponse(400, THROTTLE_HOST_BODY)
+    }) as unknown as typeof globalThis.fetch
+
+    await expect(
+      withTimersRun(getUrlInfo('key', 'https://example.com', 'https://example.com/page')),
+    ).rejects.toThrow(/ThrottleHost/)
+
+    // 1 initial attempt + BING_MAX_RETRIES.
+    expect(calls).toBe(5)
+  })
+
+  it('does NOT retry an auth failure', async () => {
+    let calls = 0
+    globalThis.fetch = vi.fn(async () => {
+      calls++
+      return new Response('nope', { status: 401 })
+    }) as unknown as typeof globalThis.fetch
+
+    await expect(withTimersRun(getSites('key'))).rejects.toThrow(/invalid or unauthorized/)
+    expect(calls).toBe(1)
+  })
+
+  it('does NOT retry a non-throttle 400', async () => {
+    let calls = 0
+    globalThis.fetch = vi.fn(async () => {
+      calls++
+      return errorResponse(400, '{"ErrorCode":14,"Message":"ERROR!!! NotAuthorized"}')
+    }) as unknown as typeof globalThis.fetch
+
+    await expect(withTimersRun(getSites('key'))).rejects.toThrow(/NotAuthorized/)
+    // The failure mode this must never regress into: 550 NotAuthorized errors
+    // were logged on this instance, and retrying each five times would have
+    // quintupled the load for nothing.
+    expect(calls).toBe(1)
+  })
+
+  it('retries a THROTTLED write, which Bing rejects before acting on it', async () => {
+    let calls = 0
+    globalThis.fetch = vi.fn(async () => {
+      calls++
+      if (calls === 1) return errorResponse(400, THROTTLE_HOST_BODY)
+      return jsonResponse({ d: null })
+    }) as unknown as typeof globalThis.fetch
+
+    await withTimersRun(submitUrlBatch('key', 'https://example.com/', ['https://example.com/a']))
+    expect(calls).toBe(2)
+  })
+
+  it('does NOT retry a write that failed ambiguously', async () => {
+    // A 5xx on SubmitUrlBatch may mean Bing accepted the URLs and lost the
+    // response. Replaying it would spend the daily submission quota twice on
+    // work that may already be done, and the quota cannot be reclaimed.
+    let calls = 0
+    globalThis.fetch = vi.fn(async () => {
+      calls++
+      return new Response('upstream boom', { status: 503 })
+    }) as unknown as typeof globalThis.fetch
+
+    await expect(
+      withTimersRun(submitUrlBatch('key', 'https://example.com/', ['https://example.com/a'])),
+    ).rejects.toThrow(/Bing API error \(503\)/)
+    expect(calls).toBe(1)
+  })
+
+  it('DOES retry the same ambiguous failure on a read', async () => {
+    let calls = 0
+    globalThis.fetch = vi.fn(async () => {
+      calls++
+      if (calls === 1) return new Response('upstream boom', { status: 503 })
+      return jsonResponse({ d: [] })
+    }) as unknown as typeof globalThis.fetch
+
+    await withTimersRun(getSites('key'))
+    expect(calls).toBe(2)
+  })
+
+  it('tolerates a non-JSON error body without claiming a throttle', async () => {
+    let calls = 0
+    globalThis.fetch = vi.fn(async () => {
+      calls++
+      return new Response('<html>Gateway Error</html>', { status: 400 })
+    }) as unknown as typeof globalThis.fetch
+
+    await expect(withTimersRun(getSites('key'))).rejects.toThrow(/Bing API error \(400\)/)
+    expect(calls).toBe(1)
+  })
+})

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.148.3",
+  "version": "4.148.4",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.148.3",
+  "version": "4.148.4",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -452,7 +452,11 @@ importers:
         specifier: ^0.31.9
         version: 0.31.9
 
-  packages/integration-bing: {}
+  packages/integration-bing:
+    dependencies:
+      '@ainyc/canonry-contracts':
+        specifier: workspace:*
+        version: link:../contracts
 
   packages/integration-cloud-run:
     dependencies:


### PR DESCRIPTION
Replaces #947, which GitHub auto-closed when its base branch was deleted on merge of #946. Same branch, same commit, now targeting `main` directly. Review history and the fix write-up are on #947.

## What

`integration-bing` was the only integration with **no retry at all**. GBP, Places, GA4 and every LLM provider already go through `withRetry`; Bing failed on the first attempt.

Bing throttles per host and per API key, and the host limit is shared by every project on an instance — so a refresh inspecting a few dozen URLs hits it no matter how careful one project is. The live evidence from the runs table:

| Time | Succeeded | Failed |
|---|---|---|
| 14:28 | 10 | 20 |
| 13:40 | 10 | 23 |
| 02:53 | 10 | 47 |

Exactly ten succeed, then everything behind them fails. 229 throttle failures over three days.

## Changes

**`BingApiError` carries the condition.** It now holds Bing's own `ErrorCode` and an `isThrottle` flag (4 = per-key, 5 = per-host, plus HTTP 429). Bing reports throttling as a 400 with the detail in the body, so the status alone cannot tell a throttle from a bad request. Carrying the code makes it structural rather than something callers parse out of prose, and lets the predicate from #946 see it.

**Every call goes through `withRetry`.** `bingFetchOnce` does the request; the exported `bingFetch` wraps it, so retry is a property of the client rather than something each call site remembers. Four retries, 2s base, 30s ceiling, honouring `Retry-After`. The base is well above the 1s default on purpose — the observed pattern is a burst succeeding and everything behind it throttling within the same second, which a sub-second backoff walks straight back into.

## What is retried, and what is not

Retry is split by what the failure actually tells us, because not every Bing call is safe to replay — `submitUrl` / `submitUrlBatch` spend a 10,000/day quota and `addSite` mutates the account:

| Failure | GET | POST |
|---|---|---|
| Throttle | retry | retry |
| 5xx / network | retry | **fail fast** |

A throttle is rejected at the gate, so a repeat cannot double-submit — that is the case this PR exists for. A 5xx or dropped connection is ambiguous about whether Bing acted, so replaying a POST could submit the same URLs twice and burn quota that cannot be reclaimed.

Auth, validation, not-found and non-throttle Bing codes still fail on the first attempt. That matters: the same instance logged **550 `NotAuthorized` errors** earlier this year, and retrying each five times would have quintupled load against a wall.

## Behaviour change

HTTP 429 is now retried rather than thrown immediately, so a persistent 429 surfaces after the retry budget. The existing `throws BingApiError on 429` test is **updated to assert that** — it checks the error still surfaces, carries `isThrottle: true`, and that exactly 5 attempts were made. Not deleted, not skipped.

## Tests

12 new in `bing-throttle-retry.test.ts` (fake timers, so backoff costs no wall-clock). `integration-bing` is 25 tests, all passing. Mutation-checked: removing the idempotency guard fails `does NOT retry a write that failed ambiguously` with `expected 5 to be 1`.

## Note

`integration-bing` had no `dependencies` at all; this adds `@ainyc/canonry-contracts: workspace:*`, matching `integration-google-analytics`.
