### PR TITLE
docs(ci): correct the bump-aeo-audit bundling claim

### DIFF
--- a/.github/workflows/bump-aeo-audit.yml
+++ b/.github/workflows/bump-aeo-audit.yml
@@ -2,12 +2,23 @@ name: Bump aeo-audit
 
 # Keeps the pinned @ainyc/aeo-audit engine current. aeo-audit ships often, so
 # this checks npm on a schedule, bumps the exact pin, and — only if the bump
-# survives typecheck, lint, build, and the full test suite — opens a PR. The
-# build gate matters: aeo-audit is bundled into the published package via tsup,
-# so a breaking major can break the bundle without failing typecheck. Gating
-# happens IN this job (not just on the PR), so a breaking aeo-audit release
-# fails here and never produces a green PR. Run it on demand from the Actions
-# tab via "Run workflow".
+# survives typecheck, lint, build, and the full test suite — opens a PR.
+#
+# Why the gates run IN this job rather than only on the PR: aeo-audit is an
+# EXTERNAL runtime dependency, not a bundled one. tsup externalizes everything
+# in `dependencies`, and aeo-audit is not in `noExternal`, so the pinned version
+# is what `npm i -g @canonry/canonry` resolves and installs on a user's machine.
+# The pin is therefore a supply-chain decision, and a breaking aeo-audit release
+# must fail here and never produce a green PR.
+#
+# Run it on demand from the Actions tab via "Run workflow".
+#
+# NOTE: the final "Open pull request" step needs AEO_AUDIT_BUMP_TOKEN. The
+# GITHUB_TOKEN fallback cannot open a PR while the Canonry org disallows
+# "Allow GitHub Actions to create and approve pull requests" — the job runs
+# every gate green and then dies on the last step, leaving a bump on the branch
+# with no PR behind it. That silently froze the pin at 4.0.1 from 2026-06-22
+# until #950 landed 4.2.0 by hand.
 
 on:
   schedule:
@@ -72,9 +83,11 @@ jobs:
         if: steps.bump.outputs.changed == 'true'
         run: pnpm run lint
 
-      # Build all packages recursively (matches ci.yml's build job). tsup bundles
-      # @ainyc/aeo-audit into the published canonry, so this catches a breaking
-      # major that typecheck misses. Runs before the long test suite to fail fast.
+      # Build all packages recursively (matches ci.yml's build job) — a bump that
+      # typechecks can still break the SPA build or the asset copy. aeo-audit
+      # itself is external (see the header), so a breaking engine change surfaces
+      # in typecheck and the test suite, not here. Runs before the long test suite
+      # to fail fast.
       - name: Build (gate the bump)
         if: steps.bump.outputs.changed == 'true'
         run: pnpm -r run build


### PR DESCRIPTION
Comment-only fix to `.github/workflows/bump-aeo-audit.yml`. No behavior change.

### The wrong claim

The workflow asserted twice that aeo-audit is bundled:

> The build gate matters: aeo-audit is bundled into the published package via tsup, so a breaking major can break the bundle without failing typecheck.

> tsup bundles `@ainyc/aeo-audit` into the published canonry, so this catches a breaking major that typecheck misses.

It isn't bundled. tsup externalizes everything in `dependencies` by default, and `@ainyc/aeo-audit` is in `dependencies` and **not** in `noExternal`. Confirmed against the published artifact:

```
$ npm view @canonry/canonry dependencies
@ainyc/aeo-audit: 4.0.1     # one of 21 runtime deps
```

### Why it matters

The comment inverted its own rationale. Because the dep is external:

- A breaking engine change surfaces in **typecheck and the test suite**, not in the bundle — so the build gate isn't what catches it. What the build gate actually protects is the SPA build and asset copy, which the corrected comment now says.
- The pinned version is what **`npm i -g @canonry/canonry` installs on a user's machine**. That makes the pin a supply-chain decision, which is the real argument for running every gate in the bump job rather than only on the PR — and it's the fact the old comment obscured.

It also matters for the open question of migrating to `@canonry/aeo-audit` on GitHub Packages: under the "it's bundled" reading that migration looks free, when in fact it would make public installs of canonry fail with a 401.

### Also recorded

A note on why the job has failed every Monday since 2026-06-22: `AEO_AUDIT_BUMP_TOKEN` isn't set, and the `GITHUB_TOKEN` fallback can't open a PR while the Canonry org disallows Actions from creating them. Every gate passes and the final step dies, leaving a bump on the branch with no PR behind it — which is how the pin sat at 4.0.1 for seven weeks. See #950.
