### PR TITLE
perf(gsc): overlap URL inspections instead of serialising them

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.148.7",
+  "version": "4.148.8",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.148.7",
+  "version": "4.148.8",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/gsc-inspect-paced.ts
+++ b/packages/canonry/src/gsc-inspect-paced.ts
@@ -4,8 +4,9 @@ import type { GscUrlInspectionResult } from '@ainyc/canonry-integration-google'
 /**
  * Paced, rate-aware driver for GSC URL Inspection loops.
  *
- * The URL Inspection API has a ~1 req/sec soft limit and a 2000/property/day
- * cap. Two callers inspect URLs in a loop (`gsc-inspect-sitemap` walks the
+ * Google documents two per-site limits for URL Inspection: **2000 QPD** and
+ * **600 QPM** (https://developers.google.com/webmaster-tools/limits). We pace
+ * well under the per-minute figure — see the constants below for why. Two callers inspect URLs in a loop (`gsc-inspect-sitemap` walks the
  * whole sitemap; `gsc-sync` inspects the top pages by clicks). Both used to
  * call `inspectUrl` with no retry, so a transient quota response silently
  * marked a URL as failed and polluted the coverage snapshot.
@@ -18,8 +19,39 @@ import type { GscUrlInspectionResult } from '@ainyc/canonry-integration-google'
  * burn the daily quota grinding every URL.
  */
 
-/** Base spacing between successive inspections (~1 req/sec soft limit). */
+/**
+ * Minimum spacing between successive request STARTS, across all workers.
+ *
+ * This is a rate control: one start per second is at most 60 QPM, an order of
+ * magnitude under Google's documented 600 QPM. It is deliberately conservative
+ * — the endpoint signals per-minute pressure with a transient 403 rather than
+ * a 429 (see the retry predicate below), so the ceiling is not something we
+ * want to probe in production.
+ *
+ * It is NOT a concurrency control. The two were conflated: because the loop was
+ * serial, the effective rate was bounded by Google's own per-call latency
+ * (~6.3s for a live index lookup) rather than by this spacing, so a site paid
+ * ~7.4s per URL and got ~9.5 QPM — six times slower than this constant allows.
+ * `INSPECT_MAX_CONCURRENCY` lifts that accidental cap while this figure keeps
+ * the rate posture exactly where it was.
+ */
 export const INSPECT_BASE_DELAY_MS = 1000
+
+/**
+ * How many inspections may be in flight at once.
+ *
+ * Bounded by hand rather than derived from the documented QPM: reports from
+ * practitioners put the safe operating point around 5-10 concurrent, with
+ * throttling appearing well before the documented ceiling. 5 is the bottom of
+ * that range — roughly a 5x throughput gain over the serial loop, with the
+ * request rate still capped by `INSPECT_BASE_DELAY_MS` and the circuit breaker
+ * still watching for sustained failure.
+ *
+ * Raise this only with measurement. The daily 2000 QPD cap is unaffected by
+ * concurrency, so it buys wall-clock on mid-sized sites and nothing at all on
+ * sites past the quota — those need derived coverage, not more parallelism.
+ */
+export const INSPECT_MAX_CONCURRENCY = 5
 /**
  * Extra random jitter (0..N ms) added to the base spacing so two overlapping
  * inspection runs (e.g. a manual run racing the coverage-refresh chain) do not
@@ -32,6 +64,12 @@ export const INSPECT_MAX_RETRIES = 3
 export const INSPECT_MAX_BACKOFF_MS = 30_000
 /**
  * Abort the whole loop after this many consecutive rate/auth-shaped failures.
+ *
+ * "Consecutive" means consecutive in COMPLETION order. With more than one
+ * request in flight a success can land before failures that started earlier, so
+ * the run length is not a pure property of the input — it is a live signal that
+ * the property is failing right now, which is what the breaker is for. Tests
+ * asserting an exact run length must pin `concurrency: 1`.
  * Distinguishes a sustained quota-exhaustion / property-misconfig (every call
  * fails) from scattered per-URL data errors (404s etc.) that should not stop
  * the run. Only retryable (rate/server/network) failures count toward it; a
@@ -71,6 +109,11 @@ export interface PacedInspectDeps {
   sleep?: (ms: number) => Promise<void>
   /** Returns 0..1 for the pacing jitter — injected in tests for determinism. */
   jitter?: () => number
+  /**
+   * Requests in flight at once. Defaults to `INSPECT_MAX_CONCURRENCY`; clamped
+   * to at least 1, so `1` restores the old strictly-serial behaviour.
+   */
+  concurrency?: number
   log?: PacedInspectLogger
 }
 
