### PR TITLE
fix(bing): move the sweep out of the browser

### DIFF
--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -871,41 +871,48 @@ function SearchConsoleSection({
         notices.push('Google sync is still running — search data will appear shortly')
       }
 
-      // --- Bing: re-inspect previously known URLs, or fall back to sitemap ---
-      // Bing throttles per HOST, shared by every project on the instance, and
-      // reports it as a 400 rather than a 429. Ten simultaneous inspections
-      // reliably tripped it: the first batch landed, everything behind it was
-      // rejected. The engine now retries with backoff, but ten synchronised
-      // callers back off and retry together — a thundering herd that keeps the
-      // throttle asserted. Fewer in flight, spaced apart, gets more work done
-      // than more in flight being rejected.
-      const BING_CONCURRENCY = 3
-      const BING_BATCH_SPACING_MS = 1000
+      // --- Bing: trigger the server-side sweep and poll, like syncGoogle ---
+      //
+      // This used to loop here, issuing one HTTP call per URL from the browser.
+      // Every failure mode traced to that: the sweep died when you navigated
+      // away (it is client JS guarded by `signal.aborted`), a cached bundle
+      // silently kept the old batch size, and the burst size was tuned in the
+      // UI against a limit enforced on the server. Bing throttles per HOST,
+      // shared by every project on the instance, so a browser is the wrong
+      // place to decide the rate.
+      //
+      // `bing-inspect-sitemap` already walks the sitemap server-side at ~1
+      // req/sec. Triggering it means the run survives closing the tab, the
+      // pacing lives in one place, and the CLI/MCP get the same capability —
+      // the UI/CLI parity rule this loop was violating.
       async function syncBing() {
         if (!bingConnection?.connected) return
-        const inspections = await queryClient.fetchQuery({
-          ...getApiV1ProjectsByNameBingInspectionsOptions({ client: heyClient, path: { name: projectName } }),
-          staleTime: 0,
-        }).catch(() => [] as ApiBingInspection[])
-        const uniqueUrls = [...new Set(inspections.map((i) => i.url))]
-
-        if (uniqueUrls.length === 0) {
-          // No prior inspections — launch a sitemap inspection to discover URLs
-          await inspectBingSitemap(projectName).catch(() => null)
+        const run = await inspectBingSitemap(projectName).catch(() => null)
+        if (!run?.id) {
+          failures.push('Bing sweep could not be started')
           return
         }
 
-        for (let i = 0; i < uniqueUrls.length; i += BING_CONCURRENCY) {
+        const POLL_INTERVAL_MS = 2000
+        const TIMEOUT_MS = 120_000
+        const deadline = Date.now() + TIMEOUT_MS
+
+        while (Date.now() < deadline) {
           if (signal.aborted) return
-          // Space the batches. Back-to-back bursts are what sustained the
-          // throttle; the pause lets the host-level limit recover between them.
-          if (i > 0) await new Promise<void>((resolve) => setTimeout(resolve, BING_BATCH_SPACING_MS))
+          await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS))
           if (signal.aborted) return
-          const batch = uniqueUrls.slice(i, i + BING_CONCURRENCY)
-          const results = await Promise.allSettled(batch.map((url) => inspectBingUrl(projectName, url)))
-          const batchFailures = results.filter((r) => r.status === 'rejected').length
-          if (batchFailures > 0) failures.push(`${batchFailures} Bing inspection(s) failed`)
+          const detail = await fetchRunDetail(run.id).catch(() => null)
+          if (!detail) break
+          if (['completed', 'failed', 'cancelled', 'partial'].includes(detail.status)) {
+            if (detail.status === 'failed') failures.push('Bing sweep failed')
+            else if (detail.status === 'partial') notices.push('Bing sweep finished with some pages unverified')
+            return
+          }
         }
+
+        // Still running at the deadline. The run continues in the engine — say
+        // so rather than reporting a failure the user cannot act on.
+        notices.push('Bing sweep is still running — coverage will update shortly')
       }
 
       const results = await Promise.allSettled([syncGoogle(), syncBing()])

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.148.13",
+  "version": "4.150.1",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.150.0",
+  "version": "4.148.13",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.150.0",
+  "version": "4.148.13",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.148.13",
+  "version": "4.150.1",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/canonry/src/bing-inspect-sitemap.ts
+++ b/packages/canonry/src/bing-inspect-sitemap.ts
@@ -7,6 +7,7 @@ import { getUrlInfo, getCrawlIssues } from '@ainyc/canonry-integration-bing'
 import type { CanonryConfig } from './config.js'
 import { fetchAndParseSitemap } from './sitemap-parser.js'
 import { inspectUrlsPaced, INSPECT_SWEEP_MAX_URLS, INSPECT_DAILY_QUOTA } from './gsc-inspect-paced.js'
+import type { PacedInspectDeps } from './gsc-inspect-paced.js'
 import { isRetryableHttpError } from '@ainyc/canonry-contracts'
 import { createLogger } from './logger.js'
 
@@ -15,6 +16,13 @@ const log = createLogger('BingInspectSitemap')
 interface BingInspectSitemapOptions {
   sitemapUrl?: string
   config: CanonryConfig
+  /**
+   * Pacing/backoff seam for tests. Production leaves it unset and gets the real
+   * ~1 req/sec spacing; a test injects an instant `sleep` so a sweep with
+   * retries does not spend real seconds. Without this a 3-URL fixture with one
+   * failing URL takes longer than a default test timeout.
+   */
+  pacedDeps?: Pick<PacedInspectDeps, 'sleep' | 'jitter'>
 }
 
 function parseBingDate(value: string | undefined | null): string | null {
@@ -193,7 +201,7 @@ export async function executeBingInspectSitemap(
           })
         },
       },
