### PR TITLE
fix(web): open one Property at a time in the measurement table

### DIFF
--- a/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementOverview.tsx
+++ b/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementOverview.tsx
@@ -617,7 +617,10 @@ export function AdvancedMeasurementOverview({
   const [search, setSearch] = useState(viewSearch ?? '')
   const [propertyLimit, setPropertyLimit] = useState(PROPERTY_LIST_LIMIT)
   const [flaggedLimit, setFlaggedLimit] = useState(FLAGGED_RESULTS_INITIAL_LIMIT)
-  const [expandedPropertyIds, setExpandedPropertyIds] = useState<ReadonlySet<string>>(new Set())
+  // One id, not a set: each expansion adds an engine sub-row per provider plus a
+  // details panel, so two open at once push the rest of a several-hundred-row
+  // table off screen. Opening a Property closes whichever one was open.
+  const [expandedPropertyId, setExpandedPropertyId] = useState<string | null>(null)
   const lastRequestedSearch = useRef(viewSearch ?? '')
 
   const legacyScope = classReportingAvailable && !usesServerView && selectedClass !== 'all'
@@ -736,13 +739,8 @@ export function AdvancedMeasurementOverview({
   }
 
   function toggleProperty(propertyId: string) {
-    const willExpand = !expandedPropertyIds.has(propertyId)
-    setExpandedPropertyIds(current => {
-      const next = new Set(current)
-      if (next.has(propertyId)) next.delete(propertyId)
-      else next.add(propertyId)
-      return next
-    })
+    const willExpand = expandedPropertyId !== propertyId
+    setExpandedPropertyId(willExpand ? propertyId : null)
     if (willExpand) onPropertyExpand?.(propertyId)
   }
 
@@ -848,7 +846,7 @@ export function AdvancedMeasurementOverview({
             <thead><tr><th>Property</th><th>Mention</th><th>Citation</th><th>Status</th><th><span className="sr-only">Details</span></th></tr></thead>
             <tbody>
               {shownProperties.map(property => {
-                const expanded = expandedPropertyIds.has(property.id)
+                const expanded = expandedPropertyId === property.id
                 return (
                   <Fragment key={property.id}>
                     <tr

--- a/apps/web/test/advanced-measurement-overview.test.tsx
+++ b/apps/web/test/advanced-measurement-overview.test.tsx
@@ -304,6 +304,31 @@ describe('AdvancedMeasurementOverview', () => {
     expect(screen.getByRole('button', { name: 'Hide details for Downtown Office' })).toBeTruthy()
   })
 
+  // Each expansion adds an engine sub-row per provider plus a details panel, so
+  // two open at once push the rest of a several-hundred-row table off screen.
+  it('opens one Property at a time, collapsing the previously open one', () => {
+    renderOverview()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show details for Downtown Office' }))
+    expect(screen.getByRole('button', { name: 'Hide details for Downtown Office' })).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show details for Uptown Office' }))
+
+    expect(screen.getByRole('button', { name: 'Hide details for Uptown Office' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Show details for Downtown Office' })).toBeTruthy()
+  })
+
+  it('collapses the open Property when it is clicked again, leaving none open', () => {
+    renderOverview()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show details for Downtown Office' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Hide details for Downtown Office' }))
+
+    expect(screen.getByRole('button', { name: 'Show details for Downtown Office' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Show details for Uptown Office' })).toBeTruthy()
+    expect(screen.queryByText('Assigned queries')).toBeNull()
+  })
+
   it('badges bridged property and evidence rows as Historical', () => {
     const current = report()
     const first = current.classScopes!.nonBrand.aggregate.properties[0]!


### PR DESCRIPTION
Expanding a Property in the advanced-measurement table adds an engine sub-row per provider plus a details panel. With two open at once the rest of the table is pushed off screen, and a portfolio scope holds several hundred rows — so the reader loses their place in exactly the case the list exists for.

Opening a Property now closes whichever one was open. Clicking the open row still collapses it, leaving none open.

The state changes from `ReadonlySet<string>` to a single nullable id, which makes the invariant structural instead of something every call site has to maintain.

## Tests

Both written first and confirmed failing before the fix:

- `opens one Property at a time, collapsing the previously open one` — failed against the Set implementation.
- `collapses the open Property when it is clicked again, leaving none open` — a regression guard for the existing behaviour; mutation-proven by making `toggleProperty` never collapse, which fails it.

803 web tests pass, typecheck clean, lint 0 errors.