### PR TITLE
chore(deps): bump @ainyc/aeo-audit to 4.2.0

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint src/ test/"
   },
   "dependencies": {
-    "@ainyc/aeo-audit": "4.0.1",
+    "@ainyc/aeo-audit": "4.2.0",
     "@ainyc/canonry-config": "workspace:*",
     "tsx": "^4.20.5"
   }

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -47,7 +47,7 @@
     "lint": "eslint src/ test/"
   },
   "dependencies": {
-    "@ainyc/aeo-audit": "4.0.1",
+    "@ainyc/aeo-audit": "4.2.0",
     "@anthropic-ai/sdk": "^0.91.1",
     "@fastify/rate-limit": "^11.2.0",
     "@fastify/static": "^9.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,8 +180,8 @@ importers:
   apps/worker:
     dependencies:
       '@ainyc/aeo-audit':
-        specifier: 4.0.1
-        version: 4.0.1
+        specifier: 4.2.0
+        version: 4.2.0
       '@ainyc/canonry-config':
         specifier: workspace:*
         version: link:../../packages/config
@@ -270,8 +270,8 @@ importers:
   packages/canonry:
     dependencies:
       '@ainyc/aeo-audit':
-        specifier: 4.0.1
-        version: 4.0.1
+        specifier: 4.2.0
+        version: 4.2.0
       '@anthropic-ai/sdk':
         specifier: ^0.91.1
         version: 0.91.1(zod@4.3.6)
@@ -592,8 +592,8 @@ importers:
 
 packages:
 
-  '@ainyc/aeo-audit@4.0.1':
-    resolution: {integrity: sha512-8K0fjY5uxcJSEaYW0ccNxxr3BM+nBbMrrltHaKAso6+SFJybK57gLDeIp5h7f+GSJ2QaeZR51XUxGYBgqkQKEQ==}
+  '@ainyc/aeo-audit@4.2.0':
+    resolution: {integrity: sha512-He2hE8xXvUj2BxxLnCf3tAn38nBDKtj9lzLILvuw1AIdm+K35U8PkuHvJ00pLb3dXLlh/9znkhNHtf20x2VDSw==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -4861,10 +4861,11 @@ packages:
 
 snapshots:
 
-  '@ainyc/aeo-audit@4.0.1':
+  '@ainyc/aeo-audit@4.2.0':
     dependencies:
       cheerio: 1.2.0
       ipaddr.js: 2.3.0
+      undici: 7.24.4
 
   '@anthropic-ai/sdk@0.91.1(zod@4.3.6)':
     dependencies:


### PR DESCRIPTION
Bumps **`@ainyc/aeo-audit`** `4.0.1` → `4.2.0` (the latest version published to public npm).

### Why this is opened by hand

The weekly `bump-aeo-audit` job has **failed every Monday since 2026-06-22** — 7 consecutive runs. Every gate passed each time; only the final step failed:

> `GitHub Actions is not permitted to create or approve pull requests.`

`AEO_AUDIT_BUMP_TOKEN` is not configured, so the action falls back to `GITHUB_TOKEN`, and the **Canonry org** forbids Actions from opening PRs (the repo-level toggle returns `409 Conflict` — it has to be changed at the org). So a green bump was force-pushed to this branch every week with no PR behind it, and the engine pin silently sat 4 releases behind.

### What lands

| | |
|---|---|
| 4.1.0 | `compare` regression gate + `compareMeta` on reports |
| 4.1.1 | engine-version resolution fix in the Guard action |
| **4.1.2** | **SSRF:** sitemap mode now validates *every* outbound fetch — the sitemap, `robots.txt`, and every sitemap-index child `<loc>` previously went through a raw `fetch()` with auto-follow redirects. Also bounds child fan-out. `executeSiteAudit` runs exactly this path. |
| **4.1.3** | **SSRF:** pins the validated IP to close a DNS-rebinding TOCTOU on every redirect hop. Adds `undici` as a transitive dep — already `external` in `tsup.config.ts` and already a direct canonry dep at `^7.24.2`. |
| 4.2.0 | Content Signals Policy scored by value rather than mere presence: a site declaring `ai-input=no` is no longer *rewarded* for opting out of AEO. Scoring change on `ai-crawler-access`; no API or output-shape change. |

The two SSRF fixes are the reason not to sit on this any longer — `canonry technical-aeo run` crawls operator-supplied sitemap URLs through precisely the code that was unguarded.

### Compatibility

`schemaVersion` stays **3.1** and no field `executeSiteAudit` persists changed shape, so `site_audit_snapshots` / `site_audit_pages` are unaffected. Canonry version is intentionally **not** bumped — per `scripts/bump-aeo-audit.mjs` the engine updates in-repo and ships with the next canonry release.

### Verification

`typecheck`, `lint`, and `build` pass locally. The DB-backed test suite could **not** run locally — `better-sqlite3@12.6.2` has no prebuild for Node 26 and fails to compile against it, so ~2050 tests fail on a missing binding regardless of this change. **CI (Node 22) is the gate for tests here.** The bump job itself already ran the full four-gate suite green against 4.2.0 on 2026-08-03.

Instead, the integration surface was smoke-tested directly against 4.2.0 with a real crawl of `canonry.ai`:

```
schemaVersion   : 3.1
aggregateScore  : 86
pagesDiscovered : 45 | audited: 3
page fields     : url, overallScore, status, factors, metadata, priority
factor fields   : id, name, weight, score, findings, recommendations
computeFactorAverages -> 16 factors
4.2.0 Content Signals factor: present (avg 100)
```

### Follow-ups (not in this PR)

1. **Unblock the robot.** Either allow Actions to create PRs at the org level, or add an `AEO_AUDIT_BUMP_TOKEN` PAT secret (the workflow already prefers it). Otherwise this recurs next Monday.
2. **The engine has moved off public npm.** aeo-audit 4.3.0 renamed the package to `@canonry/aeo-audit` and repointed `publishConfig` at GitHub Packages; public npm is frozen at 4.2.0 while the engine is at 4.5.0. Since `@ainyc/aeo-audit` is an *external* runtime dep of the published `@canonry/canonry`, adopting the new scope as-is would make `npm i -g @canonry/canonry` fail with a 401. Needs a decision — ideally upstream resumes publishing to public npm now that the repo is public again.
3. **`computeFactorAverages` owes an update** once ≥4.5.0 is reachable: it averages page-specific factors (FAQ, definition blocks) across pages they do not apply to. 4.5.0's `applicable` analyzer flag and `applicable*` fields are the fix, and its changelog names canonry directly.
