### PR TITLE
feat(web): put the measurement scope and query class in the URL

### DIFF
--- a/apps/web/src/lib/measurement-view-url.ts
+++ b/apps/web/src/lib/measurement-view-url.ts
@@ -1,0 +1,56 @@
+/**
+ * The advanced-measurement view state as URL search params.
+ *
+ * Scale is why this is in the URL at all. With a handful of properties an
+ * operator can re-pick a market after every reload; with hundreds of markets
+ * that re-pick IS the interaction, and a scope held only in component state
+ * cannot be linked, bookmarked, reloaded, or reported in a bug.
+ *
+ * Defaults are written as ABSENT rather than as `scope=all&class=non-brand`,
+ * so the common case leaves a clean URL and only a deliberate choice shows up.
+ */
+
+export type MeasurementQueryClass = 'all' | 'non-brand' | 'branded'
+
+export interface MeasurementViewState {
+  scope: 'all' | 'group'
+  groupKey?: string
+  queryClass: MeasurementQueryClass
+}
+
+export const DEFAULT_MEASUREMENT_VIEW: MeasurementViewState = { scope: 'all', queryClass: 'non-brand' }
+
+const QUERY_CLASSES: readonly MeasurementQueryClass[] = ['all', 'non-brand', 'branded']
+
+function isQueryClass(value: unknown): value is MeasurementQueryClass {
+  return typeof value === 'string' && (QUERY_CLASSES as readonly string[]).includes(value)
+}
+
+/**
+ * Read view state out of the URL. Anything unrecognised degrades to the
+ * default rather than throwing: these values arrive from a bookmark a person
+ * saved months ago, or from a link someone edited by hand, and a malformed one
+ * must not be able to break the page.
+ */
+export function parseMeasurementViewSearch(search: { scope?: string; class?: string }): MeasurementViewState {
+  const queryClass = isQueryClass(search.class) ? search.class : DEFAULT_MEASUREMENT_VIEW.queryClass
+  const raw = search.scope
+  if (typeof raw !== 'string' || raw === 'all' || raw.length === 0) {
+    return { scope: 'all', queryClass }
+  }
+  const groupKey = raw.startsWith('group:') ? raw.slice('group:'.length) : ''
+  // `group:` with nothing after it names no group, so it is not a group scope.
+  if (!groupKey) return { scope: 'all', queryClass }
+  return { scope: 'group', groupKey, queryClass }
+}
+
+/**
+ * Write view state back to the URL, omitting every default. Returns the two
+ * keys only, for spreading over the rest of the existing search params.
+ */
+export function measurementViewSearch(view: MeasurementViewState): { scope?: string; class?: string } {
+  return {
+    scope: view.scope === 'group' && view.groupKey ? `group:${view.groupKey}` : undefined,
+    class: view.queryClass === DEFAULT_MEASUREMENT_VIEW.queryClass ? undefined : view.queryClass,
+  }
+}

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState, useCallback } from 'react'
 import { ChevronDown, RefreshCw, Trash2 } from 'lucide-react'
 import { useNavigate, useParams, useSearch } from '@tanstack/react-router'
 import { Link } from '@tanstack/react-router'
+
+import { measurementViewSearch, parseMeasurementViewSearch } from '../lib/measurement-view-url.js'
 import { useQueryClient } from '@tanstack/react-query'
 import { RunKinds, RunStatuses } from '@ainyc/canonry-contracts'
 