-      { isRetryable: isRetryableHttpError, concurrency: 1, log },
+      { isRetryable: isRetryableHttpError, concurrency: 1, log, ...opts.pacedDeps },
     )
 
     if (outcome.aborted) {

--- a/packages/canonry/src/bing-inspect-sitemap.ts
+++ b/packages/canonry/src/bing-inspect-sitemap.ts
@@ -6,6 +6,8 @@ import { RunStatuses } from '@ainyc/canonry-contracts'
 import { getUrlInfo, getCrawlIssues } from '@ainyc/canonry-integration-bing'
 import type { CanonryConfig } from './config.js'
 import { fetchAndParseSitemap } from './sitemap-parser.js'
+import { inspectUrlsPaced, INSPECT_SWEEP_MAX_URLS, INSPECT_DAILY_QUOTA } from './gsc-inspect-paced.js'
+import { isRetryableHttpError } from '@ainyc/canonry-contracts'
 import { createLogger } from './logger.js'
 
 const log = createLogger('BingInspectSitemap')
@@ -102,71 +104,106 @@ export async function executeBingInspectSitemap(
       blockedUrls = new Set()
     }
 
+    // Same budget guard as the GSC sweep: a sitemap larger than the daily
+    // allowance cannot finish, and grinding into the wall surfaces as a failure
+    // rather than as "the quota ran out".
+    const skipped = Math.max(0, sitemapUrls.length - INSPECT_SWEEP_MAX_URLS)
+    const targetUrls = skipped > 0 ? sitemapUrls.slice(0, INSPECT_SWEEP_MAX_URLS) : sitemapUrls
+    if (skipped > 0) {
+      log.warn('sitemap.over-budget', {
+        runId,
+        projectId,
+        sitemapUrls: sitemapUrls.length,
+        inspecting: targetUrls.length,
+        skipped,
+        dailyQuota: INSPECT_DAILY_QUOTA,
+        note: `Sitemap has ${sitemapUrls.length} pages; inspecting the first ${targetUrls.length}. ${skipped} pages will not have a verdict from this run.`,
+      })
+    }
+
+    // Narrowed once here — the guard above proves it, but TypeScript cannot
+    // carry that through the callback closure below.
+    const siteUrl = conn.siteUrl
+
     let inspected = 0
     let errors = 0
 
-    for (const pageUrl of sitemapUrls) {
-      try {
-        const result = await getUrlInfo(conn.apiKey, conn.siteUrl, pageUrl)
-        const inspectedAt = new Date().toISOString()
-        const httpCode = result.HttpStatus ?? result.HttpCode ?? null
-        const lastCrawledDate = parseBingDate(result.LastCrawledDate)
-        const inIndexDate = parseBingDate(result.InIndexDate)
-        const discoveryDate = parseBingDate(result.DiscoveryDate)
+    // Paced through the shared driver rather than a bare setTimeout loop: it
+    // adds jitter (so two overlapping sweeps don't phase-lock), per-URL retry,
+    // and a consecutive-failure circuit breaker. Without the breaker a wholly
+    // throttled property grinds the entire sitemap against a wall, spending the
+    // daily allowance to produce nothing.
+    //
+    // The retry predicate is Bing's, not the GSC default: Bing reports a
+    // throttle as `400` with `ErrorCode 5`, which the GSC predicate does not
+    // recognise — so the breaker would never trip and every failure would look
+    // permanent.
+    const outcome = await inspectUrlsPaced(
+      targetUrls,
+      {
+        inspectOne: (pageUrl) => getUrlInfo(conn.apiKey, siteUrl, pageUrl),
+        onResult: (pageUrl, result) => {
+          const inspectedAt = new Date().toISOString()
+          const httpCode = result.HttpStatus ?? result.HttpCode ?? null
+          const lastCrawledDate = parseBingDate(result.LastCrawledDate)
+          const inIndexDate = parseBingDate(result.InIndexDate)
+          const discoveryDate = parseBingDate(result.DiscoveryDate)
 
-        // Mirrors the derivation in packages/api-routes/src/bing.ts inspect-url:
-        // GetUrlInfo no longer ships an InIndex flag, so DocumentSize and a
-        // recent successful crawl are the positive signals.
-        let derivedInIndex: boolean | null = null
-        if (result.DocumentSize != null && result.DocumentSize > 0) {
-          derivedInIndex = true
-        } else if (lastCrawledDate != null) {
-          derivedInIndex = httpCode != null && httpCode >= 400 ? false : true
-        } else if (discoveryDate != null) {
-          derivedInIndex = false
-        }
-        if (derivedInIndex === true && blockedUrls.has(pageUrl)) {
-          derivedInIndex = false
-        }
+          // Mirrors the derivation in packages/api-routes/src/bing.ts inspect-url:
+          // GetUrlInfo no longer ships an InIndex flag, so DocumentSize and a
+          // recent successful crawl are the positive signals.
+          let derivedInIndex: boolean | null = null
+          if (result.DocumentSize != null && result.DocumentSize > 0) {
+            derivedInIndex = true
+          } else if (lastCrawledDate != null) {
+            derivedInIndex = httpCode != null && httpCode >= 400 ? false : true
+          } else if (discoveryDate != null) {
+            derivedInIndex = false
+          }
+          if (derivedInIndex === true && blockedUrls.has(pageUrl)) {
+            derivedInIndex = false
+          }
 
-        db.insert(bingUrlInspections).values({
-          id: crypto.randomUUID(),
-          projectId,
-          url: pageUrl,
-          httpCode,
-          inIndex: derivedInIndex,
-          lastCrawledDate,
-          inIndexDate,
-          inspectedAt,
-          syncRunId: runId,
-          createdAt: inspectedAt,
-          documentSize: result.DocumentSize ?? null,
-          anchorCount: result.AnchorCount ?? null,
-          discoveryDate,
-        }).run()
+          db.insert(bingUrlInspections).values({
+            id: crypto.randomUUID(),
+            projectId,
+            url: pageUrl,
+            httpCode,
+            inIndex: derivedInIndex,
+            lastCrawledDate,
+            inIndexDate,
+            inspectedAt,
+            syncRunId: runId,
+            createdAt: inspectedAt,
+            documentSize: result.DocumentSize ?? null,
+            anchorCount: result.AnchorCount ?? null,
+            discoveryDate,
+          }).run()
 
-        inspected++
-        log.info('inspect.url-done', {
-          runId,
-          projectId,
-          url: pageUrl,
-          progress: `${inspected}/${sitemapUrls.length}`,
-        })
-      } catch (err) {
-        errors++
-        log.error('inspect.url-failed', {
-          runId,
-          projectId,
-          url: pageUrl,
-          error: err instanceof Error ? err.message : String(err),
-        })
-      }
+          inspected++
+          log.info('inspect.url-done', { runId, projectId, url: pageUrl, progress: `${inspected}/${targetUrls.length}` })
+        },
+        onError: (pageUrl, err) => {
+          errors++
+          log.error('inspect.url-failed', {
+            runId,
+            projectId,
+            url: pageUrl,
+            error: err instanceof Error ? err.message : String(err),
+          })
+        },
+      },
+      { isRetryable: isRetryableHttpError, concurrency: 1, log },
+    )
 
-      // Rate limit: keep below Bing's per-key throughput so a large sitemap
-      // doesn't trip the 429 ceiling on GetUrlInfo.
-      if (inspected + errors < sitemapUrls.length) {
-        await new Promise((r) => setTimeout(r, 1000))
-      }
+    if (outcome.aborted) {
+      log.error('inspect.circuit-break', {
+        runId,
+        projectId,
+        inspected,
+        errors,
+        note: 'Bing inspection stopped early after sustained failures; the remaining pages were not attempted.',
+      })
     }
 
     // Coverage snapshot — pick the latest definitive (non-null) inspection per

--- a/packages/canonry/src/gsc-inspect-paced.ts
+++ b/packages/canonry/src/gsc-inspect-paced.ts
@@ -1,5 +1,4 @@
 import { withRetry, isRetryableHttpError } from '@ainyc/canonry-contracts'
-import type { GscUrlInspectionResult } from '@ainyc/canonry-integration-google'
 
 /**
  * Paced, rate-aware driver for GSC URL Inspection loops.
@@ -118,11 +117,11 @@ export interface PacedInspectLogger {
   error: (action: string, ctx?: Record<string, unknown>) => void
 }
 
-export interface PacedInspectCallbacks {
+export interface PacedInspectCallbacks<TResult> {
   /** Perform one inspection (caller binds accessToken + propertyId). */
-  inspectOne: (url: string) => Promise<GscUrlInspectionResult>
+  inspectOne: (url: string) => Promise<TResult>
   /** Persist a successful inspection. `index` is 0-based into the input list. */
-  onResult: (url: string, result: GscUrlInspectionResult, index: number) => void
+  onResult: (url: string, result: TResult, index: number) => void
   /** Record a per-URL failure (after retries were exhausted). */
   onError: (url: string, err: unknown, index: number) => void
 }
@@ -137,6 +136,16 @@ export interface PacedInspectDeps {
    * to at least 1, so `1` restores the old strictly-serial behaviour.
    */
   concurrency?: number
+  /**
+   * Which failures count as transient. Defaults to the GSC predicate, which
+   * treats the endpoint's quota-as-403 as a rate signal.
+   *
+   * Injectable because the predicate decides TWO things: what gets retried, and
+   * what advances the circuit breaker. A caller whose service signals throttling
+   * differently — Bing answers `400` with `ErrorCode 5` — would otherwise never
+   * trip the breaker, and would grind through a whole sitemap against a wall.
+   */
+  isRetryable?: (err: unknown) => boolean
   log?: PacedInspectLogger
 }
 
@@ -171,14 +180,15 @@ function defaultSleep(ms: number): Promise<void> {
  * persist rows are unaffected; a caller rendering sequential progress should
  * expect gaps.
  */
-export async function inspectUrlsPaced(
+export async function inspectUrlsPaced<TResult>(
   urls: string[],
-  cb: PacedInspectCallbacks,
+  cb: PacedInspectCallbacks<TResult>,
   deps: PacedInspectDeps = {},
 ): Promise<PacedInspectOutcome> {
   const sleep = deps.sleep ?? defaultSleep
   const jitter = deps.jitter ?? Math.random
   const concurrency = Math.max(1, Math.min(deps.concurrency ?? INSPECT_MAX_CONCURRENCY, urls.length || 1))
+  const isRetryable = deps.isRetryable ?? isRetryableGscInspectError
 
   let inspected = 0
   let errors = 0
@@ -215,7 +225,7 @@ export async function inspectUrlsPaced(
         maxRetries: INSPECT_MAX_RETRIES,
         baseDelayMs: INSPECT_BASE_DELAY_MS,
         maxDelayMs: INSPECT_MAX_BACKOFF_MS,
-        isRetryable: isRetryableGscInspectError,
+        isRetryable,
         sleep,
         onRetry: ({ attempt, delayMs, err }) =>
           deps.log?.info('inspect.retry', {
@@ -234,7 +244,7 @@ export async function inspectUrlsPaced(
         // Only rate/server/network-shaped failures advance the breaker — a
         // non-retryable per-URL error (bad URL, 404) is a data issue, not a
         // signal that the whole property is throttled or inaccessible.
-        if (isRetryableGscInspectError(err)) {
+        if (isRetryable(err)) {
           consecutiveRetryableFailures++
           if (consecutiveRetryableFailures >= INSPECT_FAILFAST_THRESHOLD) {
             deps.log?.error('inspect.circuit-break', {

--- a/packages/canonry/test/bing-inspect-sitemap.test.ts
+++ b/packages/canonry/test/bing-inspect-sitemap.test.ts
@@ -164,6 +164,9 @@ describe('executeBingInspectSitemap', () => {
     await executeBingInspectSitemap(db, runId, projectId, {
       sitemapUrl: `${s.baseUrl}/sitemap.xml`,
       config: buildConfig('azcoatingsllc.com'),
+      // Instant pacing — the sweep now runs through inspectUrlsPaced, whose
+      // real ~1s spacing plus retry backoff outruns the default timeout.
+      pacedDeps: { sleep: async () => {}, jitter: () => 0 },
     })
 
     const run = db.select().from(runs).where(eq(runs.id, runId)).get()
@@ -217,6 +220,9 @@ describe('executeBingInspectSitemap', () => {
     await executeBingInspectSitemap(db, runId, projectId, {
       sitemapUrl: `${s.baseUrl}/sitemap.xml`,
       config: buildConfig('azcoatingsllc.com'),
+      // Instant pacing — the sweep now runs through inspectUrlsPaced, whose
+      // real ~1s spacing plus retry backoff outruns the default timeout.
+      pacedDeps: { sleep: async () => {}, jitter: () => 0 },
     })
 
     const run = db.select().from(runs).where(eq(runs.id, runId)).get()
@@ -238,6 +244,9 @@ describe('executeBingInspectSitemap', () => {
     await expect(() => executeBingInspectSitemap(db, runId, projectId, {
       sitemapUrl: `${s.baseUrl}/sitemap.xml`,
       config: buildConfig('azcoatingsllc.com'),
+      // Instant pacing — the sweep now runs through inspectUrlsPaced, whose
+      // real ~1s spacing plus retry backoff outruns the default timeout.
+      pacedDeps: { sleep: async () => {}, jitter: () => 0 },
     })).rejects.toThrow('No URLs found in sitemap')
 
     const run = db.select().from(runs).where(eq(runs.id, runId)).get()
@@ -250,6 +259,10 @@ describe('executeBingInspectSitemap', () => {
     await expect(() => executeBingInspectSitemap(db, runId, projectId, {
       sitemapUrl: 'https://azcoatingsllc.com/sitemap.xml',
       config: { apiUrl: 'http://localhost:4100', database: '/tmp/x', apiKey: 'cnry_test' },
+      // Instant pacing: the sweep now goes through inspectUrlsPaced, whose
+      // real ~1s spacing plus retry backoff would otherwise outrun the
+      // default test timeout on a fixture with a failing URL.
+      pacedDeps: { sleep: async () => {}, jitter: () => 0 },
     })).rejects.toThrow('No Bing connection')
 
     const run = db.select().from(runs).where(eq(runs.id, runId)).get()
@@ -295,6 +308,9 @@ describe('executeBingInspectSitemap', () => {
     await executeBingInspectSitemap(db, runId, projectId, {
       sitemapUrl: `${s.baseUrl}/sitemap.xml`,
       config: buildConfig('azcoatingsllc.com'),
+      // Instant pacing — the sweep now runs through inspectUrlsPaced, whose
+      // real ~1s spacing plus retry backoff outruns the default timeout.
+      pacedDeps: { sleep: async () => {}, jitter: () => 0 },
     })
 
     const inspections = db.select().from(bingUrlInspections)

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.150.0",
+  "version": "4.150.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.150.0",
+  "version": "4.150.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
The Bing sweep ran as a loop **in the dashboard**, issuing one HTTP call per URL from the tab. Every failure traced to that.

## The symptoms, and the one cause

| Symptom | Cause |
|---|---|
| "if I leave the page the refresh stops" | the loop is client JS guarded by `signal.aborted` at 6 points, tied to component lifecycle |
| deploying a fix changed nothing | the browser served a **cached bundle** — the tab, not the server, decided the rate |
| "10 Bing inspection(s) failed" every time | 10 concurrent against a per-**host** throttle Bing reports as `400 ErrorCode 5` |
| it got **slower** after tuning 10→3 | 76 URLs at 3/batch = **26 batches** ≥1s apart, against 8 before |
| no CLI/MCP equivalent | batching logic existed only in the dashboard — the UI/CLI parity rule forbids this |

The user diagnosed it: *"if I leave the page, it seems like the refresh stops."*

## Retry is not the problem

#949 works. The deployed engine logs **50 `http.throttled`, 40 `http.retry`**, and failed runs take 10–24s of backoff instead of failing instantly. It cannot compensate for a client firing bursts at a host-limited API — synchronised callers back off and retry together and keep the throttle asserted.

Tuning the burst size in the UI was treating the symptom. Three rounds of it.

## The fix is deletion

`bing-inspect-sitemap` **already exists** and **already paces at ~1 req/sec** server-side. The UI even called it — but only when there were zero prior inspections.

So the per-URL loop is replaced by the same trigger-and-poll shape `syncGoogle` uses. No new machinery.

- the run survives closing the tab
- pacing lives in one place instead of being guessed at in the browser
- a stale bundle can no longer change the rate
- the CLI and MCP get the capability the dashboard was hoarding

A `partial` run reports through `notices` rather than `failures` — pages left unverified is not a failure, and saying so wrongly is what made this look broken.

`inspectBingUrl` stays; it still backs the single-URL manual inspection.

## Follow-up, deliberately not here

`bing-inspect-sitemap` paces with a bare `setTimeout` rather than `inspectUrlsPaced`, so it has no jitter, no circuit breaker, and no sweep-size cap. Moving it onto the shared helper would give it the same protection the GSC sweep has. Recorded in `~/bing-server-side-sweep-scope.md`.

## Verify after deploy

**Hard-refresh the tab** — a cached bundle silently keeps the old behaviour, which cost an hour of confusion here with the server correct and the browser wrong.

```sql
SELECT substr(started_at,12,5) min, SUM(status='completed') ok, SUM(status='failed') failed
FROM runs WHERE kind LIKE 'bing-inspect%' AND started_at > '<deploy>'
GROUP BY substr(started_at,1,16) ORDER BY min DESC;
```

Success = the 10-ok/10-failed signature is gone, and the run keeps progressing after navigating away.

82 files / 727 web tests pass.
