### PR TITLE
Stop two suites failing for reasons that are not about the code

### DIFF
--- a/packages/api-routes/test/measurement-property-evidence-shape.test.ts
+++ b/packages/api-routes/test/measurement-property-evidence-shape.test.ts
@@ -18,7 +18,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import Fastify, { type FastifyInstance } from 'fastify'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   canonicalMeasurementPlanV2Json,
   type MeasurementAnswerEvidence,
@@ -49,6 +49,21 @@ import {
   PAGING_NODE_COUNTS,
   seedPagingSnapshots,
 } from './measurement-property-evidence-paging-fixture.js'
+
+/**
+ * The paging walk below is quadratic, and that is a fact about the ROUTE, not
+ * about the test. `measurement-property-evidence.ts` rebuilds the entire
+ * evidence set on every request and then linear-scans it to resolve the cursor,
+ * so walking one 156-row fixture at limit=1,2,3,7,50,100 issues 315 HTTP
+ * injects to return 156 rows. Measured at ~2.6s on an idle 12-core box, which
+ * is inside the 5000ms default with less headroom than it looks — the limit=1
+ * and limit=2 passes alone are ~216 of those 315 requests.
+ *
+ * The ceiling is raised so this does not flake on slower hardware. It is NOT a
+ * fix: deep paging re-derives the whole set per page in production too, and
+ * that belongs in its own change against the route.
+ */
+vi.setConfig({ testTimeout: 30_000 })
 
 const NOW = '2026-08-01T12:00:00.000Z'
 const VERSION_ID = 'version-paging'

--- a/packages/api-routes/test/session-auth-login-cost.test.ts
+++ b/packages/api-routes/test/session-auth-login-cost.test.ts
@@ -12,11 +12,32 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import Fastify from 'fastify'
-import { afterEach, beforeEach, expect, test } from 'vitest'
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 import { apiKeys, createClient, migrate, type DatabaseClient } from '@ainyc/canonry-db'
 import { apiRoutes } from '../src/index.js'
 import { hashApiKey } from '../src/auth.js'
 import { hashUserPassword, verifyUserPassword } from '../src/user-password.js'
+
+/**
+ * Every sign-in in this file pays a REAL scrypt derivation (N=32768,
+ * `user-password.ts`), and the tests that exercise the per-caller budget
+ * deliberately pay thirty of them in sequence, because thirty is where the
+ * budget trips. Measured on an idle 12-core box: 111ms per derivation, and
+ * 4.0-5.1s for the worst tests here — one of them already over vitest's 5000ms
+ * default. On slower CI hardware they would fail outright, and the failure
+ * would look like a hang rather than the arithmetic it is.
+ *
+ * The cost is the point: these tests assert that an expensive, unauthenticated
+ * derivation is admitted under a budget and kept off the event loop, and a
+ * cheaper hash would not exercise either property. The cost factor is also not
+ * recorded in the stored digest (`scrypt$1$<salt>$<digest>`), so it is a global
+ * invariant every stored password depends on — not something to make
+ * environment-dependent for a faster suite.
+ *
+ * So: raise the ceiling for this file only. 30s still surfaces a real hang,
+ * and every other suite keeps the 5s default.
+ */
+vi.setConfig({ testTimeout: 30_000 })
 
 const ROOT_KEY = 'cnry_login_cost_root'
 const ADMIN_PASSWORD = 'a-long-enough-admin-password'
@@ -111,20 +132,30 @@ test('one exhausted caller does not lock everybody else out', async () => {
   expect(other.statusCode).toBe(401)
 })
 
