### PR TITLE
fix(auth): expire OAuth signed state after 15 minutes

### DIFF
--- a/packages/api-routes/src/google.ts
+++ b/packages/api-routes/src/google.ts
@@ -171,8 +171,20 @@ function signState(payload: string, secret: string): string {
   return crypto.createHmac('sha256', secret).update(payload).digest('hex')
 }
 
+/**
+ * Signed OAuth states are otherwise valid forever (the HMAC has no expiry
+ * built in). A captured `state` — e.g. leaked via a proxy's access log, a
+ * browser history entry, or a referrer header on the redirect leg — would
+ * stay replayable indefinitely as long as the initiating project still
+ * exists with the same id/name/domain. `issuedAt` + this ceiling closes that
+ * window; 15 minutes comfortably covers the real user-facing consent flow
+ * (redirect to Google, user reviews the consent screen, redirect back)
+ * while keeping a stale/leaked state from being useful later.
+ */
+const OAUTH_STATE_MAX_AGE_MS = 15 * 60 * 1000
+
 function buildSignedState(data: Record<string, unknown>, secret: string): string {
-  const payload = JSON.stringify(data)
+  const payload = JSON.stringify({ ...data, issuedAt: Date.now() })
   const sig = signState(payload, secret)
   return Buffer.from(JSON.stringify({ payload, sig })).toString('base64url')
 }
@@ -182,7 +194,14 @@ function verifySignedState(encoded: string, secret: string): Record<string, unkn
     const { payload, sig } = JSON.parse(Buffer.from(encoded, 'base64url').toString()) as { payload: string; sig: string }
     const expected = signState(payload, secret)
     if (!crypto.timingSafeEqual(Buffer.from(sig, 'hex'), Buffer.from(expected, 'hex'))) return null
-    return JSON.parse(payload) as Record<string, unknown>
+    const parsed = JSON.parse(payload) as Record<string, unknown>
+    // States minted before this field existed (`issuedAt` absent) are
+    // treated as expired rather than ageless — see the pre-`projectId`
+    // handling at the call site for the same "stale state, restart the
+    // flow" precedent.
+    const issuedAt = typeof parsed.issuedAt === 'number' ? parsed.issuedAt : null
+    if (issuedAt === null || Date.now() - issuedAt > OAUTH_STATE_MAX_AGE_MS) return null
+    return parsed
   } catch {
     return null
   }

