### PR TITLE
fix(measurement): five defects an adversarial audit found in the new surface

### DIFF
--- a/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementOverview.tsx
+++ b/apps/web/src/components/project/advanced-measurement/AdvancedMeasurementOverview.tsx
@@ -514,20 +514,28 @@ function SegmentedControl<T extends string>({
 /**
  * The two headline rates.
  *
- * Cited and mentioned are rates over the SAME population — one assignment being
- * a Property paired with a query — which is what lets them share a single
- * denominator line. `propertiesMentioned` is deliberately NOT here: it counts
- * PROPERTIES, so printing it under the same denominator would state something
- * false about one of the three. The per-Property picture is the outcome counts
- * below, which give four states rather than one ratio.
+ * The unit of both is an assignment — a Property paired with a query — but the
+ * two POPULATIONS are not guaranteed equal. The API measures mention over the
+ * answered slots and citation over the source-complete ones, and an answer
+ * arriving with incomplete source capture is routine, so the denominators
+ * diverge on real runs. A single shared basis line is therefore printed only
+ * when the two are actually the same number; otherwise each rate carries its
+ * own, because one line reading "of 250" under a 50% that was measured over 300
+ * tells the reader 125 mentions where the measured figure is 150.
+ *
+ * `propertiesMentioned` is deliberately NOT here: it counts PROPERTIES, so
+ * printing it alongside would state something false about one of the three. The
+ * per-Property picture is the outcome counts below.
  */
 function CoverageHero({ cited, mentioned }: {
   cited: AdvancedMeasurementMetric
   mentioned: AdvancedMeasurementMetric
 }) {
-  const denominator = isMeasured(cited) ? cited.denominator
-    : isMeasured(mentioned) ? mentioned.denominator
-    : null
+  const sharedDenominator = isMeasured(cited) && isMeasured(mentioned)
+    ? cited.denominator === mentioned.denominator ? cited.denominator : null
+    : isMeasured(cited) ? cited.denominator
+      : isMeasured(mentioned) ? mentioned.denominator
+        : null
   const percent = (metric: AdvancedMeasurementMetric): string =>
     isMeasured(metric) ? `${Math.round((metric.numerator / metric.denominator) * 100)}%` : 'N/A'
   return (
@@ -541,11 +549,16 @@ function CoverageHero({ cited, mentioned }: {
             {percent(metric)}
           </p>
           <p className="mt-1 text-xs text-secondary">{label}</p>
+          {sharedDenominator === null && isMeasured(metric) ? (
+            <p className="mt-0.5 font-mono text-xs text-faint tabular-nums">
+              {metric.numerator} of {metric.denominator}
+            </p>
+          ) : null}
         </div>
       ))}
-      {denominator === null ? null : (
+      {sharedDenominator === null ? null : (
         <p className="ml-auto self-end font-mono text-xs text-secondary">
-          of {denominator}
+          of {sharedDenominator}
           <InfoTooltip text="One assignment is a Property paired with a query. Branded queries are a separate filter and are never averaged in." />
         </p>
       )}
@@ -561,9 +574,12 @@ function CoverageHero({ cited, mentioned }: {
  * reachable on the tooltip since cited-only is the actionable half — the engine
  * used the page and recommended somebody else.
  *
- * The counts are the server's, over the whole scope. Nothing is computed here,
- * and an absent block renders nothing rather than a row of zeroes, which would
- * read as a measured finding instead of a missing field.
+ * The counts are the server's, over the Properties currently LISTED — they
+ * narrow with the search box exactly as the table and its "N properties" count
+ * do. Saying "in scope" would be a promise the numbers stop keeping the moment
+ * someone types. Nothing is computed here, and an absent block renders nothing
+ * rather than a row of zeroes, which would read as a measured finding instead
+ * of a missing field.
  */
 function OutcomeCounts({ outcomes }: {
   outcomes: NonNullable<NonNullable<AdvancedMeasurementOverviewReport['currentView']>['outcomes']>
@@ -585,7 +601,7 @@ function OutcomeCounts({ outcomes }: {
             <InfoTooltip text={`Which signal: ${outcomes.mentionedOnly} mentioned, not cited. ${outcomes.citedOnly} cited, not mentioned.`} />
           ) : null}
           {entry.key === 'not-measured' ? (
-            <InfoTooltip text={`Sums to ${outcomes.total}. Every Property in scope is in exactly one group.`} />
+            <InfoTooltip text={`Sums to ${outcomes.total}. Every Property listed is in exactly one group.`} />
           ) : null}
         </span>
       ))}
@@ -652,7 +668,12 @@ export function AdvancedMeasurementOverview({
   useEffect(() => {
     if (viewSearch === undefined) return
     lastRequestedSearch.current = viewSearch
-    setSearch(viewSearch)
+    // The parent trims before storing, so what echoes back after a pause can
+    // be the same term minus the space just typed. Writing that into the
+    // controlled input deletes the space and merges the next word onto the
+    // last one. An echo that differs only by surrounding whitespace is this
+    // round trip, not a new term from elsewhere, so the box is left alone.
+    setSearch(current => (current.trim() === viewSearch.trim() ? current : viewSearch))
   }, [viewSearch])
 
   useEffect(() => {
@@ -770,18 +791,18 @@ export function AdvancedMeasurementOverview({
       </header>
 
       {!isViewLoading ? (
-
         <CoverageHero
-
           cited={classMetric(aggregate.metrics.citationCoverage)}
-
           mentioned={classMetric(aggregate.metrics.mentionCoverage)}
-
         />
-
       ) : <div className="h-20 animate-pulse rounded-md bg-surface-subtle" aria-label="Updating measurement results" />}
 
-      {report.currentView?.outcomes ? <OutcomeCounts outcomes={report.currentView.outcomes} /> : null}
+      {/* Gated with the hero and the table: while the new view is in flight the
+          cache still holds the PREVIOUS scope's counts, and a stale split shown
+          under a control that already reads "Branded" is worse than no split. */}
+      {!isViewLoading && report.currentView?.outcomes
+        ? <OutcomeCounts outcomes={report.currentView.outcomes} />
+        : null}
 
       <div className="flex flex-wrap items-end gap-4 border-b border-default pb-4">
         <div className="space-y-1">

--- a/apps/web/src/lib/measurement-view-url.ts
+++ b/apps/web/src/lib/measurement-view-url.ts
@@ -45,6 +45,26 @@ export function parseMeasurementViewSearch(search: { scope?: string; class?: str
 }
 
 /**
+ * Whether a change of plan identity (`"<project>:<revision>"`) should discard
+ * the view the URL is carrying.
+ *
+ * A scope names a group inside one project's plan revision, so carrying it
+ * across a different plan points it at nothing and the reset is right. Two
+ * cases are NOT changes, and both were live bugs:
+ *
+ * - **No previous identity.** On first mount the URL's scope is exactly what
+ *   the reader asked for. Resetting discards every shared or bookmarked link
+ *   the instant it opens.
+ * - **Identity not yet known.** The plan is fetched, so the revision reads as
+ *   unknown for the first render or two and then appears. That appearance is
+ *   the answer arriving, not the plan changing.
+ */
+export function shouldResetMeasurementView(previous: string | null, next: string | null): boolean {
+  if (next === null || previous === null) return false
+  return previous !== next
+}
+
+/**
  * Write view state back to the URL, omitting every default. Returns the two
  * keys only, for spreading over the rest of the existing search params.
  */

--- a/apps/web/src/pages/ProjectPage.tsx
+++ b/apps/web/src/pages/ProjectPage.tsx
@@ -3,7 +3,7 @@ import { ChevronDown, RefreshCw, Trash2 } from 'lucide-react'
 import { useNavigate, useParams, useSearch } from '@tanstack/react-router'
 import { Link } from '@tanstack/react-router'
 
-import { measurementViewSearch, parseMeasurementViewSearch } from '../lib/measurement-view-url.js'
+import { measurementViewSearch, parseMeasurementViewSearch, shouldResetMeasurementView } from '../lib/measurement-view-url.js'
 import { useQueryClient } from '@tanstack/react-query'
 import { RunKinds, RunStatuses } from '@ainyc/canonry-contracts'
 
@@ -1787,10 +1787,21 @@ function ProjectPageContent({
     ? null
     : Number(activeMeasurementPlan.plan.schemaVersion)
   const activeMeasurementRevision = activeMeasurementPlan?.revision ?? 0
+  // Reset the view only when the plan it belongs to actually CHANGES. The
+  // identity is null until the plan resolves, and the first identity we ever
+  // see is not a change — see `shouldResetMeasurementView`, which is where the
+  // two "not a change" cases are pinned by tests.
+  const measurementPlanIdentity = planGroupKeysLoaded
+    ? `${projectName}:${activeMeasurementRevision}`
+    : null
+  const lastMeasurementPlanIdentity = useRef<string | null>(null)
   useEffect(() => {
+    const previous = lastMeasurementPlanIdentity.current
+    if (measurementPlanIdentity !== null) lastMeasurementPlanIdentity.current = measurementPlanIdentity
+    if (!shouldResetMeasurementView(previous, measurementPlanIdentity)) return
     setAdvancedMeasurementView({ scope: 'all', queryClass: 'non-brand' })
     setHasExpandedAdvancedProperty(false)
-  }, [projectName, activeMeasurementRevision])
+  }, [measurementPlanIdentity, setAdvancedMeasurementView])
   const advancedMeasurementOverviewQueryInput = {
     client: heyClient,
     path: { name: projectName },

--- a/apps/web/test/advanced-measurement-overview.test.tsx
+++ b/apps/web/test/advanced-measurement-overview.test.tsx
@@ -1027,6 +1027,59 @@ describe('outcome count row', () => {
     renderOverview()
     expect(screen.queryByLabelText('Property outcomes')).toBeNull()
   })
+
+  // The parent trims the term before storing it, so a pause after a space
+  // echoes back a shorter string. Writing that echo into the controlled input
+  // deletes the space the user just typed, and the next word merges onto the
+  // last one: "Downtown " + "Office" becomes "DowntownOffice", which matches
+  // nothing.
+  it('does not eat a trailing space when the trimmed term echoes back', () => {
+    const { rerender } = renderOverviewReturning({
+      report: { ...report(), currentView: undefined },
+      viewSearch: '',
+    })
+    const box = screen.getByPlaceholderText('Search properties') as HTMLInputElement
+
+    fireEvent.change(box, { target: { value: 'Downtown ' } })
+    expect(box.value).toBe('Downtown ')
+
+    rerender(
+      <AdvancedMeasurementOverview
+        report={{ ...report(), currentView: undefined }}
+        canEdit
+        viewSearch="Downtown"
+      />,
+    )
+
+    expect(box.value).toBe('Downtown ')
+  })
+
+  // While a new view loads, the cache still holds the PREVIOUS scope's counts.
+  // Every other data block swaps to a skeleton for exactly that reason; leaving
+  // this one up presents non-brand numbers as the branded view's split.
+  it('hides the counts while a new view is loading rather than showing the old ones', () => {
+    renderOverview({
+      isViewLoading: true,
+      report: withOutcomes({
+        bothSignals: 14, mentionedOnly: 11, citedOnly: 6, neither: 9, notMeasured: 7, total: 47,
+      }),
+    })
+
+    expect(screen.queryByLabelText('Property outcomes')).toBeNull()
+  })
+
+  // The counts narrow with the search box, exactly as the table and its
+  // "N properties" count do. Claiming they cover the whole scope is a promise
+  // the numbers stop keeping the moment someone types.
+  it('describes the counts as covering the listed Properties, not the whole scope', () => {
+    renderOverview({ report: withOutcomes({
+      bothSignals: 1, mentionedOnly: 1, citedOnly: 0, neither: 0, notMeasured: 0, total: 2,
+    }) })
+
+    const tip = screen.getByRole('button', { name: /Sums to 2/ })
+    expect(tip.getAttribute('aria-label')).not.toContain('in scope')
+    expect(tip.getAttribute('aria-label')).toContain('listed')
+  })
 })
 
 describe('coverage hero', () => {
@@ -1041,6 +1094,48 @@ describe('coverage hero', () => {
     expect(hero.textContent).toContain('cited')
     expect(hero.textContent).toContain('mentioned')
     expect(hero.textContent).toContain('of 8')
+  })
+
+  // The two rates are NOT always over the same population: the API measures
+  // mention over answered slots and citation over source-complete slots, and
+  // partial source capture is routine. One shared basis line would misstate
+  // whichever rate it did not come from.
+  it('gives each rate its own basis when the two populations differ', () => {
+    const current = report()
+    renderOverview({
+      report: {
+        ...current,
+        classScopes: {
+          ...current.classScopes!,
+          nonBrand: {
+            ...current.classScopes!.nonBrand,
+            aggregate: {
+              ...current.classScopes!.nonBrand.aggregate,
+              metrics: {
+                ...current.classScopes!.nonBrand.aggregate.metrics,
+                citationCoverage: ratio(50, 250),
+                mentionCoverage: ratio(150, 300),
+              },
+            },
+          },
+        },
+      },
+    })
+    const hero = screen.getByLabelText('Coverage')
+
+    expect(within(hero).getByText('20%')).toBeTruthy()
+    expect(within(hero).getByText('50%')).toBeTruthy()
+    // The killer: one line reading "of 250" under both rates would tell a
+    // reader that 50% meant 125 mentions, when the measured figure is 150.
+    expect(hero.textContent).toContain('50 of 250')
+    expect(hero.textContent).toContain('150 of 300')
+  })
+
+  it('keeps the single shared basis when both rates really do share a population', () => {
+    renderOverview()
+    const hero = screen.getByLabelText('Coverage')
+    expect(hero.textContent).toContain('of 8')
+    expect(hero.textContent).not.toContain('2 of 8')
   })
 
   it('does not put a per-Property count in a hero denominated in assignments', () => {

--- a/apps/web/test/measurement-view-url.test.ts
+++ b/apps/web/test/measurement-view-url.test.ts
@@ -1,9 +1,10 @@
-import { expect, test } from 'vitest'
+import { describe, expect, it, test } from 'vitest'
 
 import {
   DEFAULT_MEASUREMENT_VIEW,
   measurementViewSearch,
   parseMeasurementViewSearch,
+  shouldResetMeasurementView,
 } from '../src/lib/measurement-view-url.js'
 
 test('reads a group scope and a query class out of the URL', () => {
@@ -58,4 +59,31 @@ test('every state survives a URL round trip', () => {
   for (const state of states) {
     expect(parseMeasurementViewSearch(measurementViewSearch(state))).toEqual(state)
   }
+})
+
+describe('shouldResetMeasurementView', () => {
+  // The reset exists because a scope names a group inside one project's plan
+  // revision; carry it across a different plan and it points at nothing.
+  it('resets when the plan identity genuinely changes', () => {
+    expect(shouldResetMeasurementView('acme:4', 'acme:5')).toBe(true)
+    expect(shouldResetMeasurementView('acme:4', 'other:4')).toBe(true)
+  })
+
+  // The bug this pins: on first mount there is no previous identity, and the
+  // URL's scope is precisely what the reader asked for. Resetting there throws
+  // away every shared or bookmarked link the moment it opens.
+  it('never resets on the first identity it sees', () => {
+    expect(shouldResetMeasurementView(null, 'acme:4')).toBe(false)
+  })
+
+  // The plan arrives asynchronously, so the identity is unknown for the first
+  // render or two. An unknown value is not a change.
+  it('does not treat a not-yet-loaded plan as a change', () => {
+    expect(shouldResetMeasurementView(null, null)).toBe(false)
+    expect(shouldResetMeasurementView('acme:4', null)).toBe(false)
+  })
+
+  it('does not reset on a re-render with the same identity', () => {
+    expect(shouldResetMeasurementView('acme:4', 'acme:4')).toBe(false)
+  })
 })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "canonry",
   "private": true,
-  "version": "4.153.1",
+  "version": "4.153.2",
   "type": "module",
   "packageManager": "pnpm@10.28.2",
   "scripts": {

--- a/packages/canonry/package.json
+++ b/packages/canonry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canonry/canonry",
-  "version": "4.153.1",
+  "version": "4.153.2",
   "type": "module",
   "description": "Agent-first open-source AEO operating platform - track how answer engines cite your domain",
   "license": "FSL-1.1-ALv2",

--- a/packages/contracts/src/measurement-plan-v2.ts
+++ b/packages/contracts/src/measurement-plan-v2.ts
@@ -523,7 +523,12 @@ export const measurementOverviewResponseSchema = z.object({
     ),
   }).strict(),
   properties: measurementCursorPageSchema(measurementPropertyRowSchema),
-  /** Scope-wide outcome split. Counted over EVERY Property in scope, not the page. */
+  /**
+   * Outcome split over the whole RESULT SET, not the page — so paging through
+   * does not move it. It narrows with `search` exactly as `properties.totalEstimate`
+   * does, because both are computed from the same filtered rows; with no search
+   * that result set is the entire scope.
+   */
   outcomes: measurementOutcomeCountsSchema,
   flags: z.object({ total: z.number().int().nonnegative() }).strict(),
   namedShareOfVoice: measurementNamedShareOfVoiceSchema.optional(),

--- a/plugins/canonry/.claude-plugin/plugin.json
+++ b/plugins/canonry/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "canonry",
   "displayName": "Canonry",
-  "version": "4.153.1",
+  "version": "4.153.2",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",

--- a/plugins/canonry/.codex-plugin/plugin.json
+++ b/plugins/canonry/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canonry",
-  "version": "4.153.1",
+  "version": "4.153.2",
   "description": "Operate Canonry AEO projects through guided skills and the typed Canonry MCP server.",
   "author": {
     "name": "Canonry",


### PR DESCRIPTION
An adversarial audit of the just-merged advanced-measurement work (five independent lenses, each finding then handed to a skeptic prompted to refute it) confirmed five defects. Every fix ships the test that reproduces it, written first and confirmed failing against the old code.

## 1. The hero stated one denominator for two different populations

The API measures mention over the **answered** slots (`scopeMentionRate`) and citation over the **source-complete** ones (`indexedScopeCitationRate`). An answer arriving with incomplete source capture is routine, so the denominators diverge on real runs.

The hero printed whichever one `cited` happened to carry. With `citationCoverage = 50/250` and `mentionCoverage = 150/300` it rendered "20%", "50%", and a single "of 250" — telling the reader 125 mentions where the measured figure is 150. No numerators were shown anywhere, so there was nothing to catch it with.

The shared basis line now prints only when the two denominators actually match; otherwise each rate carries its own. The doc comment asserting they were "rates over the SAME population" was mine and was false.

## 2. The outcome counts claimed a scope they do not cover

The counts narrow with the search box — as do the table and `properties.totalEstimate`, which are computed from the same filtered rows. That behaviour is coherent and is unchanged here.

What was wrong was the description. The tooltip said "Every Property **in scope** is in exactly one group" and the contract said "Counted over **EVERY** Property in scope, not the page". Both stop being true the moment someone types. Both now describe the result set they actually cover.

## 3. The outcome row survived a view change

`OutcomeCounts` was the only data block not gated on `isViewLoading`. The hero and the table swap to skeletons while the new view is in flight — precisely because the cache is still serving the previous scope. So switching to Branded left the non-brand split (14 / 17 / 9 / 7, "Sums to 47") on screen under a control that already read "Branded".

## 4. A shared link never rendered its own view

The reset effect had no first-run guard: on mount it rewrote the URL to `scope=all&class=non-brand`, discarding whatever the link carried, and pushed a history entry over the bookmarked URL. It fired a second time when the revision flipped from unknown to loaded.

Opening `?scope=group:emea&class=branded` therefore landed on All properties / Non-brand — defeating the entire point of putting the view in the URL.

The decision is now `shouldResetMeasurementView(previous, next)`, a pure function in `measurement-view-url.ts` with both "not a change" cases pinned by tests: no previous identity, and an identity that is not yet known.

## 5. The search box ate a trailing space

The parent trims before storing, so pausing after a space echoed back the shorter term, and the controlled input dropped the space the user had just typed. Resuming turned "Downtown " + "Office" into "DowntownOffice", which was sent to the server and rendered "No properties match this search." for a Property that exists.

An echo that differs only by surrounding whitespace is that round trip, not a new term, so it no longer rewrites the box.

## Verification

- 812 web tests, 2495 api-routes tests, typecheck clean, lint 0 errors.
- `pnpm gen` produces no SDK drift (the contract change is a comment).
- Version bumped to 4.153.2; plugin manifests synced (`plugin:check` clean).