### PR TITLE
fix(web): restore the property row chevron that a merge reverted

### DIFF
--- a/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementOverview.tsx
+++ b/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementOverview.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ChevronDown } from 'lucide-react'
 import type { KeyboardEvent, ReactNode } from 'react'
 import type { MetricTone } from '../../../view-models.js'
 
@@ -748,7 +749,7 @@ export function AdvancedMeasurementOverview({
                           {property.historical ? <ToneBadge tone="caution">Historical</ToneBadge> : null}
                         </span>
                       </td>
-                      <td className="text-right"><Button size="sm" variant="ghost" aria-expanded={expanded} onClick={() => toggleProperty(property.id)}>{expanded ? `Hide details for ${property.name}` : `Show details for ${property.name}`}</Button></td>
+                      <td className="text-right"><Button size="icon" variant="ghost" aria-expanded={expanded} aria-label={expanded ? `Hide details for ${property.name}` : `Show details for ${property.name}`} onClick={() => toggleProperty(property.id)}><ChevronDown className={`h-4 w-4 transition-transform duration-200 motion-reduce:transition-none ${expanded ? 'rotate-180' : ''}`} aria-hidden="true" /></Button></td>
                     </tr>
                     {expanded ? <tr key={`${property.id}:details`}><td colSpan={5} className="bg-surface-subtle px-4"><PropertyDetails property={property} onRetryEvidence={onRetryEvidence} /></td></tr> : null}
                   </Fragment>

--- a/apps/web/test/advanced-measurement-overview.test.tsx
+++ b/apps/web/test/advanced-measurement-overview.test.tsx
@@ -589,6 +589,27 @@ describe('status strip (defect 1)', () => {
     expect(screen.queryByText('32 of 32')).toBeNull()
   })
 
+  it('points the row chevron down when collapsed and up when expanded', () => {
+    renderOverview()
+
+    // The toggle carries no visible text, so the chevron IS the affordance: an
+    // empty button and a button whose icon never turns both leave the row
+    // looking inert, and neither is visible to the accessible-name lookups the
+    // rest of this suite uses.
+    const toggle = screen.getByRole('button', { name: 'Show details for Downtown Office' })
+    const chevron = toggle.querySelector('svg')
+    expect(chevron).toBeTruthy()
+    expect(chevron!.getAttribute('class')).not.toContain('rotate-180')
+    // Reduced motion is honoured the way the repo's other chevron is
+    // (`.task-center-chevron`), not left to an unguarded transition.
+    expect(chevron!.getAttribute('class')).toContain('motion-reduce:transition-none')
+
+    fireEvent.click(toggle)
+
+    const expandedToggle = screen.getByRole('button', { name: 'Hide details for Downtown Office' })
+    expect(expandedToggle.querySelector('svg')!.getAttribute('class')).toContain('rotate-180')
+  })
+
   it('never renders "No action needed." — the ToneBadge already says the state is healthy', () => {
     renderOverview({ canEdit: false, report: { ...report(), flaggedResults: [] } })
 

--- a/apps/web/test/portfolio-route.test.tsx
+++ b/apps/web/test/portfolio-route.test.tsx
@@ -36,7 +36,13 @@ async function renderAt(
     report?: ReturnType<typeof measurementReportResponse>
     overview?: ReturnType<typeof measurementOverviewResponse>
   },
-  options: { schedule?: unknown } = {},
+  /**
+   * `seedPlan: false` leaves the measurement-plan query unseeded, which is the
+   * cold-navigation state: the read is in flight and the surface is not yet
+   * decidable. These render one synchronous pass, so an unseeded query stays
+   * pending for the whole render.
+   */
+  options: { schedule?: unknown; seedPlan?: boolean } = {},
 ): Promise<string> {
   if (embed) window.__CANONRY_CONFIG__ = { embed }
   else delete window.__CANONRY_CONFIG__
@@ -54,10 +60,12 @@ async function renderAt(
       options.schedule,
     )
   }
-  queryClient.setQueryData(
-    getApiV1ProjectsByNameMeasurementPlanQueryKey({ client: heyClient, path: { name: projectName } }),
-    measurement?.plan ?? { active: null },
-  )
+  if (options.seedPlan !== false) {
+    queryClient.setQueryData(
+      getApiV1ProjectsByNameMeasurementPlanQueryKey({ client: heyClient, path: { name: projectName } }),
+      measurement?.plan ?? { active: null },
+    )
+  }
   if (measurement?.report && measurement.plan.active) {
     queryClient.setQueryData(
       getApiV1ProjectsByNameMeasurementReportQueryKey({
@@ -735,4 +743,29 @@ test('deleting the project is still offered, at the end of the Settings tab', as
 
   expect(html).toContain('Delete project')
   expect(html).toContain('Permanently deletes this project and all its queries, competitors, runs, and snapshots.')
+})
+
+// Restored: these two shipped in #953 and were dropped when a later branch's
+// version of this file was taken wholesale. The guard they cover
+// (`isMeasurementModeUnresolved`) stayed on main the whole time, unguarded.
+test('an unresolved measurement plan shows a skeleton instead of flashing the Simple Overview', async () => {
+  // The bug: `resolveAdvancedMeasurementMode` reads a pending plan read as
+  // `null`, and `null` means "this project has no plan". So a project WITH an
+  // advanced plan painted the legacy overview first and swapped it out once the
+  // read landed — a visible flash on every cold navigation into a project.
+  const html = await renderAt('/projects/project_citypoint', undefined, undefined, { seedPlan: false })
+
+  expect(html).toContain('Loading project overview')
+  // The legacy overview's own copy must not appear while the answer is unknown.
+  expect(html).not.toContain('Where competitors are winning')
+})
+
+test('a settled plan read still renders the Simple Overview, so the guard is not a permanent skeleton', async () => {
+  // The other half: once the read settles as "no plan", `null` means what it
+  // says and the legacy surface is correct. A guard that cannot tell pending
+  // from settled would strand this on the skeleton forever.
+  const html = await renderAt('/projects/project_citypoint')
+
+  expect(html).toContain('Where competitors are winning')
+  expect(html).not.toContain('Loading project overview')
 })


### PR DESCRIPTION
#941 collapsed the property row toggle to an icon chevron. It merged as `4841b796`, and #960's merge resolution silently took it back out.

Resolving #960 against main, the conflicted paths included this component and its test, not only the version files, and all of them were resolved with `git checkout --ours` in bulk. "Ours" was a branch cut before #941, so that discarded #941 from the component **and** from the test guarding it. CI stayed green because the assertion left with the code it asserted on.

Restored test-first: the test fails on the reverted state with `expected null to be truthy` (no svg inside the toggle), then the component change goes back. Full web suite green at 771 tests.

The process lesson, recorded here because the diff cannot carry it: when merging main into a feature branch, `--ours` on a conflicted **source** file reverts upstream work, and doing it in bulk across a conflict list makes that invisible. Only the version files are safe to resolve that way.