### PR TITLE
test(ads): widen the reconcile backoff so the intermediate attempt is observable

### DIFF
--- a/packages/api-routes/test/ads-routes.test.ts
+++ b/packages/api-routes/test/ads-routes.test.ts
@@ -2030,7 +2030,15 @@ describe('ads routes', () => {
       currentStatus: 'active',
       adsReconcileSweepIntervalMs: 5,
       adsReconcilePendingStaleMs: 1,
-      adsReconcileBackoffBaseMs: 50,
+      // Backoff is `base * 2^(attempts-1)`, and the assertions below prove a
+      // NEGATIVE — that no further attempt happened during a real-time sleep.
+      // A negative like that is only as reliable as the gap between the sleep
+      // and the next scheduled attempt. At base 50 those gaps were 25ms and
+      // 50ms, which ordinary CI scheduling jitter crosses: a `setTimeout(25)`
+      // on a contended runner routinely lands past 50ms, the next attempt
+      // fires, and the assertion fails on a machine slower than the author's.
+      // At base 400 the same sleeps sit 375ms and 750ms clear of the window.
+      adsReconcileBackoffBaseMs: 400,
       adsReconcileMaxAttempts: 3,
     })
     await ctx.app.ready()
@@ -2063,7 +2071,7 @@ describe('ads routes', () => {
         .where(eq(adsOperations.operationKey, operationKey)).get()).toMatchObject({
         state: 'unknown', reconcileAttempts: 2,
       })
-    }, { timeout: 500, interval: 5 })
+    }, { timeout: 2000, interval: 5 })
     await new Promise((resolve) => setTimeout(resolve, 50))
     expect(ctx.db.select().from(adsOperations)
       .where(eq(adsOperations.operationKey, operationKey)).get()).toMatchObject({
@@ -2078,7 +2086,7 @@ describe('ads routes', () => {
         errorCode: 'ADS_RECONCILIATION_QUARANTINED',
         leaseOwner: null,
       })
-    }, { timeout: 750, interval: 5 })
+    }, { timeout: 3000, interval: 5 })
     await new Promise((resolve) => setTimeout(resolve, 75))
     expect(ctx.db.select().from(adsOperations)
       .where(eq(adsOperations.operationKey, operationKey)).get()).toMatchObject({


### PR DESCRIPTION
`backs off inconclusive sweeps, quarantines at the attempt cap` has now failed **three times tonight** on branches touching only `apps/web` — twice on [#966](https://github.com/Canonry/canonry/pull/966) (including a rerun) and once on [#955](https://github.com/Canonry/canonry/pull/955). It passes locally every time: 2487/2487 in the api-routes project. The difference is the runner, not the code under test.

## Mechanism

The test polls every 5ms waiting for `reconcileAttempts: 2`, and backoff is `base * 2^(attempts-1)`. At base 50, attempt 2 is due 50ms after attempt 1 and attempt 3 is due 100ms after that.

When a contended runner stalls the sweep long enough that **both windows have already elapsed**, the sweeper takes attempt 2 and attempt 3 back-to-back within a few milliseconds and the poller never observes the intermediate value. `vi.waitFor` then times out — which surfaces as `expected {…} to match object { reconcileAttempts: 2 }`, the exact CI failure.

Base moves 50 → 400, so consecutive attempts are 400ms and 800ms apart. A stall has to be an order of magnitude longer before two attempts collapse into one poll interval. The two negative assertions gain the same margin: their 25ms and 50ms sleeps now sit 375ms and 750ms clear of the next attempt.

## Evidence, honestly

This is reasoned from the failure signature and the backoff arithmetic, **not reproduced locally**. I tried to force it by stretching the sleep past the old window; the test still passed, which ruled out my first hypothesis and pointed at stall-collapse instead. Test duration unchanged at ~13s; api-routes green at 2487.