--- a/packages/api-routes/test/google.test.ts
+++ b/packages/api-routes/test/google.test.ts
@@ -9,12 +9,25 @@ import { createClient, migrate, projects, runs, auditLog, gscCoverageSnapshots, 
 import { AppError } from '@ainyc/canonry-contracts'
 import { googleOAuthSuccessHtml, googleRoutes } from '../src/google.js'
 
-// Reproduce state signing functions from google.ts to verify behavior
+// Reproduce state signing functions from google.ts to verify behavior.
+// Kept in sync with `OAUTH_STATE_MAX_AGE_MS` / `buildSignedState` /
+// `verifySignedState` there — `buildSignedState` stamps `issuedAt` by
+// default (matching production), and tests that need to emulate a
+// pre-TTL "legacy" state or an expired one pass `issuedAt` explicitly.
+const OAUTH_STATE_MAX_AGE_MS = 15 * 60 * 1000
+
 function signState(payload: string, secret: string): string {
   return crypto.createHmac('sha256', secret).update(payload).digest('hex')
 }
 
 function buildSignedState(data: Record<string, unknown>, secret: string): string {
+  const payload = JSON.stringify({ issuedAt: Date.now(), ...data })
+  const sig = signState(payload, secret)
+  return Buffer.from(JSON.stringify({ payload, sig })).toString('base64url')
+}
+
+/** Build a state payload with no `issuedAt` at all — emulates a state minted before the TTL field existed. */
+function buildSignedStateWithoutIssuedAt(data: Record<string, unknown>, secret: string): string {
   const payload = JSON.stringify(data)
   const sig = signState(payload, secret)
   return Buffer.from(JSON.stringify({ payload, sig })).toString('base64url')
@@ -25,7 +38,10 @@ function verifySignedState(encoded: string, secret: string): Record<string, unkn
     const { payload, sig } = JSON.parse(Buffer.from(encoded, 'base64url').toString()) as { payload: string; sig: string }
     const expected = signState(payload, secret)
     if (!crypto.timingSafeEqual(Buffer.from(sig, 'hex'), Buffer.from(expected, 'hex'))) return null
-    return JSON.parse(payload) as Record<string, unknown>
+    const parsed = JSON.parse(payload) as Record<string, unknown>
+    const issuedAt = typeof parsed.issuedAt === 'number' ? parsed.issuedAt : null
+    if (issuedAt === null || Date.now() - issuedAt > OAUTH_STATE_MAX_AGE_MS) return null
+    return parsed
   } catch {
     return null
   }
@@ -134,6 +150,29 @@ describe('state signing', () => {
 
   it('rejects garbage input', () => {
     const result = verifySignedState('not-valid-base64url!!!', 'secret')
+    expect(result).toBeNull()
+  })
+
+  it('rejects a state older than the TTL — closes the indefinite-replay window', () => {
+    const secret = 'my-test-secret'
+    const staleIssuedAt = Date.now() - OAUTH_STATE_MAX_AGE_MS - 1000
+    const encoded = buildSignedState({ domain: 'example.com', type: 'gsc', issuedAt: staleIssuedAt }, secret)
+    const result = verifySignedState(encoded, secret)
+    expect(result).toBeNull()
+  })
+
+  it('accepts a state right at the edge of the TTL window', () => {
+    const secret = 'my-test-secret'
+    const freshIssuedAt = Date.now() - OAUTH_STATE_MAX_AGE_MS + 5000
+    const encoded = buildSignedState({ domain: 'example.com', type: 'gsc', issuedAt: freshIssuedAt }, secret)
+    const result = verifySignedState(encoded, secret)
+    expect(result).not.toBeNull()
+  })
+
+  it('rejects a correctly-signed state with no issuedAt at all (pre-TTL-migration state)', () => {
+    const secret = 'my-test-secret'
+    const encoded = buildSignedStateWithoutIssuedAt({ domain: 'example.com', type: 'gsc' }, secret)
+    const result = verifySignedState(encoded, secret)
     expect(result).toBeNull()
   })
 })


### PR DESCRIPTION
## Why

Follow-up from a review of authentication + test coverage. Signed OAuth state (`google.ts`, used for the Google/GA4/GBP connect flow) was HMAC-signed but had **no TTL** — the code already had a comment acknowledging this as a known gap:

> Since signed states have no TTL, a captured pre-upgrade state would otherwise stay replayable.

A captured `state` value (leaked via a proxy access log, browser history, or a `Referer` header on the redirect leg) stayed replayable indefinitely as long as the initiating project still existed with the same id/name/domain.

## What changed

- `buildSignedState` now stamps an `issuedAt` timestamp into the signed payload.
- `verifySignedState` rejects any state older than 15 minutes (comfortably covers the real user-facing consent round trip: redirect to Google → user reviews consent → redirect back), and rejects any correctly-signed state that predates this field entirely — mirroring the existing pre-`projectId` legacy-state handling already in the callback handler.
- Updated `google.test.ts`'s local repro helpers (`buildSignedState`/`verifySignedState`, duplicated there because the real ones are private to `google.ts`) to match, added a `buildSignedStateWithoutIssuedAt` helper for the pre-migration case, and added three new tests:
  - rejects a state older than the TTL
  - accepts a state right at the edge of the TTL window
  - rejects a correctly-signed state with no `issuedAt` at all

No behavior change to any other auth path. No API/CLI surface change. Diff is 66 lines (under the 100-line non-doc threshold), so no version bump per `AGENTS.md`.

## Verification

- `tsc --noEmit -p packages/api-routes/tsconfig.json` — clean.
- `eslint src/google.ts test/google.test.ts` — 0 errors (pre-existing warnings only, unrelated to this diff).
- `vitest run --project api-routes -t "state signing"` — 7/7 passing (pure-logic describe block, no DB dependency).
- Could **not** run the DB-backed `googleRoutes: GET /projects/:name/google/callback` describe blocks in this sandbox: `better-sqlite3`'s native binding fails to load under Node 26.5.0 (ABI mismatch) — this is a sandbox environment issue unrelated to the change (the repo's own `scripts/check-node.mjs` preinstall guard already documents Node 26 as unsupported; CI runs Node 22). Recommend CI/a Node-22 environment re-run these before merge to confirm the callback-path tests (which exercise the "legacy state omits projectId" and "redirect_uri_mismatch help page" cases against the new TTL logic) still pass — I traced the logic by hand and they should, since `buildSignedState` now stamps a fresh `issuedAt` by default in every existing test call site.

## Context

This was flagged as a Medium-severity finding in an authentication review of this repo (alongside a scope-annotation-convention recommendation and thin provider/integration test-coverage findings, tracked separately as follow-ups, not addressed in this PR).
