### PR TITLE
fix: keep the site map alive when toggling nav and footer links

### DIFF
--- a/apps/web/src/components/project/SiteGraphSigma.tsx
+++ b/apps/web/src/components/project/SiteGraphSigma.tsx
@@ -1,5 +1,6 @@
 import {
   Component,
+  type ErrorInfo,
   useCallback,
   useDeferredValue,
   useEffect,
@@ -58,6 +59,12 @@ export interface SiteGraphSigmaProps {
   layoutUnavailableReason?: SiteCrawlGraphLayoutUnavailableReason | null
   /** Server-identified crawl root. Without it no page gets the root marker. */
   rootNodeKey?: string | null
+  /**
+   * Nav and footer links are hidden through the edge reducer, so flipping this
+   * never changes the graph and never rebuilds the renderer. Pages cannot move
+   * as a result, which is what the toggle promises.
+   */
+  showTemplateLinks?: boolean
   selectedNodeKey?: string | null
   onSelectNode?: (node: SiteGraphSigmaNode) => void
   ariaLabel?: string
@@ -161,8 +168,10 @@ class GraphRenderBoundary extends Component<GraphRenderBoundaryProps, GraphRende
     return { failed: true }
   }
 
-  override componentDidCatch(error: Error): void {
-    console.error('[SiteGraphSigma] WebGL renderer failed', error)
+  override componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Surfaced, never swallowed: this is the only record of WHY the map died,
+    // and the state it puts on screen deliberately does not blame the browser.
+    console.error('[SiteGraphSigma] the map failed to render', error, info.componentStack)
   }
 
   override componentDidUpdate(previousProps: GraphRenderBoundaryProps): void {
@@ -221,15 +230,10 @@ function sigmaTheme(element: HTMLElement): SigmaSiteGraphTheme {
     edgeActive: color('edgeActive'),
     label: color('label'),
     background: color('background'),
-    root: color('root'),
   }
 }
 
 /**
- * Sigma 3's circle program cannot stroke a node, so the root's ring is painted
- * on the 2D label canvas above the WebGL layer. The root always carries
- * `forceLabel`, so that canvas always runs for it.
- *
  * The label text is drawn here rather than delegated to Sigma's
  * `drawDiscNodeLabel`: importing `sigma/rendering` for a value touches
  * `WebGL2RenderingContext` at module load, which does not exist during SSR or
@@ -239,17 +243,6 @@ function createSiteGraphNodeLabelRenderer(
   theme: SigmaSiteGraphTheme,
 ): NodeLabelDrawingFunction<SigmaSiteGraphNodeAttributes, SigmaSiteGraphEdgeAttributes> {
   return (context, data, settings) => {
-    const ringColor = (data as Partial<SigmaSiteGraphNodeAttributes>).ringColor
-    if (typeof ringColor === 'string') {
-      context.save()
-      context.strokeStyle = ringColor
-      context.lineWidth = 3
-      context.beginPath()
-      context.arc(data.x, data.y, data.size + 4, 0, Math.PI * 2)
-      context.stroke()
-      context.restore()
-    }
-
     if (!data.label) return
     context.save()
     context.fillStyle = settings.labelColor.color ?? theme.label
@@ -333,6 +326,9 @@ function supportsWebGl(): boolean {
   }
 }
 
+/**
+ * The browser genuinely cannot run the map. Probed once, at mount.
+ */
 function GraphUnavailableState() {
   return (
     <div className="flex h-full min-h-80 items-center justify-center px-6 text-center">
@@ -346,11 +342,31 @@ function GraphUnavailableState() {
   )
 }
 
+/**
+ * WE failed to draw, in a browser that has already proved it can. Saying
+ * "WebGL is unavailable" here sends the reader to debug their machine for our
+ * bug, so this state owns the failure and offers the only useful action.
+ */
+function GraphRenderFailedState({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="flex h-full min-h-80 items-center justify-center px-6 text-center" role="alert">
+      <div className="max-w-md">
+        <p className="text-sm font-medium text-heading">The map could not be drawn</p>
+        <p className="mt-1 text-sm text-secondary">
+          Something went wrong while drawing this map. The page inventory below is unaffected.
+        </p>
+        <Button variant="secondary" size="sm" className="mt-4" onClick={onRetry}>Try again</Button>
+      </div>
+    </div>
+  )
+}
+
 interface SigmaRuntimeProps {
   reactSigma: ReactSigmaBindings
   graph: SigmaSiteGraph
   theme: SigmaSiteGraphTheme
   selectedNodeKey: string | null
+  showTemplateLinks: boolean
   onSelectNodeKey: (nodeKey: string) => void
   onHoverNode: (hovered: HoveredNode | null) => void
   onCameraReady: (actions: CameraActions | null) => void
@@ -361,6 +377,7 @@ function SigmaRuntime({
   graph,
   theme,
   selectedNodeKey,
+  showTemplateLinks,
   onSelectNodeKey,
   onHoverNode,
   onCameraReady,
@@ -437,11 +454,18 @@ function SigmaRuntime({
     // opened with its zoomed-in treatment: every label drawn and the whole
     // edge mesh visible. Reading live also means pan and zoom never need a
     // full 20k/50k graph refresh to stay correct.
+    // Applying settings to an instance whose graph is not this one would be
+    // writing to a renderer react-sigma is about to replace, or has already
+    // killed: on a graph change React runs THIS effect (a child) between the
+    // container's cleanup and its re-creation. Waiting for the matching
+    // instance is what keeps that ordering from throwing.
+    if (sigma.getGraph() !== graph) return
     const reducers = createSigmaSiteGraphReducers(
       graph,
       focusNodeKey,
       () => sigma.getCamera().getState().ratio,
       theme,
+      showTemplateLinks,
     )
     sigma.setSetting('nodeReducer', reducers.nodeReducer)
     sigma.setSetting('edgeReducer', reducers.edgeReducer)
@@ -456,7 +480,7 @@ function SigmaRuntime({
     // destroyed instance schedules a refresh with no `circle` program. A live
     // instance is overwritten by the next effect, and an unmounted one needs
     // no reset.
-  }, [focusNodeKey, graph, sigma, theme])
+  }, [focusNodeKey, graph, showTemplateLinks, sigma, theme])
 
   return null
 }
@@ -467,6 +491,7 @@ export function SiteGraphSigma({
   layoutState = 'ready',
   layoutUnavailableReason,
   rootNodeKey = null,
+  showTemplateLinks = true,
   selectedNodeKey,
   onSelectNode,
   ariaLabel,
@@ -488,6 +513,8 @@ export function SiteGraphSigma({
   const [searchOpen, setSearchOpen] = useState(false)
   const [activeResultIndex, setActiveResultIndex] = useState(0)
   const [statusMessage, setStatusMessage] = useState('')
+  /** Bumping this remounts the renderer, which is what "Try again" means. */
+  const [renderAttempt, setRenderAttempt] = useState(0)
   const lastControlledFocusRef = useRef<string | null>(null)
   const deferredSearchValue = useDeferredValue(searchValue)
   const effectiveSelectedNodeKey = selectedNodeKey === undefined
@@ -692,7 +719,7 @@ export function SiteGraphSigma({
   }
 
   const activeResult = searchResults.at(activeResultIndex)
-  const fallback = <GraphUnavailableState />
+  const fallback = <GraphRenderFailedState onRetry={() => setRenderAttempt((attempt) => attempt + 1)} />
   const SigmaContainerComponent = reactSigma?.SigmaContainer
 
   return (
@@ -799,12 +826,12 @@ export function SiteGraphSigma({
       </div>
 
       <div className="relative min-h-0 flex-1 overflow-hidden">
-        {rendererState === 'unavailable' ? fallback : rendererState === 'checking' || !theme || !builtGraph || !sigmaSettings || !reactSigma || !SigmaContainerComponent ? (
+        {rendererState === 'unavailable' ? <GraphUnavailableState /> : rendererState === 'checking' || !theme || !builtGraph || !sigmaSettings || !reactSigma || !SigmaContainerComponent ? (
           <div className="flex h-full min-h-80 items-center justify-center px-6 text-center" role="status">
             <p className="text-sm text-secondary">Preparing the interactive site map...</p>
           </div>
         ) : (
-          <GraphRenderBoundary fallback={fallback} resetToken={builtGraph.graph}>
+          <GraphRenderBoundary fallback={fallback} resetToken={renderAttempt}>
             <div aria-hidden="true" className="absolute inset-0">
               <SigmaContainerComponent
                 graph={builtGraph.graph}
@@ -817,6 +844,7 @@ export function SiteGraphSigma({
                   graph={builtGraph.graph}
                   theme={theme}
                   selectedNodeKey={effectiveSelectedNodeKey}
+                  showTemplateLinks={showTemplateLinks}
                   onSelectNodeKey={handleSigmaSelect}
                   onHoverNode={handleHoverNode}
                   onCameraReady={handleCameraReady}

--- a/apps/web/src/components/project/SiteHealthSection.tsx
+++ b/apps/web/src/components/project/SiteHealthSection.tsx
@@ -314,16 +314,48 @@ function LinkMetrics({ page }: { page: InspectableCrawlPage }) {
   )
 }
 
+/**
+ * What an empty link list MEANS, in plain words with the real numbers.
+ *
+ * A page whose only connections are nav and footer chrome is editorially
+ * orphaned, which is the single most useful thing this map can tell someone.
+ * Drawing nothing and saying nothing turns that finding into what looks like a
+ * broken map, so the counts are always named. Both numbers come from the
+ * neighbours read; nothing here is inferred.
+ */
+export function emptyLinkCopy(
+  direction: 'inbound' | 'outbound',
+  hiddenTemplateCount: number,
+  truncated: boolean,
+): string {
+  if (hiddenTemplateCount === 0) {
+    return direction === 'inbound'
+      ? 'Nothing links to this page.'
+      : 'This page links to nothing.'
+  }
+  const lead = direction === 'inbound'
+    ? 'No content links to this page.'
+    : 'No content links from this page.'
+  // A truncated list can only prove a lower bound, so it says so rather than
+  // rounding a partial count into a fact.
+  const hidden = truncated
+    ? `At least ${metricValue(hiddenTemplateCount)} nav and footer links hidden.`
+    : `${countedLinks(hiddenTemplateCount, 'nav and footer link')} hidden.`
+  return `${lead} ${hidden}`
+}
+
 function NeighborTable({
   direction,
   edges,
   truncated,
   rootHost,
+  hiddenTemplateCount,
 }: {
   direction: 'inbound' | 'outbound'
   edges: SiteCrawlEdgeDto[]
   truncated: boolean
   rootHost: string | null
+  hiddenTemplateCount: number
 }) {
   const heading = direction === 'inbound' ? 'Links in' : 'Links out'
   return (
@@ -336,7 +368,7 @@ function NeighborTable({
       </div>
       {edges.length === 0 ? (
         <p className="rounded-lg border border-subtle bg-surface-subtle px-3 py-4 text-sm text-secondary">
-          No {direction} internal links were observed.
+          {emptyLinkCopy(direction, hiddenTemplateCount, truncated)}
         </p>
       ) : (
         <div className="evidence-table-wrap max-h-64 overflow-auto">
@@ -398,6 +430,7 @@ function PageInspector({
   reasonSource,
   reasonsState,
   onRetryReasons,
+  showTemplateLinks,
 }: {
   page: InspectableCrawlPage | null
   isLoading: boolean
@@ -415,6 +448,8 @@ function PageInspector({
   reasonSource: SiteCrawlPageDto | null
   reasonsState: PageReasonsState
   onRetryReasons: () => void
+  /** Mirrors the map, so the two never disagree about one page. */
+  showTemplateLinks: boolean
 }) {
   if (!page) {
     return (
@@ -427,6 +462,12 @@ function PageInspector({
 
   const status = crawlStatus(page)
   const reasons = indexabilityReasons(reasonSource ?? page)
+  // The inspector shows what the MAP shows. Listing nav links the map is
+  // hiding would make the two disagree about the same page.
+  const visibleInbound = showTemplateLinks ? inbound : inbound.filter((edge) => !edge.isTemplate)
+  const visibleOutbound = showTemplateLinks ? outbound : outbound.filter((edge) => !edge.isTemplate)
+  const hiddenInboundCount = inbound.length - visibleInbound.length
+  const hiddenOutboundCount = outbound.length - visibleOutbound.length
   return (
     <section className="border-t border-default pt-5" aria-labelledby="site-health-page-inspector-title">
       <div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-start">
@@ -487,8 +528,20 @@ function PageInspector({
           </p>
         ) : (
           <div className="grid gap-5 lg:grid-cols-2">
-            <NeighborTable direction="inbound" edges={inbound} truncated={inboundTruncated} rootHost={rootHost} />
-            <NeighborTable direction="outbound" edges={outbound} truncated={outboundTruncated} rootHost={rootHost} />
+            <NeighborTable
+              direction="inbound"
+              edges={visibleInbound}
+              truncated={inboundTruncated}
+              rootHost={rootHost}
+              hiddenTemplateCount={hiddenInboundCount}
+            />
+            <NeighborTable
+              direction="outbound"
+              edges={visibleOutbound}
+              truncated={outboundTruncated}
+              rootHost={rootHost}
+              hiddenTemplateCount={hiddenOutboundCount}
+            />
           </div>
           )}
         </div>
@@ -1325,6 +1378,7 @@ export function SiteHealthSection({ projectName, projectId }: { projectName: str
             reasonSource={inventoryPage}
             reasonsState={reasonsState}
             onRetryReasons={() => { void selectedPageQuery.refetch() }}
+            showTemplateLinks={showTemplateLinks || templateFilterUnavailable}
           />
         </div>
       ) : (
@@ -1392,7 +1446,11 @@ export function SiteHealthSection({ projectName, projectId }: { projectName: str
               ) : (
                 <SiteGraphSigma
                   nodes={graphQuery.data?.nodes ?? []}
-                  edges={visibleGraphEdges}
+                  // Every edge, always. Hiding is done by the edge reducer, so
+                  // the graph identity never changes and the renderer is never
+                  // rebuilt when the toggle flips.
+                  edges={graphEdges}
+                  showTemplateLinks={showTemplateLinks || templateFilterUnavailable}
                   layoutState={graphQuery.data?.layout.state ?? 'unavailable'}
                   layoutUnavailableReason={graphQuery.data?.layout.state === 'unavailable' ? graphQuery.data.layout.reason : null}
                   rootNodeKey={graphQuery.data?.rootNodeKey ?? null}
@@ -1440,6 +1498,7 @@ export function SiteHealthSection({ projectName, projectId }: { projectName: str
             reasonSource={inventoryPage}
             reasonsState={reasonsState}
             onRetryReasons={() => { void selectedPageQuery.refetch() }}
+            showTemplateLinks={showTemplateLinks || templateFilterUnavailable}
           />
         </div>
       )}

--- a/apps/web/src/components/project/site-graph-sigma.ts
+++ b/apps/web/src/components/project/site-graph-sigma.ts
@@ -25,16 +25,6 @@ export const SITE_GRAPH_EDGE_TOKEN = {
   fallback: '#71717a',
 } as const
 
-/**
- * Ring drawn around the crawl root. It is a fifth Okabe-Ito hue so it stays
- * distinguishable from the four state colors, and it clears 3:1 against both
- * graph canvases.
- */
-export const SITE_GRAPH_ROOT_TOKEN = {
-  property: '--chart-site-health-root',
-  fallback: '#cc79a7',
-} as const
-
 /** Smallest dot we will draw; below this a node stops being clickable. */
 export const SITE_GRAPH_NODE_MIN_SIZE = 2.5
 /** Largest dot on a small map. Dense maps scale down from here. */
@@ -96,6 +86,8 @@ export interface SiteGraphSigmaEdge {
   targetNodeKey: string | null
   followable: boolean
   occurrences: number
+  /** Nav/footer chrome. Null when this scan could not tell them apart. */
+  isTemplate?: boolean | null
 }
 
 export interface SigmaSiteGraphTheme {
@@ -111,7 +103,6 @@ export interface SigmaSiteGraphTheme {
   edgeActive: string
   label: string
   background: string
-  root: string
 }
 
 /**
@@ -132,7 +123,6 @@ export const SITE_GRAPH_SIGMA_COLOR_TOKENS = {
   edgeActive: { property: '--chart-neutral-text', fallback: '#a1a1aa' },
   label: { property: '--chart-tooltip-label', fallback: '#e4e4e7' },
   background: { property: '--chart-tooltip-bg', fallback: '#18181b' },
-  root: SITE_GRAPH_ROOT_TOKEN,
 } as const satisfies Record<keyof SigmaSiteGraphTheme, { property: string; fallback: string }>
 
 const SIGMA_HEX_COLOR = /^#(?:[\da-f]{3}|[\da-f]{4}|[\da-f]{6}|[\da-f]{8})$/i
@@ -160,8 +150,6 @@ export interface SigmaSiteGraphNodeAttributes extends Record<string, unknown> {
   zIndex: number
   /** True only for the server-identified crawl root. */
   isRoot: boolean
-  /** Ring color painted around the root node; null for every other page. */
-  ringColor: string | null
 }
 
 export interface SigmaSiteGraphEdgeAttributes extends Record<string, unknown> {
@@ -170,6 +158,7 @@ export interface SigmaSiteGraphEdgeAttributes extends Record<string, unknown> {
   baseColor: string
   followable: boolean
   occurrences: number
+  isTemplate: boolean
   type: 'line'
   zIndex: number
 }
@@ -365,7 +354,6 @@ export function buildSigmaSiteGraph(
       forceLabel: isRoot || node.depth === 0 || node.path.trim() === '/',
       zIndex: isRoot ? 2 : node.depth === 0 ? 1 : 0,
       isRoot,
-      ringColor: isRoot ? theme.root : null,
     })
   }
 
@@ -384,6 +372,7 @@ export function buildSigmaSiteGraph(
       baseColor: theme.edge,
       followable: edge.followable,
       occurrences: edge.occurrences,
+      isTemplate: edge.isTemplate === true,
       type: 'line',
       zIndex: 0,
     })
@@ -441,6 +430,14 @@ export function createSigmaSiteGraphReducers(
    */
   cameraRatio: number | (() => number),
   theme: SigmaSiteGraphTheme,
+  /**
+   * Nav and footer links are hidden by REDUCING them away, never by handing
+   * Sigma a different graph. Rebuilding the graph made react-sigma tear down
+   * and recreate the whole renderer on a checkbox, which is both wasteful and
+   * the source of a crash (a child effect keyed on the graph fired against the
+   * instance the parent had just killed).
+   */
+  showTemplateLinks = true,
 ): SigmaSiteGraphReducers {
   const hasFocus = Boolean(focusNodeKey && graph.hasNode(focusNodeKey))
   const focused = hasFocus ? focusNodeKey : null
@@ -519,6 +516,7 @@ export function createSigmaSiteGraphReducers(
       return { ...attributes, forceLabel: false, label: '' }
     },
     edgeReducer: (edgeKey, attributes) => {
+      if (attributes.isTemplate && !showTemplateLinks) return { ...attributes, hidden: true }
       const overview = readRatio() > SITE_GRAPH_OVERVIEW_CAMERA_RATIO
       const [sourceNodeKey, targetNodeKey] = graph.extremities(edgeKey)
       const highlighted = Boolean(

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -160,9 +160,6 @@
      the genuinely hidden pages use. */
   --chart-site-health-resource: #d4d4d8;
   --chart-site-health-redirect: #9aa7b8;
-  /* Ring around the home page. A further Okabe-Ito hue, so it never reads as
-     one of the page states. */
-  --chart-site-health-root: #cc79a7;
   --chart-neutral-text: #a1a1aa;
   --chart-neutral-text-dim: #71717a;
   --chart-neutral-text-faint: #52525b;
@@ -317,7 +314,6 @@
   --chart-site-health-unchecked: #52525b;
   --chart-site-health-resource: #3f3f46;
   --chart-site-health-redirect: #4b5563;
-  --chart-site-health-root: #8c4a72;
   --chart-neutral-text: #52525b;
   --chart-neutral-text-dim: #71717a;
   --chart-neutral-text-faint: #a1a1aa;

--- a/apps/web/test/design-tokens.test.ts
+++ b/apps/web/test/design-tokens.test.ts
@@ -294,7 +294,6 @@ test('Site Health uses a color-vision-safe graph palette in both themes', async 
     '--chart-site-health-unchecked: #a1a1aa',
     '--chart-site-health-resource: #d4d4d8',
     '--chart-site-health-redirect: #9aa7b8',
-    '--chart-site-health-root: #cc79a7',
   ]) {
     expect(source, `dark graph palette must contain "${declaration}"`).toContain(declaration)
   }
@@ -306,7 +305,6 @@ test('Site Health uses a color-vision-safe graph palette in both themes', async 
     '--chart-site-health-unchecked: #52525b',
     '--chart-site-health-resource: #3f3f46',
     '--chart-site-health-redirect: #4b5563',
-    '--chart-site-health-root: #8c4a72',
   ]) {
     expect(light, `light graph palette must contain "${declaration}"`).toContain(declaration)
   }
@@ -323,10 +321,10 @@ test('Site Health uses a color-vision-safe graph palette in both themes', async 
     return (values[0]! + 0.05) / (values[1]! + 0.05)
   }
 
-  for (const color of ['#56b4e9', '#e69f00', '#d55e00', '#a1a1aa', '#d4d4d8', '#9aa7b8', '#cc79a7']) {
+  for (const color of ['#56b4e9', '#e69f00', '#d55e00', '#a1a1aa', '#d4d4d8', '#9aa7b8']) {
     expect(contrast(color, '#18181b'), `${color} must remain visible on the dark graph`).toBeGreaterThanOrEqual(3)
   }
-  for (const color of ['#0072b2', '#a86f00', '#b23a2b', '#52525b', '#3f3f46', '#4b5563', '#8c4a72']) {
+  for (const color of ['#0072b2', '#a86f00', '#b23a2b', '#52525b', '#3f3f46', '#4b5563']) {
     expect(contrast(color, '#ffffff'), `${color} must remain visible on the light graph`).toBeGreaterThanOrEqual(3)
   }
   expect(contrast('#71717a', '#18181b'), 'default links must remain visible on the dark graph').toBeGreaterThanOrEqual(3)

--- a/apps/web/test/site-graph-sigma-adapter.test.ts
+++ b/apps/web/test/site-graph-sigma-adapter.test.ts
@@ -12,7 +12,6 @@ import {
   SITE_GRAPH_FOCUSED_NEIGHBOR_LABEL_LIMIT,
   SITE_GRAPH_LABEL_BUDGETS,
   SITE_GRAPH_OVERVIEW_LABEL_BUDGET,
-  SITE_GRAPH_ROOT_TOKEN,
   siteGraphLabelBudget,
   siteGraphMaxNodeSize,
   siteGraphRootNodeSize,
@@ -44,7 +43,6 @@ const theme: SigmaSiteGraphTheme = {
   edgeActive: 'rgb(22, 23, 24)',
   label: 'rgb(25, 26, 27)',
   background: 'rgb(28, 29, 30)',
-  root: 'rgb(31, 32, 33)',
 }
 
 function node(
@@ -153,10 +151,6 @@ describe('buildSigmaSiteGraph', () => {
     expect(SITE_GRAPH_EDGE_TOKEN).toEqual({
       property: '--chart-neutral-text-dim',
       fallback: '#71717a',
-    })
-    expect(SITE_GRAPH_ROOT_TOKEN).toEqual({
-      property: '--chart-site-health-root',
-      fallback: '#cc79a7',
     })
   })
 
@@ -423,10 +417,10 @@ describe('the crawl root', () => {
     const unidentified = buildSigmaSiteGraph([node('home', { path: '/', depth: 0 })], [], theme)
     expect(unidentified.graph.getNodeAttribute('home', 'isRoot')).toBe(false)
     expect(unidentified.graph.getNodeAttribute('home', 'label')).toBe('● /')
-    expect(unidentified.graph.getNodeAttribute('home', 'ringColor')).toBeNull()
+    expect(unidentified.graph.getNodeAttribute('home', 'isRoot')).toBe(false)
   })
 
-  it('is named, always labeled, oversized, and ringed regardless of link score', () => {
+  it('is labeled and oversized regardless of link score, with no alarm marker', () => {
     const root = graphWithRoot().graph.getNodeAttributes('home')
 
     // The root reads as the path it is; the ring and the forced label are
@@ -434,7 +428,9 @@ describe('the crawl root', () => {
     expect(root.label).toBe('● /')
     expect(root.forceLabel).toBe(true)
     expect(root.isRoot).toBe(true)
-    expect(root.ringColor).toBe(theme.root)
+    // No ring: a coloured halo read as "selected" or "broken here", when all
+    // it meant was "you are here". The label and the size say that already.
+    expect(root.ringColor).toBeUndefined()
     // The lowest possible internal-link score must not shrink it.
     expect(root.size).toBeCloseTo(siteGraphRootNodeSize(3), 9)
     expect(root.size).toBeGreaterThan(
@@ -443,7 +439,7 @@ describe('the crawl root', () => {
     expect(root.zIndex).toBeGreaterThan(graphWithRoot().graph.getNodeAttribute('services', 'zIndex'))
   })
 
-  it('keeps its label and ring in the overview and while another page has focus', () => {
+  it('keeps its label in the overview and while another page has focus', () => {
     const built = graphWithRoot()
     const root = built.graph.getNodeAttributes('home')
 
@@ -451,7 +447,6 @@ describe('the crawl root', () => {
     expect(overview.nodeReducer('home', root)).toMatchObject({
       label: '● /',
       forceLabel: true,
-      ringColor: theme.root,
     })
 
     // Focused elsewhere, and not even a neighbor of the focus.
@@ -459,7 +454,6 @@ describe('the crawl root', () => {
     expect(focusedElsewhere.nodeReducer('home', root)).toMatchObject({
       label: '● /',
       forceLabel: true,
-      ringColor: theme.root,
     })
     expect(focusedElsewhere.nodeReducer('home', root).color).toBe(theme.eligible)
 

--- a/apps/web/test/site-graph-sigma.test.tsx
+++ b/apps/web/test/site-graph-sigma.test.tsx
@@ -13,6 +13,7 @@ const sigmaMocks = vi.hoisted(() => ({
   gotoNode: vi.fn(),
   shouldThrow: false,
   cameraRatio: 1,
+  graphsSeen: [] as unknown[],
   containerProps: null as {
     graph?: {
       nodes: () => string[]
@@ -33,11 +34,10 @@ const sigmaMocks = vi.hoisted(() => ({
 const sigmaMockInstance = {
   setSetting: sigmaMocks.setSetting,
   refresh: sigmaMocks.refresh,
-  getGraph: () => ({
-    hasNode: () => true,
-    areNeighbors: (left: string, right: string) => left === right || left === 'home' || right === 'home',
-    extremities: () => ['home', 'pricing'],
-  }),
+  // The real Sigma reports the graph it renders, and SiteGraphSigma checks it
+  // before configuring: applying settings to an instance built for a different
+  // graph is exactly the bug that killed the map on a toggle.
+  getGraph: () => sigmaMocks.containerProps?.graph ?? null,
   getCamera: () => ({ getState: () => ({ ratio: sigmaMocks.cameraRatio }) }),
 }
 
@@ -55,6 +55,10 @@ vi.mock('@react-sigma/core', async () => {
       }
     }) => {
       if (sigmaMocks.shouldThrow) throw new Error('WebGL renderer failed')
+      // Each distinct graph object is a real Sigma instance, and a real WebGL
+      // context, in the browser. Browsers cap live contexts, so this is the
+      // number that must not grow when a checkbox is flipped.
+      if (graph && !sigmaMocks.graphsSeen.includes(graph)) sigmaMocks.graphsSeen.push(graph)
       sigmaMocks.containerProps = { graph, settings }
       return React.createElement(
         'div',
@@ -111,6 +115,11 @@ const edges = [{
   occurrences: 1,
 }]
 
+const templateEdges = [
+  { edgeKey: 'home-pricing', sourceNodeKey: 'home', targetNodeKey: 'pricing', followable: true, occurrences: 1, isTemplate: false },
+  { edgeKey: 'nav-pricing', sourceNodeKey: 'pricing', targetNodeKey: 'home', followable: true, occurrences: 1, isTemplate: true },
+]
+
 function mockWebGl(supported: boolean) {
   vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(((contextId: string) => {
     if (contextId === 'webgl' || contextId === 'webgl2') return supported ? {} : null
@@ -122,6 +131,7 @@ beforeEach(() => {
   sigmaMocks.handlers = {}
   sigmaMocks.shouldThrow = false
   sigmaMocks.containerProps = null
+  sigmaMocks.graphsSeen = []
   sigmaMocks.setSetting.mockReset()
   sigmaMocks.refresh.mockReset()
   sigmaMocks.zoomIn.mockReset()
@@ -421,13 +431,27 @@ describe('SiteGraphSigma', () => {
     expect(screen.getByText(/page inventory remains available/i)).toBeTruthy()
   })
 
-  it('contains renderer failures without taking down Site Health', async () => {
+  it('owns a render failure instead of blaming the browser for it', async () => {
+    // The map had already drawn in this browser, so "could not start WebGL"
+    // sent the reader to debug their machine for our bug.
     mockWebGl(true)
     sigmaMocks.shouldThrow = true
-    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    render(<SiteGraphSigma nodes={nodes} edges={edges} />)
+
+    expect(await screen.findByText('The map could not be drawn')).toBeTruthy()
+    expect(screen.queryByText('Interactive map unavailable')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeTruthy()
+    // The underlying error is logged, never swallowed.
+    expect(consoleError).toHaveBeenCalled()
+  })
+
+  it('still says WebGL is unavailable when the browser genuinely cannot start it', async () => {
+    mockWebGl(false)
     render(<SiteGraphSigma nodes={nodes} edges={edges} />)
 
     expect(await screen.findByText('Interactive map unavailable')).toBeTruthy()
+    expect(screen.queryByText('The map could not be drawn')).toBeNull()
   })
 
   it('distinguishes an empty graph from missing server layout positions', () => {
@@ -453,5 +477,55 @@ describe('SiteGraphSigma', () => {
     )
     expect(screen.getByText('Map could not be built')).toBeTruthy()
     expect(screen.getByText('The map could not be created for this scan. Run a new scan to try again.')).toBeTruthy()
+  })
+
+  it('keeps one renderer alive across repeated nav and footer toggling', async () => {
+    // The live bug: ticking "Show nav and footer links" replaced the map with
+    // the WebGL fallback. Visibility used to be expressed by handing the
+    // renderer a SHORTER edge list, which is a different graph, which made
+    // react-sigma kill and rebuild the whole Sigma instance. Browsers cap live
+    // WebGL contexts, and the rebuild also let a child effect fire against the
+    // instance that had just been killed.
+    mockWebGl(true)
+    const { rerender } = render(
+      <SiteGraphSigma nodes={nodes} edges={edges} showTemplateLinks={false} />,
+    )
+    await waitFor(() => expect(sigmaMocks.refresh).toHaveBeenCalled())
+    expect(sigmaMocks.graphsSeen).toHaveLength(1)
+
+    for (let i = 0; i < 12; i++) {
+      rerender(<SiteGraphSigma nodes={nodes} edges={edges} showTemplateLinks={i % 2 === 0} />)
+    }
+
+    // One graph, therefore one Sigma instance and one WebGL context, however
+    // many times the toggle is flipped.
+    expect(sigmaMocks.graphsSeen).toHaveLength(1)
+    // And the map is still on screen: no fallback of either kind.
+    expect(screen.queryByText('The map could not be drawn')).toBeNull()
+    expect(screen.queryByText('Interactive map unavailable')).toBeNull()
+    expect(sigmaMocks.containerProps?.graph).toBe(sigmaMocks.graphsSeen[0])
+  })
+
+  it('re-reduces on toggle so the edges actually change without a rebuild', async () => {
+    mockWebGl(true)
+    sigmaMocks.cameraRatio = 0.1
+    const { rerender } = render(
+      <SiteGraphSigma nodes={nodes} edges={templateEdges} showTemplateLinks={false} />,
+    )
+    await waitFor(() => expect(sigmaMocks.refresh).toHaveBeenCalled())
+
+    const visibleEdges = () => {
+      const edgeReducer = sigmaMocks.setSetting.mock.calls
+        .filter(([setting]) => setting === 'edgeReducer').at(-1)![1] as (key: string, attributes: never) => Record<string, unknown>
+      const graph = sigmaMocks.containerProps!.graph!
+      return graph.edges().filter((edgeKey: string) => (
+        edgeReducer(edgeKey, graph.getEdgeAttributes(edgeKey) as never).hidden !== true
+      ))
+    }
+
+    expect(visibleEdges()).toEqual(['home-pricing'])
+    rerender(<SiteGraphSigma nodes={nodes} edges={templateEdges} showTemplateLinks />)
+    expect(visibleEdges()).toEqual(['home-pricing', 'nav-pricing'])
+    expect(sigmaMocks.graphsSeen).toHaveLength(1)
   })
 })

--- a/apps/web/test/site-health-section.test.tsx
+++ b/apps/web/test/site-health-section.test.tsx
@@ -35,14 +35,34 @@ vi.mock('../src/components/project/TechnicalAeoSection.js', () => ({
   ),
 }))
 
+// Stable ids for the edge arrays the map is handed, so a test can assert the
+// renderer was never given a NEW array (which would rebuild Sigma). Hoisted
+// because the mock factory runs before this module body does.
+const { edgeIdentity } = vi.hoisted(() => {
+  const seen = new WeakMap<object, number>()
+  let next = 0
+  return {
+    edgeIdentity(edges: unknown): number {
+      if (!edges || typeof edges !== 'object') return -1
+      const existing = seen.get(edges as object)
+      if (existing !== undefined) return existing
+      next += 1
+      seen.set(edges as object, next)
+      return next
+    },
+  }
+})
+
 vi.mock('../src/components/project/SiteGraphSigma.js', () => ({
   SiteGraphSigma: ({
     nodes,
     edges,
+    showTemplateLinks,
     onSelectNode,
   }: {
     nodes: Array<{ nodeKey: string; path: string; x: number; y: number }>
     edges?: Array<{ edgeKey: string }>
+    showTemplateLinks?: boolean
     onSelectNode?: (node: { nodeKey: string; path: string; x: number; y: number }) => void
   }) => (
     <div role="img" aria-label="Interactive site map">
@@ -52,6 +72,10 @@ vi.mock('../src/components/project/SiteGraphSigma.js', () => ({
       {/* What the renderer was actually handed, so a test can assert which
           links are drawn and that positions never move. */}
       <span data-testid="site-map-edge-keys">{(edges ?? []).map((edge) => edge.edgeKey).join(',')}</span>
+      <span data-testid="site-map-show-template">{String(showTemplateLinks)}</span>
+      {/* Identity of the edge array the renderer was handed. Toggling must not
+          change it, because a new array rebuilds the whole Sigma instance. */}
+      <span data-testid="site-map-edges-identity">{String(edgeIdentity(edges))}</span>
       <span data-testid="site-map-node-positions">
         {nodes.map((node) => `${node.nodeKey}:${node.x},${node.y}`).join(';')}
       </span>
@@ -1194,8 +1218,11 @@ test('the map opens on content links only and says what it is hiding', () => {
   expect(screen.getByTestId('site-map-link-counts').textContent)
     .toContain('Showing 1 content link. 1 nav and footer link hidden.')
 
-  // Only the content link is drawn.
-  expect(screen.getByTestId('site-map-edge-keys').textContent).toBe('home-services')
+  // The renderer holds EVERY edge and is told to hide the template ones.
+  // Handing it a shorter list instead would rebuild the renderer on a
+  // checkbox, which is what used to kill the map.
+  expect(screen.getByTestId('site-map-edge-keys').textContent).toBe('home-services,nav-contact')
+  expect(screen.getByTestId('site-map-show-template').textContent).toBe('false')
 })
 
 test('switching nav and footer links on draws them without moving a page', () => {
@@ -1205,6 +1232,7 @@ test('switching nav and footer links on draws them without moving a page', () =>
   fireEvent.click(screen.getByRole('checkbox', { name: 'Show nav and footer links' }))
 
   expect(screen.getByTestId('site-map-edge-keys').textContent).toBe('home-services,nav-contact')
+  expect(screen.getByTestId('site-map-show-template').textContent).toBe('true')
   expect(screen.getByTestId('site-map-link-counts').textContent)
     .toContain('Showing 1 content link and 1 nav and footer link.')
   // The layout was published without template links, so drawing them is a
@@ -1245,4 +1273,60 @@ test('says when a map\'s page positions still include the nav mesh', () => {
   }))
 
   expect(screen.getByText(/Page positions on this map were set before nav and footer links were separated/)).not.toBeNull()
+})
+
+test('reads an empty content-link set as a finding, with the real hidden counts', async () => {
+  // canonry.ai: the homepage has 49 inbound / 30 outbound links but only 1
+  // inbound / 5 outbound CONTENT links. With nav and footer hidden (the
+  // default) a page whose only connections are chrome drew nothing and said
+  // nothing, so a correct and interesting result looked like a broken map.
+  const fetchMock = vi.fn(async () => new Response('{}', { status: 500 }))
+  vi.stubGlobal('fetch', fetchMock)
+  const queryClient = seedTemplateLinkGraph()
+  const templateEdge = (edgeKey: string, sourceNodeKey: string, targetNodeKey: string) => ({
+    edgeKey,
+    sourceNodeKey,
+    sourceUrl: `https://citypoint.example/${sourceNodeKey}`,
+    targetNodeKey,
+    targetUrl: `https://citypoint.example/${targetNodeKey}`,
+    relation: 'anchor',
+    internal: true,
+    followable: true,
+    occurrences: 1,
+    followableOccurrences: 1,
+    nofollowOccurrences: 0,
+    anchors: ['Home'],
+    isTemplate: true,
+    templateRatio: 0.9,
+  })
+  queryClient.setQueryData(getApiV1ProjectsByNameTechnicalAeoInternalLinksNeighborsQueryKey({
+    client: heyClient,
+    path: { name: projectName },
+    query: { runId: 'run_1', nodeKey: 'page_services', limit: 100 },
+  }), {
+    project: projectName,
+    hasCrawlData: true,
+    runId: 'run_1',
+    nodeKey: 'page_services',
+    url: servicesPage.url,
+    templateDetection: 'applied',
+    linkKind: 'all',
+    // Only nav links point here, which is the whole finding.
+    inbound: [templateEdge('t1', 'page_home', 'page_services'), templateEdge('t2', 'page_contact', 'page_services')],
+    outbound: [],
+    inboundTruncated: false,
+    outboundTruncated: false,
+  })
+
+  renderSection(queryClient)
+  fireEvent.click(screen.getByRole('button', { name: '/services/roof-repair' }))
+
+  // Named counts, not an apology and not silence.
+  expect(await screen.findByText('No content links to this page. 2 nav and footer links hidden.')).toBeTruthy()
+  // Zero of ANY kind is a different fact and says so.
+  expect(screen.getByText('This page links to nothing.')).toBeTruthy()
+
+  // Switching nav links on shows them rather than the finding.
+  fireEvent.click(screen.getByRole('checkbox', { name: 'Show nav and footer links' }))
+  expect(screen.queryByText('No content links to this page. 2 nav and footer links hidden.')).toBeNull()
 })


### PR DESCRIPTION
## The bug

On a dense site (canonry.ai: 50 pages / 1,259 links / 61 content links) the map renders, then ticking **Show nav and footer links** replaces it with *"Interactive map unavailable — This browser could not start WebGL."* In a browser that drew the same map a second earlier.

## Root cause

Two independent defects stacked into one misleading symptom.

**Why it broke.** Hiding template links was expressed by handing `SiteGraphSigma` a *shorter edge list*. A different array means `buildSigmaSiteGraph` returns a different graphology instance, and `@react-sigma/core`'s `SigmaContainer` keys its lifecycle effect on `[containerRef, graph, sigmaSettings]` — so a checkbox destroyed the Sigma instance and constructed a new one.

The crash is in the ordering. React runs passive effects **children before parents**, destroys before creates. On the toggle render:

1. our reducer effect's cleanup (child)
2. `SigmaContainer`'s cleanup → **`instance.kill()`**
3. our reducer effect's body (child) — deps include `graph`, which changed, so it runs; but context still holds the **killed** instance → `setSetting()` + `refresh()` on a dead renderer
4. `SigmaContainer` finally constructs the replacement

Step 3 throws. I confirmed the ordering empirically with a throwaway test replicating `SigmaContainer`'s exact effect shape (the real library can't initialise WebGL in jsdom): the child effect provably fires against the killed instance. Context exhaustion was a plausible second-order effect of the same churn, but it isn't needed to explain a failure on the *first* toggle.

**Why the message was wrong.** `GraphRenderBoundary`'s fallback was `GraphUnavailableState` — the same component used for genuinely absent WebGL. Any render error was therefore reported as the user's browser being incapable.

## The fix

**Visibility is a reduce-time decision.** The graph holds *every* edge, each tagged `isTemplate`, and the edge reducer hides template edges. The graph identity never changes, so the renderer is never rebuilt, no WebGL context is recycled, and the toggle keeps its own promise that pages do not move.

**Plus a structural guard.** The reducer effect refuses to configure an instance whose `getGraph()` is not the graph it was handed. That makes the whole class of bug impossible even when the graph legitimately changes (switching scans), which would have hit the same crash.

**Honest states.** WebGL support is probed once at mount and keeps the original message. A runtime render failure gets its own state — *"The map could not be drawn"* — with a retry that remounts the renderer, and `componentDidCatch` logs the error and component stack instead of swallowing it.

## Also, from live use on canonry.ai

- **The root ring is gone.** The pink halo read as "selected" or "something is wrong here" when it meant "you are here". The forced `/` label and larger minimum size already locate the root and carry no alarm. The `--chart-site-health-root` token and its contrast assertions are removed with it.
- **An empty edge set is now the finding.** The homepage has 49 inbound / 30 outbound links but only 1 / 5 *content* links, so with nav hidden it drew nothing and explained nothing — a correct, interesting result that looked like a broken map. It now reads **"No content links to this page. 44 nav and footer links hidden."**, with **"Nothing links to this page."** reserved for the genuinely unlinked. Counts come from the neighbours read; a truncated list says "At least N" rather than passing a partial count off as a total. The inspector's link tables now respect the same toggle, so the map and the panel can no longer disagree about one page.

## Tests

- Toggling 12 times leaves exactly **one** graph (therefore one Sigma instance, one WebGL context) and no fallback of either kind
- Toggling re-reduces: the visible edge set actually changes, with no rebuild
- A render failure shows "The map could not be drawn" with a retry and logs the error; genuine WebGL-unsupported still shows the original message
- The map is handed every edge plus `showTemplateLinks=false`, rather than a filtered list
- Empty-link findings assert the exact copy and the real counts, and disappear when nav links are switched on
- Root node keeps its label and size and carries no ring

## Validation

- `pnpm run typecheck` - clean
- `pnpm run test` - **638 files, 8158 tests, all passing**
- `pnpm run lint` - 0 errors
- `pnpm --filter @ainyc/canonry-api-client gen:check` - no drift
- `node scripts/sync-canonry-plugin.mjs --check` - matches v4.158.0
- `bash scripts/check-docs.sh` - passing

## Not verified

The fix is asserted through the runtime with a mocked Sigma; jsdom cannot run WebGL, so the original repro needs a human eye on a dense site before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)