### PR TITLE
fix(test,bing): stop tests writing the real config; stop the Bing burst

### DIFF
--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -872,7 +872,15 @@ function SearchConsoleSection({
       }
 
       // --- Bing: re-inspect previously known URLs, or fall back to sitemap ---
-      const BING_CONCURRENCY = 10
+      // Bing throttles per HOST, shared by every project on the instance, and
+      // reports it as a 400 rather than a 429. Ten simultaneous inspections
+      // reliably tripped it: the first batch landed, everything behind it was
+      // rejected. The engine now retries with backoff, but ten synchronised
+      // callers back off and retry together — a thundering herd that keeps the
+      // throttle asserted. Fewer in flight, spaced apart, gets more work done
+      // than more in flight being rejected.
+      const BING_CONCURRENCY = 3
+      const BING_BATCH_SPACING_MS = 1000
       async function syncBing() {
         if (!bingConnection?.connected) return
         const inspections = await queryClient.fetchQuery({
@@ -888,6 +896,10 @@ function SearchConsoleSection({
         }
 
         for (let i = 0; i < uniqueUrls.length; i += BING_CONCURRENCY) {
+          if (signal.aborted) return
+          // Space the batches. Back-to-back bursts are what sustained the
+          // throttle; the pause lets the host-level limit recover between them.
+          if (i > 0) await new Promise<void>((resolve) => setTimeout(resolve, BING_BATCH_SPACING_MS))
           if (signal.aborted) return
           const batch = uniqueUrls.slice(i, i + BING_CONCURRENCY)
           const results = await Promise.allSettled(batch.map((url) => inspectBingUrl(projectName, url)))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.148.11",
+  "version": "4.148.12",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.148.11",
+  "version": "4.148.12",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.148.11",
+  "version": "4.148.12",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.148.11",
+  "version": "4.148.12",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/test-setup/vitest-defaults.ts
+++ b/test-setup/vitest-defaults.ts
@@ -9,7 +9,9 @@
  *   1. Disables canonry telemetry. Even packages that don't import the
  *      telemetry module benefit — invokeCli-style tests sometimes pull
  *      in code paths that fire `cli.command` events.
- *   2. Replaces `globalThis.fetch` with a guard that throws on any
+ *   2. Redirects `CANONRY_CONFIG_DIR` at a throwaway directory, so no test can
+ *      write to the operator's real `~/.canonry/config.yaml`.
+ *   3. Replaces `globalThis.fetch` with a guard that throws on any
  *      non-localhost request, so a test that forgets to mock fetch
  *      can't silently hit the real internet.
  *
@@ -19,6 +21,9 @@
  * the guard back on cleanup. The guard stays in effect between tests.
  */
 
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 process.env.CANONRY_TELEMETRY_DISABLED = '1'
 
 const TELEMETRY_HOSTS = new Set([
@@ -49,6 +54,27 @@ function urlOf(input: string | URL | Request): URL | null {
     return null
   }
   return null
+}
+
+/**
+ * Point every test at a throwaway config directory.
+ *
+ * Several code paths persist to the operator's config as a side effect of
+ * ordinary work — `executeGscSync` writes refreshed OAuth tokens back through
+ * `saveConfigPatch`, for instance. A test that calls one with fixture
+ * credentials will happily overwrite the real `~/.canonry/config.yaml`; on
+ * 2026-08-06 that replaced twelve live Google connections with a single
+ * `example.com` fixture and broke the operator's Search Console auth.
+ *
+ * Same reasoning as the network guard below: a unit test must not reach
+ * outside its own sandbox, and a config write is a side effect on the
+ * developer's machine every bit as real as an HTTP call.
+ *
+ * An explicitly-set `CANONRY_CONFIG_DIR` is respected — a test that wants a
+ * specific directory has already opted in.
+ */
+if (!process.env.CANONRY_CONFIG_DIR?.trim()) {
+  process.env.CANONRY_CONFIG_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'canonry-test-config-'))
 }
 
 globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {


### PR DESCRIPTION
Two fixes found by operating the deployed engine, not by writing code.

## 1. A test overwrote the operator's live config

`executeGscSync` persists refreshed OAuth tokens through `saveConfigPatch`, which writes `~/.canonry/config.yaml`. A test calling it with fixture credentials writes **those fixtures to the real file**.

On 2026-08-06 that replaced twelve live Google connections with a single `example.com` entry and `clientId: 'id'`, breaking Search Console auth with `invalid_client`. The file went from 20KB to 10.9KB. Recovery was a surgical restore of the `google` block from a backup — everything else (`bing`, `ga4`, `providers`, `cloudRun`, `wordpress`, `places`) was byte-identical and survived.

**The fix is global, not a patch to the one test.** The shared vitest setup already blocks external network calls on the principle that a unit test must not reach outside its sandbox. A config write is the same class of side effect on a developer's machine, so the guard sits next to it: `CANONRY_CONFIG_DIR` is redirected to a throwaway directory unless a test explicitly sets one.

Verified by md5 — running the gsc-sync suite now leaves the real config byte-identical.

Any code path that persists config is a landmine for any future test that touches it, and this suite runs on every commit. Fixing the single test would have left the trap armed.

## 2. Ten simultaneous Bing inspections sustain the throttle

The retry from #949 **works**. The deployed engine logs:

```
http.throttled   50
http.retry       40
failed runs      10-24s of backoff   (was: instant failure)
```

Half the work now lands where none of the second batch did. But it cannot finish the job alone.

Bing throttles per **host** — shared by every project on the instance — and the dashboard still fired ten inspections at once with no spacing. Ten synchronised callers back off and retry together, so the herd keeps the throttle asserted.

Concurrency **10 → 3**, plus a 1s pause between batches. Fewer in flight, spaced apart, completes more work than more in flight being rejected.

This is the same lesson as the GSC side, inverted:

| | rate control | concurrency |
|---|---|---|
| GSC (#958) | present (1/s) | accidentally 1 |
| Bing (here) | absent | 10 |

Rate and concurrency are separate controls, and this codebase kept conflating them.

## Still the wrong place

The sweep belongs server-side, driven by `inspectUrlsPaced` — the paced, retrying, circuit-broken helper the engine already has for GSC. That would also close the UI/CLI parity gap where this batching loop exists only in the dashboard, so the CLI and MCP have no equivalent. Scoped separately; this makes the refresh work today.

423 files / 5626 tests pass.
