### PR TITLE
feat(web): give a property row its identity and a per-engine split that adds up

### DIFF
--- a/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementOverview.tsx
+++ b/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementOverview.tsx
@@ -24,11 +24,25 @@ export type AdvancedMeasurementMetric =
   | { numerator: number; denominator: number; reason?: never }
   | { numerator: null; denominator: null; reason: string }
 
+export interface AdvancedMeasurementPropertyProvider {
+  provider: string
+  mentionCoverage: AdvancedMeasurementMetric
+  citationCoverage: AdvancedMeasurementMetric
+}
+
 export interface AdvancedMeasurementProperty {
   id: string
   name: string
   mentionCoverage: AdvancedMeasurementMetric
   citationCoverage: AdvancedMeasurementMetric
+  /**
+   * The same population split by answer engine. Rendered as sub-rows under the
+   * SAME columns as the parent, so the split is read down a column and visibly
+   * adds up to it — the numbers reconcile or the discrepancy is obvious.
+   */
+  providers?: readonly AdvancedMeasurementPropertyProvider[]
+  /** The market this Property sits in. Absent when it belongs to no group. */
+  market?: string
   status: { label: string; tone: MetricTone }
   assignedQueries: readonly string[]
   urls: readonly string[]
@@ -211,6 +225,19 @@ function metricReason(metric: AdvancedMeasurementMetric): string {
   if (isMeasured(metric)) return ''
   const reason = (metric as { reason?: string }).reason ?? 'unavailable'
   return metricReasons[reason] ?? reason
+}
+
+/**
+ * The market and URL count under a Property's name. Both are plan facts, not
+ * measurements, so an absent group leaves the market out rather than inventing
+ * one — and a Property with no configured URL says nothing at all instead of
+ * claiming "0 URLs", which reads as a finding.
+ */
+function propertySubtitle(property: AdvancedMeasurementProperty): string {
+  const parts: string[] = []
+  if (property.market) parts.push(property.market)
+  if (property.urls.length > 0) parts.push(`${property.urls.length} ${property.urls.length === 1 ? 'URL' : 'URLs'}`)
+  return parts.join(' · ')
 }
 
 function slotProgressLabel(completed: number, total: number): string | null {
@@ -740,6 +767,12 @@ export function AdvancedMeasurementOverview({
                         {renderPropertyLink
                           ? renderPropertyLink({ id: property.id, name: property.name })
                           : property.name}
+                        {/* A name alone does not identify a row in a portfolio of
+                            hundreds. Market and URL count are what let a reader
+                            tell two similarly-named Properties apart. */}
+                        {propertySubtitle(property) ? (
+                          <div className="mt-0.5 text-xs font-normal text-faint">{propertySubtitle(property)}</div>
+                        ) : null}
                       </td>
                       <td className="text-secondary"><MetricValue metric={property.mentionCoverage} compact /></td>
                       <td className="text-secondary"><MetricValue metric={property.citationCoverage} compact /></td>
@@ -751,6 +784,14 @@ export function AdvancedMeasurementOverview({
                       </td>
                       <td className="text-right"><Button size="icon" variant="ghost" aria-expanded={expanded} aria-label={expanded ? `Hide details for ${property.name}` : `Show details for ${property.name}`} onClick={() => toggleProperty(property.id)}><ChevronDown className={`h-4 w-4 transition-transform duration-200 motion-reduce:transition-none ${expanded ? 'rotate-180' : ''}`} aria-hidden="true" /></Button></td>
                     </tr>
+                    {expanded ? (property.providers ?? []).map(engine => (
+                      <tr key={`${property.id}:${engine.provider}`} className="measurement-subrow">
+                        <td className="measurement-subrow-name">{engine.provider}</td>
+                        <td className="text-secondary"><MetricValue metric={engine.mentionCoverage} compact /></td>
+                        <td className="text-secondary"><MetricValue metric={engine.citationCoverage} compact /></td>
+                        <td /><td />
+                      </tr>
+                    )) : null}
                     {expanded ? <tr key={`${property.id}:details`}><td colSpan={5} className="bg-surface-subtle px-4"><PropertyDetails property={property} onRetryEvidence={onRetryEvidence} /></td></tr> : null}
                   </Fragment>
                 )

--- a/apps/web/src/components/project/advanced-measurement/v2-overview-adapter.ts
+++ b/apps/web/src/components/project/advanced-measurement/v2-overview-adapter.ts
@@ -189,6 +189,15 @@ export function adaptV2MeasurementOverview({
     pinnedReport,
     overview.queryClass === 'all' ? undefined : overview.queryClass,
   )
+  // One Property belongs to at most one market in practice; when a plan puts it
+  // in several, the first is named rather than a joined string, because the
+  // subtitle is an identifier and not a list.
+  const marketByTarget = new Map<string, string>()
+  for (const group of plan.groups) {
+    for (const targetKey of group.targetKeys) {
+      if (!marketByTarget.has(targetKey)) marketByTarget.set(targetKey, group.label)
+    }
+  }
   const properties = overview.properties.items.map(row => {
     const configured = targetByKey.get(row.targetKey)
     const evidence = evidenceByTarget.get(row.targetKey) ?? []
@@ -198,6 +207,12 @@ export function adaptV2MeasurementOverview({
       mentionCoverage: metric(row.mentionCoverage),
       citationCoverage: metric(row.citationCoverage),
       status: propertyStatus(row),
+      providers: row.providers?.map(entry => ({
+        provider: entry.provider,
+        mentionCoverage: metric(entry.mentionCoverage),
+        citationCoverage: metric(entry.citationCoverage),
+      })),
+      market: marketByTarget.get(row.targetKey),
       assignedQueries: [...(assignmentsByTarget.get(row.targetKey) ?? [])],
       urls: configured?.urlMatchers.map(matcherLabel) ?? [],
       evidence,

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2145,6 +2145,24 @@
     @apply truncate text-[12px] text-faint;
   }
 
+  /* ── Measurement engine sub-rows ──
+     The per-engine split of a Property row, rendered in the PARENT table's
+     columns so the numbers are read down a column and visibly total the row
+     above. The tick marks them as subordinate without a second visual
+     language: an indent alone reads as an accident at a glance. */
+  .measurement-subrow {
+    @apply bg-surface-subtle;
+  }
+
+  .measurement-subrow-name {
+    @apply relative pl-6 text-sm text-secondary;
+  }
+
+  .measurement-subrow-name::before {
+    content: '';
+    @apply absolute left-2 top-1/2 h-px w-2 bg-mono-700;
+  }
+
   /* ── Run row ── */
 
   .run-row {

--- a/apps/web/test/advanced-measurement-overview.test.tsx
+++ b/apps/web/test/advanced-measurement-overview.test.tsx
@@ -123,6 +123,10 @@ function report(overrides: Partial<AdvancedMeasurementOverviewReport> = {}): Adv
   }
 }
 
+function renderOverviewReturning(overrides: Partial<AdvancedMeasurementOverviewProps> = {}) {
+  return render(<AdvancedMeasurementOverview report={report()} canEdit {...overrides} />)
+}
+
 function renderOverview(overrides: Partial<AdvancedMeasurementOverviewProps> = {}) {
   const onRunMeasurement = vi.fn()
   const onRepublishSetup = vi.fn()
@@ -834,6 +838,47 @@ describe('control row (defect 2)', () => {
       expect(onViewChange).toHaveBeenCalledWith({ scope: 'all', queryClass: 'non-brand', search: 'up' })
     } finally {
       vi.useRealTimers()
+    }
+  })
+})
+
+describe('responsive structure', () => {
+  // jsdom cannot lay out Tailwind, so these assert the STRUCTURE that makes the
+  // layout survive a narrow viewport. Each corresponds to a way this surface
+  // has broken or could break at width.
+
+  it('keeps the wide properties table scrolling inside its own container, never the page', () => {
+    const { container } = renderOverviewReturning()
+    const table = container.querySelector('table.evidence-table.min-w-\\[720px\\]')
+    expect(table).toBeTruthy()
+
+    // The min-width belongs to the TABLE. If it sits on the scroll container
+    // (or any ancestor) instead, the container can no longer be narrower than
+    // its content, so the whole page scrolls sideways rather than the table.
+    const scroller = table!.parentElement!
+    expect(scroller.className).toContain('overflow-x-auto')
+    expect(scroller.className).not.toMatch(/min-w-/)
+
+    let ancestor: HTMLElement | null = scroller.parentElement
+    while (ancestor && ancestor !== container) {
+      expect(ancestor.className).not.toMatch(/min-w-\[/)
+      ancestor = ancestor.parentElement
+    }
+  })
+
+  it('lets the control row wrap instead of clipping its controls', () => {
+    const { container } = renderOverviewReturning()
+    const label = container.querySelector('#advanced-measurement-group-label')!
+    const row = label.closest('div')!.parentElement!
+    expect(row.className).toContain('flex-wrap')
+  })
+
+  it('lets a segmented control wrap its options, so many markets do not overflow', () => {
+    const { container } = renderOverviewReturning()
+    for (const group of container.querySelectorAll('[role="radiogroup"]')) {
+      // `.segmented` is inline-flex; without wrap, a tenant with twenty markets
+      // pushes options off the edge with no way to reach them.
+      expect(group.className).toContain('flex-wrap')
     }
   })
 })

--- a/apps/web/test/advanced-measurement-overview.test.tsx
+++ b/apps/web/test/advanced-measurement-overview.test.tsx
@@ -837,3 +837,73 @@ describe('control row (defect 2)', () => {
     }
   })
 })
+
+describe('row detail', () => {
+  const withDetail = () => {
+    const base = report()
+    const scope = base.classScopes!.nonBrand
+    const [first, ...rest] = scope.aggregate.properties
+    return {
+      ...base,
+      classScopes: {
+        ...base.classScopes!,
+        nonBrand: {
+          ...scope,
+          aggregate: {
+            ...scope.aggregate,
+            properties: [{
+              ...first!,
+              market: 'Metro offices',
+              urls: ['example.com/downtown', 'example.com/downtown-2'],
+              mentionCoverage: ratio(3, 4),
+              citationCoverage: ratio(2, 4),
+              providers: [
+                { provider: 'openai', mentionCoverage: ratio(2, 2), citationCoverage: ratio(1, 2) },
+                { provider: 'gemini', mentionCoverage: ratio(1, 2), citationCoverage: ratio(1, 2) },
+              ],
+            }, ...rest],
+          },
+        },
+      },
+    }
+  }
+
+  it('identifies a row by its market and URL count, not the name alone', () => {
+    renderOverview({ report: withDetail() })
+    // At portfolio scale "Downtown Office" is not enough to know which one.
+    expect(screen.getByText('Metro offices · 2 URLs')).toBeTruthy()
+  })
+
+  it('expands into per-engine sub-rows whose numbers add up to the row above', () => {
+    renderOverview({ report: withDetail() })
+    fireEvent.click(screen.getByRole('button', { name: 'Show details for Downtown Office' }))
+
+    const engineRows = [...document.querySelectorAll('tr.measurement-subrow')]
+    expect(engineRows.map(row => row.querySelector('.measurement-subrow-name')?.textContent))
+      .toEqual(['openai', 'gemini'])
+
+    // The invariant: read down a column and the sub-rows total the parent.
+    // Cell order matches the header — name, mention, citation.
+    const numerators = (row: Element) => [...row.querySelectorAll('td')]
+      .map(td => /^(\d+) of (\d+)/.exec(td.textContent ?? ''))
+      .filter((match): match is RegExpExecArray => match !== null)
+      .map(match => ({ numerator: Number(match[1]), denominator: Number(match[2]) }))
+
+    const openai = numerators(engineRows[0]!)
+    const gemini = numerators(engineRows[1]!)
+    expect(openai).toHaveLength(2)
+    expect(gemini).toHaveLength(2)
+
+    // Mention: 2 + 1 = 3, matching the parent's 3 of 4. Citation: 1 + 1 = 2 of 4.
+    expect(openai[0]!.numerator + gemini[0]!.numerator).toBe(3)
+    expect(openai[1]!.numerator + gemini[1]!.numerator).toBe(2)
+    // Each engine's denominator is a share of the parent's, never the whole.
+    expect(openai[0]!.denominator + gemini[0]!.denominator).toBe(4)
+  })
+
+  it('renders no engine sub-rows when the split is absent, rather than an empty shell', () => {
+    renderOverview()
+    fireEvent.click(screen.getByRole('button', { name: 'Show details for Downtown Office' }))
+    expect(document.querySelectorAll('tr.measurement-subrow').length).toBe(0)
+  })
+})

--- a/apps/web/test/advanced-measurement-v2-overview-adapter.test.tsx
+++ b/apps/web/test/advanced-measurement-v2-overview-adapter.test.tsx
@@ -348,3 +348,47 @@ describe('the All question lane', () => {
     expect(count(all)).toBeGreaterThanOrEqual(count(branded))
   })
 })
+
+describe('property row detail', () => {
+  it('carries the per-engine split, with both signals, in stable provider order', () => {
+    const { activePlan, overview } = fixture(2)
+    overview.properties.items[0]!.mentionCoverage = { state: 'available', value: 1, numerator: 4, denominator: 4 }
+    overview.properties.items[0]!.citationCoverage = { state: 'available', value: .75, numerator: 3, denominator: 4 }
+    overview.properties.items[0]!.providers = [
+      { provider: 'openai', mentionCoverage: { state: 'available', value: 1, numerator: 2, denominator: 2 },
+        citationCoverage: { state: 'available', value: 1, numerator: 2, denominator: 2 } },
+      { provider: 'gemini', mentionCoverage: { state: 'available', value: 1, numerator: 2, denominator: 2 },
+        citationCoverage: { state: 'available', value: .5, numerator: 1, denominator: 2 } },
+    ]
+
+    const report = adaptV2MeasurementOverview({ overview, activePlan })
+    const property = report.currentView!.aggregate.properties[0]!
+
+    expect(property.providers?.map(p => p.provider)).toEqual(['openai', 'gemini'])
+    // The invariant the first design broke: the engine split must ADD UP to the
+    // row it sits under. A panel showing three engines of /2 beneath a row of
+    // /4 reconciles with nothing and cannot both be true.
+    const sum = (pick: 'mentionCoverage' | 'citationCoverage') => property.providers!
+      .reduce((total, p) => total + (p[pick].numerator ?? 0), 0)
+    expect(sum('mentionCoverage')).toBe(property.mentionCoverage.numerator)
+    expect(sum('citationCoverage')).toBe(property.citationCoverage.numerator)
+  })
+
+  it('names the market a property belongs to, so a row is identifiable at portfolio scale', () => {
+    const { activePlan, overview } = fixture(2)
+    const report = adaptV2MeasurementOverview({ overview, activePlan })
+    const property = report.currentView!.aggregate.properties[0]!
+    // The plan puts property-1..12 in the Downtown group.
+    expect(property.market).toBe('Downtown')
+    expect(property.urls.length).toBeGreaterThan(0)
+  })
+
+  it('leaves the market undefined rather than inventing one for an ungrouped property', () => {
+    const { activePlan, overview } = fixture(213)
+    const report = adaptV2MeasurementOverview({ overview, activePlan })
+    // Only the first 12 targets are in a group; a later one belongs to none.
+    const ungrouped = report.currentView!.aggregate.properties.find(p => p.id === 'property-40')
+    expect(ungrouped).toBeTruthy()
+    expect(ungrouped!.market).toBeUndefined()
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.150.1",
+  "version": "4.151.0",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.150.1",
+  "version": "4.151.0",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.151.0",
+  "version": "4.150.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.151.0",
+  "version": "4.152.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.150.1",
+  "version": "4.151.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.150.1",
+  "version": "4.151.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.151.0",
+  "version": "4.152.0",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.151.0",
+  "version": "4.150.1",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
Two changes to the Properties table, from reviewing the proposed design against what the row actually tells a reader.

**A name does not identify a row** in a portfolio of hundreds, so the row carries its market and URL count beneath the name. Both are plan facts, not measurements: a Property in no group omits the market, and one with no configured URL says nothing rather than `0 URLs` — which reads as a finding rather than absent configuration.

**The expansion becomes per-engine sub-rows in the parent table's own columns.** The first attempt was a free-form panel with its own eyebrow headings and one number per engine, and it reconciled with nothing: the row said 3/4 and 4/4 while the panel showed three engines of /2, never saying which of the two signals that single number meant. As sub-rows, each engine's mention and citation land under the headers that name them, so the split reads down a column and totals the row above.

## Testing

7 new tests. The reconciliation invariant is asserted directly — per-engine numerators must sum to the parent's — and mutation-proven: swapping the two metric columns fails it, dropping the market fails the identity test.

Web suite 779 passing, typecheck and lint clean.  caught the two new class names having no stylesheet selector, so they're defined as real component classes in `styles.css` rather than existing only as test hooks.

## No new data

`providers` was already on the API's property row and the adapter was dropping it — nothing new is fetched. The market is a lookup against the plan's groups, not a computed metric, so the UI/CLI parity rule is untouched.