@@ -1668,12 +1670,30 @@ function ProjectPageContent({
   const [competitorFilter, setCompetitorFilter] = useState<string | null>(null)
   const [locationTimeline, setLocationTimeline] = useState<import('../api.js').ApiTimelineEntry[] | null>(null)
   const [_locationTimelineLoading, setLocationTimelineLoading] = useState(false)
-  const [advancedMeasurementView, setAdvancedMeasurementView] = useState<{
+  // Scope and query class come from the URL so a market is a place you can
+  // link, bookmark and reload — at hundreds of markets, re-picking one after
+  // every navigation IS the interaction. `search` stays local: it changes on
+  // every keystroke and belongs in neither the URL nor the history stack.
+  const measurementSearchParams = useSearch({ strict: false }) as { scope?: string; class?: string }
+  const urlMeasurementView = parseMeasurementViewSearch(measurementSearchParams)
+  const [advancedMeasurementSearch, setAdvancedMeasurementSearch] = useState<string | undefined>(undefined)
+  const setAdvancedMeasurementView = useCallback((next: {
     scope: 'all' | 'group'
     groupKey?: string
     queryClass: 'all' | 'non-brand' | 'branded'
     search?: string
-  }>({ scope: 'all', queryClass: 'non-brand' })
+  }) => {
+    setAdvancedMeasurementSearch(next.search)
+    // Scope and class are deliberate, low-frequency choices, so they PUSH:
+    // pressing back after picking a market should return to the previous
+    // market, which is what a reader expects of a control that changes what
+    // the page is about.
+    void navigate({
+      to: '.',
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...measurementViewSearch(next) }),
+      replace: false,
+    })
+  }, [navigate])
   const [hasExpandedAdvancedProperty, setHasExpandedAdvancedProperty] = useState(false)
 
   const visibilityEvidence = model?.visibilityEvidence ?? []
@@ -1718,6 +1738,30 @@ function ProjectPageContent({
     ? `Next AI sweep ${new Date(sweepSchedule.nextRunAt).toLocaleString()}`
     : null
   const activeMeasurementPlan = activeMeasurementPlanQuery.data?.active ?? null
+
+  // A bookmark outlives the group it names. Once the plan has actually loaded
+  // and we can see which groups exist, a URL naming one that does not is
+  // resolved to all-properties BEFORE any request goes out — otherwise the page
+  // asks the server for a scope that cannot exist and paints a skeleton at
+  // someone who simply followed an old link. While the plan is still in flight
+  // the key is left alone: absence of an answer is not evidence the group is
+  // gone.
+  const planGroupKeysLoaded = activeMeasurementPlanQuery.data !== undefined
+  const planGroupKeys = new Set(
+    activeMeasurementPlan && Number(activeMeasurementPlan.plan.schemaVersion) === 2
+      ? (activeMeasurementPlan.plan as { groups?: { stableKey: string }[] }).groups?.map(group => group.stableKey) ?? []
+      : [],
+  )
+  const measurementScopeIsStale = urlMeasurementView.scope === 'group'
+    && Boolean(urlMeasurementView.groupKey)
+    && planGroupKeysLoaded
+    && !planGroupKeys.has(urlMeasurementView.groupKey!)
+  const advancedMeasurementView = {
+    ...(measurementScopeIsStale
+      ? { scope: 'all' as const, queryClass: urlMeasurementView.queryClass }
+      : urlMeasurementView),
+    ...(advancedMeasurementSearch ? { search: advancedMeasurementSearch } : {}),
+  }
   const activeMeasurementPlanSchemaVersion = activeMeasurementPlan === null
     ? null
     : Number(activeMeasurementPlan.plan.schemaVersion)

--- a/apps/web/src/router/routes.tsx
+++ b/apps/web/src/router/routes.tsx
@@ -75,6 +75,15 @@ type SearchParams = {
   runProject?: string
   runWindow?: string
   runQuery?: string
+  /**
+   * Advanced-measurement view state, in the URL so a market is a place you can
+   * link, bookmark, and reload. `all` (the default) is omitted rather than
+   * written, so the common case leaves a clean URL.
+   *   scope=group:<stableKey> | scope=all
+   *   class=all | non-brand | branded
+   */
+  scope?: string
+  class?: string
 }
 
 function RootLayoutWithErrorBoundary() {
@@ -96,6 +105,8 @@ export const rootRoute = createRootRouteWithContext<RouterContext>()({
     runProject: typeof search.runProject === 'string' ? search.runProject : undefined,
     runWindow: typeof search.runWindow === 'string' ? search.runWindow : undefined,
     runQuery: typeof search.runQuery === 'string' ? search.runQuery : undefined,
+    scope: typeof search.scope === 'string' ? search.scope : undefined,
+    class: typeof search.class === 'string' ? search.class : undefined,
   }),
 })
 

--- a/apps/web/test/advanced-measurement-overview.test.tsx
+++ b/apps/web/test/advanced-measurement-overview.test.tsx
@@ -123,6 +123,10 @@ function report(overrides: Partial<AdvancedMeasurementOverviewReport> = {}): Adv
   }
 }
 