@@ -88,11 +131,22 @@ function defaultSleep(ms: number): Promise<void> {
 }
 
 /**
- * Inspect `urls` one at a time, pacing to stay under the soft rate limit,
- * retrying transient rate/server responses with jittered exponential backoff,
- * and stopping early via a consecutive-failure circuit breaker. The caller
- * owns persistence (via `onResult` / `onError`) and decides what an `aborted`
- * outcome means for its run status.
+ * Inspect `urls` with a bounded number in flight, a globally paced request
+ * rate, per-URL retry with jittered exponential backoff, and a
+ * consecutive-failure circuit breaker. The caller owns persistence (via
+ * `onResult` / `onError`) and decides what an `aborted` outcome means for its
+ * run status.
+ *
+ * Rate and concurrency are separate controls here, which is the fix: every
+ * worker takes its start slot from one shared clock, so the request rate is
+ * identical to the old serial loop's no matter how many workers run. What
+ * changes is that Google's ~6.3s per-call latency is now overlapped instead of
+ * serialised.
+ *
+ * `onResult` / `onError` may fire OUT OF ORDER — each carries the URL's
+ * original index so a caller can still report position. Callers that only
+ * persist rows are unaffected; a caller rendering sequential progress should
+ * expect gaps.
  */
 export async function inspectUrlsPaced(
   urls: string[],
@@ -101,14 +155,39 @@ export async function inspectUrlsPaced(
 ): Promise<PacedInspectOutcome> {
   const sleep = deps.sleep ?? defaultSleep
   const jitter = deps.jitter ?? Math.random
+  const concurrency = Math.max(1, Math.min(deps.concurrency ?? INSPECT_MAX_CONCURRENCY, urls.length || 1))
 
   let inspected = 0
   let errors = 0
   let consecutiveRetryableFailures = 0
+  let nextIndex = 0
+  let aborted = false
+  let abortError: unknown
 
-  for (let index = 0; index < urls.length; index++) {
-    const url = urls[index]!
-    try {
+  // One shared gate for the whole pool. Serialising only the WAIT (not the
+  // request) is what keeps the rate at one start per INSPECT_BASE_DELAY_MS
+  // while allowing `concurrency` requests to be in flight.
+  let ratePromise: Promise<void> = Promise.resolve()
+  const takeRateSlot = (): Promise<void> => {
+    const wait = ratePromise.then(() => sleep(INSPECT_BASE_DELAY_MS + jitter() * INSPECT_PACING_JITTER_MS))
+    ratePromise = wait
+    return wait
+  }
+
+  async function worker(): Promise<void> {
+    for (;;) {
+      if (aborted) return
+      const index = nextIndex++
+      if (index >= urls.length) return
+      const url = urls[index]!
+
+      // Only the very first request starts immediately. Every other start —
+      // including the rest of the opening batch — waits its turn on the shared
+      // gate, so the pool never bursts `concurrency` requests at once.
+      if (index > 0) await takeRateSlot()
+      if (aborted) return
+
+      try {
       const result = await withRetry(() => cb.inspectOne(url), {
         maxRetries: INSPECT_MAX_RETRIES,
         baseDelayMs: INSPECT_BASE_DELAY_MS,
@@ -123,35 +202,37 @@ export async function inspectUrlsPaced(
             error: err instanceof Error ? err.message : String(err),
           }),
       })
-      cb.onResult(url, result, index)
-      inspected++
-      consecutiveRetryableFailures = 0
-    } catch (err) {
-      errors++
-      cb.onError(url, err, index)
-      // Only rate/server/network-shaped failures advance the breaker — a
-      // non-retryable per-URL error (bad URL, 404) is a data issue, not a
-      // signal that the whole property is throttled or inaccessible.
-      if (isRetryableGscInspectError(err)) {
-        consecutiveRetryableFailures++
-        if (consecutiveRetryableFailures >= INSPECT_FAILFAST_THRESHOLD) {
-          deps.log?.error('inspect.circuit-break', {
-            consecutiveFailures: consecutiveRetryableFailures,
-            inspected,
-            errors,
-            remaining: urls.length - index - 1,
-          })
-          return { inspected, errors, aborted: true, abortError: err }
+        cb.onResult(url, result, index)
+        inspected++
+        consecutiveRetryableFailures = 0
+      } catch (err) {
+        errors++
+        cb.onError(url, err, index)
+        // Only rate/server/network-shaped failures advance the breaker — a
+        // non-retryable per-URL error (bad URL, 404) is a data issue, not a
+        // signal that the whole property is throttled or inaccessible.
+        if (isRetryableGscInspectError(err)) {
+          consecutiveRetryableFailures++
+          if (consecutiveRetryableFailures >= INSPECT_FAILFAST_THRESHOLD) {
+            deps.log?.error('inspect.circuit-break', {
+              consecutiveFailures: consecutiveRetryableFailures,
+              inspected,
+              errors,
+              remaining: urls.length - nextIndex,
+            })
+            // Shared flag rather than an early return: the sibling workers must
+            // stop claiming work too, and their in-flight calls are awaited
+            // below so nothing is orphaned.
+            aborted = true
+            abortError = err
+            return
+          }
         }
       }
     }
-
-    // Pace the next call. Failures already slept through their backoff inside
-    // withRetry; this base spacing keeps the steady-state rate under the limit.
-    if (index < urls.length - 1) {
-      await sleep(INSPECT_BASE_DELAY_MS + jitter() * INSPECT_PACING_JITTER_MS)
-    }
   }
 
-  return { inspected, errors, aborted: false }
+  await Promise.all(Array.from({ length: concurrency }, () => worker()))
+
+  return aborted ? { inspected, errors, aborted: true, abortError } : { inspected, errors, aborted: false }
 }

--- a/packages/canonry/test/gsc-inspect-paced.test.ts
+++ b/packages/canonry/test/gsc-inspect-paced.test.ts
@@ -150,7 +150,7 @@ describe('inspectUrlsPaced', () => {
         onResult: () => {},
         onError: () => {},
       },
-      fastDeps(),
+      fastDeps({ concurrency: 1 }),
     )
 
     expect(outcome.aborted).toBe(true)
@@ -162,6 +162,11 @@ describe('inspectUrlsPaced', () => {
 
   it('resets the breaker on success so scattered failures do not abort', async () => {
     // 4 fail, 1 success, 4 fail — max run of consecutive failures is 4 (< threshold of 5).
+    //
+    // Pinned to one worker: the breaker counts failures consecutive in
+    // COMPLETION order, and with several in flight a success can land before
+    // failures that started earlier, so the run length is not a property of the
+    // input any more. Concurrent breaker behaviour is covered separately below.
     const outcome = await inspectUrlsPaced(
       urls(9),
       {
@@ -172,7 +177,7 @@ describe('inspectUrlsPaced', () => {
         onResult: () => {},
         onError: () => {},
       },
-      fastDeps(),
+      fastDeps({ concurrency: 1 }),
     )
 
     expect(outcome.aborted).toBe(false)
@@ -200,5 +205,87 @@ describe('inspectUrlsPaced', () => {
     expect(outcome.errors).toBe(6)
     // No retries on a non-retryable status: exactly one call per URL.
     expect(calls).toBe(6)
+  })
+})
+
+/**
+ * Concurrency was added because the loop was serial, not because the rate limit
+ * required it: Google documents 600 QPM per site and the pacing allows 60, but
+ * running one call at a time meant throughput was bounded by Google's ~6.3s
+ * per-call latency instead — about 9.5 QPM.
+ */
+describe('inspectUrlsPaced concurrency', () => {
+  it('never exceeds the configured number in flight', async () => {
+    let inFlight = 0
+    let peak = 0
+    await inspectUrlsPaced(
+      urls(20),
+      {
+        inspectOne: async () => {
+          inFlight++
+          peak = Math.max(peak, inFlight)
+          await Promise.resolve()
+          inFlight--
+          return FAKE_RESULT
+        },
+        onResult: () => {},
+        onError: () => {},
+      },
+      fastDeps({ concurrency: 4 }),
+    )
+
+    expect(peak).toBeLessThanOrEqual(4)
+  })
+
+  it('keeps the request rate identical to the serial loop', async () => {
+    // The whole safety argument: workers take start slots from one shared
+    // clock, so N URLs cost N-1 spacings no matter how many run at once.
+    const serial = fastDeps({ concurrency: 1 })
+    await inspectUrlsPaced(urls(8), { inspectOne: async () => FAKE_RESULT, onResult: () => {}, onError: () => {} }, serial)
+
+    const parallel = fastDeps({ concurrency: 5 })
+    await inspectUrlsPaced(urls(8), { inspectOne: async () => FAKE_RESULT, onResult: () => {}, onError: () => {} }, parallel)
+
+    expect(parallel.sleeps).toEqual(serial.sleeps)
+    expect(parallel.sleeps).toHaveLength(7)
+  })
+
+  it('does not burst the opening batch', async () => {
+    // An earlier version skipped the gate for the first `concurrency` requests,
+    // which fired 5 at once before any pacing applied.
+    const deps = fastDeps({ concurrency: 5 })
+    await inspectUrlsPaced(urls(5), { inspectOne: async () => FAKE_RESULT, onResult: () => {}, onError: () => {} }, deps)
+
+    expect(deps.sleeps).toHaveLength(4)
+  })
+
+  it('inspects every URL exactly once and reports each original index', async () => {
+    const seen: Array<{ url: string; index: number }> = []
+    const outcome = await inspectUrlsPaced(
+      urls(12),
+      {
+        inspectOne: async () => FAKE_RESULT,
+        onResult: (url, _r, index) => { seen.push({ url, index }) },
+        onError: () => {},
+      },
+      fastDeps({ concurrency: 5 }),
+    )
+
+    expect(outcome.inspected).toBe(12)
+    expect(new Set(seen.map((s) => s.url)).size).toBe(12)
+    // Results may arrive out of order, but each carries its own index.
+    for (const { url, index } of seen) expect(url).toBe(`https://example.com/p${index}`)
+  })
+
+  it('still trips the breaker when the whole property is failing', async () => {
+    const outcome = await inspectUrlsPaced(
+      urls(50),
+      { inspectOne: async () => { throw statusErr(403) }, onResult: () => {}, onError: () => {} },
+      fastDeps({ concurrency: 5 }),
+    )
+
+    expect(outcome.aborted).toBe(true)
+    // Stopped early rather than burning the daily quota on all 50.
+    expect(outcome.errors).toBeLessThan(50)
   })
 })

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.148.7",
+  "version": "4.148.8",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.148.7",
+  "version": "4.148.8",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
Stacked on #957. Review that first; this diff is only the third commit.

This one exists because I checked Google's published limits and found the code — and my own earlier claim that inspection "cannot be made faster" — was wrong.

## The conflation

`INSPECT_BASE_DELAY_MS = 1000` is a **rate** control: one start per second, 60 QPM. [Google documents](https://developers.google.com/webmaster-tools/limits) **600 QPM** per site alongside the 2000 QPD cap.

But the loop was serial, so the rate was never the binding constraint. Each call spends ~6.3s inside Google's live index lookup, so a site paid ~7.4s per URL and achieved **~9.5 QPM** — six times slower than our own pacing allows, sixty times under what Google publishes.

The file's comment asserted a "~1 req/sec soft limit" that Google does not document anywhere. That claim is removed and replaced with the real figures and a link.

## The change

Concurrency becomes a separate, explicit control:

```
INSPECT_MAX_CONCURRENCY = 5     requests in flight
INSPECT_BASE_DELAY_MS   = 1000  spacing between STARTS — unchanged
```

**The rate posture is deliberately untouched.** Every worker takes its start slot from one shared clock, so N URLs cost N−1 spacings no matter how many workers run. There is a test asserting the sleep sequence is byte-identical between concurrency 1 and 5.

We are not probing the documented ceiling. We are removing an accidental cap that had nothing to do with it.

`5` is the bottom of the range practitioners report as safe — not a number derived from the documented QPM. The endpoint signals per-minute pressure with a transient 403 rather than a 429, which suggests real throttling well below the published figure, so this moves one step and leaves headroom. Raise it only with measurement.

## Effect

| | Serial (today) | 5 concurrent |
|---|---|---|
| Throughput | ~9.5 QPM | ~47 QPM |
| 1,000-page sweep | ~2.0 hrs | ~20 min |

It buys **nothing** past the daily quota — 5,000 pages is 2.5× the 2000 QPD cap however parallel it is. Those need the derived coverage from #957.

## Two things this surfaced

**A burst bug in my first version.** It skipped the rate gate for the opening `concurrency` requests, firing 5 at once before any pacing applied. An existing test caught it. The gate now applies to every start except the very first, and reintroducing the bug fails 3 tests.

**Two existing tests changed — flagging explicitly.** The circuit breaker counts failures consecutive in *completion* order, and with several in flight a success can land before failures that started earlier, so an exact run length is no longer a property of the input. Both breaker tests assert exact run lengths, so they are now pinned to `concurrency: 1` — which is precisely what they were written to verify. Their intent is unchanged and neither was weakened; the constraint is documented on `INSPECT_FAILFAST_THRESHOLD`.

A new test covers the case that matters concurrently: a wholly failing property still trips the breaker and stops early rather than burning the daily quota on all 50 URLs.

## Tests

15 in `gsc-inspect-paced.test.ts`, up from 10. New: in-flight ceiling, rate parity with serial, no opening burst, every URL inspected exactly once with its original index despite out-of-order completion, breaker under concurrency.

3,141 tests pass across `canonry` / `contracts` / `db`.