-test('a burst of sign-in attempts leaves the server answering other requests', async () => {
-  const burst = Array.from({ length: 24 }, (_, index) =>
-    login(`nobody-${index}`, `198.51.100.${index % 200}`))
+test('the server still answers an unrelated request during a burst of sign-ins', async () => {
+  // This asserted `elapsed < 400` for a while. That is a claim about how fast
+  // the machine is, not about the server, and it flaked on any loaded or slower
+  // one. It also never earned its name: forcing the derivation back onto the
+  // event loop (`scryptSync`) leaves this test green in every formulation I
+  // tried — a wall-clock bound, a settled-before-me ordering check, and the same
+  // with the handlers given a tick to start. The two tests above are what
+  // actually hold that property, and they DO fail under that mutation, because
+  // they assert on a timer queued around the derivation rather than on a clock.
+  //
+  // So this is an integration smoke check and is written as one: 24 concurrent
+  // unauthenticated derivations are in flight, and an unrelated route still
+  // answers. No timing claim, nothing that can rot into a false guarantee.
+  const burst = Promise.all(Array.from({ length: 24 }, (_, index) =>
+    login(`nobody-${index}`, `198.51.100.${index % 200}`)))
 
-  const started = Date.now()
   const health = await app.inject({ method: 'GET', url: '/api/v1/openapi.json' })
-  const elapsed = Date.now() - started
-
   expect(health.statusCode).toBe(200)
-  // Generous: the point is that it is not serialized behind two dozen
-  // derivations, which measured about three quarters of a second.
-  expect(elapsed).toBeLessThan(400)
 
-  await Promise.all(burst)
+  // And the burst itself still resolves — every attempt gets an answer rather
+  // than hanging behind the budget.
+  const statuses = (await burst).map(response => response.statusCode)
+  expect(statuses).toHaveLength(24)
+  expect(statuses.every(status => status === 401 || status === 429)).toBe(true)
 })
 
 test('a correct password still signs in once the guessing stops', async () => {

--- a/packages/api-routes/test/session-auth-panel.test.ts
+++ b/packages/api-routes/test/session-auth-panel.test.ts
@@ -13,7 +13,7 @@ import os from 'node:os'
 import path from 'node:path'
 import Fastify from 'fastify'
 import { eq } from 'drizzle-orm'
-import { afterEach, beforeEach, expect, test } from 'vitest'
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 import {
   adsConnections,
   apiKeys,
@@ -26,6 +26,27 @@ import {
 import { apiRoutes } from '../src/index.js'
 import { hashApiKey } from '../src/auth.js'
 import { USER_SESSION_COOKIE_NAME } from '../src/user-session.js'
+
+/**
+ * Every sign-in in this file pays a REAL scrypt derivation (N=32768,
+ * `user-password.ts`), and the tests that exercise the per-caller budget
+ * deliberately pay thirty of them in sequence, because thirty is where the
+ * budget trips. Measured on an idle 12-core box: 111ms per derivation, and
+ * 4.0-5.1s for the worst tests here — one of them already over vitest's 5000ms
+ * default. On slower CI hardware they would fail outright, and the failure
+ * would look like a hang rather than the arithmetic it is.
+ *
+ * The cost is the point: these tests assert that an expensive, unauthenticated
+ * derivation is admitted under a budget and kept off the event loop, and a
+ * cheaper hash would not exercise either property. The cost factor is also not
+ * recorded in the stored digest (`scrypt$1$<salt>$<digest>`), so it is a global
+ * invariant every stored password depends on — not something to make
+ * environment-dependent for a faster suite.
+ *
+ * So: raise the ceiling for this file only. 30s still surfaces a real hang,
+ * and every other suite keeps the 5s default.
+ */
+vi.setConfig({ testTimeout: 30_000 })
 
 const ROOT_KEY = 'cnry_panel_root'
 const READ_KEY = 'cnry_panel_read'

--- a/packages/api-routes/test/session-auth-panel2.test.ts
+++ b/packages/api-routes/test/session-auth-panel2.test.ts
@@ -9,11 +9,32 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import Fastify from 'fastify'
-import { afterEach, beforeEach, expect, test } from 'vitest'
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 import { apiKeys, createClient, migrate, projects, type DatabaseClient } from '@ainyc/canonry-db'
 import { apiRoutes } from '../src/index.js'
 import { hashApiKey } from '../src/auth.js'
 import { USER_SESSION_COOKIE_NAME } from '../src/user-session.js'
+
+/**
+ * Every sign-in in this file pays a REAL scrypt derivation (N=32768,
+ * `user-password.ts`), and the tests that exercise the per-caller budget
+ * deliberately pay thirty of them in sequence, because thirty is where the
+ * budget trips. Measured on an idle 12-core box: 111ms per derivation, and
+ * 4.0-5.1s for the worst tests here — one of them already over vitest's 5000ms
+ * default. On slower CI hardware they would fail outright, and the failure
+ * would look like a hang rather than the arithmetic it is.
+ *
+ * The cost is the point: these tests assert that an expensive, unauthenticated
+ * derivation is admitted under a budget and kept off the event loop, and a
+ * cheaper hash would not exercise either property. The cost factor is also not
+ * recorded in the stored digest (`scrypt$1$<salt>$<digest>`), so it is a global
+ * invariant every stored password depends on — not something to make
+ * environment-dependent for a faster suite.
+ *
+ * So: raise the ceiling for this file only. 30s still surfaces a real hang,
+ * and every other suite keeps the 5s default.
+ */
+vi.setConfig({ testTimeout: 30_000 })
 
 const ROOT_KEY = 'cnry_panel2_root'
 const ADS_KEY = 'cnry_panel2_ads'

--- a/packages/api-routes/test/session-auth-users.test.ts
+++ b/packages/api-routes/test/session-auth-users.test.ts
@@ -12,7 +12,7 @@ import os from 'node:os'
 import path from 'node:path'
 import Fastify from 'fastify'
 import { eq } from 'drizzle-orm'
-import { afterEach, beforeEach, expect, test } from 'vitest'
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 import {
   apiKeys,
   createClient,
@@ -29,6 +29,27 @@ import { apiRoutes } from '../src/index.js'
 import { hashApiKey } from '../src/auth.js'
 import { hashSessionToken, UNKNOWN_ACCOUNT_DIGEST, USER_SESSION_COOKIE_NAME, USER_SESSION_TTL_MS } from '../src/user-session.js'
 import { hashUserPassword, verifyUserPassword } from '../src/user-password.js'
+
+/**
+ * Every sign-in in this file pays a REAL scrypt derivation (N=32768,
+ * `user-password.ts`), and the tests that exercise the per-caller budget
+ * deliberately pay thirty of them in sequence, because thirty is where the
+ * budget trips. Measured on an idle 12-core box: 111ms per derivation, and
+ * 4.0-5.1s for the worst tests here — one of them already over vitest's 5000ms
+ * default. On slower CI hardware they would fail outright, and the failure
+ * would look like a hang rather than the arithmetic it is.
+ *
+ * The cost is the point: these tests assert that an expensive, unauthenticated
+ * derivation is admitted under a budget and kept off the event loop, and a
+ * cheaper hash would not exercise either property. The cost factor is also not
+ * recorded in the stored digest (`scrypt$1$<salt>$<digest>`), so it is a global
+ * invariant every stored password depends on — not something to make
+ * environment-dependent for a faster suite.
+ *
+ * So: raise the ceiling for this file only. 30s still surfaces a real hang,
+ * and every other suite keeps the 5s default.
+ */
+vi.setConfig({ testTimeout: 30_000 })
 
 const ROOT_KEY = 'cnry_users_root'
 const READ_KEY = 'cnry_users_read'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,27 @@
 packages:
   - apps/*
   - packages/*
+
+# Refuse to run a script against a node_modules that no longer matches the
+# lockfile, rather than letting the run fail somewhere confusing later.
+#
+# The failure this prevents, hit twice in one afternoon: a commit adds a
+# workspace dependency (`@ainyc/canonry-contracts` to integration-bing), someone
+# pulls or rebases onto it without installing, and the whole api-routes suite
+# dies at import with `Cannot find package '@ainyc/canonry-contracts' imported
+# from packages/integration-bing/src/bing-client.ts`. That reads as a broken
+# import in a package nobody touched, and the actual remedy — `pnpm install` —
+# appears nowhere in the message.
+#
+# `error` is the only mode that fits. `install` would mutate node_modules
+# mid-command, papering over the lockfile problem `--frozen-lockfile` exists to
+# catch; `prompt` blocks on stdin and would hang any non-interactive runner. The
+# value must be the string `error`: `true` parses fine, matches no branch, and
+# is a silent no-op.
+#
+# Costs a few hundredths of a second when in sync — the check short-circuits on
+# manifest mtimes and only reads the lockfile when one is newer than the last
+# install. It cannot fire spuriously in CI, where every job installs before it
+# runs anything (.github/actions/setup), and it never blocks `pnpm install`
+# itself, so the remedy it names always works.
+verifyDepsBeforeRun: error


### PR DESCRIPTION
Two unrelated fixes, both about tests failing in ways that name the wrong cause.

## `verifyDepsBeforeRun`

pnpm 10.28.2 can refuse to run a script against a `node_modules` that no longer matches the lockfile, and we were not using it. Without it, pulling a commit that adds a workspace dependency and running tests before installing kills the whole api-routes suite at import:

```
Error: Cannot find package '@ainyc/canonry-contracts' imported from packages/integration-bing/src/bing-client.ts
```

which reads as a broken import in a package nobody touched. It now fails immediately with `The workspace structure has changed since last install` / `Run "pnpm install"`, and covers lint, typecheck and build too rather than test alone.

One line in `pnpm-workspace.yaml`. The value must be the string `error`: `true` parses and is a silent no-op, the root `package.json` `pnpm` block is ignored, and the CLI flag is rejected. CI cannot trip it since every job installs before it runs anything.

Note: the first `pnpm run` after pulling this will ask for one `pnpm install`, because changing `pnpm-workspace.yaml` is itself an install-invalidating change.

## Test timeouts

The four `session-auth` suites pay real scrypt (N=32768, measured 111ms per derivation) and the budget tests pay thirty in sequence on purpose, because thirty is where the budget trips. Measured on an idle box, the worst test is **5063ms against vitest's 5000ms default**, with six more at 4.0-4.9s. On slower hardware they fail outright and the failure looks like a hang.

Those files plus the evidence paging suite now set a 30s ceiling with the measured cost written down. Everything else keeps the 5s default so a real hang still surfaces.

The scrypt cost is deliberately **not** made environment-configurable. N is not recorded in the stored digest (`scrypt$1$<salt>$<digest>`), so it is a global invariant every stored password depends on, and an override reaching production would fail every existing account.

## The assertion that never worked

`expect(elapsed).toBeLessThan(400)` asserted how fast the machine is, not anything about the server. It also never earned its name: forcing the derivation back onto the event loop with `scryptSync` leaves it green in all three formulations tried (wall-clock bound, settled-before-me ordering, and the same with handlers given a tick to start). The two dedicated event-loop tests **do** fail under that mutation, so the property is covered. That test is now written as the integration smoke check it actually is, with no timing claim.

## Not fixed here

The paging suite's ceiling is a stopgap. `measurement-property-evidence.ts` rebuilds the entire evidence set per request and linear-scans for the cursor, so walking a 156-row fixture issues 315 injects. That is a production cost too and needs its own change against the route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)