+function renderOverviewReturning(overrides: Partial<AdvancedMeasurementOverviewProps> = {}) {
+  return render(<AdvancedMeasurementOverview report={report()} canEdit {...overrides} />)
+}
+
 function renderOverview(overrides: Partial<AdvancedMeasurementOverviewProps> = {}) {
   const onRunMeasurement = vi.fn()
   const onRepublishSetup = vi.fn()
@@ -834,6 +838,47 @@ describe('control row (defect 2)', () => {
       expect(onViewChange).toHaveBeenCalledWith({ scope: 'all', queryClass: 'non-brand', search: 'up' })
     } finally {
       vi.useRealTimers()
+    }
+  })
+})
+
+describe('responsive structure', () => {
+  // jsdom cannot lay out Tailwind, so these assert the STRUCTURE that makes the
+  // layout survive a narrow viewport. Each corresponds to a way this surface
+  // has broken or could break at width.
+
+  it('keeps the wide properties table scrolling inside its own container, never the page', () => {
+    const { container } = renderOverviewReturning()
+    const table = container.querySelector('table.evidence-table.min-w-\\[720px\\]')
+    expect(table).toBeTruthy()
+
+    // The min-width belongs to the TABLE. If it sits on the scroll container
+    // (or any ancestor) instead, the container can no longer be narrower than
+    // its content, so the whole page scrolls sideways rather than the table.
+    const scroller = table!.parentElement!
+    expect(scroller.className).toContain('overflow-x-auto')
+    expect(scroller.className).not.toMatch(/min-w-/)
+
+    let ancestor: HTMLElement | null = scroller.parentElement
+    while (ancestor && ancestor !== container) {
+      expect(ancestor.className).not.toMatch(/min-w-\[/)
+      ancestor = ancestor.parentElement
+    }
+  })
+
+  it('lets the control row wrap instead of clipping its controls', () => {
+    const { container } = renderOverviewReturning()
+    const label = container.querySelector('#advanced-measurement-group-label')!
+    const row = label.closest('div')!.parentElement!
+    expect(row.className).toContain('flex-wrap')
+  })
+
+  it('lets a segmented control wrap its options, so many markets do not overflow', () => {
+    const { container } = renderOverviewReturning()
+    for (const group of container.querySelectorAll('[role="radiogroup"]')) {
+      // `.segmented` is inline-flex; without wrap, a tenant with twenty markets
+      // pushes options off the edge with no way to reach them.
+      expect(group.className).toContain('flex-wrap')
     }
   })
 })

--- a/apps/web/test/measurement-view-url.test.ts
+++ b/apps/web/test/measurement-view-url.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from 'vitest'
+
+import {
+  DEFAULT_MEASUREMENT_VIEW,
+  measurementViewSearch,
+  parseMeasurementViewSearch,
+} from '../src/lib/measurement-view-url.js'
+
+test('reads a group scope and a query class out of the URL', () => {
+  expect(parseMeasurementViewSearch({ scope: 'group:north', class: 'branded' }))
+    .toEqual({ scope: 'group', groupKey: 'north', queryClass: 'branded' })
+})
+
+test('an absent search is the default view, not an error', () => {
+  expect(parseMeasurementViewSearch({})).toEqual(DEFAULT_MEASUREMENT_VIEW)
+})
+
+test('a malformed scope degrades to all properties rather than throwing', () => {
+  // These arrive from hand-edited links and months-old bookmarks. Each must
+  // land on the default; none may throw.
+  for (const scope of ['', 'group:', 'group', 'nonsense', 'all', 'GROUP:north']) {
+    expect(parseMeasurementViewSearch({ scope }).scope).toBe('all')
+  }
+})
+
+test('a malformed class degrades to non-brand, which is never pooled with branded', () => {
+  for (const cls of ['', 'BRANDED', 'nonbrand', 'both']) {
+    expect(parseMeasurementViewSearch({ class: cls }).queryClass).toBe('non-brand')
+  }
+})
+
+test('a group key containing a colon survives the round trip', () => {
+  // Stable keys are slugs today, but the format must not silently truncate a
+  // key that happens to contain the separator.
+  const view = parseMeasurementViewSearch({ scope: 'group:north:west' })
+  expect(view.groupKey).toBe('north:west')
+  expect(measurementViewSearch(view).scope).toBe('group:north:west')
+})
+
+test('defaults are written as absent, so the common case leaves a clean URL', () => {
+  expect(measurementViewSearch(DEFAULT_MEASUREMENT_VIEW)).toEqual({ scope: undefined, class: undefined })
+})
+
+test('a deliberate choice is written, and only that choice', () => {
+  expect(measurementViewSearch({ scope: 'group', groupKey: 'north', queryClass: 'non-brand' }))
+    .toEqual({ scope: 'group:north', class: undefined })
+  expect(measurementViewSearch({ scope: 'all', queryClass: 'branded' }))
+    .toEqual({ scope: undefined, class: 'branded' })
+})
+
+test('every state survives a URL round trip', () => {
+  const states = [
+    DEFAULT_MEASUREMENT_VIEW,
+    { scope: 'all' as const, queryClass: 'branded' as const },
+    { scope: 'group' as const, groupKey: 'north', queryClass: 'all' as const },
+    { scope: 'group' as const, groupKey: 'south', queryClass: 'branded' as const },
+  ]
+  for (const state of states) {
+    expect(parseMeasurementViewSearch(measurementViewSearch(state))).toEqual(state)
+  }
+})

--- a/apps/web/test/portfolio-route.test.tsx
+++ b/apps/web/test/portfolio-route.test.tsx
@@ -35,6 +35,7 @@ async function renderAt(
     plan: ReturnType<typeof measurementPlanResponse> | ReturnType<typeof measurementPlanV2Response>
     report?: ReturnType<typeof measurementReportResponse>
     overview?: ReturnType<typeof measurementOverviewResponse>
+    overviewKey?: { scope?: 'all' | 'group'; groupKey?: string; queryClass?: 'all' | 'non-brand' | 'branded' }
   },
   /**
    * `seedPlan: false` leaves the measurement-plan query unseeded, which is the
@@ -77,13 +78,24 @@ async function renderAt(
     )
   }
   if (measurement?.overview) {
+    // Seed under the EXACT scope/class the page is expected to request. A test
+    // that seeds `all` and asserts a group rendered proves nothing: the page
+    // would read the seeded `all` page either way. Seeding only the group key
+    // is what makes "did the URL drive the request?" observable — get it wrong
+    // and the surface paints a skeleton instead.
+    const q = {
+      scope: measurement.overviewKey?.scope ?? 'all',
+      ...(measurement.overviewKey?.groupKey ? { groupKey: measurement.overviewKey.groupKey } : {}),
+      queryClass: measurement.overviewKey?.queryClass ?? 'non-brand',
+      limit: 50,
+    }
     queryClient.setQueryData(
       getApiV1ProjectsByNameMeasurementOverviewInfiniteQueryKey({
         client: heyClient,
         path: { name: projectName },
-        query: { scope: 'all', queryClass: 'non-brand', limit: 50 },
+        query: q,
       }),
-      { pages: [measurement.overview], pageParams: [{ path: { name: projectName }, query: { scope: 'all', queryClass: 'non-brand', limit: 50 } }] },
+      { pages: [measurement.overview], pageParams: [{ path: { name: projectName }, query: q }] },
     )
   }
   const router = createAppRouter(queryClient, { initialEntries: [pathname] })
@@ -180,6 +192,7 @@ function measurementOverviewResponse(overrides: {
   totalEstimate?: number
   label?: string
   targetKey?: string
+  queryClass?: 'all' | 'non-brand' | 'branded'
 } = {}) {
   return {
     mode: 'active-v2' as const,
@@ -188,7 +201,7 @@ function measurementOverviewResponse(overrides: {
       ...(overrides.scopeKey ? { key: overrides.scopeKey } : {}),
       label: overrides.scopeLabel ?? 'All Properties',
     },
-    queryClass: 'non-brand' as const,
+    queryClass: (overrides.queryClass ?? 'non-brand') as 'all' | 'non-brand' | 'branded',
     measurement: {
       state: 'complete' as const,
       displayedRunId: 'run-synthetic',
@@ -768,4 +781,61 @@ test('a settled plan read still renders the Simple Overview, so the guard is not
 
   expect(html).toContain('Where competitors are winning')
   expect(html).not.toContain('Loading project overview')
+})
+
+// ── Measurement view state lives in the URL ──────────────────────────────────
+//
+// Scale is the reason. At 47 properties an operator can re-pick a market after
+// every reload; at 200+ markets that is the whole interaction, and a scope that
+// only exists in component state cannot be linked, bookmarked, or reloaded.
+// `?scope=group:<key>` makes a market a place you can send someone.
+
+test('a scope in the URL selects that group on first paint, with no interaction', async () => {
+  const html = await renderAt(
+    '/projects/project_citypoint?scope=group:north',
+    undefined,
+    {
+      plan: measurementPlanV2Response(2),
+      overview: measurementOverviewResponse({ scope: 'group', scopeKey: 'north', scopeLabel: 'North' }),
+      overviewKey: { scope: 'group', groupKey: 'north' },
+    },
+  )
+
+  // The group control reflects the URL rather than defaulting to all-properties.
+  const doc = new DOMParser().parseFromString(html, 'text/html')
+  const group = doc.querySelector('[aria-labelledby="advanced-measurement-group-label"]')
+  const checked = group?.querySelector('[role="radio"][aria-checked="true"], option[selected]')
+  expect(checked?.textContent).toBe('North')
+})
+
+test('a query class in the URL selects that class on first paint', async () => {
+  const html = await renderAt(
+    '/projects/project_citypoint?class=branded',
+    undefined,
+    {
+      plan: measurementPlanV2Response(2),
+      overview: measurementOverviewResponse({ queryClass: 'branded' }),
+      overviewKey: { queryClass: 'branded' },
+    },
+  )
+
+  const doc = new DOMParser().parseFromString(html, 'text/html')
+  const control = doc.querySelector('[aria-labelledby="advanced-measurement-class-label"]')
+  const checked = control?.querySelector('[role="radio"][aria-checked="true"]')
+  expect(checked?.textContent).toBe('Branded')
+})
+
+test('a stale group key in the URL falls back to all properties instead of erroring', async () => {
+  // A bookmark outlives the group it names. The page must still render.
+  const html = await renderAt(
+    '/projects/project_citypoint?scope=group:deleted-market',
+    undefined,
+    { plan: measurementPlanV2Response(2), overview: measurementOverviewResponse() },
+  )
+
+  const doc = new DOMParser().parseFromString(html, 'text/html')
+  const group = doc.querySelector('[aria-labelledby="advanced-measurement-group-label"]')
+  const checked = group?.querySelector('[role="radio"][aria-checked="true"], option[selected]')
+  expect(checked?.textContent).toBe('All properties')
+  expect(html).not.toContain('Something went wrong')
 })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.150.1",
+  "version": "4.151.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.150.1",
+  "version": "4.151.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.151.0",
+  "version": "4.150.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.150.1",
+  "version": "4.151.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.150.1",
+  "version": "4.151.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.151.0",
+  "version": "4.150.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
Scale is the reason. With a handful of Properties an operator can re-pick a market after every navigation; with hundreds of markets that re-pick **is** the interaction, and a scope held only in component state cannot be linked, bookmarked, reloaded, or quoted in a bug report.

- `?scope=group:<key>` and `?class=branded`. Defaults are written as **absent**, so the ordinary case leaves a clean URL.
- Scope and class **push** a history entry (deliberate, low-frequency; back should return to the previous market). The property search stays local state - it changes per keystroke and belongs in neither the URL nor the history stack.
- **A bookmark outlives the group it names.** Once the plan has loaded, a URL naming a group that no longer exists resolves to all-properties *before any request goes out*, so an old link renders the portfolio rather than asking the server for an impossible scope and painting a skeleton. While the plan is in flight the key is left alone - absence of an answer is not evidence the group is gone.
- Parsing degrades rather than throws; every malformed scope/class in the tests lands on the default.

Also locks responsive structure that was previously unguarded: the wide table scrolls **inside its own container** (a test walks every ancestor to prove the min-width is on the table, not the scroller - the latter makes the whole page scroll sideways), the control row wraps, and segmented controls wrap their options so twenty markets stay reachable.

## Testing

15 new tests. Every behaviour mutation-proven: ignoring the URL fails 3, never treating a key as stale fails 1, moving the min-width onto the scroller fails 1, unwrapping the segmented control fails 1. Web suite 787 passing, lint clean.